### PR TITLE
🚸 Make CMake function for adding Python bindings reusable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ project(
   VERSION ${MQT_CORE_VERSION}
   DESCRIPTION "MQT Core - The Backbone of the Munich Quantum Toolkit")
 
-include(ExternalDependencies)
+include(cmake/ExternalDependencies.cmake)
 include(AddMQTPythonBinding)
 
 # set the include directory for the build tree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ project(
   DESCRIPTION "MQT Core - The Backbone of the Munich Quantum Toolkit")
 
 include(ExternalDependencies)
-include(AddMQTCoreBinding)
+include(AddMQTPythonBinding)
 
 # set the include directory for the build tree
 set(MQT_CORE_INCLUDE_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include/mqt-core")

--- a/bindings/dd/CMakeLists.txt
+++ b/bindings/dd/CMakeLists.txt
@@ -11,7 +11,8 @@ if(NOT TARGET dd)
   file(GLOB_RECURSE DD_SOURCES **.cpp)
 
   # declare the Python module
-  add_mqt_core_binding(
+  add_mqt_python_binding(
+    CORE
     ${MQT_CORE_TARGET_NAME}-dd-bindings
     ${DD_SOURCES}
     MODULE_NAME

--- a/bindings/dd/register_dd.cpp
+++ b/bindings/dd/register_dd.cpp
@@ -51,7 +51,7 @@ struct Matrix {
 };
 Matrix getMatrix(const dd::mEdge& m, size_t numQubits, dd::fp threshold = 0.);
 
-PYBIND11_MODULE(dd, mod, py::mod_gil_not_used()) {
+PYBIND11_MODULE(MQT_CORE_MODULE_NAME, mod, py::mod_gil_not_used()) {
   // Vector Decision Diagrams
   registerVectorDDs(mod);
 

--- a/bindings/ir/CMakeLists.txt
+++ b/bindings/ir/CMakeLists.txt
@@ -11,7 +11,8 @@ if(NOT TARGET ir)
   file(GLOB_RECURSE IR_SOURCES **.cpp)
 
   # declare the Python module
-  add_mqt_core_binding(
+  add_mqt_python_binding(
+    CORE
     ${MQT_CORE_TARGET_NAME}-ir-bindings
     ${IR_SOURCES}
     MODULE_NAME

--- a/bindings/ir/register_ir.cpp
+++ b/bindings/ir/register_ir.cpp
@@ -26,7 +26,7 @@ void registerOperations(py::module& m);
 void registerSymbolic(py::module& m);
 void registerQuantumComputation(py::module& m);
 
-PYBIND11_MODULE(ir, m, py::mod_gil_not_used()) {
+PYBIND11_MODULE(MQT_CORE_MODULE_NAME, m, py::mod_gil_not_used()) {
   registerPermutation(m);
   py::module registers = m.def_submodule("registers");
   registerRegisters(registers);

--- a/cmake/AddMQTPythonBinding.cmake
+++ b/cmake/AddMQTPythonBinding.cmake
@@ -30,6 +30,12 @@ function(add_mqt_python_binding package_name target_name)
   if(ARG_MODULE_NAME)
     # the library name must be the same as the module name
     set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${ARG_MODULE_NAME})
+    target_compile_definitions(${target_name}
+                               PRIVATE MQT_${package_name}_MODULE_NAME=${ARG_MODULE_NAME})
+  else()
+    # use the target name as the module name
+    target_compile_definitions(${target_name}
+                               PRIVATE MQT_${package_name}_MODULE_NAME=${target_name})
   endif()
 
   # add project libraries to the link libraries
@@ -42,5 +48,5 @@ function(add_mqt_python_binding package_name target_name)
   install(
     TARGETS ${target_name}
     DESTINATION ${ARG_INSTALL_DIR}
-    COMPONENT MQT_${package_name}_MODULE_NAME_Python)
+    COMPONENT ${MQT_${package_name}_TARGET_NAME}_Python)
 endfunction()

--- a/cmake/AddMQTPythonBinding.cmake
+++ b/cmake/AddMQTPythonBinding.cmake
@@ -6,15 +6,13 @@
 #
 # Licensed under the MIT License
 
-function(add_mqt_core_binding target_name)
+function(add_mqt_python_binding package_name target_name)
   # parse the arguments
   cmake_parse_arguments(ARG "" "MODULE_NAME;INSTALL_DIR" "LINK_LIBS" ${ARGN})
   set(SOURCES ${ARG_UNPARSED_ARGUMENTS})
 
-  # set default "." for INSTALL_DIR
-  if(NOT ARG_INSTALL_DIR)
-    set(ARG_INSTALL_DIR ".")
-  endif()
+  set(MQT_PACKAGE_MODULE_NAME MQT_${package_name}_MODULE_NAME)
+  set(MQT_PACKAGE_TARGET_NAME MQT_${package_name}_TARGET_NAME)
 
   # declare the Python module
   pybind11_add_module(
@@ -27,13 +25,18 @@ function(add_mqt_core_binding target_name)
     # source code goes here
     ${SOURCES})
 
+  # set default "." for INSTALL_DIR
+  if(NOT ARG_INSTALL_DIR)
+    set(ARG_INSTALL_DIR ".")
+  endif()
+
   if(ARG_MODULE_NAME)
     # the library name must be the same as the module name
     set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${ARG_MODULE_NAME})
-    target_compile_definitions(${target_name} PRIVATE MQT_CORE_MODULE_NAME=${ARG_MODULE_NAME})
+    target_compile_definitions(${target_name} PRIVATE MQT_PACKAGE_MODULE_NAME=${ARG_MODULE_NAME})
   else()
     # use the target name as the module name
-    target_compile_definitions(${target_name} PRIVATE MQT_CORE_MODULE_NAME=${target_name})
+    target_compile_definitions(${target_name} PRIVATE MQT_PACKAGE_MODULE_NAME=${target_name})
   endif()
 
   # add project libraries to the link libraries
@@ -46,5 +49,5 @@ function(add_mqt_core_binding target_name)
   install(
     TARGETS ${target_name}
     DESTINATION ${ARG_INSTALL_DIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Python)
+    COMPONENT ${MQT_PACKAGE_TARGET_NAME}_Python)
 endfunction()

--- a/cmake/AddMQTPythonBinding.cmake
+++ b/cmake/AddMQTPythonBinding.cmake
@@ -11,9 +11,6 @@ function(add_mqt_python_binding package_name target_name)
   cmake_parse_arguments(ARG "" "MODULE_NAME;INSTALL_DIR" "LINK_LIBS" ${ARGN})
   set(SOURCES ${ARG_UNPARSED_ARGUMENTS})
 
-  set(MQT_PACKAGE_MODULE_NAME MQT_${package_name}_MODULE_NAME)
-  set(MQT_PACKAGE_TARGET_NAME MQT_${package_name}_TARGET_NAME)
-
   # declare the Python module
   pybind11_add_module(
     # name of the extension
@@ -33,10 +30,6 @@ function(add_mqt_python_binding package_name target_name)
   if(ARG_MODULE_NAME)
     # the library name must be the same as the module name
     set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${ARG_MODULE_NAME})
-    target_compile_definitions(${target_name} PRIVATE MQT_PACKAGE_MODULE_NAME=${ARG_MODULE_NAME})
-  else()
-    # use the target name as the module name
-    target_compile_definitions(${target_name} PRIVATE MQT_PACKAGE_MODULE_NAME=${target_name})
   endif()
 
   # add project libraries to the link libraries
@@ -49,5 +42,5 @@ function(add_mqt_python_binding package_name target_name)
   install(
     TARGETS ${target_name}
     DESTINATION ${ARG_INSTALL_DIR}
-    COMPONENT ${MQT_PACKAGE_TARGET_NAME}_Python)
+    COMPONENT MQT_${package_name}_MODULE_NAME_Python)
 endfunction()


### PR DESCRIPTION
## Description

This PR makes the function for adding Python bindings reusable across MQT repositories. The function has been added in 

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes or removals~~.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
