### PR TITLE
♻️ MLIR | Routing Pass: Use `passthrough` attribute for entry_point checking

### DIFF
--- a/mlir/test/Dialect/MQTOpt/Transforms/Transpilation/naive-routing-errors.mlir
+++ b/mlir/test/Dialect/MQTOpt/Transforms/Transpilation/naive-routing-errors.mlir
@@ -10,7 +10,7 @@
 
 
 module {
-    func.func @entryTooManyQubits() attributes { entry_point } {
+    func.func @entryTooManyQubits() attributes {passthrough = ["entry_point"]} {
         %q0_0 = mqtopt.allocQubit
         %q1_0 = mqtopt.allocQubit
         %q2_0 = mqtopt.allocQubit

--- a/mlir/test/Dialect/MQTOpt/Transforms/Transpilation/naive-routing.mlir
+++ b/mlir/test/Dialect/MQTOpt/Transforms/Transpilation/naive-routing.mlir
@@ -9,9 +9,8 @@
 // RUN: quantum-opt %s -split-input-file --pass-pipeline="builtin.module(route-sc,verify-routing-sc)" -verify-diagnostics | FileCheck %s
 
 module {
-
     // CHECK-LABEL: func.func @entrySABRE
-    func.func @entrySABRE() attributes { entry_point } {
+    func.func @entrySABRE() attributes {passthrough = ["entry_point"]} {
 
         //
         // Figure 4 in SABRE Paper "Tackling the Qubit Mapping Problem for NISQ-Era Quantum Devices".
@@ -71,7 +70,7 @@ module {
     }
 
     // CHECK-LABEL: func.func @entryBell
-    func.func @entryBell() attributes { entry_point } {
+    func.func @entryBell() attributes {passthrough = ["entry_point"]} {
 
         //
         // The bell state.
@@ -100,7 +99,7 @@ module {
     }
 
     // CHECK-LABEL: func.func @entryBellLoop
-    func.func @entryBellLoop() attributes { entry_point } {
+    func.func @entryBellLoop() attributes {passthrough = ["entry_point"]} {
 
         //
         // Bell in a loop.
@@ -136,7 +135,7 @@ module {
     }
 
     // CHECK-LABEL: func.func @entryGHZ
-    func.func @entryGHZ() attributes { entry_point } {
+    func.func @entryGHZ() attributes {passthrough = ["entry_point"]} {
 
         //
         // GHZ in a loop.
@@ -184,7 +183,7 @@ module {
         return
     }
 
-    func.func @entryBranching() attributes { entry_point } {
+    func.func @entryBranching() attributes {passthrough = ["entry_point"]} {
 
         //
         // This test shows that the routing algorithm can handle
@@ -223,7 +222,7 @@ module {
     }
 
     // CHECK-LABEL: func.func @entryAll
-    func.func @entryAll() attributes { entry_point } {
+    func.func @entryAll() attributes {passthrough = ["entry_point"]} {
 
         //
         // All of the above quantum computations in a single entry point.


### PR DESCRIPTION
## Description

The translation from `mqt-ir` to `mqtref` produces entry point functions using the `passthrough` attribute as described 
in the [MLIR LLVM dialect documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#attribute-pass-through). 

Essentially, this PR ensures that the routing pass routes functions defined as
```mlir 
func.func @hello() attributes {passthrough = ["entry_point"]} {...}
```
instead of
```mlir 
func.func @hello() attributes { entry_point } {...}
```

## Checklist:

- [ ] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.
