### PR TITLE
🐛 Fix invalid prop_type in QDMI device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ releases may include breaking changes.
 ### Fixed
 
 - 🐛 Fix QIR function names for adjoint gates ([#1830]) ([**@denialhaag**])
-- 🐛 Fix invalid `prop_type` in QDMI SC Device ([#1842])
+- 🐛 Fix invalid `prop_type` for `QDMI_DEVICE_PROPERTY_COUPLINGMAP` in QDMI SC Device ([#1842])
   ([**@MatthiasReumann**])
 
 ## [3.6.1] - 2026-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,8 @@ releases may include breaking changes.
 ### Fixed
 
 - 🐛 Fix QIR function names for adjoint gates ([#1830]) ([**@denialhaag**])
-- 🐛 Fix invalid `prop_type` for `QDMI_DEVICE_PROPERTY_COUPLINGMAP` in QDMI SC Device ([#1842])
-  ([**@MatthiasReumann**])
+- 🐛 Fix invalid `prop_type` for `QDMI_DEVICE_PROPERTY_COUPLINGMAP` in QDMI SC
+  Device ([#1842]) ([**@MatthiasReumann**])
 
 ## [3.6.1] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,8 @@ releases may include breaking changes.
 ### Fixed
 
 - 🐛 Fix QIR function names for adjoint gates ([#1830]) ([**@denialhaag**])
-- 🐛 Fix invalid `prop_type` in QDMI SC Device ([#1842]) ([**@MatthiasReumann**])
+- 🐛 Fix invalid `prop_type` in QDMI SC Device ([#1842])
+  ([**@MatthiasReumann**])
 
 ## [3.6.1] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ releases may include breaking changes.
 ### Fixed
 
 - 🐛 Fix QIR function names for adjoint gates ([#1830]) ([**@denialhaag**])
+- 🐛 Fix invalid `prop_type` in QDMI SC Device ([#1842]) ([**@MatthiasReumann**])
 
 ## [3.6.1] - 2026-05-20
 
@@ -592,6 +593,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1842]: https://github.com/munich-quantum-toolkit/core/pull/1842
 [#1830]: https://github.com/munich-quantum-toolkit/core/pull/1830
 [#1828]: https://github.com/munich-quantum-toolkit/core/pull/1828
 [#1826]: https://github.com/munich-quantum-toolkit/core/pull/1826

--- a/src/qdmi/devices/sc/Device.cpp
+++ b/src/qdmi/devices/sc/Device.cpp
@@ -88,8 +88,9 @@ auto Device::queryProperty(const QDMI_Device_Property prop, const size_t size,
       QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE, prop, size, value, sizeRet)
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_SITES, MQT_SC_QDMI_Site, sites_, prop,
                     size, value, sizeRet)
-  ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_COUPLINGMAP, MQT_SC_QDMI_Site,
-                    couplingMap_, prop, size, value, sizeRet)
+  #define SITE_PAIR std::pair<MQT_SC_QDMI_Site, MQT_SC_QDMI_Site>
+  ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_COUPLINGMAP, SITE_PAIR, couplingMap_,
+                    prop, size, value, sizeRet)
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_OPERATIONS, MQT_SC_QDMI_Operation,
                     operations_, prop, size, value, sizeRet)
   if (prop == QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS) {

--- a/src/qdmi/devices/sc/Device.cpp
+++ b/src/qdmi/devices/sc/Device.cpp
@@ -88,7 +88,7 @@ auto Device::queryProperty(const QDMI_Device_Property prop, const size_t size,
       QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE, prop, size, value, sizeRet)
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_SITES, MQT_SC_QDMI_Site, sites_, prop,
                     size, value, sizeRet)
-  #define SITE_PAIR std::pair<MQT_SC_QDMI_Site, MQT_SC_QDMI_Site>
+#define SITE_PAIR std::pair<MQT_SC_QDMI_Site, MQT_SC_QDMI_Site>
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_COUPLINGMAP, SITE_PAIR, couplingMap_,
                     prop, size, value, sizeRet)
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_OPERATIONS, MQT_SC_QDMI_Operation,


### PR DESCRIPTION
## Description

This pull request fixes a copy-paste bug in the `qdmi::sc::Device`, where the wrong `prop_type` for the coupling map was used. Currently, the code on the `main` branch returns 1/2 of the coupling map. 

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
