### PR TITLE
:bug: Replace use of tablegen internal names

### DIFF
--- a/mlir/include/mlir/Dialect/QC/IR/QCInterfaces.td
+++ b/mlir/include/mlir/Dialect/QC/IR/QCInterfaces.td
@@ -68,17 +68,17 @@ def UnitaryOpInterface : OpInterface<"UnitaryOpInterface"> {
         InterfaceMethod<
             "Returns true if the operation has any control qubits, otherwise false.",
             "bool", "isControlled", (ins),
-            [{ return getNumControls(impl, tablegen_opaque_val) > 0; }]
+            [{ return $_op.getNumControls() > 0; }]
         >,
         InterfaceMethod<
             "Returns true if the operation only acts on a single qubit.",
             "bool", "isSingleQubit", (ins),
-            [{ return getNumQubits(impl, tablegen_opaque_val) == 1; }]
+            [{ return $_op.getNumQubits() == 1; }]
         >,
         InterfaceMethod<
             "Returns true if the operation acts on two qubits.",
             "bool", "isTwoQubit", (ins),
-            [{ return getNumQubits(impl, tablegen_opaque_val) == 2; }]
+            [{ return $_op.getNumQubits() == 2; }]
         >,
 
         // Identification

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOInterfaces.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOInterfaces.td
@@ -89,17 +89,17 @@ def UnitaryOpInterface : OpInterface<"UnitaryOpInterface"> {
         InterfaceMethod<
             "Returns true if the operation has any control qubits, otherwise false.",
             "bool", "isControlled", (ins),
-            [{ return getNumControls(impl, tablegen_opaque_val) > 0; }]
+            [{ return $_op.getNumControls() > 0; }]
         >,
         InterfaceMethod<
             "Returns true if the operation only acts on a single qubit.",
             "bool", "isSingleQubit", (ins),
-            [{ return getNumQubits(impl, tablegen_opaque_val) == 1; }]
+            [{ return $_op.getNumQubits() == 1; }]
         >,
         InterfaceMethod<
             "Returns true if the operation acts on two qubits.",
             "bool", "isTwoQubit", (ins),
-            [{ return getNumQubits(impl, tablegen_opaque_val) == 2; }]
+            [{ return $_op.getNumQubits() == 2; }]
         >,
 
         // Identification


### PR DESCRIPTION
## Description

Currently, some tablegen internal names are used to refer to the instance contained in the interface.
For non-static interface methods, $_attr/$_op/$_type may be used to refer to the contained instance. This will ensure portability in the future if the tablegen implementation changes these names.

Since this is an internal change which should have no outside effect, I did not add it to the changelog.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
