### PR TITLE
🔧 Swap priority of `ruff-check` and `ruff-format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,11 +147,11 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.20
     hooks:
-      - id: ruff-format
-        types_or: [python, pyi, jupyter, markdown]
-        priority: 6
       - id: ruff-check
         require_serial: true
+        priority: 6
+      - id: ruff-format
+        types_or: [python, pyi, jupyter, markdown]
         priority: 7
 
   ## Check Python types with ty


### PR DESCRIPTION
## Description

This PR swaps the priority of the `ruff-check` and `ruff-format` hooks. It is recommended to run `ruff-check` before `ruff-format`: https://github.com/astral-sh/ruff-pre-commit#using-ruff-with-pre-commit

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.