### PR TITLE
🎨 Return registers from `allocQubitRegister()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 - ✨ Add conversions between Jeff and QCO ([#1479], [#1548], [#1565]) ([**@denialhaag**])
 - ✨ Add a `place-and-route` pass for mapping circuits to architectures with restricted topologies ([#1537], [#1547], [#1568], [#1581], [#1583], [#1588]) ([**@MatthiasReumann**])
 - ✨ Add initial infrastructure for new QC and QCO MLIR dialects
-  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1623], [#1624])
+  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1623], [#1624], [#1627])
   ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**])
 
 ### Changed
@@ -335,6 +335,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1627]: https://github.com/munich-quantum-toolkit/core/pull/1627
 [#1624]: https://github.com/munich-quantum-toolkit/core/pull/1624
 [#1623]: https://github.com/munich-quantum-toolkit/core/pull/1623
 [#1602]: https://github.com/munich-quantum-toolkit/core/pull/1602

--- a/docs/mlir/QC.md
+++ b/docs/mlir/QC.md
@@ -9,3 +9,9 @@ tocdepth: 3
 ```{include} Dialects/QCInterfaces.md
 :heading-offset: 1
 ```
+
+## Passes
+
+```{include} Passes/QCTransforms.md
+
+```

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -115,7 +115,11 @@ public:
       return qubits[index];
     }
 
-    operator Value() const { return value; }
+    /**
+     * @brief Conversion to the backing MemRef value
+     * @return The MemRef value representing the qubit register
+     */
+    explicit operator Value() const { return value; }
   };
 
   /**

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -12,7 +12,6 @@
 
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
-#include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
@@ -20,6 +19,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstdint>
 #include <string>
@@ -94,6 +94,20 @@ public:
   // Memory Management
   //===--------------------------------------------------------------------===//
 
+  struct QubitRegister {
+    Value value;
+    SmallVector<Value> qubits;
+
+    Value operator[](size_t index) const {
+      if (index >= qubits.size()) {
+        llvm::report_fatal_error("Qubit index out of bounds");
+      }
+      return qubits[index];
+    }
+
+    operator Value() const { return value; }
+  };
+
   /**
    * @brief Allocate a single qubit initialized to |0⟩
    * @return A qubit reference
@@ -126,7 +140,7 @@ public:
   /**
    * @brief Allocate a qubit register
    * @param size Number of qubits (must be positive)
-   * @return Vector of qubit references
+   * @return A QubitRegister structure
    *
    * @par Example:
    * ```c++
@@ -139,7 +153,7 @@ public:
    * %q2 = memref.load %memref[%c2] : memref<3x!qc.qubit>
    * ```
    */
-  llvm::SmallVector<Value> allocQubitRegister(int64_t size);
+  QubitRegister allocQubitRegister(int64_t size);
 
   /**
    * @brief A small structure representing a single classical bit within a

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -94,10 +94,20 @@ public:
   // Memory Management
   //===--------------------------------------------------------------------===//
 
+  /**
+   * @brief Represents a qubit register with its qubits.
+   */
   struct QubitRegister {
+    /// The MemRef value representing the qubit register
     Value value;
+    /// The allocated qubit values
     SmallVector<Value> qubits;
 
+    /**
+     * @brief Access a specific qubit in the register
+     * @param index The index of the qubit to access
+     * @return The specified qubit value
+     */
     Value operator[](size_t index) const {
       if (index >= qubits.size()) {
         llvm::report_fatal_error("Qubit index out of bounds");
@@ -140,7 +150,7 @@ public:
   /**
    * @brief Allocate a qubit register
    * @param size Number of qubits (must be positive)
-   * @return A QubitRegister structure
+   * @return A `QubitRegister` structure
    *
    * @par Example:
    * ```c++
@@ -198,7 +208,7 @@ public:
    * @brief Allocate a classical bit register
    * @param size Number of bits
    * @param name Register name (default: "c")
-   * @return A ClassicalRegister structure
+   * @return A `ClassicalRegister` structure
    *
    * @par Example:
    * ```c++

--- a/mlir/include/mlir/Dialect/QC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QC/Transforms/Passes.td
@@ -16,11 +16,9 @@ def ShrinkQubitRegistersPass
   let dependentDialects = ["mlir::qc::QCDialect", "mlir::arith::ArithDialect",
                            "mlir::memref::MemRefDialect"];
   let summary =
-      "Shrink static qc::QubitType memref registers to accessed indices.";
+      "Shrink static `qc::QubitType` MemRef registers to accessed indices.";
   let description = [{
-    Shrinks one-dimensional static memref registers with element type
-    `!qc.qubit` by removing never-read indices and remapping `memref.load`
-    users accordingly.
+    Shrinks one-dimensional static MemRef registers with element type `!qc.qubit` by removing never-read indices and remapping `memref.load` users accordingly.
   }];
 }
 

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -13,7 +13,6 @@
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
-#include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
@@ -21,6 +20,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstdint>
 #include <string>
@@ -103,6 +103,20 @@ public:
   // Memory Management
   //===--------------------------------------------------------------------===//
 
+  struct QubitRegister {
+    Value value;
+    SmallVector<Value> qubits;
+
+    Value operator[](size_t index) const {
+      if (index >= qubits.size()) {
+        llvm::reportFatalUsageError("Qubit index out of bounds");
+      }
+      return qubits[index];
+    }
+
+    operator Value() const { return value; }
+  };
+
   /**
    * @brief Allocate a single qubit initialized to |0⟩
    * @return A tracked, valid qubit SSA value
@@ -135,7 +149,7 @@ public:
   /**
    * @brief Allocate a qubit register
    * @param size Number of qubits (must be positive)
-   * @return Vector of tracked, valid qubit SSA values
+   * @return A QubitRegister structure
    *
    * @par Example:
    * ```c++
