### PR TITLE
:construction_worker: add windows CI for MLIR

### DIFF
--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -189,10 +189,10 @@ jobs:
           "{0}" %*' -f $targetPath
 
           # Write to a directory that's definitely in PATH
-          $batchContent | Out-File -FilePath "C:\Windows\quantum-opt.cmd" -Encoding ascii
+          $batchContent | Out-File -FilePath "C:\Windows\quantum-opt" -Encoding ascii
 
           # Verify the batch file
-          Get-Content "C:\Windows\quantum-opt.cmd"
-          Write-Output "Batch file created at C:\Windows\quantum-opt.cmd pointing to $targetPath"
+          Get-Content "C:\Windows\quantum-opt"
+          Write-Output "Batch file created at C:\Windows\quantum-opt pointing to $targetPath"
 
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -184,7 +184,8 @@ jobs:
         run: |
           cmake --build build --config Release --target quantum-opt
           tree build /F /A
-          echo "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          #echo "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "PATH=${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release;$env:PATH" >> $env:GITHUB_ENV
           Rename-Item -Path "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -NewName "quantum-opt"
           dir "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release"
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -183,4 +183,5 @@ jobs:
       - name: Build MLIR components and directly run lit tests
         run: |
           cmake --build build --config Release --target quantum-opt
+          tree build
       #    cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -126,7 +126,7 @@ jobs:
                   }
                 } |
                 Where-Object { $_ -ne $null }
-          echo "Latest version: $latest"
+          echo "Latest tag: $tag"
           echo "latest=$latest" >> $env:GITHUB_OUTPUT
 
       - name: Try to get MLIR from cache

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -111,9 +111,7 @@ jobs:
         uses: actions/cache@v3
         id: mlir-cache
         with:
-          path: |
-            llvm-project/build
-            ${{ github.workspace }}/llvm-install
+          path: ${{ github.workspace }}/llvm-install
           key: ${{ runner.os }}-llvm-${{ matrix.llvm-version }}
           restore-keys: |
             ${{ runner.os }}-llvm-${{ matrix.llvm-version }}

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -101,26 +101,47 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
+    outputs:
+      llvm-latest-tag: ${{ steps.get-latest.outputs.latest }}
     steps:
       # check out the repository
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Find latest release of llvm-project
+        id: get-latest
+        run: |
+          $tag = git ls-remote --tags origin "llvmorg-${{ matrix.llvm-version }}.*" |
+                  Where-Object { $_ -match "llvmorg-\d+\.\d+\.\d+" } |
+                  Sort-Object -Property {
+                    if ($_ -match "llvmorg-(\d+)\.(\d+)\.(\d+)") {
+                      [int]$Matches[1]*10000 + [int]$Matches[2]*100 + [int]$Matches[3]
+                    }
+                  } |
+                  Select-Object -Last 1
+          $latest = $tag | ForEach-Object {
+                  if ($_ -match "refs/tags/llvmorg-(\d+\.\d+\.\d+)") {
+                    $Matches[1]  # Extract just the version number (e.g., "20.1.0")
+                  }
+                } |
+                Where-Object { $_ -ne $null }
+          echo "latest=$latest" >> $env:GITHUB_OUTPUT
+
       - name: Try to get MLIR from cache
         uses: actions/cache@v4
         id: mlir-cache
         with:
           path: ${{ github.workspace }}/llvm-install
-          key: ${{ runner.os }}-llvm-${{ matrix.llvm-version }}
+          key: ${{ runner.os }}-llvm-${{ steps.get-latest.outputs.latest }}
           restore-keys: |
-            ${{ runner.os }}-llvm-${{ matrix.llvm-version }}
+            ${{ runner.os }}-llvm-${{ steps.get-latest.outputs.latest }}
 
       # build the llvm-project from source
       - name: Install llvm and mlir
         if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
