### PR TITLE
🚸 Add dedicated option for only building MQT Core as shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ endif()
 option(MQT_CORE_INSTALL "Generate installation instructions for MQT Core"
        ${MQT_CORE_MASTER_PROJECT})
 option(BUILD_MQT_CORE_TESTS "Also build tests for the MQT Core project" ${MQT_CORE_MASTER_PROJECT})
+option(BUILD_MQT_CORE_SHARED_LIBS "Build MQT Core libraries as shared libraries"
+       ${BUILD_SHARED_LIBS})
 
 # try to determine the project version
 include(GetVersion)

--- a/cmake/AddMQTCoreLibrary.cmake
+++ b/cmake/AddMQTCoreLibrary.cmake
@@ -22,11 +22,7 @@ endfunction()
 
 function(add_mqt_core_library name)
   cmake_parse_arguments(ARG "" "ALIAS_NAME" "" ${ARGN})
-  if(BUILD_MQT_CORE_SHARED_LIBS)
-    add_library(${name} SHARED ${ARG_UNPARSED_ARGUMENTS})
-  else()
-    add_library(${name} ${ARG_UNPARSED_ARGUMENTS})
-  endif()
+  add_library(${name} $<$<BOOL:${BUILD_MQT_CORE_SHARED_LIBS}>:SHARED> ${ARG_UNPARSED_ARGUMENTS})
   if(NOT ARG_ALIAS_NAME)
     # remove prefix 'mqt-' from target name if exists
     string(REGEX REPLACE "^${MQT_CORE_TARGET_NAME}" "" ALIAS_NAME_ARG ${name})

--- a/cmake/AddMQTCoreLibrary.cmake
+++ b/cmake/AddMQTCoreLibrary.cmake
@@ -22,7 +22,11 @@ endfunction()
 
 function(add_mqt_core_library name)
   cmake_parse_arguments(ARG "" "ALIAS_NAME" "" ${ARGN})
-  add_library(${name} $<$<BOOL:${BUILD_MQT_CORE_SHARED_LIBS}>:SHARED> ${ARG_UNPARSED_ARGUMENTS})
+  if(BUILD_MQT_CORE_SHARED_LIBS)
+    add_library(${name} SHARED ${ARG_UNPARSED_ARGUMENTS})
+  else()
+    add_library(${name} ${ARG_UNPARSED_ARGUMENTS})
+  endif()
   if(NOT ARG_ALIAS_NAME)
     # remove prefix 'mqt-' from target name if exists
     string(REGEX REPLACE "^${MQT_CORE_TARGET_NAME}" "" ALIAS_NAME_ARG ${name})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ git-only = [
 [tool.scikit-build.cmake.define]
 BUILD_MQT_CORE_BINDINGS = "ON"
 BUILD_MQT_CORE_TESTS = "OFF"
-BUILD_SHARED_LIBS = "ON"
+BUILD_MQT_CORE_SHARED_LIBS = "ON"
 
 [[tool.scikit-build.overrides]]
 if.python-version = ">=3.13"

--- a/src/algorithms/CMakeLists.txt
+++ b/src/algorithms/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-algorithms)
     ${MQT_CORE_TARGET_NAME}-algorithms
     PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/.. FILES
            ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_algorithms_export.h)
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_MQT_CORE_SHARED_LIBS)
     target_compile_definitions(${MQT_CORE_TARGET_NAME}-algorithms
                                PUBLIC MQT_CORE_ALGO_STATIC_DEFINE)
   endif()

--- a/src/circuit_optimizer/CMakeLists.txt
+++ b/src/circuit_optimizer/CMakeLists.txt
@@ -44,7 +44,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-circuit-optimizer)
     ${MQT_CORE_TARGET_NAME}-circuit-optimizer
     PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/.. FILES
            ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_circuit_optimizer_export.h)
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_MQT_CORE_SHARED_LIBS)
     target_compile_definitions(${MQT_CORE_TARGET_NAME}-circuit-optimizer
                                PUBLIC MQT_CORE_CIRCUIT_OPTIMIZER_STATIC_DEFINE)
   endif()

--- a/src/datastructures/CMakeLists.txt
+++ b/src/datastructures/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-ds)
   target_sources(
     ${MQT_CORE_TARGET_NAME}-ds PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/..
                                       FILES ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_ds_export.h)
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_MQT_CORE_SHARED_LIBS)
     target_compile_definitions(${MQT_CORE_TARGET_NAME}-ds PUBLIC MQT_CORE_DS_STATIC_DEFINE)
   endif()
 

--- a/src/dd/CMakeLists.txt
+++ b/src/dd/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-dd)
   target_sources(
     ${MQT_CORE_TARGET_NAME}-dd PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/..
                                       FILES ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_dd_export.h)
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_MQT_CORE_SHARED_LIBS)
     target_compile_definitions(${MQT_CORE_TARGET_NAME}-dd PUBLIC MQT_CORE_DD_STATIC_DEFINE)
   endif()
 

--- a/src/ir/CMakeLists.txt
+++ b/src/ir/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NOT TARGET MQT::CoreIR)
   target_sources(
     ${MQT_CORE_TARGET_NAME}-ir PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/..
                                       FILES ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_ir_export.h)
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_MQT_CORE_SHARED_LIBS)
     target_compile_definitions(${MQT_CORE_TARGET_NAME}-ir PUBLIC MQT_CORE_IR_STATIC_DEFINE)
   endif()
 

--- a/src/na/CMakeLists.txt
+++ b/src/na/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-na)
   target_sources(
     ${MQT_CORE_TARGET_NAME}-na PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/..
                                       FILES ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_na_export.h)
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_MQT_CORE_SHARED_LIBS)
     target_compile_definitions(${MQT_CORE_TARGET_NAME}-na PUBLIC MQT_CORE_NA_STATIC_DEFINE)
   endif()
 

--- a/src/qasm3/CMakeLists.txt
+++ b/src/qasm3/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT TARGET MQT::CoreQASM)
   target_sources(
     ${MQT_CORE_TARGET_NAME}-qasm PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/..
                                         FILES ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_qasm_export.h)
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_MQT_CORE_SHARED_LIBS)
     target_compile_definitions(${MQT_CORE_TARGET_NAME}-qasm PUBLIC MQT_CORE_QASM_STATIC_DEFINE)
   endif()
 

--- a/src/zx/CMakeLists.txt
+++ b/src/zx/CMakeLists.txt
@@ -85,7 +85,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-zx)
   target_sources(
     ${MQT_CORE_TARGET_NAME}-zx PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/..
                                       FILES ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_zx_export.h)
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_MQT_CORE_SHARED_LIBS)
     target_compile_definitions(${MQT_CORE_TARGET_NAME}-zx PUBLIC MQT_CORE_ZX_STATIC_DEFINE)
   endif()
 


### PR DESCRIPTION
## Description

Also pulled out from #881.
Builds on #961 and adds a dedicated option for only building the MQT Core libraries as shared libraries without forcing this on every other library.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
