### PR TITLE
⚡ Improve uv build caching by removing unconditional `reinstall-package` and configuring dedicated `cache-keys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
+- ⚡ Improve uv build caching by removing unconditional `reinstall-package` and configuring dedicated `cache-keys` ([#1412]) ([**@burgholzer**])
 - 👨‍💻📦 Build `spdlog` as a shared library on project installs ([#1411]) ([**@burgholzer**])
 - ♻️🏁 Remove Windows-specific restrictions for dynamic QDMI device library handling ([#1406]) ([**@burgholzer**])
 - ♻️ Migrate Python bindings from `pybind11` to `nanobind` ([#1383]) ([**@denialhaag**], [**@burgholzer**])
@@ -288,6 +289,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1412]: https://github.com/munich-quantum-toolkit/core/pull/1412
 [#1411]: https://github.com/munich-quantum-toolkit/core/pull/1411
 [#1406]: https://github.com/munich-quantum-toolkit/core/pull/1406
 [#1402]: https://github.com/munich-quantum-toolkit/core/pull/1402

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,7 +303,11 @@ repair-wheel-command = "uvx abi3audit --strict --report {wheel}"
 
 [tool.uv]
 required-version = ">=0.5.20"
-reinstall-package = ["mqt-core"]
+cache-keys = [
+  { file = "pyproject.toml" },
+  { git = { commit = true, tags = true } },
+  { file = "bindings/**/*.cpp"},
+]
 
 [tool.uv.sources]
 mqt-core = { workspace = true }


### PR DESCRIPTION
## Description

This PR removes the unconditional `reinstall-package = ["mqt-core"]` configuration from the `uv` settings.
The purpose of this setting was to ensure that mqt-core is rebuilt, when the `bindings` directory changed, in order to avoid having a stale version of mqt-core installed.
However, this had the unintended consequence that the package was _always_ rebuilt and `uv` could never cache the built wheel.
This is extremely apparent in our CI, where this adds very negatively to our CI runtimes.
Our Python test suite runs 5 versions of Python (at the moment 3.10, 3.11, 3.12, 3.13, and 3.14) both with minimum dependencies and latest dependencies. On main, this produces 10 separate builds.

Simply dropping the setting was not an option because of the above use case.
But it turns out that `uv` is offering more fine granular controls over the caching mechanism since literally forever and we just haven't found it.
This PR, instead of the unconditional `reinstall-package`, sets `tool.uv.cache-keys` which means that the package will be rebuilt whenever
- `pyproject.toml` changes (uv does this by default), or
- any commit or tag information changes (which matches changes caused by setuptools-scm), or
- any `.cpp` file in the `bindings` folder changes.

This reduces the number of builds from 10 down to 3 (3.10, 3.11, 3.12+ ABI3), which should drastically decrease our CI times.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
