### PR TITLE
🔥 remove irrelevant special casing for GRCS functionality construction

### DIFF
--- a/include/dd/FunctionalityConstruction.hpp
+++ b/include/dd/FunctionalityConstruction.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "QuantumComputation.hpp"
-#include "algorithms/GoogleRandomCircuitSampling.hpp"
 #include "algorithms/Grover.hpp"
 #include "dd/Operations.hpp"
 
@@ -30,11 +29,6 @@ MatrixDD buildFunctionality(const qc::Grover* qc,
 template <class Config>
 MatrixDD buildFunctionalityRecursive(const qc::Grover* qc,
                                      std::unique_ptr<dd::Package<Config>>& dd);
-
-template <class DDPackage>
-MatrixDD buildFunctionality(GoogleRandomCircuitSampling* qc,
-                            std::unique_ptr<DDPackage>& dd,
-                            std::optional<std::size_t> ncycles = std::nullopt);
 
 inline void dumpTensorNetwork(std::ostream& of, const QuantumComputation& qc) {
   of << "{\"tensors\": [\n";

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -199,32 +199,6 @@ MatrixDD buildFunctionalityRecursive(const qc::Grover* qc,
   return e;
 }
 
-template <class DDPackage>
-MatrixDD buildFunctionality(GoogleRandomCircuitSampling* qc,
-                            std::unique_ptr<DDPackage>& dd,
-                            const std::optional<std::size_t> ncycles) {
-  if (ncycles.has_value() && (*ncycles < qc->cycles.size() - 2U)) {
-    qc->removeCycles(qc->cycles.size() - 2U - *ncycles);
-  }
-
-  const auto nq = qc->getNqubits();
-  Permutation permutation = qc->initialLayout;
-  auto e = dd->makeIdent(nq);
-  dd->incRef(e);
-  for (const auto& cycle : qc->cycles) {
-    auto f = dd->makeIdent(nq);
-    for (const auto& op : cycle) {
-      f = dd->multiply(getDD(op.get(), dd, permutation), f);
-    }
-    auto g = dd->multiply(f, e);
-    dd->decRef(e);
-    dd->incRef(g);
-    e = g;
-    dd->garbageCollect();
-  }
-  return e;
-}
-
 template MatrixDD
 buildFunctionality(const qc::QuantumComputation* qc,
                    std::unique_ptr<Package<DDPackageConfig>>& dd);
@@ -243,8 +217,4 @@ buildFunctionality(const qc::Grover* qc,
 template MatrixDD
 buildFunctionalityRecursive(const qc::Grover* qc,
                             std::unique_ptr<Package<DDPackageConfig>>& dd);
-template MatrixDD
-buildFunctionality(GoogleRandomCircuitSampling* qc,
-                   std::unique_ptr<Package<DDPackageConfig>>& dd,
-                   const std::optional<std::size_t> ncycles);
 } // namespace dd

--- a/test/algorithms/test_grcs.cpp
+++ b/test/algorithms/test_grcs.cpp
@@ -1,5 +1,4 @@
 #include "algorithms/GoogleRandomCircuitSampling.hpp"
-#include "dd/FunctionalityConstruction.hpp"
 #include "dd/Simulation.hpp"
 
 #include "gtest/gtest.h"
@@ -30,16 +29,6 @@ TEST_F(GRCS, simulate) {
   auto in = dd->makeZeroState(qcBris.getNqubits());
   const std::optional<std::size_t> ncycles = 4;
   ASSERT_NO_THROW({ simulate(&qcBris, in, dd, ncycles); });
-  std::cout << qcBris << "\n";
-  qcBris.printStatistics(std::cout);
-}
-
-TEST_F(GRCS, buildFunctionality) {
-  auto qcBris =
-      qc::GoogleRandomCircuitSampling("./circuits/grcs/bris_4_40_9_v2.txt");
-
-  auto dd = std::make_unique<dd::Package<>>(qcBris.getNqubits());
-  ASSERT_NO_THROW({ buildFunctionality(&qcBris, dd, 4); });
   std::cout << qcBris << "\n";
   qcBris.printStatistics(std::cout);
 }


### PR DESCRIPTION
## Description

This PR removes a special case handling for when the functionality of a GRCS circuit is being constructed. As this is a useless and irrelevant task to conduct in general, there is no real need for special case treatment. 
In addition, this blocks adding optional flags to the `buildFunctionality` method as desired in #487.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
