### PR TITLE
🔧 Configure templating action to run on `v3.x`

### DIFF
--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -2,7 +2,7 @@ name: Templating
 on:
   push:
     branches:
-      - main
+      - v3.x
   pull_request:
     paths:
       - ".github/workflows/templating.yml"
@@ -31,6 +31,7 @@ jobs:
           token: ${{ steps.create-token.outputs.token }}
           name: Core
           organization: ${{ github.repository_owner }}
-          project-type: c++-mlir-python
+          project-type: c++-python
           repository: ${{ github.event.repository.name }}
+          base-branch: v3.x
           release-drafter-categories: ${{ steps.read-release-drafter-categories.outputs.release_drafter_categories }}


### PR DESCRIPTION
## Description

This PR configures the templating action to run on `v3.x` to keep the templates up to date without doing manual backports.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
