### PR TITLE
🎨 Clean up `llvm` includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637]) ([**@denialhaag**])
 - ✨ Add a `place-and-route` pass for mapping circuits to architectures with restricted topologies ([#1537], [#1547], [#1568], [#1581], [#1583], [#1588], [#1664]) ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add initial infrastructure for new QC and QCO MLIR dialects
-  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1620], [#1623], [#1624], [#1626], [#1627], [#1635])
+  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1620], [#1623], [#1624], [#1626], [#1627], [#1635], [#1673])
   ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**])
 
 ### Changed
@@ -361,6 +361,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1673]: https://github.com/munich-quantum-toolkit/core/pull/1673
 [#1664]: https://github.com/munich-quantum-toolkit/core/pull/1664
 [#1662]: https://github.com/munich-quantum-toolkit/core/pull/1662
 [#1652]: https://github.com/munich-quantum-toolkit/core/pull/1652

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <llvm/ADT/DenseSet.h>
-#include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -10,20 +10,24 @@
 
 #pragma once
 
-#include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
-#include <mlir/IR/BuiltinOps.h>
-#include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
-#include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
 
 #include <cstdint>
 #include <string>
 #include <variant>
 
-namespace mlir::qc {
+namespace mlir {
+
+// Forward declarations
+class MLIRContext;
+class ModuleOp;
+class Operation;
+class ValueRange;
+
+namespace qc {
 
 /**
  * @brief Builder API for constructing quantum programs in the QC dialect
@@ -104,19 +108,14 @@ public:
     /// The MemRef value representing the qubit register
     Value value;
     /// The allocated qubit values
-    llvm::SmallVector<Value> qubits;
+    SmallVector<Value> qubits;
 
     /**
      * @brief Access a specific qubit in the register
      * @param index The index of the qubit to access
      * @return The specified qubit value
      */
-    Value operator[](size_t index) const {
-      if (index >= qubits.size()) {
-        llvm::report_fatal_error("Qubit index out of bounds");
-      }
-      return qubits[index];
-    }
+    Value operator[](size_t index) const;
 
     /**
      * @brief Conversion to the backing MemRef value
@@ -199,16 +198,7 @@ public:
      * @param index The index of the bit to access (must be less than size)
      * @return A Bit structure representing the specified bit
      */
-    Bit operator[](const int64_t index) const {
-      if (index < 0 || index >= size) {
-        const std::string msg = "Bit index " + std::to_string(index) +
-                                " out of bounds for register '" + name +
-                                "' of size " + std::to_string(size);
-        llvm::reportFatalUsageError(msg.c_str());
-      }
-      return {
-          .registerName = name, .registerSize = size, .registerIndex = index};
-    }
+    Bit operator[](const int64_t index) const;
   };
 
   /**
@@ -889,8 +879,7 @@ public:
    * } : !qc.qubit
    * ```
    */
-  QCProgramBuilder& ctrl(ValueRange controls,
-                         const llvm::function_ref<void()>& body);
+  QCProgramBuilder& ctrl(ValueRange controls, const function_ref<void()>& body);
 
   /**
    * @brief Apply an inverse (i.e., adjoint) operation.
@@ -909,7 +898,7 @@ public:
    * }
    * ```
    */
-  QCProgramBuilder& inv(const llvm::function_ref<void()>& body);
+  QCProgramBuilder& inv(const function_ref<void()>& body);
 
   //===--------------------------------------------------------------------===//
   // Deallocation
@@ -963,19 +952,19 @@ public:
    */
   static OwningOpRef<ModuleOp>
   build(MLIRContext* context,
-        const llvm::function_ref<void(QCProgramBuilder&)>& buildFunc);
+        const function_ref<void(QCProgramBuilder&)>& buildFunc);
 
 private:
   enum class AllocationMode : uint8_t { Unset, Static, Dynamic };
 
   MLIRContext* ctx{};
-  ModuleOp module;
+  Operation* module;
 
   /// Track allocated qubits for automatic deallocation
-  llvm::DenseSet<Value> allocatedQubits;
+  DenseSet<Value> allocatedQubits;
 
   /// Track allocated MemRefs for automatic deallocation
-  llvm::DenseSet<Value> allocatedMemrefs;
+  DenseSet<Value> allocatedMemrefs;
 
   /// Check if the builder has been finalized
   void checkFinalized() const;
@@ -986,4 +975,5 @@ private:
   /// Ensure static and dynamic qubit allocation modes are not mixed.
   void ensureAllocationMode(AllocationMode requestedMode);
 };
-} // namespace mlir::qc
+} // namespace qc
+} // namespace mlir

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -104,7 +104,7 @@ public:
     /// The MemRef value representing the qubit register
     Value value;
     /// The allocated qubit values
-    SmallVector<Value> qubits;
+    llvm::SmallVector<Value> qubits;
 
     /**
      * @brief Access a specific qubit in the register

--- a/mlir/include/mlir/Dialect/QC/IR/QCDialect.h
+++ b/mlir/include/mlir/Dialect/QC/IR/QCDialect.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <mlir/IR/Dialect.h>
 #include <mlir/IR/OpDefinition.h>
 
 #define DIALECT_NAME_QC "qc"

--- a/mlir/include/mlir/Dialect/QC/IR/QCInterfaces.h
+++ b/mlir/include/mlir/Dialect/QC/IR/QCInterfaces.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include <llvm/ADT/StringRef.h>
 #include <mlir/IR/OpDefinition.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 

--- a/mlir/include/mlir/Dialect/QC/IR/QCInterfaces.h
+++ b/mlir/include/mlir/Dialect/QC/IR/QCInterfaces.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <mlir/IR/OpDefinition.h>
-#include <mlir/IR/Value.h>
 #include <mlir/Support/LLVM.h>
 
 #include <cstddef>

--- a/mlir/include/mlir/Dialect/QC/IR/QCOps.td
+++ b/mlir/include/mlir/Dialect/QC/IR/QCOps.td
@@ -960,7 +960,7 @@ def CtrlOp
     }];
 
   let builders = [OpBuilder<(ins "ValueRange":$controls,
-      "const llvm::function_ref<void()>&":$bodyBuilder)>];
+      "const function_ref<void()>&":$bodyBuilder)>];
 
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
@@ -1002,8 +1002,7 @@ def InvOp : QCOp<"inv",
         static StringRef getBaseSymbol() { return "inv"; }
     }];
 
-  let builders = [OpBuilder<(ins
-      "const llvm::function_ref<void()>&":$bodyBuilder)>];
+  let builders = [OpBuilder<(ins "const function_ref<void()>&":$bodyBuilder)>];
 
   let hasCanonicalizer = 1;
   let hasVerifier = 1;

--- a/mlir/include/mlir/Dialect/QC/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QC/Transforms/Passes.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include "mlir/Dialect/QC/IR/QCDialect.h"
-
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassRegistry.h>
 

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -10,9 +10,6 @@
 
 #pragma once
 
-#include <llvm/ADT/DenseMap.h>
-#include <llvm/ADT/DenseSet.h>
-#include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -10,13 +10,9 @@
 
 #pragma once
 
-#include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
-#include <mlir/IR/BuiltinOps.h>
-#include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
-#include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
 
 #include <cstdint>
@@ -24,7 +20,15 @@
 #include <utility>
 #include <variant>
 
-namespace mlir::qco {
+namespace mlir {
+
+// Forward declarations
+class MLIRContext;
+class ModuleOp;
+class Operation;
+class ValueRange;
+
+namespace qco {
 
 /**
  * @brief Builder API for constructing quantum programs in the QCO dialect
@@ -112,19 +116,14 @@ public:
     /// The QTensor value representing the qubit register
     Value value;
     /// The allocated qubit values
-    llvm::SmallVector<Value> qubits;
+    SmallVector<Value> qubits;
 
     /**
      * @brief Access a specific qubit in the register
      * @param index The index of the qubit to access
      * @return The specified qubit value
      */
-    Value& operator[](size_t index) {
-      if (index >= qubits.size()) {
-        llvm::reportFatalUsageError("Qubit index out of bounds");
-      }
-      return qubits[index];
-    }
+    Value& operator[](size_t index);
 
     /**
      * @brief Conversion to the backing QTensor value
@@ -207,16 +206,7 @@ public:
      * @param index The index of the bit to access (must be less than size)
      * @return A Bit structure representing the specified bit
      */
-    Bit operator[](const int64_t index) const {
-      if (index < 0 || index >= size) {
-        const std::string msg = "Bit index " + std::to_string(index) +
-                                " out of bounds for register '" + name +
-                                "' of size " + std::to_string(size);
-        llvm::reportFatalUsageError(msg.c_str());
-      }
-      return {
-          .registerName = name, .registerSize = size, .registerIndex = index};
-    }
+    Bit operator[](int64_t index) const;
   };
 
   /**
@@ -1155,7 +1145,7 @@ public:
    * ```c++
    * {controls_out, targets_out} =
    *   builder.ctrl(q0_in, q1_in,
-   *     [&](ValueRange targets) -> llvm::SmallVector<Value> {
+   *     [&](ValueRange targets) -> SmallVector<Value> {
    *       return {builder.x(targets[0])};
    *   });
    * ```
@@ -1168,7 +1158,7 @@ public:
    */
   std::pair<ValueRange, ValueRange>
   ctrl(ValueRange controls, ValueRange targets,
-       llvm::function_ref<SmallVector<Value>(ValueRange)> body);
+       function_ref<SmallVector<Value>(ValueRange)> body);
 
   /**
    * @brief Apply an inverse operation
@@ -1180,7 +1170,7 @@ public:
    * @par Example:
    * ```c++
    * qubits_out = builder.inv(q0_in,
-   *   [&](ValueRange qubits) -> llvm::SmallVector<Value> {
+   *   [&](ValueRange qubits) -> SmallVector<Value> {
    *     return {builder.s(qubits[0])};
    *   }
    * );
@@ -1193,7 +1183,7 @@ public:
    * ```
    */
   ValueRange inv(ValueRange qubits,
-                 llvm::function_ref<SmallVector<Value>(ValueRange)> body);
+                 function_ref<SmallVector<Value>(ValueRange)> body);
 
   //===--------------------------------------------------------------------===//
   // Deallocation
@@ -1244,7 +1234,7 @@ public:
    * ```c++
    * auto result =
    *   builder.qcoIf(condition, q0,
-   *     [&](ValueRange args) -> llvm::SmallVector<Value> {
+   *     [&](ValueRange args) -> SmallVector<Value> {
    *       auto q1 = builder.h(args[0]);
    *       return {q1};
    *     });
@@ -1260,8 +1250,8 @@ public:
    */
   ValueRange
   qcoIf(const std::variant<bool, Value>& condition, ValueRange qubits,
-        llvm::function_ref<SmallVector<Value>(ValueRange)> thenBody,
-        llvm::function_ref<SmallVector<Value>(ValueRange)> elseBody = nullptr);
+        function_ref<SmallVector<Value>(ValueRange)> thenBody,
+        function_ref<SmallVector<Value>(ValueRange)> elseBody = nullptr);
 
   //===--------------------------------------------------------------------===//
   // Finalization
@@ -1291,13 +1281,13 @@ public:
    */
   static OwningOpRef<ModuleOp>
   build(MLIRContext* context,
-        const llvm::function_ref<void(QCOProgramBuilder&)>& buildFunc);
+        const function_ref<void(QCOProgramBuilder&)>& buildFunc);
 
 private:
   enum class AllocationMode : uint8_t { Unset, Static, Dynamic };
 
   MLIRContext* ctx{};
-  ModuleOp module;
+  Operation* module;
 
   /// Check if the builder has been finalized
   void checkFinalized() const;
@@ -1337,7 +1327,7 @@ private:
   /// Only values present in this map are valid for use in operations.
   /// When an operation consumes a qubit and produces a new one, the old value
   /// is removed and the new output is added.
-  llvm::DenseMap<Value, QubitInfo> validQubits;
+  DenseMap<Value, QubitInfo> validQubits;
 
   /**
    * @brief Validate that a tensor value is valid and unconsumed. This also
@@ -1367,7 +1357,7 @@ private:
   /// Only values present in this map are valid for use in operations.
   /// When an operation consumes a tensor and produces a new one, the old value
   /// is removed and the new output is added.
-  llvm::DenseMap<Value, TensorInfo> validTensors;
+  DenseMap<Value, TensorInfo> validTensors;
 
   /// Track whether static or dynamic qubit allocation is used.
   AllocationMode allocationMode = AllocationMode::Unset;
@@ -1375,4 +1365,5 @@ private:
   /// Ensure static and dynamic qubit allocation modes are not mixed.
   void ensureAllocationMode(AllocationMode requestedMode);
 };
-} // namespace mlir::qco
+} // namespace qco
+} // namespace mlir

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -112,7 +112,7 @@ public:
     /// The QTensor value representing the qubit register
     Value value;
     /// The allocated qubit values
-    SmallVector<Value> qubits;
+    llvm::SmallVector<Value> qubits;
 
     /**
      * @brief Access a specific qubit in the register
@@ -1155,7 +1155,7 @@ public:
    * ```c++
    * {controls_out, targets_out} =
    *   builder.ctrl(q0_in, q1_in,
-   *     [&](ValueRange targets) -> SmallVector<Value> {
+   *     [&](ValueRange targets) -> llvm::SmallVector<Value> {
    *       return {builder.x(targets[0])};
    *   });
    * ```
@@ -1180,7 +1180,7 @@ public:
    * @par Example:
    * ```c++
    * qubits_out = builder.inv(q0_in,
-   *   [&](ValueRange qubits) -> SmallVector<Value> {
+   *   [&](ValueRange qubits) -> llvm::SmallVector<Value> {
    *     return {builder.s(qubits[0])};
    *   }
    * );
@@ -1244,7 +1244,7 @@ public:
    * ```c++
    * auto result =
    *   builder.qcoIf(condition, q0,
-   *     [&](ValueRange args) -> SmallVector<Value> {
+   *     [&](ValueRange args) -> llvm::SmallVector<Value> {
    *       auto q1 = builder.h(args[0]);
    *       return {q1};
    *     });

--- a/mlir/include/mlir/Dialect/QCO/IR/QCODialect.h
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCODialect.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <mlir/IR/Dialect.h>
-#include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OpDefinition.h>
 
 #define DIALECT_NAME_QCO "qco"

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOInterfaces.h
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOInterfaces.h
@@ -13,8 +13,6 @@
 #include <Eigen/Core>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/OpDefinition.h>
-#include <mlir/IR/Value.h>
-#include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
 
 #include <complex>

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOInterfaces.h
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOInterfaces.h
@@ -11,11 +11,11 @@
 #pragma once
 
 #include <Eigen/Core>
-#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/OpDefinition.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
 
 #include <complex>
 #include <cstddef>

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1132,7 +1132,7 @@ def CtrlOp
            build($_builder, $_state, controls.getTypes(), targets.getTypes(), controls, targets);
         }]>,
                   OpBuilder<(ins "ValueRange":$controls, "ValueRange":$targets,
-                      "llvm::function_ref<llvm::SmallVector<Value>(ValueRange)"
+                      "function_ref<SmallVector<Value>(ValueRange)"
                       ">":$bodyBuilder)>];
 
   let hasCanonicalizer = 1;
@@ -1202,7 +1202,7 @@ def InvOp
            build($_builder, $_state, qubits.getTypes(), qubits);
         }]>,
                   OpBuilder<(ins "ValueRange":$qubits,
-                      "llvm::function_ref<llvm::SmallVector<Value>(ValueRange)"
+                      "function_ref<SmallVector<Value>(ValueRange)"
                       ">":$bodyBuilder)>];
 
   let hasCanonicalizer = 1;
@@ -1256,15 +1256,14 @@ def IfOp
         `{` type($results) `}`
     }];
 
-  let builders =
-      [OpBuilder<(ins "Value":$condition, "ValueRange":$qubits), [{
+  let builders = [OpBuilder<(ins "Value":$condition, "ValueRange":$qubits), [{
            build($_builder, $_state, qubits.getTypes(), condition, qubits);
         }]>,
-       OpBuilder<(ins "Value":$condition, "ValueRange":$qubits,
-           "llvm::function_ref<llvm::SmallVector<Value>(ValueRange)"
-           ">":$thenBuilder,
-           CArg<"llvm::function_ref<llvm::SmallVector<Value>(ValueRange)>",
-                "nullptr">:$elseBuilder)>];
+                  OpBuilder<(ins "Value":$condition, "ValueRange":$qubits,
+                      "function_ref<SmallVector<Value>(ValueRange)"
+                      ">":$thenBuilder,
+                      CArg<"function_ref<SmallVector<Value>(ValueRange)>",
+                           "nullptr">:$elseBuilder)>];
 
   let extraClassDeclaration = [{
         Block *thenBlock() {

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -10,10 +10,9 @@
 
 #pragma once
 
-#include "mlir/Dialect/Utils/Utils.h"
-
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/PatternMatch.h>
+#include <mlir/Support/LLVM.h>
 
 namespace mlir::qco {
 
@@ -27,7 +26,7 @@ namespace mlir::qco {
  * @return LogicalResult Success or failure of the removal.
  */
 template <typename InverseOpType, typename OpType>
-mlir::LogicalResult
+LogicalResult
 removeInversePairOneTargetZeroParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the inverse operation
   auto nextOp =
@@ -52,7 +51,7 @@ removeInversePairOneTargetZeroParameter(OpType op, PatternRewriter& rewriter) {
  * @return LogicalResult Success or failure of the removal.
  */
 template <typename InverseOpType, typename OpType>
-mlir::LogicalResult
+LogicalResult
 removeInversePairTwoTargetZeroParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the inverse operation
   auto nextOp =
@@ -82,7 +81,7 @@ removeInversePairTwoTargetZeroParameter(OpType op, PatternRewriter& rewriter) {
  * @return LogicalResult Success or failure of the removal.
  */
 template <typename OpType>
-mlir::LogicalResult
+LogicalResult
 removeTwoTargetZeroParameterPairWithSwappedTargets(OpType op,
                                                    PatternRewriter& rewriter) {
   // Check if the successor is the same operation
@@ -118,8 +117,8 @@ removeTwoTargetZeroParameterPairWithSwappedTargets(OpType op,
  * @return LogicalResult Success or failure of the merge.
  */
 template <typename SquareOpType, typename OpType>
-mlir::LogicalResult mergeOneTargetZeroParameter(OpType op,
-                                                PatternRewriter& rewriter) {
+LogicalResult mergeOneTargetZeroParameter(OpType op,
+                                          PatternRewriter& rewriter) {
   // Check if the successor is the same operation
   auto nextOp = llvm::dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
@@ -148,8 +147,7 @@ mlir::LogicalResult mergeOneTargetZeroParameter(OpType op,
  * @return LogicalResult Success or failure of the merge.
  */
 template <typename OpType>
-mlir::LogicalResult mergeOneTargetOneParameter(OpType op,
-                                               PatternRewriter& rewriter) {
+LogicalResult mergeOneTargetOneParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the same operation
   auto nextOp = llvm::dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
@@ -179,8 +177,7 @@ mlir::LogicalResult mergeOneTargetOneParameter(OpType op,
  * @return LogicalResult Success or failure of the merge.
  */
 template <typename OpType>
-mlir::LogicalResult mergeTwoTargetOneParameter(OpType op,
-                                               PatternRewriter& rewriter) {
+LogicalResult mergeTwoTargetOneParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the same operation
   auto nextOp = llvm::dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
@@ -217,7 +214,7 @@ mlir::LogicalResult mergeTwoTargetOneParameter(OpType op,
  * @return LogicalResult Success or failure of the merge.
  */
 template <typename OpType>
-mlir::LogicalResult
+LogicalResult
 mergeTwoTargetOneParameterWithSwappedTargets(OpType op,
                                              PatternRewriter& rewriter) {
   // Check if the successor is the same operation

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Mapping/Architecture.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Mapping/Architecture.h
@@ -12,9 +12,7 @@
 
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/ADT/Twine.h>
 #include <llvm/Support/ErrorHandling.h>
-#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <string>
@@ -27,15 +25,15 @@ namespace mlir::qco {
  */
 class [[nodiscard]] Architecture {
 public:
-  using CouplingSet = mlir::DenseSet<std::pair<std::size_t, std::size_t>>;
-  using NeighbourVector = mlir::SmallVector<mlir::SmallVector<std::size_t, 4>>;
+  using CouplingSet = llvm::DenseSet<std::pair<std::size_t, std::size_t>>;
+  using NeighbourVector = llvm::SmallVector<llvm::SmallVector<std::size_t>>;
 
   explicit Architecture(std::string name, std::size_t nqubits,
                         CouplingSet couplingSet)
       : name_(std::move(name)), nqubits_(nqubits),
         couplingSet_(std::move(couplingSet)), neighbours_(nqubits),
-        dist_(nqubits, mlir::SmallVector<std::size_t>(nqubits, UINT64_MAX)),
-        prev_(nqubits, mlir::SmallVector<std::size_t>(nqubits, UINT64_MAX)) {
+        dist_(nqubits, llvm::SmallVector<std::size_t>(nqubits, UINT64_MAX)),
+        prev_(nqubits, llvm::SmallVector<std::size_t>(nqubits, UINT64_MAX)) {
     floydWarshallWithPathReconstruction();
     collectNeighbours();
   }
@@ -63,7 +61,7 @@ public:
   /**
    * @brief Collect all neighbours of @p u.
    */
-  [[nodiscard]] mlir::SmallVector<std::size_t, 4>
+  [[nodiscard]] llvm::SmallVector<std::size_t>
   neighboursOf(std::size_t u) const;
 
   /**
@@ -73,7 +71,7 @@ public:
   [[nodiscard]] std::size_t maxDegree() const;
 
 private:
-  using Matrix = mlir::SmallVector<mlir::SmallVector<std::size_t, 0>, 0>;
+  using Matrix = llvm::SmallVector<llvm::SmallVector<std::size_t>>;
 
   /**
    * @brief Find all shortest paths in the coupling map between two qubits.

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Mapping/Architecture.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Mapping/Architecture.h
@@ -32,8 +32,8 @@ public:
                         CouplingSet couplingSet)
       : name_(std::move(name)), nqubits_(nqubits),
         couplingSet_(std::move(couplingSet)), neighbours_(nqubits),
-        dist_(nqubits, SmallVector(nqubits, UINT64_MAX)),
-        prev_(nqubits, SmallVector(nqubits, UINT64_MAX)) {
+        dist_(nqubits, SmallVector<size_t>(nqubits, UINT64_MAX)),
+        prev_(nqubits, SmallVector<size_t>(nqubits, UINT64_MAX)) {
     floydWarshallWithPathReconstruction();
     collectNeighbours();
   }

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Mapping/Architecture.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Mapping/Architecture.h
@@ -12,7 +12,7 @@
 
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/ErrorHandling.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <string>
@@ -25,15 +25,15 @@ namespace mlir::qco {
  */
 class [[nodiscard]] Architecture {
 public:
-  using CouplingSet = llvm::DenseSet<std::pair<std::size_t, std::size_t>>;
-  using NeighbourVector = llvm::SmallVector<llvm::SmallVector<std::size_t>>;
+  using CouplingSet = DenseSet<std::pair<std::size_t, std::size_t>>;
+  using NeighbourVector = SmallVector<SmallVector<std::size_t, 4>>;
 
   explicit Architecture(std::string name, std::size_t nqubits,
                         CouplingSet couplingSet)
       : name_(std::move(name)), nqubits_(nqubits),
         couplingSet_(std::move(couplingSet)), neighbours_(nqubits),
-        dist_(nqubits, llvm::SmallVector<std::size_t>(nqubits, UINT64_MAX)),
-        prev_(nqubits, llvm::SmallVector<std::size_t>(nqubits, UINT64_MAX)) {
+        dist_(nqubits, SmallVector(nqubits, UINT64_MAX)),
+        prev_(nqubits, SmallVector(nqubits, UINT64_MAX)) {
     floydWarshallWithPathReconstruction();
     collectNeighbours();
   }
@@ -61,8 +61,7 @@ public:
   /**
    * @brief Collect all neighbours of @p u.
    */
-  [[nodiscard]] llvm::SmallVector<std::size_t>
-  neighboursOf(std::size_t u) const;
+  [[nodiscard]] SmallVector<std::size_t, 4> neighboursOf(std::size_t u) const;
 
   /**
    * @brief Return the maximum degree (connectivity) of any qubit in the
@@ -71,7 +70,7 @@ public:
   [[nodiscard]] std::size_t maxDegree() const;
 
 private:
-  using Matrix = llvm::SmallVector<llvm::SmallVector<std::size_t>>;
+  using Matrix = SmallVector<SmallVector<std::size_t, 0>, 0>;
 
   /**
    * @brief Find all shortest paths in the coupling map between two qubits.

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
@@ -10,9 +10,6 @@
 
 #pragma once
 
-#include "mlir/Dialect/QCO/IR/QCODialect.h"
-
-#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassRegistry.h>
 

--- a/mlir/include/mlir/Dialect/QCO/Utils/Drivers.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/Drivers.h
@@ -88,9 +88,9 @@ LogicalResult walkProgram(Region& region, const WalkProgramFn& fn) {
   return success();
 }
 
-using ReleasedOps = SmallVector<UnitaryOpInterface, 8>;
+using ReleasedOps = llvm::SmallVector<UnitaryOpInterface, 8>;
 using PendingWiresMap =
-    DenseMap<UnitaryOpInterface, SmallVector<std::size_t, 2>>;
+    DenseMap<UnitaryOpInterface, llvm::SmallVector<std::size_t, 2>>;
 
 struct IsReady {
   bool operator()(PendingWiresMap::value_type& kv) const {
@@ -138,10 +138,10 @@ LogicalResult walkProgramGraph(MutableArrayRef<WireIterator> wires,
   PendingWiresMap pending;
   pending.reserve(wires.size());
 
-  SmallVector<std::size_t> curr(wires.size());
+  llvm::SmallVector<std::size_t> curr(wires.size());
   std::iota(curr.begin(), curr.end(), 0UL);
 
-  SmallVector<std::size_t> next;
+  llvm::SmallVector<std::size_t> next;
   next.reserve(wires.size());
 
   while (!curr.empty()) {
@@ -149,7 +149,7 @@ LogicalResult walkProgramGraph(MutableArrayRef<WireIterator> wires,
       auto& it = wires[i];
       while (Traits::isActive(it)) {
         const auto res =
-            TypeSwitch<Operation*, WalkResult>(it.operation())
+            llvm::TypeSwitch<Operation*, WalkResult>(it.operation())
                 .template Case<UnitaryOpInterface>([&](UnitaryOpInterface& op) {
                   // If there are fewer wires than the qubit requires inputs,
                   // it's impossible to release the operation. Hence, fail.

--- a/mlir/include/mlir/Dialect/QCO/Utils/Drivers.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/Drivers.h
@@ -88,9 +88,9 @@ LogicalResult walkProgram(Region& region, const WalkProgramFn& fn) {
   return success();
 }
 
-using ReleasedOps = llvm::SmallVector<UnitaryOpInterface, 8>;
+using ReleasedOps = SmallVector<UnitaryOpInterface, 8>;
 using PendingWiresMap =
-    DenseMap<UnitaryOpInterface, llvm::SmallVector<std::size_t, 2>>;
+    DenseMap<UnitaryOpInterface, SmallVector<std::size_t, 2>>;
 
 struct IsReady {
   bool operator()(PendingWiresMap::value_type& kv) const {
@@ -138,10 +138,10 @@ LogicalResult walkProgramGraph(MutableArrayRef<WireIterator> wires,
   PendingWiresMap pending;
   pending.reserve(wires.size());
 
-  llvm::SmallVector<std::size_t> curr(wires.size());
+  SmallVector<std::size_t> curr(wires.size());
   std::iota(curr.begin(), curr.end(), 0UL);
 
-  llvm::SmallVector<std::size_t> next;
+  SmallVector<std::size_t> next;
   next.reserve(wires.size());
 
   while (!curr.empty()) {
@@ -149,7 +149,7 @@ LogicalResult walkProgramGraph(MutableArrayRef<WireIterator> wires,
       auto& it = wires[i];
       while (Traits::isActive(it)) {
         const auto res =
-            llvm::TypeSwitch<Operation*, WalkResult>(it.operation())
+            TypeSwitch<Operation*, WalkResult>(it.operation())
                 .template Case<UnitaryOpInterface>([&](UnitaryOpInterface& op) {
                   // If there are fewer wires than the qubit requires inputs,
                   // it's impossible to release the operation. Hence, fail.

--- a/mlir/include/mlir/Dialect/QCO/Utils/WireIterator.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/WireIterator.h
@@ -30,20 +30,20 @@ class [[nodiscard]] WireIterator {
 public:
   using iterator_category = std::bidirectional_iterator_tag;
   using difference_type = std::ptrdiff_t;
-  using value_type = mlir::Operation*;
+  using value_type = Operation*;
 
   WireIterator() : op_(nullptr), qubit_(nullptr), isSentinel_(false) {}
-  explicit WireIterator(mlir::Value qubit)
+  explicit WireIterator(Value qubit)
       : op_(qubit.getDefiningOp()), qubit_(qubit), isSentinel_(false) {}
 
   /// @returns the operation the iterator points to.
-  [[nodiscard]] mlir::Operation* operation() const { return op_; }
+  [[nodiscard]] Operation* operation() const { return op_; }
 
   /// @returns the operation the iterator points to.
-  [[nodiscard]] mlir::Operation* operator*() const { return operation(); }
+  [[nodiscard]] Operation* operator*() const { return operation(); }
 
   /// @returns the qubit the iterator points to.
-  [[nodiscard]] mlir::Value qubit() const;
+  [[nodiscard]] Value qubit() const;
 
   WireIterator& operator++() {
     forward();
@@ -83,8 +83,8 @@ private:
   /// @brief Move to the previous operation on the qubit wire.
   void backward();
 
-  mlir::Operation* op_;
-  mlir::Value qubit_;
+  Operation* op_;
+  Value qubit_;
   bool isSentinel_;
 };
 

--- a/mlir/include/mlir/Dialect/QIR/Builder/QIRProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QIR/Builder/QIRProgramBuilder.h
@@ -14,15 +14,11 @@
 
 #include <llvm/ADT/StringMap.h>
 #include <llvm/Support/Allocator.h>
-#include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/StringSaver.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
-#include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Types.h>
-#include <mlir/IR/Value.h>
-#include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
 
 #include <cstdint>
@@ -31,11 +27,14 @@
 #include <variant>
 
 namespace mlir {
+// Forward declarations
 class Block;
+class MLIRContext;
+class ModuleOp;
 class Operation;
-} // namespace mlir
+class ValueRange;
 
-namespace mlir::qir {
+namespace qir {
 
 /**
  * @brief Builder API for constructing QIR (Quantum Intermediate
@@ -192,7 +191,7 @@ public:
    * %q2 = llvm.load %ptr2 : !llvm.ptr -> !llvm.ptr
    * ```
    */
-  llvm::SmallVector<Value> allocQubitRegister(int64_t size);
+  SmallVector<Value> allocQubitRegister(int64_t size);
 
   /**
    * @brief A small structure representing a single classical bit within a
@@ -200,7 +199,7 @@ public:
    */
   struct Bit {
     /// Name of the register containing this bit
-    llvm::StringRef registerName;
+    StringRef registerName;
     /// Size of the register containing this bit
     int64_t registerSize{};
     /// Index of this bit within the register
@@ -221,16 +220,7 @@ public:
      * @param index The index of the bit to access (must be less than size)
      * @return A Bit structure representing the specified bit
      */
-    Bit operator[](const int64_t index) const {
-      if (index < 0 || index >= size) {
-        const std::string msg = "Bit index " + std::to_string(index) +
-                                " out of bounds for register '" + name +
-                                "' of size " + std::to_string(size);
-        llvm::reportFatalUsageError(msg.c_str());
-      }
-      return {
-          .registerName = name, .registerSize = size, .registerIndex = index};
-    }
+    Bit operator[](const int64_t index) const;
   };
 
   /**
@@ -885,13 +875,13 @@ public:
    */
   static OwningOpRef<ModuleOp>
   build(MLIRContext* context,
-        const llvm::function_ref<void(QIRProgramBuilder&)>& buildFunc);
+        const function_ref<void(QIRProgramBuilder&)>& buildFunc);
 
 private:
   enum class AllocationMode : uint8_t { Unset, Static, Dynamic };
 
   /// The main module
-  ModuleOp module;
+  Operation* module{};
 
   /// The main function
   Operation* mainFunc{};
@@ -913,22 +903,22 @@ private:
   Value exitCode;
 
   /// Cache static qubit pointers for reuse
-  llvm::DenseMap<int64_t, Value> staticQubits;
+  DenseMap<int64_t, Value> staticQubits;
 
   /// Set of qubit pointers
-  llvm::DenseSet<Value> qubits;
+  DenseSet<Value> qubits;
 
   /// Set of qubit-array pointers
-  llvm::DenseSet<Value> qubitArrays;
+  DenseSet<Value> qubitArrays;
 
   /// Map from register name to result-array pointer
   llvm::StringMap<Value> resultArrays;
 
   /// Map from (register name, index) to loaded result
-  llvm::DenseMap<std::pair<llvm::StringRef, int64_t>, Value> loadedResults;
+  DenseMap<std::pair<StringRef, int64_t>, Value> loadedResults;
 
   /// Map from result index to result pointer for non-register results
-  llvm::DenseMap<int64_t, Value> resultPtrs;
+  DenseMap<int64_t, Value> resultPtrs;
 
   /// Track qubit and result counts for QIR metadata
   QIRMetadata metadata_;
@@ -947,10 +937,9 @@ private:
    * @param targets Target qubits
    * @param fnName Name of the QIR function to call
    */
-  void
-  createCallOp(const llvm::SmallVector<std::variant<double, Value>>& parameters,
-               ValueRange controls, const llvm::SmallVector<Value>& targets,
-               llvm::StringRef fnName);
+  void createCallOp(const SmallVector<std::variant<double, Value>>& parameters,
+                    ValueRange controls, const SmallVector<Value>& targets,
+                    StringRef fnName);
 
   /**
    * @brief Generate array-based output recording in the output block
@@ -973,4 +962,5 @@ private:
   void ensureAllocationMode(AllocationMode requestedMode);
 };
 
-} // namespace mlir::qir
+} // namespace qir
+} // namespace mlir

--- a/mlir/include/mlir/Dialect/QIR/Builder/QIRProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QIR/Builder/QIRProgramBuilder.h
@@ -12,12 +12,7 @@
 
 #include "mlir/Dialect/QIR/Utils/QIRMetadata.h"
 
-#include <llvm/ADT/DenseMap.h>
-#include <llvm/ADT/DenseSet.h>
-#include <llvm/ADT/STLFunctionalExtras.h>
-#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>
-#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/Allocator.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/StringSaver.h>
@@ -28,6 +23,7 @@
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstdint>
 #include <string>
@@ -953,7 +949,7 @@ private:
    */
   void
   createCallOp(const llvm::SmallVector<std::variant<double, Value>>& parameters,
-               ValueRange controls, const SmallVector<Value>& targets,
+               ValueRange controls, const llvm::SmallVector<Value>& targets,
                llvm::StringRef fnName);
 
   /**

--- a/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
+++ b/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
@@ -12,7 +12,6 @@
 
 #include "mlir/Dialect/QIR/Utils/QIRMetadata.h"
 
-#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Location.h>
 #include <mlir/IR/Types.h>

--- a/mlir/include/mlir/Dialect/QTensor/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QTensor/Transforms/Passes.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
-
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassRegistry.h>
 

--- a/mlir/include/mlir/Support/Passes.h
+++ b/mlir/include/mlir/Support/Passes.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "mlir/Support/LogicalResult.h"
+#include <mlir/Support/LLVM.h>
 
 namespace mlir {
 class ModuleOp;

--- a/mlir/include/mlir/Support/PrettyPrinting.h
+++ b/mlir/include/mlir/Support/PrettyPrinting.h
@@ -27,7 +27,7 @@ class ModuleOp;
  * @param str The string to measure
  * @return The display width in columns
  */
-int calculateDisplayWidth(llvm::StringRef str);
+int calculateDisplayWidth(StringRef str);
 
 /**
  * @brief Wrap a long line into multiple lines that fit within the box
@@ -43,30 +43,29 @@ int calculateDisplayWidth(llvm::StringRef str);
  * @param indent Number of spaces to indent wrapped lines
  * @param result Output vector to store wrapped lines
  */
-void wrapLine(llvm::StringRef line, int maxWidth,
-              llvm::SmallVectorImpl<llvm::SmallString<128>>& result,
-              int indent = 0);
+void wrapLine(StringRef line, int maxWidth,
+              SmallVectorImpl<SmallString<128>>& result, int indent = 0);
 
 /**
  * @brief Print top border of a box
  *
  * @param os Output stream to write to
  */
-void printBoxTop(llvm::raw_ostream& os = llvm::errs());
+void printBoxTop(raw_ostream& os = llvm::errs());
 
 /**
  * @brief Print middle separator of a box
  *
  * @param os Output stream to write to
  */
-void printBoxMiddle(llvm::raw_ostream& os = llvm::errs());
+void printBoxMiddle(raw_ostream& os = llvm::errs());
 
 /**
  * @brief Print bottom border of a box
  *
  * @param os Output stream to write to
  */
-void printBoxBottom(llvm::raw_ostream& os = llvm::errs());
+void printBoxBottom(raw_ostream& os = llvm::errs());
 
 /**
  * @brief Print a box line with text and proper padding
@@ -78,8 +77,8 @@ void printBoxBottom(llvm::raw_ostream& os = llvm::errs());
  * @param indent Number of spaces to indent the text (0 for left-aligned)
  * @param os Output stream to write to
  */
-void printBoxLine(llvm::StringRef text, int indent = 0,
-                  llvm::raw_ostream& os = llvm::errs());
+void printBoxLine(StringRef text, int indent = 0,
+                  raw_ostream& os = llvm::errs());
 
 /**
  * @brief Print multiple lines of text within the box, with line wrapping
@@ -92,8 +91,8 @@ void printBoxLine(llvm::StringRef text, int indent = 0,
  * @param indent Number of spaces to indent the text
  * @param os Output stream to write to
  */
-void printBoxText(llvm::StringRef text, int indent = 0,
-                  llvm::raw_ostream& os = llvm::errs());
+void printBoxText(StringRef text, int indent = 0,
+                  raw_ostream& os = llvm::errs());
 
 /**
  * @brief Pretty print an MLIR module with a header and box formatting
@@ -102,7 +101,7 @@ void printBoxText(llvm::StringRef text, int indent = 0,
  * @param header Optional header text to display above the module
  * @param os Output stream to write to
  */
-void printProgram(ModuleOp module, llvm::StringRef header = "",
-                  llvm::raw_ostream& os = llvm::errs());
+void printProgram(ModuleOp module, StringRef header = "",
+                  raw_ostream& os = llvm::errs());
 
 } // namespace mlir

