### PR TITLE
♻️ Use `llc` instead of random `clang` for compiling QIR test circuits to improve robustness and handle opaque pointers correctly across LLVM versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
+- ♻️ Use `llc` instead of random `clang` for compiling QIR test circuits to improve robustness and handle opaque pointers correctly across LLVM versions ([#1447]) ([**@burgholzer**])
 - ♻️ Extract singleton pattern into reusable template base class for QDMI devices and driver ([#1444]) ([**@ystade**], [**@burgholzer**])
 - 🚚 Reorganize QDMI code structure by moving devices into dedicated subdirectories and separating driver and common utilities ([#1444]) ([**@ystade**])
 - 📦 Build MLIR by default for C++ library builds ([#1356]) ([**@burgholzer**], [**@denialhaag**])
@@ -309,6 +310,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1447]: https://github.com/munich-quantum-toolkit/core/pull/1447
 [#1446]: https://github.com/munich-quantum-toolkit/core/pull/1446
 [#1444]: https://github.com/munich-quantum-toolkit/core/pull/1444
 [#1443]: https://github.com/munich-quantum-toolkit/core/pull/1443

--- a/test/qir/runtime/CMakeLists.txt
+++ b/test/qir/runtime/CMakeLists.txt
@@ -6,6 +6,18 @@
 #
 # Licensed under the MIT License
 
+# Find llc tool (LLVM is guaranteed to be available at this point)
+find_program(
+  LLC_EXECUTABLE
+  NAMES llc
+  HINTS ${LLVM_TOOLS_BINARY_DIR})
+
+if(NOT LLC_EXECUTABLE)
+  message(FATAL_ERROR "llc not found. This should not happen since LLVM is available.")
+endif()
+
+message(STATUS "Found llc: ${LLC_EXECUTABLE}")
+
 # macro to add a test executable for one qir circuit
 macro(ADD_QIR_CIRCUIT target_name circuit_path)
   if(NOT TARGET ${target_name})
@@ -13,12 +25,10 @@ macro(ADD_QIR_CIRCUIT target_name circuit_path)
     get_filename_component(circuit_name ${circuit_path} NAME_WE)
     add_custom_command(
       OUTPUT ${circuit_name}.o
-      COMMAND
-        clang
-        "$<$<BOOL:${CMAKE_OSX_DEPLOYMENT_TARGET}>:-mmacos-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}>"
-        -c ${circuit_path} -o ${circuit_name}.o
+      COMMAND ${LLC_EXECUTABLE} -filetype=obj -relocation-model=pic ${circuit_path} -o
+              ${circuit_name}.o
       DEPENDS ${circuit_path}
-      COMMENT "Compiling ${circuit_path} to ${circuit_name}.o")
+      COMMENT "Compiling ${circuit_path} to ${circuit_name}.o with llc")
     add_executable(${target_name} ${circuit_name}.o)
     target_link_libraries(${target_name} PRIVATE MQT::CoreQIRRuntime)
     set_target_properties(${target_name} PROPERTIES LINKER_LANGUAGE CXX)


### PR DESCRIPTION
## Description

An issue has come up, where somewhen was seeing compiler problems related to the QIR runner tests complaining about having to enable opaque pointers.
Turns out, we were simply assuming that a `clang` executable exists and can be executed to compile the QIR files.
Not only was this brittle, but also the cause for the error, because this might pick up an old LLVM version that did not have opaque pointers enabled by default (pre LLVM 15).
While I was about to simply add a conditional to add an extra flag to the clang invocation, Claude suggested to directly use the LLVM compiler `llc` instead.
Turns out that we actually ship this as part of our LLVM distribution from the `setup-mlir` project; so it seems to come with a regular LLVM installation.

So this PR changes the CMake code to directly use the `llc` binary that we get from the LLVM version that we found in the configuration.
This is much more robust now and feels like a very elegant solution ✨ 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
