### PR TITLE
Add entry_point attribute in `QuantumComputation` translation

### DIFF
--- a/mlir/lib/Dialect/MQTRef/Translation/ImportQuantumComputation.cpp
+++ b/mlir/lib/Dialect/MQTRef/Translation/ImportQuantumComputation.cpp
@@ -261,6 +261,11 @@ mlir::OwningOpRef<mlir::ModuleOp> translateQuantumComputationToMLIR(
   auto funcType = builder.getFunctionType({}, {});
   auto mainFunc = builder.create<mlir::func::FuncOp>(loc, "main", funcType);
 
+  // Add entry_point attribute to identify the main function
+  const auto entryPointAttr = mlir::StringAttr::get(context, "entry_point");
+  mainFunc->setAttr("passthrough",
+                    mlir::ArrayAttr::get(context, {entryPointAttr}));
+
   auto& entryBlock = mainFunc.getBody().emplaceBlock();
   builder.setInsertionPointToStart(&entryBlock);
 

--- a/mlir/unittests/translation/test_translation.cpp
+++ b/mlir/unittests/translation/test_translation.cpp
@@ -92,7 +92,7 @@ TEST_F(ImportTest, EntryPoint) {
 
   const auto outputString = getOutputString(&module);
   const auto* checkString = R"(
-    CHECK: func.func @main()
+    CHECK: func.func @main() attributes {passthrough = ["entry_point"]}
     CHECK: return
   )";
 


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->

## Description

This PR adds the `entry_point` attribute to the main function during the translation from `QuantumComputation` to `MQTRef`.
This attribute is later used to identify the main function during the conversion to `QIR`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
