### PR TITLE
🏁 Fix dynamic loading of QDMI device DLLs on Windows when an absolute path is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 - ⬆️ Require LLVM 22.1 for C++ library builds ([#1549]) ([**@burgholzer**], [**@denialhaag**])
 - 📦 Build MLIR by default for C++ library builds ([#1356]) ([**@burgholzer**], [**@denialhaag**])
 
+### Fixed
+
+- 🏁 Fix dynamic loading of QDMI device DLLs on Windows when an absolute path is provided ([#1720]) ([**@burgholzer**])
+
 ### Removed
 
 - 🔥 Remove the density matrix support from the MQT Core DD package ([#1466]) ([**@burgholzer**])
@@ -388,6 +392,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1720]: https://github.com/munich-quantum-toolkit/core/pull/1720
 [#1709]: https://github.com/munich-quantum-toolkit/core/pull/1709
 [#1702]: https://github.com/munich-quantum-toolkit/core/pull/1702
 [#1700]: https://github.com/munich-quantum-toolkit/core/pull/1700

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -74,10 +74,14 @@ namespace {
 [[nodiscard]] auto loadDeviceLibrary(const std::string& libName) -> HMODULE {
   const auto requested = std::filesystem::path(libName);
 
-  const std::filesystem::path path = requested.has_parent_path()
-                                         ? requested
-                                         : getDriverDirectory() / requested;
+  if (requested.has_parent_path()) {
+    // A directory component was supplied: Directly load the library.
+    return LoadLibraryW(requested.wstring().c_str());
+  }
 
+  // Bare filename: resolve relative to the driver's own directory so that
+  // builtin device DLLs installed next to the driver are found reliably.
+  const auto path = getDriverDirectory() / requested;
   return LoadLibraryExW(path.wstring().c_str(), nullptr,
                         LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
                             LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);


### PR DESCRIPTION
## Description

This fixes an oversight in #1694 that broke dynamic QDMI library loading on Windows and was discovered in https://github.com/iqm-finland/QDMI-on-IQM/pull/63
If an absolute path is provided, the implementation now falls back to the previously-working one that used the simpler `LoadLibraryW` for loading the DLL.

I'll to a test run of this PR in the QDMI-on-IQM repo before we merge and release.

AI (Claude Code) was used to diagnose the issue and come up with potential solutions.
The actual solution was implemented manually.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
