### PR TITLE
🐛 restore installation of Boost multiprecision headers

### DIFF
--- a/src/zx/CMakeLists.txt
+++ b/src/zx/CMakeLists.txt
@@ -31,6 +31,12 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-zx)
                                  INTERFACE $<BUILD_INTERFACE:${MULTIPRECISION_INCLUDE_DIR}>)
       add_library(MQT::Multiprecision ALIAS multiprecision)
 
+      # add headers using file sets
+      file(GLOB_RECURSE MULTIPRECISION_HEADERS ${MULTIPRECISION_INCLUDE_DIR}/*.hpp)
+
+      target_sources(multiprecision PUBLIC FILE_SET HEADERS BASE_DIRS ${MULTIPRECISION_INCLUDE_DIR}
+                                           FILES ${MULTIPRECISION_HEADERS})
+
       set(MQT_CORE_ZX_SYSTEM_BOOST
           FALSE
           CACHE BOOL "Whether a system version of Boost was used")


### PR DESCRIPTION
## Description

This PR restores the installation of the Boost multiprecision headers to ensure that they are installed together with the mqt-core package. This fixes a regression introduced when adopting file sets in mqt-core.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