-          git clone --depth 1 https://github.com/llvm/llvm-project.git --branch llvmorg-${{ matrix.llvm-version }}.1.0
+          git clone --depth 1 https://github.com/llvm/llvm-project.git --branch llvmorg-${{ steps.get-latest.outputs.latest }}
           cd llvm-project
           cmake -S llvm -B build_llvm `
             -DLLVM_ENABLE_PROJECTS=mlir `

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/llvm/llvm-project.git --branch llvmorg-${{ matrix.llvm-version }}.1.0
           cd llvm-project
-          cmake -S llvm -B build -G "Ninja" `
+          cmake -S llvm -B build_llvm -G "Ninja" `
             -DLLVM_ENABLE_PROJECTS=mlir `
             -DLLVM_BUILD_EXAMPLES=OFF `
             -DLLVM_TARGETS_TO_BUILD="X86" `
@@ -134,7 +134,7 @@ jobs:
             -DLLVM_ENABLE_UTILS=ON `
             -DLLVM_INSTALL_UTILS=ON `
             -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\llvm-install
-          cmake --build build --target install --config Release
+          cmake --build build_llvm --target install --config Release
 
       # set up uv for faster Python package management
       - name: Install the latest version of uv

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -183,9 +183,6 @@ jobs:
       - name: Build MLIR components and directly run lit tests
         run: |
           cmake --build build --config Release --target quantum-opt
-          tree build /F /A
-          #echo "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "PATH=${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release;$env:PATH" >> $env:GITHUB_ENV
-          Rename-Item -Path "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -NewName "quantum-opt"
-          dir "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release"
+          New-Alias -Name "quantum-opt" -Value "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -Scope Global
+          Get-Alias -Name "quantum-opt"
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -126,6 +126,7 @@ jobs:
                   }
                 } |
                 Where-Object { $_ -ne $null }
+          echo "Latest version: $latest"
           echo "latest=$latest" >> $env:GITHUB_OUTPUT
 
       - name: Try to get MLIR from cache

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -186,4 +186,5 @@ jobs:
           tree build /F /A
           echo "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           Rename-Item -Path "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -NewName "quantum-opt"
+          dir "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release"
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   cpp-test-mlir:
-    name: 🇨‌ Test MLIR with LLVM@${{ matrix.llvm-version }}
+    name: 🐧 Test MLIR with LLVM@${{ matrix.llvm-version }}
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -86,6 +86,84 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_MQT_CORE_MLIR=ON \
             -DLLVM_EXTERNAL_LIT=$(which lit)
+
+      # build the project and run the tests
+      - name: Build MLIR components and directly run lit tests
+        run: cmake --build build --config Release --target check-quantum-opt
+
+  cpp-test-mlir-windows:
+    name: 🏁 Test MLIR with LLVM@${{ matrix.llvm-version }}
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        llvm-version: [19, 20]
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: 4
+      CTEST_PARALLEL_LEVEL: 4
+      FORCE_COLOR: 3
+    steps:
+      # check out the repository
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Try to get MLIR from cache
+        uses: actions/cache@v3
+        id: mlir-cache
+        with:
+          path: |
+            llvm-project/build
+            ${{ github.workspace }}/llvm-install
+          key: ${{ runner.os }}-llvm-${{ matrix.llvm-version }}
+          restore-keys: |
+            ${{ runner.os }}-llvm-${{ matrix.llvm-version }}
+
+      # build the llvm-project from source
+      - name: Install llvm and mlir
+        if: steps.mlir-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 https://github.com/llvm/llvm-project.git --branch llvmorg-${{ matrix.llvm-version }}.1.0
+          cd llvm-project
+          mkdir build
+          cd build
+          cmake ..\llvm -G "Ninja" `
+            -DLLVM_ENABLE_PROJECTS=mlir `
+            -DLLVM_BUILD_EXAMPLES=OFF `
+            -DLLVM_TARGETS_TO_BUILD="X86" `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DLLVM_BUILD_TESTS=OFF `
+            -DLLVM_INCLUDE_TESTS=OFF `
+            -DLLVM_INCLUDE_EXAMPLES=OFF `
+            -DLLVM_ENABLE_ASSERTIONS=ON `
+            -DLLVM_ENABLE_UTILS=ON `
+            -DLLVM_INSTALL_UTILS=ON `
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\llvm-install
+          cmake --build . --target install --config Release
+
+      # set up uv for faster Python package management
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: 3.13
+          activate-environment: true
+
+      # make sure ninja is installed
+      - name: Install Ninja
+        run: uv tool install ninja
+
+      # make sure the lit test runner is installed
+      - name: Install lit
+        run: |
+          uv pip install lit
+
+      # configure the project with CMake
+      - name: Configure CMake for MLIR
+        run: |
+          cmake -G Ninja -S . -B build `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DBUILD_MQT_CORE_MLIR=ON `
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}\llvm-install `
+            -DLLVM_EXTERNAL_LIT=${{ github.workspace }}\.venv\Scripts\lit.exe
 
       # build the project and run the tests
       - name: Build MLIR components and directly run lit tests

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -109,9 +109,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Clone the llvm-project repository so we can search its tags
+      - name: Clone llvm-project
+        run: |
+          git clone --depth 1 https://github.com/llvm/llvm-project.git
+
       - name: Find latest release of llvm-project
         id: get-latest
         run: |
