### PR TITLE
🔧 Configure `check-merge-conflict` to fail fast

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-merge-conflict
+        args: [--assume-in-merge]
+        fail_fast: true
         priority: 0
       - id: end-of-file-fixer
         priority: 1


### PR DESCRIPTION
## Description

This PR configures the `check-merge-conflict` hook to fail fast. This should prevent the issue described in https://github.com/munich-quantum-toolkit/core/pull/1703#issuecomment-4441111873.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.