### PR TITLE
🎨 Add `mlir` Namespace For Architecture

### DIFF
--- a/mlir/include/mlir/Dialect/QCO/Transforms/Mapping/Architecture.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Mapping/Architecture.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <utility>
 
-namespace mlir {
+namespace mlir::qco {
 
 /**
  * @brief A quantum accelerator's architecture.
@@ -98,4 +98,4 @@ private:
   Matrix prev_;
 };
 
-} // namespace mlir
+} // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Architecture.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Architecture.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 
 using namespace mlir;
+using namespace mlir::qco;
 
 std::string_view Architecture::name() const { return name_; }
 

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -38,6 +38,7 @@
 #include <tuple>
 
 using namespace mlir;
+using namespace mlir::qco;
 
 namespace {
 struct ArchitectureParam {


### PR DESCRIPTION
## Description

This pull requests wraps the Architecture class inside the `mlir` namespace. This is useful in the rare cases when you want to compile QMAP and the MLIR Compiler to a single binary (which both define a class `Architecture`). Otherwise you will get a segfault because they have the same symbol in the symbol table. 

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
