### PR TITLE
♻️ Fix argument names of build methods

### DIFF
--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/GPhaseOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/GPhaseOp.cpp
@@ -19,8 +19,8 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void GPhaseOp::build(OpBuilder& builder, OperationState& state,
+void GPhaseOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                      const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, thetaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/POp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/POp.cpp
@@ -19,8 +19,8 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void POp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void POp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                 const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubitIn, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubitIn, thetaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/ROp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/ROp.cpp
@@ -19,10 +19,10 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void ROp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void ROp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                 const std::variant<double, Value>& theta,
                 const std::variant<double, Value>& phi) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  auto phiOperand = variantToValue(builder, state.location, phi);
-  build(builder, state, qubitIn, thetaOperand, phiOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  auto phiOperand = variantToValue(odsBuilder, odsState.location, phi);
+  build(odsBuilder, odsState, qubitIn, thetaOperand, phiOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RXOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RXOp.cpp
@@ -19,8 +19,8 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void RXOp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void RXOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubitIn, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubitIn, thetaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RXXOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RXXOp.cpp
@@ -19,8 +19,9 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void RXXOp::build(OpBuilder& builder, OperationState& state, Value qubit0In,
-                  Value qubit1In, const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand);
+void RXXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                  Value qubit0In, Value qubit1In,
+                  const std::variant<double, Value>& theta) {
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RYOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RYOp.cpp
@@ -19,8 +19,8 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void RYOp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void RYOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubitIn, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubitIn, thetaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RYYOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RYYOp.cpp
@@ -19,8 +19,9 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void RYYOp::build(OpBuilder& builder, OperationState& state, Value qubit0In,
-                  Value qubit1In, const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand);
+void RYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                  Value qubit0In, Value qubit1In,
+                  const std::variant<double, Value>& theta) {
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RZOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RZOp.cpp
@@ -19,8 +19,8 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void RZOp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void RZOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubitIn, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubitIn, thetaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RZXOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RZXOp.cpp
@@ -19,8 +19,9 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void RZXOp::build(OpBuilder& builder, OperationState& state, Value qubit0In,
-                  Value qubit1In, const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand);
+void RZXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                  Value qubit0In, Value qubit1In,
+                  const std::variant<double, Value>& theta) {
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RZZOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/RZZOp.cpp
@@ -19,8 +19,9 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void RZZOp::build(OpBuilder& builder, OperationState& state, Value qubit0In,
-                  Value qubit1In, const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand);
+void RZZOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                  Value qubit0In, Value qubit1In,
+                  const std::variant<double, Value>& theta) {
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/U2Op.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/U2Op.cpp
@@ -19,10 +19,10 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void U2Op::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void U2Op::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& phi,
                  const std::variant<double, Value>& lambda) {
-  auto phiOperand = variantToValue(builder, state.location, phi);
-  auto lambdaOperand = variantToValue(builder, state.location, lambda);
-  build(builder, state, qubitIn, phiOperand, lambdaOperand);
+  auto phiOperand = variantToValue(odsBuilder, odsState.location, phi);
+  auto lambdaOperand = variantToValue(odsBuilder, odsState.location, lambda);
+  build(odsBuilder, odsState, qubitIn, phiOperand, lambdaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/UOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/UOp.cpp
@@ -19,12 +19,12 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void UOp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void UOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                 const std::variant<double, Value>& theta,
                 const std::variant<double, Value>& phi,
                 const std::variant<double, Value>& lambda) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  auto phiOperand = variantToValue(builder, state.location, phi);
-  auto lambdaOperand = variantToValue(builder, state.location, lambda);
-  build(builder, state, qubitIn, thetaOperand, phiOperand, lambdaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  auto phiOperand = variantToValue(odsBuilder, odsState.location, phi);
+  auto lambdaOperand = variantToValue(odsBuilder, odsState.location, lambda);
+  build(odsBuilder, odsState, qubitIn, thetaOperand, phiOperand, lambdaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/XXMinusYYOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/XXMinusYYOp.cpp
@@ -19,11 +19,11 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void XXMinusYYOp::build(OpBuilder& builder, OperationState& state,
+void XXMinusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                         Value qubit0In, Value qubit1In,
                         const std::variant<double, Value>& theta,
                         const std::variant<double, Value>& beta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  auto betaOperand = variantToValue(builder, state.location, beta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand, betaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  auto betaOperand = variantToValue(odsBuilder, odsState.location, beta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand, betaOperand);
 }

--- a/mlir/lib/Dialect/QC/IR/Operations/StandardGates/XXPlusYYOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/StandardGates/XXPlusYYOp.cpp
@@ -19,11 +19,11 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::utils;
 
-void XXPlusYYOp::build(OpBuilder& builder, OperationState& state,
+void XXPlusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                        Value qubit0In, Value qubit1In,
                        const std::variant<double, Value>& theta,
                        const std::variant<double, Value>& beta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  auto betaOperand = variantToValue(builder, state.location, beta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand, betaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  auto betaOperand = variantToValue(odsBuilder, odsState.location, beta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand, betaOperand);
 }

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
@@ -132,14 +132,14 @@ Value BarrierOp::getParameter(const size_t /*i*/) {
   llvm::reportFatalUsageError("BarrierOp has no parameters");
 }
 
-void BarrierOp::build(OpBuilder& builder, OperationState& state,
+void BarrierOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                       ValueRange qubits) {
   SmallVector<Type> resultTypes;
   resultTypes.reserve(qubits.size());
   for (auto qubit : qubits) {
     resultTypes.push_back(qubit.getType());
   }
-  build(builder, state, resultTypes, qubits);
+  build(odsBuilder, odsState, resultTypes, qubits);
 }
 
 void BarrierOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/GPhaseOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/GPhaseOp.cpp
@@ -45,10 +45,10 @@ struct RemoveTrivialGPhase final : OpRewritePattern<GPhaseOp> {
 
 } // namespace
 
-void GPhaseOp::build(OpBuilder& builder, OperationState& state,
+void GPhaseOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                      const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, thetaOperand);
 }
 
 void GPhaseOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/POp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/POp.cpp
@@ -52,10 +52,10 @@ struct RemoveTrivialP final : OpRewritePattern<POp> {
 
 } // namespace
 
-void POp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void POp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                 const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubitIn, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubitIn, thetaOperand);
 }
 
 void POp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ROp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ROp.cpp
@@ -70,12 +70,12 @@ struct ReplaceRWithRY final : OpRewritePattern<ROp> {
 
 } // namespace
 
-void ROp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void ROp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                 const std::variant<double, Value>& theta,
                 const std::variant<double, Value>& phi) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  auto phiOperand = variantToValue(builder, state.location, phi);
-  build(builder, state, qubitIn, thetaOperand, phiOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  auto phiOperand = variantToValue(odsBuilder, odsState.location, phi);
+  build(odsBuilder, odsState, qubitIn, thetaOperand, phiOperand);
 }
 
 void ROp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXOp.cpp
@@ -52,10 +52,10 @@ struct RemoveTrivialRX final : OpRewritePattern<RXOp> {
 
 } // namespace
 
-void RXOp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void RXOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubitIn, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubitIn, thetaOperand);
 }
 
 void RXOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
