### PR TITLE
🎨 Stop pre-commit if there are merge conflicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: check-case-conflict
+      - id: check-merge-conflict
         args: ["--assume-in-merge"]
     fail_fast: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,14 @@ ci:
   skip: [mypy]
 
 repos:
+  # Check for merge conflicts
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-case-conflict
+        args: ["--assume-in-merge"]
+    fail_fast: true
+
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -21,7 +29,6 @@ repos:
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-docstring-first
-      - id: check-merge-conflict
       - id: check-symlinks
       - id: check-toml
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: check-merge-conflict
         args: ["--assume-in-merge"]
-    fail_fast: true
+        fail_fast: true
 
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Description

This PR makes it so that `pre-commit` fails immediately if it detects a merge conflict.

The action added in https://github.com/munich-quantum-toolkit/templates/pull/1 may create PRs with merge conflicts. These merge conflicts should be resolved manually by a developer. The changes in this PR ensure that merge markers are not formatted by subsequent hooks. 

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
