### PR TITLE
🩹 Fix MLIR workflow

### DIFF
--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -68,6 +68,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: 3.13
+          activate-environment: true
 
       # make sure ninja is installed
       - name: Install Ninja

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "mlir/**"
+      - ".github/workflows/ci_mlir.yml"
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

#936 broke the MLIR workflow. This went unnoticed because the MLIR workflow would not trigger on workflow-only changes.
This PR fixes the oversight and enables the CI to run on workflow-only changes, which should be demonstrated by this PR.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
