### PR TITLE
:sparkles: Add IPO Passes to `mqt-cc`

### DIFF
--- a/mlir/include/mlir/Compiler/CompilerPipeline.h
+++ b/mlir/include/mlir/Compiler/CompilerPipeline.h
@@ -39,6 +39,9 @@ struct QuantumCompilerConfig {
 
   /// Print IR after each stage
   bool printIRAfterAllStages = false;
+
+  /// Enable quaternion-based rotation gate merging
+  bool mergeRotationGates = false;
 };
 
 /**

--- a/mlir/include/mlir/Compiler/CompilerPipeline.h
+++ b/mlir/include/mlir/Compiler/CompilerPipeline.h
@@ -45,6 +45,9 @@ struct QuantumCompilerConfig {
 
   // Enable function inlining during cleanup passes
   bool enableInlining = false;
+
+  // Enable interprocedural optimizations
+  bool enableIpo = false;
 };
 
 /**

--- a/mlir/include/mlir/Compiler/CompilerPipeline.h
+++ b/mlir/include/mlir/Compiler/CompilerPipeline.h
@@ -42,6 +42,9 @@ struct QuantumCompilerConfig {
 
   /// Enable quaternion-based rotation gate merging
   bool mergeRotationGates = false;
+
+  // Enable function inlining during cleanup passes
+  bool enableInlining = false;
 };
 
 /**
@@ -120,7 +123,7 @@ private:
    * Always adds the standard MLIR canonicalization pass followed by dead
    * value removal.
    */
-  static void addCleanupPasses(PassManager& pm);
+  static void addCleanupPasses(PassManager& pm, bool doInlining = false);
 
   /**
    * @brief Configure PassManager with diagnostic options

--- a/mlir/include/mlir/Dialect/QCO/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/QCO/CMakeLists.txt
@@ -7,3 +7,4 @@
 # Licensed under the MIT License
 
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/mlir/include/mlir/Dialect/QCO/Transforms/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
-# Copyright (c) 2025 Munich Quantum Software Company GmbH
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/mlir/include/mlir/Dialect/QCO/Transforms/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+# Copyright (c) 2025 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name QCO)
+add_public_tablegen_target(MLIRQCOTransformsIncGen)
+add_mlir_doc(Passes QCOPasses Passes/ -gen-pass-doc)

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
- * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
  * All rights reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+ * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include <mlir/Pass/Pass.h> // from @llvm-project
+
+namespace mlir::qco {
+#define GEN_PASS_DECL
+#include "mlir/Dialect/QCO/Transforms/Passes.h.inc" // IWYU pragma: export
+
+#define GEN_PASS_REGISTRATION
+#include "mlir/Dialect/QCO/Transforms/Passes.h.inc" // IWYU pragma: export
+} // namespace mlir::qco

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
@@ -26,5 +26,6 @@ void runQuantumArgumentPromotion(ModuleOp module, SymbolTable& symbolTable);
 void runAncillaHoisting(ModuleOp module, SymbolTable& symbolTable);
 void runQuantumFunctionBoundaryCommutation(ModuleOp module,
                                            SymbolTable& symbolTable);
+void populateReuseQubitsPatterns(mlir::RewritePatternSet& patterns);
 
 } // namespace mlir::qco

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
@@ -10,6 +10,9 @@
 
 #pragma once
 
+#include "mlir/IR/BuiltinOps.h"
+
+#include <mlir/IR/SymbolTable.h>
 #include <mlir/Pass/Pass.h> // from @llvm-project
 
 namespace mlir::qco {
@@ -18,4 +21,7 @@ namespace mlir::qco {
 
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/QCO/Transforms/Passes.h.inc" // IWYU pragma: export
+
+void runQuantumArgumentPromotion(ModuleOp module, SymbolTable& symbolTable);
+
 } // namespace mlir::qco

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
@@ -23,5 +23,6 @@ namespace mlir::qco {
 #include "mlir/Dialect/QCO/Transforms/Passes.h.inc" // IWYU pragma: export
 
 void runQuantumArgumentPromotion(ModuleOp module, SymbolTable& symbolTable);
+void runAncillaHoisting(ModuleOp module, SymbolTable& symbolTable);
 
 } // namespace mlir::qco

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
@@ -24,5 +24,7 @@ namespace mlir::qco {
 
 void runQuantumArgumentPromotion(ModuleOp module, SymbolTable& symbolTable);
 void runAncillaHoisting(ModuleOp module, SymbolTable& symbolTable);
+void runQuantumFunctionBoundaryCommutation(ModuleOp module,
+                                           SymbolTable& symbolTable);
 
 } // namespace mlir::qco

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -1,5 +1,5 @@
-// Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
-// Copyright (c) 2025 Munich Quantum Software Company GmbH
+// Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+// Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
 // All rights reserved.
 //
 // SPDX-License-Identifier: MIT

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+// Copyright (c) 2025 Munich Quantum Software Company GmbH
+// All rights reserved.
+//
+// SPDX-License-Identifier: MIT
+//
+// Licensed under the MIT License
+
+include "mlir/Pass/PassBase.td"
+
+def MergeRotationGates : Pass<"qco-merge-rotation-gates",
+"mlir::ModuleOp"> {
+  let summary = "Merge rotation gates using quaternion-based fusion";
+  let description = [{
+    Merges consecutive rotation gates of different types (rx, ry, rz, u)
+    using quaternion representation and Hamilton product.
+  }];
+
+  let dependentDialects = ["::mlir::math::MathDialect"];
+}

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -19,6 +19,16 @@ def MergeRotationGates : Pass<"qco-merge-rotation-gates",
   let dependentDialects = ["::mlir::math::MathDialect"];
 }
 
+def ReuseQubitsPass : Pass<"reuse-qubits", "mlir::ModuleOp"> {
+  let dependentDialects = [ "mlir::scf::SCFDialect" ];
+  let summary = "Reduce the number of required qubits by reusing existing ones that are no longer used.";
+  let description = [{
+    This pass performs qubit reuse, searching for qubits that are first referenced after the final reference to a different qubit.
+    In these cases, rather than using a new qubit, the old qubit can be reset and reused.
+  }];
+}
+
+
 def QuantumIPO : Pass<"quantum-ipo", "mlir::ModuleOp"> {
     let summary = "Quantum Interprocedural Optimization Pass";
     let description = [{

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -25,5 +25,5 @@ def QuantumIPO : Pass<"quantum-ipo", "mlir::ModuleOp"> {
         Performs interprocedural optimizations on quantum functions.
     }];
 
-    let dependentDialects = ["::mlir::func::FuncDialect", "::mlir::arith::ArithDialect"];
+    let dependentDialects = ["::mlir::func::FuncDialect", "::mlir::arith::ArithDialect", "::mlir::tensor::TensorDialect"];
 }

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -18,3 +18,12 @@ def MergeRotationGates : Pass<"qco-merge-rotation-gates",
 
   let dependentDialects = ["::mlir::math::MathDialect"];
 }
+
+def QuantumIPO : Pass<"quantum-ipo", "mlir::ModuleOp"> {
+    let summary = "Quantum Interprocedural Optimization Pass";
+    let description = [{
+        Performs interprocedural optimizations on quantum functions.
+    }];
+
+    let dependentDialects = ["::mlir::func::FuncDialect", "::mlir::arith::ArithDialect"];
+}

--- a/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
+++ b/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
@@ -21,6 +21,7 @@ namespace mlir::qir {
 // QIR function names
 
 inline constexpr auto QIR_INITIALIZE = "__quantum__rt__initialize";
+inline constexpr auto QIR_ALLOC = "__quantum__rt__qubit_allocate";
 inline constexpr auto QIR_MEASURE = "__quantum__qis__mz__body";
 inline constexpr auto QIR_RECORD_OUTPUT = "__quantum__rt__result_record_output";
 inline constexpr auto QIR_ARRAY_RECORD_OUTPUT =

--- a/mlir/lib/Compiler/CMakeLists.txt
+++ b/mlir/lib/Compiler/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_library(
   QCToQCO
   QCOToQC
   QCToQIR
+  MLIRQCOTransforms
   MQT::MLIRSupport
   MQT::ProjectOptions
   DISABLE_INSTALL)

--- a/mlir/lib/Compiler/CompilerPipeline.cpp
+++ b/mlir/lib/Compiler/CompilerPipeline.cpp
@@ -162,12 +162,16 @@ QuantumCompilerPipeline::runPipeline(ModuleOp module,
 
   // Stage 5: Optimization passes
   // TODO: Add optimization passes
-  pm.addPass(mlir::qco::createMergeRotationGates());
 
-  addCleanupPasses(pm);
-  if (failed(pm.run(module))) {
-    return failure();
+  // quaternion gate merging pass
+  if (config_.mergeRotationGates) {
+    pm.addPass(mlir::qco::createMergeRotationGates());
+    if (failed(pm.run(module))) {
+      return failure();
+    }
+    pm.clear();
   }
+
   if (record != nullptr && config_.recordIntermediates) {
     record->afterOptimization = captureIR(module);
     if (config_.printIRAfterAllStages) {
@@ -175,7 +179,6 @@ QuantumCompilerPipeline::runPipeline(ModuleOp module,
                        totalStages);
     }
   }
-  pm.clear();
 
   // Stage 6: QCO canonicalization
   addCleanupPasses(pm);

--- a/mlir/lib/Compiler/CompilerPipeline.cpp
+++ b/mlir/lib/Compiler/CompilerPipeline.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Conversion/QCOToQC/QCOToQC.h"
 #include "mlir/Conversion/QCToQCO/QCToQCO.h"
 #include "mlir/Conversion/QCToQIR/QCToQIR.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
 #include "mlir/Support/PrettyPrinting.h"
 
 #include <llvm/ADT/StringRef.h>
@@ -161,6 +162,8 @@ QuantumCompilerPipeline::runPipeline(ModuleOp module,
 
   // Stage 5: Optimization passes
   // TODO: Add optimization passes
+  pm.addPass(mlir::qco::createMergeRotationGates());
+
   addCleanupPasses(pm);
   if (failed(pm.run(module))) {
     return failure();

--- a/mlir/lib/Compiler/CompilerPipeline.cpp
+++ b/mlir/lib/Compiler/CompilerPipeline.cpp
@@ -18,9 +18,12 @@
 
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/InliningUtils.h>
 #include <mlir/Transforms/Passes.h>
 #include <string>
 
@@ -59,8 +62,14 @@ static void prettyPrintStage(ModuleOp module, const llvm::StringRef stageName,
   llvm::errs().flush();
 }
 
-void QuantumCompilerPipeline::addCleanupPasses(PassManager& pm) {
+void QuantumCompilerPipeline::addCleanupPasses(PassManager& pm,
+                                               bool doInlining) {
   // Always run canonicalization and dead value removal
+
+  if (doInlining) {
+    pm.addPass(createInlinerPass());
+  }
+
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createRemoveDeadValuesPass());
   pm.addPass(createSymbolDCEPass());
@@ -120,7 +129,7 @@ QuantumCompilerPipeline::runPipeline(ModuleOp module,
   }
 
   // Stage 2: QC canonicalization
-  addCleanupPasses(pm);
+  addCleanupPasses(pm, config_.enableInlining);
   if (pm.run(module).failed()) {
     return failure();
   }

--- a/mlir/lib/Compiler/CompilerPipeline.cpp
+++ b/mlir/lib/Compiler/CompilerPipeline.cpp
@@ -172,20 +172,13 @@ QuantumCompilerPipeline::runPipeline(ModuleOp module,
 
   // Stage 5: Optimization passes
   // TODO: Add optimization passes
-  pm.addPass(mlir::qco::createQuantumIPO());
-  if (failed(pm.run(module))) {
-    return failure();
-  }
-  pm.clear();
-
-  // quaternion gate merging pass
-  if (config_.mergeRotationGates) {
-    pm.addPass(mlir::qco::createMergeRotationGates());
+  if (config_.enableIpo) {
+    pm.addPass(mlir::qco::createQuantumIPO());
     if (failed(pm.run(module))) {
       return failure();
     }
-    pm.clear();
   }
+  pm.clear();
 
   if (record != nullptr && config_.recordIntermediates) {
     record->afterOptimization = captureIR(module);

--- a/mlir/lib/Compiler/CompilerPipeline.cpp
+++ b/mlir/lib/Compiler/CompilerPipeline.cpp
@@ -63,6 +63,7 @@ void QuantumCompilerPipeline::addCleanupPasses(PassManager& pm) {
   // Always run canonicalization and dead value removal
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createRemoveDeadValuesPass());
+  pm.addPass(createSymbolDCEPass());
 }
 
 void QuantumCompilerPipeline::configurePassManager(PassManager& pm) const {
@@ -162,6 +163,11 @@ QuantumCompilerPipeline::runPipeline(ModuleOp module,
 
   // Stage 5: Optimization passes
   // TODO: Add optimization passes
+  pm.addPass(mlir::qco::createQuantumIPO());
+  if (failed(pm.run(module))) {
+    return failure();
+  }
+  pm.clear();
 
   // quaternion gate merging pass
   if (config_.mergeRotationGates) {

--- a/mlir/lib/Compiler/CompilerPipeline.cpp
+++ b/mlir/lib/Compiler/CompilerPipeline.cpp
@@ -70,9 +70,9 @@ void QuantumCompilerPipeline::addCleanupPasses(PassManager& pm,
     pm.addPass(createInlinerPass());
   }
 
+  pm.addPass(createSymbolDCEPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createRemoveDeadValuesPass());
-  pm.addPass(createSymbolDCEPass());
 }
 
 void QuantumCompilerPipeline::configurePassManager(PassManager& pm) const {
@@ -174,9 +174,10 @@ QuantumCompilerPipeline::runPipeline(ModuleOp module,
   // TODO: Add optimization passes
   if (config_.enableIpo) {
     pm.addPass(mlir::qco::createQuantumIPO());
-    if (failed(pm.run(module))) {
-      return failure();
-    }
+  }
+  pm.addPass(mlir::qco::createReuseQubitsPass());
+  if (failed(pm.run(module))) {
+    return failure();
   }
   pm.clear();
 
@@ -246,7 +247,8 @@ QuantumCompilerPipeline::runPipeline(ModuleOp module,
     pm.clear();
 
     // Stage 10: QIR canonicalization (optional)
-    addCleanupPasses(pm);
+    // TODO uncomment
+    // addCleanupPasses(pm);
     if (failed(pm.run(module))) {
       return failure();
     }

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -12,9 +12,11 @@
 
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
 
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
@@ -266,6 +268,30 @@ public:
     // Convert QCO qubit values to QC qubit references
     addConversion([ctx](qco::QubitType /*type*/) -> Type {
       return qc::QubitType::get(ctx);
+    });
+
+    addConversion([&](RankedTensorType type) -> Type {
+      // Attempt to convert the element type recursively
+      const Type convertedElementType = convertType(type.getElementType());
+
+      // If the element type couldn't be converted, fail the conversion for the
+      // tensor
+      if (!convertedElementType) {
+        return nullptr;
+      }
+
+      // Return a new tensor type with the converted element type,
+      // preserving the original shape and encoding
+      return RankedTensorType::get(type.getShape(), convertedElementType,
+                                   type.getEncoding());
+    });
+
+    addConversion([&](UnrankedTensorType type) -> Type {
+      Type convertedElementType = convertType(type.getElementType());
+      if (!convertedElementType) {
+        return nullptr;
+      }
+      return UnrankedTensorType::get(convertedElementType);
     });
   }
 };
@@ -835,6 +861,73 @@ struct ConvertQCOYieldOp final : OpConversionPattern<qco::YieldOp> {
   }
 };
 
+class ConvertTensorFromElements
+    : public OpConversionPattern<tensor::FromElementsOp> {
+public:
+  using OpConversionPattern<tensor::FromElementsOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tensor::FromElementsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter& rewriter) const override {
+    // 1. Ask the TypeConverter for the new tensor type
+    // (It will use our rules to return tensor<...x!qc.qubit>)
+    Type newResultType = typeConverter->convertType(op.getType());
+    if (!newResultType)
+      return failure();
+
+    // 2. Rebuild the operation using the CONVERTED operands from the adaptor.
+    // The adaptor holds your new !qc.qubit values, not the old !qco.qubit ones.
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(op, newResultType,
+                                                        adaptor.getElements());
+
+    return success();
+  }
+};
+
+// Pattern for tensor.extract
+class ConvertTensorExtract : public OpConversionPattern<tensor::ExtractOp> {
+public:
+  using OpConversionPattern<tensor::ExtractOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tensor::ExtractOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter& rewriter) const override {
+    // The result of extract is the scalar element (!qc.qubit)
+    Type newResultType = typeConverter->convertType(op.getType());
+    if (!newResultType)
+      return failure();
+
+    // Rebuild using the converted tensor and the indices
+    rewriter.replaceOpWithNewOp<tensor::ExtractOp>(
+        op, newResultType, adaptor.getTensor(), adaptor.getIndices());
+
+    return success();
+  }
+};
+
+// Pattern for tensor.insert
+class ConvertTensorInsert : public OpConversionPattern<tensor::InsertOp> {
+public:
+  using OpConversionPattern<tensor::InsertOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tensor::InsertOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter& rewriter) const override {
+    // The result of insert is the updated tensor (tensor<...x!qc.qubit>)
+    Type newResultType = typeConverter->convertType(op.getType());
+    if (!newResultType)
+      return failure();
+
+    // Rebuild using the converted scalar, converted destination tensor, and
+    // indices
+    rewriter.replaceOpWithNewOp<tensor::InsertOp>(
+        op, newResultType, adaptor.getScalar(), adaptor.getDest(),
+        adaptor.getIndices());
+
+    return success();
+  }
+};
+
 /**
  * @brief Pass implementation for QCO-to-QC conversion
  *
@@ -879,18 +972,19 @@ struct QCOToQC final : impl::QCOToQCBase<QCOToQC> {
 
     // Register operation conversion patterns
     // Note: No state tracking needed - OpAdaptors handle type conversion
-    patterns.add<ConvertQCOAllocOp, ConvertQCODeallocOp, ConvertQCOStaticOp,
-                 ConvertQCOMeasureOp, ConvertQCOResetOp, ConvertQCOGPhaseOp,
-                 ConvertQCOIdOp, ConvertQCOXOp, ConvertQCOYOp, ConvertQCOZOp,
-                 ConvertQCOHOp, ConvertQCOSOp, ConvertQCOSdgOp, ConvertQCOTOp,
-                 ConvertQCOTdgOp, ConvertQCOSXOp, ConvertQCOSXdgOp,
-                 ConvertQCORXOp, ConvertQCORYOp, ConvertQCORZOp, ConvertQCOPOp,
-                 ConvertQCOROp, ConvertQCOU2Op, ConvertQCOUOp, ConvertQCOSWAPOp,
-                 ConvertQCOiSWAPOp, ConvertQCODCXOp, ConvertQCOECROp,
-                 ConvertQCORXXOp, ConvertQCORYYOp, ConvertQCORZXOp,
-                 ConvertQCORZZOp, ConvertQCOXXPlusYYOp, ConvertQCOXXMinusYYOp,
-                 ConvertQCOBarrierOp, ConvertQCOCtrlOp, ConvertQCOYieldOp>(
-        typeConverter, context);
+    patterns
+        .add<ConvertQCOAllocOp, ConvertQCODeallocOp, ConvertQCOStaticOp,
+             ConvertQCOMeasureOp, ConvertQCOResetOp, ConvertQCOGPhaseOp,
+             ConvertQCOIdOp, ConvertQCOXOp, ConvertQCOYOp, ConvertQCOZOp,
+             ConvertQCOHOp, ConvertQCOSOp, ConvertQCOSdgOp, ConvertQCOTOp,
+             ConvertQCOTdgOp, ConvertQCOSXOp, ConvertQCOSXdgOp, ConvertQCORXOp,
+             ConvertQCORYOp, ConvertQCORZOp, ConvertQCOPOp, ConvertQCOROp,
+             ConvertQCOU2Op, ConvertQCOUOp, ConvertQCOSWAPOp, ConvertQCOiSWAPOp,
+             ConvertQCODCXOp, ConvertQCOECROp, ConvertQCORXXOp, ConvertQCORYYOp,
+             ConvertQCORZXOp, ConvertQCORZZOp, ConvertQCOXXPlusYYOp,
+             ConvertQCOXXMinusYYOp, ConvertQCOBarrierOp, ConvertQCOCtrlOp,
+             ConvertQCOYieldOp, ConvertTensorFromElements, ConvertTensorExtract,
+             ConvertTensorInsert>(typeConverter, context);
 
     // Conversion of qco types in func.func signatures
     // Note: This currently has limitations with signature changes
@@ -913,6 +1007,25 @@ struct QCOToQC final : impl::QCOToQCBase<QCOToQC> {
 
     // Conversion of qco types in control-flow ops (e.g., cf.br, cf.cond_br)
     populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
+
+    // Conversion of qco types in structured control-flow ops (e.g., cf.br,
+    // cf.cond_br)
+    scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter,
+                                                         patterns, target);
+
+    // Conversion of qco types in tensor ops
+    target.addDynamicallyLegalOp<tensor::FromElementsOp>(
+        [&](tensor::FromElementsOp op) {
+          // It's only legal if its result type has been converted to use !qc
+          return typeConverter.isLegal(op.getType());
+        });
+
+    target.addDynamicallyLegalOp<tensor::ExtractOp, tensor::InsertOp>(
+        [&](Operation* op) {
+          // This checks if the operation's result types and operand types are
+          // all valid
+          return typeConverter.isLegal(op);
+        });
 
     // Apply the conversion
     if (failed(applyPartialConversion(module, target, std::move(patterns)))) {

--- a/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Conversion/QCToQIR/QCToQIR.h"
 
+#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
@@ -32,6 +33,8 @@
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/LLVMTypes.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/BuiltinTypes.h>
@@ -75,11 +78,11 @@ struct LoweringState : QIRMetadata {
   DenseMap<StringRef, int64_t> registerStartIndexMap;
 
   /// Map from index to pointer value for reuse
-  DenseMap<int64_t, Value> ptrMap;
+  DenseMap<std::pair<Operation*, int64_t>, Value> ptrMap;
 
   /// Map from (register_name, register_index) to result pointer
   /// This allows caching result pointers for measurements with register info
-  DenseMap<std::pair<StringRef, int64_t>, Value> registerResultMap;
+  DenseMap<std::tuple<Operation*, StringRef, int64_t>, Value> registerResultMap;
 
   /// Modifier information
   int64_t inCtrlOp = 0;
@@ -197,10 +200,155 @@ struct QCToQIRTypeConverter final : LLVMTypeConverter {
     // Convert QubitType to LLVM pointer (QIR uses opaque pointers for qubits)
     addConversion(
         [ctx](QubitType /*type*/) { return LLVM::LLVMPointerType::get(ctx); });
