### PR TITLE
🚸 expose MQT_CORE_VERSION as part of the `add_mqt_core_library` macro

### DIFF
--- a/cmake/AddMQTCoreLibrary.cmake
+++ b/cmake/AddMQTCoreLibrary.cmake
@@ -47,4 +47,7 @@ function(add_mqt_core_library name)
     PROPERTIES VERSION ${PROJECT_VERSION}
                SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
                EXPORT_NAME Core${ARG_ALIAS_NAME})
+
+  # Make version available
+  target_compile_definitions(${name} PRIVATE MQT_CORE_VERSION="${MQT_CORE_VERSION}")
 endfunction()

--- a/src/qdmi/dd/CMakeLists.txt
+++ b/src/qdmi/dd/CMakeLists.txt
@@ -52,9 +52,8 @@ if(NOT TARGET ${TARGET_NAME})
       ${MQT_CORE_TARGETS} ${TARGET_NAME}
       PARENT_SCOPE)
 
-  # Make QDMI and MQT Core Version available
-  target_compile_definitions(${TARGET_NAME} PRIVATE QDMI_VERSION="${QDMI_VERSION}"
-                                                    MQT_CORE_VERSION="${MQT_CORE_VERSION}")
+  # Make QDMI version available
+  target_compile_definitions(${TARGET_NAME} PRIVATE QDMI_VERSION="${QDMI_VERSION}")
 
   # Generate additional alias for the target required for generate_device_defs_executable function
   # in the tests

--- a/src/qdmi/na/CMakeLists.txt
+++ b/src/qdmi/na/CMakeLists.txt
@@ -143,9 +143,8 @@ if(NOT TARGET ${TARGET_NAME})
       ${MQT_CORE_TARGETS} ${TARGET_NAME}
       PARENT_SCOPE)
 
-  # Make QDMI and MQT Core Version available
-  target_compile_definitions(${TARGET_NAME} PRIVATE QDMI_VERSION="${QDMI_VERSION}"
-                                                    MQT_CORE_VERSION="${MQT_CORE_VERSION}")
+  # Make QDMI version available
+  target_compile_definitions(${TARGET_NAME} PRIVATE QDMI_VERSION="${QDMI_VERSION}")
 
   # Generate additional alias for the target required for generate_device_defs_executable function
   # in the tests

--- a/src/qdmi/sc/CMakeLists.txt
+++ b/src/qdmi/sc/CMakeLists.txt
@@ -143,9 +143,8 @@ if(NOT TARGET ${TARGET_NAME})
       ${MQT_CORE_TARGETS} ${TARGET_NAME}
       PARENT_SCOPE)
 
-  # Make QDMI and MQT Core Version available
-  target_compile_definitions(${TARGET_NAME} PRIVATE QDMI_VERSION="${QDMI_VERSION}"
-                                                    MQT_CORE_VERSION="${MQT_CORE_VERSION}")
+  # Make QDMI version available
+  target_compile_definitions(${TARGET_NAME} PRIVATE QDMI_VERSION="${QDMI_VERSION}")
 
   # Generate additional alias for the target required for generate_device_defs_executable function
   # in the tests


### PR DESCRIPTION
## Description

Picking apart #1403 even more.
This small PR directly exposes the MQT Core version as part of the CMake library macro.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
