### PR TITLE
WIP: Support for `IfElseOp` operation

### DIFF
--- a/include/mqt-core/ir/operations/IfElseOperation.hpp
+++ b/include/mqt-core/ir/operations/IfElseOperation.hpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+ * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
 #pragma once
 
 #include "ir/Definitions.hpp"

--- a/include/mqt-core/ir/operations/IfElseOperation.hpp
+++ b/include/mqt-core/ir/operations/IfElseOperation.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "ir/Definitions.hpp"
+#include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
+#include "ir/operations/ClassicControlledOperation.hpp"
+#include "ir/operations/Operation.hpp"
+
+#include <memory>
+#include <optional>
+
+namespace qc {
+class IfElseOperation final : public Operation {
+public:
+  IfElseOperation(std::unique_ptr<Operation>&& thenOp,
+                  std::unique_ptr<Operation>&& elseOp,
+                  ClassicalRegister controlReg, std::uint64_t expectedVal = 1U,
+                  ComparisonKind kind = Eq);
+  IfElseOperation(std::unique_ptr<Operation>&& thenOp,
+                  std::unique_ptr<Operation>&& elseOp, Bit cBit,
+                  std::uint64_t expectedVal = 1U, ComparisonKind kind = Eq);
+  IfElseOperation(const IfElseOperation& op);
+  IfElseOperation& operator=(const IfElseOperation& op);
+
+  [[nodiscard]] std::unique_ptr<Operation> clone() const override {
+    return std::make_unique<IfElseOperation>(*this);
+  }
+
+  [[nodiscard]] bool isUnitary() const override { return false; }
+  [[nodiscard]] bool isNonUnitaryOperation() const override { return true; }
+
+  [[nodiscard]] const Operation* getThenBranch() const {
+    return thenBranch.get();
+  }
+  [[nodiscard]] const Operation* getElseBranch() const {
+    return elseBranch.get();
+  }
+
+  [[nodiscard]] const auto& getControlRegister() const noexcept {
+    return controlRegister;
+  }
+  [[nodiscard]] const auto& getControlBit() const noexcept {
+    return controlBit;
+  }
+  [[nodiscard]] auto getExpectedValue() const noexcept { return expectedValue; }
+  [[nodiscard]] auto getComparisonKind() const noexcept {
+    return comparisonKind;
+  }
+
+  void addControl(Control) override {}
+  void clearControls() override {}
+  void removeControl(Control) override {}
+  Controls::iterator removeControl(Controls::iterator it) override {
+    return it;
+  }
+
+  [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
+                            const Permutation& perm2) const override;
+  [[nodiscard]] bool equals(const Operation& op) const override {
+    return equals(op, {}, {});
+  }
+
+  void dumpOpenQASM(std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
+                    const BitIndexToRegisterMap& bitMap, std::size_t indent,
+                    bool openQASM3) const override;
+
+  void invert() override {
+    thenBranch->invert();
+    if (elseBranch) {
+      elseBranch->invert();
+    }
+  }
+
+private:
+  std::unique_ptr<Operation> thenBranch;
+  std::unique_ptr<Operation> elseBranch;
+  std::optional<ClassicalRegister> controlRegister;
+  std::optional<Bit> controlBit;
+  std::uint64_t expectedValue = 1U;
+  ComparisonKind comparisonKind = Eq;
+};
+} // namespace qc
+
+namespace std {
+template <> struct hash<qc::IfElseOperation> {
+  std::size_t operator()(qc::IfElseOperation const& op) const noexcept;
+};
+} // namespace std

--- a/include/mqt-core/ir/operations/OpType.inc
+++ b/include/mqt-core/ir/operations/OpType.inc
@@ -68,7 +68,10 @@ HANDLE_OP_TYPE(38, AodActivate, 0, "aod_activate")
 HANDLE_OP_TYPE(39, AodDeactivate, 0, "aod_deactivate")
 HANDLE_OP_TYPE(40, AodMove, 0, "aod_move")
 
