### PR TITLE
🔧 Update CMake configuration for MLIR subproject

### DIFF
--- a/cmake/SetupMLIR.cmake
+++ b/cmake/SetupMLIR.cmake
@@ -7,7 +7,8 @@
 # Licensed under the MIT License
 
 # set the include directory for the build tree
-set(MQT_MLIR_INCLUDE_BUILD_DIR "${CMAKE_SOURCE_DIR}/mlir/include")
+set(MQT_MLIR_SOURCE_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/mlir/include")
+set(MQT_MLIR_BUILD_INCLUDE_DIR "${PROJECT_BINARY_DIR}/mlir/include")
 set(MQT_MLIR_MIN_VERSION 19.0)
 
 # MLIR must be installed on the system
@@ -30,8 +31,8 @@ include(HandleLLVMOptions)
 
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
-include_directories(${MQT_MLIR_INCLUDE_BUILD_DIR})
-include_directories(${CMAKE_BINARY_DIR}/mlir/include)
+include_directories(${MQT_MLIR_SOURCE_INCLUDE_DIR})
+include_directories(${MQT_MLIR_BUILD_INCLUDE_DIR})
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
@@ -41,4 +42,4 @@ add_compile_definitions(MLIR_VERSION_MAJOR=${MLIR_VERSION_MAJOR})
 
 # set the binary directory for the build tree such that, e.g., docs can be generated in the build
 # tree
-set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
+set(MLIR_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -6,8 +6,9 @@
 #
 # Licensed under the MIT License
 
-# add a compile feature for C++17
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD
+    17
+    CACHE STRING "C++ standard to conform to")
 
 # add main library code
 add_subdirectory(include)

--- a/mlir/lib/Dialect/MQTDyn/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/MQTDyn/IR/CMakeLists.txt
@@ -10,8 +10,21 @@ add_mlir_dialect_library(MLIRMQTDyn MQTDynOps.cpp DEPENDS MLIRMQTDynOpsIncGen
                          MLIRMQTDynInterfacesIncGen)
 
 # collect header files
-file(GLOB_RECURSE IR_HEADERS ${MQT_MLIR_INCLUDE_BUILD_DIR}/mlir/Dialect/MQTDyn/IR/*.h)
+file(GLOB_RECURSE IR_HEADERS_SOURCE "${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Dialect/MQTDyn/IR/*.h")
+file(GLOB_RECURSE IR_HEADERS_BUILD "${MQT_MLIR_BUILD_INCLUDE_DIR}/mlir/Dialect/MQTDyn/IR/*.inc")
 
 # add public headers using file sets
-target_sources(MLIRMQTDyn PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_MLIR_INCLUDE_BUILD_DIR} FILES
-                                 ${IR_HEADERS})
+target_sources(
+  MLIRMQTDyn
+  PUBLIC FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_SOURCE_INCLUDE_DIR}
+         FILES
+         ${IR_HEADERS_SOURCE}
+         FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_BUILD_INCLUDE_DIR}
+         FILES
+         ${IR_HEADERS_BUILD})

--- a/mlir/lib/Dialect/MQTDyn/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/MQTDyn/Transforms/CMakeLists.txt
@@ -16,9 +16,23 @@ add_mlir_library(MLIRMQTDynTransforms ${TRANSFORMS_SOURCES} LINK_LIBS ${LIBRARIE
                  MLIRMQTDynTransformsIncGen)
 
 # collect header files
-file(GLOB_RECURSE TRANSFORMS_HEADERS
-     ${MQT_MLIR_INCLUDE_BUILD_DIR}/mlir/Dialect/MQTDyn/Transforms/*.h)
+file(GLOB_RECURSE TRANSFORMS_HEADERS_SOURCE
+     ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Dialect/MQTDyn/Transforms/*.h)
+file(GLOB_RECURSE TRANSFORMS_HEADERS_BUILD
+     ${MQT_MLIR_BUILD_INCLUDE_DIR}/mlir/Dialect/MQTDyn/Transforms/*.inc)
 
 # add public headers using file sets
-target_sources(MLIRMQTDynTransforms PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_MLIR_INCLUDE_BUILD_DIR}
-                                           FILES ${TRANSFORMS_HEADERS})
+target_sources(
+  MLIRMQTDynTransforms
+  PUBLIC FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_SOURCE_INCLUDE_DIR}
+         FILES
+         ${TRANSFORMS_HEADERS_SOURCE}
+         FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_BUILD_INCLUDE_DIR}
+         FILES
+         ${TRANSFORMS_HEADERS_BUILD})

--- a/mlir/lib/Dialect/MQTOpt/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/MQTOpt/IR/CMakeLists.txt
@@ -8,10 +8,22 @@
 
 add_mlir_dialect_library(MLIRMQTOpt MQTOptOps.cpp DEPENDS MLIRMQTOptOpsIncGen
                          MLIRMQTOptInterfacesIncGen)
-
 # collect header files
-file(GLOB_RECURSE IR_HEADERS ${MQT_MLIR_INCLUDE_BUILD_DIR}/mlir/Dialect/MQTOpt/IR/*.h)
+file(GLOB_RECURSE IR_HEADERS_SOURCE "${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Dialect/MQTOpt/IR/*.h")
+file(GLOB_RECURSE IR_HEADERS_BUILD "${MQT_MLIR_BUILD_INCLUDE_DIR}/mlir/Dialect/MQTOpt/IR/*.inc")
 
 # add public headers using file sets
-target_sources(MLIRMQTOpt PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_MLIR_INCLUDE_BUILD_DIR} FILES
-                                 ${IR_HEADERS})
+target_sources(
+  MLIRMQTOpt
+  PUBLIC FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_SOURCE_INCLUDE_DIR}
+         FILES
+         ${IR_HEADERS_SOURCE}
+         FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_BUILD_INCLUDE_DIR}
+         FILES
+         ${IR_HEADERS_BUILD})

--- a/mlir/lib/Dialect/MQTOpt/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/CMakeLists.txt
@@ -16,9 +16,23 @@ add_mlir_library(MLIRMQTOptTransforms ${TRANSFORMS_SOURCES} LINK_LIBS ${LIBRARIE
                  MLIRMQTOptTransformsIncGen)
 
 # collect header files
-file(GLOB_RECURSE TRANSFORMS_HEADERS
-     ${MQT_MLIR_INCLUDE_BUILD_DIR}/mlir/Dialect/MQTOpt/Transforms/*.h)
+file(GLOB_RECURSE TRANSFORMS_HEADERS_SOURCE
+     ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Dialect/MQTOpt/Transforms/*.h)
+file(GLOB_RECURSE TRANSFORMS_HEADERS_BUILD
+     ${MQT_MLIR_BUILD_INCLUDE_DIR}/mlir/Dialect/MQTOpt/Transforms/*.inc)
 
 # add public headers using file sets
-target_sources(MLIRMQTOptTransforms PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_MLIR_INCLUDE_BUILD_DIR}
-                                           FILES ${TRANSFORMS_HEADERS})
+target_sources(
+  MLIRMQTOptTransforms
+  PUBLIC FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_SOURCE_INCLUDE_DIR}
+         FILES
+         ${TRANSFORMS_HEADERS_SOURCE}
+         FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_BUILD_INCLUDE_DIR}
+         FILES
+         ${TRANSFORMS_HEADERS_BUILD})


### PR DESCRIPTION
## Description

This PR takes some of the lessons learned from working on #881 and adjusts the CMake configuration for the MLIR subproject.

In particular, it fixes the header file sets to also include the header generated in the build folder.
It also fixes some of the CMake variable used in the `SetupMLIR.cmake` script so that the script still works, when MQT Core is used as a submodule.
Lastly, this PR turns the `CMAKE_CXX_STANDARD` into a cache variable, which seems to be the recommended best practice because it allows overriding the standard from a top-level project.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
