### PR TITLE
🍎🔥 Stop testing on `x86` macOS and shipping wheels for Intel-based Macs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,6 @@ jobs:
           [
             ubuntu-24.04,
             ubuntu-24.04-arm,
-            macos-13,
             macos-14,
             windows-2022,
             windows-11-arm,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-13, macos-14]
+        runs-on: [macos-14]
         compiler: [clang]
-        config: [Release]
-        include:
-          - runs-on: macos-14
-            compiler: clang
-            config: Debug
+        config: [Debug, Release]
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@v1.16
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -109,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-13, macos-14, macos-15]
+        runs-on: [macos-14, macos-15]
         compiler: [clang, clang-19, clang-20, gcc-14, gcc-15]
         config: [Release, Debug]
         exclude:
@@ -172,8 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, windows-2022]
+        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, windows-2022]
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@v1.16
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -229,7 +224,6 @@ jobs:
           [
             ubuntu-24.04,
             ubuntu-24.04-arm,
-            macos-13,
             macos-14,
             windows-2022,
             windows-11-arm,

--- a/.github/workflows/reusable-mlir-tests.yml
+++ b/.github/workflows/reusable-mlir-tests.yml
@@ -18,7 +18,6 @@ jobs:
           [
             ubuntu-24.04,
             ubuntu-24.04-arm,
-            macos-13,
             macos-14,
             windows-2025,
             windows-11-arm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Removed
 
-- Remove `ClassicControlledOperation` from C++ library and Python package ([#1117]) ([**@denialhaag**])
+- 🔥 Stop testing on `x86` macOS and shipping wheels for Intel-based Macs ([#1165]) ([**@burgholzer**])
+- 🔥 Remove `ClassicControlledOperation` from C++ library and Python package ([#1117]) ([**@denialhaag**])
 
 ### Fixed
 
@@ -180,6 +181,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1165]: https://github.com/munich-quantum-toolkit/core/pull/1165
 [#1157]: https://github.com/munich-quantum-toolkit/core/pull/1157
 [#1147]: https://github.com/munich-quantum-toolkit/core/pull/1147
 [#1140]: https://github.com/munich-quantum-toolkit/core/pull/1140

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,6 +23,14 @@ If no else-operation is needed, the `if_()` method can be used.
 qc.if_(op_type=OpType.x, target=0, control_bit=0)
 ```
 
+### End of support for x86 macOS systems
+
+Starting with this release, MQT Core no longer ships Python wheels for x86 macOS systems.
+This comes as a result of GitHub removing the respective (`macos-13`) runners from their infrastructure.
+Users still on these systems can still install MQT Core from source as we continue to ship a source distribution.
+However, we will no longer run CI tests on these systems.
+As a consequence, we also no longer guarantee that MQT Core builds and runs correctly on these systems.
+
 ## [3.2.0]
 
 The shared library ABI version (`SOVERSION`) is increased from `3.1` to `3.2`.

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -58,7 +58,7 @@ endif()
 if(DEPLOY)
   # set the macOS deployment target appropriately
   set(CMAKE_OSX_DEPLOYMENT_TARGET
-      "10.15"
+      "11.0"
       CACHE STRING "" FORCE)
 endif()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,15 +292,11 @@ test-skip = [
 environment = { DEPLOY = "ON" }
 
 [tool.cibuildwheel.macos]
-environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 
 [tool.cibuildwheel.windows]
 before-build = "uv pip install delvewheel>=1.9.0"
 repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt --ignore-existing"
-
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_arm64"
-environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 
 
 [tool.uv]


### PR DESCRIPTION
## Description

This PR drops running our tests and deployment workflows on `macos-13` runners.
Hence, this marks the end of us shipping macOS x86 wheels with MQT Core.
While I do not expect any immediate problems and incompatibilities, this means that people still on those systems will either have to stick with an old version of MQT Core or will have to build the new version from source.

I'll let this sit in draft for a while until it becomes relevant.
If nothing bigger comes up, this will be part of the next minor release.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