@@ -52,10 +52,11 @@ struct RemoveTrivialRXX final : OpRewritePattern<RXXOp> {
 
 } // namespace
 
-void RXXOp::build(OpBuilder& builder, OperationState& state, Value qubit0In,
-                  Value qubit1In, const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand);
+void RXXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                  Value qubit0In, Value qubit1In,
+                  const std::variant<double, Value>& theta) {
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand);
 }
 
 void RXXOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYOp.cpp
@@ -52,10 +52,10 @@ struct RemoveTrivialRY final : OpRewritePattern<RYOp> {
 
 } // namespace
 
-void RYOp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void RYOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubitIn, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubitIn, thetaOperand);
 }
 
 void RYOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
@@ -52,10 +52,11 @@ struct RemoveTrivialRYY final : OpRewritePattern<RYYOp> {
 
 } // namespace
 
-void RYYOp::build(OpBuilder& builder, OperationState& state, Value qubit0In,
-                  Value qubit1In, const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand);
+void RYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                  Value qubit0In, Value qubit1In,
+                  const std::variant<double, Value>& theta) {
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand);
 }
 
 void RYYOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZOp.cpp
@@ -52,10 +52,10 @@ struct RemoveTrivialRZ final : OpRewritePattern<RZOp> {
 
 } // namespace
 
-void RZOp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void RZOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubitIn, thetaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubitIn, thetaOperand);
 }
 
 void RZOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
@@ -52,10 +52,11 @@ struct RemoveTrivialRZX final : OpRewritePattern<RZXOp> {
 
 } // namespace
 
