### PR TITLE
🎨 Remove remaining explicit `llvm` namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637]) ([**@denialhaag**])
 - ✨ Add a `place-and-route` pass for mapping circuits to architectures with restricted topologies ([#1537], [#1547], [#1568], [#1581], [#1583], [#1588], [#1664]) ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add initial infrastructure for new QC and QCO MLIR dialects
-  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1620], [#1623], [#1624], [#1626], [#1627], [#1635], [#1673])
+  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1620], [#1623], [#1624], [#1626], [#1627], [#1635], [#1673], [#1675])
   ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**])
 
 ### Changed
@@ -361,6 +361,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1675]: https://github.com/munich-quantum-toolkit/core/pull/1675
 [#1673]: https://github.com/munich-quantum-toolkit/core/pull/1673
 [#1664]: https://github.com/munich-quantum-toolkit/core/pull/1664
 [#1662]: https://github.com/munich-quantum-toolkit/core/pull/1662

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -29,8 +29,7 @@ template <typename InverseOpType, typename OpType>
 LogicalResult
 removeInversePairOneTargetZeroParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the inverse operation
-  auto nextOp =
-      llvm::dyn_cast<InverseOpType>(*op.getOutputQubit(0).user_begin());
+  auto nextOp = dyn_cast<InverseOpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
     return failure();
   }
@@ -54,8 +53,7 @@ template <typename InverseOpType, typename OpType>
 LogicalResult
 removeInversePairTwoTargetZeroParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the inverse operation
-  auto nextOp =
-      llvm::dyn_cast<InverseOpType>(*op.getOutputQubit(0).user_begin());
+  auto nextOp = dyn_cast<InverseOpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
     return failure();
   }
@@ -85,7 +83,7 @@ LogicalResult
 removeTwoTargetZeroParameterPairWithSwappedTargets(OpType op,
                                                    PatternRewriter& rewriter) {
   // Check if the successor is the same operation
-  auto nextOp = llvm::dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
+  auto nextOp = dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
     return failure();
   }
@@ -120,7 +118,7 @@ template <typename SquareOpType, typename OpType>
 LogicalResult mergeOneTargetZeroParameter(OpType op,
                                           PatternRewriter& rewriter) {
   // Check if the successor is the same operation
-  auto nextOp = llvm::dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
+  auto nextOp = dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
     return failure();
   }
@@ -149,7 +147,7 @@ LogicalResult mergeOneTargetZeroParameter(OpType op,
 template <typename OpType>
 LogicalResult mergeOneTargetOneParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the same operation
-  auto nextOp = llvm::dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
+  auto nextOp = dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
     return failure();
   }
@@ -179,7 +177,7 @@ LogicalResult mergeOneTargetOneParameter(OpType op, PatternRewriter& rewriter) {
 template <typename OpType>
 LogicalResult mergeTwoTargetOneParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the same operation
-  auto nextOp = llvm::dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
+  auto nextOp = dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
     return failure();
   }
@@ -218,7 +216,7 @@ LogicalResult
 mergeTwoTargetOneParameterWithSwappedTargets(OpType op,
                                              PatternRewriter& rewriter) {
   // Check if the successor is the same operation
-  auto nextOp = llvm::dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
+  auto nextOp = dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
   if (!nextOp) {
     return failure();
   }

--- a/mlir/include/mlir/Dialect/QCO/Utils/Drivers.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/Drivers.h
@@ -64,8 +64,8 @@ LogicalResult walkProgram(Region& region, const WalkProgramFn& fn) {
         .template Case<UnitaryOpInterface>([&](UnitaryOpInterface& op) {
           for (const auto& [prevV, nextV] :
                llvm::zip(op.getInputQubits(), op.getOutputQubits())) {
-            const auto prevQ = llvm::cast<TypedValue<QubitType>>(prevV);
-            const auto nextQ = llvm::cast<TypedValue<QubitType>>(nextV);
+            const auto prevQ = cast<TypedValue<QubitType>>(prevV);
+            const auto nextQ = cast<TypedValue<QubitType>>(nextV);
             qubits.remap(prevQ, nextQ);
           }
         })

--- a/mlir/include/mlir/Dialect/QTensor/IR/QTensorOps.td
+++ b/mlir/include/mlir/Dialect/QTensor/IR/QTensorOps.td
@@ -86,8 +86,8 @@ def FromElementsOp
            TypesMatchWith<
                "operand types match result element type", "result", "elements",
                "SmallVector<Type, 2>("
-               "::llvm::cast<RankedTensorType>($_self).getNumElements(), "
-               "::llvm::cast<RankedTensorType>($_self).getElementType())">]> {
+               "cast<RankedTensorType>($_self).getNumElements(), "
+               "cast<RankedTensorType>($_self).getElementType())">]> {
   let summary = "Create a tensor from a range of values";
   let description = [{
         The `qtensor.from_elements` operation is a wrapper operation of the `tensor.from_elements` operation.
@@ -110,14 +110,13 @@ def FromElementsOp
 }
 
 def ExtractOp
-    : QTensorOp<
-          "extract",
-          [Pure,
-           TypesMatchWith<"result type matches element type of tensor",
-                          "tensor", "result",
-                          "::llvm::cast<TensorType>($_self).getElementType()">,
-           TypesMatchWith<"returned tensor type matches input tensor", "tensor",
-                          "out_tensor", "$_self">]> {
+    : QTensorOp<"extract",
+                [Pure,
+                 TypesMatchWith<"result type matches element type of tensor",
+                                "tensor", "result",
+                                "cast<TensorType>($_self).getElementType()">,
+                 TypesMatchWith<"returned tensor type matches input tensor",
+                                "tensor", "out_tensor", "$_self">]> {
   let summary = "Extract element from tensor";
   let description = [{
         The `qtensor.extract` operation is the modified version of the standard `tensor.extract`
@@ -138,14 +137,13 @@ def ExtractOp
 }
 
 def InsertOp
-    : QTensorOp<
-          "insert",
-          [Pure,
-           TypesMatchWith<"result type matches type of dest", "dest", "result",
-                          "$_self">,
-           TypesMatchWith<
-               "scalar type matches element type of dest", "dest", "scalar",
-               "::llvm::cast<TensorType>($_self).getElementType()">]> {
+    : QTensorOp<"insert", [Pure,
+                           TypesMatchWith<"result type matches type of dest",
+                                          "dest", "result", "$_self">,
+                           TypesMatchWith<
+                               "scalar type matches element type of dest",
+                               "dest", "scalar",
+                               "cast<TensorType>($_self).getElementType()">]> {
   let summary = "Insert element into tensor";
   let description = [{
         The `qtensor.insert` operation is a wrapper operation for the `tensor.insert` operation of the tensor dialect.

--- a/mlir/include/mlir/Dialect/QTensor/IR/QTensorUtils.h
+++ b/mlir/include/mlir/Dialect/QTensor/IR/QTensorUtils.h
@@ -12,9 +12,9 @@
 
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 
-#include <llvm/Support/Casting.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/Value.h>
+#include <mlir/Support/LLVM.h>
 
 namespace mlir::qtensor {
 
@@ -40,17 +40,17 @@ inline bool areEquivalentIndices(Value lhs, Value rhs) {
  * @brief Tensor-transforming ops in a scalar extract/insert chain.
  */
 inline bool isTensorChainOp(Operation* op) {
-  return llvm::isa<InsertOp, ExtractOp>(op);
+  return isa<InsertOp, ExtractOp>(op);
 }
 
 /**
  * @brief Returns the tensor input of a tensor-transforming op.
  */
 inline Value getTensorChainInput(Operation* op) {
-  if (auto insertOp = llvm::dyn_cast<InsertOp>(op)) {
+  if (auto insertOp = dyn_cast<InsertOp>(op)) {
     return insertOp.getDest();
   }
-  if (auto extractOp = llvm::dyn_cast<ExtractOp>(op)) {
+  if (auto extractOp = dyn_cast<ExtractOp>(op)) {
     return extractOp.getTensor();
   }
   return nullptr;
@@ -60,10 +60,10 @@ inline Value getTensorChainInput(Operation* op) {
  * @brief Returns the tensor output of a tensor-transforming op.
  */
 inline Value getTensorChainOutput(Operation* op) {
-  if (auto insertOp = llvm::dyn_cast<InsertOp>(op)) {
+  if (auto insertOp = dyn_cast<InsertOp>(op)) {
     return insertOp.getResult();
   }
-  if (auto extractOp = llvm::dyn_cast<ExtractOp>(op)) {
+  if (auto extractOp = dyn_cast<ExtractOp>(op)) {
     return extractOp.getOutTensor();
   }
   return nullptr;
@@ -73,11 +73,11 @@ inline Value getTensorChainOutput(Operation* op) {
  * @brief Rewire the tensor input of a tensor-transforming op.
  */
 inline void setTensorChainInput(Operation* op, Value tensor) {
-  if (llvm::isa<InsertOp>(op)) {
+  if (isa<InsertOp>(op)) {
     op->setOperand(1, tensor);
     return;
   }
-  if (llvm::isa<ExtractOp>(op)) {
+  if (isa<ExtractOp>(op)) {
     op->setOperand(0, tensor);
   }
 }

--- a/mlir/unittests/TestCaseUtils.h
+++ b/mlir/unittests/TestCaseUtils.h
@@ -17,6 +17,7 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <cstdlib>

--- a/mlir/unittests/TestCaseUtils.h
+++ b/mlir/unittests/TestCaseUtils.h
@@ -17,7 +17,6 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/IR/BuiltinOps.h>
-#include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <cstdlib>


### PR DESCRIPTION
## Description

This PR is a small follow-up to #1673. It removes the remaining explicit `llvm` namespaces.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
