### PR TITLE
✨ Add `replaceWithAdditionalQubits` utility function to `qco.if`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,9 @@ releases may include breaking changes.
   [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1710],
   [#1717], [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780],
   [#1781], [#1782], [#1787], [#1806], [#1807], [#1808], [#1823], [#1824],
-  [#1830], [#1869], [#1872]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
-  [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
-  [**@simon1hofmann**])
+  [#1830], [#1869], [#1872]) ([**@burgholzer**], [**@denialhaag**],
+  [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
+  [**@MatthiasReumann**], [**@simon1hofmann**])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ releases may include breaking changes.
   [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1710],
   [#1717], [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780],
   [#1781], [#1782], [#1787], [#1806], [#1807], [#1808], [#1823], [#1824],
-  [#1830]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
+  [#1830], [#1872]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
   [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
   [**@simon1hofmann**])
 
@@ -602,6 +602,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1872]: https://github.com/munich-quantum-toolkit/core/pull/1872
 [#1849]: https://github.com/munich-quantum-toolkit/core/pull/1849
 [#1848]: https://github.com/munich-quantum-toolkit/core/pull/1848
 [#1844]: https://github.com/munich-quantum-toolkit/core/pull/1844

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1322,7 +1322,8 @@ def IfOp
 
         /// Append the specified additional "qubit" operands: replace this
         /// if-op with a new if-op that has the additional qubit operands.
-        /// The branch bodies of this if-op is moved over to the new if-op.
+        /// The operands can be of qubit or qtensor type.
+        /// The branch bodies of this if-op are moved over to the new if-op.
         /// The newly added qubits are yielded from each branch.
         IfOp replaceWithAdditionalQubits(RewriterBase& rewriter, ValueRange addons);
     }];

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1320,8 +1320,8 @@ def IfOp
         /// for the else-block, or `nullptr` on failure.
         OpOperand* getTiedElseYieldedValue(BlockArgument bbArg);
 
-        /// Append the specified additional "qubit" operands: replace this 
-        /// if-op with a new if-op that has the additional qubit operands. 
+        /// Append the specified additional "qubit" operands: replace this
+        /// if-op with a new if-op that has the additional qubit operands.
         /// The branch bodies of this if-op is moved over to the new if-op.
         /// The newly added qubits are yielded from each branch.
         IfOp replaceWithAdditionalQubits(RewriterBase& rewriter, ValueRange addons);

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1319,6 +1319,12 @@ def IfOp
         /// Return the yielded value that corresponds to the given argument
         /// for the else-block, or `nullptr` on failure.
         OpOperand* getTiedElseYieldedValue(BlockArgument bbArg);
+
+        /// Append the specified additional "qubit" operands: replace this 
+        /// if-op with a new if-op that has the additional qubit operands. 
+        /// The branch bodies of this if-op is moved over to the new if-op.
+        /// The newly added qubits are yielded from each branch.
+        IfOp replaceWithAdditionalQubits(RewriterBase& rewriter, ValueRange addons);
     }];
 
   let extraClassDefinition = [{

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -333,7 +333,7 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
   inits.append(getQubits().begin(), getQubits().end());
   inits.append(addons.begin(), addons.end());
 
-  auto newIfOp = rewriter.create<qco::IfOp>(getLoc(), getCondition(), inits);
+  auto newIfOp = rewriter.create<IfOp>(getLoc(), getCondition(), inits);
 
   const auto processRegion = [&](Region& oldRegion, Region& newRegion) {
     Block* oldBlock = &oldRegion.front();
@@ -349,7 +349,7 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
         newBlock->getArguments().take_front(oldBlock->getNumArguments()));
 
     // Update the yield operation to include additional qubits.
-    auto yield = cast<qco::YieldOp>(newBlock->getTerminator());
+    auto yield = cast<YieldOp>(newBlock->getTerminator());
 
     SmallVector<Value> newResults;
     newResults.reserve(inits.size());
@@ -358,7 +358,7 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
                       newBlock->getArguments().take_back(addons.size()).end());
 
     rewriter.setInsertionPoint(yield);
-    rewriter.replaceOpWithNewOp<qco::YieldOp>(yield, newResults);
+    rewriter.replaceOpWithNewOp<YieldOp>(yield, newResults);
   };
 
   // Process both regions

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -342,7 +342,7 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
         SmallVector<Type>(inits.size(), QubitType::get(rewriter.getContext())),
         SmallVector<Location>(inits.size(), newIfOp.getLoc()));
 
-    // Merge the old block into the new block, 
+    // Merge the old block into the new block,
     // keeping only the original arguments.
     rewriter.mergeBlocks(
         oldBlock, newBlock,

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -335,9 +335,8 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
 
   SmallVector<Type> types;
   types.reserve(getQubits().size() + addons.size());
-  llvm::append_range(
-      types, llvm::map_range(getQubits(), [](Value q) { return q.getType(); }));
-  llvm::append_range(types, addons.getTypes());
+  types.append(getQubits().getTypes().begin(), getQubits().getTypes().end());
+  types.append(addons.getTypes().begin(), addons.getTypes().end());
 
   SmallVector<Location> locs(getQubits().size() + addons.size(), getLoc());
 

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -357,7 +357,7 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
     auto yield = cast<YieldOp>(newBlock->getTerminator());
 
     const auto args = newBlock->getArguments().take_back(addons.size());
-    
+
     SmallVector<Value> newResults;
     newResults.reserve(inits.size());
     newResults.append(yield.getTargets().begin(), yield.getTargets().end());

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -333,14 +333,20 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
   inits.append(getQubits().begin(), getQubits().end());
   inits.append(addons.begin(), addons.end());
 
+  SmallVector<Type> types;
+  types.reserve(getQubits().size() + addons.size());
+  llvm::append_range(
+      types, llvm::map_range(getQubits(), [](Value q) { return q.getType(); }));
+  llvm::append_range(
+      types, llvm::map_range(addons, [](Value q) { return q.getType(); }));
+
+  SmallVector<Location> locs(getQubits().size() + addons.size(), getLoc());
+
   auto newIfOp = rewriter.create<IfOp>(getLoc(), getCondition(), inits);
 
   const auto processRegion = [&](Region& oldRegion, Region& newRegion) {
     Block* oldBlock = &oldRegion.front();
-    Block* newBlock = rewriter.createBlock(
-        &newRegion, {},
-        SmallVector<Type>(inits.size(), QubitType::get(rewriter.getContext())),
-        SmallVector<Location>(inits.size(), newIfOp.getLoc()));
+    Block* newBlock = rewriter.createBlock(&newRegion, {}, types, locs);
 
     // Merge the old block into the new block,
     // keeping only the original arguments.
@@ -357,7 +363,6 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
     newResults.append(newBlock->getArguments().take_back(addons.size()).begin(),
                       newBlock->getArguments().take_back(addons.size()).end());
 
-    rewriter.setInsertionPoint(yield);
     rewriter.replaceOpWithNewOp<YieldOp>(yield, newResults);
   };
 

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -337,8 +337,7 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
   types.reserve(getQubits().size() + addons.size());
   llvm::append_range(
       types, llvm::map_range(getQubits(), [](Value q) { return q.getType(); }));
-  llvm::append_range(
-      types, llvm::map_range(addons, [](Value q) { return q.getType(); }));
+  llvm::append_range(types, addons.getTypes());
 
   SmallVector<Location> locs(getQubits().size() + addons.size(), getLoc());
 
@@ -357,11 +356,12 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
     // Update the yield operation to include additional qubits.
     auto yield = cast<YieldOp>(newBlock->getTerminator());
 
+    const auto args = newBlock->getArguments().take_back(addons.size());
+    
     SmallVector<Value> newResults;
     newResults.reserve(inits.size());
     newResults.append(yield.getTargets().begin(), yield.getTargets().end());
-    newResults.append(newBlock->getArguments().take_back(addons.size()).begin(),
-                      newBlock->getArguments().take_back(addons.size()).end());
+    newResults.append(args.begin(), args.end());
 
     rewriter.replaceOpWithNewOp<YieldOp>(yield, newResults);
   };

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -325,3 +325,45 @@ OpOperand* IfOp::getTiedElseYieldedValue(BlockArgument bbArg) {
   }
   return &elseYield().getTargetsMutable()[bbArg.getArgNumber()];
 }
+
+IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
+                                       ValueRange addons) {
+  SmallVector<Value> inits;
+  inits.reserve(getQubits().size() + addons.size());
+  inits.append(getQubits().begin(), getQubits().end());
+  inits.append(addons.begin(), addons.end());
+
+  auto newIfOp = rewriter.create<qco::IfOp>(getLoc(), getCondition(), inits);
+
+  const auto processRegion = [&](Region& oldRegion, Region& newRegion) {
+    Block* oldBlock = &oldRegion.front();
+    Block* newBlock = rewriter.createBlock(
+        &newRegion, {},
+        SmallVector<Type>(inits.size(), QubitType::get(rewriter.getContext())),
+        SmallVector<Location>(inits.size(), newIfOp.getLoc()));
+
+    // Merge the old block into the new block, 
+    // keeping only the original arguments.
+    rewriter.mergeBlocks(
+        oldBlock, newBlock,
+        newBlock->getArguments().take_front(oldBlock->getNumArguments()));
+
+    // Update the yield operation to include additional qubits.
+    auto yield = cast<qco::YieldOp>(newBlock->getTerminator());
+
+    SmallVector<Value> newResults;
+    newResults.reserve(inits.size());
+    newResults.append(yield.getTargets().begin(), yield.getTargets().end());
+    newResults.append(newBlock->getArguments().take_back(addons.size()).begin(),
+                      newBlock->getArguments().take_back(addons.size()).end());
+
+    rewriter.setInsertionPoint(yield);
+    rewriter.replaceOpWithNewOp<qco::YieldOp>(yield, newResults);
+  };
+
+  // Process both regions
+  processRegion(getThenRegion(), newIfOp.getThenRegion());
+  processRegion(getElseRegion(), newIfOp.getElseRegion());
+
+  return newIfOp;
+}

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -328,46 +328,38 @@ OpOperand* IfOp::getTiedElseYieldedValue(BlockArgument bbArg) {
 
 IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
                                        ValueRange addons) {
-  SmallVector<Value> inits;
-  inits.reserve(getQubits().size() + addons.size());
-  inits.append(getQubits().begin(), getQubits().end());
-  inits.append(addons.begin(), addons.end());
+  if (addons.empty()) {
+    return *this;
+  }
 
-  SmallVector<Type> types;
-  types.reserve(getQubits().size() + addons.size());
-  types.append(getQubits().getTypes().begin(), getQubits().getTypes().end());
-  types.append(addons.getTypes().begin(), addons.getTypes().end());
+  SmallVector<Value> allQubits;
+  allQubits.reserve(getQubits().size() + addons.size());
+  allQubits.append(getQubits().begin(), getQubits().end());
+  allQubits.append(addons.begin(), addons.end());
+  const auto allQubitTypes = ValueRange(allQubits).getTypes();
 
-  SmallVector<Location> locs(getQubits().size() + addons.size(), getLoc());
+  auto newIfOp = create(rewriter, getLoc(), getCondition(), allQubits);
 
-  auto newIfOp = rewriter.create<IfOp>(getLoc(), getCondition(), inits);
+  const auto rewriteRegion = [&rewriter, &allQubitTypes,
+                              &addons](Region& oldRegion, Region& newRegion) {
+    auto* oldBlock = &oldRegion.front();
+    const auto numOldArgs = oldBlock->getNumArguments();
+    auto* newBlock = rewriter.createBlock(&newRegion, {}, allQubitTypes);
+    const auto oldArgs = newBlock->getArguments().take_front(numOldArgs);
+    const auto addonArgs = newBlock->getArguments().drop_front(numOldArgs);
 
-  const auto processRegion = [&](Region& oldRegion, Region& newRegion) {
-    Block* oldBlock = &oldRegion.front();
-    Block* newBlock = rewriter.createBlock(&newRegion, {}, types, locs);
+    rewriter.mergeBlocks(oldBlock, newBlock, oldArgs);
 
-    // Merge the old block into the new block,
-    // keeping only the original arguments.
-    rewriter.mergeBlocks(
-        oldBlock, newBlock,
-        newBlock->getArguments().take_front(oldBlock->getNumArguments()));
-
-    // Update the yield operation to include additional qubits.
     auto yield = cast<YieldOp>(newBlock->getTerminator());
-
-    const auto args = newBlock->getArguments().take_back(addons.size());
-
-    SmallVector<Value> newResults;
-    newResults.reserve(inits.size());
-    newResults.append(yield.getTargets().begin(), yield.getTargets().end());
-    newResults.append(args.begin(), args.end());
-
-    rewriter.replaceOpWithNewOp<YieldOp>(yield, newResults);
+    SmallVector<Value> yieldedValues;
+    yieldedValues.reserve(yield.getTargets().size() + addons.size());
+    yieldedValues.append(yield.getTargets().begin(), yield.getTargets().end());
+    yieldedValues.append(addonArgs.begin(), addonArgs.end());
+    rewriter.replaceOpWithNewOp<YieldOp>(yield, yieldedValues);
   };
 
-  // Process both regions
-  processRegion(getThenRegion(), newIfOp.getThenRegion());
-  processRegion(getElseRegion(), newIfOp.getElseRegion());
+  rewriteRegion(getThenRegion(), newIfOp.getThenRegion());
+  rewriteRegion(getElseRegion(), newIfOp.getElseRegion());
 
   rewriter.eraseOp(*this);
 

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -369,5 +369,7 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
   processRegion(getThenRegion(), newIfOp.getThenRegion());
   processRegion(getElseRegion(), newIfOp.getElseRegion());
 
+  rewriter.eraseOp(*this);
+
   return newIfOp;
 }


### PR DESCRIPTION
## Description

Adds the analog of MLIR's `replaceWithreplaceWithAdditionalIterOperands` to the `qco::IfOp`.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