+          cd llvm-project
           $tag = git ls-remote --tags origin "llvmorg-${{ matrix.llvm-version }}.*" |
                   Where-Object { $_ -match "llvmorg-\d+\.\d+\.\d+" } |
                   Sort-Object -Property {
@@ -142,7 +148,9 @@ jobs:
       - name: Install llvm and mlir
         if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
-          git clone --depth 1 https://github.com/llvm/llvm-project.git --branch llvmorg-${{ steps.get-latest.outputs.latest }}
+          cd llvm-project
+          git fetch llvmorg-${{ steps.get-latest.outputs.latest }}
+          git checkout llvmorg-${{ steps.get-latest.outputs.latest }}
           cd llvm-project
           cmake -S llvm -B build_llvm `
             -DLLVM_ENABLE_PROJECTS=mlir `

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -187,10 +187,10 @@ jobs:
           $targetPath = "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe"
           $batchContent = '@echo off
           "{0}" %*' -f $targetPath
-          
+
           # Write to a directory that's definitely in PATH
           $batchContent | Out-File -FilePath "C:\Windows\quantum-opt.cmd" -Encoding ascii
-          
+
           # Verify the batch file
           Get-Content "C:\Windows\quantum-opt.cmd"
           Write-Output "Batch file created at C:\Windows\quantum-opt.cmd pointing to $targetPath"

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -185,8 +185,7 @@ jobs:
           cmake --build build --config Release --target quantum-opt
 
           $targetPath = "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe"
-          $batchContent = '@echo off
-          "{0}" %*' -f $targetPath
+          $batchContent = '"{0}" "$@"' -f $targetPath
 
           # Write to a directory that's definitely in PATH
           $batchContent | Out-File -FilePath "C:\Windows\quantum-opt" -Encoding ascii

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -183,5 +183,6 @@ jobs:
       - name: Build MLIR components and directly run lit tests
         run: |
           cmake --build build --config Release --target quantum-opt
-          tree build
-      #    cmake --build build --config Release --target check-quantum-opt
+          tree build /F /A
+          echo "$env:{{ github.workspace }}\\build\\mlir\\tools\\quantum-opt" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+          cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Try to get MLIR from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: mlir-cache
         with:
           path: ${{ github.workspace }}/llvm-install

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -185,4 +185,5 @@ jobs:
           cmake --build build --config Release --target quantum-opt
           tree build /F /A
           echo "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Rename-Item -Path ""${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -NewName "quantum-opt"
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -180,7 +180,7 @@ jobs:
             -DLLVM_EXTERNAL_LIT=${{ github.workspace }}\.venv\Scripts\lit.exe
 
       # build the project and run the tests
-      #- name: Build MLIR components and directly run lit tests
-      #  run: |
-      #    cmake --build build --config Release --target quantum-opt
+      - name: Build MLIR components and directly run lit tests
+        run: |
+          cmake --build build --config Release --target quantum-opt
       #    cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -184,5 +184,5 @@ jobs:
         run: |
           cmake --build build --config Release --target quantum-opt
           tree build /F /A
-          echo "{{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -184,5 +184,5 @@ jobs:
         run: |
           cmake --build build --config Release --target quantum-opt
           tree build /F /A
-          echo "$env:{{ github.workspace }}\\build\\mlir\\tools\\quantum-opt" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "{{ github.workspace }}\\build\\mlir\\tools\\quantum-opt" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -181,4 +181,6 @@ jobs:
 
       # build the project and run the tests
       - name: Build MLIR components and directly run lit tests
-        run: cmake --build build --config Release --target check-quantum-opt
+        run: |
+          cmake --build build --config Release --target quantum-opt
+          cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -186,4 +186,5 @@ jobs:
           New-Alias -Name "quantum-opt" -Value "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -Scope Global
           $aliasDef = (Get-Alias -Name "quantum-opt").Definition
           Write-Output "The alias 'quantum-opt' points to: $aliasDef"
+          $env:LIT_OPTS="--param quantum_opt_path=${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe"
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -184,5 +184,5 @@ jobs:
         run: |
           cmake --build build --config Release --target quantum-opt
           tree build /F /A
-          echo "{{ github.workspace }}\\build\\mlir\\tools\\quantum-opt" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "{{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -185,5 +185,5 @@ jobs:
           cmake --build build --config Release --target quantum-opt
           tree build /F /A
           echo "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          Rename-Item -Path ""${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -NewName "quantum-opt"
+          Rename-Item -Path "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -NewName "quantum-opt"
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -183,8 +183,16 @@ jobs:
       - name: Build MLIR components and directly run lit tests
         run: |
           cmake --build build --config Release --target quantum-opt
-          New-Alias -Name "quantum-opt" -Value "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -Scope Global
-          $aliasDef = (Get-Alias -Name "quantum-opt").Definition
-          Write-Output "The alias 'quantum-opt' points to: $aliasDef"
-          $env:LIT_OPTS="--param quantum_opt_path=${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe"
+
+          $targetPath = "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe"
+          $batchContent = '@echo off
+          "{0}" %*' -f $targetPath
+          
+          # Write to a directory that's definitely in PATH
+          $batchContent | Out-File -FilePath "C:\Windows\quantum-opt.cmd" -Encoding ascii
+          
+          # Verify the batch file
+          Get-Content "C:\Windows\quantum-opt.cmd"
+          Write-Output "Batch file created at C:\Windows\quantum-opt.cmd pointing to $targetPath"
+
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -109,16 +109,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Clone the llvm-project repository so we can search its tags
-      - name: Clone llvm-project
-        run: |
-          git clone --depth 1 https://github.com/llvm/llvm-project.git
-
       - name: Find latest release of llvm-project
         id: get-latest
         run: |
-          cd llvm-project
-          $tag = git ls-remote --tags origin "llvmorg-${{ matrix.llvm-version }}.*" |
+          $tag = git ls-remote --tags https://github.com/llvm/llvm-project.git "llvmorg-${{ matrix.llvm-version }}.*" |
                   Where-Object { $_ -match "llvmorg-\d+\.\d+\.\d+" } |
                   Sort-Object -Property {
                     if ($_ -match "llvmorg-(\d+)\.(\d+)\.(\d+)") {
@@ -148,9 +142,8 @@ jobs:
       - name: Install llvm and mlir
         if: steps.mlir-cache.outputs.cache-hit != 'true'
         run: |
+          git clone --depth 1 https://github.com/llvm/llvm-project.git --branch llvmorg-${{ steps.get-latest.outputs.latest }}
           cd llvm-project
-          git fetch llvmorg-${{ steps.get-latest.outputs.latest }}
-          git checkout llvmorg-${{ steps.get-latest.outputs.latest }}
           cmake -S llvm -B build_llvm `
             -DLLVM_ENABLE_PROJECTS=mlir `
             -DLLVM_BUILD_EXAMPLES=OFF `

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/llvm/llvm-project.git --branch llvmorg-${{ matrix.llvm-version }}.1.0
           cd llvm-project
-          cmake -S llvm -B build_llvm -G "Ninja" `
+          cmake -S llvm -B build_llvm `
             -DLLVM_ENABLE_PROJECTS=mlir `
             -DLLVM_BUILD_EXAMPLES=OFF `
             -DLLVM_TARGETS_TO_BUILD="X86" `
@@ -143,10 +143,6 @@ jobs:
           python-version: 3.13
           activate-environment: true
 
-      # make sure ninja is installed
-      - name: Install Ninja
-        run: uv tool install ninja
-
       # make sure the lit test runner is installed
       - name: Install lit
         run: |
@@ -155,7 +151,7 @@ jobs:
       # configure the project with CMake
       - name: Configure CMake for MLIR
         run: |
-          cmake -G Ninja -S . -B build `
+          cmake -S . -B build `
             -DCMAKE_BUILD_TYPE=Release `
             -DBUILD_MQT_CORE_MLIR=ON `
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}\llvm-install `

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -151,7 +151,6 @@ jobs:
           cd llvm-project
           git fetch llvmorg-${{ steps.get-latest.outputs.latest }}
           git checkout llvmorg-${{ steps.get-latest.outputs.latest }}
-          cd llvm-project
           cmake -S llvm -B build_llvm `
             -DLLVM_ENABLE_PROJECTS=mlir `
             -DLLVM_BUILD_EXAMPLES=OFF `

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -180,7 +180,7 @@ jobs:
             -DLLVM_EXTERNAL_LIT=${{ github.workspace }}\.venv\Scripts\lit.exe
 
       # build the project and run the tests
-      - name: Build MLIR components and directly run lit tests
-        run: |
-          cmake --build build --config Release --target quantum-opt
-          cmake --build build --config Release --target check-quantum-opt
+      #- name: Build MLIR components and directly run lit tests
+      #  run: |
+      #    cmake --build build --config Release --target quantum-opt
+      #    cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -184,5 +184,6 @@ jobs:
         run: |
           cmake --build build --config Release --target quantum-opt
           New-Alias -Name "quantum-opt" -Value "${{ github.workspace }}\\build\\mlir\\tools\\quantum-opt\\Release\\quantum-opt.exe" -Scope Global
-          Get-Alias -Name "quantum-opt"
+          $aliasDef = (Get-Alias -Name "quantum-opt").Definition
+          Write-Output "The alias 'quantum-opt' points to: $aliasDef"
           cmake --build build --config Release --target check-quantum-opt

--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -124,9 +124,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/llvm/llvm-project.git --branch llvmorg-${{ matrix.llvm-version }}.1.0
           cd llvm-project
-          mkdir build
-          cd build
-          cmake ..\llvm -G "Ninja" `
+          cmake -S llvm -B build -G "Ninja" `
             -DLLVM_ENABLE_PROJECTS=mlir `
             -DLLVM_BUILD_EXAMPLES=OFF `
             -DLLVM_TARGETS_TO_BUILD="X86" `
@@ -138,7 +136,7 @@ jobs:
             -DLLVM_ENABLE_UTILS=ON `
             -DLLVM_INSTALL_UTILS=ON `
             -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\llvm-install
-          cmake --build . --target install --config Release
+          cmake --build build --target install --config Release
 
       # set up uv for faster Python package management
       - name: Install the latest version of uv


### PR DESCRIPTION
## Description

This PR adds MLIR CI tests for windows runners.
This is achieved by building MLIR from source so the first execution should take a bit longer.
Afterwards, the cache will be used to store the built versions of MLIR.

This PR contributes to #925

**Note:** To install a specific version, the runner clones the tag `llvmorg-{version}.1.0`. It seems that the first release of a new major `llvm-project` version is typically called `{version}.1.0` so this should keep working, but there is no guarantee.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
