### PR TITLE
✨ Directly emit LLVM IR when emitting QIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@ with the exception that minor releases may include breaking changes.
   [#1624], [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700],
   [#1710], [#1717], [#1728], [#1730], [#1749], [#1751], [#1762], [#1765],
   [#1774], [#1780], [#1781], [#1782], [#1787], [#1802], [#1806], [#1807],
-  [#1808], [#1809]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
-  [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
+  [#1808], [#1809], [#1823])
+  ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**],
+  [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
   [**@simon1hofmann**])
 
 ### Changed
@@ -598,6 +599,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1823]: https://github.com/munich-quantum-toolkit/core/pull/1823
 [#1809]: https://github.com/munich-quantum-toolkit/core/pull/1809
 [#1808]: https://github.com/munich-quantum-toolkit/core/pull/1808
 [#1807]: https://github.com/munich-quantum-toolkit/core/pull/1807

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.td
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.td
@@ -33,14 +33,6 @@ def QCToQIRAdaptive : Pass<"qc-to-qir-adaptive"> {
       Any blocks in-between have no restrictions regarding their operations as long as they are supported.
     - Measurement results may be used as classical values to drive conditional branches.
     - Non-quantum dialects are lowered via MLIR's built-in conversions.
-
-    Producing LLVM IR:
-
-    - After conversion to the LLVM dialect, produce LLVM IR with:
-
-      ```
-      mlir-translate --mlir-to-llvmir input.mlir > output.ll
-      ```
   }];
 
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
@@ -35,14 +35,6 @@ def QCToQIRBase : Pass<"qc-to-qir-base"> {
       3. Epilogue block: Records measurement results and returns from the entry function.
     - Blocks are connected via unconditional branches in the order listed above.
     - Non-quantum dialects are lowered via MLIR's built-in conversions.
-
-    Producing LLVM IR:
-
-    - After conversion to the LLVM dialect, produce LLVM IR with:
-
-      ```
-      mlir-translate --mlir-to-llvmir input.mlir > output.ll
-      ```
   }];
 
   let dependentDialects = ["mlir::LLVM::LLVMDialect"];

--- a/mlir/tools/mqt-cc/CMakeLists.txt
+++ b/mlir/tools/mqt-cc/CMakeLists.txt
@@ -8,7 +8,18 @@
 
 # Build the compiler driver executable
 add_mlir_tool(mqt-cc mqt-cc.cpp DEPENDS MQTCompilerPipeline SUPPORT_PLUGINS)
-target_link_libraries(mqt-cc PRIVATE MQTCompilerPipeline MLIRParser MLIRSupport MLIRQCTranslation)
+llvm_map_components_to_libnames(llvm_native_libs bitwriter)
+target_link_libraries(
+  mqt-cc
+  PRIVATE MQTCompilerPipeline
+          MLIRParser
+          MLIRSupport
+          MLIRQCTranslation
+          MLIRBytecodeWriter
+          MLIRTargetLLVMIRExport
+          MLIRBuiltinToLLVMIRTranslation
+          MLIRLLVMToLLVMIRTranslation
+          ${llvm_native_libs})
 
 mqt_mlir_target_use_project_options(mqt-cc)
 llvm_update_compile_flags(mqt-cc)

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -42,6 +42,7 @@
 #include <mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h>
 #include <mlir/Target/LLVMIR/Export.h>
 
+#include <memory>
 #include <string>
 #include <utility>
 

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -149,9 +149,8 @@ static mlir::LogicalResult writeOutput(ModuleType mod, StringRef filename) {
   if constexpr (std::is_same_v<ModuleType, mlir::ModuleOp>) {
     if (filename == "-") {
       mod.print(output->os());
-    } else if (writeBytecodeToFile(mod, output->os()).failed()) {
-      llvm::errs() << "Failed to write bytecode to file: " << filename << "\n";
-      return mlir::failure();
+    } else {
+      writeBytecodeToFile(mod, output->os());
     }
   } else if constexpr (std::is_same_v<ModuleType, llvm::Module*>) {
     if (filename == "-") {
@@ -256,11 +255,9 @@ int main(int argc, char** argv) {
       return 1;
     }
     if (writeOutput<llvm::Module*>(llvmMod.get(), outputFilename).failed()) {
-      llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
       return 1;
     }
   } else if (writeOutput<ModuleOp>(mod.get(), outputFilename).failed()) {
-    llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
     return 1;
   }
 

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -14,11 +14,17 @@
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 
+#include <llvm/Bitcode/BitcodeWriter.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Support/CommandLine.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/InitLLVM.h>
 #include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/SystemUtils.h>
 #include <llvm/Support/ToolOutputFile.h>
 #include <llvm/Support/raw_ostream.h>
+#include <mlir/Bytecode/BytecodeWriter.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -32,6 +38,9 @@
 #include <mlir/Support/FileUtilities.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
+#include <mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h>
+#include <mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h>
+#include <mlir/Target/LLVMIR/Export.h>
 
 #include <string>
 #include <utility>
@@ -89,7 +98,7 @@ static llvm::cl::opt<bool> enableHadamardLifting(
     llvm::cl::init(false));
 
 /**
- * @brief Load and parse a .qasm file
+ * @brief Load and parse a `.qasm` file
  */
 static OwningOpRef<ModuleOp> loadQASMFile(StringRef filename,
                                           MLIRContext* context) {
@@ -107,7 +116,7 @@ static OwningOpRef<ModuleOp> loadQASMFile(StringRef filename,
 }
 
 /**
- * @brief Load and parse a .mlir file
+ * @brief Load and parse a `.mlir` file
  */
 static OwningOpRef<ModuleOp> loadMLIRFile(StringRef filename,
                                           MLIRContext* context) {
@@ -125,7 +134,7 @@ static OwningOpRef<ModuleOp> loadMLIRFile(StringRef filename,
 }
 
 /**
- * @brief Write the module to the output file
+ * @brief Write an MLIR module to an output file
  */
 static mlir::LogicalResult writeOutput(ModuleOp module, StringRef filename) {
   std::string errorMessage;
@@ -135,8 +144,34 @@ static mlir::LogicalResult writeOutput(ModuleOp module, StringRef filename) {
     return mlir::failure();
   }
 
-  module.print(output->os());
-  output->keep();
+  if (filename == "-") {
+    module->print(output->os());
+    output->keep();
+    return mlir::success();
+  }
+
+  return writeBytecodeToFile(module, output->os());
+}
+
+/**
+ * @brief Write an LLVM module to an output file
+ */
+static mlir::LogicalResult writeOutputLLVM(llvm::Module* module,
+                                           StringRef filename) {
+  std::string errorMessage;
+  const auto output = openOutputFile(filename, &errorMessage);
+  if (!output) {
+    llvm::errs() << errorMessage << "\n";
+    return mlir::failure();
+  }
+
+  if (filename == "-") {
+    module->print(output->os(), nullptr);
+    output->keep();
+  } else {
+    llvm::WriteBitcodeToFile(*module, output->os());
+  }
+
   return mlir::success();
 }
 
@@ -153,6 +188,8 @@ int main(int argc, char** argv) {
       .insert<arith::ArithDialect, cf::ControlFlowDialect, func::FuncDialect,
               LLVM::LLVMDialect, memref::MemRefDialect, qc::QCDialect,
               qco::QCODialect, qtensor::QTensorDialect, scf::SCFDialect>();
+  registerBuiltinDialectTranslation(registry);
+  registerLLVMDialectTranslation(registry);
 
   MLIRContext context(registry);
   context.loadAllAvailableDialects();
@@ -213,9 +250,23 @@ int main(int argc, char** argv) {
   }
 
   // Write the output
-  if (writeOutput(module.get(), outputFilename).failed()) {
-    llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
-    return 1;
+  if (convertToQIRBase || convertToQIRAdaptive) {
+    llvm::LLVMContext llvmContext;
+    std::unique_ptr<llvm::Module> llvmModule =
+        translateModuleToLLVMIR(*module, llvmContext);
+    if (!llvmModule) {
+      llvm::errs() << "Failed to translate MLIR module to LLVM IR\n";
+      return 1;
+    }
+    if (writeOutputLLVM(llvmModule.get(), outputFilename).failed()) {
+      llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
+      return 1;
+    }
+  } else {
+    if (writeOutput(module.get(), outputFilename).failed()) {
+      llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
+      return 1;
+    }
   }
 
   return 0;

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -152,6 +152,12 @@ static mlir::LogicalResult writeOutput(ModuleOp module, StringRef filename) {
     return mlir::failure();
   }
 
+  output->os().flush();
+  if (output->os().has_error()) {
+    llvm::errs() << "I/O error while writing output file: " << filename << "\n";
+    return mlir::failure();
+  }
+
   output->keep();
   return mlir::success();
 }
@@ -172,6 +178,12 @@ static mlir::LogicalResult writeOutputLLVM(llvm::Module* module,
     module->print(output->os(), nullptr);
   } else {
     llvm::WriteBitcodeToFile(*module, output->os());
+  }
+
+  output->os().flush();
+  if (output->os().has_error()) {
+    llvm::errs() << "I/O error while writing output file: " << filename << "\n";
+    return mlir::failure();
   }
 
   output->keep();

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -147,11 +147,13 @@ static mlir::LogicalResult writeOutput(ModuleOp module, StringRef filename) {
 
   if (filename == "-") {
     module->print(output->os());
-    output->keep();
-    return mlir::success();
+  } else if (writeBytecodeToFile(module, output->os()).failed()) {
+    llvm::errs() << "Failed to write bytecode to file: " << filename << "\n";
+    return mlir::failure();
   }
 
-  return writeBytecodeToFile(module, output->os());
+  output->keep();
+  return mlir::success();
 }
 
 /**
@@ -168,11 +170,11 @@ static mlir::LogicalResult writeOutputLLVM(llvm::Module* module,
 
   if (filename == "-") {
     module->print(output->os(), nullptr);
-    output->keep();
   } else {
     llvm::WriteBitcodeToFile(*module, output->os());
   }
 
+  output->keep();
   return mlir::success();
 }
 
@@ -263,11 +265,9 @@ int main(int argc, char** argv) {
       llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
       return 1;
     }
-  } else {
-    if (writeOutput(module.get(), outputFilename).failed()) {
-      llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
-      return 1;
-    }
+  } else if (writeOutput(module.get(), outputFilename).failed()) {
+    llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
+    return 1;
   }
 
   return 0;

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -117,7 +117,7 @@ static OwningOpRef<ModuleOp> loadQASMFile(StringRef filename,
 }
 
 /**
- * @brief Load and parse a `.mlir` file
+ * @brief Load and parse an `.mlir` file
  */
 static OwningOpRef<ModuleOp> loadMLIRFile(StringRef filename,
                                           MLIRContext* context) {

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -135,9 +135,10 @@ static OwningOpRef<ModuleOp> loadMLIRFile(StringRef filename,
 }
 
 /**
- * @brief Write an MLIR module to an output file
+ * @brief Write a module to an output file
  */
-static mlir::LogicalResult writeOutput(ModuleOp mod, StringRef filename) {
+template <typename ModuleType>
+static mlir::LogicalResult writeOutput(ModuleType mod, StringRef filename) {
   std::string errorMessage;
   const auto output = openOutputFile(filename, &errorMessage);
   if (!output) {
@@ -145,39 +146,21 @@ static mlir::LogicalResult writeOutput(ModuleOp mod, StringRef filename) {
     return mlir::failure();
   }
 
-  if (filename == "-") {
-    mod->print(output->os());
-  } else if (writeBytecodeToFile(mod, output->os()).failed()) {
-    llvm::errs() << "Failed to write bytecode to file: " << filename << "\n";
-    return mlir::failure();
-  }
-
-  output->os().flush();
-  if (output->os().has_error()) {
-    llvm::errs() << "I/O error while writing output file: " << filename << "\n";
-    return mlir::failure();
-  }
-
-  output->keep();
-  return mlir::success();
-}
-
-/**
- * @brief Write an LLVM module to an output file
- */
-static mlir::LogicalResult writeOutputLLVM(llvm::Module* mod,
-                                           StringRef filename) {
-  std::string errorMessage;
-  const auto output = openOutputFile(filename, &errorMessage);
-  if (!output) {
-    llvm::errs() << errorMessage << "\n";
-    return mlir::failure();
-  }
-
-  if (filename == "-") {
-    mod->print(output->os(), nullptr);
+  if constexpr (std::is_same_v<ModuleType, mlir::ModuleOp>) {
+    if (filename == "-") {
+      mod.print(output->os());
+    } else if (writeBytecodeToFile(mod, output->os()).failed()) {
+      llvm::errs() << "Failed to write bytecode to file: " << filename << "\n";
+      return mlir::failure();
+    }
+  } else if constexpr (std::is_same_v<ModuleType, llvm::Module*>) {
+    if (filename == "-") {
+      mod->print(output->os(), nullptr);
+    } else {
+      llvm::WriteBitcodeToFile(*mod, output->os());
+    }
   } else {
-    llvm::WriteBitcodeToFile(*mod, output->os());
+    llvm_unreachable("Unsupported module type");
   }
 
   output->os().flush();
@@ -272,11 +255,11 @@ int main(int argc, char** argv) {
       llvm::errs() << "Failed to translate MLIR module to LLVM IR\n";
       return 1;
     }
-    if (writeOutputLLVM(llvmMod.get(), outputFilename).failed()) {
+    if (writeOutput<llvm::Module*>(llvmMod.get(), outputFilename).failed()) {
       llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
       return 1;
     }
-  } else if (writeOutput(mod.get(), outputFilename).failed()) {
+  } else if (writeOutput<ModuleOp>(mod.get(), outputFilename).failed()) {
     llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
     return 1;
   }

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -137,7 +137,7 @@ static OwningOpRef<ModuleOp> loadMLIRFile(StringRef filename,
 /**
  * @brief Write an MLIR module to an output file
  */
-static mlir::LogicalResult writeOutput(ModuleOp module, StringRef filename) {
+static mlir::LogicalResult writeOutput(ModuleOp mod, StringRef filename) {
   std::string errorMessage;
   const auto output = openOutputFile(filename, &errorMessage);
   if (!output) {
@@ -146,8 +146,8 @@ static mlir::LogicalResult writeOutput(ModuleOp module, StringRef filename) {
   }
 
   if (filename == "-") {
-    module->print(output->os());
-  } else if (writeBytecodeToFile(module, output->os()).failed()) {
+    mod->print(output->os());
+  } else if (writeBytecodeToFile(mod, output->os()).failed()) {
     llvm::errs() << "Failed to write bytecode to file: " << filename << "\n";
     return mlir::failure();
   }
@@ -165,7 +165,7 @@ static mlir::LogicalResult writeOutput(ModuleOp module, StringRef filename) {
 /**
  * @brief Write an LLVM module to an output file
  */
-static mlir::LogicalResult writeOutputLLVM(llvm::Module* module,
+static mlir::LogicalResult writeOutputLLVM(llvm::Module* mod,
                                            StringRef filename) {
   std::string errorMessage;
   const auto output = openOutputFile(filename, &errorMessage);
@@ -175,9 +175,9 @@ static mlir::LogicalResult writeOutputLLVM(llvm::Module* module,
   }
 
   if (filename == "-") {
-    module->print(output->os(), nullptr);
+    mod->print(output->os(), nullptr);
   } else {
-    llvm::WriteBitcodeToFile(*module, output->os());
+    llvm::WriteBitcodeToFile(*mod, output->os());
   }
 
   output->os().flush();
@@ -210,13 +210,13 @@ int main(int argc, char** argv) {
   context.loadAllAvailableDialects();
 
   // Load the input .mlir file
-  OwningOpRef<ModuleOp> module;
+  OwningOpRef<ModuleOp> mod;
   if (inputFilename.getValue().ends_with(".qasm")) {
-    module = loadQASMFile(inputFilename, &context);
+    mod = loadQASMFile(inputFilename, &context);
   } else {
-    module = loadMLIRFile(inputFilename, &context);
+    mod = loadMLIRFile(inputFilename, &context);
   }
-  if (!module) {
+  if (!mod) {
     return 1;
   }
 
@@ -235,8 +235,7 @@ int main(int argc, char** argv) {
   // Run the compilation pipeline
   CompilationRecord record;
   if (const QuantumCompilerPipeline pipeline(config);
-      pipeline
-          .runPipeline(module.get(), recordIntermediates ? &record : nullptr)
+      pipeline.runPipeline(mod.get(), recordIntermediates ? &record : nullptr)
           .failed()) {
     llvm::errs() << "Compilation pipeline failed\n";
     return 1;
@@ -267,17 +266,17 @@ int main(int argc, char** argv) {
   // Write the output
   if (convertToQIRBase || convertToQIRAdaptive) {
     llvm::LLVMContext llvmContext;
-    std::unique_ptr<llvm::Module> llvmModule =
-        translateModuleToLLVMIR(*module, llvmContext);
-    if (!llvmModule) {
+    std::unique_ptr<llvm::Module> llvmMod =
+        translateModuleToLLVMIR(*mod, llvmContext);
+    if (!llvmMod) {
       llvm::errs() << "Failed to translate MLIR module to LLVM IR\n";
       return 1;
     }
-    if (writeOutputLLVM(llvmModule.get(), outputFilename).failed()) {
+    if (writeOutputLLVM(llvmMod.get(), outputFilename).failed()) {
       llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
       return 1;
     }
-  } else if (writeOutput(module.get(), outputFilename).failed()) {
+  } else if (writeOutput(mod.get(), outputFilename).failed()) {
     llvm::errs() << "Failed to write output file: " << outputFilename << "\n";
     return 1;
   }


### PR DESCRIPTION
## Description

This PR changes the behavior of `mqt-cc` to directly emit LLVM IR when called with `--emit-qir-base` or `--emit-qir-adaptive`.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