+
+    addConversion([this, ctx](RankedTensorType type) -> Type {
+      // First, ask the converter what the element type translates to
+      // (This will recursively call the rule above and give you !llvm.ptr)
+      Type convertedElementType = convertType(type.getElementType());
+      if (!convertedElementType)
+        return nullptr;
+
+      // ==========================================
+      // CHOOSE ONE OF THE FOLLOWING RETURN TARGETS
+      // ==========================================
+
+      // OPTION 1: The Standard QIR Array (%Array*)
+      // In the official QIR specification, arrays are dynamically managed
+      // opaque pointers, exactly like qubits.
+      // return LLVM::LLVMPointerType::get(ctx);
+
+      // OPTION 2: A Static LLVM Array (!llvm.array<5 x ptr>)
+      // If you are just doing simple stack-allocated C-style arrays
+      // and your tensors are strictly 1D and statically sized:
+      if (type.getRank() == 1 && !type.isDynamicDim(0)) {
+        return LLVM::LLVMArrayType::get(convertedElementType,
+                                        type.getShape()[0]);
+      }
+
+      return nullptr; // Fail if it's a shape we don't support
+    });
   }
 };
 
 namespace {
+
+class TensorFromElementsToLLVM
+    : public OpConversionPattern<tensor::FromElementsOp> {
+public:
+  using OpConversionPattern<tensor::FromElementsOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tensor::FromElementsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter& rewriter) const override {
+    Location loc = op.getLoc();
+
+    // 1. Get the converted target type (!llvm.array<N x ptr>)
+    Type llvmArrayType = typeConverter->convertType(op.getType());
+    if (!llvmArrayType)
+      return failure();
+
+    // 2. Start with an uninitialized LLVM array
+    Value currentArray = rewriter.create<LLVM::UndefOp>(loc, llvmArrayType);
+
+    // 3. Loop through the converted operands (!llvm.ptr) and insert them
+    auto elements = adaptor.getElements();
+    for (auto it : llvm::enumerate(elements)) {
+      // The position must be an array of int64_t
+      ArrayRef<int64_t> position({static_cast<int64_t>(it.index())});
+
+      // Insert the value at the current index, which returns a NEW array value
+      currentArray = rewriter.create<LLVM::InsertValueOp>(loc, currentArray,
+                                                          it.value(), position);
+    }
+
+    // 4. Replace the original tensor op with the fully populated LLVM array
+    rewriter.replaceOp(op, currentArray);
+    return success();
+  }
+};
+
+class TensorInsertToLLVM : public OpConversionPattern<tensor::InsertOp> {
+public:
+  using OpConversionPattern<tensor::InsertOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tensor::InsertOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter& rewriter) const override {
+    // 1. Get the converted inputs from the adaptor
+    // adaptor.getDest() holds the !llvm.array we are inserting into
+    // adaptor.getScalar() holds the !llvm.ptr we are inserting
+    Value destArray = adaptor.getDest();
+    Value scalarToInsert = adaptor.getScalar();
+
+    // 2. Get the index. Assuming 1D tensors for your qubits.
+    Value indexValue = op.getIndices().front();
+
+    // 3. Just like extract, llvm.insertvalue strictly requires a static,
+    // compile-time constant for the array position.
+    auto constOp = indexValue.getDefiningOp<arith::ConstantIndexOp>();
+    if (!constOp) {
+      return op.emitError(
+          "Dynamic indexing into LLVM arrays is not supported in this pattern. "
+          "A static constant index is required.");
+    }
+
+    // 4. Extract the integer position
+    int64_t staticIndex = constOp.value();
+    ArrayRef<int64_t> position({staticIndex});
+
+    // 5. Build the llvm.insertvalue operation.
+    // This op returns the newly updated !llvm.array, so we can use it to
+    // replace the tensor op.
+    rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(
+        op,
+        destArray,      // The base array
+        scalarToInsert, // The new value to put inside it
+        position        // The static index
+    );
+
+    return success();
+  }
+};
+
+class TensorExtractToLLVM : public OpConversionPattern<tensor::ExtractOp> {
+public:
+  using OpConversionPattern<tensor::ExtractOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tensor::ExtractOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter& rewriter) const override {
+    Location loc = op.getLoc();
+
+    // 1. Get the converted array (!llvm.array) from the adaptor
+    Value llvmArray = adaptor.getTensor();
+
+    // 2. tensor.extract can have multiple indices for multi-dimensional
+    // tensors, but we assume 1D here for your 5x qubit tensor.
+    Value indexValue = op.getIndices().front();
+
+    // 3. We must prove the index is a constant because LLVM requires static
+    // positions
+    auto constOp = indexValue.getDefiningOp<arith::ConstantIndexOp>();
+    if (!constOp) {
+      // If the index is dynamic (calculated at runtime), this simple pattern
+      // fails. You would need to allocate memory (alloca) and use GEP/Load
+      // instead.
+      return op.emitError(
+          "Dynamic indexing into LLVM arrays is not supported in this pattern");
+    }
+
+    // 4. Create the LLVM extractvalue operation
+    int64_t staticIndex = constOp.value();
+    ArrayRef<int64_t> position({staticIndex});
+
+    rewriter.replaceOpWithNewOp<LLVM::ExtractValueOp>(
+        op,
+        typeConverter->convertType(op.getType()), // The result type (!llvm.ptr)
+        llvmArray, position);
+
+    return success();
+  }
+};
 
 /**
  * @brief Converts qc.alloc operation to static QIR qubit allocations
@@ -233,6 +381,7 @@ struct ConvertQCAllocQIR final : StatefulOpConversionPattern<AllocOp> {
     const auto numQubits = static_cast<int64_t>(state.numQubits);
     auto& ptrMap = state.ptrMap;
     auto& registerMap = state.registerStartIndexMap;
+    const auto parentOp = op->getParentOfType<LLVM::LLVMFuncOp>();
 
     // Get or create pointer value
     if (op.getRegisterName() && op.getRegisterSize() && op.getRegisterIndex()) {
@@ -247,10 +396,11 @@ struct ConvertQCAllocQIR final : StatefulOpConversionPattern<AllocOp> {
         // Register is already tracked
         // The pointer was created by the step below
         const auto globalIndex = it->second + registerIndex;
-        if (!ptrMap.contains(globalIndex)) {
+        const auto key = std::make_pair(parentOp, globalIndex);
+        if (!ptrMap.contains(key)) {
           return op.emitError("Pointer not found");
         }
-        rewriter.replaceOp(op, ptrMap.at(globalIndex));
+        rewriter.replaceOp(op, ptrMap.at(key));
         return success();
       }
 
@@ -260,11 +410,12 @@ struct ConvertQCAllocQIR final : StatefulOpConversionPattern<AllocOp> {
       pointers.reserve(registerSize);
       for (int64_t i = 0; i < registerSize; ++i) {
         Value val{};
-        if (const auto it = ptrMap.find(numQubits + i); it != ptrMap.end()) {
+        const auto key = std::make_pair(parentOp, numQubits + i);
+        if (const auto it = ptrMap.find(key); it != ptrMap.end()) {
           val = it->second;
         } else {
           val = createPointerFromIndex(rewriter, op.getLoc(), numQubits + i);
-          ptrMap[numQubits + i] = val;
+          ptrMap[key] = val;
         }
         pointers.push_back(val);
       }
@@ -275,11 +426,13 @@ struct ConvertQCAllocQIR final : StatefulOpConversionPattern<AllocOp> {
 
     // no register info, check if ptr has already been allocated (as a Result)
     Value val{};
-    if (const auto it = ptrMap.find(numQubits); it != ptrMap.end()) {
+
+    const auto key = std::make_pair(parentOp, numQubits);
+    if (const auto it = ptrMap.find(key); it != ptrMap.end()) {
       val = it->second;
     } else {
       val = createPointerFromIndex(rewriter, op.getLoc(), numQubits);
-      ptrMap[numQubits] = val;
+      ptrMap[key] = val;
     }
     rewriter.replaceOp(op, val);
     state.numQubits++;
@@ -341,15 +494,18 @@ struct ConvertQCStaticQIR final : StatefulOpConversionPattern<StaticOp> {
                   ConversionPatternRewriter& rewriter) const override {
     const auto index = static_cast<int64_t>(op.getIndex());
     auto& state = getState();
+    const auto parentOp = op->getParentOfType<LLVM::LLVMFuncOp>();
+
     // Get or create a pointer to the qubit
     Value val{};
-    if (const auto it = state.ptrMap.find(index); it != state.ptrMap.end()) {
+    const auto key = std::make_pair(parentOp, index);
+    if (const auto it = state.ptrMap.find(key); it != state.ptrMap.end()) {
       // Reuse existing pointer
       val = it->second;
     } else {
       // Create and cache for reuse
       val = createPointerFromIndex(rewriter, op.getLoc(), index);
-      state.ptrMap.try_emplace(index, val);
+      state.ptrMap.try_emplace(key, val);
     }
     rewriter.replaceOp(op, val);
 
@@ -399,6 +555,7 @@ struct ConvertQCMeasureQIR final : StatefulOpConversionPattern<MeasureOp> {
     const auto numResults = static_cast<int64_t>(state.numResults);
     auto& ptrMap = state.ptrMap;
     auto& registerResultMap = state.registerResultMap;
+    const auto parentOp = op->getParentOfType<LLVM::LLVMFuncOp>();
 
     // Get or create result pointer value
     Value resultValue;
@@ -408,7 +565,7 @@ struct ConvertQCMeasureQIR final : StatefulOpConversionPattern<MeasureOp> {
           static_cast<int64_t>(op.getRegisterSize().value());
       const auto registerIndex =
           static_cast<int64_t>(op.getRegisterIndex().value());
-      const auto key = std::make_pair(registerName, registerIndex);
+      const auto key = std::make_tuple(parentOp, registerName, registerIndex);
 
       if (const auto it = registerResultMap.find(key);
           it != registerResultMap.end()) {
@@ -417,13 +574,14 @@ struct ConvertQCMeasureQIR final : StatefulOpConversionPattern<MeasureOp> {
         // Allocate the entire register as static results
         for (int64_t i = 0; i < registerSize; ++i) {
           Value val{};
-          if (const auto it = ptrMap.find(numResults + i); it != ptrMap.end()) {
+          const auto keyInside = std::make_pair(parentOp, numResults + i);
+          if (const auto it = ptrMap.find(keyInside); it != ptrMap.end()) {
             val = it->second;
           } else {
             val = createPointerFromIndex(rewriter, op.getLoc(), numResults + i);
-            ptrMap[numResults + i] = val;
+            ptrMap[keyInside] = val;
           }
-          registerResultMap.try_emplace({registerName, i}, val);
+          registerResultMap.try_emplace({parentOp, registerName, i}, val);
         }
         state.numResults += registerSize;
         resultValue = registerResultMap.at(key);
@@ -432,18 +590,20 @@ struct ConvertQCMeasureQIR final : StatefulOpConversionPattern<MeasureOp> {
       // Choose a safe default register name
       StringRef defaultRegName = "c";
       if (llvm::any_of(registerResultMap, [](const auto& entry) {
-            return entry.first.first == "c";
+            return std::get<1>(entry.first) == "c";
           })) {
         defaultRegName = "__unnamed__";
       }
       // No register info, check if ptr has already been allocated (as a Qubit)
-      if (const auto it = ptrMap.find(numResults); it != ptrMap.end()) {
+      const auto keyInside = std::make_pair(parentOp, numResults);
+      if (const auto it = ptrMap.find(keyInside); it != ptrMap.end()) {
         resultValue = it->second;
       } else {
         resultValue = createPointerFromIndex(rewriter, op.getLoc(), numResults);
-        ptrMap[numResults] = resultValue;
+        ptrMap[keyInside] = resultValue;
       }
-      registerResultMap.insert({{defaultRegName, numResults}, resultValue});
+      registerResultMap.insert(
+          {{parentOp, defaultRegName, numResults}, resultValue});
       state.numResults++;
     }
 
@@ -1065,7 +1225,10 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
     // Group measurements by register
     llvm::StringMap<SmallVector<std::pair<int64_t, Value>>> registerGroups;
     for (const auto& [key, resultPtr] : state->registerResultMap) {
-      const auto& [registerName, registerIndex] = key;
+      const auto& [func, registerName, registerIndex] = key;
+      if (func != main) {
+        continue; // Only consider measurements from the current function
+      }
       registerGroups[registerName].emplace_back(registerIndex, resultPtr);
     }
 
@@ -1167,6 +1330,7 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
 
       if (applyPartialConversion(moduleOp, target, std::move(funcPatterns))
               .failed()) {
+        moduleOp->dump();
         signalPassFailure();
         return;
       }
@@ -1191,6 +1355,9 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
       target.addIllegalDialect<QCDialect>();
 
       // Add conversion patterns for QC operations
+      qcPatterns.add<TensorFromElementsToLLVM>(typeConverter, ctx);
+      qcPatterns.add<TensorExtractToLLVM>(typeConverter, ctx);
+      qcPatterns.add<TensorInsertToLLVM>(typeConverter, ctx);
       qcPatterns.add<ConvertQCAllocQIR>(typeConverter, ctx, &state);
       qcPatterns.add<ConvertQCDeallocQIR>(typeConverter, ctx);
       qcPatterns.add<ConvertQCStaticQIR>(typeConverter, ctx, &state);
@@ -1246,6 +1413,8 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
       RewritePatternSet stdPatterns(ctx);
       target.addIllegalDialect<arith::ArithDialect>();
       target.addIllegalDialect<cf::ControlFlowDialect>();
+
+      mlir::populateSCFToControlFlowConversionPatterns(stdPatterns);
 
       cf::populateControlFlowToLLVMConversionPatterns(typeConverter,
                                                       stdPatterns);

--- a/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QCToQIR.cpp
@@ -77,16 +77,14 @@ struct LoweringState : QIRMetadata {
   /// Map from register name to register start index
   DenseMap<StringRef, int64_t> registerStartIndexMap;
 
+  DenseMap<Operation*, SmallVector<Value>> controlMap;
+
   /// Map from index to pointer value for reuse
   DenseMap<std::pair<Operation*, int64_t>, Value> ptrMap;
 
   /// Map from (register_name, register_index) to result pointer
   /// This allows caching result pointers for measurements with register info
   DenseMap<std::tuple<Operation*, StringRef, int64_t>, Value> registerResultMap;
-
-  /// Modifier information
-  int64_t inCtrlOp = 0;
-  DenseMap<int64_t, SmallVector<Value>> posCtrls;
 };
 
 /**
@@ -117,6 +115,18 @@ private:
 
 } // namespace
 
+void collectCtrls(qc::CtrlOp op, LoweringState& state,
+                  SmallVector<Value> ctrls) {
+  ctrls.append(op.getControls().begin(), op.getControls().end());
+
+  for (auto& innerOp : op.getRegion().front()) {
+    state.controlMap[&innerOp] = ctrls;
+    if (auto nestedCtrl = dyn_cast<qc::CtrlOp>(innerOp)) {
+      collectCtrls(nestedCtrl, state, ctrls);
+    }
+  }
+}
+
 /**
  * @brief Helper to convert a QC operation to a LLVM CallOp
  *
@@ -139,9 +149,7 @@ convertUnitaryToCallOp(QCOpType& op, QCOpAdaptorType& adaptor,
                        LoweringState& state, StringRef fnName,
                        size_t numTargets, size_t numParams) {
   // Query state for modifier information
-  const auto inCtrlOp = state.inCtrlOp;
-  const SmallVector<Value> posCtrls =
-      inCtrlOp != 0 ? state.posCtrls[inCtrlOp] : SmallVector<Value>{};
+  const SmallVector<Value> posCtrls = state.controlMap.lookup(op);
   const size_t numCtrls = posCtrls.size();
 
   // Define argument types
@@ -172,14 +180,11 @@ convertUnitaryToCallOp(QCOpType& op, QCOpAdaptorType& adaptor,
 
   SmallVector<Value> operands;
   operands.reserve(numParams + numCtrls + numTargets);
-  operands.append(posCtrls.begin(), posCtrls.end());
-  operands.append(adaptor.getOperands().begin(), adaptor.getOperands().end());
-
-  // Clean up modifier information
-  if (inCtrlOp != 0) {
-    state.posCtrls.erase(inCtrlOp);
-    state.inCtrlOp--;
+  for (auto value : posCtrls) {
+    operands.push_back(rewriter.getRemappedValue(value));
   }
+  // operands.append(posCtrls.begin(), posCtrls.end());
+  operands.append(adaptor.getOperands().begin(), adaptor.getOperands().end());
 
   // Replace operation with CallOp
   rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, fnDecl, operands);
@@ -377,6 +382,20 @@ struct ConvertQCAllocQIR final : StatefulOpConversionPattern<AllocOp> {
   LogicalResult
   matchAndRewrite(AllocOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
+    auto* ctx = op.getContext();
+    // auto& state = getState();
+    // auto& ptrMap = state.ptrMap;
+    const auto ptrType = LLVM::LLVMPointerType::get(ctx);
+    const auto fnSignature = LLVM::LLVMFunctionType::get(
+        LLVM::LLVMPointerType::get(op.getContext()), {});
+    const auto fnDecl =
+        getOrCreateFunctionDeclaration(rewriter, op, QIR_ALLOC, fnSignature);
+    auto allocCall =
+        rewriter.create<LLVM::CallOp>(op->getLoc(), fnDecl, ValueRange{});
+    // rewriter.replaceAllUsesWith(op->getResults(), allocCall.getResults());
+    // rewriter.eraseOp(op);
+    rewriter.replaceOp(op, allocCall->getResults());
+    return success();
     auto& state = getState();
     const auto numQubits = static_cast<int64_t>(state.numQubits);
     auto& ptrMap = state.ptrMap;
@@ -436,6 +455,7 @@ struct ConvertQCAllocQIR final : StatefulOpConversionPattern<AllocOp> {
     }
     rewriter.replaceOp(op, val);
     state.numQubits++;
+    op->getParentOp()->dump();
     return success();
   }
 };
@@ -679,7 +699,7 @@ struct ConvertQCGPhaseOpQIR final : StatefulOpConversionPattern<GPhaseOp> {
   matchAndRewrite(GPhaseOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
     auto& state = getState();
-    if (state.inCtrlOp != 0) {
+    if (state.controlMap.contains(op)) {
       return op.emitError("Controlled GPhaseOps cannot be converted to QIR");
     }
     return convertUnitaryToCallOp(op, adaptor, rewriter, getContext(), state,
@@ -711,9 +731,7 @@ struct ConvertQCGPhaseOpQIR final : StatefulOpConversionPattern<GPhaseOp> {
     matchAndRewrite(OP_CLASS op, OpAdaptor adaptor,                            \
                     ConversionPatternRewriter& rewriter) const override {      \
       auto& state = getState();                                                \
-      const auto inCtrlOp = state.inCtrlOp;                                    \
-      const size_t numCtrls =                                                  \
-          inCtrlOp != 0 ? state.posCtrls[inCtrlOp].size() : 0;                 \
+      const size_t numCtrls = state.controlMap.lookup(op).size();              \
       const auto fnName = getFnName##OP_NAME_BIG(numCtrls);                    \
       return convertUnitaryToCallOp(op, adaptor, rewriter, getContext(),       \
                                     state, fnName, 1, 0);                      \
@@ -759,9 +777,7 @@ DEFINE_ONE_TARGET_ZERO_PARAMETER(SXdgOp, SXDG, sxdg, sxdg)
     matchAndRewrite(OP_CLASS op, OpAdaptor adaptor,                            \
                     ConversionPatternRewriter& rewriter) const override {      \
       auto& state = getState();                                                \
-      const auto inCtrlOp = state.inCtrlOp;                                    \
-      const size_t numCtrls =                                                  \
-          inCtrlOp != 0 ? state.posCtrls[inCtrlOp].size() : 0;                 \
+      const size_t numCtrls = state.controlMap.lookup(op).size();              \
       const auto fnName = getFnName##OP_NAME_BIG(numCtrls);                    \
       return convertUnitaryToCallOp(op, adaptor, rewriter, getContext(),       \
                                     state, fnName, 1, 1);                      \
@@ -800,9 +816,7 @@ DEFINE_ONE_TARGET_ONE_PARAMETER(POp, P, p, p, theta)
     matchAndRewrite(OP_CLASS op, OpAdaptor adaptor,                            \
                     ConversionPatternRewriter& rewriter) const override {      \
       auto& state = getState();                                                \
-      const auto inCtrlOp = state.inCtrlOp;                                    \
-      const size_t numCtrls =                                                  \
-          inCtrlOp != 0 ? state.posCtrls[inCtrlOp].size() : 0;                 \
+      const size_t numCtrls = state.controlMap.lookup(op).size();              \
       const auto fnName = getFnName##OP_NAME_BIG(numCtrls);                    \
       return convertUnitaryToCallOp(op, adaptor, rewriter, getContext(),       \
                                     state, fnName, 1, 2);                      \
@@ -839,9 +853,7 @@ DEFINE_ONE_TARGET_TWO_PARAMETER(U2Op, U2, u2, u2, phi, lambda)
     matchAndRewrite(OP_CLASS op, OpAdaptor adaptor,                            \
                     ConversionPatternRewriter& rewriter) const override {      \
       auto& state = getState();                                                \
-      const auto inCtrlOp = state.inCtrlOp;                                    \
-      const size_t numCtrls =                                                  \
-          inCtrlOp != 0 ? state.posCtrls[inCtrlOp].size() : 0;                 \
+      const size_t numCtrls = state.controlMap.lookup(op).size();              \
       const auto fnName = getFnName##OP_NAME_BIG(numCtrls);                    \
       return convertUnitaryToCallOp<OP_CLASS>(                                 \
           op, adaptor, rewriter, getContext(), state, fnName, 1, 3);           \
@@ -877,9 +889,7 @@ DEFINE_ONE_TARGET_THREE_PARAMETER(UOp, U, u, u3)
     matchAndRewrite(OP_CLASS op, OpAdaptor adaptor,                            \
                     ConversionPatternRewriter& rewriter) const override {      \
       auto& state = getState();                                                \
-      const auto inCtrlOp = state.inCtrlOp;                                    \
-      const size_t numCtrls =                                                  \
-          inCtrlOp != 0 ? state.posCtrls[inCtrlOp].size() : 0;                 \
+      const size_t numCtrls = state.controlMap.lookup(op).size();              \
       const auto fnName = getFnName##OP_NAME_BIG(numCtrls);                    \
       return convertUnitaryToCallOp(op, adaptor, rewriter, getContext(),       \
                                     state, fnName, 2, 0);                      \
@@ -918,9 +928,7 @@ DEFINE_TWO_TARGET_ZERO_PARAMETER(ECROp, ECR, ecr, ecr)
     matchAndRewrite(OP_CLASS op, OpAdaptor adaptor,                            \
                     ConversionPatternRewriter& rewriter) const override {      \
       auto& state = getState();                                                \
-      const auto inCtrlOp = state.inCtrlOp;                                    \
-      const size_t numCtrls =                                                  \
-          inCtrlOp != 0 ? state.posCtrls[inCtrlOp].size() : 0;                 \
+      const size_t numCtrls = state.controlMap.lookup(op).size();              \
       const auto fnName = getFnName##OP_NAME_BIG(numCtrls);                    \
       return convertUnitaryToCallOp(op, adaptor, rewriter, getContext(),       \
                                     state, fnName, 2, 1);                      \
@@ -960,9 +968,7 @@ DEFINE_TWO_TARGET_ONE_PARAMETER(RZZOp, RZZ, rzz, rzz, theta)
     matchAndRewrite(OP_CLASS op, OpAdaptor adaptor,                            \
                     ConversionPatternRewriter& rewriter) const override {      \
       auto& state = getState();                                                \
-      const auto inCtrlOp = state.inCtrlOp;                                    \
-      const size_t numCtrls =                                                  \
-          inCtrlOp != 0 ? state.posCtrls[inCtrlOp].size() : 0;                 \
+      const size_t numCtrls = state.controlMap.lookup(op).size();              \
       const auto fnName = getFnName##OP_NAME_BIG(numCtrls);                    \
       return convertUnitaryToCallOp(op, adaptor, rewriter, getContext(),       \
                                     state, fnName, 2, 2);                      \
@@ -1003,10 +1009,6 @@ struct ConvertQCCtrlQIR final : StatefulOpConversionPattern<CtrlOp> {
                   ConversionPatternRewriter& rewriter) const override {
     // Update modifier information
     auto& state = getState();
-    state.inCtrlOp++;
-    const SmallVector<Value> posCtrls(adaptor.getControls().begin(),
-                                      adaptor.getControls().end());
-    state.posCtrls[state.inCtrlOp] = posCtrls;
 
     // Inline region and remove operation
     rewriter.inlineBlockBefore(&op.getRegion().front(), op->getBlock(),
@@ -1330,7 +1332,6 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
 
       if (applyPartialConversion(moduleOp, target, std::move(funcPatterns))
               .failed()) {
-        moduleOp->dump();
         signalPassFailure();
         return;
       }
@@ -1348,12 +1349,15 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
     addInitialize(main, ctx);
 
     LoweringState state;
+    moduleOp->walk([&](qc::CtrlOp op) {
+      if (!op->getParentOfType<qc::CtrlOp>()) {
+        collectCtrls(op, state, {});
+      }
+    });
 
     // Stage 3: Convert QC dialect to LLVM (QIR calls)
     {
       RewritePatternSet qcPatterns(ctx);
-      target.addIllegalDialect<QCDialect>();
-
       // Add conversion patterns for QC operations
       qcPatterns.add<TensorFromElementsToLLVM>(typeConverter, ctx);
       qcPatterns.add<TensorExtractToLLVM>(typeConverter, ctx);
@@ -1395,6 +1399,8 @@ struct QCToQIR final : impl::QCToQIRBase<QCToQIR> {
       qcPatterns.add<ConvertQCBarrierQIR>(typeConverter, ctx, &state);
       qcPatterns.add<ConvertQCCtrlQIR>(typeConverter, ctx, &state);
       qcPatterns.add<ConvertQCYieldQIR>(typeConverter, ctx, &state);
+
+      target.addIllegalDialect<QCDialect>();
 
       if (applyPartialConversion(moduleOp, target, std::move(qcPatterns))
               .failed()) {

--- a/mlir/lib/Dialect/QCO/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCO/CMakeLists.txt
@@ -8,3 +8,4 @@
 
 add_subdirectory(Builder)
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
@@ -118,6 +118,34 @@ static void printTargetAliasing(OpAsmPrinter& printer, Operation* /*op*/,
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/QCO/IR/QCOOpsDialect.cpp.inc"
+#include "mlir/Transforms/InliningUtils.h"
+
+// Define the opt-in rules for inlining the qc dialect
+struct QCOInlinerInterface : public mlir::DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  // Tell MLIR that any operation from the qc dialect can be inlined
+  bool isLegalToInline(mlir::Operation* op, mlir::Region* dest,
+                       bool wouldBeCloned,
+                       mlir::IRMapping& valueMapping) const override {
+    return true;
+  }
+
+  // Tell MLIR that regions (like the inside of loops/ifs) in the qc dialect can
+  // be inlined
+  bool isLegalToInline(mlir::Region* dest, mlir::Region* src,
+                       bool wouldBeCloned,
+                       mlir::IRMapping& valueMapping) const override {
+    return true;
+  }
+
+  // Tell MLIR that it's safe to inline calls to functions containing qc
+  // operations
+  bool isLegalToInline(mlir::Operation* call, mlir::Operation* callable,
+                       bool wouldBeCloned) const override {
+    return true;
+  }
+};
 
 void QCODialect::initialize() {
   // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
@@ -132,6 +160,8 @@ void QCODialect::initialize() {
 #include "mlir/Dialect/QCO/IR/QCOOps.cpp.inc"
 
       >();
+
+  addInterface<QCOInlinerInterface>();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/QCO/IR/QubitManagement/DeallocOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QubitManagement/DeallocOp.cpp
@@ -34,6 +34,9 @@ struct RemoveAllocDeallocPair final : OpRewritePattern<DeallocOp> {
     if (!allocOp) {
       return failure();
     }
+    if (allocOp.getResult().getNumUses() > 1) {
+      return failure();
+    }
 
     // Remove the AllocOp and the DeallocOp
     rewriter.eraseOp(op);

--- a/mlir/lib/Dialect/QCO/Transforms/AncillaHoisting.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/AncillaHoisting.cpp
@@ -13,6 +13,7 @@
 //
 #include "mlir/Analysis/CallGraph.h" // <--- The specialization is defined here
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
 
 #include "llvm/ADT/SCCIterator.h" // <--- The iterator is defined here
 
@@ -38,10 +39,41 @@ using namespace mlir;
 
 mlir::qco::DeallocOp findDeallocForAlloc(mlir::qco::AllocOp alloc) {
   Value currentValue = alloc.getResult();
+  uint32_t currentIndexInTensor = 0;
+  bool isInTensor = false;
   while (currentValue) {
     if (!currentValue.hasOneUse()) {
-      // Multiple users, should not happen.
-      return nullptr;
+      if (isInTensor) {
+        for (auto* user : currentValue.getUsers()) {
+          if (auto extractOp = dyn_cast<mlir::tensor::ExtractOp>(user)) {
+            const auto operands = extractOp.getIndices();
+            if (operands.size() != 1) {
+              // Not a 1D tensor, should not happen.
+              return nullptr;
+            }
+            const auto indexValue = operands[0];
+            if (auto constIndex = dyn_cast<arith::ConstantIndexOp>(
+                    indexValue.getDefiningOp())) {
+              if (constIndex.value() == currentIndexInTensor) {
+                // Index does not match, should not happen.
+                currentValue = extractOp.getResult();
+                isInTensor = false;
+                break;
+              }
+            }
+          } else {
+            return nullptr;
+          }
+        }
+        if (isInTensor) {
+          // No extract found, should not happen.
+          return nullptr;
+        }
+        continue;
+      } else {
+        // Multiple users, should not happen.
+        return nullptr;
+      }
     }
     auto* user = *currentValue.getUsers().begin();
     if (auto deallocOp = dyn_cast<mlir::qco::DeallocOp>(user)) {
@@ -53,6 +85,32 @@ mlir::qco::DeallocOp findDeallocForAlloc(mlir::qco::AllocOp alloc) {
     }
     if (auto measureOp = dyn_cast<mlir::qco::MeasureOp>(user)) {
       currentValue = measureOp.getQubitOut();
+      continue;
+    }
+    if (auto resetOp = dyn_cast<mlir::qco::ResetOp>(user)) {
+      currentValue = resetOp.getQubitOut();
+      continue;
+    }
+    if (auto callOp = dyn_cast<mlir::func::CallOp>(user)) {
+      // TODO-Damian this only works if the indices are the same. Implement a
+      // helper function to get the index
+      for (auto i = 0ULL; i < user->getNumOperands(); i++) {
+        if (user->getOperand(i) == currentValue) {
+          currentValue = user->getResult(i);
+          break;
+        }
+      }
+      continue;
+    }
+    if (auto fromElementsOp = dyn_cast<mlir::tensor::FromElementsOp>(user)) {
+      for (auto i = 0ULL; i < user->getNumOperands(); i++) {
+        if (user->getOperand(i) == currentValue) {
+          currentIndexInTensor = i;
+          isInTensor = true;
+          break;
+        }
+      }
+      currentValue = fromElementsOp.getResult();
       continue;
     }
     if (user->getNumResults() != 1) {
@@ -200,6 +258,13 @@ void runAncillaHoisting(ModuleOp module, SymbolTable& symbolTable) {
 
   for (auto& func : hoistingCandidates) {
     tryAncillaHoisting(func, symbolTable);
+
+    RewritePatternSet patterns(module.getContext());
+    populateReuseQubitsPatterns(patterns);
+    if (!applyPatternsGreedily(module, std::move(patterns)).succeeded()) {
+      throw std::runtime_error(
+          "Failed to apply reuse qubits patterns after ancilla hoisting.");
+    }
   }
 }
 

--- a/mlir/lib/Dialect/QCO/Transforms/AncillaHoisting.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/AncillaHoisting.cpp
@@ -201,7 +201,6 @@ void runAncillaHoisting(ModuleOp module, SymbolTable& symbolTable) {
   for (auto& func : hoistingCandidates) {
     tryAncillaHoisting(func, symbolTable);
   }
-  symbolTable.lookup("main")->dump();
 }
 
 } // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Transforms/AncillaHoisting.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/AncillaHoisting.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+//
+// Created by damian on 2/10/26.
+//
+#include "mlir/Analysis/CallGraph.h" // <--- The specialization is defined here
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+
+#include "llvm/ADT/SCCIterator.h" // <--- The iterator is defined here
+
+#include <array>
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace {
+using namespace mlir;
+
+mlir::qco::DeallocOp findDeallocForAlloc(mlir::qco::AllocOp alloc) {
+  Value currentValue = alloc.getResult();
+  while (currentValue) {
+    if (!currentValue.hasOneUse()) {
+      // Multiple users, should not happen.
+      return nullptr;
+    }
+    auto* user = *currentValue.getUsers().begin();
+    if (auto deallocOp = dyn_cast<mlir::qco::DeallocOp>(user)) {
+      return deallocOp;
+    }
+    if (auto unitaryOp = dyn_cast<mlir::qco::UnitaryOpInterface>(user)) {
+      currentValue = unitaryOp.getOutputForInput(currentValue);
+      continue;
+    }
+    if (auto measureOp = dyn_cast<mlir::qco::MeasureOp>(user)) {
+      currentValue = measureOp.getQubitOut();
+      continue;
+    }
+    if (user->getNumResults() != 1) {
+      // Multiple results, should not happen.
+      return nullptr;
+    }
+    currentValue = user->getResult(0);
+  }
+  return nullptr;
+}
+
+bool isRecursiveHelper(CallGraphNode* current, CallGraphNode* target,
+                       llvm::DenseSet<CallGraphNode*>& visited) {
+  if (!visited.insert(current).second)
+    return false; // Already visited
+
+  for (auto& edge : *current) {
+    CallGraphNode* callee = edge.getTarget();
+    if (callee == target)
+      return true;
+    if (isRecursiveHelper(callee, target, visited))
+      return true;
+  }
+
+  return false;
+}
+
+bool isRecursive(CallGraph& cg, func::FuncOp func) {
+  CallGraphNode* node = cg.lookupNode(func.getCallableRegion());
+  if (!node)
+    return false;
+
+  llvm::DenseSet<CallGraphNode*> visited;
+  // Start from the function's callees to avoid immediately returning true
+  for (auto& edge : *node) {
+    if (isRecursiveHelper(edge.getTarget(), node, visited))
+      return true;
+  }
+
+  return false;
+}
+
+void tryAncillaHoisting(func::FuncOp funcOp, SymbolTable& symbolTable) {
+  funcOp.walk([&](mlir::qco::AllocOp allocOp) {
+    if (allocOp->getBlock()->getParentOp() != funcOp) {
+      // Not directly in the function body, skip.
+      return;
+    }
+
+    auto dealloc = findDeallocForAlloc(allocOp);
+
+    if (!dealloc) {
+      // No matching dealloc found, skip.
+      return;
+    }
+
+    // Add a block argument for the ancilla qubit.
+    OpBuilder builder(dealloc);
+    auto block = allocOp->getBlock();
+    auto loc = allocOp.getLoc();
+    auto qubitType = allocOp.getType();
+    auto newArg = block->addArgument(qubitType, loc);
+
+    // Replace all uses of the alloc with the new block argument.
+    allocOp.replaceAllUsesWith(newArg);
+
+    // Erase the original alloc operation.
+    allocOp.erase();
+
+    // Replace the dealloc with a reset
+    builder.setInsertionPoint(dealloc);
+    auto resetOp = builder.create<mlir::qco::ResetOp>(dealloc.getLoc(),
+                                                      dealloc.getQubit());
+    dealloc.erase();
+
+    // Add reset outcome to function results and alloc to function arguments
+    auto funcType = funcOp.getFunctionType();
+    SmallVector<Type> newArgTypes(funcType.getInputs().begin(),
+                                  funcType.getInputs().end());
+    SmallVector<Type> newResultTypes(funcType.getResults().begin(),
+                                     funcType.getResults().end());
+    newArgTypes.push_back(newArg.getType());
+    newResultTypes.push_back(resetOp.getResult().getType());
+    auto newFuncType =
+        FunctionType::get(funcOp.getContext(), newArgTypes, newResultTypes);
+    funcOp.setType(newFuncType);
+
+    // Also add reset outcome to return
+    funcOp.walk([&](func::ReturnOp returnOp) {
+      OpBuilder returnBuilder(returnOp);
+      SmallVector<Value> newReturnValues(returnOp.getOperands().begin(),
+                                         returnOp.getOperands().end());
+      newReturnValues.push_back(resetOp.getResult());
+      returnBuilder.create<func::ReturnOp>(returnOp.getLoc(), newReturnValues);
+      returnOp.erase();
+    });
+
+    // Update all call sites to handle the new return value
+    // We use the SymbolTable to find all calls to this function
+    if (auto uses = symbolTable.getSymbolUses(funcOp, funcOp->getParentOp())) {
+      for (auto use : *uses) {
+        if (auto callOp = dyn_cast<func::CallOp>(use.getUser())) {
+          builder.setInsertionPoint(callOp);
+
+          // A. Add new alloc
+          auto newAlloc = builder.create<mlir::qco::AllocOp>(loc);
+
+          // B. Create New Call
+          SmallVector<Value> newCallOperands =
+              llvm::to_vector(callOp.getOperands());
+          newCallOperands.push_back(newAlloc);
+          auto newCall =
+              builder.create<func::CallOp>(loc, funcOp, newCallOperands);
+
+          // C. Add dealloc after call
+          builder.create<mlir::qco::DeallocOp>(
+              loc, newCall.getResult(newCall.getNumResults() - 1));
+          for (unsigned i = 0; i < callOp.getNumResults(); ++i) {
+            callOp.getResult(i).replaceAllUsesWith(newCall.getResult(i));
+          }
+          callOp.erase();
+        }
+      }
+    }
+  });
+}
+
+}; // end anonymous namespace
+
+namespace mlir::qco {
+
+void runAncillaHoisting(ModuleOp module, SymbolTable& symbolTable) {
+  SmallVector<func::FuncOp> hoistingCandidates;
+  mlir::CallGraph callGraph(module);
+
+  module.walk([&](func::FuncOp func) {
+    if (func.isPublic() || func.isDeclaration()) {
+      return;
+    }
+    if (isRecursive(callGraph, func)) {
+      return;
+    }
+    hoistingCandidates.push_back(func);
+  });
+
+  for (auto& func : hoistingCandidates) {
+    tryAncillaHoisting(func, symbolTable);
+  }
+  symbolTable.lookup("main")->dump();
+}
+
+} // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
-# Copyright (c) 2025 Munich Quantum Software Company GmbH
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
 # All rights reserved.
 #
 # SPDX-License-Identifier: MIT

--- a/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
@@ -19,9 +19,9 @@ add_mlir_library(MLIRQCOTransforms ${TRANSFORMS_SOURCES} LINK_LIBS ${LIBRARIES} 
 
 # collect header files
 file(GLOB_RECURSE TRANSFORMS_HEADERS_SOURCE
-  ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Dialect/QCO/Transforms/*.h)
+     ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Dialect/QCO/Transforms/*.h)
 file(GLOB_RECURSE TRANSFORMS_HEADERS_BUILD
-  ${MQT_MLIR_BUILD_INCLUDE_DIR}/mlir/Dialect/QCO/Transforms/*.inc)
+     ${MQT_MLIR_BUILD_INCLUDE_DIR}/mlir/Dialect/QCO/Transforms/*.inc)
 
 # add public headers using file sets
 target_sources(

--- a/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+# Copyright (c) 2025 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+set(LIBRARIES ${dialect_libs} MQT::CoreIR)
+add_compile_options(-fexceptions)
+
+message(STATUS "MLIR_DIALECT_LIBS contains: ${dialect_libs}")
+
+file(GLOB_RECURSE TRANSFORMS_SOURCES *.cpp)
+
+add_mlir_library(MLIRQCOTransforms ${TRANSFORMS_SOURCES} LINK_LIBS ${LIBRARIES} DEPENDS
+                 MLIRQCOTransformsIncGen)
+
+# collect header files
+file(GLOB_RECURSE TRANSFORMS_HEADERS_SOURCE
+  ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Dialect/QCO/Transforms/*.h)
+file(GLOB_RECURSE TRANSFORMS_HEADERS_BUILD
+  ${MQT_MLIR_BUILD_INCLUDE_DIR}/mlir/Dialect/QCO/Transforms/*.inc)
+
+# add public headers using file sets
+target_sources(
+  MLIRQCOTransforms
+  PUBLIC FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_SOURCE_INCLUDE_DIR}
+         FILES
+         ${TRANSFORMS_HEADERS_SOURCE}
+         FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${MQT_MLIR_BUILD_INCLUDE_DIR}
+         FILES
+         ${TRANSFORMS_HEADERS_BUILD})

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumArgumentPromotion.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumArgumentPromotion.cpp
@@ -80,6 +80,10 @@ static tensor::InsertOp findInsertForExtract(tensor::ExtractOp extract) {
       currentVal = unitaryOp.getOutputForInput(currentVal);
       continue;
     }
+    if (auto measureOp = dyn_cast<mlir::qco::MeasureOp>(user)) {
+      currentVal = measureOp.getQubitOut();
+      continue;
+    }
     if (user->getNumResults() != 1) {
       // Multiple results, should not happen.
       return nullptr;

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumArgumentPromotion.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumArgumentPromotion.cpp
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/**
+ * @brief This pass performs quantum inter-procedural optimizations (IPO).
+ */
+
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+
+#include <algorithm>
+#include <array>
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace {
+
+using namespace mlir;
+
+static bool areInsertExtractRelated(tensor::ExtractOp extract,
+                                    tensor::InsertOp insert) {
+  auto current = insert.getDest();
+  while (current) {
+    auto users = current.getUsers();
+    for (const auto user : users) {
+      if (user == extract) {
+        return true;
+      }
+    }
+    auto* def = current.getDefiningOp();
+    if (!def) {
+      return false;
+    }
+    if (auto insertOp = dyn_cast<tensor::InsertOp>(def)) {
+      current = insertOp.getDest();
+    } else {
+      return false;
+    }
+  }
+  return false;
+}
+
+static tensor::InsertOp findInsertForExtract(tensor::ExtractOp extract) {
+  auto currentVal = extract.getResult();
+  while (currentVal) {
+    if (!currentVal.hasOneUse()) {
+      // Multiple users, should not happen.
+      return nullptr;
+    }
+    auto* user = *currentVal.getUsers().begin();
+    if (auto insertOp = dyn_cast<tensor::InsertOp>(user)) {
+      const auto indexValue = insertOp.getIndices()[0];
+      if (auto constIndex =
+              dyn_cast<arith::ConstantIndexOp>(indexValue.getDefiningOp())) {
+        return insertOp;
+      }
+      return nullptr;
+    }
+    if (auto unitaryOp = dyn_cast<qco::UnitaryOpInterface>(user)) {
+      currentVal = unitaryOp.getOutputForInput(currentVal);
+      continue;
+    }
+    if (user->getNumResults() != 1) {
+      // Multiple results, should not happen.
+      return nullptr;
+    }
+    currentVal = user->getResult(0);
+  }
+  return nullptr;
+}
+
+static SmallVector<std::pair<int64_t, int64_t>>
+canPromoteArgument(BlockArgument arg) {
+  const auto tensorType = dyn_cast<RankedTensorType>(arg.getType());
+  if (!tensorType) {
+    return {};
+  }
+
+  SmallVector<std::pair<int64_t, int64_t>> usedIndices;
+  for (auto* user : arg.getUsers()) {
+    if (auto extractOp = dyn_cast<tensor::ExtractOp>(user)) {
+      if (extractOp.getIndices().size() != 1) {
+        return {};
+      }
+      auto insertOp = findInsertForExtract(extractOp);
+      if (!insertOp) {
+        return {};
+      }
+      if (!areInsertExtractRelated(extractOp, insertOp)) {
+        return {};
+      }
+      auto extractIndexValue = extractOp.getIndices()[0];
+      auto insertIndex = dyn_cast<arith::ConstantIndexOp>(
+                             insertOp.getIndices()[0].getDefiningOp())
+                             .value();
+      if (auto constExtractIndex = dyn_cast<arith::ConstantIndexOp>(
+              extractIndexValue.getDefiningOp())) {
+        usedIndices.emplace_back(constExtractIndex.value(), insertIndex);
+      } else {
+        return {};
+      }
+    } else {
+      if (!isa<tensor::InsertOp>(user)) {
+        return {};
+      }
+    }
+  }
+
+  if (usedIndices.empty()) {
+    return {};
+  }
+  return usedIndices;
+}
+
+void promoteArgument(BlockArgument arg,
+                     SmallVector<std::pair<int64_t, int64_t>> indexMap,
+                     SymbolTable& symTable) {
+  // We know some pre-conditions for this method to be executed:
+  //   - `arg` is a tensor type
+  //   - All users of `arg` are either `tensor::ExtractOp` or `tensor::InsertOp`
+  //   - All values extracted from `arg` are later on once again inserted into
+  //   it
+  //     - The insertion indices do not necessarily map to the extraction
+  //     indices.
+  //     - `indexMap` provides the mapping from extraction index to insertion
+  //     index.
+  //   - At least one entry of the vector is not used (and does not appear in
+  //   the `indexMap`.
+  // 1. Get Context and Function
+  // Fix: BlockArgs belong to a Block, not an Op. Get the block's parent Op.
+  Block* entryBlock = arg.getOwner();
+  auto funcOp = dyn_cast<func::FuncOp>(entryBlock->getParentOp());
+  if (!funcOp)
+    return; // Should not happen if arg is a func argument
+
+  OpBuilder builder(funcOp);
+  MLIRContext* ctx = funcOp.getContext();
+  const unsigned argIndex = arg.getArgNumber();
+  const auto loc = arg.getLoc();
+
+  // Determine the Scalar Type (QubitType)
+  // Assuming the input tensor contains the QubitType
+  auto tensorType = dyn_cast<RankedTensorType>(arg.getType());
+  const auto qubitType = tensorType.getElementType();
+
+  // ====================================================
+  // 2. Update Function Signature
+  // ====================================================
+
+  // A. Input Types
+  SmallVector<Type> newArgTypes = llvm::to_vector(funcOp.getArgumentTypes());
+
+  // Remove the old tensor argument
+  newArgTypes.erase(newArgTypes.begin() + argIndex);
+
+  // Insert N new scalar arguments
+  for (size_t i = 0; i < indexMap.size(); ++i) {
+    newArgTypes.insert(newArgTypes.begin() + argIndex + i, qubitType);
+  }
+
+  // B. Result Types
+  // (We assume the function returns the modified tensor, which must also be
+  // split)
+  SmallVector<Type> newResultTypes = llvm::to_vector(funcOp.getResultTypes());
+
+  // Find which result corresponds to our tensor.
+  // For simplicity, we assume the function has 1 result which is this tensor.
+  // In a complex case, you'd trace the return op operands.
+  const int resultIndexToReplace = 0; // TODO
+  if (!newResultTypes.empty() && newResultTypes[0] == tensorType) {
+    newResultTypes.erase(newResultTypes.begin() + resultIndexToReplace);
+    for (size_t i = 0; i < indexMap.size(); ++i) {
+      newResultTypes.insert(newResultTypes.begin() + resultIndexToReplace + i,
+                            qubitType);
+    }
+  }
+
+  // Set the new function type
+  auto newFuncType = FunctionType::get(ctx, newArgTypes, newResultTypes);
+  funcOp.setFunctionType(newFuncType);
+
+  // ====================================================
+  // 3. Update Entry Block Arguments
+  // ====================================================
+
+  // Create the new scalar arguments in the block
+  SmallVector<Value> newArgs;
+  for (size_t i = 0; i < indexMap.size(); ++i) {
+    // Insert after the original arg to keep indices stable for a moment
+    BlockArgument newArg =
+        entryBlock->insertArgument(argIndex + i + 1, qubitType, loc);
+    newArgs.push_back(newArg);
+  }
+
+  // Map: Extraction Index -> New Block Argument
+  DenseMap<int64_t, Value> extractToArgMap;
+  for (size_t i = 0; i < indexMap.size(); ++i) {
+    extractToArgMap[indexMap[i].first] = newArgs[i];
+  }
+
+  // ====================================================
+  // 4. Rewrite Body (Extracts & Inserts)
+  // ====================================================
+
+  // We need to collect "Insert" values to update the ReturnOp later.
+  // Map: Insertion Index -> Value to Return
+  DenseMap<int64_t, Value> insertToRetMap;
+
+  // We cannot iterate safely while modifying, so collect users first.
+  // Note: We only look at direct users of the argument for Extracts,
+  // but we might need to follow the chain for Inserts.
+  llvm::SmallVector<Operation*> users(arg.getUsers());
+
+  for (Operation* user : users) {
+    // --- Handle Extracts ---
+    if (auto extractOp = dyn_cast<tensor::ExtractOp>(user)) {
+      // Check if indices are constant
+      int64_t idx = -1;
+      if (auto cst = getConstantIntValue(extractOp.getIndices().front())) {
+        idx = *cst;
+      }
+
+      // If this index is in our map, replace the extract op
+      if (extractToArgMap.count(idx)) {
+        extractOp.replaceAllUsesWith(extractToArgMap[idx]);
+        extractOp.erase();
+      }
+      continue;
+    }
+
+    // --- Handle Inserts (Chain collection) ---
+    // If the argument is the 'dest' of an insert, it starts a chain.
+    if (auto insertOp = dyn_cast<tensor::InsertOp>(user)) {
+      if (insertOp.getDest() == arg) {
+        // This is the start of the insertion chain.
+        // We walk down the chain of inserts to find all scalar values.
+        Operation* current = insertOp;
+        while (auto currentInsert =
+                   dyn_cast_or_null<tensor::InsertOp>(current)) {
+
+          // Get the scalar value being inserted
+          Value scalarVal = currentInsert.getScalar();
+
+          // Get the index
+          if (auto cst =
+                  getConstantIntValue(currentInsert.getIndices().front())) {
+            insertToRetMap[*cst] = scalarVal;
+          }
+
+          // Move to the next user of this insert's result
+          Value result = currentInsert.getResult();
+          if (result.hasOneUse()) {
+            current = *result.getUsers().begin();
+          } else {
+            // If used by ReturnOp, we stop.
+            if (!result.getUsers().empty() &&
+                isa<func::ReturnOp>(*result.getUsers().begin()))
+              break;
+            current = nullptr;
+          }
+
+          // Mark the insert to be erased (it's no longer needed)
+          // We can't erase immediately while walking, so we mark/defer or rely
+          // on DCE. For now, we leave it; it will become dead code when we
+          // update the ReturnOp.
+        }
+      }
+    }
+  }
+
+  // ====================================================
+  // 5. Update Return Op
+  // ====================================================
+
+  Operation* terminator = entryBlock->getTerminator();
+  if (auto returnOp = dyn_cast<func::ReturnOp>(terminator)) {
+    SmallVector<Value> newReturns = llvm::to_vector(returnOp.getOperands());
+
+    // Remove the old tensor return
+    newReturns.erase(newReturns.begin() + resultIndexToReplace);
+
+    // Insert the new scalar returns based on the Insertion Map
+    for (size_t i = 0; i < indexMap.size(); ++i) {
+      int64_t requiredInsertIdx = indexMap[i].second;
+
+      // We must have found a value for this index, or the logic is broken
+      // (or we default to passing through the input arg if unchanged?)
+      Value retVal = insertToRetMap[requiredInsertIdx];
+
+      // Fallback: If no insert touched this index, it means the value is
+      // unchanged. We pass the input argument directly to the output.
+      if (!retVal) {
+        retVal = extractToArgMap[indexMap[i].first];
+      }
+
+      newReturns.insert(newReturns.begin() + resultIndexToReplace + i, retVal);
+    }
+    returnOp->setOperands(newReturns);
+  }
+
+  // Clean up the original argument
+  const auto eraseRecursively = [](auto&& self, Operation* op) -> void {
+    for (auto user : op->getUsers()) {
+      self(self, user);
+    }
+    op->erase();
+  };
+  for (auto user : entryBlock->getArgument(argIndex).getUsers()) {
+    eraseRecursively(eraseRecursively, user);
+  }
+  entryBlock->eraseArgument(argIndex);
+
+  // ====================================================
+  // 6. Update Call Sites
+  // ====================================================
+
+  // We use the SymbolTable to find all calls to this function
+  if (auto uses = symTable.getSymbolUses(funcOp, funcOp->getParentOp())) {
+    for (auto use : *uses) {
+      if (auto callOp = dyn_cast<func::CallOp>(use.getUser())) {
+        builder.setInsertionPoint(callOp);
+
+        // A. Prepare New Operands (Caller side extraction)
+        SmallVector<Value> newCallOperands =
+            llvm::to_vector(callOp.getOperands());
+        Value originalTensorInput = newCallOperands[argIndex];
+
+        // Remove old tensor operand
+        newCallOperands.erase(newCallOperands.begin() + argIndex);
+
+        // Add new extracted operands
+        SmallVector<Value> extractedScalars;
+        for (size_t i = 0; i < indexMap.size(); ++i) {
+          int64_t idx = indexMap[i].first;
+          Value idxVal = builder.create<arith::ConstantIndexOp>(loc, idx);
+          Value scalar = builder.create<tensor::ExtractOp>(
+              loc, originalTensorInput, idxVal);
+
+          extractedScalars.push_back(scalar);
+          newCallOperands.insert(newCallOperands.begin() + argIndex + i,
+                                 scalar);
+        }
+
+        // B. Create New Call
+        auto newCall =
+            builder.create<func::CallOp>(loc, funcOp, newCallOperands);
+
+        // C. Reconstruct Tensor (Caller side insertion)
+        // We take the existing tensor (originalTensorInput) or a fresh init?
+        // Usually, in SROA, we are updating the tensor.
+        Value reconstructedTensor = originalTensorInput;
+
+        // The new call returns N scalars. We insert them back.
+        for (size_t i = 0; i < indexMap.size(); ++i) {
+          int64_t idx = indexMap[i].second;
+          Value scalarResult = newCall.getResult(resultIndexToReplace + i);
+          Value idxVal = builder.create<arith::ConstantIndexOp>(loc, idx);
+
+          reconstructedTensor = builder.create<tensor::InsertOp>(
+              loc, scalarResult, reconstructedTensor, idxVal);
+        }
+
+        // D. Replace users of the old call result
+        callOp.getResult(resultIndexToReplace)
+            .replaceAllUsesWith(reconstructedTensor);
+        callOp.erase();
+      }
+    }
+  }
+}
+} // namespace
+
+namespace mlir::qco {
+
+void runQuantumArgumentPromotion(ModuleOp module, SymbolTable& symbolTable) {
+  std::vector<
+      std::pair<BlockArgument, SmallVector<std::pair<int64_t, int64_t>>>>
+      argsToPromote;
+
+  module.walk([&](func::FuncOp func) {
+    if (func.isPublic() || func.isDeclaration()) {
+      return;
+    }
+    for (auto arg : func.getArguments()) {
+      auto usedIndices = canPromoteArgument(arg);
+      if (!usedIndices.empty()) {
+        argsToPromote.emplace_back(arg, usedIndices);
+      }
+    }
+  });
+
+  for (auto& arg : argsToPromote) {
+    promoteArgument(arg.first, arg.second, symbolTable);
+  }
+}
+
+} // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumFunctionBoundaryCommutation.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumFunctionBoundaryCommutation.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+//
+// Created by damian on 2/10/26.
+//
+#include "mlir/Analysis/CallGraph.h" // <--- The specialization is defined here
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+
+#include "llvm/ADT/SCCIterator.h" // <--- The iterator is defined here
+
+#include <array>
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace {
+using namespace mlir;
+
+mlir::func::FuncOp copyFunction(mlir::func::FuncOp funcOp,
+                                mlir::StringRef newName) {
+  OpBuilder builder(funcOp);
+  builder.setInsertionPointAfter(funcOp);
+
+  auto newFunc = funcOp.clone();
+  newFunc.setName(newName.str());
+
+  return newFunc;
+}
+
+bool doOpsCancel(qco::UnitaryOpInterface first,
+                 qco::UnitaryOpInterface second) {
+  // For now, let's just consider self-inverses and single-qubit, non-controlled
+  // gates.
+  if (first.getOperation()->getName() != second.getOperation()->getName()) {
+    return false;
+  }
+  if (first.getNumQubits() != 1 || second.getNumQubits() != 1) {
+    return false;
+  }
+  if (isa<qco::XOp, qco::YOp, qco::ZOp, qco::HOp>(first)) {
+    return true;
+  }
+  return false;
+}
+
+void tryBoundaryCommutation(func::CallOp call, SymbolTable& symbolTable,
+                            uint32_t parameter) {
+  auto calleeName = call.getCallee();
+  auto funcOp = symbolTable.lookup<func::FuncOp>(calleeName);
+
+  if (!funcOp || funcOp.isExternal()) {
+    return;
+  }
+
+  auto argOutside = call.getArgOperands()[parameter];
+  auto argInside = funcOp.getArgument(parameter);
+
+  if (!argInside.hasOneUse()) {
+    return;
+  }
+
+  auto lastOp = dyn_cast<qco::UnitaryOpInterface>(argOutside.getDefiningOp());
+  auto nextOp =
+      dyn_cast<qco::UnitaryOpInterface>(*argInside.getUsers().begin());
+
+  if (!lastOp || !nextOp) {
+    return;
+  }
+
+  if (!doOpsCancel(lastOp, nextOp)) {
+    return;
+  }
+  argOutside.replaceAllUsesWith(lastOp.getInputQubit(0));
+  lastOp.erase();
+
+  auto newFunc = copyFunction(funcOp, funcOp.getName().str() +
+                                          "_spec_boundary_commutation");
+  symbolTable.insert(newFunc);
+
+  auto newParameter = newFunc.getArgument(parameter);
+  auto newUser =
+      mlir::dyn_cast<qco::UnitaryOpInterface>(*newParameter.getUsers().begin());
+
+  for (auto i = 0U; i < newUser.getNumQubits(); ++i) {
+    newUser.getOutputQubit(i).replaceAllUsesWith(newUser.getInputQubit(i));
+  }
+  newUser.erase();
+
+  call.setCallee(newFunc.getName());
+}
+
+}; // end anonymous namespace
+
+namespace mlir::qco {
+
+void runQuantumFunctionBoundaryCommutation(ModuleOp module,
+                                           SymbolTable& symbolTable) {
+  module.walk([&](func::CallOp call) {
+    for (uint32_t i = 0; i < call.getArgOperands().size(); ++i) {
+      const auto arg = call.getArgOperands()[i];
+      if (!isa<qco::QubitType>(arg.getType())) {
+        continue;
+      }
+      tryBoundaryCommutation(call, symbolTable, i);
+    }
+  });
+}
+
+} // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumFunctionBoundaryCommutation.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumFunctionBoundaryCommutation.cpp
@@ -78,6 +78,9 @@ void tryBoundaryCommutation(func::CallOp call, SymbolTable& symbolTable,
   if (!argInside.hasOneUse()) {
     return;
   }
+  if (argOutside.getDefiningOp() == nullptr) {
+    return;
+  }
 
   auto lastOp = dyn_cast<qco::UnitaryOpInterface>(argOutside.getDefiningOp());
   auto nextOp =

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumFunctionBoundaryCommutation.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumFunctionBoundaryCommutation.cpp
@@ -63,8 +63,9 @@ bool doOpsCancel(qco::UnitaryOpInterface first,
   return false;
 }
 
-void tryBoundaryCommutation(func::CallOp call, SymbolTable& symbolTable,
-                            uint32_t parameter) {
+void tryBoundaryCommutation(
+    func::CallOp call, SymbolTable& symbolTable, uint32_t parameter,
+    std::unordered_map<std::string, func::FuncOp>& previousSpecializations) {
   auto calleeName = call.getCallee();
   auto funcOp = symbolTable.lookup<func::FuncOp>(calleeName);
 
@@ -96,6 +97,11 @@ void tryBoundaryCommutation(func::CallOp call, SymbolTable& symbolTable,
   argOutside.replaceAllUsesWith(lastOp.getInputQubit(0));
   lastOp.erase();
 
+  if (previousSpecializations.contains(funcOp.getName().str())) {
+    call.setCallee(previousSpecializations[funcOp.getName().str()].getName());
+    return;
+  }
+
   auto newFunc = copyFunction(funcOp, funcOp.getName().str() +
                                           "_spec_boundary_commutation");
   symbolTable.insert(newFunc);
@@ -108,6 +114,7 @@ void tryBoundaryCommutation(func::CallOp call, SymbolTable& symbolTable,
     newUser.getOutputQubit(i).replaceAllUsesWith(newUser.getInputQubit(i));
   }
   newUser.erase();
+  previousSpecializations[funcOp.getName().str()] = newFunc;
 
   call.setCallee(newFunc.getName());
 }
@@ -118,13 +125,14 @@ namespace mlir::qco {
 
 void runQuantumFunctionBoundaryCommutation(ModuleOp module,
                                            SymbolTable& symbolTable) {
+  std::unordered_map<std::string, func::FuncOp> previousSpecializations;
   module.walk([&](func::CallOp call) {
     for (uint32_t i = 0; i < call.getArgOperands().size(); ++i) {
       const auto arg = call.getArgOperands()[i];
       if (!isa<qco::QubitType>(arg.getType())) {
         continue;
       }
-      tryBoundaryCommutation(call, symbolTable, i);
+      tryBoundaryCommutation(call, symbolTable, i, previousSpecializations);
     }
   });
 }

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+//
+// Created by damian on 1/21/26.
+//
+
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+
+#include <algorithm>
+#include <array>
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace {
+void updateSpecializedCall(mlir::func::CallOp callOp,
+                           mlir::func::FuncOp newCallee,
+                           mlir::PatternRewriter& rewriter) {
+  rewriter.modifyOpInPlace(callOp,
+                           [&] { callOp.setCallee(newCallee.getName()); });
+}
+
+mlir::func::FuncOp copyFunction(mlir::func::FuncOp funcOp,
+                                mlir::StringRef newName,
+                                mlir::PatternRewriter& rewriter) {
+  const mlir::OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointAfter(funcOp);
+
+  auto newFunc = funcOp.clone();
+
+  rewriter.modifyOpInPlace(newFunc, [&] { newFunc.setName(newName.str()); });
+
+  return newFunc;
+}
+
+} // end anonymous namespace
+
+namespace mlir::qco {
+
+#define GEN_PASS_DEF_QUANTUMIPO
+#include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
+
+/**
+ * @brief This pattern attempts to perform context-sensitive specialization.
+ */
+struct ContextSensitiveSpecializationPattern final
+    : mlir::OpRewritePattern<func::CallOp> {
+
+  SymbolTable& symbolTable;
+
+  constexpr static const auto ANGLES_TO_SPECIALIZE =
+      std::array<double, 5>{0.0, M_PI, M_PI_2, M_PI_2 + M_PI, 2 * M_PI};
+
+  static bool operationIsNopOnZero(mlir::Operation* op) {
+    return mlir::isa<qco::CtrlOp>(op) || mlir::isa<qco::ZOp>(op) ||
+           mlir::isa<qco::SOp>(op) ||
+           mlir::isa<qco::ResetOp>(op); // TODO more ops?
+  }
+
+  static bool operationIsNopOnPlus(mlir::Operation* op) {
+    return mlir::isa<qco::XOp>(op);
+  }
+
+  explicit ContextSensitiveSpecializationPattern(mlir::MLIRContext* context,
+                                                 SymbolTable& symbolTable)
+      : OpRewritePattern(context), symbolTable(symbolTable) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(func::CallOp callOp,
+                  mlir::PatternRewriter& rewriter) const override {
+    auto found = false;
+    for (auto i = 0U; i < callOp.getArgOperands().size(); ++i) {
+      if (trySpecialize(callOp, i, rewriter)) {
+        found = true;
+      }
+    }
+    return mlir::LogicalResult::success(found);
+  }
+
+  bool trySpecialize(func::CallOp callOp, unsigned operand,
+                     mlir::PatternRewriter& rewriter) const {
+    const auto argValue = callOp.getArgOperands()[operand];
+
+    auto calleeName = callOp.getCallee();
+    auto funcOp = symbolTable.lookup<func::FuncOp>(calleeName);
+
+    if (!funcOp || funcOp.isExternal()) {
+      return false;
+    }
+
+    auto* definingOp = argValue.getDefiningOp();
+    if (argValue.getType() == qco::QubitType::get(rewriter.getContext())) {
+      // CSS for qubit types.
+      if (mlir::isa<qco::AllocOp>(definingOp) ||
+          mlir::isa<qco::ResetOp>(definingOp)) {
+        return trySpecializeZero(callOp, funcOp, operand, rewriter);
+      }
+      if (mlir::isa<qco::HOp>(definingOp)) {
+        const auto* precedingOp = definingOp->getOperand(0).getDefiningOp();
+        if (precedingOp && (mlir::isa<qco::AllocOp>(precedingOp) ||
+                            mlir::isa<qco::ResetOp>(precedingOp))) {
+          return trySpecializePlus(callOp, funcOp, operand, rewriter);
+        }
+      }
+    }
+    if (argValue.getType() == mlir::Float64Type::get(rewriter.getContext())) {
+      // CSS for double types.
+      if (mlir::isa<arith::ConstantOp>(definingOp)) {
+        auto constOp = mlir::cast<arith::ConstantOp>(definingOp);
+        return trySpecializeRotationArguments(
+            callOp, funcOp,
+            mlir::cast<mlir::FloatAttr>(constOp.getValue()).getValueAsDouble(),
+            operand, rewriter);
+        // TODO we still need a canonicalization for this(?)
+      }
+    }
+
+    return false;
+  }
+
+  bool trySpecializeZero(func::CallOp callOp, func::FuncOp funcOp,
+                         unsigned operand,
+                         mlir::PatternRewriter& rewriter) const {
+    auto parameter = funcOp.getArgument(operand);
+    if (!parameter.hasOneUse()) {
+      return false;
+    }
+    if (!operationIsNopOnZero(*parameter.getUsers().begin())) {
+      return false;
+    }
+
+    auto newFunc = copyFunction(funcOp,
+                                funcOp.getName().str() + "_spec_zero_arg_" +
+                                    std::to_string(operand),
+                                rewriter);
+    symbolTable.insert(newFunc);
+
+    auto newParameter = newFunc.getArgument(operand);
+    while (newParameter.hasOneUse() &&
+           operationIsNopOnZero(*newParameter.getUsers().begin())) {
+      auto newUser = mlir::dyn_cast<qco::UnitaryOpInterface>(
+          *newParameter.getUsers().begin());
+      for (auto i = 0U; i < newUser.getNumQubits(); ++i) {
+        rewriter.replaceAllUsesWith(newUser.getOutputQubit(i),
+                                    newUser.getInputQubit(i));
+      }
+      rewriter.eraseOp(newUser);
+    }
+
+    updateSpecializedCall(callOp, newFunc, rewriter);
+    return true;
+  }
+
+  bool trySpecializePlus(func::CallOp callOp, func::FuncOp funcOp,
+                         unsigned operand,
+                         mlir::PatternRewriter& rewriter) const {
+    auto parameter = funcOp.getArgument(operand);
+    if (!parameter.hasOneUse()) {
+      return false;
+    }
+    if (!operationIsNopOnPlus(*parameter.getUsers().begin())) {
+      return false;
+    }
+
+    auto newFunc = copyFunction(funcOp,
+                                funcOp.getName().str() + "_spec_plus_arg_" +
+                                    std::to_string(operand),
+                                rewriter);
+    symbolTable.insert(newFunc);
+
+    auto newParameter = newFunc.getArgument(operand);
+    while (newParameter.hasOneUse() &&
+           operationIsNopOnPlus(*newParameter.getUsers().begin())) {
+      auto newUser = mlir::dyn_cast<qco::UnitaryOpInterface>(
+          *newParameter.getUsers().begin());
+      for (auto i = 0U; i < newUser.getNumQubits(); ++i) {
+        rewriter.replaceAllUsesWith(newUser.getOutputQubit(i),
+                                    newUser.getInputQubit(i));
+      }
+      rewriter.eraseOp(newUser);
+    }
+
+    updateSpecializedCall(callOp, newFunc, rewriter);
+    return true;
+  }
+
+  bool trySpecializeRotationArguments(func::CallOp callOp, func::FuncOp funcOp,
+                                      double angle, unsigned operand,
+                                      mlir::PatternRewriter& rewriter) const {
+    if (std::ranges::none_of(ANGLES_TO_SPECIALIZE, [angle](double a) {
+          return std::abs(a - angle) < 1e-9;
+        })) {
+      return false;
+    }
+
+    const std::string suffix = "_spec_fixed_angle_" + std::to_string(operand);
+    if (funcOp.getName().contains(suffix)) {
+      // Already specialized
+      return false;
+    }
+
+    auto newFunc =
+        copyFunction(funcOp, funcOp.getName().str() + suffix, rewriter);
+    symbolTable.insert(newFunc);
+
+    auto newParameter = newFunc.getArgument(operand);
+    rewriter.setInsertionPointToStart(&*newFunc.getBody().getBlocks().begin());
+    auto constant = rewriter.create<mlir::arith::ConstantOp>(
+        newFunc.getBody().getLoc(),
+        rewriter.getFloatAttr(mlir::Float64Type::get(rewriter.getContext()),
+                              angle));
+    rewriter.replaceAllUsesWith(newParameter, constant.getResult());
+
+    updateSpecializedCall(callOp, newFunc, rewriter);
+    return true;
+  }
+};
+
+/**
+ * @brief Populates the given pattern set with the different IPO patterns.
+ *
+ * @param patterns The pattern set to populate.
+ */
+static void populateQuantumIPOPatterns(mlir::RewritePatternSet& patterns,
+                                       SymbolTable& symbolTable) {
+  patterns.add<ContextSensitiveSpecializationPattern>(patterns.getContext(),
+                                                      symbolTable);
+}
+
+/**
+ * @brief This pass performs quantum inter-procedural optimizations (IPO).
+ */
+struct QuantumIPO final : impl::QuantumIPOBase<QuantumIPO> {
+  using impl::QuantumIPOBase<QuantumIPO>::QuantumIPOBase;
+
+  void runOnOperation() override {
+    // Get the current operation being operated on.
+    auto op = getOperation();
+    auto* ctx = &getContext();
+    SymbolTable symbolTable(op);
+
+    // Define the set of patterns to use.
+    mlir::RewritePatternSet patterns(ctx);
+    populateQuantumIPOPatterns(patterns, symbolTable);
+
+    // Apply patterns in an iterative and greedy manner.
+    if (mlir::failed(mlir::applyPatternsGreedily(op, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
@@ -61,6 +61,13 @@ namespace mlir::qco {
 #define GEN_PASS_DEF_QUANTUMIPO
 #include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
 
+struct PreviousSpecializations {
+  std::map<std::pair<std::string, uint32_t>, func::FuncOp> zeroSpecializations;
+  std::map<std::pair<std::string, uint32_t>, func::FuncOp> plusSpecializations;
+  std::map<std::tuple<std::string, uint32_t, double>, func::FuncOp>
+      rotationSpecializations;
+};
+
 /**
  * @brief This pattern attempts to perform context-sensitive specialization.
  */
@@ -68,6 +75,7 @@ struct ContextSensitiveSpecializationPattern final
     : mlir::OpRewritePattern<func::CallOp> {
 
   SymbolTable& symbolTable;
+  PreviousSpecializations& previousSpecializations;
 
   constexpr static const auto ANGLES_TO_SPECIALIZE =
       std::array<double, 5>{0.0, M_PI, M_PI_2, M_PI_2 + M_PI, 2 * M_PI};
@@ -87,8 +95,10 @@ struct ContextSensitiveSpecializationPattern final
   }
 
   explicit ContextSensitiveSpecializationPattern(mlir::MLIRContext* context,
-                                                 SymbolTable& symbolTable)
-      : OpRewritePattern(context), symbolTable(symbolTable) {}
+                                                 SymbolTable& symbolTable,
+                                                 PreviousSpecializations& prev)
+      : OpRewritePattern(context), symbolTable(symbolTable),
+        previousSpecializations(prev) {}
 
   mlir::LogicalResult
   matchAndRewrite(func::CallOp callOp,
@@ -141,7 +151,6 @@ struct ContextSensitiveSpecializationPattern final
             callOp, funcOp,
             mlir::cast<mlir::FloatAttr>(constOp.getValue()).getValueAsDouble(),
             operand, rewriter);
-        // TODO we still need a canonicalization for this(?)
       }
     }
 
@@ -159,11 +168,20 @@ struct ContextSensitiveSpecializationPattern final
       return false;
     }
 
+    auto key = std::make_pair(funcOp.getName().str(), operand);
+    if (previousSpecializations.zeroSpecializations.contains(key)) {
+      updateSpecializedCall(callOp,
+                            previousSpecializations.zeroSpecializations.at(key),
+                            rewriter);
+      return true;
+    }
+
     auto newFunc = copyFunction(funcOp,
                                 funcOp.getName().str() + "_spec_zero_arg_" +
                                     std::to_string(operand),
                                 rewriter);
     symbolTable.insert(newFunc);
+    previousSpecializations.zeroSpecializations.insert({key, newFunc});
 
     auto newParameter = newFunc.getArgument(operand);
     while (
@@ -196,11 +214,20 @@ struct ContextSensitiveSpecializationPattern final
       return false;
     }
 
+    auto key = std::make_pair(funcOp.getName().str(), operand);
+    if (previousSpecializations.plusSpecializations.contains(key)) {
+      updateSpecializedCall(callOp,
+                            previousSpecializations.plusSpecializations.at(key),
+                            rewriter);
+      return true;
+    }
+
     auto newFunc = copyFunction(funcOp,
                                 funcOp.getName().str() + "_spec_plus_arg_" +
                                     std::to_string(operand),
                                 rewriter);
     symbolTable.insert(newFunc);
+    previousSpecializations.plusSpecializations.insert({key, newFunc});
 
     auto newParameter = newFunc.getArgument(operand);
     while (newParameter.hasOneUse() &&
@@ -233,9 +260,18 @@ struct ContextSensitiveSpecializationPattern final
       return false;
     }
 
+    auto key = std::make_tuple(funcOp.getName().str(), operand, angle);
+    if (previousSpecializations.rotationSpecializations.contains(key)) {
+      updateSpecializedCall(
+          callOp, previousSpecializations.rotationSpecializations.at(key),
+          rewriter);
+      return true;
+    }
+
     auto newFunc =
         copyFunction(funcOp, funcOp.getName().str() + suffix, rewriter);
     symbolTable.insert(newFunc);
+    previousSpecializations.rotationSpecializations.insert({key, newFunc});
 
     auto newParameter = newFunc.getArgument(operand);
     rewriter.setInsertionPointToStart(&*newFunc.getBody().getBlocks().begin());
@@ -255,10 +291,12 @@ struct ContextSensitiveSpecializationPattern final
  *
  * @param patterns The pattern set to populate.
  */
-static void populateQuantumIPOPatterns(mlir::RewritePatternSet& patterns,
-                                       SymbolTable& symbolTable) {
-  patterns.add<ContextSensitiveSpecializationPattern>(patterns.getContext(),
-                                                      symbolTable);
+static void
+populateQuantumIPOPatterns(mlir::RewritePatternSet& patterns,
+                           SymbolTable& symbolTable,
+                           PreviousSpecializations& previousSpecializations) {
+  patterns.add<ContextSensitiveSpecializationPattern>(
+      patterns.getContext(), symbolTable, previousSpecializations);
 }
 
 /**
@@ -275,7 +313,8 @@ struct QuantumIPO final : impl::QuantumIPOBase<QuantumIPO> {
 
     // Define the set of patterns to use.
     mlir::RewritePatternSet patterns(ctx);
-    populateQuantumIPOPatterns(patterns, symbolTable);
+    PreviousSpecializations previousSpecializations;
+    populateQuantumIPOPatterns(patterns, symbolTable, previousSpecializations);
 
     // Apply patterns in an iterative and greedy manner.
     if (mlir::failed(mlir::applyPatternsGreedily(op, std::move(patterns)))) {

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
@@ -114,6 +114,11 @@ struct ContextSensitiveSpecializationPattern final
     }
 
     auto* definingOp = argValue.getDefiningOp();
+
+    if (!definingOp) {
+      return false;
+    }
+
     if (argValue.getType() == qco::QubitType::get(rewriter.getContext())) {
       // CSS for qubit types.
       if (mlir::isa<qco::AllocOp>(definingOp) ||
@@ -161,15 +166,19 @@ struct ContextSensitiveSpecializationPattern final
     symbolTable.insert(newFunc);
 
     auto newParameter = newFunc.getArgument(operand);
-    while (newParameter.hasOneUse() &&
-           operationIsNopOnZero(*newParameter.getUsers().begin(), parameter)) {
+    while (
+        newParameter.hasOneUse() &&
+        operationIsNopOnZero(*newParameter.getUsers().begin(), newParameter)) {
       auto newUser = mlir::dyn_cast<qco::UnitaryOpInterface>(
           *newParameter.getUsers().begin());
       for (auto i = 0U; i < newUser.getNumQubits(); ++i) {
-        rewriter.replaceAllUsesWith(newUser.getOutputQubit(i),
-                                    newUser.getInputQubit(i));
+        // TODO-DAMIAN use getOutputQubit/Input again (at current version, this
+        // seems to use the output of the inner op)
+        rewriter.replaceAllUsesWith(newUser->getResult(i),
+                                    newUser->getOperand(i));
       }
       rewriter.eraseOp(newUser);
+      break;
     }
 
     updateSpecializedCall(callOp, newFunc, rewriter);

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
@@ -275,6 +275,8 @@ struct QuantumIPO final : impl::QuantumIPOBase<QuantumIPO> {
 
     runQuantumArgumentPromotion(op, symbolTable);
     runAncillaHoisting(op, symbolTable);
+    runQuantumFunctionBoundaryCommutation(op, symbolTable);
+    runQuantumFunctionBoundaryCommutation(op, symbolTable);
   }
 };
 

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
@@ -21,6 +21,7 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
@@ -267,6 +268,8 @@ struct QuantumIPO final : impl::QuantumIPOBase<QuantumIPO> {
     if (mlir::failed(mlir::applyPatternsGreedily(op, std::move(patterns)))) {
       signalPassFailure();
     }
+
+    runQuantumArgumentPromotion(op, symbolTable);
   }
 };
 

--- a/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuantumIPO.cpp
@@ -72,9 +72,13 @@ struct ContextSensitiveSpecializationPattern final
   constexpr static const auto ANGLES_TO_SPECIALIZE =
       std::array<double, 5>{0.0, M_PI, M_PI_2, M_PI_2 + M_PI, 2 * M_PI};
 
-  static bool operationIsNopOnZero(mlir::Operation* op) {
-    return mlir::isa<qco::CtrlOp>(op) || mlir::isa<qco::ZOp>(op) ||
-           mlir::isa<qco::SOp>(op) ||
+  static bool operationIsNopOnZero(mlir::Operation* op,
+                                   mlir::Value zeroArgument) {
+    if (auto ctrl = mlir::dyn_cast<qco::CtrlOp>(op)) {
+      return std::find(ctrl.getControlsIn().begin(), ctrl.getControlsIn().end(),
+                       zeroArgument) != ctrl.getControlsIn().end();
+    }
+    return mlir::isa<qco::ZOp>(op) || mlir::isa<qco::SOp>(op) ||
            mlir::isa<qco::ResetOp>(op); // TODO more ops?
   }
 
@@ -146,7 +150,7 @@ struct ContextSensitiveSpecializationPattern final
     if (!parameter.hasOneUse()) {
       return false;
     }
-    if (!operationIsNopOnZero(*parameter.getUsers().begin())) {
+    if (!operationIsNopOnZero(*parameter.getUsers().begin(), parameter)) {
       return false;
     }
 
@@ -158,7 +162,7 @@ struct ContextSensitiveSpecializationPattern final
 
     auto newParameter = newFunc.getArgument(operand);
     while (newParameter.hasOneUse() &&
-           operationIsNopOnZero(*newParameter.getUsers().begin())) {
+           operationIsNopOnZero(*newParameter.getUsers().begin(), parameter)) {
       auto newUser = mlir::dyn_cast<qco::UnitaryOpInterface>(
           *newParameter.getUsers().begin());
       for (auto i = 0U; i < newUser.getNumQubits(); ++i) {
@@ -270,6 +274,7 @@ struct QuantumIPO final : impl::QuantumIPOBase<QuantumIPO> {
     }
 
     runQuantumArgumentPromotion(op, symbolTable);
+    runAncillaHoisting(op, symbolTable);
   }
 };
 

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
- * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
  * All rights reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -162,7 +162,7 @@ struct MergeRotationGatesPattern final
     }
 
     auto loc = op->getLoc();
-    auto angle = op.getParams()[0];
+    auto angle = op.getParameter(0);
 
     if (type == "rx") {
       return createAxisQuaternion(angle, 'x', loc, rewriter);
@@ -226,13 +226,12 @@ struct MergeRotationGatesPattern final
   static Quaternion quaternionFromUGate(UnitaryOpInterface op,
                                         mlir::PatternRewriter& rewriter) {
     auto loc = op->getLoc();
-    auto params = op.getParams();
 
     // U gate uses ZYZ decomposition:
     // U(alpha, beta, gamma) = Rz(alpha) * Ry(beta) * Rz(gamma)
-    auto qAlpha = createAxisQuaternion(params[0], 'z', loc, rewriter);
-    auto qBeta = createAxisQuaternion(params[1], 'y', loc, rewriter);
-    auto qGamma = createAxisQuaternion(params[2], 'z', loc, rewriter);
+    auto qAlpha = createAxisQuaternion(op.getParameter(0), 'z', loc, rewriter);
+    auto qBeta = createAxisQuaternion(op.getParameter(1), 'y', loc, rewriter);
+    auto qGamma = createAxisQuaternion(op.getParameter(2), 'z', loc, rewriter);
 
     auto temp = hamiltonProduct(qAlpha, qBeta, op, rewriter);
     return hamiltonProduct(temp, qGamma, op, rewriter);
@@ -249,7 +248,7 @@ struct MergeRotationGatesPattern final
     auto userNegCtrlInQubits = user.getNegCtrlInQubits();
 
     // convert back to zyz euler angles
-    auto floatType = op.getParams()[0].getType();
+    auto floatType = op.getParameter(0).getType();
     // constant 1.0
     auto oneAttr = rewriter.getFloatAttr(floatType, 1.0);
     auto one = rewriter.create<mlir::arith::ConstantOp>(loc, oneAttr);

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -20,15 +20,6 @@
 
 namespace mlir::qco {
 
-struct Quaternion {
-  mlir::Value w;
-  mlir::Value x;
-  mlir::Value y;
-  mlir::Value z;
-};
-
-static const std::unordered_set<std::string> MERGEABLE_GATES = {"u", "rx", "ry",
-                                                                "rz"};
 
 /**
  * @brief This pattern attempts to merge consecutive rotation gates.
@@ -37,6 +28,20 @@ struct MergeRotationGatesPattern final
     : mlir::OpInterfaceRewritePattern<UnitaryOpInterface> {
   explicit MergeRotationGatesPattern(mlir::MLIRContext* context)
       : OpInterfaceRewritePattern(context) {}
+
+  struct Quaternion {
+    mlir::Value w;
+    mlir::Value x;
+    mlir::Value y;
+    mlir::Value z;
+  };
+
+  static constexpr std::array<std::string_view, 4> MERGEABLE_GATES = {
+      "u", "rx", "ry", "rz"};
+
+  static bool isMergeable(std::string_view name) {
+    return std::ranges::find(MERGEABLE_GATES, name) != MERGEABLE_GATES.end();
+  }
 
   /**
    * @brief Checks if two gates can and should be merged with quaternions.
@@ -54,7 +59,7 @@ struct MergeRotationGatesPattern final
     const auto aName = a.getName().stripDialect().str();
     const auto bName = b.getName().stripDialect().str();
 
-    if (!(MERGEABLE_GATES.contains(aName) && MERGEABLE_GATES.contains(bName))) {
+    if (!(isMergeable(aName) && isMergeable(bName))) {
       return false;
     }
     return (aName != bName) || (aName == "u" && bName == "u");

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -88,34 +88,19 @@ struct MergeRotationGatesPattern final
       return mlir::failure();
     }
     auto user = mlir::dyn_cast<UnitaryOpInterface>(userOP);
+    // QCU operations cannot contain control qubits so we dont need to check for
+    // these
+
+    // Check if consecutive operations are connected and feed into on another
     if (op.getOutputQubit(0) != user.getInputQubit(0)) {
-      // if (op.getAllOutQubits() != unitaryUser.getAllInQubits()) {
       return mlir::failure();
     }
-    // TODO maybe check for size of ctrl qubits - we only merge gates without
-    // control
-    // rewriteAdditiveAngle(op, rewriter, quaternionFolding);
-    auto const type = op->getName().stripDialect().str();
 
     UnitaryOpInterface newUser =
         createOpQuaternionMergedAngle(op, user, rewriter);
 
-    // Prepare erasure of op
-    const auto& opAllInQubits = op.getAllInQubits();
-    const auto& newUserAllInQubits = newUser.getAllInQubits();
-    for (size_t i = 0; i < newUser->getOperands().size(); i++) {
-      const auto& operand = newUser->getOperand(i);
-      const auto found = llvm::find(newUserAllInQubits, operand);
-      if (found == newUserAllInQubits.end()) {
-        continue;
-      }
-      const auto idx = std::distance(newUserAllInQubits.begin(), found);
-      rewriter.modifyOpInPlace(
-          newUser, [&] { newUser->setOperand(i, opAllInQubits[idx]); });
-    }
-
     // Replace user with newUser
-    rewriter.replaceOp(user, newUser);
+    rewriter.replaceOp(user, newUser->getResults());
 
     // Erase op
     rewriter.eraseOp(op);
@@ -166,15 +151,12 @@ struct MergeRotationGatesPattern final
 
     if (type == "rx") {
       return createAxisQuaternion(angle, 'x', loc, rewriter);
-      // return {.w = cos, .x = sin, .y = zero, .z = zero};
     }
     if (type == "ry") {
       return createAxisQuaternion(angle, 'y', loc, rewriter);
-      // return {.w = cos, .x = zero, .y = sin, .z = zero};
     }
     if (type == "rz") {
       return createAxisQuaternion(angle, 'z', loc, rewriter);
-      // return {.w = cos, .x = zero, .y = zero, .z = sin};
     }
     throw std::runtime_error("Unsupported operation type: " + type);
   }
@@ -241,11 +223,6 @@ struct MergeRotationGatesPattern final
   uGateFromQuaternion(Quaternion q, UnitaryOpInterface op,
                       mlir::PatternRewriter& rewriter) {
     auto loc = op->getLoc();
-    auto user = mlir::dyn_cast<UnitaryOpInterface>(*op->getUsers().begin());
-
-    auto userInQubits = user.getInQubits();
-    auto userPosCtrlInQubits = user.getPosCtrlInQubits();
-    auto userNegCtrlInQubits = user.getNegCtrlInQubits();
 
     // convert back to zyz euler angles
     auto floatType = op.getParameter(0).getType();
@@ -280,15 +257,8 @@ struct MergeRotationGatesPattern final
     auto gamma =
         rewriter.create<mlir::arith::AddFOp>(loc, thetaPlus, thetaMinus);
 
-    const llvm::SmallVector<mlir::Value, 3> newParamsVec{
-        alpha.getResult(), beta.getResult(), gamma.getResult()};
-    const mlir::ValueRange newParams(newParamsVec);
-
-    return rewriter.create<UOp>(
-        loc, userInQubits.getType(), userPosCtrlInQubits.getType(),
-        userNegCtrlInQubits.getType(), mlir::DenseF64ArrayAttr{},
-        mlir::DenseBoolArrayAttr{}, newParams, userInQubits,
-        userPosCtrlInQubits, userNegCtrlInQubits);
+    return rewriter.create<UOp>(loc, op.getInputQubit(0), alpha.getResult(),
+                                beta.getResult(), gamma.getResult());
   }
 
   /**
@@ -353,7 +323,6 @@ struct MergeRotationGates final
     if (mlir::failed(mlir::applyPatternsGreedily(op, std::move(patterns)))) {
       signalPassFailure();
     }
-    // TODO implement pass here
   }
 };
 

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -8,16 +8,7 @@
  * Licensed under the MIT License
  */
 
-/*
- * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
- * Copyright (c) 2025 Munich Quantum Software Company GmbH
- * All rights reserved.
- *
- * SPDX-License-Identifier: MIT
- *
- * Licensed under the MIT License
- */
-
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
 #include <iostream>
@@ -25,9 +16,421 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
-#include <utility>
+#include <unordered_set>
 
 namespace mlir::qco {
+
+struct Quaternion {
+  mlir::Value w;
+  mlir::Value x;
+  mlir::Value y;
+  mlir::Value z;
+};
+
+static const std::unordered_set<std::string> MERGEABLE_GATES = {
+    "gphase", "p", "rx", "ry", "rz", "rxx", "ryy", "rzz", "rzx"};
+
+static const std::unordered_set<std::string> QUATERNION_GATES = {"u", "rx",
+                                                                 "ry", "rz"};
+
+/**
+ * @brief This pattern attempts to merge consecutive rotation gates.
+ */
+struct MergeRotationGatesPattern final
+    : mlir::OpInterfaceRewritePattern<UnitaryOpInterface> {
+  explicit MergeRotationGatesPattern(mlir::MLIRContext* context,
+                                     bool quaternionFolding)
+      : OpInterfaceRewritePattern(context),
+        quaternionFolding(quaternionFolding) {}
+
+  const bool quaternionFolding = false;
+
+  /**
+   * @brief Checks if two gates can be merged.
+   *
+   * @param a The first gate.
+   * @param b The second gate.
+   * @return True if the gates can be merged, false otherwise.
+   */
+  [[nodiscard]] static bool areGatesMergeable(mlir::Operation& a,
+                                              mlir::Operation& b) {
+    const auto aName = a.getName().stripDialect().str();
+    const auto bName = b.getName().stripDialect().str();
+
+    return ((aName == bName) && (MERGEABLE_GATES.count(aName) == 1));
+  }
+
+  /**
+   * @brief Checks if two gates can and should be merged with quaternions.
+   *
+   * Merging with quaternions should be used when merging gates of different
+   * types, or when merging u-gates (which require quaternion multiplication).
+   *
+   * @param a The first gate.
+   * @param b The second gate.
+   * @return True if the gates should be merged using quaternions, false
+   * otherwise.
+   */
+  [[nodiscard]] static bool areQuaternionMergeable(mlir::Operation& a,
+                                                   mlir::Operation& b) {
+    const auto aName = a.getName().stripDialect().str();
+    const auto bName = b.getName().stripDialect().str();
+
+    if (!(QUATERNION_GATES.contains(aName) &&
+          QUATERNION_GATES.contains(bName))) {
+      return false;
+    }
+    return (aName != bName) || (aName == "u" && bName == "u");
+  }
+
+  /**
+   * @brief Checks if all users of an operation are the same.
+   *
+   * @param users The users to check.
+   * @return True if all users are the same, false otherwise.
+   */
+  [[nodiscard]] static bool
+  areUsersUnique(const mlir::ResultRange::user_range& users) {
+    return llvm::none_of(users,
+                         [&](auto* user) { return user != *users.begin(); });
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(UnitaryInterface op,
+                  mlir::PatternRewriter& rewriter) const override {
+    const auto& users = op->getUsers();
+    if (users.empty()) {
+      return mlir::failure();
+    }
+    if (!areUsersUnique(users)) {
+      return mlir::failure();
+    }
+    auto* user = *users.begin();
+
+    if (!(areGatesMergeable(*op, *user) ||
+          (quaternionFolding && areQuaternionMergeable(*op, *user)))) {
+      return mlir::failure();
+    }
+    auto unitaryUser = mlir::dyn_cast<UnitaryInterface>(user);
+    if (op.getAllOutQubits() != unitaryUser.getAllInQubits()) {
+      return mlir::failure();
+    }
+    if (op.getPosCtrlInQubits().size() !=
+            unitaryUser.getPosCtrlInQubits().size() ||
+        op.getNegCtrlInQubits().size() !=
+            unitaryUser.getNegCtrlInQubits().size()) {
+      // We only need to check the sizes, because the order of the
+      // controls was already checked by the previous condition.
+      return mlir::failure();
+    }
+    rewriteAdditiveAngle(op, rewriter, quaternionFolding);
+    return mlir::success();
+  }
+
+  /**
+   * @brief Creates a new rotation gate.
+   *
+   * The new rotation gate is created by adding the angles of two compatible
+   * rotation gates.
+   *
+   * @tparam OpType The type of the operation to create.
+   * @param op The first instance of the rotation gate.
+   * @param user The second instance of the rotation gate.
+   * @param rewriter The pattern rewriter.
+   * @return A new rotation gate.
+   */
+  template <typename OpType>
+  static UnitaryInterface
+  createOpAdditiveAngle(UnitaryInterface op, UnitaryInterface user,
+                        mlir::PatternRewriter& rewriter) {
+    auto loc = user->getLoc();
+
+    auto userInQubits = user.getInQubits();
+    auto userPosCtrlInQubits = user.getPosCtrlInQubits();
+    auto userNegCtrlInQubits = user.getNegCtrlInQubits();
+
+    auto opParam = op.getParams()[0];
+    auto userParam = user.getParams()[0];
+    auto add = rewriter.create<mlir::arith::AddFOp>(loc, opParam, userParam);
+    const llvm::SmallVector<mlir::Value, 1> newParamsVec{add.getResult()};
+    const mlir::ValueRange newParams(newParamsVec);
+
+    return rewriter.create<OpType>(
+        loc, userInQubits.getType(), userPosCtrlInQubits.getType(),
+        userNegCtrlInQubits.getType(), mlir::DenseF64ArrayAttr{},
+        mlir::DenseBoolArrayAttr{}, newParams, userInQubits,
+        userPosCtrlInQubits, userNegCtrlInQubits);
+  }
+
+  static Quaternion createAxisQuaternion(mlir::Value angle, char axis,
+                                         mlir::Location loc,
+                                         mlir::PatternRewriter& rewriter) {
+    auto floatType = angle.getType();
+
+    // constant 0.0
+    auto zeroAttr = rewriter.getFloatAttr(floatType, 0.0);
+    auto zero = rewriter.create<mlir::arith::ConstantOp>(loc, zeroAttr);
+
+    // constant 2.0
+    auto twoAttr = rewriter.getFloatAttr(floatType, 2.0);
+    auto two = rewriter.create<mlir::arith::ConstantOp>(loc, twoAttr);
+
+    auto half = rewriter.create<mlir::arith::DivFOp>(loc, angle, two);
+    // cos(angle/2)
+    auto cos = rewriter.create<mlir::math::CosOp>(loc, floatType, half);
+    // sin(angle/2)
+    auto sin = rewriter.create<mlir::math::SinOp>(loc, floatType, half);
+
+    switch (axis) {
+    case 'x':
+      return {.w = cos, .x = sin, .y = zero, .z = zero};
+    case 'y':
+      return {.w = cos, .x = zero, .y = sin, .z = zero};
+    case 'z':
+      return {.w = cos, .x = zero, .y = zero, .z = sin};
+    default:
+      throw std::runtime_error("Invalid rotation axis");
+    }
+  }
+
+  static Quaternion quaternionFromRotation(UnitaryInterface op,
+                                           mlir::PatternRewriter& rewriter) {
+    auto const type = op->getName().stripDialect().str();
+
+    if (type == "u") {
+      return quaternionFromUGate(op, rewriter);
+    }
+
+    auto loc = op->getLoc();
+    auto angle = op.getParams()[0];
+
+    if (type == "rx") {
+      return createAxisQuaternion(angle, 'x', loc, rewriter);
+      // return {.w = cos, .x = sin, .y = zero, .z = zero};
+    }
+    if (type == "ry") {
+      return createAxisQuaternion(angle, 'y', loc, rewriter);
+      // return {.w = cos, .x = zero, .y = sin, .z = zero};
+    }
+    if (type == "rz") {
+      return createAxisQuaternion(angle, 'z', loc, rewriter);
+      // return {.w = cos, .x = zero, .y = zero, .z = sin};
+    }
+    throw std::runtime_error("Unsupported operation type: " + type);
+  }
+
+  static Quaternion hamiltonProduct(Quaternion q1, Quaternion q2,
+                                    UnitaryInterface op,
+                                    mlir::PatternRewriter& rewriter) {
+    auto loc = op->getLoc();
+
+    // wRes = w1w2 - x1x2 - y1y2 - z1z2
+    auto w1w2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.w, q2.w);
+    auto x1x2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.x, q2.x);
+    auto y1y2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.y, q2.y);
+    auto z1z2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.z, q2.z);
+    auto wTemp1 = rewriter.create<mlir::arith::SubFOp>(loc, w1w2, x1x2);
+    auto wTemp2 = rewriter.create<mlir::arith::SubFOp>(loc, wTemp1, y1y2);
+    auto wRes = rewriter.create<mlir::arith::SubFOp>(loc, wTemp2, z1z2);
+
+    // xRes = w1x2 + x1w2 + y1z2 - z1y2
+    auto w1x2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.w, q2.x);
+    auto x1w2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.x, q2.w);
+    auto y1z2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.y, q2.z);
+    auto z1y2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.z, q2.y);
+    auto xTemp1 = rewriter.create<mlir::arith::AddFOp>(loc, w1x2, x1w2);
+    auto xTemp2 = rewriter.create<mlir::arith::AddFOp>(loc, xTemp1, y1z2);
+    auto xRes = rewriter.create<mlir::arith::SubFOp>(loc, xTemp2, z1y2);
+
+    // yRes = w1y2 - x1z2 + y1w2 + z1x2
+    auto w1y2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.w, q2.y);
+    auto x1z2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.x, q2.z);
+    auto y1w2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.y, q2.w);
+    auto z1x2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.z, q2.x);
+    auto yTemp1 = rewriter.create<mlir::arith::SubFOp>(loc, w1y2, x1z2);
+    auto yTemp2 = rewriter.create<mlir::arith::AddFOp>(loc, yTemp1, y1w2);
+    auto yRes = rewriter.create<mlir::arith::AddFOp>(loc, yTemp2, z1x2);
+
+    // zRes = w1z2 + x1y2 - y1x2 + z1w2
+    auto w1z2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.w, q2.z);
+    auto x1y2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.x, q2.y);
+    auto y1x2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.y, q2.x);
+    auto z1w2 = rewriter.create<mlir::arith::MulFOp>(loc, q1.z, q2.w);
+    auto zTemp1 = rewriter.create<mlir::arith::AddFOp>(loc, w1z2, x1y2);
+    auto zTemp2 = rewriter.create<mlir::arith::SubFOp>(loc, zTemp1, y1x2);
+    auto zRes = rewriter.create<mlir::arith::AddFOp>(loc, zTemp2, z1w2);
+
+    return {.w = wRes, .x = xRes, .y = yRes, .z = zRes};
+  }
+
+  static Quaternion quaternionFromUGate(UnitaryInterface op,
+                                        mlir::PatternRewriter& rewriter) {
+    auto loc = op->getLoc();
+    auto params = op.getParams();
+
+    // U gate uses ZYZ decomposition:
+    // U(alpha, beta, gamma) = Rz(alpha) * Ry(beta) * Rz(gamma)
+    auto qAlpha = createAxisQuaternion(params[0], 'z', loc, rewriter);
+    auto qBeta = createAxisQuaternion(params[1], 'y', loc, rewriter);
+    auto qGamma = createAxisQuaternion(params[2], 'z', loc, rewriter);
+
+    auto temp = hamiltonProduct(qAlpha, qBeta, op, rewriter);
+    return hamiltonProduct(temp, qGamma, op, rewriter);
+  }
+
+  static UnitaryInterface uGateFromQuaternion(Quaternion q, UnitaryInterface op,
+                                              mlir::PatternRewriter& rewriter) {
+    auto loc = op->getLoc();
+    auto user = mlir::dyn_cast<UnitaryInterface>(*op->getUsers().begin());
+
+    auto userInQubits = user.getInQubits();
+    auto userPosCtrlInQubits = user.getPosCtrlInQubits();
+    auto userNegCtrlInQubits = user.getNegCtrlInQubits();
+
+    // convert back to zyz euler angles
+    auto floatType = op.getParams()[0].getType();
+    // constant 1.0
+    auto oneAttr = rewriter.getFloatAttr(floatType, 1.0);
+    auto one = rewriter.create<mlir::arith::ConstantOp>(loc, oneAttr);
+    // constant 2.0
+    auto twoAttr = rewriter.getFloatAttr(floatType, 2.0);
+    auto two = rewriter.create<mlir::arith::ConstantOp>(loc, twoAttr);
+
+    // calculate angle beta (for y-rotation)
+    // beta = acos(2 * (w**2 + z**2)-1)
+    auto ww = rewriter.create<mlir::arith::MulFOp>(loc, q.w, q.w);
+    auto zz = rewriter.create<mlir::arith::MulFOp>(loc, q.z, q.z);
+    auto bTemp1 = rewriter.create<mlir::arith::AddFOp>(loc, ww, zz);
+    auto bTemp2 = rewriter.create<mlir::arith::MulFOp>(loc, two, bTemp1);
+    auto bTemp3 = rewriter.create<mlir::arith::SubFOp>(loc, bTemp2, one);
+    auto beta = rewriter.create<mlir::math::AcosOp>(loc, bTemp3);
+
+    // intermediate angles for z-rotations alpha and gamma
+    // theta+ = atan2(z, w)
+    // theta- = atan2(-x, y)
+    auto xMinus = rewriter.create<mlir::arith::NegFOp>(loc, q.x);
+    auto thetaPlus = rewriter.create<mlir::math::Atan2Op>(loc, q.z, q.w);
+    auto thetaMinus = rewriter.create<mlir::math::Atan2Op>(loc, xMinus, q.y);
+
+    // z-rotations alpha and gamma
+    // alpha = theta+ - theta-
+    // gamma = theta+ + theta-
+    auto alpha =
+        rewriter.create<mlir::arith::SubFOp>(loc, thetaPlus, thetaMinus);
+    auto gamma =
+        rewriter.create<mlir::arith::AddFOp>(loc, thetaPlus, thetaMinus);
+
+    const llvm::SmallVector<mlir::Value, 3> newParamsVec{
+        alpha.getResult(), beta.getResult(), gamma.getResult()};
+    const mlir::ValueRange newParams(newParamsVec);
+
+    return rewriter.create<UOp>(
+        loc, userInQubits.getType(), userPosCtrlInQubits.getType(),
+        userNegCtrlInQubits.getType(), mlir::DenseF64ArrayAttr{},
+        mlir::DenseBoolArrayAttr{}, newParams, userInQubits,
+        userPosCtrlInQubits, userNegCtrlInQubits);
+  }
+
+  /**
+   * @brief Creates a u-gate by merging two rotation gates.
+   *
+   * The new  u-gate is created by converting the two
+   * rotation gates into quaternions. These quaternions are then
+   * multiplied/merged together by using the hamilton product. The order of
+   * multiplication needs to be the reverse order in which the gates appear in
+   * the circuit.
+   *
+   * @param op The first instance of the rotation gate.
+   * @param user The second instance of the rotation gate.
+   * @param rewriter The pattern rewriter.
+   * @return A new rotation gate.
+   */
+  static UnitaryInterface
+  createOpQuaternionMergedAngle(UnitaryInterface op, UnitaryInterface user,
+                                mlir::PatternRewriter& rewriter) {
+    auto q1 = quaternionFromRotation(op, rewriter);
+    auto q2 = quaternionFromRotation(user, rewriter);
+    auto qHam = hamiltonProduct(q2, q1, op, rewriter);
+    auto newUser = uGateFromQuaternion(qHam, op, rewriter);
+
+    return newUser;
+  }
+
+  /**
+   * @brief Merges two consecutive rotation gates into a single gate.
+   *
+   * The function supports gphase, p, rx, ry, rz, rxx, ryy, rzz, and rzx.
+   * The gates are merged by adding their angles.
+   * The merged gate is not removed if the angles add up to zero.
+   *
+   * @param op The first instance of the rotation gate.
+   * @param rewriter The pattern rewriter.
+   */
+  void static rewriteAdditiveAngle(UnitaryInterface op,
+                                   mlir::PatternRewriter& rewriter,
+                                   bool quaternionFolding) {
+    auto const type = op->getName().stripDialect().str();
+
+    auto user = mlir::dyn_cast<UnitaryInterface>(*op->getUsers().begin());
+
+    UnitaryInterface newUser;
+
+    if (quaternionFolding && areQuaternionMergeable(*op, *user)) {
+      newUser = createOpQuaternionMergedAngle(op, user, rewriter);
+    } else if (type == "gphase") {
+      newUser = createOpAdditiveAngle<GPhaseOp>(op, user, rewriter);
+    } else if (type == "p") {
+      newUser = createOpAdditiveAngle<POp>(op, user, rewriter);
+    } else if (type == "rx") {
+      newUser = createOpAdditiveAngle<RXOp>(op, user, rewriter);
+    } else if (type == "ry") {
+      newUser = createOpAdditiveAngle<RYOp>(op, user, rewriter);
+    } else if (type == "rz") {
+      newUser = createOpAdditiveAngle<RZOp>(op, user, rewriter);
+    } else if (type == "rxx") {
+      newUser = createOpAdditiveAngle<RXXOp>(op, user, rewriter);
+    } else if (type == "ryy") {
+      newUser = createOpAdditiveAngle<RYYOp>(op, user, rewriter);
+    } else if (type == "rzz") {
+      newUser = createOpAdditiveAngle<RZZOp>(op, user, rewriter);
+    } else if (type == "rzx") {
+      newUser = createOpAdditiveAngle<RZXOp>(op, user, rewriter);
+    } else {
+      throw std::runtime_error("Unsupported operation type: " + type);
+    }
+
+    // Prepare erasure of op
+    const auto& opAllInQubits = op.getAllInQubits();
+    const auto& newUserAllInQubits = newUser.getAllInQubits();
+    for (size_t i = 0; i < newUser->getOperands().size(); i++) {
+      const auto& operand = newUser->getOperand(i);
+      const auto found = llvm::find(newUserAllInQubits, operand);
+      if (found == newUserAllInQubits.end()) {
+        continue;
+      }
+      const auto idx = std::distance(newUserAllInQubits.begin(), found);
+      rewriter.modifyOpInPlace(
+          newUser, [&] { newUser->setOperand(i, opAllInQubits[idx]); });
+    }
+
+    // Replace user with newUser
+    rewriter.replaceOp(user, newUser);
+
+    // Erase op
+    rewriter.eraseOp(op);
+  }
+};
+
+/**
+ * @brief Populates the given pattern set with the `MergeRotationGatesPattern`.
+ *
+ * @param patterns The pattern set to populate.
+ */
+void populateMergeRotationGatesPatterns(mlir::RewritePatternSet& patterns,
+                                        bool quaternionFolding) {
+  patterns.add<MergeRotationGatesPattern>(patterns.getContext(),
+                                          quaternionFolding);
+}
 
 #define GEN_PASS_DEF_MERGEROTATIONGATES
 #include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
@@ -41,7 +444,9 @@ struct MergeRotationGates final
   using impl::MergeRotationGatesBase<
       MergeRotationGates>::MergeRotationGatesBase;
 
+  // TODO add flag for pass
   void runOnOperation() override {
+    std::cout << "Hello from MergeRotationGates" << std::endl;
     // TODO implement pass here
   }
 };

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -11,15 +11,26 @@
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
-#include <iostream>
+#include <algorithm>
+#include <array>
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
-#include <mlir/Support/LLVM.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
-#include <unordered_set>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
 
 namespace mlir::qco {
 
+#define GEN_PASS_DEF_MERGEROTATIONGATES
+#include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
 
 /**
  * @brief This pattern attempts to merge consecutive rotation gates.
@@ -301,9 +312,6 @@ static void
 populateMergeRotationGatesPatterns(mlir::RewritePatternSet& patterns) {
   patterns.add<MergeRotationGatesPattern>(patterns.getContext());
 }
-
-#define GEN_PASS_DEF_MERGEROTATIONGATES
-#include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
 
 /**
  * @brief This pattern attempts to merge consecutive rotation gates by using

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+ * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
 
 /*
  * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -96,7 +96,7 @@ struct MergeRotationGatesPattern final
   }
 
   mlir::LogicalResult
-  matchAndRewrite(UnitaryInterface op,
+  matchAndRewrite(UnitaryOpInterface op,
                   mlir::PatternRewriter& rewriter) const override {
     const auto& users = op->getUsers();
     if (users.empty()) {
@@ -111,7 +111,7 @@ struct MergeRotationGatesPattern final
           (quaternionFolding && areQuaternionMergeable(*op, *user)))) {
       return mlir::failure();
     }
-    auto unitaryUser = mlir::dyn_cast<UnitaryInterface>(user);
+    auto unitaryUser = mlir::dyn_cast<UnitaryOpInterface>(user);
     if (op.getAllOutQubits() != unitaryUser.getAllInQubits()) {
       return mlir::failure();
     }
@@ -140,8 +140,8 @@ struct MergeRotationGatesPattern final
    * @return A new rotation gate.
    */
   template <typename OpType>
-  static UnitaryInterface
-  createOpAdditiveAngle(UnitaryInterface op, UnitaryInterface user,
+  static UnitaryOpInterface
+  createOpAdditiveAngle(UnitaryOpInterface op, UnitaryOpInterface user,
                         mlir::PatternRewriter& rewriter) {
     auto loc = user->getLoc();
 
@@ -193,7 +193,7 @@ struct MergeRotationGatesPattern final
     }
   }
 
-  static Quaternion quaternionFromRotation(UnitaryInterface op,
+  static Quaternion quaternionFromRotation(UnitaryOpInterface op,
                                            mlir::PatternRewriter& rewriter) {
     auto const type = op->getName().stripDialect().str();
 
@@ -220,7 +220,7 @@ struct MergeRotationGatesPattern final
   }
 
   static Quaternion hamiltonProduct(Quaternion q1, Quaternion q2,
-                                    UnitaryInterface op,
+                                    UnitaryOpInterface op,
                                     mlir::PatternRewriter& rewriter) {
     auto loc = op->getLoc();
 
@@ -263,7 +263,7 @@ struct MergeRotationGatesPattern final
     return {.w = wRes, .x = xRes, .y = yRes, .z = zRes};
   }
 
-  static Quaternion quaternionFromUGate(UnitaryInterface op,
+  static Quaternion quaternionFromUGate(UnitaryOpInterface op,
                                         mlir::PatternRewriter& rewriter) {
     auto loc = op->getLoc();
     auto params = op.getParams();
@@ -278,10 +278,11 @@ struct MergeRotationGatesPattern final
     return hamiltonProduct(temp, qGamma, op, rewriter);
   }
 
-  static UnitaryInterface uGateFromQuaternion(Quaternion q, UnitaryInterface op,
-                                              mlir::PatternRewriter& rewriter) {
+  static UnitaryOpInterface
+  uGateFromQuaternion(Quaternion q, UnitaryOpInterface op,
+                      mlir::PatternRewriter& rewriter) {
     auto loc = op->getLoc();
-    auto user = mlir::dyn_cast<UnitaryInterface>(*op->getUsers().begin());
+    auto user = mlir::dyn_cast<UnitaryOpInterface>(*op->getUsers().begin());
 
     auto userInQubits = user.getInQubits();
     auto userPosCtrlInQubits = user.getPosCtrlInQubits();
@@ -345,8 +346,8 @@ struct MergeRotationGatesPattern final
    * @param rewriter The pattern rewriter.
    * @return A new rotation gate.
    */
-  static UnitaryInterface
-  createOpQuaternionMergedAngle(UnitaryInterface op, UnitaryInterface user,
+  static UnitaryOpInterface
+  createOpQuaternionMergedAngle(UnitaryOpInterface op, UnitaryOpInterface user,
                                 mlir::PatternRewriter& rewriter) {
     auto q1 = quaternionFromRotation(op, rewriter);
     auto q2 = quaternionFromRotation(user, rewriter);
@@ -366,14 +367,14 @@ struct MergeRotationGatesPattern final
    * @param op The first instance of the rotation gate.
    * @param rewriter The pattern rewriter.
    */
-  void static rewriteAdditiveAngle(UnitaryInterface op,
+  void static rewriteAdditiveAngle(UnitaryOpInterface op,
                                    mlir::PatternRewriter& rewriter,
                                    bool quaternionFolding) {
     auto const type = op->getName().stripDialect().str();
 
-    auto user = mlir::dyn_cast<UnitaryInterface>(*op->getUsers().begin());
+    auto user = mlir::dyn_cast<UnitaryOpInterface>(*op->getUsers().begin());
 
-    UnitaryInterface newUser;
+    UnitaryOpInterface newUser;
 
     if (quaternionFolding && areQuaternionMergeable(*op, *user)) {
       newUser = createOpQuaternionMergedAngle(op, user, rewriter);

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -322,7 +322,6 @@ struct MergeRotationGates final
   using impl::MergeRotationGatesBase<
       MergeRotationGates>::MergeRotationGatesBase;
 
-  // TODO add flag for pass
   void runOnOperation() override {
     // Get the current operation being operated on.
     auto op = getOperation();

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -82,24 +82,43 @@ struct MergeRotationGatesPattern final
     if (!areUsersUnique(users)) {
       return mlir::failure();
     }
-    auto* user = *users.begin();
+    auto* userOP = *users.begin();
 
-    if (!(quaternionFolding && areQuaternionMergeable(*op, *user))) {
+    if (!areQuaternionMergeable(*op, *userOP)) {
       return mlir::failure();
     }
-    auto unitaryUser = mlir::dyn_cast<UnitaryOpInterface>(user);
-    if (op.getAllOutQubits() != unitaryUser.getAllInQubits()) {
+    auto user = mlir::dyn_cast<UnitaryOpInterface>(userOP);
+    if (op.getOutputQubit(0) != user.getInputQubit(0)) {
+      // if (op.getAllOutQubits() != unitaryUser.getAllInQubits()) {
       return mlir::failure();
     }
-    if (op.getPosCtrlInQubits().size() !=
-            unitaryUser.getPosCtrlInQubits().size() ||
-        op.getNegCtrlInQubits().size() !=
-            unitaryUser.getNegCtrlInQubits().size()) {
-      // We only need to check the sizes, because the order of the
-      // controls was already checked by the previous condition.
-      return mlir::failure();
+    // TODO maybe check for size of ctrl qubits - we only merge gates without
+    // control
+    // rewriteAdditiveAngle(op, rewriter, quaternionFolding);
+    auto const type = op->getName().stripDialect().str();
+
+    UnitaryOpInterface newUser =
+        createOpQuaternionMergedAngle(op, user, rewriter);
+
+    // Prepare erasure of op
+    const auto& opAllInQubits = op.getAllInQubits();
+    const auto& newUserAllInQubits = newUser.getAllInQubits();
+    for (size_t i = 0; i < newUser->getOperands().size(); i++) {
+      const auto& operand = newUser->getOperand(i);
+      const auto found = llvm::find(newUserAllInQubits, operand);
+      if (found == newUserAllInQubits.end()) {
+        continue;
+      }
+      const auto idx = std::distance(newUserAllInQubits.begin(), found);
+      rewriter.modifyOpInPlace(
+          newUser, [&] { newUser->setOperand(i, opAllInQubits[idx]); });
     }
-    rewriteAdditiveAngle(op, rewriter, quaternionFolding);
+
+    // Replace user with newUser
+    rewriter.replaceOp(user, newUser);
+
+    // Erase op
+    rewriter.eraseOp(op);
     return mlir::success();
   }
 
@@ -296,52 +315,6 @@ struct MergeRotationGatesPattern final
     auto newUser = uGateFromQuaternion(qHam, op, rewriter);
 
     return newUser;
-  }
-
-  /**
-   * @brief Merges two consecutive rotation gates into a single gate.
-   *
-   * The function supports gphase, p, rx, ry, rz, rxx, ryy, rzz, and rzx.
-   * The gates are merged by adding their angles.
-   * The merged gate is not removed if the angles add up to zero.
-   *
-   * @param op The first instance of the rotation gate.
-   * @param rewriter The pattern rewriter.
-   */
-  void static rewriteAdditiveAngle(UnitaryOpInterface op,
-                                   mlir::PatternRewriter& rewriter,
-                                   bool quaternionFolding) {
-    auto const type = op->getName().stripDialect().str();
-
-    auto user = mlir::dyn_cast<UnitaryOpInterface>(*op->getUsers().begin());
-
-    UnitaryOpInterface newUser;
-
-    if (quaternionFolding && areQuaternionMergeable(*op, *user)) {
-      newUser = createOpQuaternionMergedAngle(op, user, rewriter);
-    } else {
-      throw std::runtime_error("Unsupported operation type: " + type);
-    }
-
-    // Prepare erasure of op
-    const auto& opAllInQubits = op.getAllInQubits();
-    const auto& newUserAllInQubits = newUser.getAllInQubits();
-    for (size_t i = 0; i < newUser->getOperands().size(); i++) {
-      const auto& operand = newUser->getOperand(i);
-      const auto found = llvm::find(newUserAllInQubits, operand);
-      if (found == newUserAllInQubits.end()) {
-        continue;
-      }
-      const auto idx = std::distance(newUserAllInQubits.begin(), found);
-      rewriter.modifyOpInPlace(
-          newUser, [&] { newUser->setOperand(i, opAllInQubits[idx]); });
-    }
-
-    // Replace user with newUser
-    rewriter.replaceOp(user, newUser);
-
-    // Erase op
-    rewriter.eraseOp(op);
   }
 };
 

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -1,0 +1,40 @@
+
+/*
+ * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+ * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+
+#include <iostream>
+#include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+#include <utility>
+
+namespace mlir::qco {
+
+#define GEN_PASS_DEF_MERGEROTATIONGATES
+#include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
+
+/**
+ * @brief This pattern attempts to merge consecutive rotation gates by using
+ * quaternions
+ */
+struct MergeRotationGates final
+    : impl::MergeRotationGatesBase<MergeRotationGates> {
+  using impl::MergeRotationGatesBase<
+      MergeRotationGates>::MergeRotationGatesBase;
+
+  void runOnOperation() override {
+    // TODO implement pass here
+  }
+};
+
+} // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/QuaternionMergeRotationGates.cpp
@@ -27,38 +27,16 @@ struct Quaternion {
   mlir::Value z;
 };
 
-static const std::unordered_set<std::string> MERGEABLE_GATES = {
-    "gphase", "p", "rx", "ry", "rz", "rxx", "ryy", "rzz", "rzx"};
-
-static const std::unordered_set<std::string> QUATERNION_GATES = {"u", "rx",
-                                                                 "ry", "rz"};
+static const std::unordered_set<std::string> MERGEABLE_GATES = {"u", "rx", "ry",
+                                                                "rz"};
 
 /**
  * @brief This pattern attempts to merge consecutive rotation gates.
  */
 struct MergeRotationGatesPattern final
     : mlir::OpInterfaceRewritePattern<UnitaryOpInterface> {
-  explicit MergeRotationGatesPattern(mlir::MLIRContext* context,
-                                     bool quaternionFolding)
-      : OpInterfaceRewritePattern(context),
-        quaternionFolding(quaternionFolding) {}
-
-  const bool quaternionFolding = false;
-
-  /**
-   * @brief Checks if two gates can be merged.
-   *
-   * @param a The first gate.
-   * @param b The second gate.
-   * @return True if the gates can be merged, false otherwise.
-   */
-  [[nodiscard]] static bool areGatesMergeable(mlir::Operation& a,
-                                              mlir::Operation& b) {
-    const auto aName = a.getName().stripDialect().str();
-    const auto bName = b.getName().stripDialect().str();
-
-    return ((aName == bName) && (MERGEABLE_GATES.count(aName) == 1));
-  }
+  explicit MergeRotationGatesPattern(mlir::MLIRContext* context)
+      : OpInterfaceRewritePattern(context) {}
 
   /**
    * @brief Checks if two gates can and should be merged with quaternions.
@@ -76,8 +54,7 @@ struct MergeRotationGatesPattern final
     const auto aName = a.getName().stripDialect().str();
     const auto bName = b.getName().stripDialect().str();
 
-    if (!(QUATERNION_GATES.contains(aName) &&
-          QUATERNION_GATES.contains(bName))) {
+    if (!(MERGEABLE_GATES.contains(aName) && MERGEABLE_GATES.contains(bName))) {
       return false;
     }
     return (aName != bName) || (aName == "u" && bName == "u");
@@ -107,8 +84,7 @@ struct MergeRotationGatesPattern final
     }
     auto* user = *users.begin();
 
-    if (!(areGatesMergeable(*op, *user) ||
-          (quaternionFolding && areQuaternionMergeable(*op, *user)))) {
+    if (!(quaternionFolding && areQuaternionMergeable(*op, *user))) {
       return mlir::failure();
     }
     auto unitaryUser = mlir::dyn_cast<UnitaryOpInterface>(user);
@@ -125,41 +101,6 @@ struct MergeRotationGatesPattern final
     }
     rewriteAdditiveAngle(op, rewriter, quaternionFolding);
     return mlir::success();
-  }
-
-  /**
-   * @brief Creates a new rotation gate.
-   *
-   * The new rotation gate is created by adding the angles of two compatible
-   * rotation gates.
-   *
-   * @tparam OpType The type of the operation to create.
-   * @param op The first instance of the rotation gate.
-   * @param user The second instance of the rotation gate.
-   * @param rewriter The pattern rewriter.
-   * @return A new rotation gate.
-   */
-  template <typename OpType>
-  static UnitaryOpInterface
-  createOpAdditiveAngle(UnitaryOpInterface op, UnitaryOpInterface user,
-                        mlir::PatternRewriter& rewriter) {
-    auto loc = user->getLoc();
-
-    auto userInQubits = user.getInQubits();
-    auto userPosCtrlInQubits = user.getPosCtrlInQubits();
-    auto userNegCtrlInQubits = user.getNegCtrlInQubits();
-
-    auto opParam = op.getParams()[0];
-    auto userParam = user.getParams()[0];
-    auto add = rewriter.create<mlir::arith::AddFOp>(loc, opParam, userParam);
-    const llvm::SmallVector<mlir::Value, 1> newParamsVec{add.getResult()};
-    const mlir::ValueRange newParams(newParamsVec);
-
-    return rewriter.create<OpType>(
-        loc, userInQubits.getType(), userPosCtrlInQubits.getType(),
-        userNegCtrlInQubits.getType(), mlir::DenseF64ArrayAttr{},
-        mlir::DenseBoolArrayAttr{}, newParams, userInQubits,
-        userPosCtrlInQubits, userNegCtrlInQubits);
   }
 
   static Quaternion createAxisQuaternion(mlir::Value angle, char axis,
@@ -378,24 +319,6 @@ struct MergeRotationGatesPattern final
 
     if (quaternionFolding && areQuaternionMergeable(*op, *user)) {
       newUser = createOpQuaternionMergedAngle(op, user, rewriter);
-    } else if (type == "gphase") {
-      newUser = createOpAdditiveAngle<GPhaseOp>(op, user, rewriter);
-    } else if (type == "p") {
-      newUser = createOpAdditiveAngle<POp>(op, user, rewriter);
-    } else if (type == "rx") {
-      newUser = createOpAdditiveAngle<RXOp>(op, user, rewriter);
-    } else if (type == "ry") {
-      newUser = createOpAdditiveAngle<RYOp>(op, user, rewriter);
-    } else if (type == "rz") {
-      newUser = createOpAdditiveAngle<RZOp>(op, user, rewriter);
-    } else if (type == "rxx") {
-      newUser = createOpAdditiveAngle<RXXOp>(op, user, rewriter);
-    } else if (type == "ryy") {
-      newUser = createOpAdditiveAngle<RYYOp>(op, user, rewriter);
-    } else if (type == "rzz") {
-      newUser = createOpAdditiveAngle<RZZOp>(op, user, rewriter);
-    } else if (type == "rzx") {
-      newUser = createOpAdditiveAngle<RZXOp>(op, user, rewriter);
     } else {
       throw std::runtime_error("Unsupported operation type: " + type);
     }
@@ -427,10 +350,9 @@ struct MergeRotationGatesPattern final
  *
  * @param patterns The pattern set to populate.
  */
-void populateMergeRotationGatesPatterns(mlir::RewritePatternSet& patterns,
-                                        bool quaternionFolding) {
-  patterns.add<MergeRotationGatesPattern>(patterns.getContext(),
-                                          quaternionFolding);
+static void
+populateMergeRotationGatesPatterns(mlir::RewritePatternSet& patterns) {
+  patterns.add<MergeRotationGatesPattern>(patterns.getContext());
 }
 
 #define GEN_PASS_DEF_MERGEROTATIONGATES
@@ -447,7 +369,18 @@ struct MergeRotationGates final
 
   // TODO add flag for pass
   void runOnOperation() override {
-    std::cout << "Hello from MergeRotationGates" << std::endl;
+    // Get the current operation being operated on.
+    auto op = getOperation();
+    auto* ctx = &getContext();
+
+    // Define the set of patterns to use.
+    mlir::RewritePatternSet patterns(ctx);
+    populateMergeRotationGatesPatterns(patterns);
+
+    // Apply patterns in an iterative and greedy manner.
+    if (mlir::failed(mlir::applyPatternsGreedily(op, std::move(patterns)))) {
+      signalPassFailure();
+    }
     // TODO implement pass here
   }
 };

--- a/mlir/lib/Dialect/QCO/Transforms/ReuseQubits.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/ReuseQubits.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+#include <utility>
+
+namespace mlir::qco {
+
+#define GEN_PASS_DEF_REUSEQUBITSPASS
+#include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
+
+/**
+ * @brief This pass attempts to reduce the number of required qubits by reusing
+ * existing ones that are no longer used.
+ */
+struct ReuseQubitsPass final : impl::ReuseQubitsPassBase<ReuseQubitsPass> {
+
+  void runOnOperation() override {
+    // Get the current operation being operated on.
+    auto op = getOperation();
+    auto* ctx = &getContext();
+
+    // Define the set of patterns to use.
+    mlir::RewritePatternSet patterns(ctx);
+    populateReuseQubitsPatterns(patterns);
+
+    // Apply patterns in an iterative and greedy manner.
+    if (mlir::failed(mlir::applyPatternsGreedily(op, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+/**
+ * @brief This pattern is responsible applying qubit reuse.
+ */
+struct ReuseQubitsPattern final : mlir::OpRewritePattern<AllocOp> {
+
+  explicit ReuseQubitsPattern(mlir::MLIRContext* context)
+      : OpRewritePattern(context) {}
+
+  /**
+   * @brief Finds all reachable `DeallocOp` operation starting from some
+   * qubit.
+   * @param allocQubit The starting qubit to check (e.g. a newly  allocated
+   * qubit).
+   * @return A set of all DeallocOp operations reachable from the given
+   */
+  static llvm::DenseSet<mlir::Operation*>
+  findAllReachableDeallocs(mlir::Value allocQubit) {
+    // Traverse def-use chain using BFS.
+    llvm::DenseSet<mlir::Operation*> reachableSinks;
+    llvm::SmallVector<mlir::Operation*> toVisit{allocQubit.getUsers().begin(),
+                                                allocQubit.getUsers().end()};
+    llvm::DenseSet<mlir::Operation*> visited;
+    while (!toVisit.empty()) {
+      auto* current = toVisit.back();
+      toVisit.pop_back();
+      visited.insert(current);
+
+      // If we reach the dealloc operation, we add it to the list of sinks.
+      if (mlir::isa<DeallocOp>(current)) {
+        reachableSinks.insert(current);
+        continue;
+      }
+
+      if (auto yieldOp = mlir::dyn_cast<mlir::scf::YieldOp>(current)) {
+        // If we reach a yield operation, we continue from the corresponding
+        // `parent` (e.g. `scf.if`).
+        toVisit.push_back(yieldOp->getParentOp());
+        continue;
+      }
+
+      // Add all users of the current operation to the visit list.
+      for (auto result : current->getResults()) {
+        for (auto* user : result.getUsers()) {
+          if (visited.contains(user)) {
+            continue;
+          }
+          toVisit.push_back(user);
+        }
+      }
+    }
+
+    return reachableSinks;
+  }
+
+  /**
+   * @brief Reorders the users of the given operation to ensure that they are
+   * after it.
+   * @param op The operation whose users should be reordered.
+   * @param rewriter The pattern rewriter to use for moving operations.
+   */
+  static void reorderUsers(mlir::Operation* startingOp,
+                           mlir::PatternRewriter& rewriter) {
+    // Search for operations that need re-ordering using BFS.
+    mlir::DenseSet<mlir::Operation*> toVisit{startingOp};
+    mlir::DenseSet<mlir::Operation*> visited;
+
+    while (!toVisit.empty()) {
+      auto* op = *toVisit.begin();
+      toVisit.erase(op);
+      visited.insert(op);
+      for (auto* user : op->getUsers()) {
+        // Move the user operation after the current operation.
+
+        while (op->getBlock() != user->getBlock()) {
+          user = user->getParentOp();
+        }
+        if (op->isBeforeInBlock(user)) {
+          continue; // Already in the correct order.
+        }
+        rewriter.moveOpAfter(user, op);
+
+        toVisit.insert(user);
+      }
+    }
+  }
+
+  /**
+   * @brief Rewrites the given `AllocOp` and `DeallocOp` to reuse the
+   * qubit instead.
+   *
+   * @param alloc The allocation that will be replaced by qubit reuse.
+   * @param sink The deallocation that will be replaced by a new reset
+   * operation.
+   * @param rewriter The pattern rewriter to use for the rewrite.
+   */
+  static void rewriteForReuse(AllocOp alloc, mlir::Operation* sink,
+                              mlir::PatternRewriter& rewriter) {
+    rewriter.setInsertionPointAfter(sink);
+    const mlir::Value originalInput = sink->getOperand(0);
+    auto reset = rewriter.replaceOpWithNewOp<ResetOp>(
+        alloc, alloc.getResult().getType(), originalInput);
+    rewriter.eraseOp(sink);
+
+    reorderUsers(reset, rewriter);
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(AllocOp op, mlir::PatternRewriter& rewriter) const override {
+    // Find all `DeallocOp` operations in the current block and check
+    // if any of them are disjoint from the qubit being allocated, indicating
+    // potential for reuse.
+
+    auto* currentBlock = op->getBlock();
+    auto deallocs = currentBlock->getOps<DeallocOp>();
+    llvm::DenseSet<mlir::Operation*> reachableDeallocs =
+        findAllReachableDeallocs(op.getResult());
+    // We search `reverse(deallocs)` rather than `deallocs` because this tends
+    // to give more readable results.
+    auto reusableDeallocs =
+        llvm::find_if(llvm::reverse(deallocs), [&](DeallocOp dealloc) {
+          // Check if the qubit to be deallocated is disjoint from the qubit to
+          // be allocated.
+          return !reachableDeallocs.contains(dealloc);
+        });
+
+    if (reusableDeallocs == llvm::reverse(deallocs).end()) {
+      return mlir::failure();
+      // No reusable dealloc found.
+      // We could also check `reset` operations next, which would
+      // always result in the optimal solution, but the complexity explodes.
+      // Therefore, we only check for deallocs here.
+    }
+
+    rewriteForReuse(op, *reusableDeallocs, rewriter);
+    return mlir::success();
+  }
+};
+
+/**
+ * @brief Populates the given pattern set with the
+ * `ReuseQubitsPattern`.
+ *
+ * @param patterns The pattern set to populate.
+ */
+void populateReuseQubitsPatterns(mlir::RewritePatternSet& patterns) {
+  patterns.add<ReuseQubitsPattern>(patterns.getContext());
+}
+
+} // namespace mlir::qco

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -80,6 +80,9 @@ const cl::opt<bool> MERGE_ROTATION_GATES(
 const cl::opt<bool> ENABLE_INLINING("inline",
                                     cl::desc("Enable function inlining"),
                                     cl::init(false));
+
+const cl::opt<bool> ENABLE_IPO("ipo", cl::desc("Enable quantum IPO"),
+                               cl::init(false));
 } // namespace
 
 /**
@@ -178,6 +181,7 @@ int main(int argc, char** argv) {
   config.printIRAfterAllStages = PRINT_IR_AFTER_ALL_STAGES;
   config.mergeRotationGates = MERGE_ROTATION_GATES;
   config.enableInlining = ENABLE_INLINING;
+  config.enableIpo = ENABLE_IPO;
 
   // Run the compilation pipeline
   CompilationRecord record;

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -28,6 +28,7 @@
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/IR/AsmState.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
@@ -157,6 +158,7 @@ int main(int argc, char** argv) {
   registry.insert<func::FuncDialect>();
   registry.insert<scf::SCFDialect>();
   registry.insert<LLVM::LLVMDialect>();
+  registry.insert<tensor::TensorDialect>();
   mlir::func::registerInlinerExtension(registry);
   MLIRContext context(registry);
   context.loadAllAvailableDialects();

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -67,6 +67,10 @@ const cl::opt<bool>
                               cl::desc("Print IR after each compiler stage"),
                               cl::init(false));
 
+const cl::opt<bool> MERGE_ROTATION_GATES(
+    "mlir-merge-rotation-gates",
+    cl::desc("Enable quaternion-based rotation gate merging"), cl::init(false));
+
 } // namespace
 
 /**
@@ -137,6 +141,7 @@ int main(int argc, char** argv) {
   config.enableTiming = ENABLE_TIMING;
   config.enableStatistics = ENABLE_STATISTICS;
   config.printIRAfterAllStages = PRINT_IR_AFTER_ALL_STAGES;
+  config.mergeRotationGates = MERGE_ROTATION_GATES;
 
   // Run the compilation pipeline
   CompilationRecord record;

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -10,6 +10,7 @@
 
 #include "ir/QuantumComputation.hpp"
 #include "mlir/Compiler/CompilerPipeline.h"
+#include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/Translation/TranslateQuantumComputationToQC.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
@@ -76,6 +77,9 @@ const cl::opt<bool> MERGE_ROTATION_GATES(
     "mlir-merge-rotation-gates",
     cl::desc("Enable quaternion-based rotation gate merging"), cl::init(false));
 
+const cl::opt<bool> ENABLE_INLINING("inline",
+                                    cl::desc("Enable function inlining"),
+                                    cl::init(false));
 } // namespace
 
 /**
@@ -150,7 +154,7 @@ int main(int argc, char** argv) {
   registry.insert<func::FuncDialect>();
   registry.insert<scf::SCFDialect>();
   registry.insert<LLVM::LLVMDialect>();
-
+  mlir::func::registerInlinerExtension(registry);
   MLIRContext context(registry);
   context.loadAllAvailableDialects();
 
@@ -173,6 +177,7 @@ int main(int argc, char** argv) {
   config.enableStatistics = ENABLE_STATISTICS;
   config.printIRAfterAllStages = PRINT_IR_AFTER_ALL_STAGES;
   config.mergeRotationGates = MERGE_ROTATION_GATES;
+  config.enableInlining = ENABLE_INLINING;
 
   // Run the compilation pipeline
   CompilationRecord record;

--- a/mlir/unittests/CMakeLists.txt
+++ b/mlir/unittests/CMakeLists.txt
@@ -12,4 +12,4 @@ add_subdirectory(Dialect)
 add_custom_target(mqt-core-mlir-unittests)
 
 add_dependencies(mqt-core-mlir-unittests mqt-core-mlir-compiler-pipeline-test
-                 mqt-core-mlir-dialect-qco-ir-modifiers-test mqt-core-mlir-dialect-utils-test)
+                 mqt-core-mlir-dialect-qco-ir-modifiers-test mqt-core-mlir-dialect-utils-test mqt-core-mlir-dialect-qco-transforms-test)

--- a/mlir/unittests/Dialect/QCO/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/CMakeLists.txt
@@ -7,3 +7,4 @@
 # Licensed under the MIT License
 
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/mlir/unittests/Dialect/QCO/IR/test_unitary_op_interface.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_unitary_op_interface.cpp
@@ -318,3 +318,20 @@ TEST_F(QcoUnitaryOpInterfaceTest, getDynamicUnitaryMatrix) {
         << "Wrong matrix at gate " << i;
   }
 }
+
+TEST_F(QcoUnitaryOpInterfaceTest, ctrCtrlTest) {
+  auto moduleOp = buildQCOIR([](qco::QCOProgramBuilder& b) {
+    auto q = b.allocQubitRegister(3);
+    b.ctrl({q[0]}, {q[1], q[2]}, [&](mlir::ValueRange targets) {
+      const auto& [innerControlsOut, innerTargetsOut] = b.ctrl(
+          {targets[0]}, {targets[1]}, [&](mlir::ValueRange innerTargets) {
+            auto q0 = b.x(innerTargets[0]);
+            return llvm::SmallVector<mlir::Value>{q0};
+          });
+      return llvm::to_vector(
+          llvm::concat<mlir::Value>(innerControlsOut, innerTargetsOut));
+    });
+  });
+
+  moduleOp->dump();
+}

--- a/mlir/unittests/Dialect/QCO/Transforms/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Transforms/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+add_executable(mqt-core-mlir-dialect-qco-transforms-test test_qco_quaternion_merge.cpp)
+
+target_link_libraries(
+  mqt-core-mlir-dialect-qco-transforms-test
+  # TODO figure out correct dependencies
+  PRIVATE GTest::gtest_main
+          MQT::CoreIR
+          MLIRQCOProgramBuilder
+          MLIRFuncDialect
+          MLIRIR
+          MLIRParser
+          MLIRSupport
+          LLVMSupport)
+
+gtest_discover_tests(mqt-core-mlir-dialect-qco-transforms-test)

--- a/mlir/unittests/Dialect/QCO/Transforms/test_qco_quaternion_merge.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/test_qco_quaternion_merge.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+
+#include <gtest/gtest.h>
+#include <llvm/Support/LogicalResult.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Pass/PassManager.h>
+#include <utility>
+#include <vector>
+
+using namespace mlir;
+using namespace mlir::qco;
+
+class QCOQuaternionMergeTest : public ::testing::Test {
+protected:
+  MLIRContext context;
+  QCOProgramBuilder builder;
+  OwningOpRef<ModuleOp> module;
+
+  using RotationGate =
+      std::pair<std::function<Value(const std::vector<double>&, Value)>,
+                std::vector<double>>;
+
+  std::function<Value(const std::vector<double>&, Value)> rx;
+  std::function<Value(const std::vector<double>&, Value)> ry;
+  std::function<Value(const std::vector<double>&, Value)> rz;
+  std::function<Value(const std::vector<double>&, Value)> u;
+
+  QCOQuaternionMergeTest() : builder(&context) {}
+
+  void SetUp() override {
+    context.loadDialect<QCODialect>();
+    context.loadDialect<func::FuncDialect>();
+    context.loadDialect<arith::ArithDialect>();
+    // context.loadDialect<math::MathDialect>();
+
+    // Setup Builder
+    builder.initialize();
+
+    rx = [this](const std::vector<double>& angles, Value q) {
+      return builder.rx(angles[0], q);
+    };
+    ry = [this](const std::vector<double>& angles, Value q) {
+      return builder.ry(angles[0], q);
+    };
+    rz = [this](const std::vector<double>& angles, Value q) {
+      return builder.rz(angles[0], q);
+    };
+    u = [this](const std::vector<double>& angles, Value q) {
+      return builder.u(angles[0], angles[1], angles[2], q);
+    };
+  }
+
+  // Counts the ammont of operations the current module/circuit contains
+  template <typename OpTy> int countOps() {
+    int count = 0;
+    module->walk([&](OpTy) { ++count; });
+    return count;
+  }
+
+  // TODO: create docstring
+  // testGateMerge takes a list of Rotation gates and uses the builder api to
+  // build a small quantum circuit, where a qubit is feed through all rotations
+  // in the list.
+  LogicalResult testGateMerge(const std::vector<RotationGate>& rotations) {
+
+    auto q = builder.allocQubitRegister(1);
+
+    Value qubit = q[0];
+
+    for (const auto& [gate, angles] : rotations) {
+      qubit = gate(angles, qubit);
+    }
+
+    module = builder.finalize();
+    return runMergePass(module.get());
+  }
+
+  LogicalResult runMergePass(ModuleOp module) {
+    PassManager pm(module.getContext());
+    pm.addPass(qco::createMergeRotationGates());
+    return pm.run(module);
+  }
+};

--- a/mlir/unittests/Dialect/QCO/Transforms/test_qco_quaternion_merge.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/test_qco_quaternion_merge.cpp
@@ -97,3 +97,103 @@ protected:
     return pm.run(module);
   }
 };
+
+//   Test Two Gates merge Successfully
+//   RX RY -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeRXRYGates) {
+  ASSERT_TRUE(testGateMerge({{rx, {1.}}, {ry, {1.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RXOp>(), 0);
+  EXPECT_EQ(countOps<RYOp>(), 0);
+}
+
+//   RX RZ -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeRXRZGates) {
+  ASSERT_TRUE(testGateMerge({{rx, {1.}}, {rz, {1.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RXOp>(), 0);
+  EXPECT_EQ(countOps<RZOp>(), 0);
+}
+
+//   RY RX -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeRYRXGates) {
+  ASSERT_TRUE(testGateMerge({{ry, {1.}}, {rx, {1.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RYOp>(), 0);
+  EXPECT_EQ(countOps<RXOp>(), 0);
+}
+
+//   RY RZ -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeRYRZGates) {
+  ASSERT_TRUE(testGateMerge({{ry, {1.}}, {rz, {1.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RYOp>(), 0);
+  EXPECT_EQ(countOps<RZOp>(), 0);
+}
+
+//   RZ RX -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeRZRXGates) {
+  ASSERT_TRUE(testGateMerge({{rz, {1.}}, {rx, {1.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RZOp>(), 0);
+  EXPECT_EQ(countOps<RXOp>(), 0);
+}
+
+//   RZ RY -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeRZRYGates) {
+  ASSERT_TRUE(testGateMerge({{rz, {1.}}, {ry, {1.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RZOp>(), 0);
+  EXPECT_EQ(countOps<RYOp>(), 0);
+}
+
+//   U  U  -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeUUGates) {
+  ASSERT_TRUE(
+      testGateMerge({{u, {1., 2., .3}}, {u, {4., 5., 6.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RZOp>(), 0);
+  EXPECT_EQ(countOps<RYOp>(), 0);
+}
+
+//   U  RX -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeURXGates) {
+  ASSERT_TRUE(testGateMerge({{u, {1., 2., .3}}, {rx, {1.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RXOp>(), 0);
+}
+
+//   U  RY -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeURYGates) {
+  ASSERT_TRUE(testGateMerge({{u, {1., 2., .3}}, {ry, {1.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RYOp>(), 0);
+}
+
+//   U  RZ -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeURZGates) {
+  ASSERT_TRUE(testGateMerge({{u, {1., 2., .3}}, {rx, {1.}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RZOp>(), 0);
+}
+
+//   RX U  -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeRXUGates) {
+  ASSERT_TRUE(testGateMerge({{rx, {1.}}, {u, {1., 2., .3}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RXOp>(), 0);
+}
+
+//   RY U  -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeRYUGates) {
+  ASSERT_TRUE(testGateMerge({{ry, {1.}}, {u, {1., 2., .3}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RYOp>(), 0);
+}
+
+//   RZ U  -> merges to U
+TEST_F(QCOQuaternionMergeTest, quaternionMergeRZUGates) {
+  ASSERT_TRUE(testGateMerge({{rz, {1.}}, {u, {1., 2., .3}}}).succeeded());
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RZOp>(), 0);
+}


### PR DESCRIPTION
## Description

***Note: This PR is currently just in a draft state, used for comparison purposes. I am planning to set up individual, smaller PRs for the specific larger sub-parts of this PR. Feel free to ignore*** 

This PR adds *Inter-Procedural Optimization* (IPO) passes to `mqt-cc`. It allows the compiler framework to perform optimizations on quantum programs that include subroutines, allowing for the reduction of runtime resources even for complex quantum programs.

*AI Assistance notes*: Gemini 3.0 Pro, Gemini 3.1 Pro, and Claude Sonnet 4.x were used to generate parts of the code and discuss and plan algorithms.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
