### PR TITLE
🔧 Allow C++ standards newer than 20

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -6,9 +6,11 @@
 #
 # Licensed under the MIT License
 
-set(CMAKE_CXX_STANDARD
-    20
-    CACHE STRING "C++ standard to conform to")
+if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 20)
+  set(CMAKE_CXX_STANDARD
+      20
+      CACHE STRING "C++ standard to conform to")
+endif()
 
 if(MSVC)
   add_compile_definitions(_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING)


### PR DESCRIPTION
## Description

This PR loosens the requirements on the C++ standard by setting `CMAKE_CXX_STANDARD` only if it is not defined or older than 20.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] ~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~
- [x] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