-LAST_OP_TYPE(41)
+// Control flow operations
+HANDLE_OP_TYPE(41, IfElse, OpTypeNone, "if_else")
+
+LAST_OP_TYPE(42)
 
 
 #undef OpTypeInv

--- a/src/ir/operations/IfElseOperation.cpp
+++ b/src/ir/operations/IfElseOperation.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+ * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
 #include "ir/operations/IfElseOperation.hpp"
 
 #include "ir/operations/OpType.hpp"

--- a/src/ir/operations/IfElseOperation.cpp
+++ b/src/ir/operations/IfElseOperation.cpp
@@ -1,0 +1,136 @@
+#include "ir/operations/IfElseOperation.hpp"
+
+#include "ir/operations/OpType.hpp"
+
+#include <cassert>
+#include <utility>
+
+namespace qc {
+IfElseOperation::IfElseOperation(std::unique_ptr<Operation>&& thenOp,
+                                 std::unique_ptr<Operation>&& elseOp,
+                                 ClassicalRegister controlReg,
+                                 const std::uint64_t expectedVal,
+                                 const ComparisonKind kind)
+    : thenBranch(std::move(thenOp)), elseBranch(std::move(elseOp)),
+      controlRegister(std::move(controlReg)), expectedValue(expectedVal),
+      comparisonKind(kind) {
+  name = "if_else";
+  type = IfElse;
+}
+
+IfElseOperation::IfElseOperation(std::unique_ptr<Operation>&& thenOp,
+                                 std::unique_ptr<Operation>&& elseOp, Bit cBit,
+                                 const std::uint64_t expectedVal,
+                                 ComparisonKind kind)
+    : thenBranch(std::move(thenOp)), elseBranch(std::move(elseOp)),
+      controlBit(cBit), expectedValue(expectedVal), comparisonKind(kind) {
+  assert(expectedVal <= 1);
+  name = "if_else";
+  type = IfElse;
+}
+
+IfElseOperation::IfElseOperation(const IfElseOperation& op)
+    : Operation(op),
+      thenBranch(op.thenBranch ? op.thenBranch->clone() : nullptr),
+      elseBranch(op.elseBranch ? op.elseBranch->clone() : nullptr),
+      controlRegister(op.controlRegister), controlBit(op.controlBit),
+      expectedValue(op.expectedValue), comparisonKind(op.comparisonKind) {}
+
+IfElseOperation& IfElseOperation::operator=(const IfElseOperation& op) {
+  if (this != &op) {
+    Operation::operator=(op);
+    thenBranch = op.thenBranch ? op.thenBranch->clone() : nullptr;
+    elseBranch = op.elseBranch ? op.elseBranch->clone() : nullptr;
+    controlRegister = op.controlRegister;
+    controlBit = op.controlBit;
+    expectedValue = op.expectedValue;
+    comparisonKind = op.comparisonKind;
+  }
+  return *this;
+}
+
+bool IfElseOperation::equals(const Operation& operation,
+                             const Permutation& perm1,
+                             const Permutation& perm2) const {
+  if (const auto* other = dynamic_cast<const IfElseOperation*>(&operation)) {
+    if (controlRegister != other->controlRegister) {
+      return false;
+    }
+    if (controlBit != other->controlBit) {
+      return false;
+    }
+    if (expectedValue != other->expectedValue ||
+        comparisonKind != other->comparisonKind) {
+      return false;
+    }
+    if (thenBranch && other->thenBranch) {
+      if (!thenBranch->equals(*other->thenBranch, perm1, perm2)) {
+        return false;
+      }
+    } else if (thenBranch || other->thenBranch) {
+      return false;
+    }
+    if (elseBranch && other->elseBranch) {
+      if (!elseBranch->equals(*other->elseBranch, perm1, perm2)) {
+        return false;
+      }
+    } else if (elseBranch || other->elseBranch) {
+      return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+void IfElseOperation::dumpOpenQASM(std::ostream& of,
+                                   const QubitIndexToRegisterMap& qubitMap,
+                                   const BitIndexToRegisterMap& bitMap,
+                                   const std::size_t indent,
+                                   const bool openQASM3) const {
+  of << std::string(indent * OUTPUT_INDENT_SIZE, ' ');
+  of << "if (";
+  if (controlRegister.has_value()) {
+    assert(!controlBit.has_value());
+    of << controlRegister->getName() << ' ' << comparisonKind << ' '
+       << expectedValue;
+  } else if (controlBit.has_value()) {
+    of << (expectedValue == 0 ? "!" : "") << bitMap.at(*controlBit).second;
+  }
+  of << ") ";
+  if (openQASM3) {
+    of << "{\n";
+  }
+  if (thenBranch) {
+    thenBranch->dumpOpenQASM(of, qubitMap, bitMap, indent + 1, openQASM3);
+  }
+  if (openQASM3) {
+    of << "}";
+    if (elseBranch) {
+      of << " else {\n";
+      elseBranch->dumpOpenQASM(of, qubitMap, bitMap, indent + 1, openQASM3);
+      of << "}";
+    }
+    of << "\n";
+  }
+}
+} // namespace qc
+
+std::size_t std::hash<qc::IfElseOperation>::operator()(
+    qc::IfElseOperation const& op) const noexcept {
+  std::size_t seed = 0U;
+  if (op.getThenBranch()) {
+    qc::hashCombine(seed, std::hash<qc::Operation>{}(*op.getThenBranch()));
+  }
+  if (op.getElseBranch()) {
+    qc::hashCombine(seed, std::hash<qc::Operation>{}(*op.getElseBranch()));
+  }
+  if (const auto& reg = op.getControlRegister(); reg.has_value()) {
+    qc::hashCombine(seed, std::hash<qc::ClassicalRegister>{}(reg.value()));
+  }
+  if (const auto& bit = op.getControlBit(); bit.has_value()) {
+    qc::hashCombine(seed, bit.value());
+  }
+  qc::hashCombine(seed, op.getExpectedValue());
+  qc::hashCombine(seed, op.getComparisonKind());
+  return seed;
+}

--- a/src/ir/operations/OpType.cpp
+++ b/src/ir/operations/OpType.cpp
@@ -58,6 +58,8 @@ std::string shortName(const OpType opType) {
     return "msr";
   case Reset:
     return "rst";
+  case IfElse:
+    return "if";
   default:
     return toString(opType);
   }
@@ -130,6 +132,7 @@ OpType opTypeFromString(const std::string& opType) {
       {"reset", OpType::Reset},
       {"barrier", OpType::Barrier},
       {"classic_controlled", OpType::ClassicControlled},
+      {"if_else", OpType::IfElse},
       {"compound", OpType::Compound},
       {"move", OpType::Move},
       {"aod_activate", OpType::AodActivate},

--- a/src/qasm3/Importer.cpp
+++ b/src/qasm3/Importer.cpp
@@ -895,8 +895,32 @@ void Importer::visitIfStatement(
       translateCondition(ifStatement->condition, ifStatement->debugInfo);
 
   // translate statements in then/else blocks
+  if (ifStatement->thenStatements.empty() &&
+      ifStatement->elseStatements.empty()) {
+    return;
+  }
+
+  std::unique_ptr<qc::Operation> thenOps = nullptr;
   if (!ifStatement->thenStatements.empty()) {
-    auto thenOps = translateBlockOperations(ifStatement->thenStatements);
+    thenOps = translateBlockOperations(ifStatement->thenStatements);
+  } else {
+    thenOps = std::make_unique<qc::CompoundOperation>();
+  }
+
+  if (!ifStatement->elseStatements.empty()) {
+    auto elseOps = translateBlockOperations(ifStatement->elseStatements);
+    if (std::holds_alternative<std::pair<qc::Bit, bool>>(condition)) {
+      const auto& [bit, val] = std::get<std::pair<qc::Bit, bool>>(condition);
+      qc->emplace_back<qc::IfElseOperation>(
+          std::move(thenOps), std::move(elseOps), bit, val ? 1 : 0);
+    } else {
+      const auto& [creg, comparisonKind, rhs] = std::get<
+          std::tuple<qc::ClassicalRegister, qc::ComparisonKind, uint64_t>>(
+          condition);
+      qc->emplace_back<qc::IfElseOperation>(
+          std::move(thenOps), std::move(elseOps), creg, rhs, comparisonKind);
+    }
+  } else {
     if (std::holds_alternative<std::pair<qc::Bit, bool>>(condition)) {
       const auto& [bit, val] = std::get<std::pair<qc::Bit, bool>>(condition);
       qc->emplace_back<qc::ClassicControlledOperation>(std::move(thenOps), bit,
@@ -907,23 +931,6 @@ void Importer::visitIfStatement(
           condition);
       qc->emplace_back<qc::ClassicControlledOperation>(std::move(thenOps), creg,
                                                        rhs, comparisonKind);
-    }
-  }
-
-  if (!ifStatement->elseStatements.empty()) {
-    auto elseOps = translateBlockOperations(ifStatement->elseStatements);
-    if (std::holds_alternative<std::pair<qc::Bit, bool>>(condition)) {
-      const auto& [bit, val] = std::get<std::pair<qc::Bit, bool>>(condition);
-      qc->emplace_back<qc::ClassicControlledOperation>(std::move(elseOps), bit,
-                                                       val ? 0 : 1);
-    } else {
-      const auto& [creg, comparisonKind, rhs] = std::get<
-          std::tuple<qc::ClassicalRegister, qc::ComparisonKind, uint64_t>>(
-          condition);
-      const auto invertedComparisonKind =
-          qc::getInvertedComparisonKind(comparisonKind);
-      qc->emplace_back<qc::ClassicControlledOperation>(
-          std::move(elseOps), creg, rhs, invertedComparisonKind);
     }
   }
 }

--- a/test/ir/test_qasm3_parser.cpp
+++ b/test/ir/test_qasm3_parser.cpp
@@ -467,8 +467,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3IfElseStatement) {
                                "c[0] = measure q[0];\n"
                                "if (c[0]) {\n"
                                "  x q[1];\n"
-                               "}\n"
-                               "if (!c[0]) {\n"
+                               "} else {\n"
                                "  x q[0];\n"
                                "  x q[1];\n"
                                "}\n";
@@ -501,8 +500,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3IfElseStatementRegister) {
                                "c[0] = measure q[0];\n"
                                "if (c == 1) {\n"
                                "  x q[1];\n"
-                               "}\n"
-                               "if (c != 1) {\n"
+                               "} else {\n"
                                "  x q[0];\n"
                                "  x q[1];\n"
                                "}\n";
@@ -608,7 +606,8 @@ TEST_F(Qasm3ParserTest, ImportQasm3IfElseNoBlock) {
                                "bit[1] c;\n"
                                "h q[0];\n"
                                "c[0] = measure q[0];\n"
-                               "if (!c[0]) {\n"
+                               "if (c[0]) {\n"
+                               "} else {\n"
                                "  x q[1];\n"
                                "}\n"
                                "x q[0];\n";


### PR DESCRIPTION
## Description

- Introduced a new IfElseOperation class representing conditional branches with optional register or bit comparisons
- Modified the QASM3 importer to generate a single IfElseOperation when an if statement has both then and else blocks
- Extended operation types with an IfElse entry and added string conversions for it
- Updated parser tests to match the new single-if-else output format

Fixes #923  
## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
