### PR TITLE
🔧 Trigger RTD Build also on Changes in MLIR Directory

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,7 +23,7 @@ build:
       - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip ci") || exit 183
       # Skip docs build if there are no changes related to docs
       - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- bindings/ include/ docs/ python/ .github/contributing* .github/support* .readthedocs.yaml;
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- bindings/ docs/ include/ mlir/include/ python/ .github/contributing* .github/support* .readthedocs.yaml;
         then
           exit 183;
         fi


### PR DESCRIPTION
## Description

In #1091 the RTD build does not show the updates of the MLIR docs because the RTD build is skipped due to a misconfiguration of RTD. This PR fixes the configuration and also triggers an RTD build on changes in the MLIR header files.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.
