### PR TITLE
:sparkles: Implement elide permutations pass in MLIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
+- ✨ Add new MLIR pass `ElidePermutations` for SWAP gate elimination ([#1151]) ([**@taminob**])
 - ✨ Add new pattern to MLIR pass `GateElimination` for identity gate removal ([#1140]) ([**@taminob**])
 - ✨ Add Clifford block collection pass to `CircuitOptimizer` module ([#885]) ([**jannikpflieger**], [**@burgholzer**])
 - ✨ Add `isControlled()` method to the `UnitaryInterface` MLIR class ([#1157]) ([**@taminob**], [**@burgholzer**])
@@ -181,6 +182,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 <!-- PR links -->
 
 [#1157]: https://github.com/munich-quantum-toolkit/core/pull/1157
+[#1151]: https://github.com/munich-quantum-toolkit/core/pull/1151
 [#1147]: https://github.com/munich-quantum-toolkit/core/pull/1147
 [#1140]: https://github.com/munich-quantum-toolkit/core/pull/1140
 [#1139]: https://github.com/munich-quantum-toolkit/core/pull/1139

--- a/mlir/include/mlir/Dialect/MQTOpt/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/MQTOpt/Transforms/Passes.h
@@ -27,6 +27,7 @@ namespace mqt::ir::opt {
 
 void populateGateEliminationPatterns(mlir::RewritePatternSet& patterns);
 void populateMergeRotationGatesPatterns(mlir::RewritePatternSet& patterns);
+void populateElidePermutationsPatterns(mlir::RewritePatternSet& patterns);
 void populateQuantumSinkShiftPatterns(mlir::RewritePatternSet& patterns);
 void populateQuantumSinkPushPatterns(mlir::RewritePatternSet& patterns);
 void populateToQuantumComputationPatterns(mlir::RewritePatternSet& patterns,

--- a/mlir/include/mlir/Dialect/MQTOpt/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/MQTOpt/Transforms/Passes.td
@@ -45,6 +45,25 @@ def MergeRotationGates : Pass<"merge-rotation-gates", "mlir::ModuleOp"> {
   }];
 }
 
+def ElidePermutations : Pass<"elide-permutations", "mlir::ModuleOp"> {
+  let summary = "This pass removes any permutation (i.e., SWAP gates) it encounters and modifies the order of the qubits instead.";
+  let description = [{
+    Elides permutations (i.e., SWAP gates) by removing them from the circuit and, instead, permuting the respective qubit values.
+
+    This optimization will not preserve the current qubit mapping and has no awareness of potential connectivity limitations.
+
+    Example:
+    ```
+    // before
+    %q0_1, %q1_1 = mqtopt.swap() %q0_0, %q1_0 : !mqtopt.Qubit, !mqtopt.Qubit
+    %q1_2, %q0_2 = mqtopt.x() %q1_1 ctrl %q0_1 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+
+    // after
+    %q0_1, %q1_1 = mqtopt.x() %q0_0 ctrl %q1_0 : !mqtopt.Qubit ctrl !mqtopt.Qubit
+    ```
+  }];
+}
+
 def QuantumSinkPass : Pass<"quantum-sink", "mlir::ModuleOp"> {
   let summary = "This pass attempts to push down operations into branches for possible optimizations.";
   let description = [{

--- a/mlir/lib/Dialect/MQTOpt/Transforms/ElidePermutations.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/ElidePermutations.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+ * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/Common/Compat.h"
+#include "mlir/Dialect/MQTOpt/Transforms/Passes.h"
+
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Support/LLVM.h>
+#include <utility>
+
+namespace mqt::ir::opt {
+
+#define GEN_PASS_DEF_ELIDEPERMUTATIONS
+#include "mlir/Dialect/MQTOpt/Transforms/Passes.h.inc"
+
+/**
+ * @brief This pattern attempts to remove SWAP gates by re-ordering qubits.
+ */
+struct ElidePermutations final
+    : impl::ElidePermutationsBase<ElidePermutations> {
+
+  void runOnOperation() override {
+    // Get the current operation being operated on.
+    auto op = getOperation();
+    auto* ctx = &getContext();
+
+    // Define the set of patterns to use.
+    mlir::RewritePatternSet patterns(ctx);
+    populateElidePermutationsPatterns(patterns);
+
+    // Apply patterns in an iterative and greedy manner.
+    if (mlir::failed(APPLY_PATTERNS_GREEDILY(op, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace mqt::ir::opt

--- a/mlir/lib/Dialect/MQTOpt/Transforms/ElidePermutationsPattern.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/ElidePermutationsPattern.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+ * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/MQTOpt/IR/MQTOptDialect.h"
+#include "mlir/Dialect/MQTOpt/Transforms/Passes.h"
+
+#include <cassert>
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+
+namespace mqt::ir::opt {
+
+/**
+ * @brief This pattern attempts to remove SWAP gates by re-ordering qubits.
+ */
+struct ElidePermutationsPattern final : mlir::OpRewritePattern<SWAPOp> {
+
+  explicit ElidePermutationsPattern(mlir::MLIRContext* context)
+      : OpRewritePattern(context) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(SWAPOp op, mlir::PatternRewriter& rewriter) const override {
+    if (op.isControlled()) {
+      return mlir::failure();
+    }
+
+    auto inQubits = op.getInQubits();
+    assert(inQubits.size() == 2);
+
+    rewriter.replaceAllOpUsesWith(op, {inQubits[1], inQubits[0]});
+
+    rewriter.eraseOp(op);
+
+    return mlir::success();
+  }
+};
+
+/**
+ * @brief Populates the given pattern set with the `ElidePermutationsPattern`.
+ *
+ * @param patterns The pattern set to populate.
+ */
+void populateElidePermutationsPatterns(mlir::RewritePatternSet& patterns) {
+  patterns.add<ElidePermutationsPattern>(patterns.getContext());
+}
+
+} // namespace mqt::ir::opt

--- a/mlir/test/Dialect/MQTOpt/Transforms/elide-permutations.mlir
+++ b/mlir/test/Dialect/MQTOpt/Transforms/elide-permutations.mlir
@@ -1,0 +1,110 @@
+// Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+// Copyright (c) 2025 Munich Quantum Software Company GmbH
+// All rights reserved.
+//
+// SPDX-License-Identifier: MIT
+//
+// Licensed under the MIT License
+
+// RUN: quantum-opt %s -split-input-file --elide-permutations | FileCheck %s
+
+// -----
+// This test checks that a single SWAP gate is removed correctly.
+
+module {
+  // CHECK-LABEL: func.func @testSingleElidePermutation
+  func.func @testSingleElidePermutation() {
+    // CHECK: %[[Q0_0:.*]] = mqtopt.allocQubit
+    // CHECK: %[[Q1_0:.*]] = mqtopt.allocQubit
+
+    // ========================== Check for operations that should be canceled ==============================
+    // CHECK-NOT: %[[ANY:.*]] = mqtopt.swap()
+
+    // ========================== Check for operations that should not be canceled ==============================
+    // CHECK: %[[Q0_1:.*]] = mqtopt.x() %[[Q0_0]]
+
+    // CHECK: mqtopt.deallocQubit %[[Q1_0]]
+    // CHECK: mqtopt.deallocQubit %[[Q0_1]]
+
+    %q0_0 = mqtopt.allocQubit
+    %q1_0 = mqtopt.allocQubit
+
+    %q0_1, %q1_1 = mqtopt.swap() %q0_0, %q1_0 : !mqtopt.Qubit, !mqtopt.Qubit
+    %q1_2 = mqtopt.x() %q1_1 : !mqtopt.Qubit
+
+    mqtopt.deallocQubit %q0_1
+    mqtopt.deallocQubit %q1_2
+
+    return
+  }
+}
+
+
+// -----
+// This test checks that a controlled SWAP gate is not removed.
+
+module {
+  // CHECK-LABEL: func.func @testControlledSwapNoElidePermutation
+  func.func @testControlledSwapNoElidePermutation() {
+    // CHECK: %[[Q0_0:.*]] = mqtopt.allocQubit
+    // CHECK: %[[Q1_0:.*]] = mqtopt.allocQubit
+    // CHECK: %[[Q2_0:.*]] = mqtopt.allocQubit
+
+    // ========================== Check for operations that should not be canceled ==============================
+    // CHECK: %[[Q01_1:.*]]:2, %[[Q2_1:.*]] = mqtopt.swap() %[[Q0_0]], %[[Q1_0]] ctrl %[[Q2_0]]
+
+    // CHECK: mqtopt.deallocQubit %[[Q01_1]]#0
+    // CHECK: mqtopt.deallocQubit %[[Q01_1]]#1
+    // CHECK: mqtopt.deallocQubit %[[Q2_1]]
+
+    %q0_0 = mqtopt.allocQubit
+    %q1_0 = mqtopt.allocQubit
+    %q2_0 = mqtopt.allocQubit
+
+    %q0_1, %q1_1, %q2_1 = mqtopt.swap() %q0_0, %q1_0 ctrl %q2_0 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+
+    mqtopt.deallocQubit %q0_1
+    mqtopt.deallocQubit %q1_1
+    mqtopt.deallocQubit %q2_1
+
+    return
+  }
+}
+
+
+// -----
+// This test checks that all removable SWAP gates are removed.
+
+module {
+  // CHECK-LABEL: func.func @testMultiSwapElidePermutation
+  func.func @testMultiSwapElidePermutation() {
+    // CHECK: %[[Q0_0:.*]] = mqtopt.allocQubit
+    // CHECK: %[[Q1_0:.*]] = mqtopt.allocQubit
+    // CHECK: %[[Q2_0:.*]] = mqtopt.allocQubit
+
+    // ========================== Check for operations that should not be canceled ==============================
+    // CHECK-NOT: %[[ANY:.*]] = mqtopt.swap()
+
+    // ========================== Check for operations that should not be canceled ==============================
+    // CHECK: %[[Q12_1:.*]]:2, %[[Q0_1:.*]] = mqtopt.swap() %[[Q1_0]], %[[Q2_0]] ctrl %[[Q0_0]]
+
+    // CHECK: mqtopt.deallocQubit %[[Q12_1]]#0
+    // CHECK: mqtopt.deallocQubit %[[Q0_1]]
+    // CHECK: mqtopt.deallocQubit %[[Q12_1]]#1
+
+    %q0_0 = mqtopt.allocQubit
+    %q1_0 = mqtopt.allocQubit
+    %q2_0 = mqtopt.allocQubit
+
+    %q0_1, %q1_1 = mqtopt.swap() %q0_0, %q1_0 : !mqtopt.Qubit, !mqtopt.Qubit
+    %q1_2, %q2_1 = mqtopt.swap() %q1_1, %q2_0 : !mqtopt.Qubit, !mqtopt.Qubit
+    %q0_2, %q1_3, %q2_2 = mqtopt.swap() %q0_1, %q1_2 ctrl %q2_1 : !mqtopt.Qubit, !mqtopt.Qubit ctrl !mqtopt.Qubit
+    %q1_4, %q2_3 = mqtopt.swap() %q1_3, %q2_2 : !mqtopt.Qubit, !mqtopt.Qubit
+
+    mqtopt.deallocQubit %q0_2
+    mqtopt.deallocQubit %q1_4
+    mqtopt.deallocQubit %q2_3
+
+    return
+  }
+}


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->

## Description

This PR adds a MLIR pass to eliminate all SWAP gates. This can be used on unmapped circuits to reduce the amount of needed swaps or in combination with another optimization called swap reconstruction to remove repeated CNOTs on two qubits.

Related to https://github.com/munich-quantum-toolkit/core/issues/1122

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