@@ -148,7 +162,7 @@ public:
    * %t3, %q2 = qtensor.extract %t2[%c2]: tensor<3x!qco.qubit>
    * ```
    */
-  llvm::SmallVector<Value> allocQubitRegister(int64_t size);
+  QubitRegister allocQubitRegister(int64_t size);
 
   /**
    * @brief A small structure representing a single classical bit within a
@@ -1125,7 +1139,7 @@ public:
    * ```c++
    * {controls_out, targets_out} =
    *   builder.ctrl(q0_in, q1_in,
-   *     [&](ValueRange targets) -> llvm::SmallVector<Value> {
+   *     [&](ValueRange targets) -> SmallVector<Value> {
    *       return {builder.x(targets[0])};
    *   });
    * ```
@@ -1138,7 +1152,7 @@ public:
    */
   std::pair<ValueRange, ValueRange>
   ctrl(ValueRange controls, ValueRange targets,
-       llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> body);
+       llvm::function_ref<SmallVector<Value>(ValueRange)> body);
 
   /**
    * @brief Apply an inverse operation
@@ -1150,7 +1164,7 @@ public:
    * @par Example:
    * ```c++
    * qubits_out = builder.inv(q0_in,
-   *   [&](ValueRange qubits) -> llvm::SmallVector<Value> {
+   *   [&](ValueRange qubits) -> SmallVector<Value> {
    *     return {builder.s(qubits[0])};
    *   }
    * );
@@ -1163,7 +1177,7 @@ public:
    * ```
    */
   ValueRange inv(ValueRange qubits,
-                 llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> body);
+                 llvm::function_ref<SmallVector<Value>(ValueRange)> body);
 
   //===--------------------------------------------------------------------===//
   // Deallocation
@@ -1214,7 +1228,7 @@ public:
    * ```c++
    * auto result =
    *   builder.qcoIf(condition, q0,
-   *     [&](ValueRange args) -> llvm::SmallVector<Value> {
+   *     [&](ValueRange args) -> SmallVector<Value> {
    *       auto q1 = builder.h(args[0]);
    *       return {q1};
    *     });
@@ -1230,9 +1244,8 @@ public:
    */
   ValueRange
   qcoIf(const std::variant<bool, Value>& condition, ValueRange qubits,
-        llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> thenBody,
-        llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> elseBody =
-            nullptr);
+        llvm::function_ref<SmallVector<Value>(ValueRange)> thenBody,
+        llvm::function_ref<SmallVector<Value>(ValueRange)> elseBody = nullptr);
 
   //===--------------------------------------------------------------------===//
   // Finalization

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -124,7 +124,11 @@ public:
       return qubits[index];
     }
 
-    operator Value() const { return value; }
+    /**
+     * @brief Conversion to the backing QTensor value
+     * @return The QTensor value representing the qubit register
+     */
+    explicit operator Value() const { return value; }
   };
 
   /**

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -103,10 +103,20 @@ public:
   // Memory Management
   //===--------------------------------------------------------------------===//
 
+  /**
+   * @brief Represents a qubit register with its qubits.
+   */
   struct QubitRegister {
+    /// The QTensor value representing the qubit register
     Value value;
+    /// The allocated qubit values
     SmallVector<Value> qubits;
 
+    /**
+     * @brief Access a specific qubit in the register
+     * @param index The index of the qubit to access
+     * @return The specified qubit value
+     */
     Value operator[](size_t index) const {
       if (index >= qubits.size()) {
         llvm::reportFatalUsageError("Qubit index out of bounds");
@@ -149,7 +159,7 @@ public:
   /**
    * @brief Allocate a qubit register
    * @param size Number of qubits (must be positive)
-   * @return A QubitRegister structure
+   * @return A `QubitRegister` structure
    *
    * @par Example:
    * ```c++
@@ -207,7 +217,7 @@ public:
    * @brief Allocate a classical bit register
    * @param size Number of bits
    * @param name Register name (default: "c")
-   * @return A ClassicalRegister structure
+   * @return A `ClassicalRegister` structure
    *
    * @par Example:
    * ```c++

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -117,7 +117,7 @@ public:
      * @param index The index of the qubit to access
      * @return The specified qubit value
      */
-    Value operator[](size_t index) const {
+    Value& operator[](size_t index) {
       if (index >= qubits.size()) {
         llvm::reportFatalUsageError("Qubit index out of bounds");
       }

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -107,7 +107,8 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
     const auto& qubit = qubits.emplace_back(load.getResult());
     allocatedQubits.insert(qubit);
   }
-  return {memref, qubits};
+
+  return {.value = memref, .qubits = qubits};
 }
 
 QCProgramBuilder::ClassicalRegister

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -108,7 +108,7 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
     allocatedQubits.insert(qubit);
   }
 
-  return {.value = memref, .qubits = qubits};
+  return {.value = memref, .qubits = std::move(qubits)};
 }
 
 QCProgramBuilder::ClassicalRegister

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -87,7 +87,7 @@ Value QCProgramBuilder::staticQubit(const uint64_t index) {
   return staticOp.getQubit();
 }
 
-llvm::SmallVector<Value>
+QCProgramBuilder::QubitRegister
 QCProgramBuilder::allocQubitRegister(const int64_t size) {
   checkFinalized();
 
@@ -107,7 +107,7 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
     const auto& qubit = qubits.emplace_back(load.getResult());
     allocatedQubits.insert(qubit);
   }
-  return qubits;
+  return {memref, qubits};
 }
 
 QCProgramBuilder::ClassicalRegister

