### PR TITLE
🐛 Refactor unitary matrix calculations in ROp, UOp, XXMinusYYOp, and XXPlusYYOp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ with the exception that minor releases may include breaking changes.
   [#1569], [#1570], [#1572], [#1573], [#1580], [#1602], [#1620], [#1623],
   [#1624], [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700],
   [#1710], [#1717], [#1728], [#1730], [#1749], [#1751], [#1762], [#1765],
-  [#1774], [#1780], [#1781], [#1782], [#1787], [#1802])
+  [#1774], [#1780], [#1781], [#1782], [#1787], [#1802], [#1807])
   ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**],
   [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
   [**@simon1hofmann**])
@@ -598,6 +598,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1807]: https://github.com/munich-quantum-toolkit/core/pull/1807
 [#1802]: https://github.com/munich-quantum-toolkit/core/pull/1802
 [#1787]: https://github.com/munich-quantum-toolkit/core/pull/1787
 [#1782]: https://github.com/munich-quantum-toolkit/core/pull/1782

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ROp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ROp.cpp
@@ -115,10 +115,13 @@ std::optional<Matrix2x2> ROp::getUnitaryMatrix() {
     return std::nullopt;
   }
 
-  const auto thetaSin = std::sin(*theta / 2);
-  const auto m01 = std::polar(thetaSin, -*phi - (std::numbers::pi / 2));
-  const auto m10 = std::polar(thetaSin, *phi - (std::numbers::pi / 2));
-  const auto thetaCos = std::cos(*theta / 2);
-  return Matrix2x2::fromElements(thetaCos, m01,  // row 0
-                                 m10, thetaCos); // row 1
+  using namespace std::complex_literals;
+  const auto halfTheta = *theta / 2;
+  const auto c = std::cos(halfTheta);
+  const auto s = std::sin(halfTheta);
+
+  const auto m01 = s * std::exp(1i * (-*phi - (std::numbers::pi / 2)));
+  const auto m10 = s * std::exp(1i * (*phi - (std::numbers::pi / 2)));
+  return Matrix2x2::fromElements(c, m01,  // row 0
+                                 m10, c); // row 1
 }

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/UOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/UOp.cpp
@@ -133,12 +133,14 @@ std::optional<Matrix2x2> UOp::getUnitaryMatrix() {
     return std::nullopt;
   }
 
-  const auto c = std::cos(*theta / 2);
-  const auto s = std::sin(*theta / 2);
+  using namespace std::complex_literals;
+  const auto halfTheta = *theta / 2;
+  const auto c = std::cos(halfTheta);
+  const auto s = std::sin(halfTheta);
 
-  const auto m01 = std::polar(s, *lambda + std::numbers::pi);
-  const auto m10 = std::polar(s, *phi);
-  const auto m11 = std::polar(c, *phi + *lambda);
+  const auto m01 = s * std::exp(1i * (*lambda + std::numbers::pi));
+  const auto m10 = s * std::exp(1i * (*phi));
+  const auto m11 = c * std::exp(1i * (*phi + *lambda));
   return Matrix2x2::fromElements(c, m01,    // row 0
                                  m10, m11); // row 1
 }

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
@@ -79,10 +79,11 @@ std::optional<Matrix4x4> XXMinusYYOp::getUnitaryMatrix() {
     return std::nullopt;
   }
 
+  using namespace std::complex_literals;
   const auto mc = std::cos(*theta / 2);
   const auto s = std::sin(*theta / 2);
-  const auto msp = std::polar(s, *beta - (std::numbers::pi / 2));
-  const auto msm = std::polar(s, -*beta - (std::numbers::pi / 2));
+  const auto msp = s * std::exp(1i * (*beta - (std::numbers::pi / 2)));
+  const auto msm = s * std::exp(1i * (-*beta - (std::numbers::pi / 2)));
   return Matrix4x4::fromElements(mc, 0, 0, msm,  // row 0
                                  0, 1, 0, 0,     // row 1
                                  0, 0, 1, 0,     // row 2

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
@@ -79,10 +79,11 @@ std::optional<Matrix4x4> XXPlusYYOp::getUnitaryMatrix() {
     return std::nullopt;
   }
 
+  using namespace std::complex_literals;
   const auto mc = std::cos(*theta / 2);
   const auto s = std::sin(*theta / 2);
-  const auto msp = std::polar(s, *beta - (std::numbers::pi / 2));
-  const auto msm = std::polar(s, -*beta - (std::numbers::pi / 2));
+  const auto msp = s * std::exp(1i * (*beta - (std::numbers::pi / 2)));
+  const auto msm = s * std::exp(1i * (-*beta - (std::numbers::pi / 2)));
   return Matrix4x4::fromElements(1, 0, 0, 0,    // row 0
                                  0, mc, msp, 0, // row 1
                                  0, msm, mc, 0, // row 2


### PR DESCRIPTION
## Description
- Fix `getUnitaryMatrix()` for `ROp`, `UOp`, `XXMinusYYOp`, and `XXPlusYYOp` when rotation angles produce negative `sin(θ/2)` or `cos(θ/2)` scalars.
- Replace `std::polar(magnitude, phase)` with `magnitude * std::exp(i·phase)`, which is well-defined for any real magnitude.

## Problem
`std::polar(ρ, θ)` requires a **non-negative** `ρ` ([LWG 2459](https://cplusplus.github.io/LWG/issue2459)). For negative rotation angles, gates like `R(θ, φ)` use `sin(θ/2)` as a matrix entry scale, which can be negative (e.g. `θ = -π/2` → `sin(θ/2) < 0`).
On libc++, `std::polar(negative, φ)` returns `NaN`, breaking unitary extraction for otherwise valid gates.

## Fix
Build phased entries as ordinary complex multiplication:
```cpp
const auto m01 = std::sin(halfTheta) * std::exp(1i * phase);
```
instead of:
```cpp
std::polar(s, phase);  // invalid when s < 0
```
std::polar(1.0, φ) remains appropriate for unit-magnitude global phases.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [ ] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
