### PR TITLE
🐛 `shortestSWAPsBetween` returns one SWAP too many

### DIFF
--- a/mlir/lib/Dialect/MQTOpt/Transforms/Transpilation/Architecture.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/Transpilation/Architecture.cpp
@@ -38,13 +38,13 @@ Architecture::shortestSWAPsBetween(uint32_t u, uint32_t v) const {
   }
 
   llvm::SmallVector<std::pair<uint32_t, uint32_t>> swaps;
-  uint32_t curr = v;
   uint32_t last = v;
+  uint32_t curr = prev_[u][v];
 
   while (curr != u) {
-    curr = prev_[u][curr];
-    swaps.emplace_back(last, curr);
+    swaps.emplace_back(last, curr); // Insert SWAP(last, curr).
     last = curr;
+    curr = prev_[u][curr];
   }
 
   return swaps;


### PR DESCRIPTION
## Description

#1301 introduced the `shortestSWAPsBetween` method to the `Architecture` class. Unfortunately, there is a bug: It returns one SWAP too many. Semantically, this is still correct but unnecessary since the qubits are already adjacent. In other words, the last SWAP swaps already adjacent qubits. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [X] The pull request only contains commits that are focused and relevant to this change.
- [X] I have added appropriate tests that cover the new/changed functionality.
- [X] I have updated the documentation to reflect these changes.
- [X] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [X] I have added migration instructions to the upgrade guide (if needed).
- [X] The changes follow the project's style guidelines and introduce no new warnings.
- [X] The changes are fully tested and pass the CI checks.
- [X] I have reviewed my own code changes.