--- a/mlir/lib/Dialect/QC/Transforms/ShrinkQubitRegisters.cpp
+++ b/mlir/lib/Dialect/QC/Transforms/ShrinkQubitRegisters.cpp
@@ -34,7 +34,8 @@ namespace mlir::qc {
 #include "mlir/Dialect/QC/Transforms/Passes.h.inc"
 
 /**
- * @brief Return the constant index of a one-dimensional memref load.
+ * @brief Return the constant index of a one-dimensional `memref.load`
+ * operation.
  */
 [[nodiscard]] static std::optional<int64_t>
 getLoadIndex(memref::LoadOp loadOp) {

--- a/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
@@ -97,9 +97,9 @@ allocateQregs(QCProgramBuilder& builder,
   // Allocate quantum registers using the builder
   SmallVector<QregInfo> qregs;
   for (const auto* qregPtr : qregPtrs) {
-    auto qubits =
+    auto qubitRegister =
         builder.allocQubitRegister(static_cast<int64_t>(qregPtr->getSize()));
-    qregs.emplace_back(qregPtr, std::move(qubits));
+    qregs.emplace_back(qregPtr, std::move(qubitRegister.qubits));
   }
 
   return qregs;

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -113,7 +113,8 @@ QCOProgramBuilder::allocQubitRegister(const int64_t size) {
     qtensor = qtensorOut;
     qubits.emplace_back(qubit);
   }
-  return {qtensor, qubits};
+
+  return {.value = qtensor, .qubits = qubits};
 }
 
 QCOProgramBuilder::ClassicalRegister

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -114,7 +114,7 @@ QCOProgramBuilder::allocQubitRegister(const int64_t size) {
     qubits.emplace_back(qubit);
   }
 
-  return {.value = qtensor, .qubits = qubits};
+  return {.value = qtensor, .qubits = std::move(qubits)};
 }
 
 QCOProgramBuilder::ClassicalRegister

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -96,7 +96,7 @@ Value QCOProgramBuilder::staticQubit(const uint64_t index) {
   return qubit;
 }
 
-llvm::SmallVector<Value>
+QCOProgramBuilder::QubitRegister
 QCOProgramBuilder::allocQubitRegister(const int64_t size) {
   checkFinalized();
 
@@ -113,7 +113,7 @@ QCOProgramBuilder::allocQubitRegister(const int64_t size) {
     qtensor = qtensorOut;
     qubits.emplace_back(qubit);
   }
-  return qubits;
+  return {qtensor, qubits};
 }
 
 QCOProgramBuilder::ClassicalRegister

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -83,21 +83,19 @@ void singleMeasurementToSingleBit(QCOProgramBuilder& b) {
 }
 
 void repeatedMeasurementToSameBit(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
+  auto q = b.allocQubitRegister(1);
   const auto& c = b.allocClassicalBitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.measure(q0, c[0]);
-  q0 = b.measure(q0, c[0]);
-  q0 = b.measure(q0, c[0]);
+  q[0] = b.measure(q[0], c[0]);
+  q[0] = b.measure(q[0], c[0]);
+  q[0] = b.measure(q[0], c[0]);
 }
 
 void repeatedMeasurementToDifferentBits(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   const auto& c = b.allocClassicalBitRegister(3);
-  auto q0 = q[0];
-  q0 = b.measure(q0, c[0]);
-  q0 = b.measure(q0, c[1]);
-  q0 = b.measure(q0, c[2]);
+  q[0] = b.measure(q[0], c[0]);
+  q[0] = b.measure(q[0], c[1]);
+  q[0] = b.measure(q[0], c[2]);
 }
 
 void multipleClassicalRegistersAndMeasurements(QCOProgramBuilder& b) {
@@ -120,9 +118,9 @@ void resetQubitWithoutOp(QCOProgramBuilder& b) {
 }
 
 void resetMultipleQubitsWithoutOp(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  b.reset(reg[0]);
-  b.reset(reg[1]);
+  auto q = b.allocQubitRegister(2);
+  q[0] = b.reset(q[0]);
+  q[1] = b.reset(q[1]);
 }
 
 void repeatedResetWithoutOp(QCOProgramBuilder& b) {
@@ -133,29 +131,25 @@ void repeatedResetWithoutOp(QCOProgramBuilder& b) {
 }
 
 void resetQubitAfterSingleOp(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.h(q0);
-  q0 = b.reset(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.h(q[0]);
+  q[0] = b.reset(q[0]);
 }
 
 void resetMultipleQubitsAfterSingleOp(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  q0 = b.h(q0);
-  q0 = b.reset(q0);
-  q1 = b.h(q1);
-  q1 = b.reset(q1);
+  auto q = b.allocQubitRegister(2);
+  q[0] = b.h(q[0]);
+  q[0] = b.reset(q[0]);
+  q[1] = b.h(q[1]);
+  q[1] = b.reset(q[1]);
 }
 
 void repeatedResetAfterSingleOp(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.h(q0);
-  q0 = b.reset(q0);
-  q0 = b.reset(q0);
-  q0 = b.reset(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.h(q[0]);
+  q[0] = b.reset(q[0]);
+  q[0] = b.reset(q[0]);
+  q[0] = b.reset(q[0]);
 }
 
 void globalPhase(QCOProgramBuilder& b) { b.gphase(0.123); }
@@ -286,10 +280,9 @@ void inverseMultipleControlledX(QCOProgramBuilder& b) {
 }
 
 void twoX(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.x(q0);
-  q0 = b.x(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.x(q[0]);
+  q[0] = b.x(q[0]);
 }
 
 void y(QCOProgramBuilder& b) {
@@ -342,10 +335,9 @@ void inverseMultipleControlledY(QCOProgramBuilder& b) {
 }
 
 void twoY(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.y(q0);
-  q0 = b.y(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.y(q[0]);
+  q[0] = b.y(q[0]);
 }
 
 void z(QCOProgramBuilder& b) {
@@ -398,10 +390,9 @@ void inverseMultipleControlledZ(QCOProgramBuilder& b) {
 }
 
 void twoZ(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.z(q0);
-  q0 = b.z(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.z(q[0]);
+  q[0] = b.z(q[0]);
 }
 
 void h(QCOProgramBuilder& b) {
@@ -454,10 +445,9 @@ void inverseMultipleControlledH(QCOProgramBuilder& b) {
 }
 
 void twoH(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.h(q0);
-  q0 = b.h(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.h(q[0]);
+  q[0] = b.h(q[0]);
 }
 
 void hWithoutRegister(QCOProgramBuilder& b) {
@@ -515,17 +505,15 @@ void inverseMultipleControlledS(QCOProgramBuilder& b) {
 }
 
 void sThenSdg(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.s(q0);
-  q0 = b.sdg(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.s(q[0]);
+  q[0] = b.sdg(q[0]);
 }
 
 void twoS(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.s(q0);
-  q0 = b.s(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.s(q[0]);
+  q[0] = b.s(q[0]);
 }
 
 void sdg(QCOProgramBuilder& b) {
@@ -578,17 +566,15 @@ void inverseMultipleControlledSdg(QCOProgramBuilder& b) {
 }
 
 void sdgThenS(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.sdg(q0);
-  q0 = b.s(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.sdg(q[0]);
+  q[0] = b.s(q[0]);
 }
 
 void twoSdg(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.sdg(q0);
-  q0 = b.sdg(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.sdg(q[0]);
+  q[0] = b.sdg(q[0]);
 }
 
 void t_(QCOProgramBuilder& b) {
@@ -641,17 +627,15 @@ void inverseMultipleControlledT(QCOProgramBuilder& b) {
 }
 
 void tThenTdg(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.t(q0);
-  q0 = b.tdg(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.t(q[0]);
+  q[0] = b.tdg(q[0]);
 }
 
 void twoT(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.t(q0);
-  q0 = b.t(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.t(q[0]);
+  q[0] = b.t(q[0]);
 }
 
 void tdg(QCOProgramBuilder& b) {
@@ -704,17 +688,15 @@ void inverseMultipleControlledTdg(QCOProgramBuilder& b) {
 }
 
 void tdgThenT(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.tdg(q0);
-  q0 = b.t(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.tdg(q[0]);
+  q[0] = b.t(q[0]);
 }
 
 void twoTdg(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.tdg(q0);
-  q0 = b.tdg(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.tdg(q[0]);
+  q[0] = b.tdg(q[0]);
 }
 
 void sx(QCOProgramBuilder& b) {
@@ -767,17 +749,15 @@ void inverseMultipleControlledSx(QCOProgramBuilder& b) {
 }
 
 void sxThenSxdg(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.sx(q0);
-  q0 = b.sxdg(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.sx(q[0]);
+  q[0] = b.sxdg(q[0]);
 }
 
 void twoSx(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.sx(q0);
-  q0 = b.sx(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.sx(q[0]);
+  q[0] = b.sx(q[0]);
 }
 
 void sxdg(QCOProgramBuilder& b) {
@@ -830,17 +810,15 @@ void inverseMultipleControlledSxdg(QCOProgramBuilder& b) {
 }
 
 void sxdgThenSx(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.sxdg(q0);
-  q0 = b.sx(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.sxdg(q[0]);
+  q[0] = b.sx(q[0]);
 }
 
 void twoSxdg(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.sxdg(q0);
-  q0 = b.sxdg(q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.sxdg(q[0]);
+  q[0] = b.sxdg(q[0]);
 }
 
 void rx(QCOProgramBuilder& b) {
@@ -893,10 +871,9 @@ void inverseMultipleControlledRx(QCOProgramBuilder& b) {
 }
 
 void twoRxOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.rx(0.123, q0);
-  q0 = b.rx(-0.123, q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.rx(0.123, q[0]);
+  q[0] = b.rx(-0.123, q[0]);
 }
 
 void rxPiOver2(QCOProgramBuilder& b) {
@@ -953,10 +930,9 @@ void inverseMultipleControlledRy(QCOProgramBuilder& b) {
   });
 }
 void twoRyOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.ry(0.456, q0);
-  q0 = b.ry(-0.456, q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.ry(0.456, q[0]);
+  q[0] = b.ry(-0.456, q[0]);
 }
 
 void ryPiOver2(QCOProgramBuilder& b) {
@@ -1014,10 +990,9 @@ void inverseMultipleControlledRz(QCOProgramBuilder& b) {
 }
 
 void twoRzOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.rz(0.789, q0);
-  q0 = b.rz(-0.789, q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.rz(0.789, q[0]);
+  q[0] = b.rz(-0.789, q[0]);
 }
 
 void p(QCOProgramBuilder& b) {
@@ -1070,10 +1045,9 @@ void inverseMultipleControlledP(QCOProgramBuilder& b) {
 }
 
 void twoPOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.p(0.123, q0);
-  q0 = b.p(-0.123, q0);
+  auto q = b.allocQubitRegister(1);
+  q[0] = b.p(0.123, q[0]);
+  q[0] = b.p(-0.123, q[0]);
 }
 
 void r(QCOProgramBuilder& b) {
@@ -1326,19 +1300,15 @@ void inverseMultipleControlledSwap(QCOProgramBuilder& b) {
 }
 
 void twoSwap(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.swap(q0, q1);
-  std::tie(q0, q1) = b.swap(q0, q1);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.swap(q[0], q[1]);
+  std::tie(q[0], q[1]) = b.swap(q[0], q[1]);
 }
 
 void twoSwapSwappedTargets(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.swap(q0, q1);
-  std::tie(q1, q0) = b.swap(q1, q0);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.swap(q[0], q[1]);
+  std::tie(q[1], q[0]) = b.swap(q[1], q[0]);
 }
 
 void iswap(QCOProgramBuilder& b) {
@@ -1448,19 +1418,15 @@ void inverseMultipleControlledDcx(QCOProgramBuilder& b) {
 }
 
 void twoDcx(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.dcx(q0, q1);
-  std::tie(q0, q1) = b.dcx(q0, q1);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.dcx(q[0], q[1]);
+  std::tie(q[0], q[1]) = b.dcx(q[0], q[1]);
 }
 
 void twoDcxSwappedTargets(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.dcx(q0, q1);
-  std::tie(q1, q0) = b.dcx(q1, q0);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.dcx(q[0], q[1]);
+  std::tie(q[1], q[0]) = b.dcx(q[1], q[0]);
 }
 
 void ecr(QCOProgramBuilder& b) {
@@ -1517,11 +1483,9 @@ void inverseMultipleControlledEcr(QCOProgramBuilder& b) {
 }
 
 void twoEcr(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.ecr(q0, q1);
-  std::tie(q0, q1) = b.ecr(q0, q1);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.ecr(q[0], q[1]);
+  std::tie(q[0], q[1]) = b.ecr(q[0], q[1]);
 }
 
 void rxx(QCOProgramBuilder& b) {
@@ -1588,37 +1552,29 @@ void fourControlledRxx(QCOProgramBuilder& b) {
 }
 
 void twoRxx(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
+  auto q = b.allocQubitRegister(2);
   // 0.045 + 0.078 = 0.123
-  std::tie(q0, q1) = b.rxx(0.045, q0, q1);
-  std::tie(q0, q1) = b.rxx(0.078, q0, q1);
+  std::tie(q[0], q[1]) = b.rxx(0.045, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.rxx(0.078, q[0], q[1]);
 }
 
 void twoRxxSwappedTargets(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
+  auto q = b.allocQubitRegister(2);
   // 0.045 + 0.078 = 0.123
-  std::tie(q0, q1) = b.rxx(0.045, q0, q1);
-  std::tie(q1, q0) = b.rxx(0.078, q1, q0);
+  std::tie(q[0], q[1]) = b.rxx(0.045, q[0], q[1]);
+  std::tie(q[1], q[0]) = b.rxx(0.078, q[1], q[0]);
 }
 
 void twoRxxOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.rxx(0.123, q0, q1);
-  std::tie(q0, q1) = b.rxx(-0.123, q0, q1);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.rxx(0.123, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.rxx(-0.123, q[0], q[1]);
 }
 
 void twoRxxOppositePhaseSwappedTargets(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.rxx(0.123, q0, q1);
-  std::tie(q1, q0) = b.rxx(-0.123, q1, q0);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.rxx(0.123, q[0], q[1]);
+  std::tie(q[1], q[0]) = b.rxx(-0.123, q[1], q[0]);
 }
 
 void ryy(QCOProgramBuilder& b) {
@@ -1675,37 +1631,29 @@ void inverseMultipleControlledRyy(QCOProgramBuilder& b) {
 }
 
 void twoRyy(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
+  auto q = b.allocQubitRegister(2);
   // 0.045 + 0.078 = 0.123
-  std::tie(q0, q1) = b.ryy(0.045, q0, q1);
-  std::tie(q0, q1) = b.ryy(0.078, q0, q1);
+  std::tie(q[0], q[1]) = b.ryy(0.045, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.ryy(0.078, q[0], q[1]);
 }
 
 void twoRyyOppositePhaseSwappedTargets(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.ryy(0.123, q0, q1);
-  std::tie(q1, q0) = b.ryy(-0.123, q1, q0);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.ryy(0.123, q[0], q[1]);
+  std::tie(q[1], q[0]) = b.ryy(-0.123, q[1], q[0]);
 }
 
 void twoRyyOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.ryy(0.123, q0, q1);
-  std::tie(q0, q1) = b.ryy(-0.123, q0, q1);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.ryy(0.123, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.ryy(-0.123, q[0], q[1]);
 }
 
 void twoRyySwappedTargets(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
+  auto q = b.allocQubitRegister(2);
   // 0.045 + 0.078 = 0.123
-  std::tie(q0, q1) = b.ryy(0.045, q0, q1);
-  std::tie(q1, q0) = b.ryy(0.078, q1, q0);
+  std::tie(q[0], q[1]) = b.ryy(0.045, q[0], q[1]);
+  std::tie(q[1], q[0]) = b.ryy(0.078, q[1], q[0]);
 }
 
 void rzx(QCOProgramBuilder& b) {
@@ -1762,11 +1710,9 @@ void inverseMultipleControlledRzx(QCOProgramBuilder& b) {
 }
 
 void twoRzxOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.rzx(0.123, q0, q1);
-  std::tie(q0, q1) = b.rzx(-0.123, q0, q1);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.rzx(0.123, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.rzx(-0.123, q[0], q[1]);
 }
 
 void rzz(QCOProgramBuilder& b) {
@@ -1823,37 +1769,29 @@ void inverseMultipleControlledRzz(QCOProgramBuilder& b) {
 }
 
 void twoRzz(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
+  auto q = b.allocQubitRegister(2);
   // 0.045 + 0.078 = 0.123
-  std::tie(q0, q1) = b.rzz(0.045, q0, q1);
-  std::tie(q0, q1) = b.rzz(0.078, q0, q1);
+  std::tie(q[0], q[1]) = b.rzz(0.045, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.rzz(0.078, q[0], q[1]);
 }
 
 void twoRzzSwappedTargets(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
+  auto q = b.allocQubitRegister(2);
   // 0.045 + 0.078 = 0.123
-  std::tie(q0, q1) = b.rzz(0.045, q0, q1);
-  std::tie(q1, q0) = b.rzz(0.078, q1, q0);
+  std::tie(q[0], q[1]) = b.rzz(0.045, q[0], q[1]);
+  std::tie(q[1], q[0]) = b.rzz(0.078, q[1], q[0]);
 }
 
 void twoRzzOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.rzz(0.123, q0, q1);
-  std::tie(q0, q1) = b.rzz(-0.123, q0, q1);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.rzz(0.123, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.rzz(-0.123, q[0], q[1]);
 }
 
 void twoRzzOppositePhaseSwappedTargets(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.rzz(0.123, q0, q1);
-  std::tie(q1, q0) = b.rzz(-0.123, q1, q0);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.rzz(0.123, q[0], q[1]);
+  std::tie(q[1], q[0]) = b.rzz(-0.123, q[1], q[0]);
 }
 
 void xxPlusYY(QCOProgramBuilder& b) {
@@ -1911,11 +1849,9 @@ void inverseMultipleControlledXxPlusYY(QCOProgramBuilder& b) {
 }
 
 void twoXxPlusYYOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.xx_plus_yy(0.123, 0.456, q0, q1);
-  std::tie(q0, q1) = b.xx_plus_yy(-0.123, 0.456, q0, q1);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.xx_plus_yy(0.123, 0.456, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.xx_plus_yy(-0.123, 0.456, q[0], q[1]);
 }
 
 void xxMinusYY(QCOProgramBuilder& b) {
@@ -1973,11 +1909,9 @@ void inverseMultipleControlledXxMinusYY(QCOProgramBuilder& b) {
 }
 
 void twoXxMinusYYOppositePhase(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  std::tie(q0, q1) = b.xx_minus_yy(0.123, 0.456, q0, q1);
-  std::tie(q0, q1) = b.xx_minus_yy(-0.123, 0.456, q0, q1);
+  auto q = b.allocQubitRegister(2);
+  std::tie(q[0], q[1]) = b.xx_minus_yy(0.123, 0.456, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.xx_minus_yy(-0.123, 0.456, q[0], q[1]);
 }
 
 void barrier(QCOProgramBuilder& b) {
@@ -2010,9 +1944,11 @@ void inverseBarrier(QCOProgramBuilder& b) {
 }
 
 void twoBarrier(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto b1 = b.barrier({reg[0], reg[1]});
-  b.barrier({b1[0], b1[1]});
+  auto q = b.allocQubitRegister(2);
+  auto b1 = b.barrier({q[0], q[1]});
+  q[0] = b1[0];
+  q[1] = b1[1];
+  b.barrier({q[0], q[1]});
 }
 
 void trivialCtrl(QCOProgramBuilder& b) {
@@ -2139,9 +2075,8 @@ void invCtrlSandwich(QCOProgramBuilder& b) {
 }
 
 void simpleIf(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.h(q0);
+  auto q = b.allocQubitRegister(1);
+  auto q0 = b.h(q[0]);
   auto [measuredQubit, measureResult] = b.measure(q0);
   b.qcoIf(measureResult, measuredQubit, [&](mlir::ValueRange qubits) {
     auto innerQubit = b.x(qubits[0]);
@@ -2150,12 +2085,10 @@ void simpleIf(QCOProgramBuilder& b) {
 }
 
 void ifTwoQubits(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto q0 = reg[0];
-  auto q1 = reg[1];
-  q0 = b.h(q0);
+  auto q = b.allocQubitRegister(2);
+  auto q0 = b.h(q[0]);
   auto [measuredQubit, measureResult] = b.measure(q0);
-  b.qcoIf(measureResult, {measuredQubit, q1}, [&](mlir::ValueRange qubits) {
+  b.qcoIf(measureResult, {measuredQubit, q[1]}, [&](mlir::ValueRange qubits) {
     auto innerQubit0 = b.x(qubits[0]);
     auto innerQubit1 = b.x(qubits[1]);
     return llvm::SmallVector<mlir::Value>{innerQubit0, innerQubit1};
@@ -2163,9 +2096,8 @@ void ifTwoQubits(QCOProgramBuilder& b) {
 }
 
 void ifElse(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.h(q0);
+  auto q = b.allocQubitRegister(1);
+  auto q0 = b.h(q[0]);
   auto [measuredQubit, measureResult] = b.measure(q0);
   b.qcoIf(
       measureResult, {measuredQubit},
@@ -2180,9 +2112,9 @@ void ifElse(QCOProgramBuilder& b) {
 }
 
 void constantTrueIf(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
+  auto q = b.allocQubitRegister(1);
   b.qcoIf(
-      true, reg.qubits,
+      true, q.qubits,
       [&](mlir::ValueRange qubits) {
         auto innerQubit = b.x(qubits[0]);
         return llvm::SmallVector<mlir::Value>{innerQubit};
@@ -2194,9 +2126,9 @@ void constantTrueIf(QCOProgramBuilder& b) {
 }
 
 void constantFalseIf(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
+  auto q = b.allocQubitRegister(1);
   b.qcoIf(
-      false, reg.qubits,
+      false, q.qubits,
       [&](mlir::ValueRange qubits) {
         auto innerQubit = b.x(qubits[0]);
         return llvm::SmallVector<mlir::Value>{innerQubit};
@@ -2208,9 +2140,8 @@ void constantFalseIf(QCOProgramBuilder& b) {
 }
 
 void nestedTrueIf(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(1);
-  auto q0 = reg[0];
-  q0 = b.h(q0);
+  auto q = b.allocQubitRegister(1);
+  auto q0 = b.h(q[0]);
   auto [measuredQubit, measureResult] = b.measure(q0);
   b.qcoIf(measureResult, measuredQubit, [&](mlir::ValueRange outerQubits) {
     auto innerResult =

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -83,19 +83,21 @@ void singleMeasurementToSingleBit(QCOProgramBuilder& b) {
 }
 
 void repeatedMeasurementToSameBit(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
+  auto reg = b.allocQubitRegister(1);
   const auto& c = b.allocClassicalBitRegister(1);
-  q[0] = b.measure(q[0], c[0]);
-  q[0] = b.measure(q[0], c[0]);
-  q[0] = b.measure(q[0], c[0]);
+  auto q0 = reg[0];
+  q0 = b.measure(q0, c[0]);
+  q0 = b.measure(q0, c[0]);
+  q0 = b.measure(q0, c[0]);
 }
 
 void repeatedMeasurementToDifferentBits(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   const auto& c = b.allocClassicalBitRegister(3);
-  q[0] = b.measure(q[0], c[0]);
-  q[0] = b.measure(q[0], c[1]);
-  q[0] = b.measure(q[0], c[2]);
+  auto q0 = q[0];
+  q0 = b.measure(q0, c[0]);
+  q0 = b.measure(q0, c[1]);
+  q0 = b.measure(q0, c[2]);
 }
 
 void multipleClassicalRegistersAndMeasurements(QCOProgramBuilder& b) {
@@ -118,9 +120,9 @@ void resetQubitWithoutOp(QCOProgramBuilder& b) {
 }
 
 void resetMultipleQubitsWithoutOp(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  q[0] = b.reset(q[0]);
-  q[1] = b.reset(q[1]);
+  auto reg = b.allocQubitRegister(2);
+  b.reset(reg[0]);
+  b.reset(reg[1]);
 }
 
 void repeatedResetWithoutOp(QCOProgramBuilder& b) {
@@ -131,25 +133,29 @@ void repeatedResetWithoutOp(QCOProgramBuilder& b) {
 }
 
 void resetQubitAfterSingleOp(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.h(q[0]);
-  q[0] = b.reset(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.h(q0);
+  q0 = b.reset(q0);
 }
 
 void resetMultipleQubitsAfterSingleOp(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  q[0] = b.h(q[0]);
-  q[0] = b.reset(q[0]);
-  q[1] = b.h(q[1]);
-  q[1] = b.reset(q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  q0 = b.h(q0);
+  q0 = b.reset(q0);
+  q1 = b.h(q1);
+  q1 = b.reset(q1);
 }
 
 void repeatedResetAfterSingleOp(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.h(q[0]);
-  q[0] = b.reset(q[0]);
-  q[0] = b.reset(q[0]);
-  q[0] = b.reset(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.h(q0);
+  q0 = b.reset(q0);
+  q0 = b.reset(q0);
+  q0 = b.reset(q0);
 }
 
 void globalPhase(QCOProgramBuilder& b) { b.gphase(0.123); }
@@ -280,9 +286,10 @@ void inverseMultipleControlledX(QCOProgramBuilder& b) {
 }
 
 void twoX(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.x(q[0]);
-  q[0] = b.x(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.x(q0);
+  q0 = b.x(q0);
 }
 
 void y(QCOProgramBuilder& b) {
@@ -335,9 +342,10 @@ void inverseMultipleControlledY(QCOProgramBuilder& b) {
 }
 
 void twoY(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.y(q[0]);
-  q[0] = b.y(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.y(q0);
+  q0 = b.y(q0);
 }
 
 void z(QCOProgramBuilder& b) {
@@ -390,9 +398,10 @@ void inverseMultipleControlledZ(QCOProgramBuilder& b) {
 }
 
 void twoZ(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.z(q[0]);
-  q[0] = b.z(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.z(q0);
+  q0 = b.z(q0);
 }
 
 void h(QCOProgramBuilder& b) {
@@ -445,9 +454,10 @@ void inverseMultipleControlledH(QCOProgramBuilder& b) {
 }
 
 void twoH(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.h(q[0]);
-  q[0] = b.h(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.h(q0);
+  q0 = b.h(q0);
 }
 
 void hWithoutRegister(QCOProgramBuilder& b) {
@@ -505,15 +515,17 @@ void inverseMultipleControlledS(QCOProgramBuilder& b) {
 }
 
 void sThenSdg(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.s(q[0]);
-  q[0] = b.sdg(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.s(q0);
+  q0 = b.sdg(q0);
 }
 
 void twoS(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.s(q[0]);
-  q[0] = b.s(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.s(q0);
+  q0 = b.s(q0);
 }
 
 void sdg(QCOProgramBuilder& b) {
@@ -566,15 +578,17 @@ void inverseMultipleControlledSdg(QCOProgramBuilder& b) {
 }
 
 void sdgThenS(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.sdg(q[0]);
-  q[0] = b.s(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.sdg(q0);
+  q0 = b.s(q0);
 }
 
 void twoSdg(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.sdg(q[0]);
-  q[0] = b.sdg(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.sdg(q0);
+  q0 = b.sdg(q0);
 }
 
 void t_(QCOProgramBuilder& b) {
@@ -627,15 +641,17 @@ void inverseMultipleControlledT(QCOProgramBuilder& b) {
 }
 
 void tThenTdg(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.t(q[0]);
-  q[0] = b.tdg(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.t(q0);
+  q0 = b.tdg(q0);
 }
 
 void twoT(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.t(q[0]);
-  q[0] = b.t(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.t(q0);
+  q0 = b.t(q0);
 }
 
 void tdg(QCOProgramBuilder& b) {
@@ -688,15 +704,17 @@ void inverseMultipleControlledTdg(QCOProgramBuilder& b) {
 }
 
 void tdgThenT(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.tdg(q[0]);
-  q[0] = b.t(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.tdg(q0);
+  q0 = b.t(q0);
 }
 
 void twoTdg(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.tdg(q[0]);
-  q[0] = b.tdg(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.tdg(q0);
+  q0 = b.tdg(q0);
 }
 
 void sx(QCOProgramBuilder& b) {
@@ -749,15 +767,17 @@ void inverseMultipleControlledSx(QCOProgramBuilder& b) {
 }
 
 void sxThenSxdg(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.sx(q[0]);
-  q[0] = b.sxdg(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.sx(q0);
+  q0 = b.sxdg(q0);
 }
 
 void twoSx(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.sx(q[0]);
-  q[0] = b.sx(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.sx(q0);
+  q0 = b.sx(q0);
 }
 
 void sxdg(QCOProgramBuilder& b) {
@@ -810,15 +830,17 @@ void inverseMultipleControlledSxdg(QCOProgramBuilder& b) {
 }
 
 void sxdgThenSx(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.sxdg(q[0]);
-  q[0] = b.sx(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.sxdg(q0);
+  q0 = b.sx(q0);
 }
 
 void twoSxdg(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.sxdg(q[0]);
-  q[0] = b.sxdg(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.sxdg(q0);
+  q0 = b.sxdg(q0);
 }
 
 void rx(QCOProgramBuilder& b) {
@@ -871,9 +893,10 @@ void inverseMultipleControlledRx(QCOProgramBuilder& b) {
 }
 
 void twoRxOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.rx(0.123, q[0]);
-  q[0] = b.rx(-0.123, q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.rx(0.123, q0);
+  q0 = b.rx(-0.123, q0);
 }
 
 void rxPiOver2(QCOProgramBuilder& b) {
@@ -930,9 +953,10 @@ void inverseMultipleControlledRy(QCOProgramBuilder& b) {
   });
 }
 void twoRyOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.ry(0.456, q[0]);
-  q[0] = b.ry(-0.456, q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.ry(0.456, q0);
+  q0 = b.ry(-0.456, q0);
 }
 
 void ryPiOver2(QCOProgramBuilder& b) {
@@ -990,9 +1014,10 @@ void inverseMultipleControlledRz(QCOProgramBuilder& b) {
 }
 
 void twoRzOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.rz(0.789, q[0]);
-  q[0] = b.rz(-0.789, q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.rz(0.789, q0);
+  q0 = b.rz(-0.789, q0);
 }
 
 void p(QCOProgramBuilder& b) {
@@ -1045,9 +1070,10 @@ void inverseMultipleControlledP(QCOProgramBuilder& b) {
 }
 
 void twoPOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  q[0] = b.p(0.123, q[0]);
-  q[0] = b.p(-0.123, q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.p(0.123, q0);
+  q0 = b.p(-0.123, q0);
 }
 
 void r(QCOProgramBuilder& b) {
@@ -1300,15 +1326,19 @@ void inverseMultipleControlledSwap(QCOProgramBuilder& b) {
 }
 
 void twoSwap(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.swap(q[0], q[1]);
-  std::tie(q[0], q[1]) = b.swap(q[0], q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.swap(q0, q1);
+  std::tie(q0, q1) = b.swap(q0, q1);
 }
 
 void twoSwapSwappedTargets(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.swap(q[0], q[1]);
-  std::tie(q[1], q[0]) = b.swap(q[1], q[0]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.swap(q0, q1);
+  std::tie(q1, q0) = b.swap(q1, q0);
 }
 
 void iswap(QCOProgramBuilder& b) {
@@ -1418,15 +1448,19 @@ void inverseMultipleControlledDcx(QCOProgramBuilder& b) {
 }
 
 void twoDcx(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.dcx(q[0], q[1]);
-  std::tie(q[0], q[1]) = b.dcx(q[0], q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.dcx(q0, q1);
+  std::tie(q0, q1) = b.dcx(q0, q1);
 }
 
 void twoDcxSwappedTargets(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.dcx(q[0], q[1]);
-  std::tie(q[1], q[0]) = b.dcx(q[1], q[0]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.dcx(q0, q1);
+  std::tie(q1, q0) = b.dcx(q1, q0);
 }
 
 void ecr(QCOProgramBuilder& b) {
@@ -1483,9 +1517,11 @@ void inverseMultipleControlledEcr(QCOProgramBuilder& b) {
 }
 
 void twoEcr(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.ecr(q[0], q[1]);
-  std::tie(q[0], q[1]) = b.ecr(q[0], q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.ecr(q0, q1);
+  std::tie(q0, q1) = b.ecr(q0, q1);
 }
 
 void rxx(QCOProgramBuilder& b) {
@@ -1552,29 +1588,37 @@ void fourControlledRxx(QCOProgramBuilder& b) {
 }
 
 void twoRxx(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
   // 0.045 + 0.078 = 0.123
-  std::tie(q[0], q[1]) = b.rxx(0.045, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.rxx(0.078, q[0], q[1]);
+  std::tie(q0, q1) = b.rxx(0.045, q0, q1);
+  std::tie(q0, q1) = b.rxx(0.078, q0, q1);
 }
 
 void twoRxxSwappedTargets(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
   // 0.045 + 0.078 = 0.123
-  std::tie(q[0], q[1]) = b.rxx(0.045, q[0], q[1]);
-  std::tie(q[1], q[0]) = b.rxx(0.078, q[1], q[0]);
+  std::tie(q0, q1) = b.rxx(0.045, q0, q1);
+  std::tie(q1, q0) = b.rxx(0.078, q1, q0);
 }
 
 void twoRxxOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.rxx(0.123, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.rxx(-0.123, q[0], q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.rxx(0.123, q0, q1);
+  std::tie(q0, q1) = b.rxx(-0.123, q0, q1);
 }
 
 void twoRxxOppositePhaseSwappedTargets(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.rxx(0.123, q[0], q[1]);
-  std::tie(q[1], q[0]) = b.rxx(-0.123, q[1], q[0]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.rxx(0.123, q0, q1);
+  std::tie(q1, q0) = b.rxx(-0.123, q1, q0);
 }
 
 void ryy(QCOProgramBuilder& b) {
@@ -1631,29 +1675,37 @@ void inverseMultipleControlledRyy(QCOProgramBuilder& b) {
 }
 
 void twoRyy(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
   // 0.045 + 0.078 = 0.123
-  std::tie(q[0], q[1]) = b.ryy(0.045, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.ryy(0.078, q[0], q[1]);
+  std::tie(q0, q1) = b.ryy(0.045, q0, q1);
+  std::tie(q0, q1) = b.ryy(0.078, q0, q1);
 }
 
 void twoRyyOppositePhaseSwappedTargets(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.ryy(0.123, q[0], q[1]);
-  std::tie(q[1], q[0]) = b.ryy(-0.123, q[1], q[0]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.ryy(0.123, q0, q1);
+  std::tie(q1, q0) = b.ryy(-0.123, q1, q0);
 }
 
 void twoRyyOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.ryy(0.123, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.ryy(-0.123, q[0], q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.ryy(0.123, q0, q1);
+  std::tie(q0, q1) = b.ryy(-0.123, q0, q1);
 }
 
 void twoRyySwappedTargets(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
   // 0.045 + 0.078 = 0.123
-  std::tie(q[0], q[1]) = b.ryy(0.045, q[0], q[1]);
-  std::tie(q[1], q[0]) = b.ryy(0.078, q[1], q[0]);
+  std::tie(q0, q1) = b.ryy(0.045, q0, q1);
+  std::tie(q1, q0) = b.ryy(0.078, q1, q0);
 }
 
 void rzx(QCOProgramBuilder& b) {
@@ -1710,9 +1762,11 @@ void inverseMultipleControlledRzx(QCOProgramBuilder& b) {
 }
 
 void twoRzxOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.rzx(0.123, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.rzx(-0.123, q[0], q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.rzx(0.123, q0, q1);
+  std::tie(q0, q1) = b.rzx(-0.123, q0, q1);
 }
 
 void rzz(QCOProgramBuilder& b) {
@@ -1769,29 +1823,37 @@ void inverseMultipleControlledRzz(QCOProgramBuilder& b) {
 }
 
 void twoRzz(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
   // 0.045 + 0.078 = 0.123
-  std::tie(q[0], q[1]) = b.rzz(0.045, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.rzz(0.078, q[0], q[1]);
+  std::tie(q0, q1) = b.rzz(0.045, q0, q1);
+  std::tie(q0, q1) = b.rzz(0.078, q0, q1);
 }
 
 void twoRzzSwappedTargets(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
   // 0.045 + 0.078 = 0.123
-  std::tie(q[0], q[1]) = b.rzz(0.045, q[0], q[1]);
-  std::tie(q[1], q[0]) = b.rzz(0.078, q[1], q[0]);
+  std::tie(q0, q1) = b.rzz(0.045, q0, q1);
+  std::tie(q1, q0) = b.rzz(0.078, q1, q0);
 }
 
 void twoRzzOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.rzz(0.123, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.rzz(-0.123, q[0], q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.rzz(0.123, q0, q1);
+  std::tie(q0, q1) = b.rzz(-0.123, q0, q1);
 }
 
 void twoRzzOppositePhaseSwappedTargets(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.rzz(0.123, q[0], q[1]);
-  std::tie(q[1], q[0]) = b.rzz(-0.123, q[1], q[0]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.rzz(0.123, q0, q1);
+  std::tie(q1, q0) = b.rzz(-0.123, q1, q0);
 }
 
 void xxPlusYY(QCOProgramBuilder& b) {
@@ -1849,9 +1911,11 @@ void inverseMultipleControlledXxPlusYY(QCOProgramBuilder& b) {
 }
 
 void twoXxPlusYYOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.xx_plus_yy(0.123, 0.456, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.xx_plus_yy(-0.123, 0.456, q[0], q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.xx_plus_yy(0.123, 0.456, q0, q1);
+  std::tie(q0, q1) = b.xx_plus_yy(-0.123, 0.456, q0, q1);
 }
 
 void xxMinusYY(QCOProgramBuilder& b) {
@@ -1909,9 +1973,11 @@ void inverseMultipleControlledXxMinusYY(QCOProgramBuilder& b) {
 }
 
 void twoXxMinusYYOppositePhase(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  std::tie(q[0], q[1]) = b.xx_minus_yy(0.123, 0.456, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.xx_minus_yy(-0.123, 0.456, q[0], q[1]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  std::tie(q0, q1) = b.xx_minus_yy(0.123, 0.456, q0, q1);
+  std::tie(q0, q1) = b.xx_minus_yy(-0.123, 0.456, q0, q1);
 }
 
 void barrier(QCOProgramBuilder& b) {
@@ -1944,11 +2010,9 @@ void inverseBarrier(QCOProgramBuilder& b) {
 }
 
 void twoBarrier(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  auto b1 = b.barrier({q[0], q[1]});
-  q[0] = b1[0];
-  q[1] = b1[1];
-  b.barrier({q[0], q[1]});
+  auto reg = b.allocQubitRegister(2);
+  auto b1 = b.barrier({reg[0], reg[1]});
+  b.barrier({b1[0], b1[1]});
 }
 
 void trivialCtrl(QCOProgramBuilder& b) {
@@ -2075,8 +2139,9 @@ void invCtrlSandwich(QCOProgramBuilder& b) {
 }
 
 void simpleIf(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  auto q0 = b.h(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.h(q0);
   auto [measuredQubit, measureResult] = b.measure(q0);
   b.qcoIf(measureResult, measuredQubit, [&](mlir::ValueRange qubits) {
     auto innerQubit = b.x(qubits[0]);
@@ -2085,10 +2150,12 @@ void simpleIf(QCOProgramBuilder& b) {
 }
 
 void ifTwoQubits(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  auto q0 = b.h(q[0]);
+  auto reg = b.allocQubitRegister(2);
+  auto q0 = reg[0];
+  auto q1 = reg[1];
+  q0 = b.h(q0);
   auto [measuredQubit, measureResult] = b.measure(q0);
-  b.qcoIf(measureResult, {measuredQubit, q[1]}, [&](mlir::ValueRange qubits) {
+  b.qcoIf(measureResult, {measuredQubit, q1}, [&](mlir::ValueRange qubits) {
     auto innerQubit0 = b.x(qubits[0]);
     auto innerQubit1 = b.x(qubits[1]);
     return llvm::SmallVector<mlir::Value>{innerQubit0, innerQubit1};
@@ -2096,8 +2163,9 @@ void ifTwoQubits(QCOProgramBuilder& b) {
 }
 
 void ifElse(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  auto q0 = b.h(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.h(q0);
   auto [measuredQubit, measureResult] = b.measure(q0);
   b.qcoIf(
       measureResult, {measuredQubit},
@@ -2112,9 +2180,9 @@ void ifElse(QCOProgramBuilder& b) {
 }
 
 void constantTrueIf(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
+  auto reg = b.allocQubitRegister(1);
   b.qcoIf(
-      true, q,
+      true, reg.qubits,
       [&](mlir::ValueRange qubits) {
         auto innerQubit = b.x(qubits[0]);
         return llvm::SmallVector<mlir::Value>{innerQubit};
@@ -2126,9 +2194,9 @@ void constantTrueIf(QCOProgramBuilder& b) {
 }
 
 void constantFalseIf(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
+  auto reg = b.allocQubitRegister(1);
   b.qcoIf(
-      false, q,
+      false, reg.qubits,
       [&](mlir::ValueRange qubits) {
         auto innerQubit = b.x(qubits[0]);
         return llvm::SmallVector<mlir::Value>{innerQubit};
@@ -2140,8 +2208,9 @@ void constantFalseIf(QCOProgramBuilder& b) {
 }
 
 void nestedTrueIf(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  auto q0 = b.h(q[0]);
+  auto reg = b.allocQubitRegister(1);
+  auto q0 = reg[0];
+  q0 = b.h(q0);
   auto [measuredQubit, measureResult] = b.measure(q0);
   b.qcoIf(measureResult, measuredQubit, [&](mlir::ValueRange outerQubits) {
     auto innerResult =


### PR DESCRIPTION
## Description

This PR refactors QC and QCO's `allocQubitRegister()` methods to actually return the created registers. This is achieved by returning `QubitRegister` structures that contain the register itself and its qubits.

Fixes #1615

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
