### PR TITLE
🎨 Reduce sorting during QIR creation

### DIFF
--- a/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
@@ -1085,21 +1085,11 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
     builder.setInsertionPoint(&outputBlock.back());
 
     if (!resultPtrs.empty()) {
-      // Sort result pointers for deterministic output
-      llvm::SmallVector<std::pair<int64_t, Value>> sortedPtrs;
-      for (const auto& [index, resultPtr] : resultPtrs) {
-        sortedPtrs.emplace_back(index, resultPtr);
-      }
-      llvm::sort(sortedPtrs, [](const auto& a, const auto& b) {
-        return a.first < b.first;
-      });
-
-      // Create output recording for each result pointer
       auto fnSig = LLVM::LLVMFunctionType::get(voidType, {ptrType, ptrType});
       auto fnDec = getOrCreateFunctionDeclaration(builder, main,
                                                   QIR_RECORD_OUTPUT, fnSig);
-
-      for (const auto& [index, ptr] : sortedPtrs) {
+      // Create output recording for each result pointer
+      for (const auto& [index, ptr] : resultPtrs) {
         auto label = createResultLabel(builder, main,
                                        "__unnamed__" + std::to_string(index))
                          .getResult();
@@ -1109,25 +1099,14 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
     }
 
     if (!resultArrays.empty()) {
-      // Sort registers by name for deterministic output
-      SmallVector<std::pair<StringRef, Value>> sortedRegisters;
-      for (auto& [name, results] : resultArrays) {
-        sortedRegisters.emplace_back(name, results);
-      }
-      llvm::sort(sortedRegisters, [](const auto& a, const auto& b) {
-        return a.first < b.first;
-      });
-
       auto fnSig = LLVM::LLVMFunctionType::get(
           voidType, {builder.getI64Type(), ptrType, ptrType});
       auto fnDec = getOrCreateFunctionDeclaration(
           builder, main, QIR_ARRAY_RECORD_OUTPUT, fnSig);
-
       // Generate output recording for each register
-      for (auto& [name, results] : sortedRegisters) {
+      for (const auto& [name, results] : resultArrays) {
         auto size = results.getDefiningOp<LLVM::AllocaOp>().getArraySize();
         auto label = createResultLabel(builder, main, name).getResult();
-
         LLVM::CallOp::create(builder, main->getLoc(), fnDec,
                              ValueRange{size, results, label});
       }

--- a/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
@@ -666,20 +666,11 @@ void QIRProgramBuilder::generateOutputRecording() {
   setInsertionPoint(outputBlock->getTerminator());
 
   if (!resultPtrs.empty()) {
-    // Sort result pointers for deterministic output
-    llvm::SmallVector<std::pair<int64_t, Value>> sortedPtrs;
-    for (const auto& [index, resultPtr] : resultPtrs) {
-      sortedPtrs.emplace_back(index, resultPtr);
-    }
-    llvm::sort(sortedPtrs,
-               [](const auto& a, const auto& b) { return a.first < b.first; });
-
-    // Create output recording for each result pointer
     auto fnSig = LLVM::LLVMFunctionType::get(voidType, {ptrType, ptrType});
     auto fnDec =
         getOrCreateFunctionDeclaration(*this, module, QIR_RECORD_OUTPUT, fnSig);
-
-    for (const auto& [index, ptr] : sortedPtrs) {
+    // Create output recording for each result pointer
+    for (const auto& [index, ptr] : resultPtrs) {
       auto label = createResultLabel(*this, module,
                                      "__unnamed__" + std::to_string(index))
                        .getResult();
@@ -688,24 +679,14 @@ void QIRProgramBuilder::generateOutputRecording() {
   }
 
   if (!resultArrays.empty()) {
-    // Sort registers by name for deterministic output
-    SmallVector<std::pair<StringRef, Value>> sortedArrays;
-    for (auto& [name, results] : resultArrays) {
-      sortedArrays.emplace_back(name, results);
-    }
-    llvm::sort(sortedArrays,
-               [](const auto& a, const auto& b) { return a.first < b.first; });
-
     auto fnSig =
         LLVM::LLVMFunctionType::get(voidType, {getI64Type(), ptrType, ptrType});
     auto fnDec = getOrCreateFunctionDeclaration(*this, module,
                                                 QIR_ARRAY_RECORD_OUTPUT, fnSig);
-
     // Create output recording for each register
-    for (auto& [name, results] : sortedArrays) {
+    for (const auto& [name, results] : resultArrays) {
       auto size = results.getDefiningOp<LLVM::AllocaOp>().getArraySize();
       auto label = createResultLabel(*this, module, name).getResult();
-
       LLVM::CallOp::create(*this, fnDec, ValueRange{size, results, label});
     }
   }

--- a/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
@@ -12,7 +12,6 @@
 
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
-#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>


### PR DESCRIPTION
## Description

This PR removes all `llvm::sort()` statements called during QIR creation. The equivalence checker does not appear to need adjustment.

Fixes #1617 

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
