### PR TITLE
🐛 Fix linear typing violation in SCF conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637], [#1676]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add a `place-and-route` pass for mapping circuits to architectures with restricted topologies ([#1537], [#1547], [#1568], [#1581], [#1583], [#1588], [#1600], [#1664]) ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add initial infrastructure for new QC and QCO MLIR dialects
-  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1620], [#1623], [#1624], [#1626], [#1627], [#1635], [#1638], [#1673], [#1675])
+  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1620], [#1623], [#1624], [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700])
   ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**])
 
 ### Changed
@@ -371,6 +371,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1700]: https://github.com/munich-quantum-toolkit/core/pull/1700
 [#1694]: https://github.com/munich-quantum-toolkit/core/pull/1694
 [#1676]: https://github.com/munich-quantum-toolkit/core/pull/1676
 [#1675]: https://github.com/munich-quantum-toolkit/core/pull/1675

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -1451,21 +1451,18 @@ private:
   void updateTensorTracking(Value inputTensor, Value outputTensor);
 
   /**
-   * @brief Take a range of qubit and tensor values and insert all extracted
-   * qubits back to the tensors
+   * @brief Prepares initial arguments for operations by re-inserting extracted
+   * qubits into their tensors
    *
-   * @details Iterates through a range of qubit and tensor values and returns
-   * the latest qubit and tensor values. Qubit values are returned without
-   * modification. Tensor values are updated by adding all extracted qubits back
-   * to the tensors. The latest tensor values after inserting the qubits are
-   * returned.
+   * @details For each tensor in @p initArgs, any qubits extracted from it that
+   * are not also present in @p initArgs are inserted back. The latest tensor
+   * values after inserting the qubits are returned. Qubit values are returned
+   * without modifications.
    *
    * @param initArgs ValueRange of the initial values
    * @return SmallVector of the updated values of the initial values.
-   * @throws Abort if a tensor and one of its extracted qubits both appear in
-   * the @p initArgs
    */
-  SmallVector<Value> insertExtractedQubits(ValueRange initArgs);
+  SmallVector<Value> prepareInitArgs(ValueRange initArgs);
 
   /**
    * @brief Update the qubit tracking of the old values with the new values

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -407,9 +407,12 @@ template <typename OpType>
   return entryBlock.getArguments().take_back(numTargets);
 }
 
-/** @brief Inserts all extracted qubits into the tensors. */
-static void insertAllExtractedQubits(LoweringState& state, Operation* target,
-                                     PatternRewriter& rewriter) {
+/**
+ * @brief Inserts extracted qubits that are not required by @p target back into
+ * their tensors.
+ */
+static void insertQubitsBeforeOp(LoweringState& state, Operation* target,
+                                 PatternRewriter& rewriter) {
   auto* region = target->getParentRegion();
   Operation* anchor = nullptr;
   SmallVector<Value> memrefs;
@@ -426,8 +429,11 @@ static void insertAllExtractedQubits(LoweringState& state, Operation* target,
   auto& qubitInfoFromRegion = state.qubitInfoMap[region];
   for (auto memref : memrefs) {
     auto& extractedQubits = qubitsFromRegion[memref];
-    // Insert all extracted qubits
+    // Insert all extracted qubits that are not required by the target
     for (auto qubit : extractedQubits) {
+      if (state.regionQubitMap[target].contains(qubit)) {
+        continue;
+      }
       auto tensor = lookupMappedTensor(state, anchor, memref);
       auto qcoQubit = lookupMappedQubit(state, anchor, qubit);
       auto index = qubitInfoFromRegion[qubit].index;
@@ -439,9 +445,12 @@ static void insertAllExtractedQubits(LoweringState& state, Operation* target,
   }
 }
 
-/** @brief Extracts all previously inserted qubits. */
-static void extractAllInsertedQubits(LoweringState& state, Operation* target,
-                                     PatternRewriter& rewriter) {
+/**
+ * @brief Re-extracts qubits from their tensors after @p target has been
+ * processed.
+ */
+static void extractQubitsAfterOp(LoweringState& state, Operation* target,
+                                 PatternRewriter& rewriter) {
   auto* region = target->getParentRegion();
   Operation* anchor = nullptr;
   SmallVector<Value> memrefs;
@@ -457,8 +466,11 @@ static void extractAllInsertedQubits(LoweringState& state, Operation* target,
   auto& qubitInfoFromRegion = state.qubitInfoMap[region];
   for (auto& memref : memrefs) {
     auto& extractedQubits = qubitsFromRegion[memref];
-    // Extract all inserted qubits
+    // Extract the previously extracted qubits
     for (auto qubit : extractedQubits) {
+      if (state.regionQubitMap[target].contains(qubit)) {
+        continue;
+      }
       auto tensor = lookupMappedTensor(state, anchor, memref);
       auto index = qubitInfoFromRegion[qubit].index;
       auto insertOp =
@@ -1244,7 +1256,7 @@ struct ConvertSCFForOp final : StatefulOpConversionPattern<scf::ForOp> {
 
     // Insert the extracted qubits back to the registers that are used inside
     // the ForOp
-    insertAllExtractedQubits(state, operation, rewriter);
+    insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
 
     // Create the new ForOp
@@ -1266,7 +1278,7 @@ struct ConvertSCFForOp final : StatefulOpConversionPattern<scf::ForOp> {
 
     // Extract all the previously inserted qubits again
     rewriter.setInsertionPointAfter(newForOp);
-    extractAllInsertedQubits(state, operation, rewriter);
+    extractQubitsAfterOp(state, operation, rewriter);
 
     auto qubits = qubitMap.getArrayRef();
     auto registers = registerMap.getArrayRef();
@@ -1324,7 +1336,7 @@ struct ConvertSCFWhileOp final : StatefulOpConversionPattern<scf::WhileOp> {
 
     // Insert the extracted qubits back to the registers that are used inside
     // the WhileOp
-    insertAllExtractedQubits(state, operation, rewriter);
+    insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
 
     // Create the new WhileOp
@@ -1353,7 +1365,7 @@ struct ConvertSCFWhileOp final : StatefulOpConversionPattern<scf::WhileOp> {
 
     // Extract all the previously inserted qubits again
     rewriter.setInsertionPointAfter(newWhileOp);
-    extractAllInsertedQubits(state, operation, rewriter);
+    extractQubitsAfterOp(state, operation, rewriter);
 
     auto qubits = qubitMap.getArrayRef();
     auto registers = registerMap.getArrayRef();
@@ -1407,7 +1419,7 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
 
     // Insert the extracted qubits back to the registers that are used inside
     // the IfOp
-    insertAllExtractedQubits(state, operation, rewriter);
+    insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
 
     // Create the new IfOp
@@ -1420,7 +1432,7 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
 
     // Extract all the previously inserted qubits again
     rewriter.setInsertionPointAfter(newIfOp);
-    extractAllInsertedQubits(state, operation, rewriter);
+    extractQubitsAfterOp(state, operation, rewriter);
 
     auto& thenRegion = newIfOp.getThenRegion();
     auto& elseRegion = newIfOp.getElseRegion();
@@ -1486,7 +1498,7 @@ struct ConvertSCFYieldOp final : StatefulOpConversionPattern<scf::YieldOp> {
     auto& state = getState();
     auto* operation = op.getOperation();
 
-    insertAllExtractedQubits(state, op.getOperation(), rewriter);
+    insertQubitsBeforeOp(state, op.getOperation(), rewriter);
     SmallVector<Value> targets = resolveAllValues(state, operation);
 
     if (isa<IfOp>(op->getParentOp())) {
@@ -1524,7 +1536,7 @@ struct ConvertSCFConditionOp final
     auto& state = getState();
     auto* operation = op.getOperation();
 
-    insertAllExtractedQubits(state, op.getOperation(), rewriter);
+    insertQubitsBeforeOp(state, op.getOperation(), rewriter);
     SmallVector<Value> targets = resolveAllValues(state, operation);
 
     rewriter.replaceOpWithNewOp<scf::ConditionOp>(op, op.getCondition(),

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -213,21 +213,14 @@ void QCOProgramBuilder::updateTensorTracking(Value inputTensor,
   validTensors.try_emplace(outputTensor, info);
 }
 
-SmallVector<Value>
-QCOProgramBuilder::insertExtractedQubits(ValueRange initArgs) {
+SmallVector<Value> QCOProgramBuilder::prepareInitArgs(ValueRange initArgs) {
   checkQubitType(initArgs);
 
-  // Gather all used tensor ids first
-  DenseSet<int64_t> tensorRegIds;
+  // Gather all initial qubits first
+  DenseSet<Value> initQubits;
   for (auto initArg : initArgs) {
-    if (!isa<QubitType>(initArg.getType())) {
-      validateTensorValue(initArg);
-      const auto tensorId = validTensors.find(initArg)->second.regId;
-      if (tensorRegIds.contains(tensorId)) {
-        llvm::reportFatalUsageError(
-            "Same tensor cannot be passed to the same operation twice");
-      }
-      tensorRegIds.insert(tensorId);
+    if (isa<QubitType>(initArg.getType())) {
+      initQubits.insert(initArg);
     }
   }
 
@@ -238,14 +231,6 @@ QCOProgramBuilder::insertExtractedQubits(ValueRange initArgs) {
   // arguments
   for (auto initArg : initArgs) {
     if (isa<QubitType>(initArg.getType())) {
-      // Check if the qubits are from one of the used tensors
-      auto it = validQubits.find(initArg);
-      if (it != validQubits.end() && it->second.regId != -1 &&
-          tensorRegIds.contains(it->second.regId)) {
-        llvm::reportFatalUsageError(
-            "Cannot pass a register and one of its extracted qubits "
-            "to the same region");
-      }
       // Directly insert qubits
       updatedArgs.emplace_back(initArg);
     } else {
@@ -256,7 +241,8 @@ QCOProgramBuilder::insertExtractedQubits(ValueRange initArgs) {
       // from this tensor
       for (auto it = validQubits.begin(); it != validQubits.end();) {
         auto& [qubit, qubitInfo] = *it;
-        if (qubitInfo.regId == regId) {
+        // Ignore qubits that are also used as initArgs
+        if (qubitInfo.regId == regId && !initQubits.contains(qubit)) {
           // Create an InsertOp for the qubit
           auto newTensor = qtensor::InsertOp::create(
                                *this, qubit, currentTensor, qubitInfo.regIndex)
@@ -919,7 +905,7 @@ ValueRange QCOProgramBuilder::scfFor(
   auto ub = variantToValue(*this, loc, upperbound);
   auto stepSize = variantToValue(*this, loc, step);
   // Get the updated arguments after inserting the extracted qubits
-  auto updatedArgs = insertExtractedQubits(initArgs);
+  auto updatedArgs = prepareInitArgs(initArgs);
 
   // Create the empty for operation
   auto forOp = scf::ForOp::create(*this, lb, ub, stepSize, updatedArgs);
@@ -956,7 +942,7 @@ ValueRange QCOProgramBuilder::scfWhile(
   checkFinalized();
 
   // Get the updated arguments after inserting the extracted qubits
-  auto updatedArgs = insertExtractedQubits(initArgs);
+  auto updatedArgs = prepareInitArgs(initArgs);
   // Create the empty while operation
   auto whileOp = scf::WhileOp::create(*this, initArgs.getTypes(), updatedArgs);
 
@@ -1016,7 +1002,7 @@ ValueRange QCOProgramBuilder::qcoIf(
   checkFinalized();
 
   auto conditionValue = variantToValue(*this, getLoc(), condition);
-  auto updatedArgs = insertExtractedQubits(initArgs);
+  auto updatedArgs = prepareInitArgs(initArgs);
   // Create the empty if operation
   auto ifOp = IfOp::create(*this, conditionValue, updatedArgs);
 

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -675,6 +675,11 @@ INSTANTIATE_TEST_SUITE_P(
         QCOToQCTestCase{"NestedForLoopWhileOp",
                         MQT_NAMED_BUILDER(qco::nestedForLoopWhileOp),
                         MQT_NAMED_BUILDER(qc::nestedForLoopWhileOp)},
-        QCOToQCTestCase{"NestedForLoopCtrlOp",
-                        MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOp),
-                        MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOp)}));
+        QCOToQCTestCase{
+            "nestedForLoopCtrlOpWithSeparateQubit",
+            MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithSeparateQubit),
+            MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOpWithSeparateQubit)},
+        QCOToQCTestCase{
+            "nestedForLoopCtrlOpWithExtractedQubit",
+            MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithExtractedQubit),
+            MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOpWithExtractedQubit)}));

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -677,6 +677,11 @@ INSTANTIATE_TEST_SUITE_P(
         QCToQCOTestCase{"NestedForLoopWhileOp",
                         MQT_NAMED_BUILDER(qc::nestedForLoopWhileOp),
                         MQT_NAMED_BUILDER(qco::nestedForLoopWhileOp)},
-        QCToQCOTestCase{"NestedForLoopCtrlOp",
-                        MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOp),
-                        MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOp)}));
+        QCToQCOTestCase{
+            "nestedForLoopCtrlOpWithSeparateQubit",
+            MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOpWithSeparateQubit),
+            MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithSeparateQubit)},
+        QCToQCOTestCase{
+            "nestedForLoopCtrlOpWithExtractedQubit",
+            MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOpWithExtractedQubit),
+            MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithExtractedQubit)}));

--- a/mlir/unittests/programs/qc_programs.cpp
+++ b/mlir/unittests/programs/qc_programs.cpp
@@ -1379,13 +1379,24 @@ void nestedForLoopWhileOp(QCProgramBuilder& b) {
   });
 }
 
-void nestedForLoopCtrlOp(QCProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
+void nestedForLoopCtrlOpWithSeparateQubit(QCProgramBuilder& b) {
+  auto reg = b.allocQubitRegister(3);
   auto control = b.allocQubit();
   b.h(control);
-  b.scfFor(0, 2, 1, [&](Value iv) {
+  b.scfFor(0, 3, 1, [&](Value iv) {
     auto q0 = b.memrefLoad(reg.value, iv);
-    b.ctrl(control, [&] { b.h(q0); });
+    b.h(q0);
+    b.ctrl(control, [&] { b.x(q0); });
+  });
+}
+
+void nestedForLoopCtrlOpWithExtractedQubit(QCProgramBuilder& b) {
+  auto reg = b.allocQubitRegister(4);
+  b.h(reg[0]);
+  b.scfFor(1, 4, 1, [&](Value iv) {
+    auto q0 = b.memrefLoad(reg.value, iv);
+    b.h(q0);
+    b.ctrl(reg[0], [&] { b.x(q0); });
   });
 }
 

--- a/mlir/unittests/programs/qc_programs.h
+++ b/mlir/unittests/programs/qc_programs.h
@@ -871,7 +871,12 @@ void nestedForLoopIfOp(QCProgramBuilder& b);
 void nestedForLoopWhileOp(QCProgramBuilder& b);
 
 /// Creates a circuit with a for operation with a register and a qubit and a
-/// nested ctrl operation.
-void nestedForLoopCtrlOp(QCProgramBuilder& b);
+/// nested ctrl operation where the qubit is separately allocated from the
+/// register.
+void nestedForLoopCtrlOpWithSeparateQubit(QCProgramBuilder& b);
+
+/// Creates a circuit with a for operation with a register and a qubit and a
+/// nested ctrl operation where the qubit is extracted from the register.
+void nestedForLoopCtrlOpWithExtractedQubit(QCProgramBuilder& b);
 
 } // namespace mlir::qc

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -2290,15 +2290,31 @@ void nestedForLoopWhileOp(QCOProgramBuilder& b) {
   });
 }
 
-void nestedForLoopCtrlOp(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
+void nestedForLoopCtrlOpWithSeparateQubit(QCOProgramBuilder& b) {
+  auto reg = b.allocQubitRegister(3);
   auto control0 = b.allocQubit();
   auto control1 = b.h(control0);
-  b.scfFor(0, 2, 1, {reg.value, control1}, [&](Value iv, ValueRange iterArgs) {
+  b.scfFor(0, 3, 1, {reg.value, control1}, [&](Value iv, ValueRange iterArgs) {
     auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
-    auto [controls, targets] = b.ctrl(iterArgs[1], q0, [&](ValueRange args) {
-      auto q1 = b.h(args[0]);
-      return SmallVector{q1};
+    auto q1 = b.h(q0);
+    auto [controls, targets] = b.ctrl(iterArgs[1], q1, [&](ValueRange args) {
+      auto q2 = b.x(args[0]);
+      return SmallVector{q2};
+    });
+    auto insert = b.qtensorInsert(targets[0], t0, iv);
+    return SmallVector{insert, controls[0]};
+  });
+}
+
+void nestedForLoopCtrlOpWithExtractedQubit(QCOProgramBuilder& b) {
+  auto reg = b.allocQubitRegister(4);
+  auto control = b.h(reg[0]);
+  b.scfFor(1, 4, 1, {reg.value, control}, [&](Value iv, ValueRange iterArgs) {
+    auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
+    auto q1 = b.h(q0);
+    auto [controls, targets] = b.ctrl(iterArgs[1], q1, [&](ValueRange args) {
+      auto q2 = b.x(args[0]);
+      return SmallVector{q2};
     });
     auto insert = b.qtensorInsert(targets[0], t0, iv);
     return SmallVector{insert, controls[0]};

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -1036,8 +1036,13 @@ void nestedForLoopIfOp(QCOProgramBuilder& b);
 void nestedForLoopWhileOp(QCOProgramBuilder& b);
 
 /// Creates a circuit with a for operation with a register and a qubit and a
-/// nested ctrl operation.
-void nestedForLoopCtrlOp(QCOProgramBuilder& b);
+/// nested ctrl operation where the qubit is separately allocated from the
+/// register.
+void nestedForLoopCtrlOpWithSeparateQubit(QCOProgramBuilder& b);
+
+/// Creates a circuit with a for operation with a register and a qubit and a
+/// nested ctrl operation where the the qubit is extracted from the register.
+void nestedForLoopCtrlOpWithExtractedQubit(QCOProgramBuilder& b);
 
 // --- QTensor Operations -------------------------------------------------- //
 

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -1041,7 +1041,7 @@ void nestedForLoopWhileOp(QCOProgramBuilder& b);
 void nestedForLoopCtrlOpWithSeparateQubit(QCOProgramBuilder& b);
 
 /// Creates a circuit with a for operation with a register and a qubit and a
-/// nested ctrl operation where the the qubit is extracted from the register.
+/// nested ctrl operation where the qubit is extracted from the register.
 void nestedForLoopCtrlOpWithExtractedQubit(QCOProgramBuilder& b);
 
 // --- QTensor Operations -------------------------------------------------- //


### PR DESCRIPTION
## Description

This PR modifies the insertion/extraction of qubits when a register is passed to an `scf` operation.
Qubits that are passed along their origin register are not inserted into the register anymore to avoid linear typing violation.

Fixes #1699

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [ ] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
