### PR TITLE
📝 Exit docs build if code fails

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,7 @@ nb_mime_priority_overrides = [
     # builder name, mime type, priority
     ("latex", "image/svg+xml", 15),
 ]
+nb_execution_raise_on_error = True
 
 
 class CDAStyle(UnsrtStyle):

--- a/docs/mqt_core_ir.md
+++ b/docs/mqt_core_ir.md
@@ -77,6 +77,8 @@ for i in range(precision):
   # Reset the qubit if not finished
   if i < precision - 1:
     qc.reset(q[0])
+
+raise Exception("This should make the docs build fail.")
 ```
 
 The circuit class provides lots of flexibility when it comes to the kind of gates that can be applied.


### PR DESCRIPTION
## Description

This PR enables the `nb_execution_raise_on_error` flag to make the docs build fail if code fails.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.
