### PR TITLE
👨‍💻📦 Build `spdlog` as a shared library on project installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
+- 👨‍💻📦 Build `spdlog` as a shared library on project installs ([#1411]) ([**@burgholzer**])
 - ♻️🏁 Remove Windows-specific restrictions for dynamic QDMI device library handling ([#1406]) ([**@burgholzer**])
 - ♻️ Migrate Python bindings from `pybind11` to `nanobind` ([#1383]) ([**@denialhaag**], [**@burgholzer**])
 - 📦️ Provide Stable ABI wheels for Python 3.12+ ([#1383]) ([**@burgholzer**], [**@denialhaag**])
@@ -287,6 +288,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1411]: https://github.com/munich-quantum-toolkit/core/pull/1411
 [#1406]: https://github.com/munich-quantum-toolkit/core/pull/1406
 [#1402]: https://github.com/munich-quantum-toolkit/core/pull/1402
 [#1385]: https://github.com/munich-quantum-toolkit/core/pull/1385

--- a/src/qdmi/na/CMakeLists.txt
+++ b/src/qdmi/na/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT TARGET ${TARGET_NAME})
   target_sources(${TARGET_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_CORE_INCLUDE_BUILD_DIR}
                                        FILES ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/na/Generator.hpp)
 
-  # Link nlohmann_json, spdlog
+  # Link nlohmann_json and spdlog
   target_link_libraries(
     ${TARGET_NAME}
     PUBLIC nlohmann_json::nlohmann_json

--- a/src/qdmi/sc/CMakeLists.txt
+++ b/src/qdmi/sc/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT TARGET ${TARGET_NAME})
   target_sources(${TARGET_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_CORE_INCLUDE_BUILD_DIR}
                                        FILES ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/sc/Generator.hpp)
 
-  # Link nlohmann_json, spdlog
+  # Link nlohmann_json and spdlog
   target_link_libraries(
     ${TARGET_NAME}
     PUBLIC nlohmann_json::nlohmann_json


### PR DESCRIPTION
## Description

Picked from #1403.
Builds `spdlog` as a shared library on library installs.
This reduces the wheel size from 14.3 MiB to 11.0 MiB on x86 linux.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