--- a/mlir/include/mlir/Support/PrettyPrinting.h
+++ b/mlir/include/mlir/Support/PrettyPrinting.h
@@ -10,10 +10,8 @@
 
 #pragma once
 
-#include <llvm/ADT/SmallString.h>
-#include <llvm/ADT/SmallVector.h>
-#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
+#include <mlir/Support/LLVM.h>
 
 namespace mlir {
 

--- a/mlir/lib/Compiler/CompilerPipeline.cpp
+++ b/mlir/lib/Compiler/CompilerPipeline.cpp
@@ -17,7 +17,6 @@
 #include "mlir/Support/Passes.h"
 #include "mlir/Support/PrettyPrinting.h"
 
-#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/PassManager.h>

--- a/mlir/lib/Compiler/CompilerPipeline.cpp
+++ b/mlir/lib/Compiler/CompilerPipeline.cpp
@@ -21,7 +21,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/PassManager.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <string>
 
@@ -35,7 +35,7 @@ namespace mlir {
  * @param stageNumber Current stage number
  * @param totalStages Total number of stages (for progress indication)
  */
-static void prettyPrintStage(ModuleOp module, const llvm::StringRef stageName,
+static void prettyPrintStage(ModuleOp module, const StringRef stageName,
                              const int stageNumber, const int totalStages) {
   llvm::errs() << "\n";
 

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -20,6 +20,7 @@
 #include <jeff/IR/JeffOps.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -31,12 +31,11 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
-#include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/MLIRContext.h>
-#include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Types.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 
@@ -62,10 +61,10 @@ using namespace qco;
  * returns its results
  */
 template <typename JeffOpType>
-static void createModified(
-    JeffOpType& op, ConversionPatternRewriter& rewriter, ValueRange controls,
-    ValueRange targets,
-    llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> lambda) {
+static void
+createModified(JeffOpType& op, ConversionPatternRewriter& rewriter,
+               ValueRange controls, ValueRange targets,
+               function_ref<SmallVector<Value>(ValueRange)> lambda) {
   auto loc = op.getLoc();
   if (op.getNumCtrls() != 0) {
     CtrlOp ctrlOp;
@@ -74,12 +73,12 @@ static void createModified(
     } else {
       ctrlOp = CtrlOp::create(
           rewriter, loc, controls, targets,
-          [&](ValueRange ctrlTargets) -> llvm::SmallVector<Value> {
+          [&](ValueRange ctrlTargets) -> SmallVector<Value> {
             auto invOp = InvOp::create(rewriter, loc, ctrlTargets, lambda);
             return invOp.getQubitsOut();
           });
     }
-    llvm::SmallVector<Value> results;
+    SmallVector<Value> results;
     llvm::append_range(results, ctrlOp.getTargetsOut());
     llvm::append_range(results, ctrlOp.getControlsOut());
     rewriter.replaceOp(op, results);
@@ -122,7 +121,7 @@ createGateFromJeff(JeffOpType& op, ConversionPatternRewriter& rewriter,
     return success();
   }
 
-  auto lambda = [&](ValueRange innerTargets) -> llvm::SmallVector<Value> {
+  auto lambda = [&](ValueRange innerTargets) -> SmallVector<Value> {
     auto qcoOp =
         QCOOpType::create(rewriter, op.getLoc(), innerTargets[TargetIndices]...,
                           parameters[ParamIndices]...);
@@ -166,7 +165,7 @@ static void createBarrierOp(jeff::CustomOp& op, jeff::CustomOpAdaptor& adaptor,
   if (op.getNumCtrls() == 0 && !op.getIsAdjoint()) {
     rewriter.replaceOpWithNewOp<BarrierOp>(op, targets);
   } else {
-    auto lambda = [&](ValueRange innerTargets) -> llvm::SmallVector<Value> {
+    auto lambda = [&](ValueRange innerTargets) -> SmallVector<Value> {
       auto qcoOp = BarrierOp::create(rewriter, op.getLoc(), innerTargets);
       return qcoOp.getQubitsOut();
     };
@@ -177,8 +176,8 @@ static void createBarrierOp(jeff::CustomOp& op, jeff::CustomOpAdaptor& adaptor,
 /**
  * @brief Gets the name of the entry point from the module attributes
  */
-static llvm::StringRef getEntryPointName(Operation* op) {
-  auto module = llvm::dyn_cast<ModuleOp>(op);
+static StringRef getEntryPointName(Operation* op) {
+  auto module = dyn_cast<ModuleOp>(op);
   if (!module) {
     llvm::reportFatalInternalError("Expected a module operation");
   }
@@ -188,20 +187,20 @@ static llvm::StringRef getEntryPointName(Operation* op) {
     llvm::reportFatalInternalError(
         "Module is missing 'jeff.entrypoint' attribute");
   }
-  auto entryPoint = llvm::cast<IntegerAttr>(entryPointAttr).getUInt();
+  auto entryPoint = cast<IntegerAttr>(entryPointAttr).getUInt();
 
   auto stringsAttr = module->getAttr("jeff.strings");
   if (!stringsAttr) {
     llvm::reportFatalInternalError(
         "Module is missing 'jeff.strings' attribute");
   }
-  auto strings = llvm::cast<ArrayAttr>(stringsAttr);
+  auto strings = cast<ArrayAttr>(stringsAttr);
 
   if (entryPoint >= strings.size()) {
     llvm::reportFatalInternalError("Entry point index is out of bounds");
   }
 
-  return llvm::cast<mlir::StringAttr>(strings[entryPoint]).getValue();
+  return cast<StringAttr>(strings[entryPoint]).getValue();
 }
 
 /**
@@ -211,7 +210,7 @@ static llvm::StringRef getEntryPointName(Operation* op) {
  * @return LogicalResult Success or failure of the cleanup
  */
 static LogicalResult cleanUp(Operation* op) {
-  auto module = llvm::dyn_cast<ModuleOp>(op);
+  auto module = dyn_cast<ModuleOp>(op);
   if (!module) {
     return failure();
   }
@@ -250,8 +249,8 @@ struct ConvertJeffQuregAllocOpToQCO final
   matchAndRewrite(jeff::QuregAllocOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
     auto sizeValue = getConstantIntValue(adaptor.getNumQubits());
-    auto tensorType = llvm::cast<RankedTensorType>(
-        getTypeConverter()->convertType(op.getType()));
+    auto tensorType =
+        cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
     Value size;
     if (sizeValue.has_value()) {
       size = arith::ConstantOp::create(rewriter, op.getLoc(),
@@ -523,7 +522,7 @@ struct ConvertJeffGPhaseOpToQCO final : OpConversionPattern<jeff::GPhaseOp> {
     if (op.getNumCtrls() == 0 && !op.getIsAdjoint()) {
       rewriter.replaceOpWithNewOp<GPhaseOp>(op, op.getRotation());
     } else {
-      auto lambda = [&](ValueRange /*targets*/) -> llvm::SmallVector<Value> {
+      auto lambda = [&](ValueRange /*targets*/) -> SmallVector<Value> {
         GPhaseOp::create(rewriter, op.getLoc(), op.getRotation());
         return {};
       };
@@ -849,7 +848,7 @@ struct ConvertJeffMainToQCO final : OpConversionPattern<func::FuncOp> {
     auto* block = &op.getBlocks().front();
 
     auto* returnOp = block->getTerminator();
-    if (!llvm::isa<func::ReturnOp>(returnOp)) {
+    if (!isa<func::ReturnOp>(returnOp)) {
       return failure();
     }
 

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -36,7 +36,6 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Types.h>
 #include <mlir/IR/ValueRange.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -19,9 +19,7 @@
 #include <jeff/IR/JeffDialect.h>
 #include <jeff/IR/JeffOps.h>
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -21,7 +21,6 @@
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Math/IR/Math.h>
@@ -33,6 +32,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Types.h>
+#include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -34,7 +34,6 @@
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Types.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -30,11 +30,10 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
-#include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/MLIRContext.h>
-#include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Types.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 
@@ -73,15 +72,15 @@ struct LoweringState {
   bool inInvOp = false;
   CtrlOp ctrlOp;
   InvOp invOp;
-  llvm::SmallVector<Value> controlsIn;
-  llvm::SmallVector<Value> controlsOut;
-  llvm::SmallVector<Value> targetsIn;
-  llvm::SmallVector<Value> targetsOut;
+  SmallVector<Value> controlsIn;
+  SmallVector<Value> controlsOut;
+  SmallVector<Value> targetsIn;
+  SmallVector<Value> targetsOut;
 
   [[nodiscard]] bool inModifier() const { return inCtrlOp || inInvOp; }
 
   // Module information
-  llvm::SmallVector<std::string> strings;
+  SmallVector<std::string> strings;
   std::string entryPointName;
 
   /// The qubit allocation mode used in the module
@@ -227,7 +226,7 @@ template <typename QCOOpType>
 static void createCustomOp(QCOOpType& op, ConversionPatternRewriter& rewriter,
                            LoweringState& state, ValueRange targets,
                            ValueRange params, const bool isAdjoint,
-                           llvm::StringRef name) {
+                           StringRef name) {
   auto* const it = llvm::find(state.strings, name);
   if (it == state.strings.end()) {
     state.strings.emplace_back(name);
@@ -258,7 +257,7 @@ static void createCustomOp(QCOOpType& op, ConversionPatternRewriter& rewriter,
 template <typename QCOOpType>
 static void createPPROp(QCOOpType& op, ConversionPatternRewriter& rewriter,
                         LoweringState& state, ValueRange targets,
-                        const llvm::SmallVector<int32_t>& pauliGates) {
+                        const SmallVector<int32_t>& pauliGates) {
   auto pauliGatesAttr =
       DenseI32ArrayAttr::get(rewriter.getContext(), pauliGates);
 
@@ -286,7 +285,7 @@ static LogicalResult cleanUp(Operation* op, LoweringState& state) {
     return failure();
   }
 
-  auto module = llvm::dyn_cast<ModuleOp>(op);
+  auto module = dyn_cast<ModuleOp>(op);
   if (!module) {
     return failure();
   }
@@ -312,7 +311,7 @@ static LogicalResult cleanUp(Operation* op, LoweringState& state) {
   module->setAttr("jeff.entrypoint",
                   builder.getIntegerAttr(uint16Type, entryPoint));
 
-  llvm::SmallVector<llvm::StringRef> stringRefs;
+  SmallVector<StringRef> stringRefs;
   stringRefs.reserve(state.strings.size());
   for (const auto& str : state.strings) {
     stringRefs.emplace_back(str);
@@ -1019,7 +1018,7 @@ struct ConvertQCOMainToJeff final : StatefulOpConversionPattern<func::FuncOp> {
     }
 
     if (!llvm::any_of(passthrough, [](Attribute attr) {
-          const auto strAttr = llvm::dyn_cast<StringAttr>(attr);
+          const auto strAttr = dyn_cast<StringAttr>(attr);
           return strAttr && strAttr.getValue() == "entry_point";
         })) {
       return failure();
@@ -1031,7 +1030,7 @@ struct ConvertQCOMainToJeff final : StatefulOpConversionPattern<func::FuncOp> {
     auto* block = &op.getBlocks().front();
 
     auto* returnOp = block->getTerminator();
-    if (!llvm::isa<func::ReturnOp>(returnOp)) {
+    if (!isa<func::ReturnOp>(returnOp)) {
       return failure();
     }
 
@@ -1070,7 +1069,7 @@ public:
     });
 
     addConversion([ctx](RankedTensorType type) -> Type {
-      if (llvm::isa<QubitType>(type.getElementType())) {
+      if (isa<QubitType>(type.getElementType())) {
         return jeff::QuregType::get(ctx, type.getShape()[0]);
       }
       return type;

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -20,6 +20,7 @@
 #include <jeff/IR/JeffOps.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -226,7 +227,7 @@ template <typename QCOOpType>
 static void createCustomOp(QCOOpType& op, ConversionPatternRewriter& rewriter,
                            LoweringState& state, ValueRange targets,
                            ValueRange params, const bool isAdjoint,
-                           StringRef name) {
+                           llvm::StringRef name) {
   auto* const it = llvm::find(state.strings, name);
   if (it == state.strings.end()) {
     state.strings.emplace_back(name);

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -18,7 +18,6 @@
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -29,7 +29,6 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Types.h>
 #include <mlir/IR/ValueRange.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -29,7 +29,7 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Types.h>
 #include <mlir/IR/ValueRange.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/DialectConversion.h>
 
 #include <cassert>
@@ -135,7 +135,7 @@ public:
     });
 
     addConversion([ctx](RankedTensorType type) -> Type {
-      if (llvm::isa<qco::QubitType>(type.getElementType())) {
+      if (isa<qco::QubitType>(type.getElementType())) {
         return MemRefType::get(type.getShape(), qc::QubitType::get(ctx));
       }
       return type;
@@ -167,7 +167,7 @@ struct ConvertQTensorAllocOp final
       return failure();
     }
     auto qubitType = qc::QubitType::get(op.getContext());
-    auto tensorType = llvm::cast<RankedTensorType>(op.getResult().getType());
+    auto tensorType = cast<RankedTensorType>(op.getResult().getType());
     auto memrefType = MemRefType::get(tensorType.getShape(), qubitType);
 
     if (tensorType.hasStaticShape()) {

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -35,7 +35,6 @@
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -19,10 +19,8 @@
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 
 #include <llvm/ADT/DenseMap.h>
-#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -101,7 +101,7 @@ enum class AllocationMode : std::uint8_t {
 struct LoweringState {
   struct ModifierFrame {
     /// QC qubits yielded from the current modifier region, in yield order.
-    SmallVector<Value> yieldOrder;
+    llvm::SmallVector<Value> yieldOrder;
 
     /// Latest QCO SSA values for QC qubits that are remapped inside the
     /// modifier region.
@@ -123,7 +123,7 @@ struct LoweringState {
   llvm::DenseMap<Region*, llvm::DenseMap<Value, QubitInfo>> qubitInfoMap;
 
   /// Stack of active modifier regions
-  SmallVector<ModifierFrame> modifierFrames;
+  llvm::SmallVector<ModifierFrame> modifierFrames;
 
   /// The qubit allocation mode used in the module
   AllocationMode allocationMode = AllocationMode::Unset;
@@ -279,7 +279,7 @@ static void assignMappedTensor(LoweringState& state, Operation* anchor,
 
 /** @brief Resolves a range of QC qubits to their latest QCO values. */
 template <typename Range>
-[[nodiscard]] static SmallVector<Value>
+[[nodiscard]] static llvm::SmallVector<Value>
 resolveMappedQubits(LoweringState& state, Operation* anchor,
                     const Range& qcQubits) {
   return llvm::to_vector(llvm::map_range(qcQubits, [&](Value qcQubit) {

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -35,6 +35,7 @@
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 
@@ -101,11 +102,11 @@ enum class AllocationMode : std::uint8_t {
 struct LoweringState {
   struct ModifierFrame {
     /// QC qubits yielded from the current modifier region, in yield order.
-    llvm::SmallVector<Value> yieldOrder;
+    SmallVector<Value> yieldOrder;
 
     /// Latest QCO SSA values for QC qubits that are remapped inside the
     /// modifier region.
-    llvm::DenseMap<Value, Value> currentQubits;
+    DenseMap<Value, Value> currentQubits;
   };
 
   /// Per-region map from original QC qubit reference to its latest QCO SSA
@@ -113,17 +114,17 @@ struct LoweringState {
   ///
   /// @details Keys are `Operation::getParentRegion()` for ops being converted
   /// (typically a `func.func` body or a modifier region).
-  llvm::DenseMap<Region*, llvm::DenseMap<Value, Value>> qubitMap;
+  DenseMap<Region*, DenseMap<Value, Value>> qubitMap;
 
   /// Per-region map from original QC register to its latest QTensor SSA value
-  llvm::DenseMap<Region*, llvm::DenseMap<Value, Value>> tensorMap;
+  DenseMap<Region*, DenseMap<Value, Value>> tensorMap;
 
   /// Per-region map from original QC qubit reference to its register
   /// information
-  llvm::DenseMap<Region*, llvm::DenseMap<Value, QubitInfo>> qubitInfoMap;
+  DenseMap<Region*, DenseMap<Value, QubitInfo>> qubitInfoMap;
 
   /// Stack of active modifier regions
-  llvm::SmallVector<ModifierFrame> modifierFrames;
+  SmallVector<ModifierFrame> modifierFrames;
 
   /// The qubit allocation mode used in the module
   AllocationMode allocationMode = AllocationMode::Unset;
@@ -191,8 +192,8 @@ currentModifierFrame(LoweringState& state) {
  * returns the pair containing the map and a mutable reference to the value in
  * the map.
  */
-[[nodiscard]] static std::pair<llvm::DenseMap<Value, Value>*, Value*>
-findRegionLocalMap(llvm::DenseMap<Region*, llvm::DenseMap<Value, Value>>& map,
+[[nodiscard]] static std::pair<DenseMap<Value, Value>*, Value*>
+findRegionLocalMap(DenseMap<Region*, DenseMap<Value, Value>>& map,
                    Operation* anchor, Value reference) {
   for (auto* current = anchor->getParentRegion(); current != nullptr;
        current = current->getParentRegion()) {
@@ -279,7 +280,7 @@ static void assignMappedTensor(LoweringState& state, Operation* anchor,
 
 /** @brief Resolves a range of QC qubits to their latest QCO values. */
 template <typename Range>
-[[nodiscard]] static llvm::SmallVector<Value>
+[[nodiscard]] static SmallVector<Value>
 resolveMappedQubits(LoweringState& state, Operation* anchor,
                     const Range& qcQubits) {
   return llvm::to_vector(llvm::map_range(qcQubits, [&](Value qcQubit) {
@@ -354,9 +355,9 @@ struct ConvertFuncReturnOp final : StatefulOpConversionPattern<func::ReturnOp> {
     // Build return values from qubitMap and collect live qubit information.
     // A qubit from the current scope is considered alive if it is returned from
     // the function. Otherwise, it is considered dead.
-    llvm::SmallVector<Value> returnValues;
+    SmallVector<Value> returnValues;
     returnValues.reserve(op.getNumOperands());
-    llvm::DenseSet<Value> liveQubits;
+    DenseSet<Value> liveQubits;
     for (auto [qcOperand, adaptorOperand] :
          llvm::zip_equal(op.getOperands(), adaptor.getOperands())) {
       if (auto it = map.find(qcOperand); it != map.end()) {
@@ -424,7 +425,7 @@ struct ConvertMemRefAllocOp final
   LogicalResult
   matchAndRewrite(memref::AllocOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
-    if (!llvm::isa<qc::QubitType>(op.getType().getElementType())) {
+    if (!isa<qc::QubitType>(op.getType().getElementType())) {
       return failure();
     }
 
@@ -475,7 +476,7 @@ struct ConvertMemRefLoadOp final : StatefulOpConversionPattern<memref::LoadOp> {
   matchAndRewrite(memref::LoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
     auto memref = op.getMemref();
-    if (!llvm::isa<qc::QubitType>(memref.getType().getElementType())) {
+    if (!isa<qc::QubitType>(memref.getType().getElementType())) {
       return failure();
     }
 
@@ -537,7 +538,7 @@ struct ConvertMemRefDeallocOp final
   matchAndRewrite(memref::DeallocOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
     auto memref = op.getMemref();
-    if (!llvm::isa<qc::QubitType>(memref.getType().getElementType())) {
+    if (!isa<qc::QubitType>(memref.getType().getElementType())) {
       return failure();
     }
 
@@ -1019,8 +1020,8 @@ protected:
 
     target.addDynamicallyLegalDialect<memref::MemRefDialect>([](Operation* op) {
       auto isQubitMemref = [](Type t) {
-        auto mt = llvm::dyn_cast<MemRefType>(t);
-        return mt && llvm::isa<qc::QubitType>(mt.getElementType());
+        auto mt = dyn_cast<MemRefType>(t);
+        return mt && isa<qc::QubitType>(mt.getElementType());
       };
       return llvm::none_of(op->getOperandTypes(), isQubitMemref) &&
              llvm::none_of(op->getResultTypes(), isQubitMemref);

--- a/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
@@ -22,7 +22,6 @@
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/Allocator.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/StringSaver.h>
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>

--- a/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
@@ -45,7 +45,6 @@
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Pass/PassManager.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 

--- a/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
@@ -16,9 +16,11 @@
 #include "mlir/Dialect/QIR/Utils/QIRMetadata.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>
+#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/Allocator.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
@@ -76,10 +78,10 @@ enum class AllocationMode : std::uint8_t {
  */
 struct LoweringState : QIRMetadata {
   /// Cache static qubit pointers for reuse
-  DenseMap<int64_t, Value> staticQubits;
+  llvm::DenseMap<int64_t, Value> staticQubits;
 
   /// Cache MemRef sizes for reuse
-  DenseMap<Value, Value> memrefSizes;
+  llvm::DenseMap<Value, Value> memrefSizes;
 
   /// Map from register name to result-array pointer
   llvm::StringMap<Value> resultArrays;
@@ -88,11 +90,11 @@ struct LoweringState : QIRMetadata {
   llvm::DenseMap<std::pair<llvm::StringRef, int64_t>, Value> loadedResults;
 
   /// Map from index to result pointer for non-register results
-  DenseMap<int64_t, Value> resultPtrs;
+  llvm::DenseMap<int64_t, Value> resultPtrs;
 
   /// Modifier information
   int64_t inCtrlOp = 0;
-  DenseMap<int64_t, SmallVector<Value>> controls;
+  llvm::DenseMap<int64_t, llvm::SmallVector<Value>> controls;
 
   /// Allocator and StringSaver for stable StringRefs
   llvm::BumpPtrAllocator allocator;
@@ -168,16 +170,16 @@ template <typename QCOpType, typename QCOpAdaptorType>
 static LogicalResult
 convertUnitaryToCallOp(QCOpType& op, QCOpAdaptorType& adaptor,
                        ConversionPatternRewriter& rewriter, MLIRContext* ctx,
-                       LoweringState& state, StringRef fnName,
+                       LoweringState& state, llvm::StringRef fnName,
                        size_t numTargets, size_t numParams) {
   // Query state for modifier information
   const auto inCtrlOp = state.inCtrlOp;
-  const SmallVector<Value> controls =
-      inCtrlOp != 0 ? state.controls[inCtrlOp] : SmallVector<Value>{};
+  const llvm::SmallVector<Value> controls =
+      inCtrlOp != 0 ? state.controls[inCtrlOp] : llvm::SmallVector<Value>{};
   const size_t numCtrls = controls.size();
 
   // Define argument types
-  SmallVector<Type> argumentTypes;
+  llvm::SmallVector<Type> argumentTypes;
   argumentTypes.reserve(numParams + numCtrls + numTargets);
   const auto ptrType = LLVM::LLVMPointerType::get(ctx);
   const auto floatType = Float64Type::get(ctx);
@@ -202,7 +204,7 @@ convertUnitaryToCallOp(QCOpType& op, QCOpAdaptorType& adaptor,
   const auto fnDecl =
       getOrCreateFunctionDeclaration(rewriter, op, fnName, fnSignature);
 
-  SmallVector<Value> operands;
+  llvm::SmallVector<Value> operands;
   operands.reserve(numParams + numCtrls + numTargets);
   operands.append(controls.begin(), controls.end());
   operands.append(adaptor.getOperands().begin(), adaptor.getOperands().end());
@@ -865,8 +867,8 @@ struct ConvertQCCtrlOp final : StatefulOpConversionPattern<CtrlOp> {
     // Update modifier information
     auto& state = getState();
     state.inCtrlOp++;
-    const SmallVector<Value> controls(adaptor.getControls().begin(),
-                                      adaptor.getControls().end());
+    const llvm::SmallVector<Value> controls(adaptor.getControls().begin(),
+                                            adaptor.getControls().end());
     state.controls[state.inCtrlOp] = controls;
 
     // Inline region and remove operation
@@ -996,12 +998,13 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
     // Move operations to appropriate blocks
     for (auto it = bodyBlock->begin(); it != bodyBlock->end();) {
       // Ensure iterator remains valid after potential move
-      if (auto& op = *it++; isa<LLVM::ReturnOp>(op)) {
+      if (auto& op = *it++; llvm::isa<LLVM::ReturnOp>(op)) {
         // Move return to output block
         outputBlockOps.splice(outputBlock->end(), bodyBlockOps,
                               Block::iterator(op));
-      } else if (isa<memref::AllocOp>(op) || isa<memref::LoadOp>(op) ||
-                 isa<AllocOp>(op) || op.hasTrait<OpTrait::ConstantLike>()) {
+      } else if (llvm::isa<memref::AllocOp>(op) ||
+                 llvm::isa<memref::LoadOp>(op) || llvm::isa<AllocOp>(op) ||
+                 op.hasTrait<OpTrait::ConstantLike>()) {
         // Move allocations and constant-like operations to entry block
         entryBlock->getOperations().splice(entryBlock->end(), bodyBlockOps,
                                            Block::iterator(op));

--- a/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
@@ -33,7 +33,6 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
-#include <mlir/Dialect/Func/Transforms/FuncConversions.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/LLVMTypes.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -47,6 +46,7 @@
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 
@@ -78,23 +78,23 @@ enum class AllocationMode : std::uint8_t {
  */
 struct LoweringState : QIRMetadata {
   /// Cache static qubit pointers for reuse
-  llvm::DenseMap<int64_t, Value> staticQubits;
+  DenseMap<int64_t, Value> staticQubits;
 
   /// Cache MemRef sizes for reuse
-  llvm::DenseMap<Value, Value> memrefSizes;
+  DenseMap<Value, Value> memrefSizes;
 
   /// Map from register name to result-array pointer
   llvm::StringMap<Value> resultArrays;
 
   /// Map from (register name, index) to loaded result
-  llvm::DenseMap<std::pair<llvm::StringRef, int64_t>, Value> loadedResults;
+  DenseMap<std::pair<StringRef, int64_t>, Value> loadedResults;
 
   /// Map from index to result pointer for non-register results
-  llvm::DenseMap<int64_t, Value> resultPtrs;
+  DenseMap<int64_t, Value> resultPtrs;
 
   /// Modifier information
   int64_t inCtrlOp = 0;
-  llvm::DenseMap<int64_t, llvm::SmallVector<Value>> controls;
+  DenseMap<int64_t, SmallVector<Value>> controls;
 
   /// Allocator and StringSaver for stable StringRefs
   llvm::BumpPtrAllocator allocator;
@@ -170,16 +170,16 @@ template <typename QCOpType, typename QCOpAdaptorType>
 static LogicalResult
 convertUnitaryToCallOp(QCOpType& op, QCOpAdaptorType& adaptor,
                        ConversionPatternRewriter& rewriter, MLIRContext* ctx,
-                       LoweringState& state, llvm::StringRef fnName,
+                       LoweringState& state, StringRef fnName,
                        size_t numTargets, size_t numParams) {
   // Query state for modifier information
   const auto inCtrlOp = state.inCtrlOp;
-  const llvm::SmallVector<Value> controls =
-      inCtrlOp != 0 ? state.controls[inCtrlOp] : llvm::SmallVector<Value>{};
+  const SmallVector<Value> controls =
+      inCtrlOp != 0 ? state.controls[inCtrlOp] : SmallVector<Value>{};
   const size_t numCtrls = controls.size();
 
   // Define argument types
-  llvm::SmallVector<Type> argumentTypes;
+  SmallVector<Type> argumentTypes;
   argumentTypes.reserve(numParams + numCtrls + numTargets);
   const auto ptrType = LLVM::LLVMPointerType::get(ctx);
   const auto floatType = Float64Type::get(ctx);
@@ -204,7 +204,7 @@ convertUnitaryToCallOp(QCOpType& op, QCOpAdaptorType& adaptor,
   const auto fnDecl =
       getOrCreateFunctionDeclaration(rewriter, op, fnName, fnSignature);
 
-  llvm::SmallVector<Value> operands;
+  SmallVector<Value> operands;
   operands.reserve(numParams + numCtrls + numTargets);
   operands.append(controls.begin(), controls.end());
   operands.append(adaptor.getOperands().begin(), adaptor.getOperands().end());
@@ -340,7 +340,7 @@ struct QCToQIRTypeConverter final : LLVMTypeConverter {
         [ctx](QubitType /*type*/) { return LLVM::LLVMPointerType::get(ctx); });
 
     addConversion([ctx](MemRefType type) -> Type {
-      if (llvm::isa<QubitType>(type.getElementType())) {
+      if (isa<QubitType>(type.getElementType())) {
         return LLVM::LLVMPointerType::get(ctx);
       }
       return type;
@@ -867,8 +867,8 @@ struct ConvertQCCtrlOp final : StatefulOpConversionPattern<CtrlOp> {
     // Update modifier information
     auto& state = getState();
     state.inCtrlOp++;
-    const llvm::SmallVector<Value> controls(adaptor.getControls().begin(),
-                                            adaptor.getControls().end());
+    const SmallVector<Value> controls(adaptor.getControls().begin(),
+                                      adaptor.getControls().end());
     state.controls[state.inCtrlOp] = controls;
 
     // Inline region and remove operation
@@ -998,13 +998,12 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
     // Move operations to appropriate blocks
     for (auto it = bodyBlock->begin(); it != bodyBlock->end();) {
       // Ensure iterator remains valid after potential move
-      if (auto& op = *it++; llvm::isa<LLVM::ReturnOp>(op)) {
+      if (auto& op = *it++; isa<LLVM::ReturnOp>(op)) {
         // Move return to output block
         outputBlockOps.splice(outputBlock->end(), bodyBlockOps,
                               Block::iterator(op));
-      } else if (llvm::isa<memref::AllocOp>(op) ||
-                 llvm::isa<memref::LoadOp>(op) || llvm::isa<AllocOp>(op) ||
-                 op.hasTrait<OpTrait::ConstantLike>()) {
+      } else if (isa<memref::AllocOp>(op) || isa<memref::LoadOp>(op) ||
+                 isa<AllocOp>(op) || op.hasTrait<OpTrait::ConstantLike>()) {
         // Move allocations and constant-like operations to entry block
         entryBlock->getOperations().splice(entryBlock->end(), bodyBlockOps,
                                            Block::iterator(op));

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -29,6 +29,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstdint>
 #include <string>
@@ -48,7 +49,7 @@ QCProgramBuilder::QCProgramBuilder(MLIRContext* context)
 
 void QCProgramBuilder::initialize() {
   // Set insertion point to the module body
-  setInsertionPointToStart(llvm::cast<ModuleOp>(module).getBody());
+  setInsertionPointToStart(cast<ModuleOp>(module).getBody());
 
   // Create main function as entry point
   auto funcType = getFunctionType({}, {getI64Type()});
@@ -110,7 +111,7 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
   auto memref = memref::AllocOp::create(*this, memrefType);
   allocatedMemrefs.insert(memref);
 
-  llvm::SmallVector<Value> qubits;
+  SmallVector<Value> qubits;
   qubits.reserve(size);
   for (int64_t i = 0; i < size; ++i) {
     auto index = arith::ConstantIndexOp::create(*this, i);
@@ -447,16 +448,14 @@ QCProgramBuilder& QCProgramBuilder::barrier(ValueRange qubits) {
 // Modifiers
 //===----------------------------------------------------------------------===//
 
-QCProgramBuilder&
-QCProgramBuilder::ctrl(ValueRange controls,
-                       const llvm::function_ref<void()>& body) {
+QCProgramBuilder& QCProgramBuilder::ctrl(ValueRange controls,
+                                         const function_ref<void()>& body) {
   checkFinalized();
   CtrlOp::create(*this, controls, body);
   return *this;
 }
 
-QCProgramBuilder&
-QCProgramBuilder::inv(const llvm::function_ref<void()>& body) {
+QCProgramBuilder& QCProgramBuilder::inv(const function_ref<void()>& body) {
   checkFinalized();
   InvOp::create(*this, body);
   return *this;
@@ -469,7 +468,7 @@ QCProgramBuilder::inv(const llvm::function_ref<void()>& body) {
 QCProgramBuilder& QCProgramBuilder::dealloc(Value qubit) {
   checkFinalized();
 
-  if (llvm::isa_and_nonnull<memref::LoadOp>(qubit.getDefiningOp())) {
+  if (isa_and_nonnull<memref::LoadOp>(qubit.getDefiningOp())) {
     llvm::reportFatalUsageError(
         "Register-backed qubits cannot be deallocated manually");
   }
@@ -524,7 +523,7 @@ OwningOpRef<ModuleOp> QCProgramBuilder::finalize() {
   // Ensure that main function exists and insertion point is valid
   auto* insertionBlock = getInsertionBlock();
   func::FuncOp mainFunc = nullptr;
-  for (auto op : llvm::cast<ModuleOp>(module).getOps<func::FuncOp>()) {
+  for (auto op : cast<ModuleOp>(module).getOps<func::FuncOp>()) {
     if (op.getName() == "main") {
       mainFunc = op;
       break;
@@ -540,7 +539,7 @@ OwningOpRef<ModuleOp> QCProgramBuilder::finalize() {
   }
 
   for (auto qubit : allocatedQubits) {
-    if (!llvm::isa<memref::LoadOp>(qubit.getDefiningOp())) {
+    if (!isa<memref::LoadOp>(qubit.getDefiningOp())) {
       DeallocOp::create(*this, qubit);
     }
   }
@@ -561,12 +560,12 @@ OwningOpRef<ModuleOp> QCProgramBuilder::finalize() {
   ctx = nullptr;
 
   // Transfer ownership to the caller
-  return llvm::cast<ModuleOp>(module);
+  return cast<ModuleOp>(module);
 }
 
 OwningOpRef<ModuleOp> QCProgramBuilder::build(
     MLIRContext* context,
-    const llvm::function_ref<void(QCProgramBuilder&)>& buildFunc) {
+    const function_ref<void(QCProgramBuilder&)>& buildFunc) {
   QCProgramBuilder builder(context);
   builder.initialize();
   buildFunc(builder);

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -14,9 +14,7 @@
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/Utils/Utils.h"
 
-#include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/FormatVariadic.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -31,6 +29,7 @@
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -48,7 +48,7 @@ QCProgramBuilder::QCProgramBuilder(MLIRContext* context)
 
 void QCProgramBuilder::initialize() {
   // Set insertion point to the module body
-  setInsertionPointToStart(module.getBody());
+  setInsertionPointToStart(llvm::cast<ModuleOp>(module).getBody());
 
   // Create main function as entry point
   auto funcType = getFunctionType({}, {getI64Type()});
@@ -66,6 +66,13 @@ void QCProgramBuilder::initialize() {
 Value QCProgramBuilder::intConstant(const int64_t value) {
   checkFinalized();
   return arith::ConstantOp::create(*this, getI64IntegerAttr(value)).getResult();
+}
+
+Value QCProgramBuilder::QubitRegister::operator[](const size_t index) const {
+  if (index >= qubits.size()) {
+    llvm::reportFatalUsageError("Qubit index out of bounds");
+  }
+  return qubits[index];
 }
 
 Value QCProgramBuilder::allocQubit() {
@@ -113,6 +120,17 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
   }
 
   return {.value = memref, .qubits = std::move(qubits)};
+}
+
+QCProgramBuilder::Bit
+QCProgramBuilder::ClassicalRegister::operator[](const int64_t index) const {
+  if (index < 0 || index >= size) {
+    const std::string msg = "Bit index " + std::to_string(index) +
+                            " out of bounds for register '" + name +
+                            "' of size " + std::to_string(size);
+    llvm::reportFatalUsageError(msg.c_str());
+  }
+  return {.registerName = name, .registerSize = size, .registerIndex = index};
 }
 
 QCProgramBuilder::ClassicalRegister
@@ -506,7 +524,7 @@ OwningOpRef<ModuleOp> QCProgramBuilder::finalize() {
   // Ensure that main function exists and insertion point is valid
   auto* insertionBlock = getInsertionBlock();
   func::FuncOp mainFunc = nullptr;
-  for (auto op : module.getOps<func::FuncOp>()) {
+  for (auto op : llvm::cast<ModuleOp>(module).getOps<func::FuncOp>()) {
     if (op.getName() == "main") {
       mainFunc = op;
       break;
@@ -543,7 +561,7 @@ OwningOpRef<ModuleOp> QCProgramBuilder::finalize() {
   ctx = nullptr;
 
   // Transfer ownership to the caller
-  return module;
+  return llvm::cast<ModuleOp>(module);
 }
 
 OwningOpRef<ModuleOp> QCProgramBuilder::build(

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -16,10 +16,10 @@
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
-#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cstddef>
@@ -37,7 +37,7 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
   LogicalResult matchAndRewrite(CtrlOp op,
                                 PatternRewriter& rewriter) const override {
     auto* bodyUnitary = op.getBodyUnitary().getOperation();
-    auto bodyCtrlOp = llvm::dyn_cast<CtrlOp>(bodyUnitary);
+    auto bodyCtrlOp = dyn_cast<CtrlOp>(bodyUnitary);
     if (!bodyCtrlOp) {
       return failure();
     }
@@ -68,14 +68,14 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
                                 PatternRewriter& rewriter) const override {
     auto* bodyUnitary = op.getBodyUnitary().getOperation();
     // Inline ops from empty control modifiers, IdOp and BarrierOp
-    if (op.getNumControls() == 0 || llvm::isa<IdOp, BarrierOp>(bodyUnitary)) {
+    if (op.getNumControls() == 0 || isa<IdOp, BarrierOp>(bodyUnitary)) {
       rewriter.moveOpBefore(bodyUnitary, op);
       rewriter.replaceOp(op, bodyUnitary->getResults());
       return success();
     }
 
     // The remaining code explicitly handles GPhaseOp and nothing else
-    auto gPhaseOp = llvm::dyn_cast<GPhaseOp>(bodyUnitary);
+    auto gPhaseOp = dyn_cast<GPhaseOp>(bodyUnitary);
     if (!gPhaseOp) {
       return failure();
     }
@@ -110,7 +110,7 @@ UnitaryOpInterface CtrlOp::getBodyUnitary() {
   // also contain constants and arithmetic operations, e.g., created as part of
   // canonicalization. Thus, the only safe way to access the unitary operation
   // is to get the second operation from the back of the region.
-  return llvm::cast<UnitaryOpInterface>(*(++getBody()->rbegin()));
+  return cast<UnitaryOpInterface>(*(++getBody()->rbegin()));
 }
 
 Value CtrlOp::getQubit(const size_t i) {
@@ -133,7 +133,7 @@ Value CtrlOp::getControl(const size_t i) {
 
 void CtrlOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                    ValueRange controls,
-                   const llvm::function_ref<void()>& bodyBuilder) {
+                   const function_ref<void()>& bodyBuilder) {
   const OpBuilder::InsertionGuard guard(odsBuilder);
   odsState.addOperands(controls);
   auto* region = odsState.addRegion();
@@ -149,22 +149,22 @@ LogicalResult CtrlOp::verify() {
   if (block.getOperations().size() < 2) {
     return emitOpError("body region must have at least two operations");
   }
-  if (!llvm::isa<YieldOp>(block.back())) {
+  if (!isa<YieldOp>(block.back())) {
     return emitOpError(
         "last operation in body region must be a yield operation");
   }
   auto iter = ++block.rbegin();
-  if (!llvm::isa<UnitaryOpInterface>(*iter)) {
+  if (!isa<UnitaryOpInterface>(*iter)) {
     return emitOpError(
         "second to last operation in body region must be a unitary operation");
   }
   for (auto it = ++iter; it != block.rend(); ++it) {
-    if (llvm::isa<UnitaryOpInterface>(*it)) {
+    if (isa<UnitaryOpInterface>(*it)) {
       return emitOpError("body region may only contain a single unitary op");
     }
   }
 
-  llvm::SmallPtrSet<Value, 4> uniqueQubits;
+  SmallPtrSet<Value, 4> uniqueQubits;
   for (const auto& control : getControls()) {
     if (!uniqueQubits.insert(control).second) {
       return emitOpError("duplicate control qubit found");

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -19,7 +19,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cstddef>

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -12,6 +12,7 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -11,9 +11,6 @@
 #include "mlir/Dialect/QC/IR/QCOps.h"
 
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/STLFunctionalExtras.h>
-#include <llvm/ADT/SmallPtrSet.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>

--- a/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
@@ -10,9 +10,7 @@
 
 #include "mlir/Dialect/QC/IR/QCOps.h"
 
-#include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>

--- a/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
@@ -19,7 +19,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <numbers>
 
@@ -38,7 +38,7 @@ struct MoveCtrlOutside final : OpRewritePattern<InvOp> {
   LogicalResult matchAndRewrite(InvOp invOp,
                                 PatternRewriter& rewriter) const override {
     auto bodyUnitary = invOp.getBodyUnitary();
-    auto innerCtrlOp = llvm::dyn_cast<CtrlOp>(bodyUnitary.getOperation());
+    auto innerCtrlOp = dyn_cast<CtrlOp>(bodyUnitary.getOperation());
     if (!innerCtrlOp) {
       return failure();
     }
@@ -66,8 +66,7 @@ struct InlineSelfAdjoint final : OpRewritePattern<InvOp> {
                                 PatternRewriter& rewriter) const override {
     auto* innerOp = op.getBodyUnitary().getOperation();
 
-    if (!llvm::isa<IdOp, HOp, XOp, YOp, ZOp, ECROp, SWAPOp, BarrierOp>(
-            innerOp)) {
+    if (!isa<IdOp, HOp, XOp, YOp, ZOp, ECROp, SWAPOp, BarrierOp>(innerOp)) {
       return failure();
     }
 
@@ -90,7 +89,7 @@ struct ReplaceWithKnownGates final : OpRewritePattern<InvOp> {
                                 PatternRewriter& rewriter) const override {
     auto* innerOp = op.getBodyUnitary().getOperation();
 
-    return llvm::TypeSwitch<Operation*, LogicalResult>(innerOp)
+    return TypeSwitch<Operation*, LogicalResult>(innerOp)
         .Case<GPhaseOp>([&](auto g) {
           Value negTheta =
               arith::NegFOp::create(rewriter, op.getLoc(), g.getTheta());
@@ -239,7 +238,7 @@ struct CancelNestedInv final : OpRewritePattern<InvOp> {
   LogicalResult matchAndRewrite(InvOp invOp,
                                 PatternRewriter& rewriter) const override {
     auto innerUnitary = invOp.getBodyUnitary();
-    auto innerInvOp = llvm::dyn_cast<InvOp>(innerUnitary.getOperation());
+    auto innerInvOp = dyn_cast<InvOp>(innerUnitary.getOperation());
     if (!innerInvOp) {
       return failure();
     }
@@ -260,11 +259,11 @@ UnitaryOpInterface InvOp::getBodyUnitary() {
   // also contain constants and arithmetic operations, e.g., created as part of
   // canonicalization. Thus, the only safe way to access the unitary operation
   // is to get the second operation from the back of the region.
-  return llvm::cast<UnitaryOpInterface>(*(++getBody()->rbegin()));
+  return cast<UnitaryOpInterface>(*(++getBody()->rbegin()));
 }
 
 void InvOp::build(OpBuilder& odsBuilder, OperationState& odsState,
-                  const llvm::function_ref<void()>& bodyBuilder) {
+                  const function_ref<void()>& bodyBuilder) {
   const OpBuilder::InsertionGuard guard(odsBuilder);
   auto* region = odsState.addRegion();
   auto& block = region->emplaceBlock();
@@ -279,17 +278,17 @@ LogicalResult InvOp::verify() {
   if (block.getOperations().size() < 2) {
     return emitOpError("body region must have at least two operations");
   }
-  if (!llvm::isa<YieldOp>(block.back())) {
+  if (!isa<YieldOp>(block.back())) {
     return emitOpError(
         "last operation in body region must be a yield operation");
   }
   auto iter = ++block.rbegin();
-  if (!llvm::isa<UnitaryOpInterface>(*iter)) {
+  if (!isa<UnitaryOpInterface>(*iter)) {
     return emitOpError(
         "second to last operation in body region must be a unitary operation");
   }
   for (auto it = ++iter; it != block.rend(); ++it) {
-    if (llvm::isa<UnitaryOpInterface>(*it)) {
+    if (isa<UnitaryOpInterface>(*it)) {
       return emitOpError("body region may only contain a single unitary op");
     }
   }

--- a/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
@@ -19,7 +19,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <numbers>

--- a/mlir/lib/Dialect/QC/Transforms/ShrinkQubitRegisters.cpp
+++ b/mlir/lib/Dialect/QC/Transforms/ShrinkQubitRegisters.cpp
@@ -20,7 +20,7 @@
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 #include <cstddef>
@@ -59,12 +59,12 @@ struct ShrinkQubitRegister final : OpRewritePattern<memref::DeallocOp> {
       return failure();
     }
 
-    auto memRefType = llvm::dyn_cast<MemRefType>(op.getMemref().getType());
+    auto memRefType = dyn_cast<MemRefType>(op.getMemref().getType());
     if (!memRefType || memRefType.getRank() != 1 ||
         !memRefType.hasStaticShape()) {
       return failure();
     }
-    if (!llvm::isa<QubitType>(memRefType.getElementType())) {
+    if (!isa<QubitType>(memRefType.getElementType())) {
       return failure();
     }
     if (!memRefType.getLayout().isIdentity()) {
@@ -74,15 +74,15 @@ struct ShrinkQubitRegister final : OpRewritePattern<memref::DeallocOp> {
       return failure();
     }
 
-    llvm::SmallVector<memref::LoadOp> loadOps;
-    llvm::SmallVector<int64_t> liveIndices;
-    llvm::DenseMap<int64_t, size_t> newIndexByOldIndex;
+    SmallVector<memref::LoadOp> loadOps;
+    SmallVector<int64_t> liveIndices;
+    DenseMap<int64_t, size_t> newIndexByOldIndex;
 
     for (auto* user : op.getMemref().getUsers()) {
       if (user == op.getOperation()) {
         continue;
       }
-      auto loadOp = llvm::dyn_cast<memref::LoadOp>(user);
+      auto loadOp = dyn_cast<memref::LoadOp>(user);
       if (!loadOp) {
         return failure();
       }

--- a/mlir/lib/Dialect/QC/Transforms/ShrinkQubitRegisters.cpp
+++ b/mlir/lib/Dialect/QC/Transforms/ShrinkQubitRegisters.cpp
@@ -11,10 +11,8 @@
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/Transforms/Passes.h"
 
-#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>

--- a/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
@@ -49,12 +49,12 @@ namespace {
  */
 struct QregInfo {
   const ::qc::QuantumRegister* qregPtr;
-  SmallVector<Value> qubits;
+  llvm::SmallVector<Value> qubits;
 };
 
-using BitMemInfo = std::pair<QCProgramBuilder::ClassicalRegister,
-                             size_t>; // (register ref, localIdx)
-using BitIndexVec = SmallVector<BitMemInfo>;
+// (register ref, localIdx)
+using BitMemInfo = std::pair<QCProgramBuilder::ClassicalRegister, size_t>;
+using BitIndexVec = llvm::SmallVector<BitMemInfo>;
 
 } // namespace
 
@@ -71,11 +71,11 @@ using BitIndexVec = SmallVector<BitMemInfo>;
  * @param quantumComputation The quantum computation to translate
  * @return Vector containing information about all quantum registers
  */
-static SmallVector<QregInfo>
+static llvm::SmallVector<QregInfo>
 allocateQregs(QCProgramBuilder& builder,
               const ::qc::QuantumComputation& quantumComputation) {
   // Build list of pointers for sorting
-  SmallVector<const ::qc::QuantumRegister*> qregPtrs;
+  llvm::SmallVector<const ::qc::QuantumRegister*> qregPtrs;
   qregPtrs.reserve(quantumComputation.getQuantumRegisters().size() +
                    quantumComputation.getAncillaRegisters().size());
   for (const auto& qreg :
@@ -94,7 +94,7 @@ allocateQregs(QCProgramBuilder& builder,
   });
 
   // Allocate quantum registers using the builder
-  SmallVector<QregInfo> qregs;
+  llvm::SmallVector<QregInfo> qregs;
   for (const auto* qregPtr : qregPtrs) {
     auto qubitRegister =
         builder.allocQubitRegister(static_cast<int64_t>(qregPtr->getSize()));
@@ -116,10 +116,10 @@ allocateQregs(QCProgramBuilder& builder,
  * @param qregs Vector containing information about all quantum registers
  * @return Flat vector of qubit values indexed by physical qubit index
  */
-static SmallVector<Value>
+static llvm::SmallVector<Value>
 buildQubitMap(const ::qc::QuantumComputation& quantumComputation,
-              const SmallVector<QregInfo>& qregs) {
-  SmallVector<Value> flatQubits;
+              const llvm::SmallVector<QregInfo>& qregs) {
+  llvm::SmallVector<Value> flatQubits;
   const auto maxPhys = quantumComputation.getHighestPhysicalQubitIndex();
   flatQubits.resize(static_cast<size_t>(maxPhys) + 1);
 
@@ -149,7 +149,7 @@ static BitIndexVec
 allocateClassicalRegisters(QCProgramBuilder& builder,
                            const ::qc::QuantumComputation& quantumComputation) {
   // Build list of pointers for sorting
-  SmallVector<const ::qc::ClassicalRegister*> cregPtrs;
+  llvm::SmallVector<const ::qc::ClassicalRegister*> cregPtrs;
   cregPtrs.reserve(quantumComputation.getClassicalRegisters().size());
   for (const auto& reg :
        quantumComputation.getClassicalRegisters() | std::views::values) {
@@ -191,7 +191,7 @@ allocateClassicalRegisters(QCProgramBuilder& builder,
  */
 static void addMeasureOp(QCProgramBuilder& builder,
                          const ::qc::Operation& operation,
-                         const SmallVector<Value>& qubits,
+                         const llvm::SmallVector<Value>& qubits,
                          const BitIndexVec& bitMap) {
   const auto& measureOp =
       dynamic_cast<const ::qc::NonUnitaryOperation&>(operation);
@@ -221,7 +221,7 @@ static void addMeasureOp(QCProgramBuilder& builder,
  */
 static void addResetOp(QCProgramBuilder& builder,
                        const ::qc::Operation& operation,
-                       const SmallVector<Value>& qubits) {
+                       const llvm::SmallVector<Value>& qubits) {
   for (const auto& target : operation.getTargets()) {
     auto qubit = qubits[target];
     builder.reset(qubit);
@@ -239,9 +239,10 @@ static void addResetOp(QCProgramBuilder& builder,
  * @param qubits Flat vector of qubit values indexed by physical qubit index
  * @return Vector of qubit values corresponding to positive controls
  */
-static SmallVector<Value> getControls(const ::qc::Operation& operation,
-                                      const SmallVector<Value>& qubits) {
-  SmallVector<Value> controls;
+static llvm::SmallVector<Value>
+getControls(const ::qc::Operation& operation,
+            const llvm::SmallVector<Value>& qubits) {
+  llvm::SmallVector<Value> controls;
   for (const auto& [control, type] : operation.getControls()) {
     if (type == ::qc::Control::Type::Neg) {
       llvm::reportFatalInternalError(
@@ -268,7 +269,7 @@ static SmallVector<Value> getControls(const ::qc::Operation& operation,
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const SmallVector<Value>& qubits) {             \
+                               const llvm::SmallVector<Value>& qubits) {       \
     const auto& target = qubits[operation.getTargets()[0]];                    \
     if (const auto& controls = getControls(operation, qubits);                 \
         controls.empty()) {                                                    \
@@ -308,7 +309,7 @@ DEFINE_ONE_TARGET_ZERO_PARAMETER(SXdg, sxdg)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const SmallVector<Value>& qubits) {             \
+                               const llvm::SmallVector<Value>& qubits) {       \
     const auto& param = operation.getParameter()[0];                           \
     const auto& target = qubits[operation.getTargets()[0]];                    \
     if (const auto& controls = getControls(operation, qubits);                 \
@@ -340,7 +341,7 @@ DEFINE_ONE_TARGET_ONE_PARAMETER(P, p)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const SmallVector<Value>& qubits) {             \
+                               const llvm::SmallVector<Value>& qubits) {       \
     const auto& param1 = operation.getParameter()[0];                          \
     const auto& param2 = operation.getParameter()[1];                          \
     const auto& target = qubits[operation.getTargets()[0]];                    \
@@ -373,7 +374,7 @@ DEFINE_ONE_TARGET_TWO_PARAMETER(U2, u2)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const SmallVector<Value>& qubits) {             \
+                               const llvm::SmallVector<Value>& qubits) {       \
     const auto& param1 = operation.getParameter()[0];                          \
     const auto& param2 = operation.getParameter()[1];                          \
     const auto& param3 = operation.getParameter()[2];                          \
@@ -406,7 +407,7 @@ DEFINE_ONE_TARGET_THREE_PARAMETER(U, u)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const SmallVector<Value>& qubits) {             \
+                               const llvm::SmallVector<Value>& qubits) {       \
     const auto& target0 = qubits[operation.getTargets()[0]];                   \
     const auto& target1 = qubits[operation.getTargets()[1]];                   \
     if (const auto& controls = getControls(operation, qubits);                 \
@@ -440,7 +441,7 @@ DEFINE_TWO_TARGET_ZERO_PARAMETER(ECR, ecr)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const SmallVector<Value>& qubits) {             \
+                               const llvm::SmallVector<Value>& qubits) {       \
     const auto& param = operation.getParameter()[0];                           \
     const auto& target0 = qubits[operation.getTargets()[0]];                   \
     const auto& target1 = qubits[operation.getTargets()[1]];                   \
@@ -475,7 +476,7 @@ DEFINE_TWO_TARGET_ONE_PARAMETER(RZZ, rzz)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const SmallVector<Value>& qubits) {             \
+                               const llvm::SmallVector<Value>& qubits) {       \
     const auto& param1 = operation.getParameter()[0];                          \
     const auto& param2 = operation.getParameter()[1];                          \
     const auto& target0 = qubits[operation.getTargets()[0]];                   \
@@ -497,8 +498,8 @@ DEFINE_TWO_TARGET_TWO_PARAMETER(XXminusYY, xx_minus_yy)
 
 static void addBarrierOp(QCProgramBuilder& builder,
                          const ::qc::Operation& operation,
-                         const SmallVector<Value>& qubits) {
-  SmallVector<Value> targets;
+                         const llvm::SmallVector<Value>& qubits) {
+  llvm::SmallVector<Value> targets;
   for (const auto& targetIdx : operation.getTargets()) {
     targets.push_back(qubits[targetIdx]);
   }
@@ -526,7 +527,7 @@ static void addBarrierOp(QCProgramBuilder& builder,
 static LogicalResult
 translateOperations(QCProgramBuilder& builder,
                     const ::qc::QuantumComputation& quantumComputation,
-                    const SmallVector<Value>& qubits,
+                    const llvm::SmallVector<Value>& qubits,
                     const BitIndexVec& bitMap) {
   if (quantumComputation.hasGlobalPhase()) {
     builder.gphase(quantumComputation.getGlobalPhase());

--- a/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
@@ -22,11 +22,10 @@
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>
-#include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -49,12 +48,12 @@ namespace {
  */
 struct QregInfo {
   const ::qc::QuantumRegister* qregPtr;
-  llvm::SmallVector<Value> qubits;
+  SmallVector<Value> qubits;
 };
 
 // (register ref, localIdx)
 using BitMemInfo = std::pair<QCProgramBuilder::ClassicalRegister, size_t>;
-using BitIndexVec = llvm::SmallVector<BitMemInfo>;
+using BitIndexVec = SmallVector<BitMemInfo>;
 
 } // namespace
 
@@ -71,11 +70,11 @@ using BitIndexVec = llvm::SmallVector<BitMemInfo>;
  * @param quantumComputation The quantum computation to translate
  * @return Vector containing information about all quantum registers
  */
-static llvm::SmallVector<QregInfo>
+static SmallVector<QregInfo>
 allocateQregs(QCProgramBuilder& builder,
               const ::qc::QuantumComputation& quantumComputation) {
   // Build list of pointers for sorting
-  llvm::SmallVector<const ::qc::QuantumRegister*> qregPtrs;
+  SmallVector<const ::qc::QuantumRegister*> qregPtrs;
   qregPtrs.reserve(quantumComputation.getQuantumRegisters().size() +
                    quantumComputation.getAncillaRegisters().size());
   for (const auto& qreg :
@@ -94,7 +93,7 @@ allocateQregs(QCProgramBuilder& builder,
   });
 
   // Allocate quantum registers using the builder
-  llvm::SmallVector<QregInfo> qregs;
+  SmallVector<QregInfo> qregs;
   for (const auto* qregPtr : qregPtrs) {
     auto qubitRegister =
         builder.allocQubitRegister(static_cast<int64_t>(qregPtr->getSize()));
@@ -116,10 +115,10 @@ allocateQregs(QCProgramBuilder& builder,
  * @param qregs Vector containing information about all quantum registers
  * @return Flat vector of qubit values indexed by physical qubit index
  */
-static llvm::SmallVector<Value>
+static SmallVector<Value>
 buildQubitMap(const ::qc::QuantumComputation& quantumComputation,
-              const llvm::SmallVector<QregInfo>& qregs) {
-  llvm::SmallVector<Value> flatQubits;
+              const SmallVector<QregInfo>& qregs) {
+  SmallVector<Value> flatQubits;
   const auto maxPhys = quantumComputation.getHighestPhysicalQubitIndex();
   flatQubits.resize(static_cast<size_t>(maxPhys) + 1);
 
@@ -149,7 +148,7 @@ static BitIndexVec
 allocateClassicalRegisters(QCProgramBuilder& builder,
                            const ::qc::QuantumComputation& quantumComputation) {
   // Build list of pointers for sorting
-  llvm::SmallVector<const ::qc::ClassicalRegister*> cregPtrs;
+  SmallVector<const ::qc::ClassicalRegister*> cregPtrs;
   cregPtrs.reserve(quantumComputation.getClassicalRegisters().size());
   for (const auto& reg :
        quantumComputation.getClassicalRegisters() | std::views::values) {
@@ -191,7 +190,7 @@ allocateClassicalRegisters(QCProgramBuilder& builder,
  */
 static void addMeasureOp(QCProgramBuilder& builder,
                          const ::qc::Operation& operation,
-                         const llvm::SmallVector<Value>& qubits,
+                         const SmallVector<Value>& qubits,
                          const BitIndexVec& bitMap) {
   const auto& measureOp =
       dynamic_cast<const ::qc::NonUnitaryOperation&>(operation);
@@ -221,7 +220,7 @@ static void addMeasureOp(QCProgramBuilder& builder,
  */
 static void addResetOp(QCProgramBuilder& builder,
                        const ::qc::Operation& operation,
-                       const llvm::SmallVector<Value>& qubits) {
+                       const SmallVector<Value>& qubits) {
   for (const auto& target : operation.getTargets()) {
     auto qubit = qubits[target];
     builder.reset(qubit);
@@ -239,10 +238,9 @@ static void addResetOp(QCProgramBuilder& builder,
  * @param qubits Flat vector of qubit values indexed by physical qubit index
  * @return Vector of qubit values corresponding to positive controls
  */
-static llvm::SmallVector<Value>
-getControls(const ::qc::Operation& operation,
-            const llvm::SmallVector<Value>& qubits) {
-  llvm::SmallVector<Value> controls;
+static SmallVector<Value> getControls(const ::qc::Operation& operation,
+                                      const SmallVector<Value>& qubits) {
+  SmallVector<Value> controls;
   for (const auto& [control, type] : operation.getControls()) {
     if (type == ::qc::Control::Type::Neg) {
       llvm::reportFatalInternalError(
@@ -269,7 +267,7 @@ getControls(const ::qc::Operation& operation,
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const llvm::SmallVector<Value>& qubits) {       \
+                               const SmallVector<Value>& qubits) {             \
     const auto& target = qubits[operation.getTargets()[0]];                    \
     if (const auto& controls = getControls(operation, qubits);                 \
         controls.empty()) {                                                    \
@@ -309,7 +307,7 @@ DEFINE_ONE_TARGET_ZERO_PARAMETER(SXdg, sxdg)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const llvm::SmallVector<Value>& qubits) {       \
+                               const SmallVector<Value>& qubits) {             \
     const auto& param = operation.getParameter()[0];                           \
     const auto& target = qubits[operation.getTargets()[0]];                    \
     if (const auto& controls = getControls(operation, qubits);                 \
@@ -341,7 +339,7 @@ DEFINE_ONE_TARGET_ONE_PARAMETER(P, p)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const llvm::SmallVector<Value>& qubits) {       \
+                               const SmallVector<Value>& qubits) {             \
     const auto& param1 = operation.getParameter()[0];                          \
     const auto& param2 = operation.getParameter()[1];                          \
     const auto& target = qubits[operation.getTargets()[0]];                    \
@@ -374,7 +372,7 @@ DEFINE_ONE_TARGET_TWO_PARAMETER(U2, u2)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const llvm::SmallVector<Value>& qubits) {       \
+                               const SmallVector<Value>& qubits) {             \
     const auto& param1 = operation.getParameter()[0];                          \
     const auto& param2 = operation.getParameter()[1];                          \
     const auto& param3 = operation.getParameter()[2];                          \
@@ -407,7 +405,7 @@ DEFINE_ONE_TARGET_THREE_PARAMETER(U, u)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const llvm::SmallVector<Value>& qubits) {       \
+                               const SmallVector<Value>& qubits) {             \
     const auto& target0 = qubits[operation.getTargets()[0]];                   \
     const auto& target1 = qubits[operation.getTargets()[1]];                   \
     if (const auto& controls = getControls(operation, qubits);                 \
@@ -441,7 +439,7 @@ DEFINE_TWO_TARGET_ZERO_PARAMETER(ECR, ecr)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const llvm::SmallVector<Value>& qubits) {       \
+                               const SmallVector<Value>& qubits) {             \
     const auto& param = operation.getParameter()[0];                           \
     const auto& target0 = qubits[operation.getTargets()[0]];                   \
     const auto& target1 = qubits[operation.getTargets()[1]];                   \
@@ -476,7 +474,7 @@ DEFINE_TWO_TARGET_ONE_PARAMETER(RZZ, rzz)
    */                                                                          \
   static void add##OP_CORE##Op(QCProgramBuilder& builder,                      \
                                const ::qc::Operation& operation,               \
-                               const llvm::SmallVector<Value>& qubits) {       \
+                               const SmallVector<Value>& qubits) {             \
     const auto& param1 = operation.getParameter()[0];                          \
     const auto& param2 = operation.getParameter()[1];                          \
     const auto& target0 = qubits[operation.getTargets()[0]];                   \
@@ -498,8 +496,8 @@ DEFINE_TWO_TARGET_TWO_PARAMETER(XXminusYY, xx_minus_yy)
 
 static void addBarrierOp(QCProgramBuilder& builder,
                          const ::qc::Operation& operation,
-                         const llvm::SmallVector<Value>& qubits) {
-  llvm::SmallVector<Value> targets;
+                         const SmallVector<Value>& qubits) {
+  SmallVector<Value> targets;
   for (const auto& targetIdx : operation.getTargets()) {
     targets.push_back(qubits[targetIdx]);
   }
@@ -527,7 +525,7 @@ static void addBarrierOp(QCProgramBuilder& builder,
 static LogicalResult
 translateOperations(QCProgramBuilder& builder,
                     const ::qc::QuantumComputation& quantumComputation,
-                    const llvm::SmallVector<Value>& qubits,
+                    const SmallVector<Value>& qubits,
                     const BitIndexVec& bitMap) {
   if (quantumComputation.hasGlobalPhase()) {
     builder.gphase(quantumComputation.getGlobalPhase());

--- a/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
@@ -26,7 +26,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <algorithm>

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -53,7 +53,7 @@ QCOProgramBuilder::QCOProgramBuilder(MLIRContext* context)
 
 void QCOProgramBuilder::initialize() {
   // Set insertion point to the module body
-  setInsertionPointToStart(module.getBody());
+  setInsertionPointToStart(mlir::cast<ModuleOp>(module).getBody());
 
   // Create main function as entry point
   auto funcType = getFunctionType({}, {getI64Type()});
@@ -71,6 +71,13 @@ void QCOProgramBuilder::initialize() {
 Value QCOProgramBuilder::intConstant(const int64_t value) {
   checkFinalized();
   return arith::ConstantOp::create(*this, getI64IntegerAttr(value)).getResult();
+}
+
+Value& QCOProgramBuilder::QubitRegister::operator[](const size_t index) {
+  if (index >= qubits.size()) {
+    llvm::reportFatalUsageError("Qubit index out of bounds");
+  }
+  return qubits[index];
 }
 
 Value QCOProgramBuilder::allocQubit() {
@@ -118,6 +125,17 @@ QCOProgramBuilder::allocQubitRegister(const int64_t size) {
   }
 
   return {.value = qtensor, .qubits = std::move(qubits)};
+}
+
+QCOProgramBuilder::Bit
+QCOProgramBuilder::ClassicalRegister::operator[](const int64_t index) const {
+  if (index < 0 || index >= size) {
+    const std::string msg = "Bit index " + std::to_string(index) +
+                            " out of bounds for register '" + name +
+                            "' of size " + std::to_string(size);
+    llvm::reportFatalUsageError(msg.c_str());
+  }
+  return {.registerName = name, .registerSize = size, .registerIndex = index};
 }
 
 QCOProgramBuilder::ClassicalRegister
@@ -902,7 +920,7 @@ OwningOpRef<ModuleOp> QCOProgramBuilder::finalize() {
   // Ensure that main function exists and insertion point is valid
   auto* insertionBlock = getInsertionBlock();
   func::FuncOp mainFunc = nullptr;
-  for (auto op : module.getOps<func::FuncOp>()) {
+  for (auto op : llvm::cast<ModuleOp>(module).getOps<func::FuncOp>()) {
     if (op.getName() == "main") {
       mainFunc = op;
       break;
@@ -958,7 +976,7 @@ OwningOpRef<ModuleOp> QCOProgramBuilder::finalize() {
   // Invalidate context to prevent use-after-finalize
   ctx = nullptr;
 
-  return module;
+  return llvm::cast<ModuleOp>(module);
 }
 
 OwningOpRef<ModuleOp> QCOProgramBuilder::build(

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -17,11 +17,9 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <llvm/ADT/DenseMap.h>
-#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/FormatVariadic.h>
 #include <llvm/Support/raw_ostream.h>
@@ -36,6 +34,7 @@
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -34,6 +34,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstdint>
 #include <string>
@@ -116,7 +117,7 @@ QCOProgramBuilder::allocQubitRegister(const int64_t size) {
 
   auto qtensor = qtensorAlloc(size);
 
-  llvm::SmallVector<Value> qubits;
+  SmallVector<Value> qubits;
   qubits.reserve(size);
   for (int64_t i = 0; i < size; ++i) {
     auto [qtensorOut, qubit] = qtensorExtract(qtensor, i);
@@ -188,11 +189,11 @@ void QCOProgramBuilder::validateTensorValue(Value tensor) const {
         "Invalid tensor value used (either consumed or not tracked)");
   }
 
-  auto tensorType = llvm::dyn_cast<RankedTensorType>(tensor.getType());
+  auto tensorType = dyn_cast<RankedTensorType>(tensor.getType());
   if (!tensorType || tensorType.getRank() != 1) {
     llvm::reportFatalUsageError("Tensor must be of 1-D RankedTensorType!");
   }
-  if (!llvm::isa<QubitType>(tensorType.getElementType())) {
+  if (!isa<QubitType>(tensorType.getElementType())) {
     llvm::reportFatalUsageError("Elements must be of QubitType!");
   }
 }
@@ -238,7 +239,7 @@ Value QCOProgramBuilder::qtensorFromElements(ValueRange elements) {
   }
 
   for (auto element : elements) {
-    if (!llvm::isa<QubitType>(element.getType())) {
+    if (!isa<QubitType>(element.getType())) {
       llvm::reportFatalUsageError("Elements must be QubitType!");
     }
     validateQubitValue(element);
@@ -357,12 +358,10 @@ Value QCOProgramBuilder::reset(Value qubit) {
     checkFinalized();                                                          \
     auto param = variantToValue(*this, getLoc(), PARAM);                       \
     const auto controlsOut =                                                   \
-        ctrl(control, {},                                                      \
-             [&](ValueRange /*targets*/) -> llvm::SmallVector<Value> {         \
-               OP_NAME(param);                                                 \
-               return {};                                                      \
-             })                                                                \
-            .first;                                                            \
+        ctrl(control, {}, [&](ValueRange /*targets*/) -> SmallVector<Value> {  \
+          OP_NAME(param);                                                      \
+          return {};                                                           \
+        }).first;                                                              \
     return controlsOut[0];                                                     \
   }                                                                            \
   ValueRange QCOProgramBuilder::mc##OP_NAME(                                   \
@@ -370,12 +369,10 @@ Value QCOProgramBuilder::reset(Value qubit) {
     checkFinalized();                                                          \
     auto param = variantToValue(*this, getLoc(), PARAM);                       \
     const auto controlsOut =                                                   \
-        ctrl(controls, {},                                                     \
-             [&](ValueRange /*targets*/) -> llvm::SmallVector<Value> {         \
-               OP_NAME(param);                                                 \
-               return {};                                                      \
-             })                                                                \
-            .first;                                                            \
+        ctrl(controls, {}, [&](ValueRange /*targets*/) -> SmallVector<Value> { \
+          OP_NAME(param);                                                      \
+          return {};                                                           \
+        }).first;                                                              \
     return controlsOut;                                                        \
   }
 
@@ -396,8 +393,8 @@ DEFINE_ZERO_TARGET_ONE_PARAMETER(GPhaseOp, gphase, theta)
   std::pair<Value, Value> QCOProgramBuilder::c##OP_NAME(Value control,         \
                                                         Value target) {        \
     checkFinalized();                                                          \
-    const auto [controlsOut, targetsOut] = ctrl(                               \
-        control, target, [&](ValueRange targets) -> llvm::SmallVector<Value> { \
+    const auto [controlsOut, targetsOut] =                                     \
+        ctrl(control, target, [&](ValueRange targets) -> SmallVector<Value> {  \
           return {OP_NAME(targets[0])};                                        \
         });                                                                    \
     return {controlsOut[0], targetsOut[0]};                                    \
@@ -406,10 +403,9 @@ DEFINE_ZERO_TARGET_ONE_PARAMETER(GPhaseOp, gphase, theta)
       ValueRange controls, Value target) {                                     \
     checkFinalized();                                                          \
     const auto [controlsOut, targetsOut] =                                     \
-        ctrl(controls, target,                                                 \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
-               return {OP_NAME(targets[0])};                                   \
-             });                                                               \
+        ctrl(controls, target, [&](ValueRange targets) -> SmallVector<Value> { \
+          return {OP_NAME(targets[0])};                                        \
+        });                                                                    \
     return {controlsOut, targetsOut[0]};                                       \
   }
 
@@ -443,8 +439,8 @@ DEFINE_ONE_TARGET_ZERO_PARAMETER(SXdgOp, sxdg)
       Value target) {                                                          \
     checkFinalized();                                                          \
     auto param = variantToValue(*this, getLoc(), PARAM);                       \
-    const auto [controlsOut, targetsOut] = ctrl(                               \
-        control, target, [&](ValueRange targets) -> llvm::SmallVector<Value> { \
+    const auto [controlsOut, targetsOut] =                                     \
+        ctrl(control, target, [&](ValueRange targets) -> SmallVector<Value> {  \
           return {OP_NAME(param, targets[0])};                                 \
         });                                                                    \
     return {controlsOut[0], targetsOut[0]};                                    \
@@ -455,10 +451,9 @@ DEFINE_ONE_TARGET_ZERO_PARAMETER(SXdgOp, sxdg)
     checkFinalized();                                                          \
     auto param = variantToValue(*this, getLoc(), PARAM);                       \
     const auto [controlsOut, targetsOut] =                                     \
-        ctrl(controls, target,                                                 \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
-               return {OP_NAME(param, targets[0])};                            \
-             });                                                               \
+        ctrl(controls, target, [&](ValueRange targets) -> SmallVector<Value> { \
+          return {OP_NAME(param, targets[0])};                                 \
+        });                                                                    \
     return {controlsOut, targetsOut[0]};                                       \
   }
 
@@ -488,8 +483,8 @@ DEFINE_ONE_TARGET_ONE_PARAMETER(POp, p, phi)
     checkFinalized();                                                          \
     auto param1 = variantToValue(*this, getLoc(), PARAM1);                     \
     auto param2 = variantToValue(*this, getLoc(), PARAM2);                     \
-    const auto [controlsOut, targetsOut] = ctrl(                               \
-        control, target, [&](ValueRange targets) -> llvm::SmallVector<Value> { \
+    const auto [controlsOut, targetsOut] =                                     \
+        ctrl(control, target, [&](ValueRange targets) -> SmallVector<Value> {  \
           return {OP_NAME(param1, param2, targets[0])};                        \
         });                                                                    \
     return {controlsOut[0], targetsOut[0]};                                    \
@@ -502,10 +497,9 @@ DEFINE_ONE_TARGET_ONE_PARAMETER(POp, p, phi)
     auto param1 = variantToValue(*this, getLoc(), PARAM1);                     \
     auto param2 = variantToValue(*this, getLoc(), PARAM2);                     \
     const auto [controlsOut, targetsOut] =                                     \
-        ctrl(controls, target,                                                 \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
-               return {OP_NAME(param1, param2, targets[0])};                   \
-             });                                                               \
+        ctrl(controls, target, [&](ValueRange targets) -> SmallVector<Value> { \
+          return {OP_NAME(param1, param2, targets[0])};                        \
+        });                                                                    \
     return {controlsOut, targetsOut[0]};                                       \
   }
 
@@ -537,8 +531,8 @@ DEFINE_ONE_TARGET_TWO_PARAMETER(U2Op, u2, phi, lambda)
     auto param1 = variantToValue(*this, getLoc(), PARAM1);                     \
     auto param2 = variantToValue(*this, getLoc(), PARAM2);                     \
     auto param3 = variantToValue(*this, getLoc(), PARAM3);                     \
-    const auto [controlsOut, targetsOut] = ctrl(                               \
-        control, target, [&](ValueRange targets) -> llvm::SmallVector<Value> { \
+    const auto [controlsOut, targetsOut] =                                     \
+        ctrl(control, target, [&](ValueRange targets) -> SmallVector<Value> {  \
           return {OP_NAME(param1, param2, param3, targets[0])};                \
         });                                                                    \
     return {controlsOut[0], targetsOut[0]};                                    \
@@ -553,10 +547,9 @@ DEFINE_ONE_TARGET_TWO_PARAMETER(U2Op, u2, phi, lambda)
     auto param2 = variantToValue(*this, getLoc(), PARAM2);                     \
     auto param3 = variantToValue(*this, getLoc(), PARAM3);                     \
     const auto [controlsOut, targetsOut] =                                     \
-        ctrl(controls, target,                                                 \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
-               return {OP_NAME(param1, param2, param3, targets[0])};           \
-             });                                                               \
+        ctrl(controls, target, [&](ValueRange targets) -> SmallVector<Value> { \
+          return {OP_NAME(param1, param2, param3, targets[0])};                \
+        });                                                                    \
     return {controlsOut, targetsOut[0]};                                       \
   }
 
@@ -582,7 +575,7 @@ DEFINE_ONE_TARGET_THREE_PARAMETER(UOp, u, theta, phi, lambda)
     checkFinalized();                                                          \
     const auto [controlsOut, targetsOut] =                                     \
         ctrl(control, {qubit0, qubit1},                                        \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
+             [&](ValueRange targets) -> SmallVector<Value> {                   \
                auto [q0, q1] = OP_NAME(targets[0], targets[1]);                \
                return {q0, q1};                                                \
              });                                                               \
@@ -594,7 +587,7 @@ DEFINE_ONE_TARGET_THREE_PARAMETER(UOp, u, theta, phi, lambda)
     checkFinalized();                                                          \
     const auto [controlsOut, targetsOut] =                                     \
         ctrl(controls, {qubit0, qubit1},                                       \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
+             [&](ValueRange targets) -> SmallVector<Value> {                   \
                auto [q0, q1] = OP_NAME(targets[0], targets[1]);                \
                return {q0, q1};                                                \
              });                                                               \
@@ -628,7 +621,7 @@ DEFINE_TWO_TARGET_ZERO_PARAMETER(ECROp, ecr)
     auto param = variantToValue(*this, getLoc(), PARAM);                       \
     const auto [controlsOut, targetsOut] =                                     \
         ctrl(control, {qubit0, qubit1},                                        \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
+             [&](ValueRange targets) -> SmallVector<Value> {                   \
                auto [q0, q1] = OP_NAME(param, targets[0], targets[1]);         \
                return {q0, q1};                                                \
              });                                                               \
@@ -642,7 +635,7 @@ DEFINE_TWO_TARGET_ZERO_PARAMETER(ECROp, ecr)
     auto param = variantToValue(*this, getLoc(), PARAM);                       \
     const auto [controlsOut, targetsOut] =                                     \
         ctrl(controls, {qubit0, qubit1},                                       \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
+             [&](ValueRange targets) -> SmallVector<Value> {                   \
                auto [q0, q1] = OP_NAME(param, targets[0], targets[1]);         \
                return {q0, q1};                                                \
              });                                                               \
@@ -680,7 +673,7 @@ DEFINE_TWO_TARGET_ONE_PARAMETER(RZZOp, rzz, theta)
     auto param2 = variantToValue(*this, getLoc(), PARAM2);                     \
     const auto [controlsOut, targetsOut] =                                     \
         ctrl(control, {qubit0, qubit1},                                        \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
+             [&](ValueRange targets) -> SmallVector<Value> {                   \
                auto [q0, q1] =                                                 \
                    OP_NAME(param1, param2, targets[0], targets[1]);            \
                return {q0, q1};                                                \
@@ -697,7 +690,7 @@ DEFINE_TWO_TARGET_ONE_PARAMETER(RZZOp, rzz, theta)
     auto param2 = variantToValue(*this, getLoc(), PARAM2);                     \
     const auto [controlsOut, targetsOut] =                                     \
         ctrl(controls, {qubit0, qubit1},                                       \
-             [&](ValueRange targets) -> llvm::SmallVector<Value> {             \
+             [&](ValueRange targets) -> SmallVector<Value> {                   \
                auto [q0, q1] =                                                 \
                    OP_NAME(param1, param2, targets[0], targets[1]);            \
                return {q0, q1};                                                \
@@ -727,9 +720,9 @@ ValueRange QCOProgramBuilder::barrier(ValueRange qubits) {
 // Modifiers
 //===----------------------------------------------------------------------===//
 
-std::pair<ValueRange, ValueRange> QCOProgramBuilder::ctrl(
-    ValueRange controls, ValueRange targets,
-    llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> body) {
+std::pair<ValueRange, ValueRange>
+QCOProgramBuilder::ctrl(ValueRange controls, ValueRange targets,
+                        function_ref<SmallVector<Value>(ValueRange)> body) {
   checkFinalized();
 
   auto ctrlOp = CtrlOp::create(*this, controls, targets);
@@ -764,9 +757,9 @@ std::pair<ValueRange, ValueRange> QCOProgramBuilder::ctrl(
   return {controlsOut, targetsOut};
 }
 
-ValueRange QCOProgramBuilder::inv(
-    ValueRange qubits,
-    llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> body) {
+ValueRange
+QCOProgramBuilder::inv(ValueRange qubits,
+                       function_ref<SmallVector<Value>(ValueRange)> body) {
   checkFinalized();
 
   auto invOp = InvOp::create(*this, qubits);
@@ -821,8 +814,8 @@ QCOProgramBuilder& QCOProgramBuilder::sink(Value qubit) {
 
 ValueRange QCOProgramBuilder::qcoIf(
     const std::variant<bool, Value>& condition, ValueRange qubits,
-    llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> thenBody,
-    llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> elseBody) {
+    function_ref<SmallVector<Value>(ValueRange)> thenBody,
+    function_ref<SmallVector<Value>(ValueRange)> elseBody) {
   checkFinalized();
 
   auto conditionValue = variantToValue(*this, getLoc(), condition);
@@ -846,7 +839,7 @@ ValueRange QCOProgramBuilder::qcoIf(
   const auto thenResult = thenBody(thenBlock.getArguments());
   YieldOp::create(*this, thenResult);
   setInsertionPointToStart(&elseBlock);
-  llvm::SmallVector<Value> elseResult;
+  SmallVector<Value> elseResult;
   if (elseBody) {
     elseResult = elseBody(elseBlock.getArguments());
     YieldOp::create(*this, elseResult);
@@ -920,7 +913,7 @@ OwningOpRef<ModuleOp> QCOProgramBuilder::finalize() {
   // Ensure that main function exists and insertion point is valid
   auto* insertionBlock = getInsertionBlock();
   func::FuncOp mainFunc = nullptr;
-  for (auto op : llvm::cast<ModuleOp>(module).getOps<func::FuncOp>()) {
+  for (auto op : cast<ModuleOp>(module).getOps<func::FuncOp>()) {
     if (op.getName() == "main") {
       mainFunc = op;
       break;
@@ -935,13 +928,12 @@ OwningOpRef<ModuleOp> QCOProgramBuilder::finalize() {
         "Insertion point is not in entry block of main function");
   }
 
-  llvm::DenseSet<int64_t> validTensorIds;
+  DenseSet<int64_t> validTensorIds;
   for (const auto& [tensor, info] : validTensors) {
     validTensorIds.insert(info.regId);
   }
 
-  llvm::DenseMap<int64_t, llvm::SmallVector<std::pair<Value, QubitInfo>>>
-      qubitsByRegister;
+  DenseMap<int64_t, SmallVector<std::pair<Value, QubitInfo>>> qubitsByRegister;
   for (auto [qubit, info] : validQubits) {
     if (info.regId == -1 || !validTensorIds.contains(info.regId)) {
       // Automatically deallocate all still-allocated qubits
@@ -976,12 +968,12 @@ OwningOpRef<ModuleOp> QCOProgramBuilder::finalize() {
   // Invalidate context to prevent use-after-finalize
   ctx = nullptr;
 
-  return llvm::cast<ModuleOp>(module);
+  return cast<ModuleOp>(module);
 }
 
 OwningOpRef<ModuleOp> QCOProgramBuilder::build(
     MLIRContext* context,
-    const llvm::function_ref<void(QCOProgramBuilder&)>& buildFunc) {
+    const function_ref<void(QCOProgramBuilder&)>& buildFunc) {
   QCOProgramBuilder builder(context);
   builder.initialize();
   buildFunc(builder);

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -24,7 +24,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cassert>
 #include <cstddef>
@@ -51,8 +51,7 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
       return failure();
     }
 
-    auto bodyCtrlOp =
-        llvm::dyn_cast<CtrlOp>(op.getBodyUnitary().getOperation());
+    auto bodyCtrlOp = dyn_cast<CtrlOp>(op.getBodyUnitary().getOperation());
     if (!bodyCtrlOp) {
       return failure();
     }
@@ -66,7 +65,7 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
 
     rewriter.replaceOpWithNewOp<CtrlOp>(
         op, newControls, newTargets,
-        [&](ValueRange newTargetArgs) -> llvm::SmallVector<Value> {
+        [&](ValueRange newTargetArgs) -> SmallVector<Value> {
           IRMapping mapping;
           auto* innerBody = bodyCtrlOp.getBody();
           for (size_t i = 0; i < bodyCtrlOp.getNumTargets(); ++i) {
@@ -92,7 +91,7 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
                                 PatternRewriter& rewriter) const override {
     auto* bodyUnitary = op.getBodyUnitary().getOperation();
     // Inline ops from empty control modifiers, IdOp and BarrierOp
-    if (op.getNumControls() == 0 || llvm::isa<IdOp, BarrierOp>(bodyUnitary)) {
+    if (op.getNumControls() == 0 || isa<IdOp, BarrierOp>(bodyUnitary)) {
       rewriter.moveOpBefore(bodyUnitary, op);
       bodyUnitary->setOperands(0, op.getNumTargets(), op.getTargetsIn());
       rewriter.replaceAllUsesWith(op.getControlsOut(), op.getControlsIn());
@@ -103,7 +102,7 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
     }
 
     // The remaining code explicitly handles GPhaseOp and nothing else
-    auto gPhaseOp = llvm::dyn_cast<GPhaseOp>(bodyUnitary);
+    auto gPhaseOp = dyn_cast<GPhaseOp>(bodyUnitary);
     if (!gPhaseOp) {
       return failure();
     }
@@ -136,7 +135,7 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
         POp::create(rewriter, gPhaseOp.getLoc(), arg, gPhaseOp.getTheta());
 
     // Add the results of the POp to the yield operation
-    auto yieldOp = llvm::cast<YieldOp>(op.getBody()->back());
+    auto yieldOp = cast<YieldOp>(op.getBody()->back());
     yieldOp->setOperands(pOp->getResults());
 
     // erase the GPhaseOp
@@ -154,7 +153,7 @@ UnitaryOpInterface CtrlOp::getBodyUnitary() {
   // also contain constants and arithmetic operations, e.g., created as part of
   // canonicalization. Thus, the only safe way to access the unitary operation
   // is to get the second operation from the back of the region.
-  return llvm::cast<UnitaryOpInterface>(*(++getBody()->rbegin()));
+  return cast<UnitaryOpInterface>(*(++getBody()->rbegin()));
 }
 
 Value CtrlOp::getInputQubit(const size_t i) {
@@ -235,10 +234,9 @@ Value CtrlOp::getOutputForInput(Value input) {
   llvm::reportFatalUsageError("Given qubit is not an input of the operation");
 }
 
-void CtrlOp::build(
-    OpBuilder& odsBuilder, OperationState& odsState, ValueRange controls,
-    ValueRange targets,
-    llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> bodyBuilder) {
+void CtrlOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                   ValueRange controls, ValueRange targets,
+                   function_ref<SmallVector<Value>(ValueRange)> bodyBuilder) {
   build(odsBuilder, odsState, controls, targets);
   auto& block = odsState.regions.front()->emplaceBlock();
 
@@ -270,7 +268,7 @@ LogicalResult CtrlOp::verify() {
              << i << " does not match target type";
     }
   }
-  if (!llvm::isa<YieldOp>(block.back())) {
+  if (!isa<YieldOp>(block.back())) {
     return emitOpError(
         "last operation in body region must be a yield operation");
   }
@@ -280,17 +278,17 @@ LogicalResult CtrlOp::verify() {
            << numTargets << " values, but found " << numYieldOperands;
   }
   auto iter = ++block.rbegin();
-  if (!llvm::isa<UnitaryOpInterface>(*iter)) {
+  if (!isa<UnitaryOpInterface>(*iter)) {
     return emitOpError(
         "second to last operation in body region must be a unitary operation");
   }
   for (auto it = ++iter; it != block.rend(); ++it) {
-    if (llvm::isa<UnitaryOpInterface>(*it)) {
+    if (isa<UnitaryOpInterface>(*it)) {
       return emitOpError("body region may only contain a single unitary op");
     }
   }
 
-  llvm::SmallPtrSet<Value, 4> uniqueQubitsIn;
+  SmallPtrSet<Value, 4> uniqueQubitsIn;
   for (const auto& control : getControlsIn()) {
     if (!uniqueQubitsIn.insert(control).second) {
       return emitOpError("duplicate control qubit found");
@@ -324,7 +322,7 @@ LogicalResult CtrlOp::verify() {
     }
   }
 
-  llvm::SmallPtrSet<Value, 4> uniqueQubitsOut;
+  SmallPtrSet<Value, 4> uniqueQubitsOut;
   for (const auto& control : getControlsOut()) {
     if (!uniqueQubitsOut.insert(control).second) {
       return emitOpError("duplicate control qubit found");

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -13,6 +13,7 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
@@ -289,7 +290,7 @@ LogicalResult CtrlOp::verify() {
     }
   }
 
-  SmallPtrSet<Value, 4> uniqueQubitsIn;
+  llvm::SmallPtrSet<Value, 4> uniqueQubitsIn;
   for (const auto& control : getControlsIn()) {
     if (!uniqueQubitsIn.insert(control).second) {
       return emitOpError("duplicate control qubit found");
@@ -323,7 +324,7 @@ LogicalResult CtrlOp::verify() {
     }
   }
 
-  SmallPtrSet<Value, 4> uniqueQubitsOut;
+  llvm::SmallPtrSet<Value, 4> uniqueQubitsOut;
   for (const auto& control : getControlsOut()) {
     if (!uniqueQubitsOut.insert(control).second) {
       return emitOpError("duplicate control qubit found");

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -13,9 +13,7 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
-#include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -23,7 +23,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cassert>

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
@@ -24,7 +24,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <numbers>
@@ -45,7 +45,7 @@ struct MoveCtrlOutside final : OpRewritePattern<InvOp> {
   LogicalResult matchAndRewrite(InvOp invOp,
                                 PatternRewriter& rewriter) const override {
     auto bodyUnitary = invOp.getBodyUnitary();
-    auto innerCtrlOp = llvm::dyn_cast<CtrlOp>(bodyUnitary.getOperation());
+    auto innerCtrlOp = dyn_cast<CtrlOp>(bodyUnitary.getOperation());
     if (!innerCtrlOp) {
       return failure();
     }
@@ -58,10 +58,10 @@ struct MoveCtrlOutside final : OpRewritePattern<InvOp> {
 
     rewriter.replaceOpWithNewOp<CtrlOp>(
         invOp, controls, targets,
-        [&](ValueRange newTargetArgs) -> llvm::SmallVector<Value> {
+        [&](ValueRange newTargetArgs) -> SmallVector<Value> {
           return InvOp::create(
                      rewriter, invOp.getLoc(), newTargetArgs,
-                     [&](ValueRange invArgs) -> llvm::SmallVector<Value> {
+                     [&](ValueRange invArgs) -> SmallVector<Value> {
                        IRMapping mapping;
                        auto* innerBody = innerCtrlOp.getBody();
                        for (size_t i = 0; i < innerCtrlOp.getNumTargets();
@@ -92,8 +92,7 @@ struct InlineSelfAdjoint final : OpRewritePattern<InvOp> {
                                 PatternRewriter& rewriter) const override {
     auto* innerOp = op.getBodyUnitary().getOperation();
 
-    if (!llvm::isa<IdOp, HOp, XOp, YOp, ZOp, ECROp, SWAPOp, BarrierOp>(
-            innerOp)) {
+    if (!isa<IdOp, HOp, XOp, YOp, ZOp, ECROp, SWAPOp, BarrierOp>(innerOp)) {
       return failure();
     }
 
@@ -117,7 +116,7 @@ struct ReplaceWithKnownGates final : OpRewritePattern<InvOp> {
                                 PatternRewriter& rewriter) const override {
     auto* innerOp = op.getBodyUnitary().getOperation();
 
-    return llvm::TypeSwitch<Operation*, LogicalResult>(innerOp)
+    return TypeSwitch<Operation*, LogicalResult>(innerOp)
         .Case<GPhaseOp>([&](auto g) {
           Value negTheta =
               arith::NegFOp::create(rewriter, op.getLoc(), g.getTheta());
@@ -262,7 +261,7 @@ struct CancelNestedInv final : OpRewritePattern<InvOp> {
   LogicalResult matchAndRewrite(InvOp op,
                                 PatternRewriter& rewriter) const override {
     auto* innerUnitary = op.getBodyUnitary().getOperation();
-    auto innerInvOp = llvm::dyn_cast<InvOp>(innerUnitary);
+    auto innerInvOp = dyn_cast<InvOp>(innerUnitary);
     if (!innerInvOp) {
       return failure();
     }
@@ -284,7 +283,7 @@ UnitaryOpInterface InvOp::getBodyUnitary() {
   // also contain constants and arithmetic operations, e.g., created as part of
   // canonicalization. Thus, the only safe way to access the unitary operation
   // is to get the second operation from the back of the region.
-  return llvm::cast<UnitaryOpInterface>(*(++getBody()->rbegin()));
+  return cast<UnitaryOpInterface>(*(++getBody()->rbegin()));
 }
 
 Value InvOp::getInputQubit(const size_t i) {
@@ -319,9 +318,9 @@ Value InvOp::getOutputForInput(Value input) {
   llvm::reportFatalUsageError("Given qubit is not an input of the operation");
 }
 
-void InvOp::build(
-    OpBuilder& odsBuilder, OperationState& odsState, ValueRange qubits,
-    llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> bodyBuilder) {
+void InvOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                  ValueRange qubits,
+                  function_ref<SmallVector<Value>(ValueRange)> bodyBuilder) {
   build(odsBuilder, odsState, qubits);
   auto& block = odsState.regions.front()->emplaceBlock();
 
@@ -353,7 +352,7 @@ LogicalResult InvOp::verify() {
              << i << " does not match target type";
     }
   }
-  if (!llvm::isa<YieldOp>(block.back())) {
+  if (!isa<YieldOp>(block.back())) {
     return emitOpError(
         "last operation in body region must be a yield operation");
   }
@@ -363,12 +362,12 @@ LogicalResult InvOp::verify() {
            << numTargets << " values, but found " << numYieldOperands;
   }
   auto iter = ++block.rbegin();
-  if (!llvm::isa<UnitaryOpInterface>(*iter)) {
+  if (!isa<UnitaryOpInterface>(*iter)) {
     return emitOpError(
         "second to last operation in body region must be a unitary operation");
   }
   for (auto it = ++iter; it != block.rend(); ++it) {
-    if (llvm::isa<UnitaryOpInterface>(*it)) {
+    if (isa<UnitaryOpInterface>(*it)) {
       return emitOpError("body region may only contain a single unitary op");
     }
   }

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
@@ -13,9 +13,7 @@
 
 #include <Eigen/Core>
 #include <llvm/ADT/STLFunctionalExtras.h>
-#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
@@ -24,7 +24,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cstddef>

--- a/mlir/lib/Dialect/QCO/IR/Operations/ResetOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/ResetOp.cpp
@@ -12,7 +12,6 @@
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorUtils.h"
 
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>

--- a/mlir/lib/Dialect/QCO/IR/Operations/ResetOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/ResetOp.cpp
@@ -18,7 +18,7 @@
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 using namespace mlir;
 using namespace mlir::qco;
@@ -40,11 +40,11 @@ static bool originatesFromQTensorAlloc(qtensor::ExtractOp extractOp) {
   }
 
   while (auto* definingOp = current.getDefiningOp()) {
-    if (llvm::isa<qtensor::AllocOp>(definingOp)) {
+    if (isa<qtensor::AllocOp>(definingOp)) {
       return true;
     }
 
-    if (auto nestedExtractOp = llvm::dyn_cast<qtensor::ExtractOp>(definingOp)) {
+    if (auto nestedExtractOp = dyn_cast<qtensor::ExtractOp>(definingOp)) {
       auto nestedExtractIndex = nestedExtractOp.getIndex();
       if (!getConstantIntValue(nestedExtractIndex)) {
         return false;
@@ -56,7 +56,7 @@ static bool originatesFromQTensorAlloc(qtensor::ExtractOp extractOp) {
       continue;
     }
 
-    if (auto insertOp = llvm::dyn_cast<qtensor::InsertOp>(definingOp)) {
+    if (auto insertOp = dyn_cast<qtensor::InsertOp>(definingOp)) {
       auto insertIndex = insertOp.getIndex();
       if (!getConstantIntValue(insertIndex)) {
         return false;

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
@@ -10,7 +10,9 @@
 
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
@@ -37,10 +39,10 @@ struct MergeSubsequentBarrier final : OpRewritePattern<BarrierOp> {
     const auto& qubitsIn = op.getQubitsIn();
 
     auto anythingToMerge = false;
-    DenseMap<size_t, Value> newQubitsOutMap;
+    llvm::DenseMap<size_t, Value> newQubitsOutMap;
 
-    SmallVector<Value> newQubitsIn;
-    SmallVector<size_t> indicesToFill;
+    llvm::SmallVector<Value> newQubitsIn;
+    llvm::SmallVector<size_t> indicesToFill;
 
     for (size_t i = 0; i < qubitsIn.size(); ++i) {
       if (llvm::isa<BarrierOp>(
@@ -63,7 +65,7 @@ struct MergeSubsequentBarrier final : OpRewritePattern<BarrierOp> {
       newQubitsOutMap[indicesToFill[i]] = newBarrier.getQubitsOut()[i];
     }
 
-    SmallVector<Value> newQubitsOut;
+    llvm::SmallVector<Value> newQubitsOut;
     newQubitsOut.reserve(op.getQubitsIn().size());
     for (size_t i = 0; i < op.getQubitsIn().size(); ++i) {
       newQubitsOut.push_back(newQubitsOutMap[i]);
@@ -110,7 +112,7 @@ Value BarrierOp::getOutputForInput(Value input) {
 
 void BarrierOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                       ValueRange qubits) {
-  SmallVector<Type> resultTypes;
+  llvm::SmallVector<Type> resultTypes;
   resultTypes.reserve(qubits.size());
   for (auto qubit : qubits) {
     resultTypes.push_back(qubit.getType());

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
@@ -17,7 +17,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cstddef>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
@@ -13,7 +13,6 @@
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
@@ -19,7 +19,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 
@@ -39,13 +39,13 @@ struct MergeSubsequentBarrier final : OpRewritePattern<BarrierOp> {
     const auto& qubitsIn = op.getQubitsIn();
 
     auto anythingToMerge = false;
-    llvm::DenseMap<size_t, Value> newQubitsOutMap;
+    DenseMap<size_t, Value> newQubitsOutMap;
 
-    llvm::SmallVector<Value> newQubitsIn;
-    llvm::SmallVector<size_t> indicesToFill;
+    SmallVector<Value> newQubitsIn;
+    SmallVector<size_t> indicesToFill;
 
     for (size_t i = 0; i < qubitsIn.size(); ++i) {
-      if (llvm::isa<BarrierOp>(
+      if (isa<BarrierOp>(
               *op.getOutputForInput(qubitsIn[i]).getUsers().begin())) {
         anythingToMerge = true;
         newQubitsOutMap[i] = qubitsIn[i];
@@ -65,7 +65,7 @@ struct MergeSubsequentBarrier final : OpRewritePattern<BarrierOp> {
       newQubitsOutMap[indicesToFill[i]] = newBarrier.getQubitsOut()[i];
     }
 
-    llvm::SmallVector<Value> newQubitsOut;
+    SmallVector<Value> newQubitsOut;
     newQubitsOut.reserve(op.getQubitsIn().size());
     for (size_t i = 0; i < op.getQubitsIn().size(); ++i) {
       newQubitsOut.push_back(newQubitsOutMap[i]);
@@ -112,7 +112,7 @@ Value BarrierOp::getOutputForInput(Value input) {
 
 void BarrierOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                       ValueRange qubits) {
-  llvm::SmallVector<Type> resultTypes;
+  SmallVector<Type> resultTypes;
   resultTypes.reserve(qubits.size());
   for (auto qubit : qubits) {
     resultTypes.push_back(qubit.getType());

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
-#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
@@ -17,7 +17,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cmath>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
@@ -67,7 +68,7 @@ void RXXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult RXXOp::fold(FoldAdaptor /*adaptor*/,
-                          SmallVectorImpl<OpFoldResult>& results) {
+                          llvm::SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
@@ -18,7 +18,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cmath>
 #include <complex>
@@ -68,7 +68,7 @@ void RXXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult RXXOp::fold(FoldAdaptor /*adaptor*/,
-                          llvm::SmallVectorImpl<OpFoldResult>& results) {
+                          SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
-#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
@@ -17,7 +17,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cmath>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
@@ -18,7 +18,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cmath>
 #include <complex>
@@ -68,7 +68,7 @@ void RYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult RYYOp::fold(FoldAdaptor /*adaptor*/,
-                          llvm::SmallVectorImpl<OpFoldResult>& results) {
+                          SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
@@ -67,7 +68,7 @@ void RYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult RYYOp::fold(FoldAdaptor /*adaptor*/,
-                          SmallVectorImpl<OpFoldResult>& results) {
+                          llvm::SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
-#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
@@ -17,7 +17,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cmath>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
@@ -18,7 +18,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cmath>
 #include <complex>
@@ -55,7 +55,7 @@ void RZXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult RZXOp::fold(FoldAdaptor /*adaptor*/,
-                          llvm::SmallVectorImpl<OpFoldResult>& results) {
+                          SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
@@ -54,7 +55,7 @@ void RZXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult RZXOp::fold(FoldAdaptor /*adaptor*/,
-                          SmallVectorImpl<OpFoldResult>& results) {
+                          llvm::SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
-#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
@@ -17,7 +17,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cmath>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
@@ -18,7 +18,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cmath>
 #include <complex>
@@ -68,7 +68,7 @@ void RZZOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult RZZOp::fold(FoldAdaptor /*adaptor*/,
-                          llvm::SmallVectorImpl<OpFoldResult>& results) {
+                          SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
@@ -67,7 +68,7 @@ void RZZOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult RZZOp::fold(FoldAdaptor /*adaptor*/,
-                          SmallVectorImpl<OpFoldResult>& results) {
+                          llvm::SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
@@ -12,8 +12,6 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
-#include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
@@ -19,7 +19,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cmath>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
@@ -16,11 +16,10 @@
 #include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
-#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cmath>
 #include <complex>
@@ -44,8 +43,7 @@ struct MergeSubsequentXXMinusYY final : OpRewritePattern<XXMinusYYOp> {
   LogicalResult matchAndRewrite(XXMinusYYOp op,
                                 PatternRewriter& rewriter) const override {
     // Check if the successor is the same operation
-    auto nextOp =
-        llvm::dyn_cast<XXMinusYYOp>(*op.getOutputQubit(0).user_begin());
+    auto nextOp = dyn_cast<XXMinusYYOp>(*op.getOutputQubit(0).user_begin());
     if (!nextOp) {
       return failure();
     }
@@ -90,7 +88,7 @@ void XXMinusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult XXMinusYYOp::fold(FoldAdaptor /*adaptor*/,
-                                llvm::SmallVectorImpl<OpFoldResult>& results) {
+                                SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
@@ -89,7 +90,7 @@ void XXMinusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult XXMinusYYOp::fold(FoldAdaptor /*adaptor*/,
-                                SmallVectorImpl<OpFoldResult>& results) {
+                                llvm::SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
@@ -12,8 +12,6 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
-#include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <Eigen/Core>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
@@ -88,7 +89,7 @@ void XXPlusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult XXPlusYYOp::fold(FoldAdaptor /*adaptor*/,
-                               SmallVectorImpl<OpFoldResult>& results) {
+                               llvm::SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
@@ -19,7 +19,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cmath>
 #include <complex>
@@ -43,8 +43,7 @@ struct MergeSubsequentXXPlusYY final : OpRewritePattern<XXPlusYYOp> {
   LogicalResult matchAndRewrite(XXPlusYYOp op,
                                 PatternRewriter& rewriter) const override {
     // Check if the successor is the same operation
-    auto nextOp =
-        llvm::dyn_cast<XXPlusYYOp>(*op.getOutputQubit(0).user_begin());
+    auto nextOp = dyn_cast<XXPlusYYOp>(*op.getOutputQubit(0).user_begin());
     if (!nextOp) {
       return failure();
     }
@@ -89,7 +88,7 @@ void XXPlusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult XXPlusYYOp::fold(FoldAdaptor /*adaptor*/,
-                               llvm::SmallVectorImpl<OpFoldResult>& results) {
+                               SmallVectorImpl<OpFoldResult>& results) {
   if (const auto theta = valueToDouble(getTheta());
       theta && std::abs(*theta) <= TOLERANCE) {
     results.emplace_back(getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
@@ -18,7 +18,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cmath>

--- a/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
@@ -14,6 +14,7 @@
 
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/OpImplementation.h>
 #include <mlir/IR/Operation.h>
@@ -34,16 +35,16 @@ using namespace mlir::qco;
 // Custom Parsers
 //===----------------------------------------------------------------------===//
 
-static ParseResult
-parseTargetAliasing(OpAsmParser& parser, Region& region,
-                    SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
+static ParseResult parseTargetAliasing(
+    OpAsmParser& parser, Region& region,
+    llvm::SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
   // 1. Parse the opening parenthesis
   if (parser.parseLParen()) {
     return failure();
   }
 
   // Temporary storage for block arguments we are about to create
-  SmallVector<OpAsmParser::Argument> blockArgs;
+  llvm::SmallVector<OpAsmParser::Argument> blockArgs;
 
   // 2. Prepare to parse the list
   if (failed(parser.parseOptionalRParen())) {
@@ -114,9 +115,9 @@ static void printTargetAliasing(OpAsmPrinter& printer, Operation* /*op*/,
   printer.printRegion(region, false);
 }
 
-static ParseResult
-parseIfOpAliasing(OpAsmParser& parser, Region& thenRegion, Region& elseRegion,
-                  SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
+static ParseResult parseIfOpAliasing(
+    OpAsmParser& parser, Region& thenRegion, Region& elseRegion,
+    llvm::SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
   // Parse the qubits keyword
   if (parser.parseKeyword("qubits")) {
     return failure();

--- a/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
@@ -19,7 +19,6 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Region.h>
 #include <mlir/IR/ValueRange.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 // The following headers are needed for some template instantiations.

--- a/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
@@ -20,7 +20,7 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Region.h>
 #include <mlir/IR/ValueRange.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 // The following headers are needed for some template instantiations.
 // IWYU pragma: begin_keep
@@ -35,16 +35,16 @@ using namespace mlir::qco;
 // Custom Parsers
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseTargetAliasing(
-    OpAsmParser& parser, Region& region,
-    llvm::SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
+static ParseResult
+parseTargetAliasing(OpAsmParser& parser, Region& region,
+                    SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
   // 1. Parse the opening parenthesis
   if (parser.parseLParen()) {
     return failure();
   }
 
   // Temporary storage for block arguments we are about to create
-  llvm::SmallVector<OpAsmParser::Argument> blockArgs;
+  SmallVector<OpAsmParser::Argument> blockArgs;
 
   // 2. Prepare to parse the list
   if (failed(parser.parseOptionalRParen())) {
@@ -115,9 +115,9 @@ static void printTargetAliasing(OpAsmPrinter& printer, Operation* /*op*/,
   printer.printRegion(region, false);
 }
 
-static ParseResult parseIfOpAliasing(
-    OpAsmParser& parser, Region& thenRegion, Region& elseRegion,
-    llvm::SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
+static ParseResult
+parseIfOpAliasing(OpAsmParser& parser, Region& thenRegion, Region& elseRegion,
+                  SmallVectorImpl<OpAsmParser::UnresolvedOperand>& operands) {
   // Parse the qubits keyword
   if (parser.parseKeyword("qubits")) {
     return failure();
@@ -160,7 +160,7 @@ static ParseResult parseIfOpAliasing(
   }
 
   // Remove duplicate operands
-  llvm::DenseSet<llvm::StringRef> seen;
+  DenseSet<StringRef> seen;
   llvm::erase_if(operands,
                  [&](const auto& op) { return !seen.insert(op.name).second; });
 

--- a/mlir/lib/Dialect/QCO/IR/QubitManagement/SinkOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QubitManagement/SinkOp.cpp
@@ -10,7 +10,6 @@
 
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
-#include <llvm/Support/Casting.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Support/LLVM.h>

--- a/mlir/lib/Dialect/QCO/IR/QubitManagement/SinkOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QubitManagement/SinkOp.cpp
@@ -13,7 +13,7 @@
 #include <llvm/Support/Casting.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 using namespace mlir;
 using namespace mlir::qco;
@@ -30,7 +30,7 @@ struct RemoveAllocSinkPair final : OpRewritePattern<SinkOp> {
   LogicalResult matchAndRewrite(SinkOp op,
                                 PatternRewriter& rewriter) const override {
     auto* defOp = op.getQubit().getDefiningOp();
-    if (!llvm::isa_and_nonnull<AllocOp, StaticOp>(defOp)) {
+    if (!isa_and_nonnull<AllocOp, StaticOp>(defOp)) {
       return failure();
     }
 

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -13,9 +13,7 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
-#include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/Builders.h>

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -27,7 +27,6 @@
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Interfaces/ControlFlowInterfaces.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cassert>

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -13,6 +13,7 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -50,13 +51,13 @@ void IfOp::build(
   // Add the block arguments and insert the yield operation
   thenBlock.addArguments(
       qubits.getTypes(),
-      SmallVector<Location>(qubits.size(), odsState.location));
+      llvm::SmallVector<Location>(qubits.size(), odsState.location));
   odsBuilder.setInsertionPointToStart(&thenBlock);
   qco::YieldOp::create(odsBuilder, odsState.location,
                        thenBuilder(thenBlock.getArguments()));
   elseBlock.addArguments(
       qubits.getTypes(),
-      SmallVector<Location>(qubits.size(), odsState.location));
+      llvm::SmallVector<Location>(qubits.size(), odsState.location));
   odsBuilder.setInsertionPointToStart(&elseBlock);
   if (elseBuilder) {
     qco::YieldOp::create(odsBuilder, odsState.location,
@@ -70,8 +71,8 @@ void IfOp::build(
 // Adjusted from
 // https://github.com/llvm/llvm-project/blob/llvmorg-22.1.1/mlir/lib/Dialect/SCF/IR/SCF.cpp
 
-void IfOp::getSuccessorRegions(RegionBranchPoint point,
-                               SmallVectorImpl<RegionSuccessor>& regions) {
+void IfOp::getSuccessorRegions(
+    RegionBranchPoint point, llvm::SmallVectorImpl<RegionSuccessor>& regions) {
   // The `then` and the `else` region branch back to the parent operation or
   // one of the recursive parent operations (early exit case).
   if (!point.isParent()) {
@@ -91,10 +92,11 @@ void IfOp::getSuccessorRegions(RegionBranchPoint point,
   }
 }
 
-void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
-                                    SmallVectorImpl<RegionSuccessor>& regions) {
+void IfOp::getEntrySuccessorRegions(
+    ArrayRef<Attribute> operands,
+    llvm::SmallVectorImpl<RegionSuccessor>& regions) {
   FoldAdaptor adaptor(operands, *this);
-  auto boolAttr = dyn_cast_or_null<BoolAttr>(adaptor.getCondition());
+  auto boolAttr = llvm::dyn_cast_or_null<BoolAttr>(adaptor.getCondition());
   if (!boolAttr || boolAttr.getValue()) {
     regions.emplace_back(&getThenRegion());
   }
@@ -111,7 +113,7 @@ void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void IfOp::getRegionInvocationBounds(
     ArrayRef<Attribute> operands,
-    SmallVectorImpl<InvocationBounds>& invocationBounds) {
+    llvm::SmallVectorImpl<InvocationBounds>& invocationBounds) {
   if (auto cond = llvm::dyn_cast_or_null<BoolAttr>(operands[0])) {
     // If the condition is known, then one region is known to be executed once
     // and the other zero times.
@@ -290,7 +292,7 @@ LogicalResult IfOp::verify() {
                          "input qubit types.");
     }
   }
-  SmallPtrSet<Value, 4> uniqueQubitsIn;
+  llvm::SmallPtrSet<Value, 4> uniqueQubitsIn;
   for (auto qubit : inputQubits) {
     if (!uniqueQubitsIn.insert(qubit).second) {
       return emitOpError("Input qubits must be unique.");

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -28,18 +28,17 @@
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Interfaces/ControlFlowInterfaces.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cassert>
 
 using namespace mlir;
 using namespace mlir::qco;
 
-void IfOp::build(
-    OpBuilder& odsBuilder, OperationState& odsState, Value condition,
-    ValueRange qubits,
-    llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> thenBuilder,
-    llvm::function_ref<llvm::SmallVector<Value>(ValueRange)> elseBuilder) {
+void IfOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                 Value condition, ValueRange qubits,
+                 function_ref<SmallVector<Value>(ValueRange)> thenBuilder,
+                 function_ref<SmallVector<Value>(ValueRange)> elseBuilder) {
   // Build the empty operation
   build(odsBuilder, odsState, qubits.getTypes(), condition, qubits);
 
@@ -49,30 +48,27 @@ void IfOp::build(
 
   const OpBuilder::InsertionGuard guard(odsBuilder);
   // Add the block arguments and insert the yield operation
-  thenBlock.addArguments(
-      qubits.getTypes(),
-      llvm::SmallVector<Location>(qubits.size(), odsState.location));
+  thenBlock.addArguments(qubits.getTypes(),
+                         SmallVector(qubits.size(), odsState.location));
   odsBuilder.setInsertionPointToStart(&thenBlock);
-  qco::YieldOp::create(odsBuilder, odsState.location,
-                       thenBuilder(thenBlock.getArguments()));
-  elseBlock.addArguments(
-      qubits.getTypes(),
-      llvm::SmallVector<Location>(qubits.size(), odsState.location));
+  YieldOp::create(odsBuilder, odsState.location,
+                  thenBuilder(thenBlock.getArguments()));
+  elseBlock.addArguments(qubits.getTypes(),
+                         SmallVector(qubits.size(), odsState.location));
   odsBuilder.setInsertionPointToStart(&elseBlock);
   if (elseBuilder) {
-    qco::YieldOp::create(odsBuilder, odsState.location,
-                         elseBuilder(elseBlock.getArguments()));
+    YieldOp::create(odsBuilder, odsState.location,
+                    elseBuilder(elseBlock.getArguments()));
   } else {
-    qco::YieldOp::create(odsBuilder, odsState.location,
-                         elseBlock.getArguments());
+    YieldOp::create(odsBuilder, odsState.location, elseBlock.getArguments());
   }
 }
 
 // Adjusted from
 // https://github.com/llvm/llvm-project/blob/llvmorg-22.1.1/mlir/lib/Dialect/SCF/IR/SCF.cpp
 
-void IfOp::getSuccessorRegions(
-    RegionBranchPoint point, llvm::SmallVectorImpl<RegionSuccessor>& regions) {
+void IfOp::getSuccessorRegions(RegionBranchPoint point,
+                               SmallVectorImpl<RegionSuccessor>& regions) {
   // The `then` and the `else` region branch back to the parent operation or
   // one of the recursive parent operations (early exit case).
   if (!point.isParent()) {
@@ -92,11 +88,10 @@ void IfOp::getSuccessorRegions(
   }
 }
 
-void IfOp::getEntrySuccessorRegions(
-    ArrayRef<Attribute> operands,
-    llvm::SmallVectorImpl<RegionSuccessor>& regions) {
+void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
+                                    SmallVectorImpl<RegionSuccessor>& regions) {
   FoldAdaptor adaptor(operands, *this);
-  auto boolAttr = llvm::dyn_cast_or_null<BoolAttr>(adaptor.getCondition());
+  auto boolAttr = dyn_cast_or_null<BoolAttr>(adaptor.getCondition());
   if (!boolAttr || boolAttr.getValue()) {
     regions.emplace_back(&getThenRegion());
   }
@@ -113,8 +108,8 @@ void IfOp::getEntrySuccessorRegions(
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void IfOp::getRegionInvocationBounds(
     ArrayRef<Attribute> operands,
-    llvm::SmallVectorImpl<InvocationBounds>& invocationBounds) {
-  if (auto cond = llvm::dyn_cast_or_null<BoolAttr>(operands[0])) {
+    SmallVectorImpl<InvocationBounds>& invocationBounds) {
+  if (auto cond = dyn_cast_or_null<BoolAttr>(operands[0])) {
     // If the condition is known, then one region is known to be executed once
     // and the other zero times.
     invocationBounds.emplace_back(0, cond.getValue() ? 1 : 0);
@@ -207,7 +202,7 @@ struct ConditionPropagation : public OpRewritePattern<IfOp> {
     }
 
     bool changed = false;
-    mlir::Type i1Ty = rewriter.getI1Type();
+    Type i1Ty = rewriter.getI1Type();
 
     // These variables serve to prevent creating duplicate constants
     // and hold constant true or false values.
@@ -258,7 +253,7 @@ LogicalResult IfOp::verify() {
   const auto numOutputQubits = outputQubits.size();
 
   for (auto type : inputQubits.getTypes()) {
-    if (!llvm::isa<QubitType>(type)) {
+    if (!isa<QubitType>(type)) {
       return emitOpError("Inputs must be qubit type!");
     }
   }
@@ -292,7 +287,7 @@ LogicalResult IfOp::verify() {
                          "input qubit types.");
     }
   }
-  llvm::SmallPtrSet<Value, 4> uniqueQubitsIn;
+  SmallPtrSet<Value, 4> uniqueQubitsIn;
   for (auto qubit : inputQubits) {
     if (!uniqueQubitsIn.insert(qubit).second) {
       return emitOpError("Input qubits must be unique.");

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Architecture.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Architecture.cpp
@@ -10,8 +10,9 @@
 
 #include "mlir/Dialect/QCO/Transforms/Mapping/Architecture.h"
 
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/Twine.h>
 #include <llvm/Support/ErrorHandling.h>
-#include <mlir/Support/LLVM.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -34,12 +35,12 @@ std::size_t Architecture::distanceBetween(std::size_t u, std::size_t v) const {
   if (dist_[u][v] == UINT64_MAX) {
     report_fatal_error("Floyd-warshall failed to compute the distance "
                        "between qubits " +
-                       Twine(u) + " and " + Twine(v));
+                       llvm::Twine(u) + " and " + llvm::Twine(v));
   }
   return dist_[u][v];
 }
 
-SmallVector<std::size_t, 4> Architecture::neighboursOf(std::size_t u) const {
+llvm::SmallVector<std::size_t> Architecture::neighboursOf(std::size_t u) const {
   return neighbours_[u];
 }
 

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Architecture.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Architecture.cpp
@@ -13,6 +13,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/Twine.h>
 #include <llvm/Support/ErrorHandling.h>
+#include <mlir/Support/LLVM.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -35,12 +36,12 @@ std::size_t Architecture::distanceBetween(std::size_t u, std::size_t v) const {
   if (dist_[u][v] == UINT64_MAX) {
     report_fatal_error("Floyd-warshall failed to compute the distance "
                        "between qubits " +
-                       llvm::Twine(u) + " and " + llvm::Twine(v));
+                       Twine(u) + " and " + Twine(v));
   }
   return dist_[u][v];
 }
 
-llvm::SmallVector<std::size_t, 4>
+SmallVector<std::size_t, 4>
 Architecture::neighboursOf(const std::size_t u) const {
   return neighbours_[u];
 }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Architecture.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Architecture.cpp
@@ -40,7 +40,8 @@ std::size_t Architecture::distanceBetween(std::size_t u, std::size_t v) const {
   return dist_[u][v];
 }
 
-llvm::SmallVector<std::size_t> Architecture::neighboursOf(std::size_t u) const {
+llvm::SmallVector<std::size_t, 4>
+Architecture::neighboursOf(const std::size_t u) const {
   return neighbours_[u];
 }
 

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -35,7 +35,7 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Threading.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <algorithm>
@@ -50,7 +50,6 @@
 #include <queue>
 #include <random>
 #include <string>
-#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -69,8 +68,8 @@ private:
   using QubitValue = TypedValue<QubitType>;
   using IndexType = std::size_t;
   using IndexGate = std::pair<IndexType, IndexType>;
-  using IndexGateSet = llvm::DenseSet<IndexGate>;
-  using Layer = llvm::DenseSet<IndexGate>;
+  using IndexGateSet = DenseSet<IndexGate>;
+  using Layer = DenseSet<IndexGate>;
 
   /**
    * @brief Specifies the layering direction.
@@ -110,7 +109,7 @@ private:
      * @return The random layout.
      */
     static Layout random(const std::size_t nqubits, const std::size_t seed) {
-      llvm::SmallVector<IndexType> mapping(nqubits);
+      SmallVector<IndexType> mapping(nqubits);
       std::iota(mapping.begin(), mapping.end(), IndexType{0});
       std::ranges::shuffle(mapping, std::mt19937_64{seed});
 
@@ -204,12 +203,12 @@ private:
     /**
      * @brief Maps a program qubit index to its hardware index.
      */
-    llvm::SmallVector<IndexType> programToHardware_;
+    SmallVector<IndexType> programToHardware_;
 
     /**
      * @brief Maps a hardware qubit index to its program index.
      */
-    llvm::SmallVector<IndexType> hardwareToProgram_;
+    SmallVector<IndexType> hardwareToProgram_;
 
   private:
     friend class MappingPass::LayoutInfo;
@@ -223,15 +222,15 @@ private:
    * @brief The layers of a circuit and the respective IR anchor for each.
    */
   struct [[nodiscard]] LayeringResult {
-    llvm::SmallVector<Layer> layers;
-    llvm::SmallVector<Operation*> anchors;
+    SmallVector<Layer> layers;
+    SmallVector<Operation*> anchors;
   };
 
   /**
    * @brief Required to use Layout as a key for LLVM maps and sets.
    */
   class [[nodiscard]] LayoutInfo {
-    using Info = llvm::DenseMapInfo<llvm::SmallVector<IndexType>>;
+    using Info = DenseMapInfo<SmallVector<IndexType>>;
 
   public:
     static Layout getEmptyKey() {
@@ -271,7 +270,7 @@ private:
     }
 
     float alpha;
-    llvm::SmallVector<float> decay;
+    SmallVector<float> decay;
   };
 
   /**
@@ -301,7 +300,7 @@ private:
      * @brief Construct a non-root node from its parent node. Apply the given
      * swap to the layout of the parent node.
      */
-    Node(Node* parent, IndexGate swap, llvm::ArrayRef<Layer> layers,
+    Node(Node* parent, IndexGate swap, ArrayRef<Layer> layers,
          const Architecture& arch, const Parameters& params)
         : layout(parent->layout), swap(swap), parent(parent),
           depth(parent->depth + 1), f(0) {
@@ -341,8 +340,7 @@ private:
      * that a naive router would insert to route the layers (with a constant
      * layout).
      */
-    [[nodiscard]] float h(llvm::ArrayRef<Layer> layers,
-                          const Architecture& arch,
+    [[nodiscard]] float h(ArrayRef<Layer> layers, const Architecture& arch,
                           const Parameters& params) const {
       float costs{0};
       for (const auto& [decay, layer] : zip(params.decay, layers)) {
@@ -362,7 +360,7 @@ private:
     /// @brief The computed initial layout.
     Layout layout;
     /// @brief A vector of SWAPs for each layer.
-    llvm::SmallVector<llvm::SmallVector<IndexGate>> swaps;
+    SmallVector<SmallVector<IndexGate>> swaps;
     /// @brief The number of inserted SWAPs.
     std::size_t nswaps{};
   };
@@ -396,7 +394,7 @@ protected:
 
       // Create trials. Currently this includes `ntrials` many random layouts.
 
-      llvm::SmallVector<Layout> trials;
+      SmallVector<Layout> trials;
       trials.reserve(this->ntrials);
       for (std::size_t i = 0; i < this->ntrials; ++i) {
         trials.emplace_back(Layout::random(arch.nqubits(), rng()));
@@ -405,7 +403,7 @@ protected:
       // Execute each of the trials (possibly in parallel). Collect the results
       // and find the one with the fewest SWAPs.
 
-      llvm::SmallVector<std::optional<TrialResult>> results(trials.size());
+      SmallVector<std::optional<TrialResult>> results(trials.size());
       parallelForEach(
           &getContext(), enumerate(trials), [&, this](auto indexedTrial) {
             auto [idx, layout] = indexedTrial;
@@ -433,7 +431,7 @@ private:
    * @returns the best trial result or nullptr if no result is valid.
    */
   [[nodiscard]] static TrialResult*
-  findBestTrial(llvm::MutableArrayRef<std::optional<TrialResult>> results) {
+  findBestTrial(MutableArrayRef<std::optional<TrialResult>> results) {
     TrialResult* best = nullptr;
     for (auto& opt : results) {
       if (opt.has_value()) {
@@ -452,8 +450,8 @@ private:
    * along the way. Repeat this procedure "niterations" times.
    * @returns the trial result or failure() on failure.
    */
-  FailureOr<TrialResult> runMappingTrial(llvm::ArrayRef<Layer> ltr,
-                                         llvm::ArrayRef<Layer> rtl,
+  FailureOr<TrialResult> runMappingTrial(ArrayRef<Layer> ltr,
+                                         ArrayRef<Layer> rtl,
                                          const Architecture& arch,
                                          const Parameters& params,
                                          Layout& layout) {
@@ -470,7 +468,7 @@ private:
     TrialResult result(layout); // Copies the final initial layout.
 
     // Helper function that adds the SWAPs to the trial result.
-    const auto collectSwaps = [&](llvm::ArrayRef<IndexGate> swaps) {
+    const auto collectSwaps = [&](ArrayRef<IndexGate> swaps) {
       result.nswaps += swaps.size();
       result.swaps.emplace_back(swaps);
     };
@@ -487,9 +485,9 @@ private:
    * @brief Collect dynamic qubits contained in the given function body.
    * @returns a vector of SSA values produced by qco.alloc operations.
    */
-  [[nodiscard]] static llvm::SmallVector<QubitValue>
+  [[nodiscard]] static SmallVector<QubitValue>
   collectDynamicQubits(Region& funcBody) {
-    return llvm::SmallVector<QubitValue>(map_range(
+    return SmallVector<QubitValue>(map_range(
         funcBody.getOps<AllocOp>(), [](AllocOp op) { return op.getResult(); }));
   }
 
@@ -498,7 +496,7 @@ private:
    * @returns a pair of vectors of layers, where [0]=forward and [1]=backward.
    */
   [[nodiscard]] static std::pair<LayeringResult, LayeringResult>
-  computeBidirectionalLayers(llvm::ArrayRef<QubitValue> dyn) {
+  computeBidirectionalLayers(ArrayRef<QubitValue> dyn) {
     auto wires = toWires(dyn);
     const auto ltr = collectLayers<Direction::Forward>(wires);
     const auto rtl = collectLayers<Direction::Backward>(wires);
@@ -522,9 +520,9 @@ private:
    * @returns a vector of hardware-index pairs (each denoting a SWAP) or
    * failure() if A* fails.
    */
-  [[nodiscard]] static FailureOr<llvm::SmallVector<IndexGate>>
-  search(llvm::ArrayRef<Layer> layers, const Layout& layout,
-         const Architecture& arch, const Parameters& params) {
+  [[nodiscard]] static FailureOr<SmallVector<IndexGate>>
+  search(ArrayRef<Layer> layers, const Layout& layout, const Architecture& arch,
+         const Parameters& params) {
     constexpr std::size_t cap = 25'000'000UL;
     const std::size_t b = arch.maxDegree() * ((arch.nqubits() + 1) / 2);
     const std::size_t budget = std::min(b * b * b, cap);
@@ -535,12 +533,12 @@ private:
 
     Node* root = std::construct_at(arena.Allocate(), layout);
     if (root->isGoal(layers.front(), arch)) {
-      return llvm::SmallVector<IndexGate>{};
+      return SmallVector<IndexGate>{};
     }
     frontier.emplace(root);
 
-    llvm::DenseMap<Layout, std::size_t, LayoutInfo> bestDepth;
-    llvm::DenseSet<IndexGate> expansionSet;
+    DenseMap<Layout, std::size_t, LayoutInfo> bestDepth;
+    DenseSet<IndexGate> expansionSet;
 
     std::size_t i = 0;
     while (!frontier.empty() && i < budget) {
@@ -568,7 +566,7 @@ private:
       // of SWAPs from this node to the root.
 
       if (curr->isGoal(layers.front(), arch)) {
-        llvm::SmallVector<IndexGate> seq(curr->depth);
+        SmallVector<IndexGate> seq(curr->depth);
         std::size_t j = seq.size() - 1;
         for (Node* n = curr; n->parent != nullptr; n = n->parent) {
           seq[j] = n->swap;
@@ -608,8 +606,8 @@ private:
    * @returns a vector of wire iterators.
    */
   template <typename QubitRange>
-  static llvm::SmallVector<WireIterator> toWires(QubitRange qubits) {
-    return llvm::SmallVector<WireIterator>(
+  static SmallVector<WireIterator> toWires(QubitRange qubits) {
+    return SmallVector<WireIterator>(
         map_range(qubits, [](auto q) { return WireIterator(q); }));
   }
 
@@ -621,7 +619,7 @@ private:
     if constexpr (d == Direction::Forward) {
       return it != std::default_sentinel;
     } else {
-      return !llvm::isa<AllocOp>(it.operation());
+      return !isa<AllocOp>(it.operation());
     }
   }
 
@@ -636,7 +634,7 @@ private:
 
     const auto advanceUntilTwoQubitOp = [&](WireIterator& it) {
       while (proceedOnWire<d>(it)) {
-        if (auto op = llvm::dyn_cast<UnitaryOpInterface>(it.operation())) {
+        if (auto op = dyn_cast<UnitaryOpInterface>(it.operation())) {
           if (op.getNumQubits() > 1) {
             break;
           }
@@ -675,19 +673,18 @@ private:
    * @returns a vector of layers.
    */
   template <Direction d>
-  static LayeringResult
-  collectLayers(llvm::MutableArrayRef<WireIterator> wires) {
+  static LayeringResult collectLayers(MutableArrayRef<WireIterator> wires) {
     constexpr auto step = d == Direction::Forward ? 1 : -1;
 
     LayeringResult result;
-    llvm::DenseMap<UnitaryOpInterface, std::size_t> visited;
+    DenseMap<UnitaryOpInterface, std::size_t> visited;
     while (true) {
       Layer layer{};
       Operation* anchor = nullptr;
       for (const auto [index, it] : enumerate(wires)) {
         while (proceedOnWire<d>(it)) {
           const auto res =
-              llvm::TypeSwitch<Operation*, WalkResult>(it.operation())
+              TypeSwitch<Operation*, WalkResult>(it.operation())
                   .Case<BarrierOp>([&](auto) {
                     std::ranges::advance(it, step);
                     return WalkResult::advance();
@@ -761,7 +758,7 @@ private:
    * @returns failure() if A* search isn't able to find a solution.
    */
   template <typename OnSwaps>
-  LogicalResult route(llvm::ArrayRef<Layer> layers, const Architecture& arch,
+  LogicalResult route(ArrayRef<Layer> layers, const Architecture& arch,
                       const Parameters& params, Layout& layout,
                       OnSwaps&& onSwaps) {
     auto&& callback = std::forward<OnSwaps>(onSwaps);
@@ -789,7 +786,7 @@ private:
    * @details Replaces dynamic with static qubits. Extends the computation with
    * as many static qubits as the architecture supports.
    */
-  static void place(llvm::ArrayRef<QubitValue> dynQubits, const Layout& layout,
+  static void place(ArrayRef<QubitValue> dynQubits, const Layout& layout,
                     Region& funcBody, IRRewriter& rewriter) {
     // 1. Replace existing dynamic allocations with mapped static ones.
     for (const auto [p, q] : enumerate(dynQubits)) {
@@ -811,12 +808,11 @@ private:
   /**
    * @brief Inserts SWAPs into the IR.
    */
-  void commit(llvm::ArrayRef<llvm::SmallVector<IndexGate>> swaps,
-              llvm::ArrayRef<Operation*> anchors, Region& funcBody,
+  void commit(ArrayRef<SmallVector<IndexGate>> swaps,
+              ArrayRef<Operation*> anchors, Region& funcBody,
               IRRewriter& rewriter) {
-    llvm::ArrayRef<Operation*>::iterator anchorIt = anchors.begin();
-    llvm::ArrayRef<llvm::SmallVector<IndexGate>>::iterator swapIt =
-        swaps.begin();
+    ArrayRef<Operation*>::iterator anchorIt = anchors.begin();
+    ArrayRef<SmallVector<IndexGate>>::iterator swapIt = swaps.begin();
 
     walkProgram(funcBody, [&](Operation* op, Qubits& qubits) {
       // Early exit if we've processed all layers.

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -17,10 +17,14 @@
 #include "mlir/Dialect/QCO/Utils/Qubits.h"
 #include "mlir/Dialect/QCO/Utils/WireIterator.h"
 
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Allocator.h>
+#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Block.h>
@@ -31,6 +35,7 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Threading.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Support/LogicalResult.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <algorithm>
@@ -64,8 +69,8 @@ private:
   using QubitValue = TypedValue<QubitType>;
   using IndexType = std::size_t;
   using IndexGate = std::pair<IndexType, IndexType>;
-  using IndexGateSet = DenseSet<IndexGate>;
-  using Layer = DenseSet<IndexGate>;
+  using IndexGateSet = llvm::DenseSet<IndexGate>;
+  using Layer = llvm::DenseSet<IndexGate>;
 
   /**
    * @brief Specifies the layering direction.
@@ -105,7 +110,7 @@ private:
      * @return The random layout.
      */
     static Layout random(const std::size_t nqubits, const std::size_t seed) {
-      SmallVector<IndexType> mapping(nqubits);
+      llvm::SmallVector<IndexType> mapping(nqubits);
       std::iota(mapping.begin(), mapping.end(), IndexType{0});
       std::ranges::shuffle(mapping, std::mt19937_64{seed});
 
@@ -199,12 +204,12 @@ private:
     /**
      * @brief Maps a program qubit index to its hardware index.
      */
-    SmallVector<IndexType> programToHardware_;
+    llvm::SmallVector<IndexType> programToHardware_;
 
     /**
      * @brief Maps a hardware qubit index to its program index.
      */
-    SmallVector<IndexType> hardwareToProgram_;
+    llvm::SmallVector<IndexType> hardwareToProgram_;
 
   private:
     friend class MappingPass::LayoutInfo;
@@ -218,15 +223,15 @@ private:
    * @brief The layers of a circuit and the respective IR anchor for each.
    */
   struct [[nodiscard]] LayeringResult {
-    SmallVector<Layer> layers;
-    SmallVector<Operation*> anchors;
+    llvm::SmallVector<Layer> layers;
+    llvm::SmallVector<Operation*> anchors;
   };
 
   /**
    * @brief Required to use Layout as a key for LLVM maps and sets.
    */
   class [[nodiscard]] LayoutInfo {
-    using Info = DenseMapInfo<SmallVector<IndexType>>;
+    using Info = llvm::DenseMapInfo<llvm::SmallVector<IndexType>>;
 
   public:
     static Layout getEmptyKey() {
@@ -266,7 +271,7 @@ private:
     }
 
     float alpha;
-    SmallVector<float> decay;
+    llvm::SmallVector<float> decay;
   };
 
   /**
@@ -296,7 +301,7 @@ private:
      * @brief Construct a non-root node from its parent node. Apply the given
      * swap to the layout of the parent node.
      */
-    Node(Node* parent, IndexGate swap, ArrayRef<Layer> layers,
+    Node(Node* parent, IndexGate swap, llvm::ArrayRef<Layer> layers,
          const Architecture& arch, const Parameters& params)
         : layout(parent->layout), swap(swap), parent(parent),
           depth(parent->depth + 1), f(0) {
@@ -336,7 +341,8 @@ private:
      * that a naive router would insert to route the layers (with a constant
      * layout).
      */
-    [[nodiscard]] float h(ArrayRef<Layer> layers, const Architecture& arch,
+    [[nodiscard]] float h(llvm::ArrayRef<Layer> layers,
+                          const Architecture& arch,
                           const Parameters& params) const {
       float costs{0};
       for (const auto& [decay, layer] : zip(params.decay, layers)) {
@@ -356,7 +362,7 @@ private:
     /// @brief The computed initial layout.
     Layout layout;
     /// @brief A vector of SWAPs for each layer.
-    SmallVector<SmallVector<IndexGate>> swaps;
+    llvm::SmallVector<llvm::SmallVector<IndexGate>> swaps;
     /// @brief The number of inserted SWAPs.
     std::size_t nswaps{};
   };
@@ -390,7 +396,7 @@ protected:
 
       // Create trials. Currently this includes `ntrials` many random layouts.
 
-      SmallVector<Layout> trials;
+      llvm::SmallVector<Layout> trials;
       trials.reserve(this->ntrials);
       for (std::size_t i = 0; i < this->ntrials; ++i) {
         trials.emplace_back(Layout::random(arch.nqubits(), rng()));
@@ -399,7 +405,7 @@ protected:
       // Execute each of the trials (possibly in parallel). Collect the results
       // and find the one with the fewest SWAPs.
 
-      SmallVector<std::optional<TrialResult>> results(trials.size());
+      llvm::SmallVector<std::optional<TrialResult>> results(trials.size());
       parallelForEach(
           &getContext(), enumerate(trials), [&, this](auto indexedTrial) {
             auto [idx, layout] = indexedTrial;
@@ -427,7 +433,7 @@ private:
    * @returns the best trial result or nullptr if no result is valid.
    */
   [[nodiscard]] static TrialResult*
-  findBestTrial(MutableArrayRef<std::optional<TrialResult>> results) {
+  findBestTrial(llvm::MutableArrayRef<std::optional<TrialResult>> results) {
     TrialResult* best = nullptr;
     for (auto& opt : results) {
       if (opt.has_value()) {
@@ -446,8 +452,8 @@ private:
    * along the way. Repeat this procedure "niterations" times.
    * @returns the trial result or failure() on failure.
    */
-  FailureOr<TrialResult> runMappingTrial(ArrayRef<Layer> ltr,
-                                         ArrayRef<Layer> rtl,
+  FailureOr<TrialResult> runMappingTrial(llvm::ArrayRef<Layer> ltr,
+                                         llvm::ArrayRef<Layer> rtl,
                                          const Architecture& arch,
                                          const Parameters& params,
                                          Layout& layout) {
@@ -464,7 +470,7 @@ private:
     TrialResult result(layout); // Copies the final initial layout.
 
     // Helper function that adds the SWAPs to the trial result.
-    const auto collectSwaps = [&](ArrayRef<IndexGate> swaps) {
+    const auto collectSwaps = [&](llvm::ArrayRef<IndexGate> swaps) {
       result.nswaps += swaps.size();
       result.swaps.emplace_back(swaps);
     };
@@ -481,9 +487,9 @@ private:
    * @brief Collect dynamic qubits contained in the given function body.
    * @returns a vector of SSA values produced by qco.alloc operations.
    */
-  [[nodiscard]] static SmallVector<QubitValue>
+  [[nodiscard]] static llvm::SmallVector<QubitValue>
   collectDynamicQubits(Region& funcBody) {
-    return SmallVector<QubitValue>(map_range(
+    return llvm::SmallVector<QubitValue>(map_range(
         funcBody.getOps<AllocOp>(), [](AllocOp op) { return op.getResult(); }));
   }
 
@@ -492,7 +498,7 @@ private:
    * @returns a pair of vectors of layers, where [0]=forward and [1]=backward.
    */
   [[nodiscard]] static std::pair<LayeringResult, LayeringResult>
-  computeBidirectionalLayers(ArrayRef<QubitValue> dyn) {
+  computeBidirectionalLayers(llvm::ArrayRef<QubitValue> dyn) {
     auto wires = toWires(dyn);
     const auto ltr = collectLayers<Direction::Forward>(wires);
     const auto rtl = collectLayers<Direction::Backward>(wires);
@@ -516,9 +522,9 @@ private:
    * @returns a vector of hardware-index pairs (each denoting a SWAP) or
    * failure() if A* fails.
    */
-  [[nodiscard]] static FailureOr<SmallVector<IndexGate>>
-  search(ArrayRef<Layer> layers, const Layout& layout, const Architecture& arch,
-         const Parameters& params) {
+  [[nodiscard]] static FailureOr<llvm::SmallVector<IndexGate>>
+  search(llvm::ArrayRef<Layer> layers, const Layout& layout,
+         const Architecture& arch, const Parameters& params) {
     constexpr std::size_t cap = 25'000'000UL;
     const std::size_t b = arch.maxDegree() * ((arch.nqubits() + 1) / 2);
     const std::size_t budget = std::min(b * b * b, cap);
@@ -529,12 +535,12 @@ private:
 
     Node* root = std::construct_at(arena.Allocate(), layout);
     if (root->isGoal(layers.front(), arch)) {
-      return SmallVector<IndexGate>{};
+      return llvm::SmallVector<IndexGate>{};
     }
     frontier.emplace(root);
 
-    DenseMap<Layout, std::size_t, LayoutInfo> bestDepth;
-    DenseSet<IndexGate> expansionSet;
+    llvm::DenseMap<Layout, std::size_t, LayoutInfo> bestDepth;
+    llvm::DenseSet<IndexGate> expansionSet;
 
     std::size_t i = 0;
     while (!frontier.empty() && i < budget) {
@@ -562,7 +568,7 @@ private:
       // of SWAPs from this node to the root.
 
       if (curr->isGoal(layers.front(), arch)) {
-        SmallVector<IndexGate> seq(curr->depth);
+        llvm::SmallVector<IndexGate> seq(curr->depth);
         std::size_t j = seq.size() - 1;
         for (Node* n = curr; n->parent != nullptr; n = n->parent) {
           seq[j] = n->swap;
@@ -602,8 +608,8 @@ private:
    * @returns a vector of wire iterators.
    */
   template <typename QubitRange>
-  static SmallVector<WireIterator> toWires(QubitRange qubits) {
-    return SmallVector<WireIterator>(
+  static llvm::SmallVector<WireIterator> toWires(QubitRange qubits) {
+    return llvm::SmallVector<WireIterator>(
         map_range(qubits, [](auto q) { return WireIterator(q); }));
   }
 
@@ -615,7 +621,7 @@ private:
     if constexpr (d == Direction::Forward) {
       return it != std::default_sentinel;
     } else {
-      return !isa<AllocOp>(it.operation());
+      return !llvm::isa<AllocOp>(it.operation());
     }
   }
 
@@ -630,7 +636,7 @@ private:
 
     const auto advanceUntilTwoQubitOp = [&](WireIterator& it) {
       while (proceedOnWire<d>(it)) {
-        if (auto op = dyn_cast<UnitaryOpInterface>(it.operation())) {
+        if (auto op = llvm::dyn_cast<UnitaryOpInterface>(it.operation())) {
           if (op.getNumQubits() > 1) {
             break;
           }
@@ -669,18 +675,19 @@ private:
    * @returns a vector of layers.
    */
   template <Direction d>
-  static LayeringResult collectLayers(MutableArrayRef<WireIterator> wires) {
+  static LayeringResult
+  collectLayers(llvm::MutableArrayRef<WireIterator> wires) {
     constexpr auto step = d == Direction::Forward ? 1 : -1;
 
     LayeringResult result;
-    DenseMap<UnitaryOpInterface, std::size_t> visited;
+    llvm::DenseMap<UnitaryOpInterface, std::size_t> visited;
     while (true) {
       Layer layer{};
       Operation* anchor = nullptr;
       for (const auto [index, it] : enumerate(wires)) {
         while (proceedOnWire<d>(it)) {
           const auto res =
-              TypeSwitch<Operation*, WalkResult>(it.operation())
+              llvm::TypeSwitch<Operation*, WalkResult>(it.operation())
                   .Case<BarrierOp>([&](auto) {
                     std::ranges::advance(it, step);
                     return WalkResult::advance();
@@ -754,7 +761,7 @@ private:
    * @returns failure() if A* search isn't able to find a solution.
    */
   template <typename OnSwaps>
-  LogicalResult route(ArrayRef<Layer> layers, const Architecture& arch,
+  LogicalResult route(llvm::ArrayRef<Layer> layers, const Architecture& arch,
                       const Parameters& params, Layout& layout,
                       OnSwaps&& onSwaps) {
     auto&& callback = std::forward<OnSwaps>(onSwaps);
@@ -782,7 +789,7 @@ private:
    * @details Replaces dynamic with static qubits. Extends the computation with
    * as many static qubits as the architecture supports.
    */
-  static void place(ArrayRef<QubitValue> dynQubits, const Layout& layout,
+  static void place(llvm::ArrayRef<QubitValue> dynQubits, const Layout& layout,
                     Region& funcBody, IRRewriter& rewriter) {
     // 1. Replace existing dynamic allocations with mapped static ones.
     for (const auto [p, q] : enumerate(dynQubits)) {
@@ -804,11 +811,12 @@ private:
   /**
    * @brief Inserts SWAPs into the IR.
    */
-  void commit(ArrayRef<SmallVector<IndexGate>> swaps,
-              ArrayRef<Operation*> anchors, Region& funcBody,
+  void commit(llvm::ArrayRef<llvm::SmallVector<IndexGate>> swaps,
+              llvm::ArrayRef<Operation*> anchors, Region& funcBody,
               IRRewriter& rewriter) {
-    ArrayRef<Operation*>::iterator anchorIt = anchors.begin();
-    ArrayRef<SmallVector<IndexGate>>::iterator swapIt = swaps.begin();
+    llvm::ArrayRef<Operation*>::iterator anchorIt = anchors.begin();
+    llvm::ArrayRef<llvm::SmallVector<IndexGate>>::iterator swapIt =
+        swaps.begin();
 
     walkProgram(funcBody, [&](Operation* op, Qubits& qubits) {
       // Early exit if we've processed all layers.

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -19,12 +19,10 @@
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/DenseMap.h>
-#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Allocator.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Block.h>

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -31,7 +31,6 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Threading.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <algorithm>

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
@@ -25,7 +25,7 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 #include <cassert>
@@ -80,7 +80,7 @@ struct MergeSingleQubitRotationGatesPattern final
 
   /// Returns whether an operation is considered mergeable
   static bool isMergeable(Operation* op) {
-    return llvm::isa<RXOp, RYOp, RZOp, POp, ROp, U2Op, UOp>(op);
+    return isa<RXOp, RYOp, RZOp, POp, ROp, U2Op, UOp>(op);
   }
 
   /// Checks if two gates a and b are mergeable via quaternion-based merging.
@@ -96,7 +96,7 @@ struct MergeSingleQubitRotationGatesPattern final
    *         RXOp, RYOp, or RZOp.
    */
   static std::optional<RotationAxis> getRotationAxis(Operation* op) {
-    return llvm::TypeSwitch<Operation*, std::optional<RotationAxis>>(op)
+    return TypeSwitch<Operation*, std::optional<RotationAxis>>(op)
         .Case<RXOp>([](auto) { return RotationAxis::X; })
         .Case<RYOp>([](auto) { return RotationAxis::Y; })
         .Case<RZOp, POp>([](auto) { return RotationAxis::Z; })
@@ -117,21 +117,20 @@ struct MergeSingleQubitRotationGatesPattern final
   static Constants createConstants(Location loc, PatternRewriter& rewriter) {
     return {
         .negOne = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(-1.0)),
+            rewriter, loc, rewriter.getF64Type(), APFloat(-1.0)),
         .zero = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(0.0)),
+            rewriter, loc, rewriter.getF64Type(), APFloat(0.0)),
         .one = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(1.0)),
+            rewriter, loc, rewriter.getF64Type(), APFloat(1.0)),
         .two = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(2.0)),
+            rewriter, loc, rewriter.getF64Type(), APFloat(2.0)),
         // Tolerance for gimbal-lock detection in quaternion-to-Euler
         // conversion. Value from reference implementation:
         // https://github.com/evbernardes/quaternion_to_euler/blob/main/euler_from_quat.py
         .eps = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(1e-12)),
-        .pi =
-            arith::ConstantFloatOp::create(rewriter, loc, rewriter.getF64Type(),
-                                           llvm::APFloat(std::numbers::pi)),
+            rewriter, loc, rewriter.getF64Type(), APFloat(1e-12)),
+        .pi = arith::ConstantFloatOp::create(
+            rewriter, loc, rewriter.getF64Type(), APFloat(std::numbers::pi)),
     };
   }
 
@@ -329,7 +328,7 @@ struct MergeSingleQubitRotationGatesPattern final
     }
 
     // Multi-parameter gates each need their own conversion
-    return llvm::TypeSwitch<Operation*, Quaternion>(op.getOperation())
+    return TypeSwitch<Operation*, Quaternion>(op.getOperation())
         .Case<ROp>(
             [&](ROp o) { return quaternionFromROp(o, constants, rewriter); })
         .Case<U2Op>(
@@ -363,7 +362,7 @@ struct MergeSingleQubitRotationGatesPattern final
                                             const Constants& constants,
                                             Location loc,
                                             PatternRewriter& rewriter) {
-    return llvm::TypeSwitch<Operation*, std::optional<Value>>(op.getOperation())
+    return TypeSwitch<Operation*, std::optional<Value>>(op.getOperation())
         .Case<RXOp, RYOp, RZOp, ROp>(
             [&](auto) -> std::optional<Value> { return std::nullopt; })
         .Case<POp>([&](auto) -> std::optional<Value> {
@@ -372,7 +371,7 @@ struct MergeSingleQubitRotationGatesPattern final
         })
         .Case<UOp, U2Op>([&](auto) -> std::optional<Value> {
           // phi is at different indexes for UOp and U2Op
-          auto phiIdx = llvm::isa<UOp>(op.getOperation()) ? 1U : 0U;
+          auto phiIdx = isa<UOp>(op.getOperation()) ? 1U : 0U;
           auto sum =
               arith::AddFOp::create(rewriter, loc, op.getParameter(phiIdx),
                                     op.getParameter(phiIdx + 1));
@@ -413,16 +412,16 @@ struct MergeSingleQubitRotationGatesPattern final
    * @param start The chain head (must satisfy isChainStart)
    * @return The chain of operations in circuit order (first applied to last)
    */
-  static llvm::SmallVector<UnitaryOpInterface>
+  static SmallVector<UnitaryOpInterface>
   collectChain(UnitaryOpInterface start) {
-    llvm::SmallVector<UnitaryOpInterface> chain = {start};
+    SmallVector chain = {start};
     auto current = start;
     while (true) {
       auto* userOp = *current->getUsers().begin();
       if (!areQuaternionMergeable(*current.getOperation(), *userOp)) {
         break;
       }
-      current = chain.emplace_back(llvm::cast<UnitaryOpInterface>(userOp));
+      current = chain.emplace_back(cast<UnitaryOpInterface>(userOp));
     }
     return chain;
   }

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
@@ -22,7 +22,6 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 #include <cassert>

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
@@ -12,11 +12,9 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
-#include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Math/IR/Math.h>

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
@@ -12,8 +12,11 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
+#include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
+#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Math/IR/Math.h>
@@ -22,6 +25,7 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 #include <cassert>
@@ -76,7 +80,7 @@ struct MergeSingleQubitRotationGatesPattern final
 
   /// Returns whether an operation is considered mergeable
   static bool isMergeable(Operation* op) {
-    return isa<RXOp, RYOp, RZOp, POp, ROp, U2Op, UOp>(op);
+    return llvm::isa<RXOp, RYOp, RZOp, POp, ROp, U2Op, UOp>(op);
   }
 
   /// Checks if two gates a and b are mergeable via quaternion-based merging.
@@ -113,20 +117,21 @@ struct MergeSingleQubitRotationGatesPattern final
   static Constants createConstants(Location loc, PatternRewriter& rewriter) {
     return {
         .negOne = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), APFloat(-1.0)),
+            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(-1.0)),
         .zero = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), APFloat(0.0)),
+            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(0.0)),
         .one = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), APFloat(1.0)),
+            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(1.0)),
         .two = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), APFloat(2.0)),
+            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(2.0)),
         // Tolerance for gimbal-lock detection in quaternion-to-Euler
         // conversion. Value from reference implementation:
         // https://github.com/evbernardes/quaternion_to_euler/blob/main/euler_from_quat.py
         .eps = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), APFloat(1e-12)),
-        .pi = arith::ConstantFloatOp::create(
-            rewriter, loc, rewriter.getF64Type(), APFloat(std::numbers::pi)),
+            rewriter, loc, rewriter.getF64Type(), llvm::APFloat(1e-12)),
+        .pi =
+            arith::ConstantFloatOp::create(rewriter, loc, rewriter.getF64Type(),
+                                           llvm::APFloat(std::numbers::pi)),
     };
   }
 
@@ -367,7 +372,7 @@ struct MergeSingleQubitRotationGatesPattern final
         })
         .Case<UOp, U2Op>([&](auto) -> std::optional<Value> {
           // phi is at different indexes for UOp and U2Op
-          auto phiIdx = isa<UOp>(op.getOperation()) ? 1U : 0U;
+          auto phiIdx = llvm::isa<UOp>(op.getOperation()) ? 1U : 0U;
           auto sum =
               arith::AddFOp::create(rewriter, loc, op.getParameter(phiIdx),
                                     op.getParameter(phiIdx + 1));
@@ -408,16 +413,16 @@ struct MergeSingleQubitRotationGatesPattern final
    * @param start The chain head (must satisfy isChainStart)
    * @return The chain of operations in circuit order (first applied to last)
    */
-  static SmallVector<UnitaryOpInterface>
+  static llvm::SmallVector<UnitaryOpInterface>
   collectChain(UnitaryOpInterface start) {
-    SmallVector<UnitaryOpInterface> chain = {start};
+    llvm::SmallVector<UnitaryOpInterface> chain = {start};
     auto current = start;
     while (true) {
       auto* userOp = *current->getUsers().begin();
       if (!areQuaternionMergeable(*current.getOperation(), *userOp)) {
         break;
       }
-      current = chain.emplace_back(cast<UnitaryOpInterface>(userOp));
+      current = chain.emplace_back(llvm::cast<UnitaryOpInterface>(userOp));
     }
     return chain;
   }

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -17,7 +17,6 @@
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LLVM.h>
 
 #include <cassert>
 #include <iterator>

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -14,10 +14,10 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
 #include <llvm/ADT/TypeSwitch.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cassert>
 #include <iterator>
@@ -25,7 +25,7 @@
 namespace mlir::qco {
 mlir::Value WireIterator::qubit() const {
   // A sink/deallocation doesn't have an OpResult.
-  if (op_ != nullptr && llvm::isa<SinkOp>(op_)) {
+  if (op_ != nullptr && isa<SinkOp>(op_)) {
     return nullptr;
   }
   return qubit_;
@@ -42,12 +42,12 @@ void WireIterator::forward() {
   op_ = *(qubit_.getUsers().begin());
 
   // A sink op defines the end of the qubit wire (dynamic and static).
-  if (llvm::isa<SinkOp>(op_)) {
+  if (isa<SinkOp>(op_)) {
     isSentinel_ = true;
     return;
   }
 
-  if (!(llvm::isa<AllocOp, StaticOp>(op_))) {
+  if (!(isa<AllocOp, StaticOp>(op_))) {
     // Find the output from the input qubit SSA value.
     mlir::TypeSwitch<mlir::Operation*>(op_)
         .Case<UnitaryOpInterface>([&](UnitaryOpInterface op) {
@@ -71,14 +71,14 @@ void WireIterator::backward() {
 
   // For sinks/deallocations, qubit_ is an OpOperand. Hence, only get the
   // def-op.
-  if (llvm::isa<SinkOp>(op_)) {
+  if (isa<SinkOp>(op_)) {
     op_ = qubit_.getDefiningOp();
     return;
   }
 
   // Allocations or static definitions define the start of the qubit wire.
   // Consequently, stop and early exit.
-  if (llvm::isa<AllocOp, StaticOp>(op_)) {
+  if (isa<AllocOp, StaticOp>(op_)) {
     return;
   }
 

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
 #include <llvm/ADT/TypeSwitch.h>
+#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
@@ -24,7 +25,7 @@
 namespace mlir::qco {
 mlir::Value WireIterator::qubit() const {
   // A sink/deallocation doesn't have an OpResult.
-  if (op_ != nullptr && mlir::isa<SinkOp>(op_)) {
+  if (op_ != nullptr && llvm::isa<SinkOp>(op_)) {
     return nullptr;
   }
   return qubit_;
@@ -41,12 +42,12 @@ void WireIterator::forward() {
   op_ = *(qubit_.getUsers().begin());
 
   // A sink op defines the end of the qubit wire (dynamic and static).
-  if (mlir::isa<SinkOp>(op_)) {
+  if (llvm::isa<SinkOp>(op_)) {
     isSentinel_ = true;
     return;
   }
 
-  if (!(mlir::isa<AllocOp, StaticOp>(op_))) {
+  if (!(llvm::isa<AllocOp, StaticOp>(op_))) {
     // Find the output from the input qubit SSA value.
     mlir::TypeSwitch<mlir::Operation*>(op_)
         .Case<UnitaryOpInterface>([&](UnitaryOpInterface op) {
@@ -70,14 +71,14 @@ void WireIterator::backward() {
 
   // For sinks/deallocations, qubit_ is an OpOperand. Hence, only get the
   // def-op.
-  if (mlir::isa<SinkOp>(op_)) {
+  if (llvm::isa<SinkOp>(op_)) {
     op_ = qubit_.getDefiningOp();
     return;
   }
 
   // Allocations or static definitions define the start of the qubit wire.
   // Consequently, stop and early exit.
-  if (mlir::isa<AllocOp, StaticOp>(op_)) {
+  if (llvm::isa<AllocOp, StaticOp>(op_)) {
     return;
   }
 

--- a/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
@@ -29,6 +29,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -49,7 +50,7 @@ QIRProgramBuilder::QIRProgramBuilder(MLIRContext* context)
 
 void QIRProgramBuilder::initialize() {
   // Set insertion point to the module body
-  setInsertionPointToStart(llvm::cast<ModuleOp>(module).getBody());
+  setInsertionPointToStart(cast<ModuleOp>(module).getBody());
 
   // Create main function: () -> i64
   auto funcType = LLVM::LLVMFunctionType::get(getI64Type(), {});
@@ -154,8 +155,7 @@ Value QIRProgramBuilder::staticQubit(const int64_t index) {
   return qubit;
 }
 
-llvm::SmallVector<Value>
-QIRProgramBuilder::allocQubitRegister(const int64_t size) {
+SmallVector<Value> QIRProgramBuilder::allocQubitRegister(const int64_t size) {
   checkFinalized();
   ensureAllocationMode(AllocationMode::Dynamic);
 
@@ -171,7 +171,7 @@ QIRProgramBuilder::allocQubitRegister(const int64_t size) {
   // Insert allocations and constants in entry block
   setInsertionPoint(entryBlock->getTerminator());
 
-  llvm::SmallVector<Value> qubits;
+  SmallVector<Value> qubits;
   qubits.reserve(size);
 
   auto allocFnSignature = LLVM::LLVMFunctionType::get(
@@ -346,9 +346,8 @@ QIRProgramBuilder& QIRProgramBuilder::reset(Value qubit) {
 //===----------------------------------------------------------------------===//
 
 void QIRProgramBuilder::createCallOp(
-    const llvm::SmallVector<std::variant<double, Value>>& parameters,
-    ValueRange controls, const llvm::SmallVector<Value>& targets,
-    StringRef fnName) {
+    const SmallVector<std::variant<double, Value>>& parameters,
+    ValueRange controls, const SmallVector<Value>& targets, StringRef fnName) {
   checkFinalized();
 
   // Save current insertion point
@@ -357,7 +356,7 @@ void QIRProgramBuilder::createCallOp(
   // Insert constants in entry block
   setInsertionPoint(entryBlock->getTerminator());
 
-  llvm::SmallVector<Value> parameterOperands;
+  SmallVector<Value> parameterOperands;
   parameterOperands.reserve(parameters.size());
   for (const auto& parameter : parameters) {
     Value parameterOperand;
@@ -373,7 +372,7 @@ void QIRProgramBuilder::createCallOp(
   setInsertionPoint(bodyBlock->getTerminator());
 
   // Define argument types
-  llvm::SmallVector<Type> argumentTypes;
+  SmallVector<Type> argumentTypes;
   argumentTypes.reserve(parameters.size() + controls.size() + targets.size());
   const auto floatType = Float64Type::get(getContext());
   // Add control pointers
@@ -396,7 +395,7 @@ void QIRProgramBuilder::createCallOp(
   auto fnDecl =
       getOrCreateFunctionDeclaration(*this, module, fnName, fnSignature);
 
-  llvm::SmallVector<Value> operands;
+  SmallVector<Value> operands;
   operands.reserve(parameters.size() + controls.size() + targets.size());
   operands.append(controls.begin(), controls.end());
   operands.append(targets.begin(), targets.end());
@@ -745,17 +744,17 @@ OwningOpRef<ModuleOp> QIRProgramBuilder::finalize() {
     LLVM::CallOp::create(*this, dec, ValueRange{size, array});
   }
 
-  auto mainFuncOp = llvm::cast<LLVM::LLVMFuncOp>(mainFunc);
+  auto mainFuncOp = cast<LLVM::LLVMFuncOp>(mainFunc);
   setQIRAttributes(mainFuncOp, metadata_);
 
   isFinalized = true;
 
-  return llvm::cast<ModuleOp>(module);
+  return cast<ModuleOp>(module);
 }
 
 OwningOpRef<ModuleOp> QIRProgramBuilder::build(
     MLIRContext* context,
-    const llvm::function_ref<void(QIRProgramBuilder&)>& buildFunc) {
+    const function_ref<void(QIRProgramBuilder&)>& buildFunc) {
   QIRProgramBuilder builder(context);
   builder.initialize();
   buildFunc(builder);

--- a/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
@@ -49,7 +49,7 @@ QIRProgramBuilder::QIRProgramBuilder(MLIRContext* context)
 
 void QIRProgramBuilder::initialize() {
   // Set insertion point to the module body
-  setInsertionPointToStart(module.getBody());
+  setInsertionPointToStart(llvm::cast<ModuleOp>(module).getBody());
 
   // Create main function: () -> i64
   auto funcType = LLVM::LLVMFunctionType::get(getI64Type(), {});
@@ -196,6 +196,17 @@ QIRProgramBuilder::allocQubitRegister(const int64_t size) {
   }
 
   return qubits;
+}
+
+QIRProgramBuilder::Bit
+QIRProgramBuilder::ClassicalRegister::operator[](const int64_t index) const {
+  if (index < 0 || index >= size) {
+    const std::string msg = "Bit index " + std::to_string(index) +
+                            " out of bounds for register '" + name +
+                            "' of size " + std::to_string(size);
+    llvm::reportFatalUsageError(msg.c_str());
+  }
+  return {.registerName = name, .registerSize = size, .registerIndex = index};
 }
 
 QIRProgramBuilder::ClassicalRegister
@@ -739,7 +750,7 @@ OwningOpRef<ModuleOp> QIRProgramBuilder::finalize() {
 
   isFinalized = true;
 
-  return module;
+  return llvm::cast<ModuleOp>(module);
 }
 
 OwningOpRef<ModuleOp> QIRProgramBuilder::build(

--- a/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
@@ -12,10 +12,8 @@
 
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
-#include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/FormatVariadic.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>

--- a/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
@@ -154,7 +154,8 @@ Value QIRProgramBuilder::staticQubit(const int64_t index) {
   return qubit;
 }
 
-SmallVector<Value> QIRProgramBuilder::allocQubitRegister(const int64_t size) {
+llvm::SmallVector<Value>
+QIRProgramBuilder::allocQubitRegister(const int64_t size) {
   checkFinalized();
   ensureAllocationMode(AllocationMode::Dynamic);
 
@@ -170,7 +171,7 @@ SmallVector<Value> QIRProgramBuilder::allocQubitRegister(const int64_t size) {
   // Insert allocations and constants in entry block
   setInsertionPoint(entryBlock->getTerminator());
 
-  SmallVector<Value> qubits;
+  llvm::SmallVector<Value> qubits;
   qubits.reserve(size);
 
   auto allocFnSignature = LLVM::LLVMFunctionType::get(
@@ -334,8 +335,9 @@ QIRProgramBuilder& QIRProgramBuilder::reset(Value qubit) {
 //===----------------------------------------------------------------------===//
 
 void QIRProgramBuilder::createCallOp(
-    const SmallVector<std::variant<double, Value>>& parameters,
-    ValueRange controls, const SmallVector<Value>& targets, StringRef fnName) {
+    const llvm::SmallVector<std::variant<double, Value>>& parameters,
+    ValueRange controls, const llvm::SmallVector<Value>& targets,
+    StringRef fnName) {
   checkFinalized();
 
   // Save current insertion point
@@ -344,7 +346,7 @@ void QIRProgramBuilder::createCallOp(
   // Insert constants in entry block
   setInsertionPoint(entryBlock->getTerminator());
 
-  SmallVector<Value> parameterOperands;
+  llvm::SmallVector<Value> parameterOperands;
   parameterOperands.reserve(parameters.size());
   for (const auto& parameter : parameters) {
     Value parameterOperand;
@@ -360,7 +362,7 @@ void QIRProgramBuilder::createCallOp(
   setInsertionPoint(bodyBlock->getTerminator());
 
   // Define argument types
-  SmallVector<Type> argumentTypes;
+  llvm::SmallVector<Type> argumentTypes;
   argumentTypes.reserve(parameters.size() + controls.size() + targets.size());
   const auto floatType = Float64Type::get(getContext());
   // Add control pointers
@@ -383,7 +385,7 @@ void QIRProgramBuilder::createCallOp(
   auto fnDecl =
       getOrCreateFunctionDeclaration(*this, module, fnName, fnSignature);
 
-  SmallVector<Value> operands;
+  llvm::SmallVector<Value> operands;
   operands.reserve(parameters.size() + controls.size() + targets.size());
   operands.append(controls.begin(), controls.end());
   operands.append(targets.begin(), targets.end());

--- a/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
@@ -29,7 +29,6 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
@@ -21,7 +21,6 @@
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/SymbolTable.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 

--- a/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
@@ -14,7 +14,6 @@
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/Builders.h>

--- a/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
@@ -22,7 +22,7 @@
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/SymbolTable.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 #include <utility>
@@ -33,20 +33,20 @@ namespace mlir::qir {
 #include "mlir/Dialect/QIR/Transforms/Passes.h.inc"
 
 [[nodiscard]] static StringAttr getMetadataKey(const Attribute attr) {
-  auto pair = llvm::dyn_cast<ArrayAttr>(attr);
+  auto pair = dyn_cast<ArrayAttr>(attr);
   if (!pair || pair.size() != 2) {
     return {};
   }
-  auto key = llvm::dyn_cast<StringAttr>(pair[0]);
-  if (!key || !llvm::isa<StringAttr>(pair[1])) {
+  auto key = dyn_cast<StringAttr>(pair[0]);
+  if (!key || !isa<StringAttr>(pair[1])) {
     return {};
   }
   return key;
 }
 
-[[nodiscard]] static llvm::StringRef getCalleeName(LLVM::CallOp callOp) {
+[[nodiscard]] static StringRef getCalleeName(LLVM::CallOp callOp) {
   auto calleeAttr = callOp.getCalleeAttr();
-  auto flatRef = llvm::dyn_cast_or_null<FlatSymbolRefAttr>(calleeAttr);
+  auto flatRef = dyn_cast_or_null<FlatSymbolRefAttr>(calleeAttr);
   if (!flatRef) {
     return {};
   }
@@ -105,14 +105,14 @@ static void normalizeQIRMetadata(ModuleOp module) {
       continue;
     }
     if (key.getValue() == "required_num_qubits") {
-      requiredNumQubitsAttr = llvm::cast<ArrayAttr>(attr);
+      requiredNumQubitsAttr = cast<ArrayAttr>(attr);
     } else if (key.getValue() == "required_num_results") {
-      requiredNumResultsAttr = llvm::cast<ArrayAttr>(attr);
+      requiredNumResultsAttr = cast<ArrayAttr>(attr);
     }
   }
 
   OpBuilder builder(module.getContext());
-  llvm::SmallVector<Attribute> updatedMetadata;
+  SmallVector<Attribute> updatedMetadata;
   updatedMetadata.reserve(passthroughAttr.size() + 2);
 
   for (const auto attr : passthroughAttr) {
@@ -166,7 +166,7 @@ struct RemoveDeadQubitArrayPair final : OpRewritePattern<LLVM::CallOp> {
 
     LLVM::CallOp allocCall = nullptr;
     for (Operation* user : allocaOp.getResult().getUsers()) {
-      auto callOp = llvm::dyn_cast<LLVM::CallOp>(user);
+      auto callOp = dyn_cast<LLVM::CallOp>(user);
       if (!callOp) {
         return failure();
       }

--- a/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/Casting.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
@@ -111,7 +112,7 @@ static void normalizeQIRMetadata(ModuleOp module) {
   }
 
   OpBuilder builder(module.getContext());
-  SmallVector<Attribute> updatedMetadata;
+  llvm::SmallVector<Attribute> updatedMetadata;
   updatedMetadata.reserve(passthroughAttr.size() + 2);
 
   for (const auto attr : passthroughAttr) {

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Dialect/QIR/Utils/QIRMetadata.h"
 
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -14,7 +14,6 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
@@ -25,6 +24,7 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstdint>
 #include <string>
@@ -32,7 +32,7 @@
 namespace mlir::qir {
 
 LLVM::LLVMFuncOp getMainFunction(Operation* op) {
-  auto module = llvm::dyn_cast<ModuleOp>(op);
+  auto module = dyn_cast<ModuleOp>(op);
   if (!module) {
     module = op->getParentOfType<ModuleOp>();
   }
@@ -47,7 +47,7 @@ LLVM::LLVMFuncOp getMainFunction(Operation* op) {
       continue;
     }
     if (llvm::any_of(passthrough, [](Attribute attr) {
-          const auto strAttr = llvm::dyn_cast<StringAttr>(attr);
+          const auto strAttr = dyn_cast<StringAttr>(attr);
           return strAttr && strAttr.getValue() == "entry_point";
         })) {
       return funcOp;
@@ -63,7 +63,7 @@ void setQIRAttributes(LLVM::LLVMFuncOp& main, const QIRMetadata& metadata) {
   }
 
   OpBuilder builder(main.getBody());
-  llvm::SmallVector<Attribute> attributes;
+  SmallVector<Attribute> attributes;
 
   // Core QIR attributes
   attributes.emplace_back(builder.getStringAttr("entry_point"));
@@ -114,7 +114,7 @@ LLVM::LLVMFuncOp getOrCreateFunctionDeclaration(OpBuilder& builder,
     const OpBuilder::InsertionGuard guard(builder);
 
     // Create the declaration at the end of the module
-    auto module = llvm::dyn_cast<ModuleOp>(op);
+    auto module = dyn_cast<ModuleOp>(op);
     if (!module) {
       module = op->getParentOfType<ModuleOp>();
     }
@@ -131,7 +131,7 @@ LLVM::LLVMFuncOp getOrCreateFunctionDeclaration(OpBuilder& builder,
     }
   }
 
-  return llvm::cast<LLVM::LLVMFuncOp>(fnDecl);
+  return cast<LLVM::LLVMFuncOp>(fnDecl);
 }
 
 LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
@@ -140,7 +140,7 @@ LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
   // Save current insertion point
   const OpBuilder::InsertionGuard guard(builder);
 
-  auto module = llvm::dyn_cast<ModuleOp>(op);
+  auto module = dyn_cast<ModuleOp>(op);
   if (!module) {
     module = op->getParentOfType<ModuleOp>();
   }

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -24,7 +24,6 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LLVM.h>
 
 #include <cstdint>
 #include <string>

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -14,6 +14,7 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
@@ -31,7 +32,7 @@
 namespace mlir::qir {
 
 LLVM::LLVMFuncOp getMainFunction(Operation* op) {
-  auto module = dyn_cast<ModuleOp>(op);
+  auto module = llvm::dyn_cast<ModuleOp>(op);
   if (!module) {
     module = op->getParentOfType<ModuleOp>();
   }
@@ -46,7 +47,7 @@ LLVM::LLVMFuncOp getMainFunction(Operation* op) {
       continue;
     }
     if (llvm::any_of(passthrough, [](Attribute attr) {
-          const auto strAttr = dyn_cast<StringAttr>(attr);
+          const auto strAttr = llvm::dyn_cast<StringAttr>(attr);
           return strAttr && strAttr.getValue() == "entry_point";
         })) {
       return funcOp;
@@ -113,7 +114,7 @@ LLVM::LLVMFuncOp getOrCreateFunctionDeclaration(OpBuilder& builder,
     const OpBuilder::InsertionGuard guard(builder);
 
     // Create the declaration at the end of the module
-    auto module = dyn_cast<ModuleOp>(op);
+    auto module = llvm::dyn_cast<ModuleOp>(op);
     if (!module) {
       module = op->getParentOfType<ModuleOp>();
     }
@@ -130,7 +131,7 @@ LLVM::LLVMFuncOp getOrCreateFunctionDeclaration(OpBuilder& builder,
     }
   }
 
-  return cast<LLVM::LLVMFuncOp>(fnDecl);
+  return llvm::cast<LLVM::LLVMFuncOp>(fnDecl);
 }
 
 LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
@@ -139,7 +140,7 @@ LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
   // Save current insertion point
   const OpBuilder::InsertionGuard guard(builder);
 
-  auto module = dyn_cast<ModuleOp>(op);
+  auto module = llvm::dyn_cast<ModuleOp>(op);
   if (!module) {
     module = op->getParentOfType<ModuleOp>();
   }

--- a/mlir/lib/Dialect/QTensor/IR/Operations/AllocOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/AllocOp.cpp
@@ -11,14 +11,13 @@
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/OpDefinition.h>
 #include <mlir/IR/OperationSupport.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cassert>
 
@@ -38,7 +37,7 @@ void AllocOp::build(OpBuilder& builder, OperationState& result, Value size) {
 }
 
 LogicalResult AllocOp::verify() {
-  auto resultType = llvm::cast<RankedTensorType>(getResult().getType());
+  auto resultType = cast<RankedTensorType>(getResult().getType());
   auto sizeValue = getConstantIntValue(getSize());
   auto resultSize = resultType.getShape()[0];
 

--- a/mlir/lib/Dialect/QTensor/IR/Operations/AllocOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/AllocOp.cpp
@@ -17,7 +17,6 @@
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/OpDefinition.h>
 #include <mlir/IR/OperationSupport.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <cassert>

--- a/mlir/lib/Dialect/QTensor/IR/Operations/AllocOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/AllocOp.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 
+#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
@@ -37,7 +38,7 @@ void AllocOp::build(OpBuilder& builder, OperationState& result, Value size) {
 }
 
 LogicalResult AllocOp::verify() {
-  auto resultType = cast<RankedTensorType>(getResult().getType());
+  auto resultType = llvm::cast<RankedTensorType>(getResult().getType());
   auto sizeValue = getConstantIntValue(getSize());
   auto resultSize = resultType.getShape()[0];
 

--- a/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
@@ -13,7 +13,7 @@
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/OpDefinition.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 using namespace mlir;
 using namespace mlir::qtensor;

--- a/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
@@ -13,7 +13,6 @@
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/OpDefinition.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 using namespace mlir;

--- a/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
@@ -18,7 +18,7 @@
 #include <mlir/IR/OpDefinition.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 
 using namespace mlir;
 using namespace mlir::qtensor;
@@ -68,7 +68,7 @@ static ExtractOp findMatchingExtractInTensorChain(InsertOp insertOp) {
   }
 
   while (auto* definingOp = current.getDefiningOp()) {
-    if (auto nestedInsertOp = llvm::dyn_cast<InsertOp>(definingOp)) {
+    if (auto nestedInsertOp = dyn_cast<InsertOp>(definingOp)) {
       auto nestedInsertIndex = nestedInsertOp.getIndex();
       if (!getConstantIntValue(nestedInsertIndex)) {
         return nullptr;
@@ -80,7 +80,7 @@ static ExtractOp findMatchingExtractInTensorChain(InsertOp insertOp) {
       current = nestedInsertOp.getDest();
       continue;
     }
-    if (auto extractOp = llvm::dyn_cast<ExtractOp>(definingOp)) {
+    if (auto extractOp = dyn_cast<ExtractOp>(definingOp)) {
       auto extractIndex = extractOp.getIndex();
       if (!getConstantIntValue(extractIndex)) {
         return nullptr;

--- a/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorUtils.h"
 
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/MLIRContext.h>

--- a/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
@@ -18,7 +18,6 @@
 #include <mlir/IR/OpDefinition.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 using namespace mlir;

--- a/mlir/lib/Dialect/QTensor/Transforms/ShrinkRegisters.cpp
+++ b/mlir/lib/Dialect/QTensor/Transforms/ShrinkRegisters.cpp
@@ -20,7 +20,7 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 #include <cassert>
@@ -45,7 +45,7 @@ namespace mlir::qtensor {
  * @brief Mark a single live index.
  */
 [[nodiscard]] static LogicalResult markLiveIndex(const int64_t index,
-                                                 llvm::BitVector& liveIndices) {
+                                                 BitVector& liveIndices) {
   if (index < 0 || std::cmp_greater_equal(index, liveIndices.size())) {
     return failure();
   }
@@ -58,21 +58,21 @@ namespace mlir::qtensor {
  */
 [[nodiscard]] static LogicalResult remapTensorOperand(Operation* op, Value from,
                                                       Value to) {
-  if (auto extractOp = llvm::dyn_cast<ExtractOp>(op)) {
+  if (auto extractOp = dyn_cast<ExtractOp>(op)) {
     if (extractOp.getTensor() != from) {
       return failure();
     }
     extractOp->setOperand(0, to);
     return success();
   }
-  if (auto insertOp = llvm::dyn_cast<InsertOp>(op)) {
+  if (auto insertOp = dyn_cast<InsertOp>(op)) {
     if (insertOp.getDest() != from) {
       return failure();
     }
     insertOp->setOperand(1, to);
     return success();
   }
-  if (auto deallocOp = llvm::dyn_cast<DeallocOp>(op)) {
+  if (auto deallocOp = dyn_cast<DeallocOp>(op)) {
     if (deallocOp.getTensor() != from) {
       return failure();
     }
@@ -85,9 +85,8 @@ namespace mlir::qtensor {
 /**
  * @brief Walk alloc->dealloc and collect all touched indices.
  */
-[[nodiscard]] static LogicalResult collectLiveIndices(AllocOp allocOp,
-                                                      llvm::BitVector& live,
-                                                      DeallocOp& deallocOp) {
+[[nodiscard]] static LogicalResult
+collectLiveIndices(AllocOp allocOp, BitVector& live, DeallocOp& deallocOp) {
   auto tensor = allocOp.getResult();
   while (true) {
     auto* user = getLinearTensorUser(tensor);
@@ -95,7 +94,7 @@ namespace mlir::qtensor {
       return failure();
     }
 
-    if (auto currentDealloc = llvm::dyn_cast<DeallocOp>(user)) {
+    if (auto currentDealloc = dyn_cast<DeallocOp>(user)) {
       if (currentDealloc.getTensor() != tensor) {
         return failure();
       }
@@ -103,7 +102,7 @@ namespace mlir::qtensor {
       return success();
     }
 
-    if (auto extractOp = llvm::dyn_cast<ExtractOp>(user)) {
+    if (auto extractOp = dyn_cast<ExtractOp>(user)) {
       if (extractOp.getTensor() != tensor) {
         return failure();
       }
@@ -115,7 +114,7 @@ namespace mlir::qtensor {
       continue;
     }
 
-    if (auto insertOp = llvm::dyn_cast<InsertOp>(user)) {
+    if (auto insertOp = dyn_cast<InsertOp>(user)) {
       if (insertOp.getDest() != tensor) {
         return failure();
       }
@@ -147,7 +146,7 @@ struct ShrinkStaticQTensor final : OpRewritePattern<AllocOp> {
       return failure();
     }
 
-    llvm::BitVector live(static_cast<size_t>(*oldSize), false);
+    BitVector live(static_cast<size_t>(*oldSize), false);
     DeallocOp oldDeallocOp{};
     if (failed(collectLiveIndices(allocOp, live, oldDeallocOp))) {
       return failure();
@@ -157,8 +156,7 @@ struct ShrinkStaticQTensor final : OpRewritePattern<AllocOp> {
       return failure();
     }
 
-    llvm::SmallVector<int64_t> newIndexByOldIndex(static_cast<size_t>(*oldSize),
-                                                  -1);
+    SmallVector<int64_t> newIndexByOldIndex(static_cast<size_t>(*oldSize), -1);
     int64_t newSize = 0;
     for (int64_t index = 0; index < *oldSize; ++index) {
       if (live.test(static_cast<size_t>(index))) {
@@ -184,7 +182,7 @@ struct ShrinkStaticQTensor final : OpRewritePattern<AllocOp> {
         return failure();
       }
 
-      if (auto deallocOp = llvm::dyn_cast<DeallocOp>(currentOp)) {
+      if (auto deallocOp = dyn_cast<DeallocOp>(currentOp)) {
         if (deallocOp != oldDeallocOp || deallocOp.getTensor() != oldTensor) {
           return failure();
         }
@@ -194,7 +192,7 @@ struct ShrinkStaticQTensor final : OpRewritePattern<AllocOp> {
         break;
       }
 
-      if (auto extractOp = llvm::dyn_cast<ExtractOp>(currentOp)) {
+      if (auto extractOp = dyn_cast<ExtractOp>(currentOp)) {
         if (extractOp.getTensor() != oldTensor) {
           return failure();
         }
@@ -230,7 +228,7 @@ struct ShrinkStaticQTensor final : OpRewritePattern<AllocOp> {
         continue;
       }
 
-      if (auto insertOp = llvm::dyn_cast<InsertOp>(currentOp)) {
+      if (auto insertOp = dyn_cast<InsertOp>(currentOp)) {
         if (insertOp.getDest() != oldTensor) {
           return failure();
         }

--- a/mlir/lib/Dialect/QTensor/Transforms/ShrinkRegisters.cpp
+++ b/mlir/lib/Dialect/QTensor/Transforms/ShrinkRegisters.cpp
@@ -11,10 +11,8 @@
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/QTensor/Transforms/Passes.h"
 
-#include <llvm/ADT/BitVector.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/Operation.h>

--- a/mlir/lib/Support/IRVerification.cpp
+++ b/mlir/lib/Support/IRVerification.cpp
@@ -36,6 +36,7 @@
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cmath>
 #include <cstddef>
@@ -119,9 +120,9 @@ struct StructuralOperationKey {
 };
 
 /// Map to track value equivalence between two modules.
-using ValueEquivalenceMap = llvm::DenseMap<mlir::Value, mlir::Value>;
+using ValueEquivalenceMap = DenseMap<mlir::Value, mlir::Value>;
 
-using OperationSet = llvm::DenseSet<Operation*>;
+using OperationSet = DenseSet<Operation*>;
 
 struct InsertWrite {
   Value scalar;
@@ -131,7 +132,7 @@ struct InsertWrite {
 struct InsertChainSummary {
   Value baseTensor;
   Value finalTensor;
-  llvm::SmallVector<InsertWrite> writes;
+  SmallVector<InsertWrite> writes;
 };
 
 } // namespace
@@ -154,13 +155,13 @@ static bool areIndexValuesEquivalent(Value lhs, Value rhs,
 }
 
 static bool isQTensorInsertOp(Operation* op) {
-  return llvm::isa<qtensor::InsertOp>(op);
+  return isa<qtensor::InsertOp>(op);
 }
 
 static bool isCommutableQTensorInsertDependency(Operation* dependent,
                                                 Operation* dependency) {
-  auto dependentInsert = llvm::dyn_cast<qtensor::InsertOp>(dependent);
-  auto dependencyInsert = llvm::dyn_cast<qtensor::InsertOp>(dependency);
+  auto dependentInsert = dyn_cast<qtensor::InsertOp>(dependent);
+  auto dependencyInsert = dyn_cast<qtensor::InsertOp>(dependency);
   if (!dependentInsert || !dependencyInsert) {
     return false;
   }
@@ -187,17 +188,16 @@ static Value getInsertChainBaseTensor(Value tensor, const OperationSet& group) {
   return current;
 }
 
-static bool
-summarizeInsertGroup(llvm::ArrayRef<Operation*> ops,
-                     llvm::SmallVectorImpl<InsertChainSummary>& chains) {
+static bool summarizeInsertGroup(ArrayRef<Operation*> ops,
+                                 SmallVectorImpl<InsertChainSummary>& chains) {
   OperationSet groupOps;
   for (Operation* op : ops) {
     groupOps.insert(op);
   }
 
-  llvm::DenseSet<Value> consumedInsertResults;
+  DenseSet<Value> consumedInsertResults;
   for (Operation* op : ops) {
-    auto insertOp = llvm::cast<qtensor::InsertOp>(op);
+    auto insertOp = cast<qtensor::InsertOp>(op);
     if (auto definingInsert =
             insertOp.getDest().getDefiningOp<qtensor::InsertOp>()) {
       if (groupOps.contains(definingInsert.getOperation())) {
@@ -206,9 +206,9 @@ summarizeInsertGroup(llvm::ArrayRef<Operation*> ops,
     }
   }
 
-  llvm::DenseMap<Value, size_t> chainByBaseTensor;
+  DenseMap<Value, size_t> chainByBaseTensor;
   for (Operation* op : ops) {
-    auto insertOp = llvm::cast<qtensor::InsertOp>(op);
+    auto insertOp = cast<qtensor::InsertOp>(op);
     const Value baseTensor =
         getInsertChainBaseTensor(insertOp.getDest(), groupOps);
 
@@ -242,7 +242,7 @@ summarizeInsertGroup(llvm::ArrayRef<Operation*> ops,
     }
 
     // Reordering writes to the same index is not semantics-preserving.
-    llvm::SmallVector<Value> seenIndices;
+    SmallVector<Value> seenIndices;
     for (const auto& write : chain.writes) {
       if (llvm::any_of(seenIndices, [&](Value seenIndex) {
             return qtensor::areEquivalentIndices(seenIndex, write.index);
@@ -257,9 +257,9 @@ summarizeInsertGroup(llvm::ArrayRef<Operation*> ops,
 }
 
 static bool areInsertWritesEquivalentRec(const size_t lhsIdx,
-                                         llvm::ArrayRef<InsertWrite> lhsWrites,
-                                         llvm::ArrayRef<InsertWrite> rhsWrites,
-                                         llvm::SmallVectorImpl<char>& rhsUsed,
+                                         ArrayRef<InsertWrite> lhsWrites,
+                                         ArrayRef<InsertWrite> rhsWrites,
+                                         SmallVectorImpl<char>& rhsUsed,
                                          ValueEquivalenceMap& valueMap) {
   if (lhsIdx == lhsWrites.size()) {
     return true;
@@ -290,13 +290,13 @@ static bool areInsertWritesEquivalentRec(const size_t lhsIdx,
   return false;
 }
 
-static bool areInsertWritesEquivalent(llvm::ArrayRef<InsertWrite> lhsWrites,
-                                      llvm::ArrayRef<InsertWrite> rhsWrites,
+static bool areInsertWritesEquivalent(ArrayRef<InsertWrite> lhsWrites,
+                                      ArrayRef<InsertWrite> rhsWrites,
                                       ValueEquivalenceMap& valueMap) {
   if (lhsWrites.size() != rhsWrites.size()) {
     return false;
   }
-  llvm::SmallVector<char> rhsUsed(rhsWrites.size(), 0);
+  SmallVector<char> rhsUsed(rhsWrites.size(), 0);
   return areInsertWritesEquivalentRec(0, lhsWrites, rhsWrites, rhsUsed,
                                       valueMap);
 }
@@ -322,10 +322,11 @@ static bool areInsertChainsEquivalent(const InsertChainSummary& lhsChain,
   return true;
 }
 
-static bool areInsertGroupsEquivalentRec(
-    const size_t lhsChainIdx, llvm::ArrayRef<InsertChainSummary> lhsChains,
-    llvm::ArrayRef<InsertChainSummary> rhsChains,
-    llvm::SmallVectorImpl<char>& rhsChainUsed, ValueEquivalenceMap& valueMap) {
+static bool areInsertGroupsEquivalentRec(const size_t lhsChainIdx,
+                                         ArrayRef<InsertChainSummary> lhsChains,
+                                         ArrayRef<InsertChainSummary> rhsChains,
+                                         SmallVectorImpl<char>& rhsChainUsed,
+                                         ValueEquivalenceMap& valueMap) {
   if (lhsChainIdx == lhsChains.size()) {
     return true;
   }
@@ -353,15 +354,15 @@ static bool areInsertGroupsEquivalentRec(
   return false;
 }
 
-static bool areInsertGroupsEquivalent(llvm::ArrayRef<Operation*> lhsOps,
-                                      llvm::ArrayRef<Operation*> rhsOps,
+static bool areInsertGroupsEquivalent(ArrayRef<Operation*> lhsOps,
+                                      ArrayRef<Operation*> rhsOps,
                                       ValueEquivalenceMap& valueMap) {
   if (lhsOps.size() != rhsOps.size()) {
     return false;
   }
 
-  llvm::SmallVector<InsertChainSummary> lhsChains;
-  llvm::SmallVector<InsertChainSummary> rhsChains;
+  SmallVector<InsertChainSummary> lhsChains;
+  SmallVector<InsertChainSummary> rhsChains;
   if (!summarizeInsertGroup(lhsOps, lhsChains) ||
       !summarizeInsertGroup(rhsOps, rhsChains)) {
     return false;
@@ -370,7 +371,7 @@ static bool areInsertGroupsEquivalent(llvm::ArrayRef<Operation*> lhsOps,
     return false;
   }
 
-  llvm::SmallVector<char> rhsChainUsed(rhsChains.size(), 0);
+  SmallVector<char> rhsChainUsed(rhsChains.size(), 0);
   return areInsertGroupsEquivalentRec(0, lhsChains, rhsChains, rhsChainUsed,
                                       valueMap);
 }
@@ -408,8 +409,8 @@ template <> struct llvm::DenseMapInfo<StructuralOperationKey> {
   }
 };
 
-static bool areFloatValuesNear(const llvm::APFloat& lhs,
-                               const llvm::APFloat& rhs, const unsigned width) {
+static bool areFloatValuesNear(const APFloat& lhs, const APFloat& rhs,
+                               const unsigned width) {
   if (lhs.isNaN() || rhs.isNaN()) {
     return lhs.isNaN() && rhs.isNaN();
   }
@@ -443,8 +444,8 @@ static bool areConstantAttributesEquivalent(const Attribute& lhs,
     return true;
   }
 
-  if (auto lhsFloat = llvm::dyn_cast<FloatAttr>(lhs)) {
-    auto rhsFloat = llvm::dyn_cast<FloatAttr>(rhs);
+  if (auto lhsFloat = dyn_cast<FloatAttr>(lhs)) {
+    auto rhsFloat = dyn_cast<FloatAttr>(rhs);
     if (!rhsFloat) {
       return false;
     }
@@ -465,8 +466,8 @@ static bool areOperationsEquivalent(Operation* lhs, Operation* rhs,
   }
 
   // Check arith::ConstantOp
-  if (auto lhsConst = llvm::dyn_cast<arith::ConstantOp>(lhs)) {
-    auto rhsConst = llvm::dyn_cast<arith::ConstantOp>(rhs);
+  if (auto lhsConst = dyn_cast<arith::ConstantOp>(lhs)) {
+    auto rhsConst = dyn_cast<arith::ConstantOp>(rhs);
     if (!rhsConst) {
       return false;
     }
@@ -478,8 +479,8 @@ static bool areOperationsEquivalent(Operation* lhs, Operation* rhs,
   }
 
   // Check LLVM::ConstantOp
-  if (auto lhsConst = llvm::dyn_cast<LLVM::ConstantOp>(lhs)) {
-    auto rhsConst = llvm::dyn_cast<LLVM::ConstantOp>(rhs);
+  if (auto lhsConst = dyn_cast<LLVM::ConstantOp>(lhs)) {
+    auto rhsConst = dyn_cast<LLVM::ConstantOp>(rhs);
     if (!rhsConst) {
       return false;
     }
@@ -490,8 +491,8 @@ static bool areOperationsEquivalent(Operation* lhs, Operation* rhs,
   }
 
   // Check LLVM::CallOp
-  if (auto lhsCall = llvm::dyn_cast<LLVM::CallOp>(lhs)) {
-    auto rhsCall = llvm::dyn_cast<LLVM::CallOp>(rhs);
+  if (auto lhsCall = dyn_cast<LLVM::CallOp>(lhs)) {
+    auto rhsCall = dyn_cast<LLVM::CallOp>(rhs);
     if (!rhsCall) {
       return false;
     }
@@ -567,19 +568,19 @@ static bool hasOrderingConstraints(Operation* op) {
 
   // Symbol-defining operations (like function declarations) can be reordered
   if (op->hasTrait<OpTrait::SymbolTable>() ||
-      llvm::isa<LLVM::LLVMFuncOp, func::FuncOp>(op)) {
+      isa<LLVM::LLVMFuncOp, func::FuncOp>(op)) {
     return false;
   }
 
   // Check for memory effects that enforce ordering
-  if (auto memInterface = llvm::dyn_cast<MemoryEffectOpInterface>(op)) {
-    llvm::SmallVector<MemoryEffects::EffectInstance> effects;
+  if (auto memInterface = dyn_cast<MemoryEffectOpInterface>(op)) {
+    SmallVector<MemoryEffects::EffectInstance> effects;
     memInterface.getEffects(effects);
 
     bool hasNonAllocFreeEffects = false;
     for (const auto& effect : effects) {
       // Allow operations with no effects or pure allocation/free effects
-      if (!llvm::isa<MemoryEffects::Allocate, MemoryEffects::Free>(
+      if (!isa<MemoryEffects::Allocate, MemoryEffects::Free>(
               effect.getEffect())) {
         hasNonAllocFreeEffects = true;
         break;
@@ -596,17 +597,14 @@ static bool hasOrderingConstraints(Operation* op) {
 
 /// Build a dependence graph for operations.
 /// Returns a map from each operation to the set of operations it depends on.
-llvm::DenseMap<
-    Operation*,
-    llvm::DenseSet<
-        Operation*>> static buildDependenceGraph(llvm::ArrayRef<Operation*>
-                                                     ops) {
-  llvm::DenseMap<Operation*, llvm::DenseSet<Operation*>> dependsOn;
-  llvm::DenseMap<Value, Operation*> valueProducers;
+DenseMap<Operation*, DenseSet<Operation*>> static buildDependenceGraph(
+    ArrayRef<Operation*> ops) {
+  DenseMap<Operation*, DenseSet<Operation*>> dependsOn;
+  DenseMap<Value, Operation*> valueProducers;
 
   // Build value-to-producer map and dependence relationships
   for (Operation* op : ops) {
-    dependsOn[op] = llvm::DenseSet<Operation*>();
+    dependsOn[op] = DenseSet<Operation*>();
 
     // This operation depends on the producers of its operands
     for (const auto operand : op->getOperands()) {
@@ -626,16 +624,15 @@ llvm::DenseMap<
 
 /// Partition operations into groups that can be compared as multisets.
 /// Operations in the same group are independent and can be reordered.
-llvm::SmallVector<llvm::SmallVector<
-    Operation*>> static partitionIndependentGroups(llvm::ArrayRef<Operation*>
-                                                       ops) {
-  llvm::SmallVector<llvm::SmallVector<Operation*>> groups;
+SmallVector<SmallVector<Operation*>> static partitionIndependentGroups(
+    ArrayRef<Operation*> ops) {
+  SmallVector<SmallVector<Operation*>> groups;
   if (ops.empty()) {
     return groups;
   }
 
   auto dependsOn = buildDependenceGraph(ops);
-  llvm::SmallVector<Operation*> currentGroup;
+  SmallVector<Operation*> currentGroup;
 
   for (auto* op : ops) {
     bool dependsOnCurrent = false;
@@ -682,15 +679,15 @@ llvm::SmallVector<llvm::SmallVector<
 }
 
 /// Compare two groups of independent operations using multiset equivalence.
-static bool areIndependentGroupsEquivalent(llvm::ArrayRef<Operation*> lhsOps,
-                                           llvm::ArrayRef<Operation*> rhsOps) {
+static bool areIndependentGroupsEquivalent(ArrayRef<Operation*> lhsOps,
+                                           ArrayRef<Operation*> rhsOps) {
   if (lhsOps.size() != rhsOps.size()) {
     return false;
   }
 
   // Build frequency maps for both groups
-  llvm::DenseMap<StructuralOperationKey, size_t> lhsFrequencyMap;
-  llvm::DenseMap<StructuralOperationKey, size_t> rhsFrequencyMap;
+  DenseMap<StructuralOperationKey, size_t> lhsFrequencyMap;
+  DenseMap<StructuralOperationKey, size_t> rhsFrequencyMap;
 
   for (auto* op : lhsOps) {
     lhsFrequencyMap[StructuralOperationKey(op)]++;
@@ -734,8 +731,8 @@ static bool areBlocksEquivalent(Block& lhs, Block& rhs,
   }
 
   // Collect all operations
-  llvm::SmallVector<Operation*> lhsOps;
-  llvm::SmallVector<Operation*> rhsOps;
+  SmallVector<Operation*> lhsOps;
+  SmallVector<Operation*> rhsOps;
 
   for (Operation& op : lhs) {
     lhsOps.push_back(&op);
@@ -784,7 +781,7 @@ static bool areBlocksEquivalent(Block& lhs, Block& rhs,
     // by trying all permutations (for small groups) or use a greedy approach
 
     // Use a simple greedy matching
-    llvm::DenseSet<Operation*> matchedRhs;
+    DenseSet<Operation*> matchedRhs;
     for (Operation* lhsOp : lhsGroup) {
       bool matched = false;
       for (Operation* rhsOp : rhsGroup) {

--- a/mlir/lib/Support/IRVerification.cpp
+++ b/mlir/lib/Support/IRVerification.cpp
@@ -12,7 +12,6 @@
 
 #include "mlir/Dialect/QTensor/IR/QTensorUtils.h"
 
-#include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/DenseMapInfo.h>
@@ -21,7 +20,6 @@
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>

--- a/mlir/lib/Support/Passes.cpp
+++ b/mlir/lib/Support/Passes.cpp
@@ -14,7 +14,6 @@
 #include "mlir/Dialect/QIR/Transforms/Passes.h"
 #include "mlir/Dialect/QTensor/Transforms/Passes.h"
 
-#include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>

--- a/mlir/lib/Support/Passes.cpp
+++ b/mlir/lib/Support/Passes.cpp
@@ -19,7 +19,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/PassManager.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/Passes.h>
 
 using namespace mlir;
@@ -31,8 +31,8 @@ static void addSimplificationPasses(PassManager& pm) {
 
 static LogicalResult
 runWithPassManager(ModuleOp module,
-                   const llvm::function_ref<void(PassManager&)> populatePasses,
-                   const llvm::StringRef errorMessage) {
+                   const function_ref<void(PassManager&)> populatePasses,
+                   const StringRef errorMessage) {
   PassManager pm(module.getContext());
   populatePasses(pm);
   if (pm.run(module).failed()) {

--- a/mlir/lib/Support/PrettyPrinting.cpp
+++ b/mlir/lib/Support/PrettyPrinting.cpp
@@ -15,6 +15,7 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <string>
@@ -29,7 +30,7 @@ constexpr int CONTENT_WIDTH = TOTAL_WIDTH - (2 * BORDER_WIDTH);
 // Pre-built strings, initialised once on first call. Each UTF-8 "═" is 3
 // bytes. BORDER_SEP is the "═" run between box corners; SPACES is used for
 // padding.
-static llvm::StringRef getBorderSep() {
+static StringRef getBorderSep() {
   static const std::string BORDER_SEP = [] {
     std::string s;
     s.reserve(static_cast<size_t>(TOTAL_WIDTH - 2) * 3U);
@@ -41,12 +42,12 @@ static llvm::StringRef getBorderSep() {
   return BORDER_SEP;
 }
 
-static llvm::StringRef getSpaces() {
+static StringRef getSpaces() {
   static const std::string SPACES(static_cast<size_t>(CONTENT_WIDTH), ' ');
   return SPACES;
 }
 
-int calculateDisplayWidth(llvm::StringRef str) {
+int calculateDisplayWidth(StringRef str) {
   auto displayWidth = 0;
   for (size_t i = 0; i < str.size();) {
     if (const unsigned char c = str[i]; (c & 0x80) == 0) {
@@ -73,9 +74,8 @@ int calculateDisplayWidth(llvm::StringRef str) {
   return displayWidth;
 }
 
-void wrapLine(llvm::StringRef line, const int maxWidth,
-              llvm::SmallVectorImpl<llvm::SmallString<128>>& result,
-              const int indent) {
+void wrapLine(StringRef line, const int maxWidth,
+              SmallVectorImpl<SmallString<128>>& result, const int indent) {
   if (line.empty()) {
     result.emplace_back("");
     return;
@@ -94,7 +94,7 @@ void wrapLine(llvm::StringRef line, const int maxWidth,
   }
 
   // Extract the content without leading whitespace
-  const llvm::StringRef content = line.substr(line.find_first_not_of(" \t"));
+  const StringRef content = line.substr(line.find_first_not_of(" \t"));
   if (content.empty()) {
     result.emplace_back(line);
     return;
@@ -114,15 +114,15 @@ void wrapLine(llvm::StringRef line, const int maxWidth,
     return;
   }
 
-  llvm::SmallString<128> currentLine;
-  llvm::SmallString<64> currentWord;
+  SmallString<128> currentLine;
+  SmallString<64> currentWord;
   auto currentWidth = 0;
   auto isFirstLine = true;
 
   // Helper: build and emit a completed line with proper indent prefix.
   // `addArrow` appends " →" to signal the line continues.
   auto flushLine = [&](const bool addArrow, const bool lastLine) {
-    llvm::SmallString<128> lineWithIndent;
+    SmallString<128> lineWithIndent;
     lineWithIndent.append(leadingSpaces, ' ');
     lineWithIndent += currentLine;
     if (addArrow && (!isFirstLine || !lastLine)) {
@@ -131,7 +131,7 @@ void wrapLine(llvm::StringRef line, const int maxWidth,
     result.emplace_back(std::move(lineWithIndent));
   };
 
-  auto addWord = [&](llvm::StringRef word) -> bool {
+  auto addWord = [&](StringRef word) -> bool {
     const int wordWidth = calculateDisplayWidth(word);
     const int spaceWidth = currentLine.empty() ? 0 : 1;
     const int effectiveWidth = isFirstLine ? firstLineWidth : contLineWidth;
@@ -161,7 +161,7 @@ void wrapLine(llvm::StringRef line, const int maxWidth,
           }
           // Start new continuation line
           currentLine = currentWord;
-          currentWidth = calculateDisplayWidth(llvm::StringRef(currentWord));
+          currentWidth = calculateDisplayWidth(StringRef(currentWord));
           isFirstLine = false;
         }
         currentWord.clear();
@@ -179,7 +179,7 @@ void wrapLine(llvm::StringRef line, const int maxWidth,
         flushLine(/*addArrow=*/true, /*lastLine=*/false);
       }
       // Add word on new continuation line (no arrow — this is the last line)
-      llvm::SmallString<128> contLine("↳ ");
+      SmallString<128> contLine("↳ ");
       contLine.append(leadingSpaces, ' ');
       contLine += currentWord;
       result.emplace_back(std::move(contLine));
@@ -203,30 +203,23 @@ void wrapLine(llvm::StringRef line, const int maxWidth,
 
   // Prepend "↳ " to all continuation lines (index >= 1) that don't have it yet
   for (size_t i = 1; i < result.size(); ++i) {
-    if (!llvm::StringRef(result[i]).contains("↳")) {
-      llvm::SmallString<128> newLine("↳ ");
-      const llvm::StringRef lineRef = result[i];
+    if (!StringRef(result[i]).contains("↳")) {
+      SmallString<128> newLine("↳ ");
+      const StringRef lineRef = result[i];
       newLine += lineRef.substr(leadingSpaces);
       result[i] = std::move(newLine);
     }
   }
 }
 
-void printBoxTop(llvm::raw_ostream& os) {
-  os << "╔" << getBorderSep() << "╗\n";
-}
+void printBoxTop(raw_ostream& os) { os << "╔" << getBorderSep() << "╗\n"; }
 
-void printBoxMiddle(llvm::raw_ostream& os) {
-  os << "╠" << getBorderSep() << "╣\n";
-}
+void printBoxMiddle(raw_ostream& os) { os << "╠" << getBorderSep() << "╣\n"; }
 
-void printBoxBottom(llvm::raw_ostream& os) {
-  os << "╚" << getBorderSep() << "╝\n";
-}
+void printBoxBottom(raw_ostream& os) { os << "╚" << getBorderSep() << "╝\n"; }
 
 // Internal helper: emit one already-wrapped line inside the box with padding.
-static void emitBoxedLine(llvm::StringRef line, const int indent,
-                          llvm::raw_ostream& os) {
+static void emitBoxedLine(StringRef line, const int indent, raw_ostream& os) {
   const int displayWidth = calculateDisplayWidth(line);
   const int padding = CONTENT_WIDTH - indent - displayWidth;
 
@@ -240,8 +233,7 @@ static void emitBoxedLine(llvm::StringRef line, const int indent,
   os << " ║\n";
 }
 
-void printBoxLine(llvm::StringRef text, const int indent,
-                  llvm::raw_ostream& os) {
+void printBoxLine(StringRef text, const int indent, raw_ostream& os) {
   // Trim trailing whitespace before processing
   const auto trimmedText = text.rtrim();
 
@@ -253,7 +245,7 @@ void printBoxLine(llvm::StringRef text, const int indent,
   }
 
   // Wrap the line
-  llvm::SmallVector<llvm::SmallString<128>, 4> wrappedLines;
+  SmallVector<SmallString<128>, 4> wrappedLines;
   wrapLine(trimmedText, CONTENT_WIDTH, wrappedLines, indent);
 
   for (const auto& line : wrappedLines) {
@@ -261,10 +253,9 @@ void printBoxLine(llvm::StringRef text, const int indent,
   }
 }
 
-void printBoxText(llvm::StringRef text, const int indent,
-                  llvm::raw_ostream& os) {
+void printBoxText(StringRef text, const int indent, raw_ostream& os) {
   // Trim trailing newlines from the entire text, then iterate line-by-line
-  llvm::StringRef remaining = text.rtrim();
+  StringRef remaining = text.rtrim();
 
   while (!remaining.empty()) {
     auto [lineStr, rest] = remaining.split('\n');
@@ -273,14 +264,13 @@ void printBoxText(llvm::StringRef text, const int indent,
   }
 }
 
-void printProgram(ModuleOp module, const llvm::StringRef header,
-                  llvm::raw_ostream& os) {
+void printProgram(ModuleOp module, const StringRef header, raw_ostream& os) {
   printBoxTop(os);
   printBoxLine(header, 0, os);
   printBoxMiddle(os);
 
   // Capture the IR to a string so we can wrap it in box lines.
-  llvm::SmallString<4096> irString;
+  SmallString<4096> irString;
   llvm::raw_svector_ostream irStream(irString);
   module.print(irStream);
 

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -19,7 +19,6 @@
 #include "qco_programs.h"
 
 #include <gtest/gtest.h>
-#include <llvm/ADT/SmallVector.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/DialectRegistry.h>

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -25,6 +25,7 @@
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Support/LLVM.h>
 
 #include <iosfwd>
 #include <memory>
@@ -125,9 +126,9 @@ TEST_F(QCOTest, DirectIfBuilder) {
   auto measureOp = MeasureOp::create(builder, q1);
   auto ifOp =
       IfOp::create(builder, measureOp.getResult(), measureOp.getQubitOut(),
-                   [&](ValueRange qubits) -> llvm::SmallVector<Value> {
+                   [&](ValueRange qubits) -> SmallVector<Value> {
                      auto innerQubit = XOp::create(builder, qubits[0]);
-                     return llvm::SmallVector<Value>{innerQubit};
+                     return SmallVector<Value>{innerQubit};
                    });
   auto r2 = qtensor::InsertOp::create(builder, ifOp.getResult(0),
                                       extractOp.getOutTensor(), c0);

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -19,7 +19,9 @@
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/Casting.h>
 #include <llvm/Support/LogicalResult.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -28,6 +30,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LogicalResult.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <cassert>
@@ -56,14 +59,14 @@ public:
   static bool isExecutable(OwningOpRef<ModuleOp>& moduleOp,
                            const Architecture& arch) {
     auto entry = *(moduleOp->getOps<func::FuncOp>().begin());
-    DenseMap<Value, std::size_t> mappings;
+    llvm::DenseMap<Value, std::size_t> mappings;
     for_each(entry.getOps<qc::StaticOp>(), [&](qc::StaticOp op) {
       mappings.try_emplace(op.getQubit(), op.getIndex());
     });
 
     bool executable = true;
     std::ignore = moduleOp->walk([&](qc::UnitaryOpInterface op) {
-      if (isa<qc::BarrierOp>(op)) {
+      if (llvm::isa<qc::BarrierOp>(op)) {
         return WalkResult::advance();
       }
       if (op.getNumQubits() > 1) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -28,7 +28,6 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Pass/PassManager.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <cassert>

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/Support/Casting.h>
 #include <llvm/Support/LogicalResult.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -30,7 +29,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Pass/PassManager.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <cassert>
@@ -59,14 +58,14 @@ public:
   static bool isExecutable(OwningOpRef<ModuleOp>& moduleOp,
                            const Architecture& arch) {
     auto entry = *(moduleOp->getOps<func::FuncOp>().begin());
-    llvm::DenseMap<Value, std::size_t> mappings;
+    DenseMap<Value, std::size_t> mappings;
     for_each(entry.getOps<qc::StaticOp>(), [&](qc::StaticOp op) {
       mappings.try_emplace(op.getQubit(), op.getIndex());
     });
 
     bool executable = true;
     std::ignore = moduleOp->walk([&](qc::UnitaryOpInterface op) {
-      if (llvm::isa<qc::BarrierOp>(op)) {
+      if (isa<qc::BarrierOp>(op)) {
         return WalkResult::advance();
       }
       if (op.getNumQubits() > 1) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
@@ -16,7 +16,6 @@
 #include <gtest/gtest.h>
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
@@ -25,7 +24,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Pass/PassManager.h>
-#include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <cassert>
@@ -56,7 +55,7 @@ protected:
    */
   struct RotationGate {
     GateType type;
-    llvm::SmallVector<double, 4> angles;
+    SmallVector<double, 4> angles;
   };
 
   MergeSingleQubitRotationGatesTest() : builder(&context) {}
@@ -80,12 +79,11 @@ protected:
   }
 
   /**
-   * @brief Extract constant floating point value from a mlir::Value
+   * @brief Extract constant floating point value from a Value
    */
-  static std::optional<double> toDouble(mlir::Value v) {
-    if (auto constOp = v.getDefiningOp<mlir::arith::ConstantOp>()) {
-      if (auto floatAttr =
-              llvm::dyn_cast<mlir::FloatAttr>(constOp.getValue())) {
+  static std::optional<double> toDouble(Value v) {
+    if (auto constOp = v.getDefiningOp<arith::ConstantOp>()) {
+      if (auto floatAttr = dyn_cast<FloatAttr>(constOp.getValue())) {
         return floatAttr.getValueAsDouble();
       }
     }
@@ -102,7 +100,7 @@ protected:
     module->walk([&](UOp op) {
       uOp = op;
       // stop after finding first UOp
-      return mlir::WalkResult::interrupt();
+      return WalkResult::interrupt();
     });
 
     if (!uOp) {
@@ -143,7 +141,7 @@ protected:
     GPhaseOp gOp = nullptr;
     module->walk([&](GPhaseOp op) {
       gOp = op;
-      return mlir::WalkResult::interrupt();
+      return WalkResult::interrupt();
     });
 
     if (!gOp) {
@@ -163,7 +161,7 @@ protected:
     EXPECT_NEAR(*param, expected, tolerance);
   }
 
-  Value buildRotations(llvm::ArrayRef<RotationGate> rotations, Value& q) {
+  Value buildRotations(ArrayRef<RotationGate> rotations, Value& q) {
     auto qubit = q;
 
     for (const auto& gate : rotations) {
@@ -208,7 +206,7 @@ protected:
    * builder api to build a small quantum circuit, where a qubit is fed through
    * all rotations in the list.
    */
-  LogicalResult testGateMerge(llvm::ArrayRef<RotationGate> rotations) {
+  LogicalResult testGateMerge(ArrayRef<RotationGate> rotations) {
     auto q = builder.allocQubitRegister(1);
 
     buildRotations(rotations, q[0]);

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
@@ -24,6 +25,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LogicalResult.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <cassert>
@@ -83,7 +85,7 @@ protected:
   static std::optional<double> toDouble(mlir::Value v) {
     if (auto constOp = v.getDefiningOp<mlir::arith::ConstantOp>()) {
       if (auto floatAttr =
-              mlir::dyn_cast<mlir::FloatAttr>(constOp.getValue())) {
+              llvm::dyn_cast<mlir::FloatAttr>(constOp.getValue())) {
         return floatAttr.getValueAsDouble();
       }
     }

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
@@ -24,7 +24,6 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Pass/PassManager.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <cassert>

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
@@ -14,7 +14,6 @@
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
 #include <gtest/gtest.h>
-#include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>

--- a/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
@@ -21,7 +21,6 @@
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Operation.h>
-#include <mlir/Support/LLVM.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <memory>

--- a/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
@@ -23,6 +23,7 @@
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Operation.h>
+#include <mlir/Support/LLVM.h>
 #include <mlir/Support/WalkResult.h>
 
 #include <memory>
@@ -129,18 +130,18 @@ TEST_F(DriversTest, ProgramGraphWalk) {
   auto func = *(mod->getOps<func::FuncOp>().begin());
 
   // Collect wires.
-  llvm::SmallVector<qco::WireIterator> wires;
+  SmallVector<qco::WireIterator> wires;
   for (qco::AllocOp op : func.getOps<qco::AllocOp>()) {
     wires.emplace_back(op.getResult());
   }
 
   // Unit-test supporting datastructure.
-  llvm::SmallVector<llvm::DenseSet<Operation*>> readyPerLayer;
+  SmallVector<DenseSet<Operation*>> readyPerLayer;
 
   // Forward pass.
   auto res = qco::walkProgramGraph<qco::WireDirection::Forward>(
       wires, [&](const qco::ReadyRange& ready, qco::ReleasedOps& released) {
-        llvm::DenseSet<Operation*> layer;
+        DenseSet<Operation*> layer;
         for (const auto& [op, progs] : ready) {
           layer.insert(op);
           released.emplace_back(op);
@@ -160,7 +161,7 @@ TEST_F(DriversTest, ProgramGraphWalk) {
   readyPerLayer.clear();
   res = qco::walkProgramGraph<qco::WireDirection::Backward>(
       wires, [&](const qco::ReadyRange& ready, qco::ReleasedOps& released) {
-        llvm::DenseSet<Operation*> layer;
+        DenseSet<Operation*> layer;
         for (const auto& [op, progs] : ready) {
           layer.insert(op);
           released.emplace_back(op);
@@ -180,7 +181,7 @@ TEST_F(DriversTest, ProgramGraphWalk) {
   readyPerLayer.clear();
   res = qco::walkProgramGraph<qco::WireDirection::Forward>(
       wires, [&](const qco::ReadyRange& ready, qco::ReleasedOps&) {
-        llvm::DenseSet<Operation*> layer;
+        DenseSet<Operation*> layer;
         for (const auto& [op, progs] : ready) {
           layer.insert(op);
         }
@@ -200,7 +201,7 @@ TEST_F(DriversTest, ProgramGraphWalk) {
   readyPerLayer.clear();
   res = qco::walkProgramGraph<qco::WireDirection::Backward>(
       wires, [&](const qco::ReadyRange& ready, qco::ReleasedOps& released) {
-        llvm::DenseSet<Operation*> layer;
+        DenseSet<Operation*> layer;
         for (const auto& [op, progs] : ready) {
           layer.insert(op);
           released.emplace_back(op);

--- a/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
@@ -16,6 +16,8 @@
 #include "mlir/Dialect/QCO/Utils/WireIterator.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/DialectRegistry.h>
@@ -127,18 +129,18 @@ TEST_F(DriversTest, ProgramGraphWalk) {
   auto func = *(mod->getOps<func::FuncOp>().begin());
 
   // Collect wires.
-  SmallVector<qco::WireIterator> wires;
+  llvm::SmallVector<qco::WireIterator> wires;
   for (qco::AllocOp op : func.getOps<qco::AllocOp>()) {
     wires.emplace_back(op.getResult());
   }
 
   // Unit-test supporting datastructure.
-  SmallVector<DenseSet<Operation*>> readyPerLayer;
+  llvm::SmallVector<llvm::DenseSet<Operation*>> readyPerLayer;
 
   // Forward pass.
   auto res = qco::walkProgramGraph<qco::WireDirection::Forward>(
       wires, [&](const qco::ReadyRange& ready, qco::ReleasedOps& released) {
-        DenseSet<Operation*> layer;
+        llvm::DenseSet<Operation*> layer;
         for (const auto& [op, progs] : ready) {
           layer.insert(op);
           released.emplace_back(op);
@@ -158,7 +160,7 @@ TEST_F(DriversTest, ProgramGraphWalk) {
   readyPerLayer.clear();
   res = qco::walkProgramGraph<qco::WireDirection::Backward>(
       wires, [&](const qco::ReadyRange& ready, qco::ReleasedOps& released) {
-        DenseSet<Operation*> layer;
+        llvm::DenseSet<Operation*> layer;
         for (const auto& [op, progs] : ready) {
           layer.insert(op);
           released.emplace_back(op);
@@ -178,7 +180,7 @@ TEST_F(DriversTest, ProgramGraphWalk) {
   readyPerLayer.clear();
   res = qco::walkProgramGraph<qco::WireDirection::Forward>(
       wires, [&](const qco::ReadyRange& ready, qco::ReleasedOps&) {
-        DenseSet<Operation*> layer;
+        llvm::DenseSet<Operation*> layer;
         for (const auto& [op, progs] : ready) {
           layer.insert(op);
         }
@@ -198,7 +200,7 @@ TEST_F(DriversTest, ProgramGraphWalk) {
   readyPerLayer.clear();
   res = qco::walkProgramGraph<qco::WireDirection::Backward>(
       wires, [&](const qco::ReadyRange& ready, qco::ReleasedOps& released) {
-        DenseSet<Operation*> layer;
+        llvm::DenseSet<Operation*> layer;
         for (const auto& [op, progs] : ready) {
           layer.insert(op);
           released.emplace_back(op);

--- a/mlir/unittests/Dialect/Utils/test_utils.cpp
+++ b/mlir/unittests/Dialect/Utils/test_utils.cpp
@@ -11,9 +11,7 @@
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <gtest/gtest.h>
-#include <llvm/ADT/APInt.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>

--- a/mlir/unittests/Dialect/Utils/test_utils.cpp
+++ b/mlir/unittests/Dialect/Utils/test_utils.cpp
@@ -22,6 +22,7 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstdint>
 #include <limits>
@@ -96,7 +97,7 @@ TEST_F(UtilsTest, valueToDoubleCastFromMaxUnsignedInteger) {
   auto op = arith::ConstantOp::create(
       *builder,
       builder->getIntegerAttr(builder->getIntegerType(bitCount, false),
-                              llvm::APInt::getMaxValue(bitCount)));
+                              APInt::getMaxValue(bitCount)));
   ASSERT_TRUE(op);
 
   const auto stdValue = utils::valueToDouble(op.getResult());
@@ -126,11 +127,11 @@ TEST_F(UtilsTest, valueToDoubleFoldedConstant) {
   auto op = createAddition(1.5, 2.0);
   ASSERT_TRUE(op);
 
-  llvm::SmallVector<Value> tmp;
-  llvm::SmallVector<Operation*> newConstants;
+  SmallVector<Value> tmp;
+  SmallVector<Operation*> newConstants;
   ASSERT_TRUE(builder->tryFold(op, tmp, &newConstants).succeeded());
   ASSERT_EQ(newConstants.size(), 1);
-  auto cst = llvm::dyn_cast<arith::ConstantOp>(newConstants[0]);
+  auto cst = dyn_cast<arith::ConstantOp>(newConstants[0]);
   ASSERT_TRUE(cst);
   const auto stdValue = utils::valueToDouble(cst.getResult());
   ASSERT_TRUE(stdValue.has_value());

--- a/mlir/unittests/TestCaseUtils.h
+++ b/mlir/unittests/TestCaseUtils.h
@@ -14,9 +14,9 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/SmallString.h>
-#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <cstdlib>

--- a/mlir/unittests/TestCaseUtils.h
+++ b/mlir/unittests/TestCaseUtils.h
@@ -14,9 +14,9 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/SmallString.h>
+#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>
-#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <cstdlib>

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -14,6 +14,7 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
+#include <mlir/Support/LLVM.h>
 
 #include <numbers>
 #include <tuple>
@@ -66,7 +67,7 @@ void staticQubitsWithCtrl(QCOProgramBuilder& b) {
 
 void staticQubitsWithInv(QCOProgramBuilder& b) {
   auto q0 = b.staticQubit(0);
-  q0 = b.inv({q0}, [&](auto targets) -> llvm::SmallVector<Value> {
+  q0 = b.inv({q0}, [&](auto targets) -> SmallVector<Value> {
     return {b.t(targets[0])};
   })[0];
 }
@@ -175,19 +176,18 @@ void multipleControlledGlobalPhase(QCOProgramBuilder& b) {
 }
 
 void inverseGlobalPhase(QCOProgramBuilder& b) {
-  b.inv({}, [&](mlir::ValueRange /*qubits*/) {
+  b.inv({}, [&](ValueRange /*qubits*/) {
     b.gphase(-0.123);
-    return llvm::SmallVector<mlir::Value>{};
+    return SmallVector<Value>{};
   });
 }
 
 void inverseMultipleControlledGlobalPhase(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
-    llvm::SmallVector<mlir::Value> controls{qubits[0], qubits[1], qubits[2]};
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
+    SmallVector controls{qubits[0], qubits[1], qubits[2]};
     auto controlsOut = b.mcgphase(-0.123, controls);
-    return llvm::SmallVector<mlir::Value>(controlsOut.begin(),
-                                          controlsOut.end());
+    return SmallVector<Value>(controlsOut.begin(), controlsOut.end());
   });
 }
 
@@ -208,13 +208,13 @@ void multipleControlledIdentity(QCOProgramBuilder& b) {
 
 void nestedControlledIdentity(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.id(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.id(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -225,18 +225,17 @@ void trivialControlledIdentity(QCOProgramBuilder& b) {
 
 void inverseIdentity(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.id(qubits[0])};
-  });
+  b.inv({q[0]},
+        [&](ValueRange qubits) { return SmallVector{b.id(qubits[0])}; });
 }
 
 void inverseMultipleControlledIdentity(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcid({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -257,13 +256,13 @@ void multipleControlledX(QCOProgramBuilder& b) {
 
 void nestedControlledX(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.x(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.x(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -274,18 +273,16 @@ void trivialControlledX(QCOProgramBuilder& b) {
 
 void inverseX(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.x(qubits[0])};
-  });
+  b.inv({q[0]}, [&](ValueRange qubits) { return SmallVector{b.x(qubits[0])}; });
 }
 
 void inverseMultipleControlledX(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcx({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -312,13 +309,13 @@ void multipleControlledY(QCOProgramBuilder& b) {
 
 void nestedControlledY(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.y(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.y(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -329,18 +326,16 @@ void trivialControlledY(QCOProgramBuilder& b) {
 
 void inverseY(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.y(qubits[0])};
-  });
+  b.inv({q[0]}, [&](ValueRange qubits) { return SmallVector{b.y(qubits[0])}; });
 }
 
 void inverseMultipleControlledY(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcy({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -367,13 +362,13 @@ void multipleControlledZ(QCOProgramBuilder& b) {
 
 void nestedControlledZ(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.z(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.z(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -384,18 +379,16 @@ void trivialControlledZ(QCOProgramBuilder& b) {
 
 void inverseZ(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.z(qubits[0])};
-  });
+  b.inv({q[0]}, [&](ValueRange qubits) { return SmallVector{b.z(qubits[0])}; });
 }
 
 void inverseMultipleControlledZ(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcz({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -422,13 +415,13 @@ void multipleControlledH(QCOProgramBuilder& b) {
 
 void nestedControlledH(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.h(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.h(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -439,18 +432,16 @@ void trivialControlledH(QCOProgramBuilder& b) {
 
 void inverseH(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.h(qubits[0])};
-  });
+  b.inv({q[0]}, [&](ValueRange qubits) { return SmallVector{b.h(qubits[0])}; });
 }
 
 void inverseMultipleControlledH(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mch({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -482,13 +473,13 @@ void multipleControlledS(QCOProgramBuilder& b) {
 
 void nestedControlledS(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.s(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.s(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -499,18 +490,16 @@ void trivialControlledS(QCOProgramBuilder& b) {
 
 void inverseS(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.s(qubits[0])};
-  });
+  b.inv({q[0]}, [&](ValueRange qubits) { return SmallVector{b.s(qubits[0])}; });
 }
 
 void inverseMultipleControlledS(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcs({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -543,13 +532,13 @@ void multipleControlledSdg(QCOProgramBuilder& b) {
 
 void nestedControlledSdg(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.sdg(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.sdg(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -560,18 +549,17 @@ void trivialControlledSdg(QCOProgramBuilder& b) {
 
 void inverseSdg(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.sdg(qubits[0])};
-  });
+  b.inv({q[0]},
+        [&](ValueRange qubits) { return SmallVector{b.sdg(qubits[0])}; });
 }
 
 void inverseMultipleControlledSdg(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcsdg({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -604,13 +592,13 @@ void multipleControlledT(QCOProgramBuilder& b) {
 
 void nestedControlledT(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.t(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.t(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -621,18 +609,16 @@ void trivialControlledT(QCOProgramBuilder& b) {
 
 void inverseT(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.t(qubits[0])};
-  });
+  b.inv({q[0]}, [&](ValueRange qubits) { return SmallVector{b.t(qubits[0])}; });
 }
 
 void inverseMultipleControlledT(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mct({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -665,13 +651,13 @@ void multipleControlledTdg(QCOProgramBuilder& b) {
 
 void nestedControlledTdg(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.tdg(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.tdg(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -682,18 +668,17 @@ void trivialControlledTdg(QCOProgramBuilder& b) {
 
 void inverseTdg(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.tdg(qubits[0])};
-  });
+  b.inv({q[0]},
+        [&](ValueRange qubits) { return SmallVector{b.tdg(qubits[0])}; });
 }
 
 void inverseMultipleControlledTdg(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mctdg({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -726,13 +711,13 @@ void multipleControlledSx(QCOProgramBuilder& b) {
 
 void nestedControlledSx(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.sx(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.sx(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -743,18 +728,17 @@ void trivialControlledSx(QCOProgramBuilder& b) {
 
 void inverseSx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.sx(qubits[0])};
-  });
+  b.inv({q[0]},
+        [&](ValueRange qubits) { return SmallVector{b.sx(qubits[0])}; });
 }
 
 void inverseMultipleControlledSx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcsx({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -787,13 +771,13 @@ void multipleControlledSxdg(QCOProgramBuilder& b) {
 
 void nestedControlledSxdg(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.sxdg(innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.sxdg(innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -804,18 +788,17 @@ void trivialControlledSxdg(QCOProgramBuilder& b) {
 
 void inverseSxdg(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.sxdg(qubits[0])};
-  });
+  b.inv({q[0]},
+        [&](ValueRange qubits) { return SmallVector{b.sxdg(qubits[0])}; });
 }
 
 void inverseMultipleControlledSxdg(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcsxdg({qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -848,13 +831,13 @@ void multipleControlledRx(QCOProgramBuilder& b) {
 
 void nestedControlledRx(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.rx(0.123, innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.rx(0.123, innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -865,18 +848,18 @@ void trivialControlledRx(QCOProgramBuilder& b) {
 
 void inverseRx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.rx(-0.123, qubits[0])};
+  b.inv({q[0]}, [&](ValueRange qubits) {
+    return SmallVector{b.rx(-0.123, qubits[0])};
   });
 }
 
 void inverseMultipleControlledRx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcrx(-0.123, {qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -908,13 +891,13 @@ void multipleControlledRy(QCOProgramBuilder& b) {
 
 void nestedControlledRy(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.ry(0.456, innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.ry(0.456, innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -925,18 +908,18 @@ void trivialControlledRy(QCOProgramBuilder& b) {
 
 void inverseRy(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.ry(-0.456, qubits[0])};
+  b.inv({q[0]}, [&](ValueRange qubits) {
+    return SmallVector{b.ry(-0.456, qubits[0])};
   });
 }
 
 void inverseMultipleControlledRy(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcry(-0.456, {qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 void twoRyOppositePhase(QCOProgramBuilder& b) {
@@ -967,13 +950,13 @@ void multipleControlledRz(QCOProgramBuilder& b) {
 
 void nestedControlledRz(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.rz(0.789, innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.rz(0.789, innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -984,18 +967,18 @@ void trivialControlledRz(QCOProgramBuilder& b) {
 
 void inverseRz(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.rz(-0.789, qubits[0])};
+  b.inv({q[0]}, [&](ValueRange qubits) {
+    return SmallVector{b.rz(-0.789, qubits[0])};
   });
 }
 
 void inverseMultipleControlledRz(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcrz(-0.789, {qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -1022,13 +1005,13 @@ void multipleControlledP(QCOProgramBuilder& b) {
 
 void nestedControlledP(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{b.p(0.123, innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.p(0.123, innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1039,18 +1022,17 @@ void trivialControlledP(QCOProgramBuilder& b) {
 
 void inverseP(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.p(-0.123, qubits[0])};
-  });
+  b.inv({q[0]},
+        [&](ValueRange qubits) { return SmallVector{b.p(-0.123, qubits[0])}; });
 }
 
 void inverseMultipleControlledP(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcp(-0.123, {qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -1077,14 +1059,13 @@ void multipleControlledR(QCOProgramBuilder& b) {
 
 void nestedControlledR(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{
-              b.r(0.123, 0.456, innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.r(0.123, 0.456, innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1095,18 +1076,18 @@ void trivialControlledR(QCOProgramBuilder& b) {
 
 void inverseR(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.r(-0.123, 0.456, qubits[0])};
+  b.inv({q[0]}, [&](ValueRange qubits) {
+    return SmallVector{b.r(-0.123, 0.456, qubits[0])};
   });
 }
 
 void inverseMultipleControlledR(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcr(-0.123, 0.456, {qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -1137,14 +1118,13 @@ void multipleControlledU2(QCOProgramBuilder& b) {
 
 void nestedControlledU2(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{
-              b.u2(0.234, 0.567, innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.u2(0.234, 0.567, innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1156,20 +1136,19 @@ void trivialControlledU2(QCOProgramBuilder& b) {
 void inverseU2(QCOProgramBuilder& b) {
   constexpr double pi = std::numbers::pi;
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{
-        b.u2(-0.567 + pi, -0.234 - pi, qubits[0])};
+  b.inv({q[0]}, [&](ValueRange qubits) {
+    return SmallVector{b.u2(-0.567 + pi, -0.234 - pi, qubits[0])};
   });
 }
 
 void inverseMultipleControlledU2(QCOProgramBuilder& b) {
   constexpr double pi = std::numbers::pi;
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcu2(-0.567 + pi, -0.234 - pi, {qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 void canonicalizeU2ToH(QCOProgramBuilder& b) {
@@ -1203,14 +1182,13 @@ void multipleControlledU(QCOProgramBuilder& b) {
 
 void nestedControlledU(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(3);
-  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](mlir::ValueRange targets) {
+  b.ctrl({reg[0]}, {reg[1], reg[2]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
-          return llvm::SmallVector<mlir::Value>{
-              b.u(0.1, 0.2, 0.3, innerTargets[0])};
+        b.ctrl({targets[0]}, {targets[1]}, [&](ValueRange innerTargets) {
+          return SmallVector{b.u(0.1, 0.2, 0.3, innerTargets[0])};
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1221,18 +1199,18 @@ void trivialControlledU(QCOProgramBuilder& b) {
 
 void inverseU(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.u(-0.1, -0.3, -0.2, qubits[0])};
+  b.inv({q[0]}, [&](ValueRange qubits) {
+    return SmallVector{b.u(-0.1, -0.3, -0.2, qubits[0])};
   });
 }
 
 void inverseMultipleControlledU(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetOut] =
         b.mcu(-0.1, -0.3, -0.2, {qubits[0], qubits[1]}, qubits[2]);
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(controlsOut, mlir::ValueRange{targetOut}));
+        llvm::concat<Value>(controlsOut, ValueRange{targetOut}));
   });
 }
 
@@ -1273,15 +1251,14 @@ void multipleControlledSwap(QCOProgramBuilder& b) {
 
 void nestedControlledSwap(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.swap(innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res = b.swap(innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1292,20 +1269,19 @@ void trivialControlledSwap(QCOProgramBuilder& b) {
 
 void inverseSwap(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
     auto res = b.swap(qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledSwap(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[2], q[3]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2], q[3]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] =
         b.mcswap({qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1338,15 +1314,14 @@ void multipleControlledIswap(QCOProgramBuilder& b) {
 
 void nestedControlledIswap(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.iswap(innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res = b.iswap(innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1357,20 +1332,19 @@ void trivialControlledIswap(QCOProgramBuilder& b) {
 
 void inverseIswap(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
     auto res = b.iswap(qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledIswap(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[2], q[3]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2], q[3]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] =
         b.mciswap({qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1391,15 +1365,14 @@ void multipleControlledDcx(QCOProgramBuilder& b) {
 
 void nestedControlledDcx(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.dcx(innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res = b.dcx(innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1410,20 +1383,19 @@ void trivialControlledDcx(QCOProgramBuilder& b) {
 
 void inverseDcx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[1], q[0]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[1], q[0]}, [&](ValueRange qubits) {
     auto res = b.dcx(qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledDcx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[3], q[2]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[3], q[2]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] =
         b.mcdcx({qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1456,15 +1428,14 @@ void multipleControlledEcr(QCOProgramBuilder& b) {
 
 void nestedControlledEcr(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.ecr(innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res = b.ecr(innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1475,20 +1446,19 @@ void trivialControlledEcr(QCOProgramBuilder& b) {
 
 void inverseEcr(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
     auto res = b.ecr(qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledEcr(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[2], q[3]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2], q[3]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] =
         b.mcecr({qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1515,15 +1485,14 @@ void multipleControlledRxx(QCOProgramBuilder& b) {
 
 void nestedControlledRxx(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.rxx(0.123, innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res = b.rxx(0.123, innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1534,20 +1503,19 @@ void trivialControlledRxx(QCOProgramBuilder& b) {
 
 void inverseRxx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
     auto res = b.rxx(-0.123, qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledRxx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[2], q[3]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2], q[3]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] =
         b.mcrxx(-0.123, {qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1604,15 +1572,14 @@ void multipleControlledRyy(QCOProgramBuilder& b) {
 
 void nestedControlledRyy(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.ryy(0.123, innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res = b.ryy(0.123, innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1623,20 +1590,19 @@ void trivialControlledRyy(QCOProgramBuilder& b) {
 
 void inverseRyy(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
     auto res = b.ryy(-0.123, qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledRyy(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[2], q[3]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2], q[3]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] =
         b.mcryy(-0.123, {qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1683,15 +1649,14 @@ void multipleControlledRzx(QCOProgramBuilder& b) {
 
 void nestedControlledRzx(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.rzx(0.123, innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res = b.rzx(0.123, innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1702,20 +1667,19 @@ void trivialControlledRzx(QCOProgramBuilder& b) {
 
 void inverseRzx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
     auto res = b.rzx(-0.123, qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledRzx(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[2], q[3]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2], q[3]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] =
         b.mcrzx(-0.123, {qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1742,15 +1706,14 @@ void multipleControlledRzz(QCOProgramBuilder& b) {
 
 void nestedControlledRzz(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.rzz(0.123, innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res = b.rzz(0.123, innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1761,20 +1724,19 @@ void trivialControlledRzz(QCOProgramBuilder& b) {
 
 void inverseRzz(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
     auto res = b.rzz(-0.123, qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledRzz(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[2], q[3]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2], q[3]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] =
         b.mcrzz(-0.123, {qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1821,16 +1783,15 @@ void multipleControlledXxPlusYY(QCOProgramBuilder& b) {
 
 void nestedControlledXxPlusYY(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.xx_plus_yy(0.123, 0.456, innerTargets[0],
-                                         innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res =
+              b.xx_plus_yy(0.123, 0.456, innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1841,20 +1802,19 @@ void trivialControlledXxPlusYY(QCOProgramBuilder& b) {
 
 void inverseXxPlusYY(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
     auto res = b.xx_plus_yy(-0.123, 0.456, qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledXxPlusYY(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[2], q[3]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2], q[3]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] = b.mcxx_plus_yy(
         -0.123, 0.456, {qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1881,16 +1841,15 @@ void multipleControlledXxMinusYY(QCOProgramBuilder& b) {
 
 void nestedControlledXxMinusYY(QCOProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);
-  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto res = b.xx_minus_yy(0.123, 0.456, innerTargets[0],
-                                          innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{res.first, res.second};
-               });
+  b.ctrl({reg[0]}, {reg[1], reg[2], reg[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto res =
+              b.xx_minus_yy(0.123, 0.456, innerTargets[0], innerTargets[1]);
+          return SmallVector{res.first, res.second};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
@@ -1901,20 +1860,19 @@ void trivialControlledXxMinusYY(QCOProgramBuilder& b) {
 
 void inverseXxMinusYY(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
     auto res = b.xx_minus_yy(-0.123, 0.456, qubits[0], qubits[1]);
-    return llvm::SmallVector<mlir::Value>{res.first, res.second};
+    return SmallVector{res.first, res.second};
   });
 }
 
 void inverseMultipleControlledXxMinusYY(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.inv({q[0], q[1], q[2], q[3]}, [&](mlir::ValueRange qubits) {
+  b.inv({q[0], q[1], q[2], q[3]}, [&](ValueRange qubits) {
     const auto& [controlsOut, targetsOut] = b.mcxx_minus_yy(
         -0.123, 0.456, {qubits[0], qubits[1]}, qubits[2], qubits[3]);
-    llvm::SmallVector<mlir::Value, 2> targets{targetsOut.first,
-                                              targetsOut.second};
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targets));
+    SmallVector<Value, 2> targets{targetsOut.first, targetsOut.second};
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targets));
   });
 }
 
@@ -1941,15 +1899,15 @@ void barrierMultipleQubits(QCOProgramBuilder& b) {
 
 void singleControlledBarrier(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.ctrl({q[1]}, {q[0]}, [&](mlir::ValueRange targets) {
-    return llvm::SmallVector<mlir::Value>{b.barrier(targets[0])};
+  b.ctrl({q[1]}, {q[0]}, [&](ValueRange targets) {
+    return SmallVector<Value>{b.barrier(targets[0])};
   });
 }
 
 void inverseBarrier(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
-  b.inv({q[0]}, [&](mlir::ValueRange qubits) {
-    return llvm::SmallVector<mlir::Value>{b.barrier(qubits[0])};
+  b.inv({q[0]}, [&](ValueRange qubits) {
+    return SmallVector<Value>{b.barrier(qubits[0])};
   });
 }
 
@@ -1963,124 +1921,119 @@ void twoBarrier(QCOProgramBuilder& b) {
 
 void trivialCtrl(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.ctrl({}, {q[0], q[1]}, [&](mlir::ValueRange targets) {
+  b.ctrl({}, {q[0], q[1]}, [&](ValueRange targets) {
     auto [q0, q1] = b.rxx(0.123, targets[0], targets[1]);
-    return llvm::SmallVector<mlir::Value>{q0, q1};
+    return SmallVector{q0, q1};
   });
 }
 
 void nestedCtrl(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.ctrl({q[0]}, {q[1], q[2], q[3]}, [&](mlir::ValueRange targets) {
-    const auto& [innerControlsOut, innerTargetsOut] =
-        b.ctrl({targets[0]}, {targets[1], targets[2]},
-               [&](mlir::ValueRange innerTargets) {
-                 auto [q0, q1] = b.rxx(0.123, innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{q0, q1};
-               });
+  b.ctrl({q[0]}, {q[1], q[2], q[3]}, [&](ValueRange targets) {
+    const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+        {targets[0]}, {targets[1], targets[2]}, [&](ValueRange innerTargets) {
+          auto [q0, q1] = b.rxx(0.123, innerTargets[0], innerTargets[1]);
+          return SmallVector{q0, q1};
+        });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
 void tripleNestedCtrl(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(5);
-  b.ctrl({q[0]}, {q[1], q[2], q[3], q[4]}, [&](mlir::ValueRange targets) {
+  b.ctrl({q[0]}, {q[1], q[2], q[3], q[4]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
         {targets[0]}, {targets[1], targets[2], targets[3]},
-        [&](mlir::ValueRange innerTargets) {
+        [&](ValueRange innerTargets) {
           const auto& [innerInnerControlsOut, innerInnerTargetsOut] =
               b.ctrl({innerTargets[0]}, {innerTargets[1], innerTargets[2]},
-                     [&](mlir::ValueRange innerInnerTargets) {
+                     [&](ValueRange innerInnerTargets) {
                        auto [q0, q1] = b.rxx(0.123, innerInnerTargets[0],
                                              innerInnerTargets[1]);
-                       return llvm::SmallVector<mlir::Value>{q0, q1};
+                       return SmallVector{q0, q1};
                      });
-          return llvm::to_vector(llvm::concat<mlir::Value>(
-              innerInnerControlsOut, innerInnerTargetsOut));
+          return llvm::to_vector(
+              llvm::concat<Value>(innerInnerControlsOut, innerInnerTargetsOut));
         });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
 void doubleNestedCtrlTwoQubits(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(6);
-  b.ctrl({q[0], q[1]}, {q[2], q[3], q[4], q[5]}, [&](mlir::ValueRange targets) {
+  b.ctrl({q[0], q[1]}, {q[2], q[3], q[4], q[5]}, [&](ValueRange targets) {
     const auto& [innerControlsOut, innerTargetsOut] =
         b.ctrl({targets[0], targets[1]}, {targets[2], targets[3]},
-               [&](mlir::ValueRange innerTargets) {
+               [&](ValueRange innerTargets) {
                  auto [q0, q1] = b.rxx(0.123, innerTargets[0], innerTargets[1]);
-                 return llvm::SmallVector<mlir::Value>{q0, q1};
+                 return SmallVector{q0, q1};
                });
     return llvm::to_vector(
-        llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+        llvm::concat<Value>(innerControlsOut, innerTargetsOut));
   });
 }
 
 void ctrlInvSandwich(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.ctrl({q[0]}, {q[1], q[2], q[3]}, [&](mlir::ValueRange targets) {
+  b.ctrl({q[0]}, {q[1], q[2], q[3]}, [&](ValueRange targets) {
     auto inner = b.inv(
-        {targets[0], targets[1], targets[2]},
-        [&](mlir::ValueRange innerTargets) {
+        {targets[0], targets[1], targets[2]}, [&](ValueRange innerTargets) {
           auto [innerControlsOut, innerTargetsOut] =
               b.ctrl({innerTargets[0]}, {innerTargets[1], innerTargets[2]},
-                     [&](mlir::ValueRange innerInnerTargets) {
+                     [&](ValueRange innerInnerTargets) {
                        auto [q0, q1] = b.rxx(-0.123, innerInnerTargets[0],
                                              innerInnerTargets[1]);
-                       return llvm::SmallVector<mlir::Value>{q0, q1};
+                       return SmallVector{q0, q1};
                      });
           return llvm::to_vector(
-              llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+              llvm::concat<Value>(innerControlsOut, innerTargetsOut));
         });
-    return llvm::SmallVector<mlir::Value>{inner};
+    return SmallVector<Value>{inner};
   });
 }
 
 void nestedInv(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
-    auto inner =
-        b.inv({qubits[0], qubits[1]}, [&](mlir::ValueRange innerQubits) {
-          auto [q0, q1] = b.rxx(0.123, innerQubits[0], innerQubits[1]);
-          return llvm::SmallVector<mlir::Value>{q0, q1};
-        });
-    return llvm::SmallVector<mlir::Value>{inner};
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
+    auto inner = b.inv({qubits[0], qubits[1]}, [&](ValueRange innerQubits) {
+      auto [q0, q1] = b.rxx(0.123, innerQubits[0], innerQubits[1]);
+      return SmallVector{q0, q1};
+    });
+    return SmallVector<Value>{inner};
   });
 }
 
 void tripleNestedInv(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
-  b.inv({q[0], q[1]}, [&](mlir::ValueRange qubits) {
-    auto inner1 =
-        b.inv({qubits[0], qubits[1]}, [&](mlir::ValueRange innerQubits) {
-          auto inner2 = b.inv({innerQubits[0], innerQubits[1]},
-                              [&](mlir::ValueRange innerInnerQubits) {
-                                auto [q0, q1] =
-                                    b.rxx(-0.123, innerInnerQubits[0],
-                                          innerInnerQubits[1]);
-                                return llvm::SmallVector<mlir::Value>{q0, q1};
-                              });
-          return llvm::SmallVector<mlir::Value>{inner2};
-        });
-    return llvm::SmallVector<mlir::Value>{inner1};
+  b.inv({q[0], q[1]}, [&](ValueRange qubits) {
+    auto inner1 = b.inv({qubits[0], qubits[1]}, [&](ValueRange innerQubits) {
+      auto inner2 = b.inv(
+          {innerQubits[0], innerQubits[1]}, [&](ValueRange innerInnerQubits) {
+            auto [q0, q1] =
+                b.rxx(-0.123, innerInnerQubits[0], innerInnerQubits[1]);
+            return SmallVector{q0, q1};
+          });
+      return SmallVector<Value>{inner2};
+    });
+    return SmallVector<Value>{inner1};
   });
 }
 
 void invCtrlSandwich(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
-  b.inv({q[0], q[1], q[2]}, [&](mlir::ValueRange qubits) {
-    const auto& [controlsOut, targetsOut] = b.ctrl(
-        {qubits[0]}, {qubits[1], qubits[2]}, [&](mlir::ValueRange targets) {
-          auto inner = b.inv(
-              {targets[0], targets[1]}, [&](mlir::ValueRange innerQubits) {
+  b.inv({q[0], q[1], q[2]}, [&](ValueRange qubits) {
+    const auto& [controlsOut, targetsOut] =
+        b.ctrl({qubits[0]}, {qubits[1], qubits[2]}, [&](ValueRange targets) {
+          auto inner =
+              b.inv({targets[0], targets[1]}, [&](ValueRange innerQubits) {
                 auto [q0, q1] = b.rxx(0.123, innerQubits[0], innerQubits[1]);
-                return llvm::SmallVector<mlir::Value>{q0, q1};
+                return SmallVector{q0, q1};
               });
-          return llvm::SmallVector<mlir::Value>{inner};
+          return SmallVector<Value>{inner};
         });
-    return llvm::to_vector(llvm::concat<mlir::Value>(controlsOut, targetsOut));
+    return llvm::to_vector(llvm::concat<Value>(controlsOut, targetsOut));
   });
 }
 
@@ -2088,9 +2041,9 @@ void simpleIf(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   auto q0 = b.h(q[0]);
   auto [measuredQubit, measureResult] = b.measure(q0);
-  b.qcoIf(measureResult, measuredQubit, [&](mlir::ValueRange qubits) {
+  b.qcoIf(measureResult, measuredQubit, [&](ValueRange qubits) {
     auto innerQubit = b.x(qubits[0]);
-    return llvm::SmallVector<mlir::Value>{innerQubit};
+    return SmallVector{innerQubit};
   });
 }
 
@@ -2098,10 +2051,10 @@ void ifTwoQubits(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
   auto q0 = b.h(q[0]);
   auto [measuredQubit, measureResult] = b.measure(q0);
-  b.qcoIf(measureResult, {measuredQubit, q[1]}, [&](mlir::ValueRange qubits) {
+  b.qcoIf(measureResult, {measuredQubit, q[1]}, [&](ValueRange qubits) {
     auto innerQubit0 = b.x(qubits[0]);
     auto innerQubit1 = b.x(qubits[1]);
-    return llvm::SmallVector<mlir::Value>{innerQubit0, innerQubit1};
+    return SmallVector{innerQubit0, innerQubit1};
   });
 }
 
@@ -2111,13 +2064,13 @@ void ifElse(QCOProgramBuilder& b) {
   auto [measuredQubit, measureResult] = b.measure(q0);
   b.qcoIf(
       measureResult, {measuredQubit},
-      [&](mlir::ValueRange qubits) {
+      [&](ValueRange qubits) {
         auto innerQubit = b.x(qubits[0]);
-        return llvm::SmallVector<mlir::Value>{innerQubit};
+        return SmallVector{innerQubit};
       },
-      [&](mlir::ValueRange qubits) {
+      [&](ValueRange qubits) {
         auto innerQubit = b.z(qubits[0]);
-        return llvm::SmallVector<mlir::Value>{innerQubit};
+        return SmallVector{innerQubit};
       });
 }
 
@@ -2125,13 +2078,13 @@ void constantTrueIf(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   b.qcoIf(
       true, q.qubits,
-      [&](mlir::ValueRange qubits) {
+      [&](ValueRange qubits) {
         auto innerQubit = b.x(qubits[0]);
-        return llvm::SmallVector<mlir::Value>{innerQubit};
+        return SmallVector{innerQubit};
       },
-      [&](mlir::ValueRange qubits) {
+      [&](ValueRange qubits) {
         auto innerQubit = b.z(qubits[0]);
-        return llvm::SmallVector<mlir::Value>{innerQubit};
+        return SmallVector{innerQubit};
       });
 }
 
@@ -2139,13 +2092,13 @@ void constantFalseIf(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   b.qcoIf(
       false, q.qubits,
-      [&](mlir::ValueRange qubits) {
+      [&](ValueRange qubits) {
         auto innerQubit = b.x(qubits[0]);
-        return llvm::SmallVector<mlir::Value>{innerQubit};
+        return SmallVector{innerQubit};
       },
-      [&](mlir::ValueRange qubits) {
+      [&](ValueRange qubits) {
         auto innerQubit = b.z(qubits[0]);
-        return llvm::SmallVector<mlir::Value>{innerQubit};
+        return SmallVector{innerQubit};
       });
 }
 
@@ -2153,11 +2106,11 @@ void nestedTrueIf(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   auto q0 = b.h(q[0]);
   auto [measuredQubit, measureResult] = b.measure(q0);
-  b.qcoIf(measureResult, measuredQubit, [&](mlir::ValueRange outerQubits) {
+  b.qcoIf(measureResult, measuredQubit, [&](ValueRange outerQubits) {
     auto innerResult =
-        b.qcoIf(measureResult, outerQubits, [&](mlir::ValueRange innerQubits) {
+        b.qcoIf(measureResult, outerQubits, [&](ValueRange innerQubits) {
           auto innerQubit = b.x(innerQubits[0]);
-          return llvm::SmallVector<mlir::Value>{innerQubit};
+          return SmallVector{innerQubit};
         });
     return llvm::to_vector(innerResult);
   });
@@ -2169,19 +2122,19 @@ void nestedFalseIf(QCOProgramBuilder& b) {
   auto [measuredQubit, measureResult] = b.measure(q0);
   b.qcoIf(
       measureResult, measuredQubit,
-      [&](mlir::ValueRange qubits) {
+      [&](ValueRange qubits) {
         auto innerQubit = b.x(qubits[0]);
-        return llvm::SmallVector<mlir::Value>{innerQubit};
+        return SmallVector{innerQubit};
       },
-      [&](mlir::ValueRange outerQubits) {
+      [&](ValueRange outerQubits) {
         auto innerResult = b.qcoIf(
             measureResult, outerQubits,
-            [&](mlir::ValueRange innerQubits) {
+            [&](ValueRange innerQubits) {
               return llvm::to_vector(innerQubits);
             },
-            [&](mlir::ValueRange innerQubits) {
+            [&](ValueRange innerQubits) {
               auto innerQubit = b.z(innerQubits[0]);
-              return llvm::SmallVector<mlir::Value>{innerQubit};
+              return SmallVector{innerQubit};
             });
         return llvm::to_vector(innerResult);
       });


### PR DESCRIPTION
## Description

This PR cleans up `llvm` includes by relying on [`mlir/Support/LLVM.h`](https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Support/LLVM.h) as much as possible in header files.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
