### PR TITLE
♻️ [MLIR] Unify Operands and Results and add Docs Page for MLIR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,7 +125,7 @@ repos:
       - id: disallow-caps
         name: Disallow improper capitalization
         language: pygrep
-        entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|Mqt|Tum
+        entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|Mqt|Tum|MQTopt|MQTdyn
         exclude: .pre-commit-config.yaml
 
   # Check best practices for scientific Python code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - ⏪️ Restore support for (MLIR and) LLVM v19 ([#934](https://github.com/munich-quantum-toolkit/core/pull/934)) ([**@flowerthrower**](https://github.com/flowerthrower)), [**@ystade**](https://github.com/ystade))
 - ⬆️ Update nlohmann_json to `v3.12.0` ([#921](https://github.com/munich-quantum-toolkit/core/pull/921)) ([**@burgholzer**](https://github.com/burgholzer))
+- ♻️ Unify operands and results in MLIR dialects and add Page for MLIR in docs ([#931](https://github.com/munich-quantum-toolkit/core/pull/931)) ([**@ystade**](https://github.com/ystade))
 
 ## [3.0.2] - 2025-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- ♻️ Unify operands and results in MLIR dialects and add Page for MLIR in docs ([#931](https://github.com/munich-quantum-toolkit/core/pull/931)) ([**@ystade**](https://github.com/ystade))
 - ⏪️ Restore support for (MLIR and) LLVM v19 ([#934](https://github.com/munich-quantum-toolkit/core/pull/934)) ([**@flowerthrower**](https://github.com/flowerthrower)), [**@ystade**](https://github.com/ystade))
 - ⬆️ Update nlohmann_json to `v3.12.0` ([#921](https://github.com/munich-quantum-toolkit/core/pull/921)) ([**@burgholzer**](https://github.com/burgholzer))
-- ♻️ Unify operands and results in MLIR dialects and add Page for MLIR in docs ([#931](https://github.com/munich-quantum-toolkit/core/pull/931)) ([**@ystade**](https://github.com/ystade))
 
 ## [3.0.2] - 2025-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- 📝 Add documentation page for MLIR ([#931](https://github.com/munich-quantum-toolkit/core/pull/931)) ([**@ystade**](https://github.com/ystade))
 - ✨ Initial implementation of the mqtdyn Dialect ([#900](https://github.com/munich-quantum-toolkit/core/pull/900)) ([**@DRovara**](https://github.com/DRovara), [**@ystade**](https://github.com/ystade))
 
 ### Fixed
@@ -17,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- ♻️ Unify operands and results in MLIR dialects and add Page for MLIR in docs ([#931](https://github.com/munich-quantum-toolkit/core/pull/931)) ([**@ystade**](https://github.com/ystade))
+- ♻️ Unify operands and results in MLIR dialects ([#931](https://github.com/munich-quantum-toolkit/core/pull/931)) ([**@ystade**](https://github.com/ystade))
 - ⏪️ Restore support for (MLIR and) LLVM v19 ([#934](https://github.com/munich-quantum-toolkit/core/pull/934)) ([**@flowerthrower**](https://github.com/flowerthrower)), [**@ystade**](https://github.com/ystade))
 - ⬆️ Update nlohmann_json to `v3.12.0` ([#921](https://github.com/munich-quantum-toolkit/core/pull/921)) ([**@burgholzer**](https://github.com/burgholzer))
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ installation
 mqt_core_ir
 dd_package
 zx_package
+mlir
 references
 CHANGELOG
 UPGRADING

--- a/docs/mlir.md
+++ b/docs/mlir.md
@@ -2,8 +2,8 @@
 
 This part of MQT explores the capabilities of the Multi-Level Intermediate Representation (MLIR) in the context of compilation for quantum computing.
 We define multiple dialects, each with its dedicated purpose.
-For example, the MQTopt dialect is designed for optimization of quantum programs and features value-semantics.
-Accompanying the dialects, we provide a set of transforms on each dialect and conversions between dialects.
+For example, the MQTOpt dialect is designed for optimization of quantum programs and features value-semantics.
+Accompanying the dialects, we provide a set of transformations on each dialect and conversions between dialects.
 
 :::{note}
 This page is a work in progress.
@@ -16,8 +16,8 @@ See the [contribution guidelines](contributing.md) for more information.
 
 ### How to print the textual representation of an operation?
 
-During debugging, it can be handy to print the textual representation of an operation.
-This can be done using the `print` method of the operation either in the evaluation field of the debugger or in the code.
+During debugging, it can be handy to dump the textual representation of an operation to stdout.
+This can be done using the `dump` method of the operation either in the evaluation field of the debugger or in the code.
 It prints the textual representation of the operation to the standard output.
 
 ```c++

--- a/docs/mlir.md
+++ b/docs/mlir.md
@@ -1,0 +1,38 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+mystnb:
+  number_source_lines: true
+---
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+%config InlineBackend.figure_formats = ['svg']
+```
+
+# MLIR in MQT
+
+This part of MQT explores the capabilities of the Multi-Level Intermediate Representation (MLIR) in the context of compilation for quantum computing.
+We define multiple dialects, each with its dedicated purpose.
+For example, the MQTopt dialect is designed for optimization of quantum programs and features value-semantics.
+Accompanying the dialects, we provide a set of transforms on each dialect and conversions between dialects.
+
+:::{note}
+This page is a work in progress. 
+The content is not yet complete and may be subject to change.
+Contributions are welcome. 
+See the [contribution guidelines](contributing.md) for more information.
+:::
+
+## FAQ
+
+### How to print the textual representation of an operation?
+
+During debugging, it can be handy to print the textual representation of an operation.
+This can be done using the `print` method of the operation either in the evaluation field of the debugger or in the code.
+It prints the textual representation of the operation to the standard output.
+
+```c++
+op->dump();
+```

--- a/docs/mlir.md
+++ b/docs/mlir.md
@@ -19,9 +19,9 @@ For example, the MQTopt dialect is designed for optimization of quantum programs
 Accompanying the dialects, we provide a set of transforms on each dialect and conversions between dialects.
 
 :::{note}
-This page is a work in progress. 
+This page is a work in progress.
 The content is not yet complete and may be subject to change.
-Contributions are welcome. 
+Contributions are welcome.
 See the [contribution guidelines](contributing.md) for more information.
 :::
 

--- a/docs/mlir.md
+++ b/docs/mlir.md
@@ -1,16 +1,3 @@
----
-file_format: mystnb
-kernelspec:
-  name: python3
-mystnb:
-  number_source_lines: true
----
-
-```{code-cell} ipython3
-:tags: [remove-cell]
-%config InlineBackend.figure_formats = ['svg']
-```
-
 # MLIR in MQT
 
 This part of MQT explores the capabilities of the Multi-Level Intermediate Representation (MLIR) in the context of compilation for quantum computing.

--- a/mlir/include/mlir/Dialect/Common/IR/CommonTraits.h
+++ b/mlir/include/mlir/Dialect/Common/IR/CommonTraits.h
@@ -85,8 +85,8 @@ class NoControlTrait
 public:
   [[nodiscard]] static mlir::LogicalResult verifyTrait(mlir::Operation* op) {
     auto unitaryOp = mlir::cast<ConcreteOp>(op);
-    if (!unitaryOp.getPosCtrlQubits().empty() ||
-        !unitaryOp.getNegCtrlQubits().empty()) {
+    if (!unitaryOp.getPosCtrlInQubits().empty() ||
+        !unitaryOp.getNegCtrlInQubits().empty()) {
       return op->emitOpError()
              << "Gate marked as NoControl should not have control qubits";
     }

--- a/mlir/include/mlir/Dialect/MQTDyn/IR/MQTDynInterfaces.td
+++ b/mlir/include/mlir/Dialect/MQTDyn/IR/MQTDynInterfaces.td
@@ -37,7 +37,7 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getInQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all positively-controllingling qubits of the operation.",
+            /*desc=*/        "Returns all positively-controlling qubits of the operation.",
             /*returnType=*/  "mlir::OperandRange",
             /*methodName=*/  "getPosCtrlQubits",
             /*args=*/        (ins),
@@ -46,7 +46,7 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getPosCtrlQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all negatively-controllingling qubits of the operation.",
+            /*desc=*/        "Returns all negatively-controlling qubits of the operation.",
             /*returnType=*/  "mlir::OperandRange",
             /*methodName=*/  "getNegCtrlQubits",
             /*args=*/        (ins),

--- a/mlir/include/mlir/Dialect/MQTDyn/IR/MQTDynInterfaces.td
+++ b/mlir/include/mlir/Dialect/MQTDyn/IR/MQTDynInterfaces.td
@@ -37,7 +37,7 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getInQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all positively controlling qubits of the operation.",
+            /*desc=*/        "Returns all positively-controllingling qubits of the operation.",
             /*returnType=*/  "mlir::OperandRange",
             /*methodName=*/  "getPosCtrlQubits",
             /*args=*/        (ins),
@@ -46,7 +46,7 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getPosCtrlQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all negatively controlling qubits of the operation.",
+            /*desc=*/        "Returns all negatively-controllingling qubits of the operation.",
             /*returnType=*/  "mlir::OperandRange",
             /*methodName=*/  "getNegCtrlQubits",
             /*args=*/        (ins),

--- a/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptInterfaces.td
+++ b/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptInterfaces.td
@@ -37,7 +37,7 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getInQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all positively control input qubits of the operation.",
+            /*desc=*/        "Returns all positively-controlling input qubits of the operation.",
             /*returnType=*/  "mlir::OperandRange",
             /*methodName=*/  "getPosCtrlInQubits",
             /*args=*/        (ins),
@@ -46,7 +46,7 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getPosCtrlInQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all negatively control input qubits of the operation.",
+            /*desc=*/        "Returns all negatively-controlling input qubits of the operation.",
             /*returnType=*/  "mlir::OperandRange",
             /*methodName=*/  "getNegCtrlInQubits",
             /*args=*/        (ins),
@@ -64,7 +64,7 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getOutQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all positively control output qubits of the operation.",
+            /*desc=*/        "Returns all positively-controlling output qubits of the operation.",
             /*returnType=*/  "mlir::ResultRange",
             /*methodName=*/  "getPosCtrlOutQubits",
             /*args=*/        (ins),
@@ -73,7 +73,7 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getPosCtrlOutQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all negatively control output qubits of the operation.",
+            /*desc=*/        "Returns all negatively-controlling output qubits of the operation.",
             /*returnType=*/  "mlir::ResultRange",
             /*methodName=*/  "getNegCtrlOutQubits",
             /*args=*/        (ins),
@@ -97,7 +97,7 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return controls;
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all control output qubits of the operation incl. positive and negative controls.",
+            /*desc=*/        "Returns all control output qubits of the operation.",
             /*returnType=*/  "std::vector<mlir::Value>",
             /*methodName=*/  "getAllCtrlOutQubits",
             /*args=*/        (ins),
@@ -151,13 +151,13 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 << "and output qubits (" << unitaryOp.getOutQubits().size() << ") must be the same";
         } else if (unitaryOp.getPosCtrlInQubits().size() != unitaryOp.getPosCtrlOutQubits().size()) {
             return $_op->emitError() <<
-                "number of positively control input qubits (" << unitaryOp.getPosCtrlInQubits().size() << ") "
-                << "and positively control output qubits (" << unitaryOp.getPosCtrlOutQubits().size()
+                "number of positively-controlling input qubits (" << unitaryOp.getPosCtrlInQubits().size() << ") "
+                << "and positively-controlling output qubits (" << unitaryOp.getPosCtrlOutQubits().size()
                 << ") must be the same";
         } else if (unitaryOp.getNegCtrlInQubits().size() != unitaryOp.getNegCtrlOutQubits().size()) {
             return $_op->emitError() <<
-                "number of negatively control input qubits (" << unitaryOp.getNegCtrlInQubits().size() << ") "
-                << "and negatively control output qubits (" << unitaryOp.getNegCtrlOutQubits().size()
+                "number of negatively-controlling input qubits (" << unitaryOp.getNegCtrlInQubits().size() << ") "
+                << "and negatively-controlling output qubits (" << unitaryOp.getNegCtrlOutQubits().size()
                 << ") must be the same";
         }
         return mlir::success();

--- a/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptInterfaces.td
+++ b/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptInterfaces.td
@@ -37,25 +37,25 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getInQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all positively control qubits of the operation.",
+            /*desc=*/        "Returns all positively control input qubits of the operation.",
             /*returnType=*/  "mlir::OperandRange",
-            /*methodName=*/  "getPosCtrlQubits",
+            /*methodName=*/  "getPosCtrlInQubits",
             /*args=*/        (ins),
             /*methodBody=*/  [{}],
             /*defaultImpl=*/ [{
-                return $_op.getPosCtrlQubits();
+                return $_op.getPosCtrlInQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all negatively control qubits of the operation.",
+            /*desc=*/        "Returns all negatively control input qubits of the operation.",
             /*returnType=*/  "mlir::OperandRange",
-            /*methodName=*/  "getNegCtrlQubits",
+            /*methodName=*/  "getNegCtrlInQubits",
             /*args=*/        (ins),
             /*methodBody=*/  [{}],
             /*defaultImpl=*/ [{
-                return $_op.getNegCtrlQubits();
+                return $_op.getNegCtrlInQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all output qubits of the operation incl. all control qubits.",
+            /*desc=*/        "Returns all output qubits of the operation excl. control qubits.",
             /*returnType=*/  "mlir::ResultRange",
             /*methodName=*/  "getOutQubits",
             /*args=*/        (ins),
@@ -64,14 +64,47 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
                 return $_op.getOutQubits();
             }]>,
         InterfaceMethod<
-            /*desc=*/        "Returns all control qubits of the operation incl. positive and negative controls.",
-            /*returnType=*/  "std::vector<mlir::Value>",
-            /*methodName=*/  "getCtrlQubits",
+            /*desc=*/        "Returns all positively control output qubits of the operation.",
+            /*returnType=*/  "mlir::ResultRange",
+            /*methodName=*/  "getPosCtrlOutQubits",
             /*args=*/        (ins),
             /*methodBody=*/  [{}],
             /*defaultImpl=*/ [{
-                const auto& posCtrlQubits = $_op.getPosCtrlQubits();
-                const auto& negCtrlQubits = $_op.getNegCtrlQubits();
+                return $_op.getPosCtrlOutQubits();
+            }]>,
+        InterfaceMethod<
+            /*desc=*/        "Returns all negatively control output qubits of the operation.",
+            /*returnType=*/  "mlir::ResultRange",
+            /*methodName=*/  "getNegCtrlOutQubits",
+            /*args=*/        (ins),
+            /*methodBody=*/  [{}],
+            /*defaultImpl=*/ [{
+                return $_op.getNegCtrlOutQubits();
+            }]>,
+        InterfaceMethod<
+            /*desc=*/        "Returns all control input qubits of the operation incl. positive and negative controls.",
+            /*returnType=*/  "std::vector<mlir::Value>",
+            /*methodName=*/  "getAllCtrlInQubits",
+            /*args=*/        (ins),
+            /*methodBody=*/  [{}],
+            /*defaultImpl=*/ [{
+                const auto& posCtrlQubits = $_op.getPosCtrlInQubits();
+                const auto& negCtrlQubits = $_op.getNegCtrlInQubits();
+                std::vector<mlir::Value> controls{};
+                controls.reserve(posCtrlQubits.size() + negCtrlQubits.size());
+                controls.insert(controls.end(), posCtrlQubits.begin(), posCtrlQubits.end());
+                controls.insert(controls.end(), negCtrlQubits.begin(), negCtrlQubits.end());
+                return controls;
+            }]>,
+        InterfaceMethod<
+            /*desc=*/        "Returns all control output qubits of the operation incl. positive and negative controls.",
+            /*returnType=*/  "std::vector<mlir::Value>",
+            /*methodName=*/  "getAllCtrlOutQubits",
+            /*args=*/        (ins),
+            /*methodBody=*/  [{}],
+            /*defaultImpl=*/ [{
+                const auto& posCtrlQubits = $_op.getPosCtrlOutQubits();
+                const auto& negCtrlQubits = $_op.getNegCtrlOutQubits();
                 std::vector<mlir::Value> controls{};
                 controls.reserve(posCtrlQubits.size() + negCtrlQubits.size());
                 controls.insert(controls.end(), posCtrlQubits.begin(), posCtrlQubits.end());
@@ -86,10 +119,25 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
             /*methodBody=*/  [{}],
             /*defaultImpl=*/ [{
                 const auto& inQubits = $_op.getInQubits();
-                const auto& controls = $_op.getCtrlQubits();
+                const auto& controls = $_op.getAllCtrlInQubits();
                 std::vector<mlir::Value> operands{};
                 operands.reserve(inQubits.size() + controls.size());
                 operands.insert(operands.end(), inQubits.begin(), inQubits.end());
+                operands.insert(operands.end(), controls.begin(), controls.end());
+                return operands;
+            }]>,
+        InterfaceMethod<
+            /*desc=*/        "Returns all output qubits of the operation incl. all control qubits.",
+            /*returnType=*/  "std::vector<mlir::Value>",
+            /*methodName=*/  "getAllOutQubits",
+            /*args=*/        (ins),
+            /*methodBody=*/  [{}],
+            /*defaultImpl=*/ [{
+                const auto& outQubits = $_op.getOutQubits();
+                const auto& controls = $_op.getAllCtrlOutQubits();
+                std::vector<mlir::Value> operands{};
+                operands.reserve(outQubits.size() + controls.size());
+                operands.insert(operands.end(), outQubits.begin(), outQubits.end());
                 operands.insert(operands.end(), controls.begin(), controls.end());
                 return operands;
             }]>
@@ -97,11 +145,20 @@ def UnitaryInterface : OpInterface<"UnitaryInterface"> {
 
     let verify = [{
         auto unitaryOp = mlir::cast<ConcreteOp>($_op);
-        if (const auto in_qubits = unitaryOp.getInQubits().size() + unitaryOp.getPosCtrlQubits().size() + unitaryOp.getNegCtrlQubits().size();
-            in_qubits != unitaryOp.getOutQubits().size()) {
+        if (unitaryOp.getInQubits().size() != unitaryOp.getOutQubits().size()) {
             return $_op->emitError() <<
-                "number of input qubits (" << in_qubits << ") " <<
-                "and output qubits (" << unitaryOp.getOutQubits().size() << ") must be the same";
+                "number of input qubits (" << unitaryOp.getInQubits().size() << ") "
+                << "and output qubits (" << unitaryOp.getOutQubits().size() << ") must be the same";
+        } else if (unitaryOp.getPosCtrlInQubits().size() != unitaryOp.getPosCtrlOutQubits().size()) {
+            return $_op->emitError() <<
+                "number of positively control input qubits (" << unitaryOp.getPosCtrlInQubits().size() << ") "
+                << "and positively control output qubits (" << unitaryOp.getPosCtrlOutQubits().size()
+                << ") must be the same";
+        } else if (unitaryOp.getNegCtrlInQubits().size() != unitaryOp.getNegCtrlOutQubits().size()) {
+            return $_op->emitError() <<
+                "number of negatively control input qubits (" << unitaryOp.getNegCtrlInQubits().size() << ") "
+                << "and negatively control output qubits (" << unitaryOp.getNegCtrlOutQubits().size()
+                << ") must be the same";
         }
         return mlir::success();
     }];

--- a/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptOps.td
+++ b/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptOps.td
@@ -93,7 +93,7 @@ class GateOp<string mnemonic, list<Trait> traits = [NoMemoryEffect]> :
 }
 
 class UnitaryOp<string mnemonic, list<Trait> traits = []> :
-    GateOp<mnemonic, traits # [AttrSizedOperandSegments, UnitaryInterface]> {
+    GateOp<mnemonic, traits # [AttrSizedOperandSegments, AttrSizedResultSegments, UnitaryInterface]> {
     let arguments = (ins
         OptionalAttr<DenseF64ArrayAttr>:$static_params,
         OptionalAttr<DenseBoolArrayAttr>:$params_mask,
@@ -110,8 +110,9 @@ class UnitaryOp<string mnemonic, list<Trait> traits = []> :
     );
 
     let assemblyFormat = [{
-        `(` $params ( `static` $static_params^ )? ( `mask` $params_mask^ )? `)` attr-dict $in_qubits ( `ctrl` $pos_ctrl_qubits^ )? ( `nctrl` $neg_ctrl_qubits^ )?
-        `:` type($out_qubits)(, type($pos_ctrl_out_qubits^))?(, type($neg_ctrl_out_qubits^))?
+        `(` $params ( `static` $static_params^ )? ( `mask` $params_mask^ )? `)`
+        attr-dict $in_qubits ( `ctrl` $pos_ctrl_in_qubits^ )? ( `nctrl` $neg_ctrl_in_qubits^ )?
+        `:` type($out_qubits)( `ctrl` type($pos_ctrl_out_qubits)^ )?( `nctrl` type($neg_ctrl_out_qubits)^ )?
     }];
 }
 

--- a/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptOps.td
+++ b/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptOps.td
@@ -99,17 +99,19 @@ class UnitaryOp<string mnemonic, list<Trait> traits = []> :
         OptionalAttr<DenseBoolArrayAttr>:$params_mask,
         Variadic<F64>:$params,
         Variadic<QubitType>:$in_qubits,
-        Variadic<QubitType>:$pos_ctrl_qubits,
-        Variadic<QubitType>:$neg_ctrl_qubits
+        Variadic<QubitType>:$pos_ctrl_in_qubits,
+        Variadic<QubitType>:$neg_ctrl_in_qubits
     );
 
     let results = (outs
-        Variadic<QubitType>:$out_qubits
+        Variadic<QubitType>:$out_qubits,
+        Variadic<QubitType>:$pos_ctrl_out_qubits,
+        Variadic<QubitType>:$neg_ctrl_out_qubits
     );
 
     let assemblyFormat = [{
         `(` $params ( `static` $static_params^ )? ( `mask` $params_mask^ )? `)` attr-dict $in_qubits ( `ctrl` $pos_ctrl_qubits^ )? ( `nctrl` $neg_ctrl_qubits^ )?
-        `:` type($out_qubits)
+        `:` type($out_qubits)(, type($pos_ctrl_out_qubits^))?(, type($neg_ctrl_out_qubits^))?
     }];
 }
 

--- a/mlir/lib/Dialect/MQTOpt/Transforms/CancelConsecutiveInversesPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/CancelConsecutiveInversesPattern.cpp
@@ -85,8 +85,10 @@ struct CancelConsecutiveInversesPattern final
     if (op.getOutQubits() != unitaryUser.getAllInQubits()) {
       return mlir::failure();
     }
-    if (op.getPosCtrlQubits().size() != unitaryUser.getPosCtrlQubits().size() ||
-        op.getNegCtrlQubits().size() != unitaryUser.getNegCtrlQubits().size()) {
+    if (op.getPosCtrlInQubits().size() !=
+            unitaryUser.getPosCtrlInQubits().size() ||
+        op.getNegCtrlInQubits().size() !=
+            unitaryUser.getNegCtrlInQubits().size()) {
       // We only need to check the sizes, because the order of the controls was
       // already checked by the previous condition.
       return mlir::failure();

--- a/mlir/lib/Dialect/MQTOpt/Transforms/CancelConsecutiveInversesPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/CancelConsecutiveInversesPattern.cpp
@@ -106,20 +106,24 @@ struct CancelConsecutiveInversesPattern final
     const auto& userOutQubits = user.getAllOutQubits();
     // Also get the op's input qubits
     const auto& opInQubits = user.getAllInQubits();
+
+    // Note: There might be multiple users of an operation. The qubits itself
+    // can only be used once (linear typing). However, the user may output
+    // multiple qubits, e.g., a CX gate, that are used by different users.
+    // Hence, the user may have multiple clid users.
     const auto& childUsers = user->getUsers();
 
     for (const auto& childUser : childUsers) {
       for (size_t i = 0; i < childUser->getOperands().size(); i++) {
         const auto& operand = childUser->getOperand(i);
-        const auto found = std::find(userOutQubits.begin(),
-                                     userOutQubits.end(), operand);
+        const auto found =
+            std::find(userOutQubits.begin(), userOutQubits.end(), operand);
         if (found == userOutQubits.end()) {
           continue;
         }
         const auto idx = std::distance(userOutQubits.begin(), found);
-        rewriter.modifyOpInPlace(childUser, [&] {
-          childUser->setOperand(i, opInQubits[idx]);
-        });
+        rewriter.modifyOpInPlace(
+            childUser, [&] { childUser->setOperand(i, opInQubits[idx]); });
       }
     }
 

--- a/mlir/lib/Dialect/MQTOpt/Transforms/CancelConsecutiveInversesPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/CancelConsecutiveInversesPattern.cpp
@@ -82,7 +82,7 @@ struct CancelConsecutiveInversesPattern final
       return mlir::failure();
     }
     auto unitaryUser = mlir::dyn_cast<UnitaryInterface>(user);
-    if (op.getOutQubits() != unitaryUser.getAllInQubits()) {
+    if (op.getAllOutQubits() != unitaryUser.getAllInQubits()) {
       return mlir::failure();
     }
     if (op.getPosCtrlInQubits().size() !=
@@ -105,12 +105,12 @@ struct CancelConsecutiveInversesPattern final
     // fresh vector on every call.
     const auto& userOutQubits = user.getAllOutQubits();
     // Also get the op's input qubits
-    const auto& opInQubits = user.getAllInQubits();
+    const auto& opInQubits = op.getAllInQubits();
 
     // Note: There might be multiple users of an operation. The qubits itself
     // can only be used once (linear typing). However, the user may output
     // multiple qubits, e.g., a CX gate, that are used by different users.
-    // Hence, the user may have multiple clid users.
+    // Hence, the user may have multiple child users.
     const auto& childUsers = user->getUsers();
 
     for (const auto& childUser : childUsers) {

--- a/mlir/lib/Dialect/MQTOpt/Transforms/FromQuantumComputationPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/FromQuantumComputationPattern.cpp
@@ -79,17 +79,14 @@ struct FromQuantumComputationPattern final : mlir::OpRewritePattern<AllocOp> {
       const mlir::Location loc, const qc::OpType type,
       const mlir::Value inQubit, mlir::ValueRange controlQubitsPositive,
       mlir::ValueRange controlQubitsNegative, mlir::PatternRewriter& rewriter) {
-    const std::vector resultTypes(1 + controlQubitsPositive.size() +
-                                      controlQubitsNegative.size(),
-                                  inQubit.getType());
-    const mlir::TypeRange outTypes(resultTypes);
-
     switch (type) {
     case qc::OpType::X:
-      return rewriter.create<XOp>(loc, outTypes, mlir::DenseF64ArrayAttr{},
-                                  mlir::DenseBoolArrayAttr{},
-                                  mlir::ValueRange{}, mlir::ValueRange{inQubit},
-                                  controlQubitsPositive, controlQubitsNegative);
+      return rewriter.create<XOp>(
+          loc, inQubit.getType(), controlQubitsPositive.getType(),
+          controlQubitsNegative.getType(), mlir::DenseF64ArrayAttr{},
+          mlir::DenseBoolArrayAttr{}, mlir::ValueRange{},
+          mlir::ValueRange{inQubit}, controlQubitsPositive,
+          controlQubitsNegative);
     default:
       throw std::runtime_error("Unsupported operation type");
     }

--- a/mlir/lib/Dialect/MQTOpt/Transforms/FromQuantumComputationPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/FromQuantumComputationPattern.cpp
@@ -199,7 +199,8 @@ struct FromQuantumComputationPattern final : mlir::OpRewritePattern<AllocOp> {
         }
         for (size_t i = 0; i < controlQubitsNegative.size(); i++) {
           currentQubitVariables[controlQubitIndicesNegative[i]] =
-              newUnitaryOp.getAllOutQubits()[i + 1 + controlQubitsPositive.size()];
+              newUnitaryOp
+                  .getAllOutQubits()[i + 1 + controlQubitsPositive.size()];
         }
       } else if (o->getType() == qc::OpType::Measure) {
         // For measurement operations, we call the `createMeasureOp` function.

--- a/mlir/lib/Dialect/MQTOpt/Transforms/FromQuantumComputationPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/FromQuantumComputationPattern.cpp
@@ -192,14 +192,14 @@ struct FromQuantumComputationPattern final : mlir::OpRewritePattern<AllocOp> {
             currentQubitVariables[o->getTargets()[0]], controlQubitsPositive,
             controlQubitsNegative, rewriter);
         currentQubitVariables[o->getTargets()[0]] =
-            newUnitaryOp.getOutQubits()[0];
+            newUnitaryOp.getAllOutQubits()[0];
         for (size_t i = 0; i < controlQubitsPositive.size(); i++) {
           currentQubitVariables[controlQubitIndicesPositive[i]] =
-              newUnitaryOp.getOutQubits()[i + 1];
+              newUnitaryOp.getAllOutQubits()[i + 1];
         }
         for (size_t i = 0; i < controlQubitsNegative.size(); i++) {
           currentQubitVariables[controlQubitIndicesNegative[i]] =
-              newUnitaryOp.getOutQubits()[i + 1 + controlQubitsPositive.size()];
+              newUnitaryOp.getAllOutQubits()[i + 1 + controlQubitsPositive.size()];
         }
       } else if (o->getType() == qc::OpType::Measure) {
         // For measurement operations, we call the `createMeasureOp` function.

--- a/mlir/lib/Dialect/MQTOpt/Transforms/QuantumSinkPushPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/QuantumSinkPushPattern.cpp
@@ -121,7 +121,7 @@ struct QuantumSinkPushPattern final
 
   mlir::LogicalResult match(UnitaryInterface op) const override {
     // We only consider 1-qubit gates.
-    if (op.getOutQubits().size() != 1) {
+    if (op.getAllOutQubits().size() != 1) {
       return mlir::failure();
     }
 

--- a/mlir/lib/Dialect/MQTOpt/Transforms/QuantumSinkShiftPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/QuantumSinkShiftPattern.cpp
@@ -84,7 +84,7 @@ struct QuantumSinkShiftPattern final
 
   mlir::LogicalResult match(UnitaryInterface op) const override {
     // We only consider 1-qubit gates.
-    if (op.getOutQubits().size() != 1) {
+    if (op.getAllOutQubits().size() != 1) {
       return mlir::failure();
     }
 

--- a/mlir/lib/Dialect/MQTOpt/Transforms/ToQuantumComputationPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/ToQuantumComputationPattern.cpp
@@ -130,7 +130,7 @@ struct ToQuantumComputationPattern final : mlir::OpRewritePattern<AllocOp> {
                        std::vector<mlir::Value>& currentQubitVariables) const {
     const auto in = op.getInQubits()[0];
     const auto ctrlIns = op.getAllCtrlInQubits();
-    const auto outs = op.getOutQubits();
+    const auto outs = op.getAllOutQubits();
 
     // Get the qubit index of every control qubit.
     std::vector<size_t> ctrlInsIndices(ctrlIns.size());

--- a/mlir/lib/Dialect/MQTOpt/Transforms/ToQuantumComputationPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/ToQuantumComputationPattern.cpp
@@ -129,7 +129,7 @@ struct ToQuantumComputationPattern final : mlir::OpRewritePattern<AllocOp> {
   void handleUnitaryOp(UnitaryInterface& op,
                        std::vector<mlir::Value>& currentQubitVariables) const {
     const auto in = op.getInQubits()[0];
-    const auto ctrlIns = op.getCtrlQubits();
+    const auto ctrlIns = op.getAllCtrlInQubits();
     const auto outs = op.getOutQubits();
 
     // Get the qubit index of every control qubit.

--- a/mlir/test/Dialect/MQTOpt/IR/bell_state_value_dialect.mlir
+++ b/mlir/test/Dialect/MQTOpt/IR/bell_state_value_dialect.mlir
@@ -18,9 +18,9 @@ module {
         %c0_i64 = arith.constant 0 : i64
         %out_qureg_0, %out_qubit_1 = "mqtopt.extractQubit"(%1, %c0_i64) : (!mqtopt.QubitRegister, i64) -> (!mqtopt.QubitRegister, !mqtopt.Qubit)
         %2 = mqtopt.x() %out_qubit : !mqtopt.Qubit
-        %3:2 = mqtopt.x() %2 ctrl %out_qubit_1 : !mqtopt.Qubit, !mqtopt.Qubit
+        %3:2 = mqtopt.x() %2 ctrl %out_qubit_1 : !mqtopt.Qubit ctrl !mqtopt.Qubit
         %cst = arith.constant 3.000000e-01 : f64
-        %4:2 = mqtopt.rz(%cst) %3#0 nctrl %3#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        %4:2 = mqtopt.rz(%cst) %3#0 nctrl %3#1 : !mqtopt.Qubit nctrl !mqtopt.Qubit
         %5 = mqtopt.u(%cst, %cst static [3.000000e-01] mask [false, true, false]) %4#0 : !mqtopt.Qubit
         %out_qubits, %out_bits = "mqtopt.measure"(%5) : (!mqtopt.Qubit) -> (!mqtopt.Qubit, i1)
         %out_qubits_2, %out_bits_3 = "mqtopt.measure"(%4#1) : (!mqtopt.Qubit) -> (!mqtopt.Qubit, i1)

--- a/mlir/test/Dialect/MQTOpt/Transforms/consecutive-inverses.mlir
+++ b/mlir/test/Dialect/MQTOpt/Transforms/consecutive-inverses.mlir
@@ -69,11 +69,23 @@ module {
     // CHECK: %[[Reg_3:.*]], %[[Q2_0:.*]] = "mqtopt.extractQubit"(%[[Reg_2]]) <{index_attr = 2 : i64}>
     %reg_3, %q2_0 = "mqtopt.extractQubit"(%reg_2) <{index_attr = 2 : i64}> : (!mqtopt.QubitRegister) -> (!mqtopt.QubitRegister, !mqtopt.Qubit)
 
-    // ========================== Check for operations that should not be cancelled ==========================
+    //===----------------------------------------------------------------===//
+    //            INPUT                  OUTPUT
+    // q_0: ──■────■────────────  >>>  ──────────
+    //      ┌─┴─┐┌─┴─┐┌───┐       >>>  ┌───┐
+    // q_1: ┤ X ├┤ X ├┤ X ├──■──  >>>  ┤ X ├──■──
+    //      └───┘└───┘└─┬─┘┌─┴─┐  >>>  └─┬─┘┌─┴─┐
+    // q_2: ────────────■──┤ X ├  >>>  ──■──┤ X ├
+    //                     └───┘  >>>       └───┘
+    //===----------------------------------------------------------------===//
+    // Check for operations that should not be cancelled
+    //===----------------------------------------------------------------===//
     // CHECK: %[[Q1_1:.*]], %[[Q2_1:.*]] = mqtopt.x() %[[Q1_0]] ctrl %[[Q2_0]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
     // CHECK: %[[Q2_2:.*]], %[[Q1_2:.*]] = mqtopt.x() %[[Q2_1]] ctrl %[[Q1_1]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
 
-    // ========================== Check for operations that should be canceled ==============================
+    //===----------------------------------------------------------------===//
+    // Check for operations that should be canceled
+    //===----------------------------------------------------------------===//
     // CHECK-NOT: %[[ANY:.*]], %[[ANY:.*]] = mqtopt.x() %[[ANY:.*]] ctrl %[[Q0_0]] : !mqtopt.Qubit, !mqtopt.Qubit
 
     %q1_1, %q0_1 = mqtopt.x() %q1_0 ctrl %q0_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit
@@ -83,9 +95,9 @@ module {
 
     // CHECK: %[[Reg_4:.*]] = "mqtopt.insertQubit"(%[[Reg_3]], %[[Q0_0]])  <{index_attr = 0 : i64}>
     %reg_4 = "mqtopt.insertQubit"(%reg_3, %q0_2) <{index_attr = 0 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
-    // CHECK: %[[Reg_5:.*]] = "mqtopt.insertQubit"(%[[Reg_4]], %[[Q2_2]])  <{index_attr = 1 : i64}>
+    // CHECK: %[[Reg_5:.*]] = "mqtopt.insertQubit"(%[[Reg_4]], %[[Q1_2]])  <{index_attr = 1 : i64}>
     %reg_5 = "mqtopt.insertQubit"(%reg_4, %q1_4) <{index_attr = 1 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
-    // CHECK: %[[Reg_6:.*]] = "mqtopt.insertQubit"(%[[Reg_5]], %[[Q1_2]])  <{index_attr = 2 : i64}>
+    // CHECK: %[[Reg_6:.*]] = "mqtopt.insertQubit"(%[[Reg_5]], %[[Q2_2]])  <{index_attr = 2 : i64}>
     %reg_6 = "mqtopt.insertQubit"(%reg_5, %q2_2) <{index_attr = 2 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
     // CHECK: "mqtopt.deallocQubitRegister"(%[[Reg_6]])
     "mqtopt.deallocQubitRegister"(%reg_6) : (!mqtopt.QubitRegister) -> ()
@@ -176,12 +188,21 @@ module {
     // CHECK: %[[Reg_3:.*]], %[[Q2_0:.*]] = "mqtopt.extractQubit"(%[[Reg_2]]) <{index_attr = 2 : i64}>
     %reg_3, %q2_0 = "mqtopt.extractQubit"(%reg_2) <{index_attr = 2 : i64}> : (!mqtopt.QubitRegister) -> (!mqtopt.QubitRegister, !mqtopt.Qubit)
 
-    // CHECK: %[[Q12_1:.*]]:2 = mqtopt.x() %[[Q1_0]] ctrl %[[Q0_0]] : !mqtopt.Qubit, !mqtopt.Qubit
-    // CHECK: %[[Q12_2:.*]]:3 = mqtopt.x() %[[Q12_1]]#0 ctrl %[[Q12_1]]#1, %[[Q2_0]] : !mqtopt.Qubit ctrl !mqtopt.Qubit, !mqtopt.Qubit
+    //===------------------------------------------------------------------===//
+    //        INPUT            OUTPUT
+    // q_0: ──■────■──  >>>  ──■────■──
+    //      ┌─┴─┐┌─┴─┐  >>>  ┌─┴─┐┌─┴─┐
+    // q_1: ┤ X ├┤ X ├  >>>  ┤ X ├┤ X ├
+    //      └───┘└─┬─┘  >>>  └───┘└─┬─┘
+    // q_2: ───────■──  >>>  ───────■──
+    //===----------------------------------------------------------------===//
+    // Check for operations that should not be cancelled
+    //===----------------------------------------------------------------===//
+    // CHECK: %[[Q1_1:.*]], %[[Q0_1:.*]] = mqtopt.x() %[[Q1_0]] ctrl %[[Q0_0]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+    // CHECK: %[[Q1_2:.*]], %[[Q02_2:.*]]:2 = mqtopt.x() %[[Q1_1]] ctrl %[[Q0_1]], %[[Q2_0]] : !mqtopt.Qubit ctrl !mqtopt.Qubit, !mqtopt.Qubit
 
     %q1_1, %q0_1 = mqtopt.x() %q1_0 ctrl %q0_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit
     %q1_2, %q02_1:2 = mqtopt.x() %q1_1 ctrl %q0_1, %q2_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit, !mqtopt.Qubit
-
 
     %reg_4 = "mqtopt.insertQubit"(%reg_3, %q02_1#0) <{index_attr = 0 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
     %reg_5 = "mqtopt.insertQubit"(%reg_4, %q1_2) <{index_attr = 1 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister

--- a/mlir/test/Dialect/MQTOpt/Transforms/consecutive-inverses.mlir
+++ b/mlir/test/Dialect/MQTOpt/Transforms/consecutive-inverses.mlir
@@ -69,23 +69,23 @@ module {
     // CHECK: %[[Reg_3:.*]], %[[Q2_0:.*]] = "mqtopt.extractQubit"(%[[Reg_2]]) <{index_attr = 2 : i64}>
     %reg_3, %q2_0 = "mqtopt.extractQubit"(%reg_2) <{index_attr = 2 : i64}> : (!mqtopt.QubitRegister) -> (!mqtopt.QubitRegister, !mqtopt.Qubit)
 
-    // ========================== Check for operations that should not be canceled ==========================
-    // CHECK: %[[Q12_1:.*]]:2 = mqtopt.x() %[[Q1_0]] ctrl %[[Q2_0]] : !mqtopt.Qubit, !mqtopt.Qubit
-    // CHECK: %[[Q12_2:.*]]:2 = mqtopt.x() %[[Q12_1]]#1 ctrl %[[Q12_1]]#0 : !mqtopt.Qubit, !mqtopt.Qubit
+    // ========================== Check for operations that should not be cancelled ==========================
+    // CHECK: %[[Q1_1:.*]], %[[Q2_1:.*]] = mqtopt.x() %[[Q1_0]] ctrl %[[Q2_0]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+    // CHECK: %[[Q2_2:.*]], %[[Q1_2:.*]] = mqtopt.x() %[[Q2_1]] ctrl %[[Q1_1]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
 
     // ========================== Check for operations that should be canceled ==============================
     // CHECK-NOT: %[[ANY:.*]], %[[ANY:.*]] = mqtopt.x() %[[ANY:.*]] ctrl %[[Q0_0]] : !mqtopt.Qubit, !mqtopt.Qubit
 
-    %q1_1, %q0_1 = mqtopt.x() %q1_0 ctrl %q0_0 : !mqtopt.Qubit, !mqtopt.Qubit
-    %q1_2, %q0_2 = mqtopt.x() %q1_1 ctrl %q0_1 : !mqtopt.Qubit, !mqtopt.Qubit
-    %q1_3, %q2_1 = mqtopt.x() %q1_2 ctrl %q2_0 : !mqtopt.Qubit, !mqtopt.Qubit
-    %q2_2, %q1_4 = mqtopt.x() %q2_1 ctrl %q1_3 : !mqtopt.Qubit, !mqtopt.Qubit
+    %q1_1, %q0_1 = mqtopt.x() %q1_0 ctrl %q0_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+    %q1_2, %q0_2 = mqtopt.x() %q1_1 ctrl %q0_1 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+    %q1_3, %q2_1 = mqtopt.x() %q1_2 ctrl %q2_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+    %q2_2, %q1_4 = mqtopt.x() %q2_1 ctrl %q1_3 : !mqtopt.Qubit ctrl !mqtopt.Qubit
 
     // CHECK: %[[Reg_4:.*]] = "mqtopt.insertQubit"(%[[Reg_3]], %[[Q0_0]])  <{index_attr = 0 : i64}>
     %reg_4 = "mqtopt.insertQubit"(%reg_3, %q0_2) <{index_attr = 0 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
-    // CHECK: %[[Reg_5:.*]] = "mqtopt.insertQubit"(%[[Reg_4]], %[[Q12_2]]#1)  <{index_attr = 1 : i64}>
+    // CHECK: %[[Reg_5:.*]] = "mqtopt.insertQubit"(%[[Reg_4]], %[[Q2_2]])  <{index_attr = 1 : i64}>
     %reg_5 = "mqtopt.insertQubit"(%reg_4, %q1_4) <{index_attr = 1 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
-    // CHECK: %[[Reg_6:.*]] = "mqtopt.insertQubit"(%[[Reg_5]], %[[Q12_2]]#0)  <{index_attr = 2 : i64}>
+    // CHECK: %[[Reg_6:.*]] = "mqtopt.insertQubit"(%[[Reg_5]], %[[Q1_2]])  <{index_attr = 2 : i64}>
     %reg_6 = "mqtopt.insertQubit"(%reg_5, %q2_2) <{index_attr = 2 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
     // CHECK: "mqtopt.deallocQubitRegister"(%[[Reg_6]])
     "mqtopt.deallocQubitRegister"(%reg_6) : (!mqtopt.QubitRegister) -> ()
@@ -144,11 +144,11 @@ module {
     // CHECK: %[[Reg_2:.*]], %[[Q1_0:.*]] = "mqtopt.extractQubit"(%[[Reg_1]]) <{index_attr = 1 : i64}>
     %reg_2, %q1_0 = "mqtopt.extractQubit"(%reg_1) <{index_attr = 1 : i64}> : (!mqtopt.QubitRegister) -> (!mqtopt.QubitRegister, !mqtopt.Qubit)
 
-    // CHECK: %[[Q12_1:.*]]:2 = mqtopt.x() %[[Q1_0]] ctrl %[[Q0_0]] : !mqtopt.Qubit, !mqtopt.Qubit
-    // CHECK: %[[Q12_2:.*]]:2 = mqtopt.x() %[[Q12_1]]#0 nctrl %[[Q12_1]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+    // CHECK: %[[Q1_1:.*]], %[[Q0_1:.*]] = mqtopt.x() %[[Q1_0]] ctrl %[[Q0_0]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+    // CHECK: %[[Q1_2:.*]], %[[Q2_2:.*]] = mqtopt.x() %[[Q1_1]] nctrl %[[Q2_1]] : !mqtopt.Qubit nctrl !mqtopt.Qubit
 
-    %q1_1, %q0_1 = mqtopt.x() %q1_0 ctrl %q0_0 : !mqtopt.Qubit, !mqtopt.Qubit
-    %q1_2, %q0_2 = mqtopt.x() %q1_1 nctrl %q0_1 : !mqtopt.Qubit, !mqtopt.Qubit
+    %q1_1, %q0_1 = mqtopt.x() %q1_0 ctrl %q0_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+    %q1_2, %q0_2 = mqtopt.x() %q1_1 nctrl %q0_1 : !mqtopt.Qubit nctrl !mqtopt.Qubit
 
 
     %reg_3 = "mqtopt.insertQubit"(%reg_2, %q0_2) <{index_attr = 0 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
@@ -177,10 +177,10 @@ module {
     %reg_3, %q2_0 = "mqtopt.extractQubit"(%reg_2) <{index_attr = 2 : i64}> : (!mqtopt.QubitRegister) -> (!mqtopt.QubitRegister, !mqtopt.Qubit)
 
     // CHECK: %[[Q12_1:.*]]:2 = mqtopt.x() %[[Q1_0]] ctrl %[[Q0_0]] : !mqtopt.Qubit, !mqtopt.Qubit
-    // CHECK: %[[Q12_2:.*]]:3 = mqtopt.x() %[[Q12_1]]#0 ctrl %[[Q12_1]]#1, %[[Q2_0]] : !mqtopt.Qubit, !mqtopt.Qubit, !mqtopt.Qubit
+    // CHECK: %[[Q12_2:.*]]:3 = mqtopt.x() %[[Q12_1]]#0 ctrl %[[Q12_1]]#1, %[[Q2_0]] : !mqtopt.Qubit ctrl !mqtopt.Qubit, !mqtopt.Qubit
 
-    %q1_1, %q0_1 = mqtopt.x() %q1_0 ctrl %q0_0 : !mqtopt.Qubit, !mqtopt.Qubit
-    %q1_2, %q02_1:2 = mqtopt.x() %q1_1 ctrl %q0_1, %q2_0 : !mqtopt.Qubit, !mqtopt.Qubit, !mqtopt.Qubit
+    %q1_1, %q0_1 = mqtopt.x() %q1_0 ctrl %q0_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+    %q1_2, %q02_1:2 = mqtopt.x() %q1_1 ctrl %q0_1, %q2_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit, !mqtopt.Qubit
 
 
     %reg_4 = "mqtopt.insertQubit"(%reg_3, %q02_1#0) <{index_attr = 0 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister

--- a/mlir/test/Dialect/MQTOpt/Transforms/to-quantum-computation.mlir
+++ b/mlir/test/Dialect/MQTOpt/Transforms/to-quantum-computation.mlir
@@ -26,7 +26,7 @@ module {
         %q0_2, %q1_2 = mqtopt.x() %q0_1 ctrl %q1_1 : !mqtopt.Qubit ctrl !mqtopt.Qubit
 
         // CHECK: %[[Q0_3:.*]], %[[C0_0:.*]] = "mqtopt.measure"(%[[Q0_2]])
-        // CHECK: %[[Q1_3:.*]] = mqtopt.x() %[[Q1_2]]#1 : !mqtopt.Qubit
+        // CHECK: %[[Q1_3:.*]] = mqtopt.x() %[[Q1_2]] : !mqtopt.Qubit
         %q1_3 = mqtopt.x() %q1_2 : !mqtopt.Qubit
 
         %q0_3, %c0_0 = "mqtopt.measure"(%q0_2) : (!mqtopt.Qubit) -> (!mqtopt.Qubit, i1)

--- a/mlir/test/Dialect/MQTOpt/Transforms/to-quantum-computation.mlir
+++ b/mlir/test/Dialect/MQTOpt/Transforms/to-quantum-computation.mlir
@@ -23,7 +23,7 @@ module {
         %q1_1 = mqtopt.x() %q1_0 : !mqtopt.Qubit
 
         // CHECK: %[[Q01_2:.*]]:2 = mqtopt.x() %[[Q0_1]] ctrl %[[Q1_1]] : !mqtopt.Qubit, !mqtopt.Qubit
-        %q0_2, %q1_2 = mqtopt.x() %q0_1 ctrl %q1_1 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q0_2, %q1_2 = mqtopt.x() %q0_1 ctrl %q1_1 : !mqtopt.Qubit ctrl !mqtopt.Qubit
 
         // CHECK: %[[Q0_3:.*]], %[[C0_0:.*]] = "mqtopt.measure"(%[[Q01_2]]#0)
         // CHECK: %[[Q1_3:.*]] = mqtopt.x() %[[Q01_2]]#1 : !mqtopt.Qubit

--- a/mlir/test/Dialect/MQTOpt/Transforms/to-quantum-computation.mlir
+++ b/mlir/test/Dialect/MQTOpt/Transforms/to-quantum-computation.mlir
@@ -22,7 +22,7 @@ module {
         // CHECK: %[[Q1_1:.*]] = mqtopt.x() %[[Q1_0]] : !mqtopt.Qubit
         %q1_1 = mqtopt.x() %q1_0 : !mqtopt.Qubit
 
-        // CHECK: %[[Q0_2:.*]], %[[Q1_2:.*]] = mqtopt.x() %[[Q0_1]] ctrl %[[Q1_1]] : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q0_2:.*]], %[[Q1_2:.*]] = mqtopt.x() %[[Q0_1]] ctrl %[[Q1_1]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
         %q0_2, %q1_2 = mqtopt.x() %q0_1 ctrl %q1_1 : !mqtopt.Qubit ctrl !mqtopt.Qubit
 
         // CHECK: %[[Q0_3:.*]], %[[C0_0:.*]] = "mqtopt.measure"(%[[Q0_2]])

--- a/mlir/test/Dialect/MQTOpt/Transforms/to-quantum-computation.mlir
+++ b/mlir/test/Dialect/MQTOpt/Transforms/to-quantum-computation.mlir
@@ -22,11 +22,11 @@ module {
         // CHECK: %[[Q1_1:.*]] = mqtopt.x() %[[Q1_0]] : !mqtopt.Qubit
         %q1_1 = mqtopt.x() %q1_0 : !mqtopt.Qubit
 
-        // CHECK: %[[Q01_2:.*]]:2 = mqtopt.x() %[[Q0_1]] ctrl %[[Q1_1]] : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q0_2:.*]], %[[Q1_2:.*]] = mqtopt.x() %[[Q0_1]] ctrl %[[Q1_1]] : !mqtopt.Qubit, !mqtopt.Qubit
         %q0_2, %q1_2 = mqtopt.x() %q0_1 ctrl %q1_1 : !mqtopt.Qubit ctrl !mqtopt.Qubit
 
-        // CHECK: %[[Q0_3:.*]], %[[C0_0:.*]] = "mqtopt.measure"(%[[Q01_2]]#0)
-        // CHECK: %[[Q1_3:.*]] = mqtopt.x() %[[Q01_2]]#1 : !mqtopt.Qubit
+        // CHECK: %[[Q0_3:.*]], %[[C0_0:.*]] = "mqtopt.measure"(%[[Q0_2]])
+        // CHECK: %[[Q1_3:.*]] = mqtopt.x() %[[Q1_2]]#1 : !mqtopt.Qubit
         %q1_3 = mqtopt.x() %q1_2 : !mqtopt.Qubit
 
         %q0_3, %c0_0 = "mqtopt.measure"(%q0_2) : (!mqtopt.Qubit) -> (!mqtopt.Qubit, i1)


### PR DESCRIPTION
## Description

Until now, operations of the MQTopt dialect had different variadic operands for target qubits and positively and negatively control qubits but only one result type. We decided that it is desirable to have the same distinction also in the results. Hence, this PR mirrors the separation for the qubit operands also for the qubit results.

Additionally, this PR creates an initial subpage in the documentation for our MLIR efforts. In particular, it kickstarts a FAQ that can be extended on demand. This page, including the FAQ, should serve as a common knowledge base about MLIR in MQT.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
