### PR TITLE
🐛 Fix dangling references in collectQubitValuesInsideSCFOps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637], [#1676], [#1706]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add a `place-and-route` pass for mapping circuits to architectures with restricted topologies ([#1537], [#1547], [#1568], [#1581], [#1583], [#1588], [#1600], [#1664], [#1709], [#1716]) ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add initial infrastructure for new QC and QCO MLIR dialects
-  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1620], [#1623], [#1624], [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717], [#1730])
+  ([#1264], [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1620], [#1623], [#1624], [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717], [#1730], [#1749])
   ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**])
 
 ### Changed
@@ -402,6 +402,7 @@ _📚 Refer to the [GitHub Release Notes](https://github.com/munich-quantum-tool
 
 <!-- PR links -->
 
+[#1749]: https://github.com/munich-quantum-toolkit/core/pull/1749
 [#1737]: https://github.com/munich-quantum-toolkit/core/pull/1737
 [#1730]: https://github.com/munich-quantum-toolkit/core/pull/1730
 [#1720]: https://github.com/munich-quantum-toolkit/core/pull/1720

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -515,9 +515,6 @@ static void extractQubitsAfterOp(LoweringState& state, Operation* target,
  */
 static std::pair<SetVector<Value>, SetVector<Value>>
 collectQubitValuesInsideSCFOps(Operation* op, LoweringState* state) {
-  SetVector<Value> localQubits;
-  SetVector<Value> localRegisters;
-
   // Helper to check if a qubit value is defined locally
   auto isDefinedLocally = [&](Region* region, Value value) {
     auto it = state->qubitInfoMap.find(region);
@@ -540,36 +537,34 @@ collectQubitValuesInsideSCFOps(Operation* op, LoweringState* state) {
             collectQubitValuesInsideSCFOps(&operation, state);
         for (Value qubit : qubits) {
           if (!isDefinedLocally(&region, qubit)) {
-            localQubits.insert(qubit);
+            state->regionQubitMap[op].insert(qubit);
           }
         }
-        localRegisters.set_union(registers);
+        state->regionRegisterMap[op].set_union(registers);
       }
       // Track qubits from loadOp
       if (auto loadOp = dyn_cast<memref::LoadOp>(operation)) {
         QubitInfo info{.reg = loadOp.getMemRef(),
                        .index = loadOp.getIndices()[0]};
         state->qubitInfoMap[&region].try_emplace(loadOp.getResult(), info);
-        localRegisters.insert(loadOp.getMemRef());
+        state->regionRegisterMap[op].insert(loadOp.getMemRef());
         continue;
       }
       // Add the QC qubit and memref operands to the maps
       for (const auto& operand : operation.getOperands()) {
         if (isa<qc::QubitType>(operand.getType())) {
           if (!isDefinedLocally(&region, operand)) {
-            localQubits.insert(operand);
+            state->regionQubitMap[op].insert(operand);
           }
         }
         if (auto memref = dyn_cast<MemRefType>(operand.getType())) {
           if (isa<qc::QubitType>(memref.getElementType())) {
-            localRegisters.insert(operand);
+            state->regionRegisterMap[op].insert(operand);
           }
         }
       }
     }
   }
-  state->regionQubitMap[op].set_union(localQubits);
-  state->regionRegisterMap[op].set_union(localRegisters);
 
   return {state->regionQubitMap[op], state->regionRegisterMap[op]};
 }

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -515,56 +515,63 @@ static void extractQubitsAfterOp(LoweringState& state, Operation* target,
  */
 static std::pair<SetVector<Value>, SetVector<Value>>
 collectQubitValuesInsideSCFOps(Operation* op, LoweringState* state) {
-  // Get the regions of the current operation
-  const auto& regions = op->getRegions();
-  auto& regionQubitMap = state->regionQubitMap[op];
-  auto& regionRegisterMap = state->regionRegisterMap[op];
+  SetVector<Value> localQubits;
+  SetVector<Value> localRegisters;
 
-  for (auto& region : regions) {
-    auto& qubitInfoMap = state->qubitInfoMap[&region];
+  // Helper to check if a qubit value is defined locally
+  auto isDefinedLocally = [&](Region* region, Value value) {
+    auto it = state->qubitInfoMap.find(region);
+    return it != state->qubitInfoMap.end() && it->second.contains(value);
+  };
+
+  for (auto& region : op->getRegions()) {
     // Skip empty regions e.g. empty else region of an If operation
     if (region.empty()) {
       continue;
     }
     // Check that the region has only one block
     assert(region.hasOneBlock() && "Expected single-block region");
+
     // Iterate through all operations of the current region
     for (auto& operation : region.front().getOperations()) {
       // Recursively walk through nested regions
       if (operation.getNumRegions() > 0) {
         auto [qubits, registers] =
             collectQubitValuesInsideSCFOps(&operation, state);
-        regionQubitMap.set_union(qubits);
-        // Remove duplicate qubits
-        regionQubitMap.remove_if(
-            [&](Value qubit) { return qubitInfoMap.contains(qubit); });
-        regionRegisterMap.set_union(registers);
+        for (Value qubit : qubits) {
+          if (!isDefinedLocally(&region, qubit)) {
+            localQubits.insert(qubit);
+          }
+        }
+        localRegisters.set_union(registers);
       }
       // Track qubits from loadOp
       if (auto loadOp = dyn_cast<memref::LoadOp>(operation)) {
         QubitInfo info{.reg = loadOp.getMemRef(),
                        .index = loadOp.getIndices()[0]};
-        qubitInfoMap.try_emplace(loadOp.getResult(), info);
-        regionRegisterMap.insert(loadOp.getMemRef());
+        state->qubitInfoMap[&region].try_emplace(loadOp.getResult(), info);
+        localRegisters.insert(loadOp.getMemRef());
         continue;
       }
       // Add the QC qubit and memref operands to the maps
       for (const auto& operand : operation.getOperands()) {
         if (isa<qc::QubitType>(operand.getType())) {
-          if (!qubitInfoMap.contains(operand)) {
-            regionQubitMap.insert(operand);
+          if (!isDefinedLocally(&region, operand)) {
+            localQubits.insert(operand);
           }
         }
         if (auto memref = dyn_cast<MemRefType>(operand.getType())) {
           if (isa<qc::QubitType>(memref.getElementType())) {
-            regionRegisterMap.insert(operand);
+            localRegisters.insert(operand);
           }
         }
       }
     }
   }
+  state->regionQubitMap[op].set_union(localQubits);
+  state->regionRegisterMap[op].set_union(localRegisters);
 
-  return {regionQubitMap, regionRegisterMap};
+  return {state->regionQubitMap[op], state->regionRegisterMap[op]};
 }
 
 namespace {

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -515,12 +515,6 @@ static void extractQubitsAfterOp(LoweringState& state, Operation* target,
  */
 static std::pair<SetVector<Value>, SetVector<Value>>
 collectQubitValuesInsideSCFOps(Operation* op, LoweringState* state) {
-  // Helper to check if a qubit value is defined locally
-  auto isDefinedLocally = [&](Region* region, Value value) {
-    auto it = state->qubitInfoMap.find(region);
-    return it != state->qubitInfoMap.end() && it->second.contains(value);
-  };
-
   for (auto& region : op->getRegions()) {
     // Skip empty regions e.g. empty else region of an If operation
     if (region.empty()) {
@@ -528,38 +522,41 @@ collectQubitValuesInsideSCFOps(Operation* op, LoweringState* state) {
     }
     // Check that the region has only one block
     assert(region.hasOneBlock() && "Expected single-block region");
-
     // Iterate through all operations of the current region
     for (auto& operation : region.front().getOperations()) {
       // Recursively walk through nested regions
       if (operation.getNumRegions() > 0) {
         auto [qubits, registers] =
             collectQubitValuesInsideSCFOps(&operation, state);
-        for (Value qubit : qubits) {
-          if (!isDefinedLocally(&region, qubit)) {
-            state->regionQubitMap[op].insert(qubit);
-          }
-        }
+        auto& regionQubitMap = state->regionQubitMap[op];
+        auto& qubitInfoMap = state->qubitInfoMap[&region];
+        regionQubitMap.set_union(qubits);
+        // Remove duplicate qubits
+        regionQubitMap.remove_if(
+            [&](Value qubit) { return qubitInfoMap.contains(qubit); });
         state->regionRegisterMap[op].set_union(registers);
       }
+      auto& qubitInfoMap = state->qubitInfoMap[&region];
+      auto& regionRegisterMap = state->regionRegisterMap[op];
       // Track qubits from loadOp
       if (auto loadOp = dyn_cast<memref::LoadOp>(operation)) {
         QubitInfo info{.reg = loadOp.getMemRef(),
                        .index = loadOp.getIndices()[0]};
-        state->qubitInfoMap[&region].try_emplace(loadOp.getResult(), info);
-        state->regionRegisterMap[op].insert(loadOp.getMemRef());
+        qubitInfoMap.try_emplace(loadOp.getResult(), info);
+        regionRegisterMap.insert(loadOp.getMemRef());
         continue;
       }
+      auto& regionQubitMap = state->regionQubitMap[op];
       // Add the QC qubit and memref operands to the maps
       for (const auto& operand : operation.getOperands()) {
         if (isa<qc::QubitType>(operand.getType())) {
-          if (!isDefinedLocally(&region, operand)) {
-            state->regionQubitMap[op].insert(operand);
+          if (!qubitInfoMap.contains(operand)) {
+            regionQubitMap.insert(operand);
           }
         }
         if (auto memref = dyn_cast<MemRefType>(operand.getType())) {
           if (isa<qc::QubitType>(memref.getElementType())) {
-            state->regionRegisterMap[op].insert(operand);
+            regionRegisterMap.insert(operand);
           }
         }
       }

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -522,22 +522,18 @@ INSTANTIATE_TEST_SUITE_P(
 /// @{
 INSTANTIATE_TEST_SUITE_P(
     QCOXOpTest, QCOToQCTest,
-    testing::Values(
-        QCOToQCTestCase{"X", MQT_NAMED_BUILDER(qco::x),
-                        MQT_NAMED_BUILDER(qc::x)},
-        QCOToQCTestCase{"SingleControlledX",
-                        MQT_NAMED_BUILDER(qco::singleControlledX),
-                        MQT_NAMED_BUILDER(qc::singleControlledX)},
-        QCOToQCTestCase{"MultipleControlledX",
-                        MQT_NAMED_BUILDER(qco::multipleControlledX),
-                        MQT_NAMED_BUILDER(qc::multipleControlledX)},
-        QCOToQCTestCase{"RepeatedControlledX",
+    testing::Values(QCOToQCTestCase{"X", MQT_NAMED_BUILDER(qco::x),
+                                    MQT_NAMED_BUILDER(qc::x)},
+                    QCOToQCTestCase{"SingleControlledX",
+                                    MQT_NAMED_BUILDER(qco::singleControlledX),
+                                    MQT_NAMED_BUILDER(qc::singleControlledX)},
+                    QCOToQCTestCase{"MultipleControlledX",
+                                    MQT_NAMED_BUILDER(qco::multipleControlledX),
+                                    MQT_NAMED_BUILDER(qc::multipleControlledX)},
+                    QCOToQCTestCase{
+                        "RepeatedControlledX",
                         MQT_NAMED_BUILDER(qco::repeatedControlledX),
-                        MQT_NAMED_BUILDER(qc::repeatedControlledX)},
-        QCOToQCTestCase{
-            "RepeatedControlledXWithRegister",
-            MQT_NAMED_BUILDER(qco::repeatedControlledXWithRegister),
-            MQT_NAMED_BUILDER(qc::repeatedControlledXWithRegister)}));
+                        MQT_NAMED_BUILDER(qc::repeatedControlledX)}));
 /// @}
 
 /// \name QCOToQC/Operations/StandardGates/XxMinusYyOp.cpp

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -522,18 +522,22 @@ INSTANTIATE_TEST_SUITE_P(
 /// @{
 INSTANTIATE_TEST_SUITE_P(
     QCOXOpTest, QCOToQCTest,
-    testing::Values(QCOToQCTestCase{"X", MQT_NAMED_BUILDER(qco::x),
-                                    MQT_NAMED_BUILDER(qc::x)},
-                    QCOToQCTestCase{"SingleControlledX",
-                                    MQT_NAMED_BUILDER(qco::singleControlledX),
-                                    MQT_NAMED_BUILDER(qc::singleControlledX)},
-                    QCOToQCTestCase{"MultipleControlledX",
-                                    MQT_NAMED_BUILDER(qco::multipleControlledX),
-                                    MQT_NAMED_BUILDER(qc::multipleControlledX)},
-                    QCOToQCTestCase{
-                        "RepeatedControlledX",
+    testing::Values(
+        QCOToQCTestCase{"X", MQT_NAMED_BUILDER(qco::x),
+                        MQT_NAMED_BUILDER(qc::x)},
+        QCOToQCTestCase{"SingleControlledX",
+                        MQT_NAMED_BUILDER(qco::singleControlledX),
+                        MQT_NAMED_BUILDER(qc::singleControlledX)},
+        QCOToQCTestCase{"MultipleControlledX",
+                        MQT_NAMED_BUILDER(qco::multipleControlledX),
+                        MQT_NAMED_BUILDER(qc::multipleControlledX)},
+        QCOToQCTestCase{"RepeatedControlledX",
                         MQT_NAMED_BUILDER(qco::repeatedControlledX),
-                        MQT_NAMED_BUILDER(qc::repeatedControlledX)}));
+                        MQT_NAMED_BUILDER(qc::repeatedControlledX)},
+        QCOToQCTestCase{
+            "RepeatedControlledXWithRegister",
+            MQT_NAMED_BUILDER(qco::repeatedControlledXWithRegister),
+            MQT_NAMED_BUILDER(qc::repeatedControlledXWithRegister)}));
 /// @}
 
 /// \name QCOToQC/Operations/StandardGates/XxMinusYyOp.cpp

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -527,10 +527,13 @@ INSTANTIATE_TEST_SUITE_P(
                     QCOToQCTestCase{"SingleControlledX",
                                     MQT_NAMED_BUILDER(qco::singleControlledX),
                                     MQT_NAMED_BUILDER(qc::singleControlledX)},
+                    QCOToQCTestCase{"MultipleControlledX",
+                                    MQT_NAMED_BUILDER(qco::multipleControlledX),
+                                    MQT_NAMED_BUILDER(qc::multipleControlledX)},
                     QCOToQCTestCase{
-                        "MultipleControlledX",
-                        MQT_NAMED_BUILDER(qco::multipleControlledX),
-                        MQT_NAMED_BUILDER(qc::multipleControlledX)}));
+                        "RepeatedControlledX",
+                        MQT_NAMED_BUILDER(qco::repeatedControlledX),
+                        MQT_NAMED_BUILDER(qc::repeatedControlledX)}));
 /// @}
 
 /// \name QCOToQC/Operations/StandardGates/XxMinusYyOp.cpp

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -536,11 +536,7 @@ INSTANTIATE_TEST_SUITE_P(
                         MQT_NAMED_BUILDER(qco::multipleControlledX)},
         QCToQCOTestCase{"RepeatedControlledX",
                         MQT_NAMED_BUILDER(qc::repeatedControlledX),
-                        MQT_NAMED_BUILDER(qco::repeatedControlledX)},
-        QCToQCOTestCase{
-            "RepeatedControlledXWithRegister",
-            MQT_NAMED_BUILDER(qc::repeatedControlledXWithRegister),
-            MQT_NAMED_BUILDER(qco::repeatedControlledXWithRegister)}));
+                        MQT_NAMED_BUILDER(qco::repeatedControlledX)}));
 
 /// @}
 

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -525,15 +525,19 @@ INSTANTIATE_TEST_SUITE_P(
 /// @{
 INSTANTIATE_TEST_SUITE_P(
     QCXOpTest, QCToQCOTest,
-    testing::Values(QCToQCOTestCase{"X", MQT_NAMED_BUILDER(qc::x),
-                                    MQT_NAMED_BUILDER(qco::x)},
-                    QCToQCOTestCase{"SingleControlledX",
-                                    MQT_NAMED_BUILDER(qc::singleControlledX),
-                                    MQT_NAMED_BUILDER(qco::singleControlledX)},
-                    QCToQCOTestCase{
-                        "MultipleControlledX",
+    testing::Values(
+        QCToQCOTestCase{"X", MQT_NAMED_BUILDER(qc::x),
+                        MQT_NAMED_BUILDER(qco::x)},
+        QCToQCOTestCase{"SingleControlledX",
+                        MQT_NAMED_BUILDER(qc::singleControlledX),
+                        MQT_NAMED_BUILDER(qco::singleControlledX)},
+        QCToQCOTestCase{"MultipleControlledX",
                         MQT_NAMED_BUILDER(qc::multipleControlledX),
-                        MQT_NAMED_BUILDER(qco::multipleControlledX)}));
+                        MQT_NAMED_BUILDER(qco::multipleControlledX)},
+        QCToQCOTestCase{"RepeatedControlledX",
+                        MQT_NAMED_BUILDER(qc::repeatedControlledX),
+                        MQT_NAMED_BUILDER(qco::repeatedControlledX)}));
+
 /// @}
 
 /// \name QCToQCO/Operations/StandardGates/XxMinusYyOp.cpp

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -536,7 +536,11 @@ INSTANTIATE_TEST_SUITE_P(
                         MQT_NAMED_BUILDER(qco::multipleControlledX)},
         QCToQCOTestCase{"RepeatedControlledX",
                         MQT_NAMED_BUILDER(qc::repeatedControlledX),
-                        MQT_NAMED_BUILDER(qco::repeatedControlledX)}));
+                        MQT_NAMED_BUILDER(qco::repeatedControlledX)},
+        QCToQCOTestCase{
+            "RepeatedControlledXWithRegister",
+            MQT_NAMED_BUILDER(qc::repeatedControlledXWithRegister),
+            MQT_NAMED_BUILDER(qco::repeatedControlledXWithRegister)}));
 
 /// @}
 

--- a/mlir/unittests/programs/qc_programs.cpp
+++ b/mlir/unittests/programs/qc_programs.cpp
@@ -271,6 +271,15 @@ void trivialControlledX(QCProgramBuilder& b) {
   b.mcx({}, q[0]);
 }
 
+void repeatedControlledX(QCProgramBuilder& b) {
+  auto control = b.allocQubit();
+  b.h(control);
+  for (auto i = 0; i < 50; i++) {
+    auto qubit = b.allocQubit();
+    b.mcx(control, qubit);
+  }
+}
+
 void inverseX(QCProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   b.inv([&]() { b.x(q[0]); });

--- a/mlir/unittests/programs/qc_programs.cpp
+++ b/mlir/unittests/programs/qc_programs.cpp
@@ -276,7 +276,7 @@ void repeatedControlledX(QCProgramBuilder& b) {
   b.h(control);
   for (auto i = 0; i < 50; i++) {
     auto qubit = b.allocQubit();
-    b.mcx(control, qubit);
+    b.cx(control, qubit);
   }
 }
 

--- a/mlir/unittests/programs/qc_programs.cpp
+++ b/mlir/unittests/programs/qc_programs.cpp
@@ -280,15 +280,6 @@ void repeatedControlledX(QCProgramBuilder& b) {
   }
 }
 
-void repeatedControlledXWithRegister(QCProgramBuilder& b) {
-  auto q = b.allocQubitRegister(50);
-  auto control = b.allocQubit();
-  b.h(control);
-  for (auto i = 0; i < 50; i++) {
-    b.cx(control, q[i]);
-  }
-}
-
 void inverseX(QCProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   b.inv([&]() { b.x(q[0]); });

--- a/mlir/unittests/programs/qc_programs.cpp
+++ b/mlir/unittests/programs/qc_programs.cpp
@@ -280,6 +280,15 @@ void repeatedControlledX(QCProgramBuilder& b) {
   }
 }
 
+void repeatedControlledXWithRegister(QCProgramBuilder& b) {
+  auto q = b.allocQubitRegister(50);
+  auto control = b.allocQubit();
+  b.h(control);
+  for (auto i = 0; i < 50; i++) {
+    b.cx(control, q[i]);
+  }
+}
+
 void inverseX(QCProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   b.inv([&]() { b.x(q[0]); });

--- a/mlir/unittests/programs/qc_programs.h
+++ b/mlir/unittests/programs/qc_programs.h
@@ -174,6 +174,10 @@ void trivialControlledX(QCProgramBuilder& b);
 /// Creates a circuit with repeated controlled X gates.
 void repeatedControlledX(QCProgramBuilder& b);
 
+/// Creates a circuit with repeated controlled X gates using qubits from a
+/// register.
+void repeatedControlledXWithRegister(QCProgramBuilder& b);
+
 /// Creates a circuit with an inverse modifier applied to an X gate.
 void inverseX(QCProgramBuilder& b);
 

--- a/mlir/unittests/programs/qc_programs.h
+++ b/mlir/unittests/programs/qc_programs.h
@@ -171,6 +171,9 @@ void nestedControlledX(QCProgramBuilder& b);
 /// Creates a circuit with a trivial controlled X gate.
 void trivialControlledX(QCProgramBuilder& b);
 
+/// Creates a circuit with repeated controlled X gates.
+void repeatedControlledX(QCProgramBuilder& b);
+
 /// Creates a circuit with an inverse modifier applied to an X gate.
 void inverseX(QCProgramBuilder& b);
 

--- a/mlir/unittests/programs/qc_programs.h
+++ b/mlir/unittests/programs/qc_programs.h
@@ -174,10 +174,6 @@ void trivialControlledX(QCProgramBuilder& b);
 /// Creates a circuit with repeated controlled X gates.
 void repeatedControlledX(QCProgramBuilder& b);
 
-/// Creates a circuit with repeated controlled X gates using qubits from a
-/// register.
-void repeatedControlledXWithRegister(QCProgramBuilder& b);
-
 /// Creates a circuit with an inverse modifier applied to an X gate.
 void inverseX(QCProgramBuilder& b);
 

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -266,15 +266,6 @@ void nestedControlledX(QCOProgramBuilder& b) {
   });
 }
 
-void repeatedControlledXWithRegister(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(50);
-  auto q0 = b.allocQubit();
-  auto control = b.h(q0);
-  for (auto i = 0; i < 50; i++) {
-    control = b.cx(control, q[i]).first;
-  }
-}
-
 void trivialControlledX(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   b.mcx({}, q[0]);

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -266,6 +266,15 @@ void nestedControlledX(QCOProgramBuilder& b) {
   });
 }
 
