### PR TITLE
✨ Add `Qubit` operation to `mqtopt` dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 - ♻️ Update the `measure` operations in the MLIR dialects to no longer support more than one qubit being measured at once ([#1106]) ([**@DRovara**])
 - ✨ Add MQT's implementation of a QDMI Device for neutral atom-based quantum computing ([#996]) ([**@ystade**])
 - ✨ Add `qubit` operation to the `MQTRef` (previously `MQTDyn`) dialect for static qubit addressing ([#1098]) ([**@MatthiasReumann**])
+- ✨ Add `qubit` operation to the `MQTOpt` dialect for static qubit addressing ([#1116]) ([**@MatthiasReumann**])
 
 ### Changed
 
@@ -162,6 +163,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1116]: https://github.com/munich-quantum-toolkit/core/pull/1116
 [#1106]: https://github.com/munich-quantum-toolkit/core/pull/1106
 [#1099]: https://github.com/munich-quantum-toolkit/core/pull/1099
 [#1098]: https://github.com/munich-quantum-toolkit/core/pull/1098

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
+- ✨ Add `qubit` operation to the `MQTOpt` dialect for static qubit addressing ([#1116]) ([**@MatthiasReumann**])
 - ✨ Add translation from `QuantumComputation` to the `MQTRef` MLIR dialect ([#1099]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add `reset` operations to the `MQTDyn` and `MQTOpt` MLIR dialects ([#1106]) ([**@DRovara**])
 - ♻️ Update the `measure` operations in the MLIR dialects to no longer support more than one qubit being measured at once ([#1106]) ([**@DRovara**])
 - ✨ Add MQT's implementation of a QDMI Device for neutral atom-based quantum computing ([#996]) ([**@ystade**])
 - ✨ Add `qubit` operation to the `MQTRef` (previously `MQTDyn`) dialect for static qubit addressing ([#1098]) ([**@MatthiasReumann**])
-- ✨ Add `qubit` operation to the `MQTOpt` dialect for static qubit addressing ([#1116]) ([**@MatthiasReumann**])
 
 ### Changed
 

--- a/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptOps.td
+++ b/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptOps.td
@@ -272,7 +272,7 @@ def InsertOp : ResourceOp<"insertQubit", [UniqueIndexDefinition]> {
 }
 
 def QubitOp : ResourceOp<"qubit"> {
-    let summary = "Assign static qubit reference";
+    let summary = "Retrieve static qubit";
     let description = [{
         The `mqtopt.qubit` operation produces an SSA value from the given index
         to a static (hardware) qubit.

--- a/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptOps.td
+++ b/mlir/include/mlir/Dialect/MQTOpt/IR/MQTOptOps.td
@@ -49,6 +49,9 @@ def MQTOptDialect : Dialect {
         For more information, see the paper "QIRO:A Static Single Assignment
         based Quantum Program Representation for Optimization"
         (https://doi.org/10.1145/3491247)
+
+        The `mqtopt` dialect supports dynamic as well as static qubit
+        addressing.
     }];
 
     // The C++ namespace that the dialect, and all sub-components, get placed
@@ -71,7 +74,7 @@ class MQTOptType<string name, string typeMnemonic, list<Trait> traits = []>
 }
 
 def QubitType : MQTOptType<"Qubit", "Qubit"> {
-    let summary = "A value-semantic qubit (state).";
+    let summary = "A value-semantic (dynamic or static) qubit (state).";
 }
 
 def QregType : MQTOptType<"QubitRegister", "QubitRegister"> {
@@ -250,8 +253,10 @@ def InsertOp : ResourceOp<"insertQubit", [UniqueIndexDefinition]> {
         This class represents an operation that inserts a qubit back into a qubit
         register. Before, the same underlying qubit must have been extracted
         from the same register at the same index. However, this property is not
-        enforced by the dialect. It is naturally satisfied when a program in the
-        mqt input dialect is converted to the mqto dialect.
+        enforced by the dialect. Moreover, the dialect permits the (invalid) insertion
+        of static qubits into registers. The dialect avoids these issues by relying on
+        the fact that the conversion from `mqtref` to `mqtopt` will never produce these
+        invalid operations.
     }];
 
     let arguments = (ins
@@ -264,6 +269,26 @@ def InsertOp : ResourceOp<"insertQubit", [UniqueIndexDefinition]> {
     let results = (outs
         QregType:$out_qreg
     );
+}
+
+def QubitOp : ResourceOp<"qubit"> {
+    let summary = "Assign static qubit reference";
+    let description = [{
+        The `mqtopt.qubit` operation produces an SSA value from the given index
+        to a static (hardware) qubit.
+
+        Example:
+        ```mlir
+        // Static (hardware) qubit with address '0'.
+        %q = "mqtopt.qubit"() <{index = 0 : i64}> : () -> !mqtopt.Qubit
+
+        // Using custom assembly.
+        %q = mqtopt.qubit 0
+        ```
+    }];
+    let arguments = (ins ConfinedAttr<I64Attr, [IntNonNegative]>:$index);
+    let results = (outs QubitType:$qubit);
+    let assemblyFormat = " attr-dict $index ";
 }
 
 #endif // MQTOPT_OPS

--- a/mlir/lib/Conversion/MQTOptToMQTRef/MQTOptToMQTRef.cpp
+++ b/mlir/lib/Conversion/MQTOptToMQTRef/MQTOptToMQTRef.cpp
@@ -179,11 +179,8 @@ struct ConvertMQTOptQubit final : OpConversionPattern<opt::QubitOp> {
   LogicalResult
   matchAndRewrite(opt::QubitOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
-    // prepare result type
     const auto& qubitType = ref::QubitType::get(rewriter.getContext());
-
     rewriter.replaceOpWithNewOp<ref::QubitOp>(op, qubitType, op.getIndex());
-
     return success();
   }
 };

--- a/mlir/lib/Conversion/MQTOptToMQTRef/MQTOptToMQTRef.cpp
+++ b/mlir/lib/Conversion/MQTOptToMQTRef/MQTOptToMQTRef.cpp
@@ -173,6 +173,21 @@ struct ConvertMQTOptReset final : OpConversionPattern<opt::ResetOp> {
   }
 };
 
+struct ConvertMQTOptQubit final : OpConversionPattern<opt::QubitOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(opt::QubitOp op, OpAdaptor /*adaptor*/,
+                  ConversionPatternRewriter& rewriter) const override {
+    // prepare result type
+    const auto& qubitType = ref::QubitType::get(rewriter.getContext());
+
+    rewriter.replaceOpWithNewOp<ref::QubitOp>(op, qubitType, op.getIndex());
+
+    return success();
+  }
+};
+
 template <typename MQTGateOptOp, typename MQTGateRefOp>
 struct ConvertMQTOptGateOp final : OpConversionPattern<MQTGateOptOp> {
   using OpConversionPattern<MQTGateOptOp>::OpConversionPattern;
@@ -232,10 +247,9 @@ struct MQTOptToMQTRef final : impl::MQTOptToMQTRefBase<MQTOptToMQTRef> {
     target.addIllegalDialect<opt::MQTOptDialect>();
     target.addLegalDialect<ref::MQTRefDialect>();
 
-    patterns
-        .add<ConvertMQTOptAlloc, ConvertMQTOptDealloc, ConvertMQTOptInsert,
-             ConvertMQTOptExtract, ConvertMQTOptMeasure, ConvertMQTOptReset>(
-            typeConverter, context);
+    patterns.add<ConvertMQTOptAlloc, ConvertMQTOptDealloc, ConvertMQTOptInsert,
+                 ConvertMQTOptExtract, ConvertMQTOptMeasure, ConvertMQTOptReset,
+                 ConvertMQTOptQubit>(typeConverter, context);
 
     ADD_CONVERT_PATTERN(GPhaseOp)
     ADD_CONVERT_PATTERN(IOp)

--- a/mlir/lib/Conversion/MQTRefToMQTOpt/MQTRefToMQTOpt.cpp
+++ b/mlir/lib/Conversion/MQTRefToMQTOpt/MQTRefToMQTOpt.cpp
@@ -296,7 +296,6 @@ struct ConvertMQTRefQubit final : StatefulOpConversionPattern<ref::QubitOp> {
   LogicalResult
   matchAndRewrite(ref::QubitOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
-
     // prepare result type
     const auto& qubitType = opt::QubitType::get(rewriter.getContext());
 

--- a/mlir/lib/Conversion/MQTRefToMQTOpt/MQTRefToMQTOpt.cpp
+++ b/mlir/lib/Conversion/MQTRefToMQTOpt/MQTRefToMQTOpt.cpp
@@ -311,8 +311,9 @@ struct ConvertMQTRefQubit final : StatefulOpConversionPattern<ref::QubitOp> {
     // map ref to opt
     getState().qubitMap[refQubit] = optQubit;
 
-    // delete the old operation
-    rewriter.eraseOp(op);
+    // replace the old operation result with the new result and delete
+    // old operation
+    rewriter.replaceOp(op, optQubit);
 
     return success();
   }

--- a/mlir/test/Conversion/mqtopt-to-mqtref.mlir
+++ b/mlir/test/Conversion/mqtopt-to-mqtref.mlir
@@ -449,10 +449,10 @@ module {
 }
 
 // -----
-// This test checks if a Bell state is converted correctly.
+// This test checks if a Bell state is converted correctly for static qubits.
 module {
-    // CHECK-LABEL: func.func @bellState()
-    func.func @bellState() {
+    // CHECK-LABEL: func.func @bellStateStatic()
+    func.func @bellStateStatic() {
         // CHECK: %[[q_0:.*]] = mqtref.qubit 0
         // CHECK: %[[q_1:.*]] = mqtref.qubit 1
         // CHECK: mqtref.h() %[[q_0]]

--- a/mlir/test/Conversion/mqtopt-to-mqtref.mlir
+++ b/mlir/test/Conversion/mqtopt-to-mqtref.mlir
@@ -434,3 +434,40 @@ module {
         return
     }
 }
+
+// -----
+// This test checks if the QubitOp is converted correctly
+module {
+    // CHECK-LABEL: func.func @testConvertQubitOp
+    func.func @testConvertQubitOp() {
+        // CHECK: %[[Q0:.*]] = mqtref.qubit 0
+        // CHECK-NOT: %[[ANY:.*]] = mqtopt.qubit 0
+
+        %q0 = mqtopt.qubit 0
+        return
+    }
+}
+
+// -----
+// This test checks if a Bell state is converted correctly.
+module {
+    // CHECK-LABEL: func.func @bellState()
+    func.func @bellState() {
+        // CHECK: %[[q_0:.*]] = mqtref.qubit 0
+        // CHECK: %[[q_1:.*]] = mqtref.qubit 1
+        // CHECK: mqtref.h() %[[q_0]]
+        // CHECK: mqtref.x() %[[q_1]] ctrl %[[q_0]]
+        // CHECK: %[[m_0:.*]] = "mqtref.measure"(%[[q_0]]) : (!mqtref.Qubit) -> i1
+        // CHECK: %[[m_1:.*]] = "mqtref.measure"(%[[q_1]]) : (!mqtref.Qubit) -> i1
+
+        %q0 = mqtopt.qubit 0
+        %q1 = mqtopt.qubit 1
+
+        %q0_1 = mqtopt.h() %q0 : !mqtopt.Qubit
+        %q1_1, %q0_2 = mqtopt.x() %q1 ctrl %q0_1 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q0_3, %m0 = "mqtopt.measure"(%q0_2) : (!mqtopt.Qubit) -> (!mqtopt.Qubit, i1)
+        %q1_2, %m1 = "mqtopt.measure"(%q1_1) : (!mqtopt.Qubit) -> (!mqtopt.Qubit, i1)
+
+        return
+    }
+}

--- a/mlir/test/Conversion/mqtref-to-mqtopt.mlir
+++ b/mlir/test/Conversion/mqtref-to-mqtopt.mlir
@@ -403,7 +403,7 @@ module {
     // CHECK-LABEL: func.func @testConvertGPhaseOp()
     func.func @testConvertGPhaseOp() {
         // CHECK: %[[c_0:.*]] = arith.constant 3.000000e-01 : f64
-        // mqtopt.gphase(%[[c_0]])
+        // CHECK: mqtopt.gphase(%[[c_0]])
 
         %cst = arith.constant 3.000000e-01 : f64
         mqtref.gphase(%cst)
@@ -461,6 +461,7 @@ module {
         return
     }
 }
+
 // -----
 // This test checks if a barrierOp with multiple inputs is converted correctly
 module {
@@ -473,6 +474,43 @@ module {
         %q1 = "mqtref.extractQubit"(%r0) <{index_attr = 1 : i64}> : (!mqtref.QubitRegister) -> !mqtref.Qubit
         mqtref.barrier() %q0, %q1
         "mqtref.deallocQubitRegister"(%r0) : (!mqtref.QubitRegister) -> ()
+        return
+    }
+}
+
+// -----
+// This test checks if the QubitOp is converted correctly
+module {
+    // CHECK-LABEL: func.func @testConvertQubitOp
+    func.func @testConvertQubitOp() {
+        // CHECK: %[[Q0:.*]] = mqtopt.qubit 0
+        // CHECK-NOT: %[[ANY:.*]] = mqtref.qubit 0
+
+        %q0 = mqtref.qubit 0
+        return
+    }
+}
+
+// -----
+// This test checks if a Bell state is converted correctly for static qubits.
+module {
+    // CHECK-LABEL: func.func @bellConvertStateStatic()
+    func.func @bellConvertStateStatic() {
+        // CHECK: %[[q0_1:.*]] = mqtopt.qubit 0
+        // CHECK: %[[q1_1:.*]] = mqtopt.qubit 1
+        // CHECK: %[[q0_2:.*]] = mqtopt.h() %[[q0_1]] : !mqtopt.Qubit
+        // CHECK: %[[q1_2:.*]], %[[q0_3:.*]] = mqtopt.x() %[[q1_1:.*]] ctrl %[[q0_2:.*]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[q0_4:.*]], [[m0_0:.*]] = "mqtopt.measure"(%[[q0_3]])
+        // CHECK: %[[q1_3:.*]], %[[m1_0:.*]] = "mqtopt.measure"(%[[q1_2]]) : (!mqtopt.Qubit) -> (!mqtopt.Qubit, i1)
+
+        %q0 = mqtref.qubit 0
+        %q1 = mqtref.qubit 1
+
+        mqtref.h() %q0
+        mqtref.x() %q1 ctrl %q0
+        %m0 = "mqtref.measure"(%q0) : (!mqtref.Qubit) -> i1
+        %m1 = "mqtref.measure"(%q1) : (!mqtref.Qubit) -> i1
+
         return
     }
 }

--- a/mlir/test/Dialect/MQTOpt/IR/dialect_features.mlir
+++ b/mlir/test/Dialect/MQTOpt/IR/dialect_features.mlir
@@ -151,8 +151,8 @@ module {
         // CHECK: %[[Q_1:.*]], [[M0_0:.*]] = "mqtopt.measure"(%[[ANY:.*]])
 
         %q_0 = mqtopt.qubit 0
-
         %q_1, %m0_0 = "mqtopt.measure"(%q_0) : (!mqtopt.Qubit) -> (!mqtopt.Qubit, i1)
+
         return
     }
 }
@@ -181,7 +181,6 @@ module {
         // CHECK: %[[Q_1:.*]] = "mqtopt.reset"(%[[ANY:.*]])
 
         %q_0 = mqtopt.qubit 0
-
         %q_1 = "mqtopt.reset"(%q_0) : (!mqtopt.Qubit) -> (!mqtopt.Qubit)
 
         return

--- a/mlir/test/Dialect/MQTOpt/IR/dialect_features.mlir
+++ b/mlir/test/Dialect/MQTOpt/IR/dialect_features.mlir
@@ -144,7 +144,21 @@ module {
 }
 
 // -----
-// This test checks if the ResetOp is parsed and handled correctly.
+// This test checks if the MeasureOp on a static qubit is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testMeasureOpStatic
+    func.func @testMeasureOpStatic() {
+        // CHECK: %[[Q_1:.*]], [[M0_0:.*]] = "mqtopt.measure"(%[[ANY:.*]])
+
+        %q_0 = mqtopt.qubit 0
+
+        %q_1, %m0_0 = "mqtopt.measure"(%q_0) : (!mqtopt.Qubit) -> (!mqtopt.Qubit, i1)
+        return
+    }
+}
+
+// -----
+// This test checks if the ResetOp on a dynamic qubit is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testResetOp
     func.func @testResetOp() {
@@ -155,6 +169,21 @@ module {
         %q_1 = "mqtopt.reset"(%q_0) : (!mqtopt.Qubit) -> (!mqtopt.Qubit)
         %reg_2 = "mqtopt.insertQubit"(%reg_1, %q_1) <{index_attr = 0 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
         "mqtopt.deallocQubitRegister"(%reg_2) : (!mqtopt.QubitRegister) -> ()
+        return
+    }
+}
+
+// -----
+// This test checks if the ResetOp on a static qubit is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testResetOpStatic
+    func.func @testResetOpStatic() {
+        // CHECK: %[[Q_1:.*]] = "mqtopt.reset"(%[[ANY:.*]])
+
+        %q_0 = mqtopt.qubit 0
+
+        %q_1 = "mqtopt.reset"(%q_0) : (!mqtopt.Qubit) -> (!mqtopt.Qubit)
+
         return
     }
 }
@@ -218,7 +247,45 @@ module {
 }
 
 // -----
-// This test checks if single qubit gates are parsed and handled correctly.
+// This test checks if no-target operations with static controls are parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testNoTargetWithStaticControls
+    func.func @testNoTargetWithStaticControls() {
+        // CHECK: %[[C0_F64:.*]] = arith.constant 3.000000e-01
+        // CHECK: %[[Q0_1:.*]] = mqtopt.gphase(%[[C0_F64]]) ctrl %[[ANY:.*]] : ctrl !mqtopt.Qubit
+        // CHECK: %[[Q01:.*]]:2 = mqtopt.gphase(%[[C0_F64]]) ctrl %[[Q0_1]], %[[ANY:.*]] : ctrl !mqtopt.Qubit, !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+
+        %c0_f64 = arith.constant 3.000000e-01 : f64
+        %q0_1 = mqtopt.gphase(%c0_f64) ctrl %q0_0 : ctrl !mqtopt.Qubit
+        %q0_2, %q1_1 = mqtopt.gphase(%c0_f64) ctrl %q0_1, %q1_0 : ctrl !mqtopt.Qubit, !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if no-target operations with positive and negative static controls are parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testNoTargetPositiveNegativeStaticControls
+    func.func @testNoTargetPositiveNegativeStaticControls() {
+        // CHECK: %[[C0_F64:.*]] = arith.constant 3.000000e-01
+        // CHECK: %[[Q0_1:.*]], %[[Q1_1:.*]] = mqtopt.gphase(%[[C0_F64]]) ctrl %[[ANY:.*]] : ctrl !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+
+        %c0_f64 = arith.constant 3.000000e-01 : f64
+        %q0_1, %q1_1 = mqtopt.gphase(%c0_f64) ctrl %q0_0 nctrl %q1_0 : ctrl !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if single qubit gates on dynamic qubits are parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testSingleQubitOp
     func.func @testSingleQubitOp() {
@@ -258,7 +325,46 @@ module {
 }
 
 // -----
-// This test checks if parameterized single qubit gates are parsed and handled correctly.
+// This test checks if single qubit gates on static qubits are parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testSingleQubitOpStatic
+    func.func @testSingleQubitOpStatic() {
+        // CHECK: %[[Q_1:.*]] = mqtopt.i() %[[ANY:.*]] : !mqtopt.Qubit
+        // CHECK: %[[Q_2:.*]] = mqtopt.h() %[[Q_1]] : !mqtopt.Qubit
+        // CHECK: %[[Q_3:.*]] = mqtopt.x() %[[Q_2]] : !mqtopt.Qubit
+        // CHECK: %[[Q_4:.*]] = mqtopt.y() %[[Q_3]] : !mqtopt.Qubit
+        // CHECK: %[[Q_5:.*]] = mqtopt.z() %[[Q_4]] : !mqtopt.Qubit
+        // CHECK: %[[Q_6:.*]] = mqtopt.s() %[[Q_5]] : !mqtopt.Qubit
+        // CHECK: %[[Q_7:.*]] = mqtopt.sdg() %[[Q_6]] : !mqtopt.Qubit
+        // CHECK: %[[Q_8:.*]] = mqtopt.t() %[[Q_7]] : !mqtopt.Qubit
+        // CHECK: %[[Q_9:.*]] = mqtopt.tdg() %[[Q_8]] : !mqtopt.Qubit
+        // CHECK: %[[Q_10:.*]] = mqtopt.v() %[[Q_9]] : !mqtopt.Qubit
+        // CHECK: %[[Q_11:.*]] = mqtopt.vdg() %[[Q_10]] : !mqtopt.Qubit
+        // CHECK: %[[Q_12:.*]] = mqtopt.sx() %[[Q_11]] : !mqtopt.Qubit
+        // CHECK: %[[Q_13:.*]] = mqtopt.sxdg() %[[Q_12]] : !mqtopt.Qubit
+
+        %q_0 = mqtopt.qubit 0
+
+        %q_1 = mqtopt.i() %q_0 : !mqtopt.Qubit
+        %q_2 = mqtopt.h() %q_1 : !mqtopt.Qubit
+        %q_3 = mqtopt.x() %q_2 : !mqtopt.Qubit
+        %q_4 = mqtopt.y() %q_3 : !mqtopt.Qubit
+        %q_5 = mqtopt.z() %q_4 : !mqtopt.Qubit
+        %q_6 = mqtopt.s() %q_5 : !mqtopt.Qubit
+        %q_7 = mqtopt.sdg() %q_6 : !mqtopt.Qubit
+        %q_8 = mqtopt.t() %q_7 : !mqtopt.Qubit
+        %q_9 = mqtopt.tdg() %q_8 : !mqtopt.Qubit
+        %q_10 = mqtopt.v() %q_9 : !mqtopt.Qubit
+        %q_11 = mqtopt.vdg() %q_10 : !mqtopt.Qubit
+        %q_12 = mqtopt.sx() %q_11 : !mqtopt.Qubit
+        %q_13 = mqtopt.sxdg() %q_12 : !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if parameterized single qubit gates on dynamic qubits are parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testSingleQubitRotationOp
     func.func @testSingleQubitRotationOp() {
@@ -286,7 +392,35 @@ module {
 }
 
 // -----
-// This test checks if controlled parameterized single qubit gates are parsed and handled correctly.
+// This test checks if parameterized single qubit gates on static qubits are parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testSingleQubitRotationOpStatic
+    func.func @testSingleQubitRotationOpStatic() {
+        // CHECK: %[[C0_F64:.*]] = arith.constant 3.000000e-01
+        // CHECK: %[[Q_1:.*]] = mqtopt.u(%[[C0_F64]], %[[C0_F64]], %[[C0_F64]]) %[[ANY:.*]] : !mqtopt.Qubit
+        // CHECK: %[[Q_2:.*]] = mqtopt.u2(%[[C0_F64]], %[[C0_F64]] static [] mask [false, false]) %[[Q_1]] : !mqtopt.Qubit
+        // CHECK: %[[Q_3:.*]] = mqtopt.p(%[[C0_F64]]) %[[Q_2]] : !mqtopt.Qubit
+        // CHECK: %[[Q_4:.*]] = mqtopt.rx(%[[C0_F64]]) %[[Q_3]] : !mqtopt.Qubit
+        // CHECK: %[[Q_5:.*]] = mqtopt.ry(%[[C0_F64]]) %[[Q_4]] : !mqtopt.Qubit
+        // CHECK: %[[Q_6:.*]] = mqtopt.rz(%[[C0_F64]]) %[[Q_5]] : !mqtopt.Qubit
+
+        %q_0 = mqtopt.qubit 0
+
+        %c0_f64 = arith.constant 3.000000e-01 : f64
+        %q_1 = mqtopt.u(%c0_f64, %c0_f64, %c0_f64) %q_0 : !mqtopt.Qubit
+        %q_2 = mqtopt.u2(%c0_f64, %c0_f64 static [] mask [false, false]) %q_1 : !mqtopt.Qubit
+        %q_3 = mqtopt.p(%c0_f64) %q_2 : !mqtopt.Qubit
+        %q_4 = mqtopt.rx(%c0_f64) %q_3 : !mqtopt.Qubit
+        %q_5 = mqtopt.ry(%c0_f64) %q_4 : !mqtopt.Qubit
+        %q_6 = mqtopt.rz(%c0_f64) %q_5 : !mqtopt.Qubit
+
+        return
+    }
+}
+
+
+// -----
+// This test checks if controlled parameterized single qubit gates on dynamic qubits are parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testControlledSingleQubitRotationOp
     func.func @testControlledSingleQubitRotationOp() {
@@ -316,7 +450,35 @@ module {
 }
 
 // -----
-// This test checks if an CX gate is parsed and handled correctly.
+// This test checks if controlled parameterized single qubit gates on static qubits are parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testControlledSingleQubitRotationOpStatic
+    func.func @testControlledSingleQubitRotationOpStatic() {
+        // CHECK: %[[C0_F64:.*]] = arith.constant 3.000000e-01
+        // CHECK: %[[Q0_1:.*]], %[[Q1_1:.*]] = mqtopt.u(%[[C0_F64]], %[[C0_F64]], %[[C0_F64]]) %[[ANY:.*]] ctrl %[[ANY:.*]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q0_2:.*]], %[[Q1_2:.*]] = mqtopt.u2(%[[C0_F64]], %[[C0_F64]]) %[[Q0_1]] ctrl %[[Q1_1]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q0_3:.*]], %[[Q1_3:.*]] = mqtopt.p(%[[C0_F64]]) %[[Q0_2]] ctrl %[[Q1_2]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q0_4:.*]], %[[Q1_4:.*]] = mqtopt.rx(%[[C0_F64]]) %[[Q0_3]] ctrl %[[Q1_3]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q0_5:.*]], %[[Q1_5:.*]] = mqtopt.ry(%[[C0_F64]]) %[[Q0_4]] ctrl %[[Q1_4]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q0_6:.*]], %[[Q1_6:.*]] = mqtopt.rz(%[[C0_F64]]) %[[Q0_5]] ctrl %[[Q1_5]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+
+        %c0_f64 = arith.constant 3.000000e-01 : f64
+        %q0_1, %q1_1 = mqtopt.u(%c0_f64, %c0_f64, %c0_f64) %q0_0 ctrl %q1_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q0_2, %q1_2 = mqtopt.u2(%c0_f64, %c0_f64) %q0_1 ctrl %q1_1 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q0_3, %q1_3 = mqtopt.p(%c0_f64) %q0_2 ctrl %q1_2 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q0_4, %q1_4 = mqtopt.rx(%c0_f64) %q0_3 ctrl %q1_3 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q0_5, %q1_5 = mqtopt.ry(%c0_f64) %q0_4 ctrl %q1_4 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q0_6, %q1_6 = mqtopt.rz(%c0_f64) %q0_5 ctrl %q1_5 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if an CX gate on dynamic qubits is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testCXOp
     func.func @testCXOp() {
@@ -334,7 +496,7 @@ module {
 }
 
 // -----
-// This test checks if a negative CX gate is parsed and handled correctly.
+// This test checks if a negative CX gate on dynamic qubits is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testNegativeCXOp
     func.func @testNegativeCXOp() {
@@ -352,7 +514,39 @@ module {
 }
 
 // -----
-// This test checks if an MCX gate is parsed and handled correctly.
+// This test checks if an CX gate on static qubits is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testCXOpStatic
+    func.func @testCXOpStatic() {
+        // CHECK: %[[Q1_1:.*]], %[[Q0_1:.*]] = mqtopt.x() %[[ANY:.*]] ctrl %[[ANY:.*]] : !mqtopt.Qubit ctrl !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+
+        %q1_1, %q0_1 = mqtopt.x() %q1_0 ctrl %q0_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if a negative CX gate on static qubits is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testNegativeCXOpStatic
+    func.func @testNegativeCXOpStatic() {
+        // CHECK: %[[Q1_1:.*]], %[[Q0_1:.*]] = mqtopt.x() %[[ANY:.*]] nctrl %[[ANY:.*]] : !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+
+        %q1_1, %q0_1 = mqtopt.x() %q1_0 nctrl %q0_0 : !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if an MCX gate on dynamic qubits is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testMCXOp
     func.func @testMCXOp() {
@@ -380,8 +574,34 @@ module {
     }
 }
 
+
 // -----
-// This test checks if an MCX gate is parsed and handled correctly.
+// This test checks if an MCX gate on static qubits is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testMCXOpStatic
+    func.func @testMCXOpStatic() {
+        // CHECK: %[[Q1_1:.*]], %[[Q02_1:.*]]:2 = mqtopt.x() %[[ANY:.*]] ctrl %[[ANY:.*]], %[[ANY:.*]] : !mqtopt.Qubit ctrl !mqtopt.Qubit, !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+        %q2_0 = mqtopt.qubit 2
+
+        //===------------------------------------------------------------------===//
+        // q0_0: ──■── q02_1#0
+        //       ┌─┴─┐
+        // q1_0: ┤ X ├ q1_1
+        //       └─┬─┘
+        // q2_0: ──■── q02_1#1
+        //===----------------------------------------------------------------===//
+
+        %q1_1, %q02_1:2 = mqtopt.x() %q1_0 ctrl %q0_0, %q2_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit, !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if an MCX gate on dynamic qubits is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testMCXOpAlternativeFormat
     func.func @testMCXOpAlternativeFormat() {
@@ -411,7 +631,32 @@ module {
 }
 
 // -----
-// This test checks if a negative MCX gate is parsed and handled correctly.
+// This test checks if an MCX gate on static qubits is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testMCXOpAlternativeFormatStatic
+    func.func @testMCXOpAlternativeFormatStatic() {
+        // CHECK: %[[Q1_1:.*]], %[[Q02_1:.*]]:2 = mqtopt.x() %[[ANY:.*]] ctrl %[[ANY:.*]], %[[ANY:.*]] : !mqtopt.Qubit ctrl !mqtopt.Qubit, !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+        %q2_0 = mqtopt.qubit 2
+
+        //===------------------------------------------------------------------===//
+        // q0_0: ──■── q102_1#0
+        //       ┌─┴─┐
+        // q1_0: ┤ X ├ q102_1#1
+        //       └─┬─┘
+        // q2_0: ──■── q102_1#2
+        //===----------------------------------------------------------------===//
+
+        %q102_1:3 = mqtopt.x() %q1_0 ctrl %q0_0, %q2_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit, !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if a negative MCX gate on dynamic qubits is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testNegativeMCXOp
     func.func @testNegativeMCXOp() {
@@ -440,7 +685,32 @@ module {
 }
 
 // -----
-// This test checks if an MCX gate is parsed and handled correctly using different types of controls.
+// This test checks if a negative MCX gate on static qubits is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testNegativeMCXOpStatic
+    func.func @testNegativeMCXOpStatic() {
+        // CHECK: %[[Q1_1:.*]], %[[Q02_1:.*]]:2 = mqtopt.x() %[[ANY:.*]] nctrl %[[ANY:.*]], %[[ANY:.*]] : !mqtopt.Qubit nctrl !mqtopt.Qubit, !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+        %q2_0 = mqtopt.qubit 2
+
+        //===------------------------------------------------------------------===//
+        // q0_0: ──○── q02_1#0
+        //       ┌─┴─┐
+        // q1_0: ┤ X ├ q1_1
+        //       └─┬─┘
+        // q2_0: ──○── q02_1#1
+        //===----------------------------------------------------------------===//
+
+        %q1_1, %q02_1:2 = mqtopt.x() %q1_0 nctrl %q0_0, %q2_0 : !mqtopt.Qubit nctrl !mqtopt.Qubit, !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if an MCX gate on dynamic qubits is parsed and handled correctly using different types of controls.
 module {
     // CHECK-LABEL: func.func @testMixedMCXOp
     func.func @testMixedMCXOp() {
@@ -469,7 +739,32 @@ module {
 }
 
 // -----
-// This test checks if two target gates are parsed and handled correctly.
+// This test checks if an MCX gate on static qubits is parsed and handled correctly using different types of controls.
+module {
+    // CHECK-LABEL: func.func @testMixedMCXOpStatic
+    func.func @testMixedMCXOpStatic() {
+        // CHECK: %[[Q1_1:.*]], %[[Q0_1:.*]], %[[Q2_1:.*]] = mqtopt.x() %[[ANY:.*]] ctrl %[[ANY:.*]] nctrl %[[ANY:.*]] : !mqtopt.Qubit ctrl !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+        %q2_0 = mqtopt.qubit 2
+
+        //===------------------------------------------------------------------===//
+        // q0_0: ──■── q0_1
+        //       ┌─┴─┐
+        // q1_0: ┤ X ├ q1_1
+        //       └─┬─┘
+        // q2_0: ──○── q2_1
+        //===----------------------------------------------------------------===//
+
+        %q1_1, %q0_1, %q2_1 = mqtopt.x() %q1_0 ctrl %q0_0 nctrl %q2_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if two target gates on dynamic qubits are parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testTwoTargetOp
     func.func @testTwoTargetOp() {
@@ -499,7 +794,35 @@ module {
 }
 
 // -----
-// This test checks if a controlled SWAP gate is parsed and handled correctly.
+// This test checks if two target gates on static qubits are parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testTwoTargetOpStatic
+    func.func @testTwoTargetOpStatic() {
+        // CHECK: %[[Q01_1:.*]]:2 = mqtopt.swap() %[[ANY:.*]], %[[ANY:.*]] : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_2:.*]]:2 = mqtopt.iswap() %[[Q01_1]]#0, %[[Q01_1]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_3:.*]]:2 = mqtopt.iswapdg() %[[Q01_2]]#0, %[[Q01_2]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_4:.*]]:2 = mqtopt.peres() %[[Q01_3]]#0, %[[Q01_3]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_5:.*]]:2 = mqtopt.peresdg() %[[Q01_4]]#0, %[[Q01_4]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_6:.*]]:2 = mqtopt.dcx() %[[Q01_5]]#0, %[[Q01_5]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_7:.*]]:2 = mqtopt.ecr() %[[Q01_6]]#0, %[[Q01_6]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+
+        %q0_1, %q1_1 = mqtopt.swap() %q0_0, %q1_0 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q0_2, %q1_2 = mqtopt.iswap() %q0_1, %q1_1 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q0_3, %q1_3 = mqtopt.iswapdg() %q0_2, %q1_2 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q0_4, %q1_4 = mqtopt.peres() %q0_3, %q1_3 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q0_5, %q1_5 = mqtopt.peresdg() %q0_4, %q1_4 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q0_6, %q1_6 = mqtopt.dcx() %q0_5, %q1_5 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q0_7, %q1_7 = mqtopt.ecr() %q0_6, %q1_6 : !mqtopt.Qubit, !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if a controlled SWAP gate on dynamic qubits is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testControlledSWAPOp
     func.func @testControlledSWAPOp() {
@@ -519,7 +842,7 @@ module {
 }
 
 // -----
-// This test checks if a negative controlled SWAP gate is parsed and handled correctly.
+// This test checks if a negative controlled SWAP gate on dynamic qubits is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testNegativeControlledSWAPOp
     func.func @testNegativeControlledSWAPOp() {
@@ -539,7 +862,41 @@ module {
 }
 
 // -----
-// This test checks if a mixed controlled SWAP gate is parsed and handled correctly.
+// This test checks if a controlled SWAP gate on static qubits is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testControlledSWAPOpStatic
+    func.func @testControlledSWAPOpStatic() {
+        // CHECK: %[[Q01_1:.*]]:2, %[[Q2_1:.*]] = mqtopt.swap() %[[ANY:.*]], %[[ANY:.*]] ctrl %[[ANY:.*]] : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+        %q2_0 = mqtopt.qubit 2
+
+        %q0_1, %q1_1, %q2_1 = mqtopt.swap() %q0_0, %q1_0 ctrl %q2_0 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if a negative controlled SWAP gate on static qubits is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testNegativeControlledSWAPOpStatic
+    func.func @testNegativeControlledSWAPOpStatic() {
+        // CHECK: %[[Q01_1:.*]]:2, %[[Q2_1:.*]] = mqtopt.swap() %[[ANY:.*]], %[[ANY:.*]] nctrl %[[ANY:.*]] : !mqtopt.Qubit, !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+        %q2_0 = mqtopt.qubit 2
+
+        %q0_1, %q1_1, %q2_1 = mqtopt.swap() %q0_0, %q1_0 nctrl %q2_0 : !mqtopt.Qubit, !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if a mixed controlled SWAP gate on dynamic qubits is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testMixedControlledSWAPOp
     func.func @testMixedControlledSWAPOp() {
@@ -573,7 +930,36 @@ module {
 }
 
 // -----
-// This test checks if parameterized multiple qubit gates are parsed and handled correctly.
+// This test checks if a mixed controlled SWAP gate on static qubits is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testMixedControlledSWAPOpStatic
+    func.func @testMixedControlledSWAPOpStatic() {
+        // CHECK: %[[Q01_1:.*]]:2, %[[Q2_1:.*]], %[[Q3_1:.*]] = mqtopt.swap() %[[ANY:.*]], %[[ANY:.*]] ctrl %[[ANY:.*]] nctrl %[[ANY:.*]] : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+        %q2_0 = mqtopt.qubit 2
+        %q3_0 = mqtopt.qubit 3
+
+        //===------------------------------------------------------------------===//
+        //       ┌──────┐
+        // q0_0: ┤      ├ q0_1
+        //       │ SWAP │
+        // q1_0: ┤      ├ q1_1
+        //       └───┬──┘
+        // q2_0: ────■─── q2_1
+        //           │
+        // q3_0: ────■─── q3_1
+        //===----------------------------------------------------------------===//
+
+        %q0_1, %q1_1, %q2_1, %q3_1 = mqtopt.swap() %q0_0, %q1_0 ctrl %q2_0 nctrl %q3_0 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit nctrl !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if parameterized multiple qubit gates on dynamic qubits are parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testMultipleQubitRotationOp
     func.func @testMultipleQubitRotationOp() {
@@ -603,7 +989,35 @@ module {
 }
 
 // -----
-// This test checks if parameterized multiple qubit gates are parsed and handled correctly.
+// This test checks if parameterized multiple qubit gates on static qubits are parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testMultipleQubitRotationOpStatic
+    func.func @testMultipleQubitRotationOpStatic() {
+        // CHECK: %[[C0_F64:.*]] = arith.constant 3.000000e-01 : f64
+        // CHECK: %[[Q01_1:.*]]:2 = mqtopt.rxx(%[[C0_F64]]) %[[ANY:.*]], %[[ANY:.*]] : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_2:.*]]:2 = mqtopt.ryy(%[[C0_F64]]) %[[Q01_1]]#0, %[[Q01_1]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_3:.*]]:2 = mqtopt.rzz(%[[C0_F64]]) %[[Q01_2]]#0, %[[Q01_2]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_4:.*]]:2 = mqtopt.rzx(%[[C0_F64]]) %[[Q01_3]]#0, %[[Q01_3]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_5:.*]]:2 = mqtopt.xxminusyy(%[[C0_F64]], %[[C0_F64]]) %[[Q01_4]]#0, %[[Q01_4]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        // CHECK: %[[Q01_6:.*]]:2 = mqtopt.xxplusyy(%[[C0_F64]], %[[C0_F64]]) %[[Q01_5]]#0, %[[Q01_5]]#1 : !mqtopt.Qubit, !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+
+        %c0_f64 = arith.constant 3.000000e-01 : f64
+        %q01_1:2 = mqtopt.rxx(%c0_f64) %q0_0, %q1_0 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q01_2:2 = mqtopt.ryy(%c0_f64) %q01_1#0, %q01_1#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q01_3:2 = mqtopt.rzz(%c0_f64) %q01_2#0, %q01_2#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q01_4:2 = mqtopt.rzx(%c0_f64) %q01_3#0, %q01_3#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q01_5:2 = mqtopt.xxminusyy(%c0_f64, %c0_f64) %q01_4#0, %q01_4#1 : !mqtopt.Qubit, !mqtopt.Qubit
+        %q01_6:2 = mqtopt.xxplusyy(%c0_f64, %c0_f64) %q01_5#0, %q01_5#1 : !mqtopt.Qubit, !mqtopt.Qubit
+
+        return
+    }
+}
+
+// -----
+// This test checks if parameterized multiple qubit gates on dynamic qubits are parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testControlledMultipleQubitRotationOp
     func.func @testControlledMultipleQubitRotationOp() {
@@ -630,6 +1044,35 @@ module {
         %reg_5 = "mqtopt.insertQubit"(%reg_4, %q01_6#1) <{index_attr = 1 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
         %reg_6 = "mqtopt.insertQubit"(%reg_5, %q2_6) <{index_attr = 2 : i64}> : (!mqtopt.QubitRegister, !mqtopt.Qubit) -> !mqtopt.QubitRegister
         "mqtopt.deallocQubitRegister"(%reg_6) : (!mqtopt.QubitRegister) -> ()
+        return
+    }
+}
+
+// -----
+// This test checks if parameterized multiple qubit gates on static qubits are parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testControlledMultipleQubitRotationOp
+    func.func @testControlledMultipleQubitRotationOp() {
+        // CHECK: %[[C0_F64:.*]] = arith.constant 3.000000e-01 : f64
+        // CHECK: %[[Q01_1:.*]]:2, %[[Q2_1:.*]] = mqtopt.rxx(%[[C0_F64]]) %[[ANY:.*]], %[[ANY:.*]] ctrl %[[ANY:.*]] : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q01_2:.*]]:2, %[[Q2_2:.*]] = mqtopt.ryy(%[[C0_F64]]) %[[Q01_1]]#0, %[[Q01_1]]#1 ctrl %[[Q2_1]] : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q01_3:.*]]:2, %[[Q2_3:.*]] = mqtopt.rzz(%[[C0_F64]]) %[[Q01_2]]#0, %[[Q01_2]]#1 ctrl %[[Q2_2]] : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q01_4:.*]]:2, %[[Q2_4:.*]] = mqtopt.rzx(%[[C0_F64]]) %[[Q01_3]]#0, %[[Q01_3]]#1 ctrl %[[Q2_3]] : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q01_5:.*]]:2, %[[Q2_5:.*]] = mqtopt.xxminusyy(%[[C0_F64]], %[[C0_F64]]) %[[Q01_4]]#0, %[[Q01_4]]#1 ctrl %[[Q2_4]] : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        // CHECK: %[[Q01_6:.*]]:2, %[[Q2_6:.*]] = mqtopt.xxplusyy(%[[C0_F64]], %[[C0_F64]]) %[[Q01_5]]#0, %[[Q01_5]]#1 ctrl %[[Q2_5]] : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+
+        %q0_0 = mqtopt.qubit 0
+        %q1_0 = mqtopt.qubit 1
+        %q2_0 = mqtopt.qubit 2
+
+        %c0_f64 = arith.constant 3.000000e-01 : f64
+        %q01_1:2, %q2_1 = mqtopt.rxx(%c0_f64) %q0_0, %q1_0 ctrl %q2_0 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q01_2:2, %q2_2 = mqtopt.ryy(%c0_f64) %q01_1#0, %q01_1#1 ctrl %q2_1 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q01_3:2, %q2_3 = mqtopt.rzz(%c0_f64) %q01_2#0, %q01_2#1 ctrl %q2_2 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q01_4:2, %q2_4 = mqtopt.rzx(%c0_f64) %q01_3#0, %q01_3#1 ctrl %q2_3 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q01_5:2, %q2_5 = mqtopt.xxminusyy(%c0_f64, %c0_f64) %q01_4#0, %q01_4#1 ctrl %q2_4 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+        %q01_6:2, %q2_6 = mqtopt.xxplusyy(%c0_f64, %c0_f64) %q01_5#0, %q01_5#1 ctrl %q2_5 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+
         return
     }
 }

--- a/mlir/test/Dialect/MQTRef/IR/dialect_features.mlir
+++ b/mlir/test/Dialect/MQTRef/IR/dialect_features.mlir
@@ -120,9 +120,7 @@ module {
         // CHECK: [[M0:.*]] = mqtref.measure %[[ANY:.*]]
 
         %q0 = mqtref.qubit 0
-
         %m0 = mqtref.measure %q0
-
         return
     }
 }
@@ -135,9 +133,7 @@ module {
         // CHECK: %[[M0:.*]] = mqtref.measure %[[ANY:.*]]
 
         %q0 = mqtref.qubit 0
-
         %m0 = mqtref.measure %q0
-
         return
     }
 }
@@ -167,9 +163,7 @@ module {
         // CHECK: "mqtref.reset"(%[[ANY:.*]]) : (!mqtref.Qubit) -> ()
 
         %q0 = mqtref.qubit 0
-
         "mqtref.reset"(%q0) : (!mqtref.Qubit) -> ()
-
         return
     }
 }

--- a/mlir/test/Dialect/MQTRef/IR/dialect_features.mlir
+++ b/mlir/test/Dialect/MQTRef/IR/dialect_features.mlir
@@ -113,11 +113,26 @@ module {
 }
 
 // -----
-// This test checks if the MeasureOp applied to a single static qubit is parsed and handled correctly.
+// This test checks if the MeasureOp on a static qubit is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testMeasureOpStatic
     func.func @testMeasureOpStatic() {
         // CHECK: [[M0:.*]] = "mqtref.measure"(%[[ANY:.*]]) : (!mqtref.Qubit) -> i1
+
+        %q0 = mqtref.qubit 0
+
+        %m0 = "mqtref.measure"(%q0) : (!mqtref.Qubit) -> i1
+
+        return
+    }
+}
+
+// -----
+// This test checks if the MeasureOp applied to a static qubit is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testMeasureOpOnStaticInput
+    func.func @testMeasureOpOnStaticInput() {
+        // CHECK: %[[M0:.*]] = "mqtref.measure"(%[[ANY:.*]]) : (!mqtref.Qubit) -> i1
 
         %q0 = mqtref.qubit 0
 
@@ -154,21 +169,6 @@ module {
         %q0 = mqtref.qubit 0
 
         "mqtref.reset"(%q0) : (!mqtref.Qubit) -> ()
-
-        return
-    }
-}
-
-// -----
-// This test checks if the MeasureOp applied to a static qubit is parsed and handled correctly.
-module {
-    // CHECK-LABEL: func.func @testMeasureOpOnStaticInput
-    func.func @testMeasureOpOnStaticInput() {
-        // CHECK: %[[M0:.*]] = "mqtref.measure"(%[[ANY:.*]]) : (!mqtref.Qubit) -> i1
-
-        %q0 = mqtref.qubit 0
-
-        %m0 = "mqtref.measure"(%q0) : (!mqtref.Qubit) -> i1
 
         return
     }

--- a/mlir/test/Dialect/MQTRef/IR/dialect_features.mlir
+++ b/mlir/test/Dialect/MQTRef/IR/dialect_features.mlir
@@ -128,7 +128,7 @@ module {
 }
 
 // -----
-// This test checks if the ResetOp is parsed and handled correctly.
+// This test checks if the ResetOp on a dynamic qubit is parsed and handled correctly.
 module {
     // CHECK-LABEL: func.func @testResetOp
     func.func @testResetOp() {
@@ -140,6 +140,21 @@ module {
         "mqtref.reset"(%q0) : (!mqtref.Qubit) -> ()
 
         "mqtref.deallocQubitRegister"(%qreg) : (!mqtref.QubitRegister) -> ()
+        return
+    }
+}
+
+// -----
+// This test checks if the ResetOp on a static qubit is parsed and handled correctly.
+module {
+    // CHECK-LABEL: func.func @testResetOpStatic
+    func.func @testResetOpStatic() {
+        // CHECK: "mqtref.reset"(%[[ANY:.*]])
+
+        %q0 = mqtref.qubit 0
+
+        "mqtref.reset"(%q0) : (!mqtref.Qubit) -> ()
+
         return
     }
 }


### PR DESCRIPTION
## Description

Resolves #1114 by adding a `Qubit` operation to the `mqtopt` dialect and implementing the respective conversion functions. 

#### Implicit assumptions 
- As stated in the description of the `InsertOp` operation: It is possible to insert a static qubit into a quantum register. 
- A static qubit automatically "inserts" itself at the end of the scope where it was defined. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
