### PR TITLE
Add `CancelConsecutiveHermitianGates` Pass

### DIFF
--- a/mlir/include/mlir/Dialect/QCO/IR/QCODialect.h
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCODialect.h
@@ -124,4 +124,8 @@ public:
   };
 };
 
+template <typename ConcreteType>
+class HermitianTrait : public OpTrait::TraitBase<ConcreteType, HermitianTrait> {
+};
+
 } // namespace mlir::qco

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -178,6 +178,10 @@ def TwoTargetZeroParameter : TargetAndParameterArityTrait<2, 0>;
 def TwoTargetOneParameter : TargetAndParameterArityTrait<2, 1>;
 def TwoTargetTwoParameter : TargetAndParameterArityTrait<2, 2>;
 
+def HermitianTrait : NativeOpTrait<"HermitianTrait"> {
+  let cppNamespace = "::mlir::qco";
+}
+
 //===----------------------------------------------------------------------===//
 // Unitary Operations
 //===----------------------------------------------------------------------===//
@@ -208,7 +212,7 @@ def GPhaseOp
   let hasCanonicalizer = 1;
 }
 
-def IdOp : QCOOp<"id", traits = [UnitaryOpInterface, OneTargetZeroParameter]> {
+def IdOp : QCOOp<"id", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
   let summary = "Apply an Id gate to a qubit";
   let description = [{
         Applies an Id gate to a qubit and returns the transformed qubit.
@@ -232,7 +236,7 @@ def IdOp : QCOOp<"id", traits = [UnitaryOpInterface, OneTargetZeroParameter]> {
   let hasCanonicalizer = 1;
 }
 
-def XOp : QCOOp<"x", traits = [UnitaryOpInterface, OneTargetZeroParameter]> {
+def XOp : QCOOp<"x", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
   let summary = "Apply an X gate to a qubit";
   let description = [{
         Applies an X gate to a qubit and returns the transformed qubit.
@@ -256,7 +260,7 @@ def XOp : QCOOp<"x", traits = [UnitaryOpInterface, OneTargetZeroParameter]> {
   let hasCanonicalizer = 1;
 }
 
-def YOp : QCOOp<"y", traits = [UnitaryOpInterface, OneTargetZeroParameter]> {
+def YOp : QCOOp<"y", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
   let summary = "Apply a Y gate to a qubit";
   let description = [{
         Applies a Y gate to a qubit and returns the transformed qubit.
@@ -280,7 +284,7 @@ def YOp : QCOOp<"y", traits = [UnitaryOpInterface, OneTargetZeroParameter]> {
   let hasCanonicalizer = 1;
 }
 
-def ZOp : QCOOp<"z", traits = [UnitaryOpInterface, OneTargetZeroParameter]> {
+def ZOp : QCOOp<"z", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
   let summary = "Apply a Z gate to a qubit";
   let description = [{
         Applies a Z gate to a qubit and returns the transformed qubit.
@@ -304,7 +308,7 @@ def ZOp : QCOOp<"z", traits = [UnitaryOpInterface, OneTargetZeroParameter]> {
   let hasCanonicalizer = 1;
 }
 
-def HOp : QCOOp<"h", traits = [UnitaryOpInterface, OneTargetZeroParameter]> {
+def HOp : QCOOp<"h", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
   let summary = "Apply a H gate to a qubit";
   let description = [{
         Applies a H gate to a qubit and returns the transformed qubit.
@@ -684,7 +688,7 @@ def UOp : QCOOp<"u", traits = [UnitaryOpInterface, OneTargetThreeParameter]> {
 }
 
 def SWAPOp
-    : QCOOp<"swap", traits = [UnitaryOpInterface, TwoTargetZeroParameter]> {
+    : QCOOp<"swap", traits = [UnitaryOpInterface, TwoTargetZeroParameter, HermitianTrait]> {
   let summary = "Apply a SWAP gate to two qubits";
   let description = [{
         Applies a SWAP gate to two qubits and returns the transformed qubits.

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -212,7 +212,8 @@ def GPhaseOp
   let hasCanonicalizer = 1;
 }
 
-def IdOp : QCOOp<"id", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
+def IdOp : QCOOp<"id", traits = [UnitaryOpInterface, OneTargetZeroParameter,
+                                 HermitianTrait]> {
   let summary = "Apply an Id gate to a qubit";
   let description = [{
         Applies an Id gate to a qubit and returns the transformed qubit.
@@ -236,7 +237,8 @@ def IdOp : QCOOp<"id", traits = [UnitaryOpInterface, OneTargetZeroParameter, Her
   let hasCanonicalizer = 1;
 }
 
-def XOp : QCOOp<"x", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
+def XOp : QCOOp<"x", traits = [UnitaryOpInterface, OneTargetZeroParameter,
+                               HermitianTrait]> {
   let summary = "Apply an X gate to a qubit";
   let description = [{
         Applies an X gate to a qubit and returns the transformed qubit.
@@ -260,7 +262,8 @@ def XOp : QCOOp<"x", traits = [UnitaryOpInterface, OneTargetZeroParameter, Hermi
   let hasCanonicalizer = 1;
 }
 
-def YOp : QCOOp<"y", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
+def YOp : QCOOp<"y", traits = [UnitaryOpInterface, OneTargetZeroParameter,
+                               HermitianTrait]> {
   let summary = "Apply a Y gate to a qubit";
   let description = [{
         Applies a Y gate to a qubit and returns the transformed qubit.
@@ -284,7 +287,8 @@ def YOp : QCOOp<"y", traits = [UnitaryOpInterface, OneTargetZeroParameter, Hermi
   let hasCanonicalizer = 1;
 }
 
-def ZOp : QCOOp<"z", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
+def ZOp : QCOOp<"z", traits = [UnitaryOpInterface, OneTargetZeroParameter,
+                               HermitianTrait]> {
   let summary = "Apply a Z gate to a qubit";
   let description = [{
         Applies a Z gate to a qubit and returns the transformed qubit.
@@ -308,7 +312,8 @@ def ZOp : QCOOp<"z", traits = [UnitaryOpInterface, OneTargetZeroParameter, Hermi
   let hasCanonicalizer = 1;
 }
 
-def HOp : QCOOp<"h", traits = [UnitaryOpInterface, OneTargetZeroParameter, HermitianTrait]> {
+def HOp : QCOOp<"h", traits = [UnitaryOpInterface, OneTargetZeroParameter,
+                               HermitianTrait]> {
   let summary = "Apply a H gate to a qubit";
   let description = [{
         Applies a H gate to a qubit and returns the transformed qubit.
@@ -687,8 +692,8 @@ def UOp : QCOOp<"u", traits = [UnitaryOpInterface, OneTargetThreeParameter]> {
   let hasCanonicalizer = 1;
 }
 
-def SWAPOp
-    : QCOOp<"swap", traits = [UnitaryOpInterface, TwoTargetZeroParameter, HermitianTrait]> {
+def SWAPOp : QCOOp<"swap", traits = [UnitaryOpInterface, TwoTargetZeroParameter,
+                                     HermitianTrait]> {
   let summary = "Apply a SWAP gate to two qubits";
   let description = [{
         Applies a SWAP gate to two qubits and returns the transformed qubits.

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -40,6 +40,16 @@ def MergeSingleQubitRotationGates
   }];
 }
 
+def CancelConsecutiveHermitianGates : Pass<"cancel-consecutive-hermitian-gates", "mlir::ModuleOp"> {
+  let dependentDialects = ["mlir::qco::QCODialect"];
+  let summary = "Cancel consecutive hermitian gates";
+  let description = [{
+    Cancels consecutive hermitian gates acting on the same qubit, reducing circuit depth and gate count. 
+    
+    The pass visits all unitary operations and removes a pair of adjacent unitaries on a wire, if both operations have the `HermitianTrait`. 
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Transpilation Passes
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -40,13 +40,14 @@ def MergeSingleQubitRotationGates
   }];
 }
 
-def CancelConsecutiveHermitianGates : Pass<"cancel-consecutive-hermitian-gates", "mlir::ModuleOp"> {
+def CancelConsecutiveHermitianGates
+    : Pass<"cancel-consecutive-hermitian-gates", "mlir::ModuleOp"> {
   let dependentDialects = ["mlir::qco::QCODialect"];
   let summary = "Cancel consecutive hermitian gates";
   let description = [{
-    Cancels consecutive hermitian gates acting on the same qubit, reducing circuit depth and gate count. 
-    
-    The pass visits all unitary operations and removes a pair of adjacent unitaries on a wire, if both operations have the `HermitianTrait`. 
+    Cancels consecutive hermitian gates acting on the same qubit, reducing circuit depth and gate count.
+
+    The pass visits all unitary operations and removes a pair of adjacent unitaries on a wire, if both operations have the `HermitianTrait`.
   }];
 }
 

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/CancelConsecutiveHermitianGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/CancelConsecutiveHermitianGates.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/CancelConsecutiveHermitianGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/CancelConsecutiveHermitianGates.cpp
@@ -1,0 +1,94 @@
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/Casting.h>
+#include <llvm/Support/Debug.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/OperationSupport.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+namespace mlir::qco {
+
+#define GEN_PASS_DEF_CANCELCONSECUTIVEHERMITIANGATES
+#include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
+
+namespace {
+struct CancelConsecutiveHermitianGatesPattern final
+    : OpInterfaceRewritePattern<UnitaryOpInterface> {
+  explicit CancelConsecutiveHermitianGatesPattern(MLIRContext* context)
+      : OpInterfaceRewritePattern(context) {}
+
+  /**
+   * @returns true, if the i-th output of @p op is the i-th input of @p other.
+   */
+  static bool haveSameOrientation(UnitaryOpInterface op,
+                                  UnitaryOpInterface other) {
+    return llvm::all_of(
+        llvm::zip_equal(op.getOutputQubits(), other.getInputQubits()),
+        [](const auto& pair) {
+          const auto& [out, in] = pair;
+          return out == in;
+        });
+  }
+
+  LogicalResult matchAndRewrite(UnitaryOpInterface op,
+                                PatternRewriter& rewriter) const override {
+    if (op->use_empty()) {
+      return failure();
+    }
+
+    if (!llvm::all_equal(op->getUsers())) {
+      return failure();
+    }
+
+    auto other = llvm::dyn_cast<UnitaryOpInterface>(*(op->getUsers().begin()));
+    if (other == nullptr) {
+      return failure();
+    }
+
+    if (!op->hasTrait<HermitianTrait>() || !other->hasTrait<HermitianTrait>()) {
+      return failure();
+    }
+
+    if (op->getName() != other->getName()) {
+      return failure();
+    }
+
+    if (op.getNumQubits() != other.getNumQubits()) {
+      return failure();
+    }
+
+    if (!haveSameOrientation(op, other)) {
+      return failure();
+    }
+
+    rewriter.replaceOp(other, op.getInputQubits());
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+} // namespace
+
+/**
+ * @brief Pass that cancels consecutive hermitian gates.
+ */
+struct CancelConsecutiveHermitianGates final
+    : impl::CancelConsecutiveHermitianGatesBase<
+          CancelConsecutiveHermitianGates> {
+  using CancelConsecutiveHermitianGatesBase<
+      CancelConsecutiveHermitianGates>::CancelConsecutiveHermitianGatesBase;
+
+protected:
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<CancelConsecutiveHermitianGatesPattern>(patterns.getContext());
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace mlir::qco

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/CMakeLists.txt
@@ -7,7 +7,8 @@
 # Licensed under the MIT License
 
 set(target_name mqt-core-mlir-unittest-optimizations)
-add_executable(${target_name} test_qco_merge_single_qubit_rotation.cpp)
+add_executable(${target_name} test_qco_merge_single_qubit_rotation.cpp
+  test_cancel_consecutive_hermitian_gates.cpp)
 
 target_link_libraries(
   ${target_name}

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/CMakeLists.txt
@@ -7,8 +7,8 @@
 # Licensed under the MIT License
 
 set(target_name mqt-core-mlir-unittest-optimizations)
-add_executable(${target_name} test_qco_merge_single_qubit_rotation.cpp
-  test_cancel_consecutive_hermitian_gates.cpp)
+add_executable(${target_name} test_cancel_consecutive_hermitian_gates.cpp
+                              test_qco_merge_single_qubit_rotation.cpp)
 
 target_link_libraries(
   ${target_name}

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_cancel_consecutive_hermitian_gates.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_cancel_consecutive_hermitian_gates.cpp
@@ -1,0 +1,306 @@
+#include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+
+#include <gtest/gtest.h>
+#include <llvm/Support/Casting.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/DialectRegistry.h>
+#include <mlir/IR/OwningOpRef.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+
+#include <cstddef>
+
+using namespace mlir;
+using namespace mlir::qco;
+
+class CancelConsecutiveHermitianGatesTest : public testing::Test {
+protected:
+  void SetUp() override {
+    // Register all necessary dialects
+    DialectRegistry registry;
+    registry.insert<qco::QCODialect, arith::ArithDialect, func::FuncDialect>();
+    context = std::make_unique<MLIRContext>();
+    context->appendDialectRegistry(registry);
+    context->loadAllAvailableDialects();
+  }
+
+  static LogicalResult runPass(OwningOpRef<ModuleOp>& moduleOp) {
+    PassManager pm(moduleOp->getContext());
+    pm.addPass(createCancelConsecutiveHermitianGates());
+    return pm.run(*moduleOp);
+  }
+
+  std::unique_ptr<MLIRContext> context;
+};
+
+/**
+ * @brief Test: Hermitian->Hermitian should be removed (one-qubit).
+ */
+TEST_F(CancelConsecutiveHermitianGatesTest, OneQubitChainEven) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  const auto q00 = builder.allocQubit();
+
+  const auto q01 = builder.x(q00);
+  const auto q02 = builder.x(q01);
+  EXPECT_TRUE(q02.getDefiningOp()->hasTrait<HermitianTrait>());
+
+  const auto q03 = builder.y(q02);
+  const auto q04 = builder.y(q03);
+  EXPECT_TRUE(q04.getDefiningOp()->hasTrait<HermitianTrait>());
+
+  const auto q05 = builder.z(q04);
+  const auto q06 = builder.z(q05);
+  EXPECT_TRUE(q06.getDefiningOp()->hasTrait<HermitianTrait>());
+
+  const auto q07 = builder.h(q06);
+  const auto q08 = builder.h(q07);
+  EXPECT_TRUE(q08.getDefiningOp()->hasTrait<HermitianTrait>());
+
+  const auto q09 = builder.id(q08);
+  const auto q010 = builder.id(q09);
+  EXPECT_TRUE(q010.getDefiningOp()->hasTrait<HermitianTrait>());
+
+  builder.sink(q010);
+
+  auto program = builder.finalize();
+
+  runPass(program);
+
+  std::size_t cnt = 0;
+  program->walk([&](Operation* op) {
+    if (llvm::isa<qco::XOp, qco::YOp, qco::ZOp, qco::HOp, qco::IdOp>(op)) {
+      cnt++;
+    }
+  });
+
+  EXPECT_EQ(cnt, 0);
+}
+
+/**
+ * @brief Test: Hermitian->Hermitian->Hermitian should remove the first pair
+ * (one-qubit).
+ */
+TEST_F(CancelConsecutiveHermitianGatesTest, OneQubitChainOdd) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  const auto q00 = builder.allocQubit();
+
+  const auto q01 = builder.x(q00);
+  const auto q02 = builder.x(q01);
+  const auto q03 = builder.x(q02);
+
+  builder.sink(q03);
+
+  auto program = builder.finalize();
+
+  runPass(program);
+
+  std::size_t cnt = 0;
+  program->walk([&](Operation* op) {
+    if (llvm::isa<qco::XOp>(op)) {
+      cnt++;
+    }
+  });
+
+  EXPECT_EQ(cnt, 1);
+}
+
+/**
+ * @brief Test: Hermitian->Hermitian should be removed on multiple disjoint
+ * qubits (one-qubit).
+ */
+TEST_F(CancelConsecutiveHermitianGatesTest, OneQubitOnDisjointQubits) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  const auto q00 = builder.allocQubit();
+  const auto q01 = builder.x(q00);
+  const auto q02 = builder.x(q01);
+  builder.sink(q02);
+
+  const auto q10 = builder.allocQubit();
+  const auto q11 = builder.h(q10);
+  const auto q12 = builder.h(q11);
+  builder.sink(q12);
+
+  auto program = builder.finalize();
+
+  runPass(program);
+
+  std::size_t cnt = 0;
+  program->walk([&](Operation* op) {
+    if (llvm::isa<qco::XOp, qco::HOp>(op)) {
+      cnt++;
+    }
+  });
+
+  EXPECT_EQ(cnt, 0);
+}
+
+/**
+ * @brief Test: Don't cancel cancelable gates, if there is another gate in
+ * between (one-qubit).
+ */
+TEST_F(CancelConsecutiveHermitianGatesTest, OneQubitInterrupted) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  const auto q00 = builder.allocQubit();
+
+  const auto q01 = builder.x(q00);
+  const auto q02 = builder.y(q01);
+  const auto q03 = builder.x(q02);
+  builder.sink(q03);
+
+  auto program = builder.finalize();
+
+  runPass(program);
+
+  std::size_t cnt = 0;
+  program->walk([&](Operation* op) {
+    if (llvm::isa<qco::XOp>(op)) {
+      cnt++;
+    }
+  });
+
+  EXPECT_EQ(cnt, 2);
+}
+
+/**
+ * @brief Test: Hermitian->Hermitian should be removed (two-qubit).
+ */
+TEST_F(CancelConsecutiveHermitianGatesTest, TwoQubitChainEven) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  const auto q00 = builder.allocQubit();
+  const auto q10 = builder.allocQubit();
+
+  const auto [q01, q11] = builder.swap(q00, q10);
+  EXPECT_TRUE(q01.getDefiningOp()->hasTrait<HermitianTrait>());
+  const auto [q02, q12] = builder.swap(q01, q11);
+
+  builder.sink(q02);
+  builder.sink(q12);
+
+  auto program = builder.finalize();
+
+  runPass(program);
+
+  std::size_t cnt = 0;
+  program->walk([&](Operation* op) {
+    if (llvm::isa<qco::SWAPOp>(op)) {
+      cnt++;
+    }
+  });
+
+  EXPECT_EQ(cnt, 0);
+}
+
+/**
+ * @brief Test: Hermitian->Hermitian->Hermitian should remove the first pair
+ * (one-qubit).
+ */
+TEST_F(CancelConsecutiveHermitianGatesTest, TwoQubitChainOdd) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  const auto q00 = builder.allocQubit();
+  const auto q10 = builder.allocQubit();
+
+  const auto [q01, q11] = builder.swap(q00, q10);
+  const auto [q02, q12] = builder.swap(q01, q11);
+  const auto [q03, q13] = builder.swap(q02, q12);
+
+  builder.sink(q03);
+  builder.sink(q13);
+
+  auto program = builder.finalize();
+
+  runPass(program);
+
+  std::size_t cnt = 0;
+  program->walk([&](Operation* op) {
+    if (llvm::isa<qco::SWAPOp>(op)) {
+      cnt++;
+    }
+  });
+
+  EXPECT_EQ(cnt, 1);
+}
+
+/**
+ * @brief Test: Hermitian->Hermitian should be removed on multiple disjoint
+ * qubits (two-qubit).
+ */
+TEST_F(CancelConsecutiveHermitianGatesTest, TwoQubitOnDisjointQubits) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  const auto q00 = builder.allocQubit();
+  const auto q10 = builder.allocQubit();
+  const auto [q01, q11] = builder.swap(q00, q10);
+  const auto [q02, q12] = builder.swap(q01, q11);
+  builder.sink(q02);
+  builder.sink(q12);
+
+  const auto q20 = builder.allocQubit();
+  const auto q30 = builder.allocQubit();
+  const auto [q21, q31] = builder.swap(q20, q30);
+  const auto [q22, q32] = builder.swap(q21, q31);
+  builder.sink(q22);
+  builder.sink(q32);
+
+  auto program = builder.finalize();
+
+  runPass(program);
+
+  std::size_t cnt = 0;
+  program->walk([&](Operation* op) {
+    if (llvm::isa<qco::SWAPOp>(op)) {
+      cnt++;
+    }
+  });
+
+  EXPECT_EQ(cnt, 0);
+}
+
+/**
+ * @brief Test: Don't cancel cancelable gates, if there is another gate in
+ * between (two-qubit).
+ */
+TEST_F(CancelConsecutiveHermitianGatesTest, TwoQubitInterrupted) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  const auto q00 = builder.allocQubit();
+  const auto q10 = builder.allocQubit();
+
+  const auto [q01, q11] = builder.swap(q00, q10);
+  const auto q02 = builder.h(q01);
+  const auto [q03, q12] = builder.swap(q02, q11);
+
+  builder.sink(q03);
+  builder.sink(q12);
+
+  auto program = builder.finalize();
+
+  runPass(program);
+
+  std::size_t cnt = 0;
+  program->walk([&](Operation* op) {
+    if (llvm::isa<qco::SWAPOp>(op)) {
+      cnt++;
+    }
+  });
+
+  EXPECT_EQ(cnt, 2);
+}

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_cancel_consecutive_hermitian_gates.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_cancel_consecutive_hermitian_gates.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"


### PR DESCRIPTION
## Description

The "Writing Your First Optimization Pass" section in  #1555 requires a rather simple example of an optimization pass. I thought a `CancelConsecutiveHermitianGates` pass could be a good choice. Hence, this pull request.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
