### PR TITLE
🩹 Fix missing `MLIRDialectUtils` link library for QTensor dialect

### DIFF
--- a/mlir/lib/Dialect/QTensor/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/QTensor/IR/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(
   LINK_LIBS
   PRIVATE
   MLIRIR
+  MLIRDialectUtils
   MLIRArithDialect
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces


### PR DESCRIPTION
## Description

This fixes a linker error on my local system setup, which manifested as
```
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(AllocOp.cpp.o): in function `mlir::qtensor::AllocOp::build(mlir::OpBuilder&, mlir::OperationState&, mlir::Value)':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/AllocOp.cpp:29:(.text+0x4d): undefined reference to `mlir::getConstantIntValue(mlir::OpFoldResult)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(AllocOp.cpp.o): in function `mlir::qtensor::AllocOp::verify()':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/AllocOp.cpp:42:(.text+0x224): undefined reference to `mlir::getConstantIntValue(mlir::OpFoldResult)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(ExtractOp.cpp.o): in function `mlir::qtensor::ExtractOp::verify()':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp:24:(.text+0xa7): undefined reference to `mlir::getConstantIntValue(mlir::OpFoldResult)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(ExtractOp.cpp.o): in function `foldExtractAfterInsert(mlir::qtensor::ExtractOp)':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp:50:(.text+0x31f): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp:50:(.text+0x32f): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(ExtractSliceOp.cpp.o): in function `mlir::qtensor::ExtractSliceOp::build(mlir::OpBuilder&, mlir::OperationState&, mlir::Value, mlir::Value, mlir::Value, llvm::ArrayRef<mlir::NamedAttribute>)':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractSliceOp.cpp:30:(.text+0x8e): undefined reference to `mlir::getConstantIntValue(mlir::OpFoldResult)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(ExtractSliceOp.cpp.o): in function `mlir::qtensor::ExtractSliceOp::verify()':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractSliceOp.cpp:42:(.text+0x2f6): undefined reference to `mlir::getConstantIntValue(mlir::OpFoldResult)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractSliceOp.cpp:43:(.text+0x342): undefined reference to `mlir::getConstantIntValue(mlir::OpFoldResult)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(ExtractSliceOp.cpp.o): in function `foldExtractAfterInsertSlice(mlir::qtensor::ExtractSliceOp)':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractSliceOp.cpp:86:(.text+0x7d9): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractSliceOp.cpp:86:(.text+0x7e9): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractSliceOp.cpp:87:(.text+0x810): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/ExtractSliceOp.cpp:87:(.text+0x820): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(InsertOp.cpp.o): in function `mlir::qtensor::InsertOp::verify()':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp:24:(.text+0xa7): undefined reference to `mlir::getConstantIntValue(mlir::OpFoldResult)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(InsertOp.cpp.o): in function `foldInsertAfterExtract(mlir::qtensor::InsertOp)':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp:55:(.text+0x360): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp:55:(.text+0x370): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(InsertSliceOp.cpp.o): in function `mlir::qtensor::InsertSliceOp::verify()':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/InsertSliceOp.cpp:26:(.text+0xee): undefined reference to `mlir::getConstantIntValue(mlir::OpFoldResult)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/InsertSliceOp.cpp:27:(.text+0x13a): undefined reference to `mlir::getConstantIntValue(mlir::OpFoldResult)'
/usr/bin/ld: mlir/lib/Dialect/QTensor/IR/libMLIRQTensorDialect.a(InsertSliceOp.cpp.o): in function `foldInsertAfterExtractSlice(mlir::qtensor::InsertSliceOp)':
/home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/InsertSliceOp.cpp:72:(.text+0x64b): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/InsertSliceOp.cpp:72:(.text+0x65b): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/InsertSliceOp.cpp:73:(.text+0x682): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
/usr/bin/ld: /home/lburgholzer/Documents/mqt-core/mlir/lib/Dialect/QTensor/IR/Operations/InsertSliceOp.cpp:73:(.text+0x692): undefined reference to `mlir::getAsOpFoldResult(mlir::Value)'
collect2: error: ld returned 1 exit status
```

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