-void RZXOp::build(OpBuilder& builder, OperationState& state, Value qubit0In,
-                  Value qubit1In, const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand);
+void RZXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                  Value qubit0In, Value qubit1In,
+                  const std::variant<double, Value>& theta) {
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand);
 }
 
 void RZXOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
@@ -52,10 +52,11 @@ struct RemoveTrivialRZZ final : OpRewritePattern<RZZOp> {
 
 } // namespace
 
-void RZZOp::build(OpBuilder& builder, OperationState& state, Value qubit0In,
-                  Value qubit1In, const std::variant<double, Value>& theta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand);
+void RZZOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                  Value qubit0In, Value qubit1In,
+                  const std::variant<double, Value>& theta) {
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand);
 }
 
 void RZZOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/U2Op.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/U2Op.cpp
@@ -96,12 +96,12 @@ struct ReplaceU2WithRY final : OpRewritePattern<U2Op> {
 
 } // namespace
 
-void U2Op::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void U2Op::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& phi,
                  const std::variant<double, Value>& lambda) {
-  auto phiOperand = variantToValue(builder, state.location, phi);
-  auto lambdaOperand = variantToValue(builder, state.location, lambda);
-  build(builder, state, qubitIn, phiOperand, lambdaOperand);
+  auto phiOperand = variantToValue(odsBuilder, odsState.location, phi);
+  auto lambdaOperand = variantToValue(odsBuilder, odsState.location, lambda);
+  build(odsBuilder, odsState, qubitIn, phiOperand, lambdaOperand);
 }
 
 void U2Op::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/UOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/UOp.cpp
@@ -97,14 +97,14 @@ struct ReplaceUWithRY final : OpRewritePattern<UOp> {
 
 } // namespace
 
-void UOp::build(OpBuilder& builder, OperationState& state, Value qubitIn,
+void UOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                 const std::variant<double, Value>& theta,
                 const std::variant<double, Value>& phi,
                 const std::variant<double, Value>& lambda) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  auto phiOperand = variantToValue(builder, state.location, phi);
-  auto lambdaOperand = variantToValue(builder, state.location, lambda);
-  build(builder, state, qubitIn, thetaOperand, phiOperand, lambdaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  auto phiOperand = variantToValue(odsBuilder, odsState.location, phi);
+  auto lambdaOperand = variantToValue(odsBuilder, odsState.location, lambda);
+  build(odsBuilder, odsState, qubitIn, thetaOperand, phiOperand, lambdaOperand);
 }
 
 void UOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
@@ -71,13 +71,13 @@ struct MergeSubsequentXXMinusYY final : OpRewritePattern<XXMinusYYOp> {
 
 } // namespace
 
-void XXMinusYYOp::build(OpBuilder& builder, OperationState& state,
+void XXMinusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                         Value qubit0In, Value qubit1In,
                         const std::variant<double, Value>& theta,
                         const std::variant<double, Value>& beta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  auto betaOperand = variantToValue(builder, state.location, beta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand, betaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  auto betaOperand = variantToValue(odsBuilder, odsState.location, beta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand, betaOperand);
 }
 
 void XXMinusYYOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
@@ -71,13 +71,13 @@ struct MergeSubsequentXXPlusYY final : OpRewritePattern<XXPlusYYOp> {
 
 } // namespace
 
-void XXPlusYYOp::build(OpBuilder& builder, OperationState& state,
+void XXPlusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                        Value qubit0In, Value qubit1In,
                        const std::variant<double, Value>& theta,
                        const std::variant<double, Value>& beta) {
-  auto thetaOperand = variantToValue(builder, state.location, theta);
-  auto betaOperand = variantToValue(builder, state.location, beta);
-  build(builder, state, qubit0In, qubit1In, thetaOperand, betaOperand);
+  auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
+  auto betaOperand = variantToValue(odsBuilder, odsState.location, beta);
+  build(odsBuilder, odsState, qubit0In, qubit1In, thetaOperand, betaOperand);
 }
 
 void XXPlusYYOp::getCanonicalizationPatterns(RewritePatternSet& results,


### PR DESCRIPTION
## Description

This PR fixes the argument names of the build method of most operations, after I had eroneously simplified them. This will silence warnings in IDEs (see https://github.com/munich-quantum-toolkit/core/pull/1464#pullrequestreview-3674260642). 

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] ~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~
- [x] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.