### PR TITLE
🐛 Throw an error when operation is initialized with duplicate qubits

### DIFF
--- a/src/ir/operations/StandardOperation.cpp
+++ b/src/ir/operations/StandardOperation.cpp
@@ -213,28 +213,28 @@ StandardOperation::StandardOperation(const Control control, const Qubit target,
                                      const OpType g,
                                      const std::vector<fp>& params)
     : StandardOperation(target, g, params) {
-  controls.insert(control);
+  StandardOperation::addControl(control);
 }
 
 StandardOperation::StandardOperation(const Control control, const Targets& targ,
                                      const OpType g,
                                      const std::vector<fp>& params)
     : StandardOperation(targ, g, params) {
-  controls.insert(control);
+  StandardOperation::addControl(control);
 }
 
 StandardOperation::StandardOperation(const Controls& c, const Qubit target,
                                      const OpType g,
                                      const std::vector<fp>& params)
     : StandardOperation(target, g, params) {
-  controls = c;
+  addControls(c);
 }
 
 StandardOperation::StandardOperation(const Controls& c, const Targets& targ,
                                      const OpType g,
                                      const std::vector<fp>& params)
     : StandardOperation(targ, g, params) {
-  controls = c;
+  addControls(c);
 }
 
 // MCF (cSWAP), Peres, parameterized two target Constructor

--- a/src/ir/operations/SymbolicOperation.cpp
+++ b/src/ir/operations/SymbolicOperation.cpp
@@ -287,28 +287,28 @@ SymbolicOperation::SymbolicOperation(const Control control, const Qubit target,
                                      const OpType g,
                                      const std::vector<SymbolOrNumber>& params)
     : SymbolicOperation(target, g, params) {
-  controls.insert(control);
+  SymbolicOperation::addControl(control);
 }
 
 SymbolicOperation::SymbolicOperation(const Control control, const Targets& targ,
                                      const OpType g,
                                      const std::vector<SymbolOrNumber>& params)
     : SymbolicOperation(targ, g, params) {
-  controls.insert(control);
+  SymbolicOperation::addControl(control);
 }
 
 SymbolicOperation::SymbolicOperation(const Controls& c, const Qubit target,
                                      const OpType g,
                                      const std::vector<SymbolOrNumber>& params)
     : SymbolicOperation(target, g, params) {
-  controls = c;
+  addControls(c);
 }
 
 SymbolicOperation::SymbolicOperation(const Controls& c, const Targets& targ,
                                      const OpType g,
                                      const std::vector<SymbolOrNumber>& params)
     : SymbolicOperation(targ, g, params) {
-  controls = c;
+  addControls(c);
 }
 
 // MCF (cSWAP), Peres, parameterized two target Constructor

--- a/test/circuit_optimizer/test_remove_operation.cpp
+++ b/test/circuit_optimizer/test_remove_operation.cpp
@@ -54,7 +54,8 @@ TEST(RemoveOperation, removeMultiQubitGates) {
   QuantumComputation qc(nqubits);
   qc.x(0);
   qc.cx(0, 1);
-  qc.cy(1, 1);
+  qc.cy(0, 1);
+  qc.cz(0, 1);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   CircuitOptimizer::removeOperation(qc, {X, Y}, 2);

--- a/test/circuit_optimizer/test_remove_operation.cpp
+++ b/test/circuit_optimizer/test_remove_operation.cpp
@@ -69,7 +69,7 @@ TEST(RemoveOperation, removeMoves) {
   QuantumComputation qc(nqubits);
   qc.x(0);
   qc.move(0, 1);
-  qc.cy(1, 1);
+  qc.cy(0, 1);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   CircuitOptimizer::removeOperation(qc, {Move}, 0);

--- a/test/ir/test_operation.cpp
+++ b/test/ir/test_operation.cpp
@@ -39,6 +39,13 @@ TEST(StandardOperation, CommutesAtQubit) {
   EXPECT_TRUE(op1.commutesAtQubit(op2, 2));
 }
 
+TEST(StandardOperation, DuplicateQubitThrowsError) {
+  qc::QuantumComputation qc(2);
+  EXPECT_THROW(qc.cx(0, 0), std::runtime_error);
+  EXPECT_THROW(qc.mcx({0, 1}, 0), std::runtime_error);
+  EXPECT_THROW(qc.mcx({0, 0}, 1), std::runtime_error);
+}
+
 TEST(CompoundOperation, CommutesAtQubit) {
   qc::CompoundOperation op1;
   op1.emplace_back<qc::StandardOperation>(0, qc::OpType::RY,


### PR DESCRIPTION
## Description

#959 revealed a bug in the existing code base related to the initialization of operations with duplicate qubits. It was possible to create operations with overlapping controls and targets which is not possible as operands must be unique.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.
