### PR TITLE
🔥 do not eagerly import Qiskit plugin

### DIFF
--- a/python/mqt/core/plugins/__init__.py
+++ b/python/mqt/core/plugins/__init__.py
@@ -7,11 +7,3 @@
 # Licensed under the MIT License
 
 """Plugins for the core package."""
-
-from __future__ import annotations
-
-from . import qiskit
-
-__all__ = [
-    "qiskit",
-]


### PR DESCRIPTION
## Description

This PR removes the reexport of the `qiskit` plugin in the `mqt.core.plugins` module.
It was noticed during working on #881 that this would lead to Python trying to import the plugin even if that was not explicitly requested, e.g. as part of an import `from mqt.core.plugins.catalyst import ...`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.