+void repeatedControlledXWithRegister(QCOProgramBuilder& b) {
+  auto q = b.allocQubitRegister(50);
+  auto q0 = b.allocQubit();
+  auto control = b.h(q0);
+  for (auto i = 0; i < 50; i++) {
+    control = b.cx(control, q[i]).first;
+  }
+}
+
 void trivialControlledX(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   b.mcx({}, q[0]);

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -276,7 +276,7 @@ void repeatedControlledX(QCOProgramBuilder& b) {
   auto control = b.h(q0);
   for (auto i = 0; i < 50; i++) {
     auto qubit = b.allocQubit();
-    control = b.mcx(control, qubit).first[0];
+    control = b.cx(control, qubit).first;
   }
 }
 

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -271,6 +271,15 @@ void trivialControlledX(QCOProgramBuilder& b) {
   b.mcx({}, q[0]);
 }
 
+void repeatedControlledX(QCOProgramBuilder& b) {
+  auto q0 = b.allocQubit();
+  auto control = b.h(q0);
+  for (auto i = 0; i < 50; i++) {
+    auto qubit = b.allocQubit();
+    control = b.mcx(control, qubit).first[0];
+  }
+}
+
 void inverseX(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   b.inv({q[0]}, [&](ValueRange qubits) { return SmallVector{b.x(qubits[0])}; });

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -161,10 +161,6 @@ void trivialControlledX(QCOProgramBuilder& b);
 /// Creates a circuit with repeated controlled X gates.
 void repeatedControlledX(QCOProgramBuilder& b);
 
-/// Creates a circuit with repeated controlled X gates using qubits from a
-/// register.
-void repeatedControlledXWithRegister(QCOProgramBuilder& b);
-
 /// Creates a circuit with an inverse modifier applied to an X gate.
 void inverseX(QCOProgramBuilder& b);
 

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -158,6 +158,9 @@ void nestedControlledX(QCOProgramBuilder& b);
 /// Creates a circuit with a trivial controlled X gate.
 void trivialControlledX(QCOProgramBuilder& b);
 
+/// Creates a circuit with repeated controlled X gates.
+void repeatedControlledX(QCOProgramBuilder& b);
+
 /// Creates a circuit with an inverse modifier applied to an X gate.
 void inverseX(QCOProgramBuilder& b);
 

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -161,6 +161,10 @@ void trivialControlledX(QCOProgramBuilder& b);
 /// Creates a circuit with repeated controlled X gates.
 void repeatedControlledX(QCOProgramBuilder& b);
 
+/// Creates a circuit with repeated controlled X gates using qubits from a
+/// register.
+void repeatedControlledXWithRegister(QCOProgramBuilder& b);
+
 /// Creates a circuit with an inverse modifier applied to an X gate.
 void inverseX(QCOProgramBuilder& b);
 


### PR DESCRIPTION
## Description

Refactors `collectQubitValuesInsideSCFOps` in the QC to QCO conversion to directly use `state->maps` to store the values instead of using a reference to it. This avoids dangling references when the maps get rehashed/reallocated after inserting values.

Fixes #1747

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [ ] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
