### PR TITLE
🚨 Silence two compiler warnings in the DD submodule

### DIFF
--- a/include/mqt-core/dd/Node.hpp
+++ b/include/mqt-core/dd/Node.hpp
@@ -57,7 +57,7 @@ struct NodeBase : LLBase {
   void mark() noexcept { flags |= MARK_FLAG; }
 
   /// @brief Unmark the node.
-  void unmark() noexcept { flags &= ~MARK_FLAG; }
+  void unmark() noexcept { flags &= static_cast<uint16_t>(~MARK_FLAG); }
 
   /// Getter for the next object.
   [[nodiscard]] NodeBase* next() const noexcept {

--- a/src/dd/Approximation.cpp
+++ b/src/dd/Approximation.cpp
@@ -42,8 +42,8 @@ public:
       : ptr(node), contribution(1.),
         distance(std::numeric_limits<double>::max()) {}
 
-  LayerNode(vNode* node, double contribution, double budget)
-      : ptr(node), contribution(contribution),
+  LayerNode(vNode* node, const double fidelityContribution, double budget)
+      : ptr(node), contribution(fidelityContribution),
         distance(std::max<double>(0, contribution - budget)) {}
 
   bool operator<(const LayerNode& other) const {


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->

## Description

This PR fixes two compiler warnings raised in the DD package submodule.
This was noticed while working on munich-quantum-toolkit/qcec#646.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
