### PR TITLE
📝 Use `uv pip install` in README

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -3,7 +3,7 @@
 "**/pull_request_template.md" = ["MD013", "MD041"]
 # The docs files may include HTML and do not need to start with a top-level heading
 "docs/**" = ["MD033", "MD041"]
-# The README may include HTML and dooes not need to start with a top-level heading
+# The README may include HTML and does not need to start with a top-level heading
 "README.md" = ["MD033", "MD041"]
 
 [per-file-flavor]

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To support this endeavor, please consider:
 `mqt.core` is available via [PyPI](https://pypi.org/project/mqt.core/).
 
 ```console
-(.venv) $ pip install mqt.core
+uv pip install mqt.core
 ```
 
 The following code gives an example on the usage:


### PR DESCRIPTION
## Description

This PR improves the README by switching from `(.venv) $ pip install mqt.core` to `uv pip install mqt.core`. The latter command can be copied and executed directly.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.