### PR TITLE
✨ Add support for IQM's `move` gate in the QDMI Qiskit backend converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add support for IQM's `move` gate in the QDMI Qiskit backend converter
+  ([#1844]) ([**@burgholzer**])
 - 🚸 Add `const` version of the `CompoundOperation`'s `getOps()` function
   ([#1826]) ([**@ystade])
 - 🐳 Add dev container configuration for consistent local development
@@ -594,6 +596,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1844]: https://github.com/munich-quantum-toolkit/core/pull/1844
 [#1842]: https://github.com/munich-quantum-toolkit/core/pull/1842
 [#1830]: https://github.com/munich-quantum-toolkit/core/pull/1830
 [#1828]: https://github.com/munich-quantum-toolkit/core/pull/1828

--- a/python/mqt/core/plugins/qiskit/backend.py
+++ b/python/mqt/core/plugins/qiskit/backend.py
@@ -19,7 +19,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from qiskit import qasm2, qasm3
-from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import Gate, QuantumCircuit
 from qiskit.circuit.library import (
     MCPhaseGate,
     MCXGate,
@@ -58,6 +58,17 @@ def __dir__() -> list[str]:
     return __all__
 
 
+class MoveGate(Gate):
+    """MOVE gate for IQM devices.
+
+    The gate is intentionally kept opaque so Qiskit does not decompose it.
+    """
+
+    def __init__(self, label: str | None = None) -> None:
+        """Initialize MOVE gate."""
+        super().__init__("move", 2, [], label=label)
+
+
 def _build_gate_mappings_for_backend(
     gate_aliases: dict[str, set[str]],
 ) -> tuple[dict[str, set[str]], dict[str, Instruction | type[Instruction]]]:
@@ -81,6 +92,7 @@ def _build_gate_mappings_for_backend(
         "mcphase": MCPhaseGate,
         "mcp": MCPhaseGate,
         "mcx_gray": MCXGate,
+        "move": MoveGate(),
     })
 
     qiskit_to_qdmi: dict[str, set[str]] = {}

--- a/test/python/plugins/qiskit/test_mock_backend.py
+++ b/test/python/plugins/qiskit/test_mock_backend.py
@@ -90,7 +90,7 @@ class MockQDMIDevice:
             elif name in {"ry", "rz", "rx", "p", "phase"}:
                 self._qubits = 1
                 self._params = 1
-            elif name in {"cz", "cx", "cnot", "cy", "ch", "swap", "iswap"}:
+            elif name in {"cz", "cx", "cnot", "cy", "ch", "swap", "iswap", "move"}:
                 self._qubits = 2
                 self._params = 0
             elif name in {"rxx", "ryy", "rzz", "rzx"}:
@@ -355,6 +355,23 @@ def test_backend_warns_on_unmappable_operation(
         ), f"Expected warning about custom_unmappable_gate, got: {warning_messages}"
 
 
+def test_backend_exposes_move_operation(
+    monkeypatch: pytest.MonkeyPatch, mock_qdmi_device_factory: type[MockQDMIDevice]
+) -> None:
+    """Backend target should expose MOVE when the device reports it."""
+    mock_device = mock_qdmi_device_factory(
+        name="Test Device",
+        num_qubits=2,
+        operations=["move", "measure"],
+    )
+    _patch_session_devices(monkeypatch, [mock_device])
+
+    provider = QDMIProvider()
+    backend = provider.get_backend("Test Device")
+
+    assert "move" in backend.target.operation_names
+
+
 def test_backend_warns_on_missing_measurement_operation(
     monkeypatch: pytest.MonkeyPatch, mock_qdmi_device_factory: type[MockQDMIDevice]
 ) -> None:
@@ -562,6 +579,14 @@ def test_map_operation_returns_none_for_unknown() -> None:
     assert QDMIBackend._map_operation_to_gate("") is None  # noqa: SLF001
 
 
+def test_map_operation_to_move_gate() -> None:
+    """MOVE operations map to an opaque 2-qubit gate."""
+    gate = QDMIBackend._map_operation_to_gate("move")  # noqa: SLF001
+    assert gate is not None
+    assert gate.name == "move"
+    assert gate.num_qubits == 2
+
+
 def test_map_qiskit_gate_to_operation_names() -> None:
     """Test the inverse gate name mapping function comprehensively."""
     # Basic gates map to themselves
@@ -590,6 +615,10 @@ def test_map_qiskit_gate_to_operation_names() -> None:
     # Case-insensitive matching
     assert QDMIBackend._map_qiskit_gate_to_operation_names("X") == {"x"}  # noqa: SLF001
     assert QDMIBackend._map_qiskit_gate_to_operation_names("CX") == {"cx", "cnot"}  # noqa: SLF001
+
+    # MOVE operation is represented as a real gate for IQM devices
+    assert QDMIBackend._map_qiskit_gate_to_operation_names("move") == {"move"}  # noqa: SLF001
+    assert QDMIBackend._map_qiskit_gate_to_operation_names("MOVE") == {"move"}  # noqa: SLF001
 
     # Fallback for unknown gates (returns lowercase name)
     assert QDMIBackend._map_qiskit_gate_to_operation_names("unknown") == {"unknown"}  # noqa: SLF001


### PR DESCRIPTION
## Description

This PR adds support for IQM's `move` gate in the QDMI Qiskit backend converter.
Previously, any QDMI device that would indicate support for a `move` operation, such as IQM's Star Topology devices, resulted in warnings for unsupported operations.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
