### PR TITLE
✨ Add support for QDMI child devices to the driver and FoMaC libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ⬆️ Raise the minimum supported QDMI version to 1.3.2 ([#1897])
+  ([**@burgholzer**])
 - ⬆️ Require LLVM 22.1 for C++ library builds ([#1549]) ([**@burgholzer**],
   [**@denialhaag**])
 - 📦 Build MLIR by default for C++ library builds ([#1356]) ([**@burgholzer**],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add support for QDMI child devices to the driver and FoMaC libraries
+  ([#1897]) ([**@burgholzer**])
 - ✨ Add typed custom property and result queries to the C++ and Python FoMaC
   libraries ([#1895]) ([**@burgholzer**])
 - ✨ Add support for custom job parameters to C++ and Python FoMaC library
@@ -631,6 +633,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1897]: https://github.com/munich-quantum-toolkit/core/pull/1897
 [#1895]: https://github.com/munich-quantum-toolkit/core/pull/1895
 [#1887]: https://github.com/munich-quantum-toolkit/core/pull/1887
 [#1877]: https://github.com/munich-quantum-toolkit/core/pull/1877

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,14 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### QDMI child devices
+
+The QDMI driver now translates device-library-specific `QDMI_Child_Device`
+handles into client-facing `QDMI_Device` handles backed by dedicated child
+sessions. Direct child devices can be queried through
+`fomac::Device::getChildDevices()` in C++ and `Device.child_devices()` in
+Python. Devices without child-device support continue to behave unchanged.
+
 ### MLIR enabled by default for C++ builds
 
 The MLIR-based functionality within MQT Core has long been experimental and

--- a/bindings/fomac/fomac.cpp
+++ b/bindings/fomac/fomac.cpp
@@ -359,6 +359,9 @@ when the custom slot is unsupported.)pb");
              &fomac::Device::getSupportedProgramFormats,
              "Returns the list of program formats supported by the device.");
 
+  device.def("child_devices", &fomac::Device::getChildDevices,
+             "Returns the direct child devices managed by this device.");
+
   device.def(
       "query_custom_property",
       [](const fomac::Device& self, const fomac::CustomProperty customProperty,

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -84,7 +84,7 @@ if(BUILD_MQT_CORE_TESTS)
 endif()
 
 # cmake-format: off
-set(QDMI_MINIMUM_VERSION 1.3.0
+set(QDMI_MINIMUM_VERSION 1.3.2
         CACHE STRING "Minimum QDMI version")
 set(QDMI_VERSION 1.3.2
         CACHE STRING "QDMI version")

--- a/include/mqt-core/fomac/FoMaC.hpp
+++ b/include/mqt-core/fomac/FoMaC.hpp
@@ -473,6 +473,14 @@ public:
   getSupportedProgramFormats() const;
 
   /**
+   * @brief Returns the direct child devices managed by this device.
+   * @return The child devices, or an empty vector if child devices are not
+   * supported.
+   * @see QDMI_DEVICE_PROPERTY_CHILDDEVICES
+   */
+  [[nodiscard]] std::vector<Device> getChildDevices() const;
+
+  /**
    * @brief Queries an implementation-defined custom device property.
    * @tparam T Expected value type. Use `std::vector<std::byte>` to retrieve the
    * raw value without interpretation.

--- a/include/mqt-core/qdmi/driver/Driver.hpp
+++ b/include/mqt-core/qdmi/driver/Driver.hpp
@@ -167,9 +167,11 @@ private:
    * @note This must be a pointer type as we need access to dynamic and static
    * libraries that are subclasses of qdmi::DeviceLibrary.
    */
-  std::unique_ptr<qdmi::DeviceLibrary> library_;
+  std::shared_ptr<qdmi::DeviceLibrary> library_;
   /// @brief The device session handle.
   QDMI_Device_Session deviceSession_ = nullptr;
+  /// Client-facing wrappers for direct child devices.
+  std::vector<std::unique_ptr<QDMI_Device_impl_d>> childDevices_;
   /**
    * @brief Map of jobs to their corresponding unique pointers of
    * QDMI_Job_impl_d objects.
@@ -178,15 +180,27 @@ private:
 
 public:
   /**
-   * @brief Constructor for the QDMI device.
-   * @details This constructor initializes the device session and allocates
-   * the device session handle.
-   * @param lib is a unique pointer to the device library that provides the
-   * device interface functions.
+   * @brief Constructs a top-level QDMI device from an exclusively owned
+   * library.
+   * @param lib is the device library to take ownership of.
    * @param config is the configuration for device session parameters.
    */
   explicit QDMI_Device_impl_d(std::unique_ptr<qdmi::DeviceLibrary>&& lib,
-                              const qdmi::DeviceSessionConfig& config = {});
+                              const qdmi::DeviceSessionConfig& config = {})
+      : QDMI_Device_impl_d(std::shared_ptr(std::move(lib)), config) {}
+
+  /**
+   * @brief Constructor for the QDMI device.
+   * @details This constructor initializes the device session and allocates
+   * the device session handle.
+   * @param lib is a shared pointer to the device library that provides the
+   * device interface functions.
+   * @param config is the configuration for device session parameters.
+   * @param childDevice optionally selects a child device for this wrapper.
+   */
+  explicit QDMI_Device_impl_d(std::shared_ptr<qdmi::DeviceLibrary> lib,
+                              const qdmi::DeviceSessionConfig& config = {},
+                              QDMI_Child_Device childDevice = nullptr);
 
   /**
    * @brief Destructor for the QDMI device.
@@ -194,6 +208,7 @@ public:
    */
   ~QDMI_Device_impl_d() {
     jobs_.clear();
+    childDevices_.clear();
     if (library_ && deviceSession_ != nullptr) {
       library_->device_session_free(deviceSession_);
     }

--- a/python/mqt/core/fomac.pyi
+++ b/python/mqt/core/fomac.pyi
@@ -307,6 +307,9 @@ class Device:
     def supported_program_formats(self) -> list[ProgramFormat]:
         """Returns the list of program formats supported by the device."""
 
+    def child_devices(self) -> list[Device]:
+        """Returns the direct child devices managed by this device."""
+
     @overload
     def query_custom_property(self, custom_property: CustomProperty, value_type: type[str]) -> str | None: ...
     @overload

--- a/src/fomac/FoMaC.cpp
+++ b/src/fomac/FoMaC.cpp
@@ -301,8 +301,8 @@ std::vector<Device> Device::getChildDevices() const {
   std::vector<QDMI_Device> handles(size / sizeof(QDMI_Device));
   if (size != 0) {
     result = QDMI_device_query_device_property(
-        device_, QDMI_DEVICE_PROPERTY_CHILDDEVICES, size, handles.data(),
-        nullptr);
+        device_, QDMI_DEVICE_PROPERTY_CHILDDEVICES, size,
+        static_cast<void*>(handles.data()), nullptr);
     qdmi::throwIfError(result, "Querying child devices");
   }
 
@@ -310,7 +310,7 @@ std::vector<Device> Device::getChildDevices() const {
   devices.reserve(handles.size());
   std::ranges::transform(
       handles, std::back_inserter(devices),
-      [](const QDMI_Device handle) { return Device(handle); });
+      [](QDMI_Device_impl_d* const handle) { return Device(handle); });
   return devices;
 }
 
@@ -779,7 +779,7 @@ std::vector<Device> Session::getDevices() {
   devices.reserve(qdmiDevices.size());
   std::ranges::transform(
       qdmiDevices, std::back_inserter(devices),
-      [](const QDMI_Device& dev) -> Device { return Device(dev); });
+      [](QDMI_Device_impl_d* const& dev) -> Device { return Device(dev); });
   return devices;
 }
 } // namespace fomac

--- a/src/fomac/FoMaC.cpp
+++ b/src/fomac/FoMaC.cpp
@@ -286,6 +286,34 @@ std::vector<QDMI_Program_Format> Device::getSupportedProgramFormats() const {
       QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS);
 }
 
+std::vector<Device> Device::getChildDevices() const {
+  size_t size = 0;
+  auto result = QDMI_device_query_device_property(
+      device_, QDMI_DEVICE_PROPERTY_CHILDDEVICES, 0, nullptr, &size);
+  if (result == QDMI_ERROR_NOTSUPPORTED) {
+    return {};
+  }
+  qdmi::throwIfError(result, "Querying child devices size");
+  if (size % sizeof(QDMI_Device) != 0) {
+    throw std::runtime_error("Invalid child device list size");
+  }
+
+  std::vector<QDMI_Device> handles(size / sizeof(QDMI_Device));
+  if (size != 0) {
+    result = QDMI_device_query_device_property(
+        device_, QDMI_DEVICE_PROPERTY_CHILDDEVICES, size, handles.data(),
+        nullptr);
+    qdmi::throwIfError(result, "Querying child devices");
+  }
+
+  std::vector<Device> devices;
+  devices.reserve(handles.size());
+  std::ranges::transform(
+      handles, std::back_inserter(devices),
+      [](const QDMI_Device handle) { return Device(handle); });
+  return devices;
+}
+
 Job Device::submitJob(const std::string& program,
                       const QDMI_Program_Format format, const size_t numShots,
                       const std::optional<CustomJobParameter>& custom1,

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -16,6 +16,7 @@
 #include <qdmi/device.h>
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstddef>
@@ -168,9 +169,9 @@ DynamicDeviceLibrary::~DynamicDeviceLibrary() {
 #undef DL_CLOSE
 } // namespace qdmi
 
-QDMI_Device_impl_d::QDMI_Device_impl_d(
-    std::unique_ptr<qdmi::DeviceLibrary>&& lib,
-    const qdmi::DeviceSessionConfig& config)
+QDMI_Device_impl_d::QDMI_Device_impl_d(std::shared_ptr<qdmi::DeviceLibrary> lib,
+                                       const qdmi::DeviceSessionConfig& config,
+                                       const QDMI_Child_Device childDevice)
     : library_(std::move(lib)) {
   if (library_->device_session_alloc(&deviceSession_) != QDMI_SUCCESS) {
     throw std::runtime_error("Failed to allocate device session");
@@ -213,9 +214,76 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(
   setParameter(config.custom4, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM4);
   setParameter(config.custom5, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM5);
 
+  if (childDevice != nullptr) {
+    const auto status =
+        static_cast<QDMI_STATUS>(library_->device_session_set_parameter(
+            deviceSession_, QDMI_DEVICE_SESSION_PARAMETER_CHILDDEVICE,
+            sizeof(childDevice), &childDevice));
+    if (status != QDMI_SUCCESS) {
+      library_->device_session_free(deviceSession_);
+      deviceSession_ = nullptr;
+      std::ostringstream ss;
+      ss << "Failed to select child device: " << qdmi::toString(status);
+      throw std::runtime_error(ss.str());
+    }
+  }
+
   if (library_->device_session_init(deviceSession_) != QDMI_SUCCESS) {
     library_->device_session_free(deviceSession_);
+    deviceSession_ = nullptr;
     throw std::runtime_error("Failed to initialize device session");
+  }
+
+  // Child sessions represent leaf devices in the QDMI multicore
+  // workflow. Only top-level sessions discover and wrap child handles.
+  if (childDevice != nullptr) {
+    return;
+  }
+
+  size_t childrenSize = 0;
+  auto status =
+      static_cast<QDMI_STATUS>(library_->device_session_query_device_property(
+          deviceSession_, QDMI_DEVICE_PROPERTY_CHILDDEVICES, 0, nullptr,
+          &childrenSize));
+  if (status == QDMI_ERROR_NOTSUPPORTED) {
+    return;
+  }
+  if (status != QDMI_SUCCESS || childrenSize % sizeof(QDMI_Child_Device) != 0) {
+    library_->device_session_free(deviceSession_);
+    deviceSession_ = nullptr;
+    if (status != QDMI_SUCCESS) {
+      throw std::runtime_error("Failed to query child devices: " +
+                               std::string(qdmi::toString(status)));
+    }
+    throw std::runtime_error("Device returned an invalid child device list");
+  }
+
+  std::vector<QDMI_Child_Device> children(childrenSize /
+                                          sizeof(QDMI_Child_Device));
+  if (childrenSize != 0) {
+    status =
+        static_cast<QDMI_STATUS>(library_->device_session_query_device_property(
+            deviceSession_, QDMI_DEVICE_PROPERTY_CHILDDEVICES, childrenSize,
+            children.data(), nullptr));
+    if (status != QDMI_SUCCESS) {
+      library_->device_session_free(deviceSession_);
+      deviceSession_ = nullptr;
+      throw std::runtime_error("Failed to query child devices: " +
+                               std::string(qdmi::toString(status)));
+    }
+  }
+
+  try {
+    childDevices_.reserve(children.size());
+    for (const auto child : children) {
+      childDevices_.emplace_back(
+          std::make_unique<QDMI_Device_impl_d>(library_, config, child));
+    }
+  } catch (...) {
+    childDevices_.clear();
+    library_->device_session_free(deviceSession_);
+    deviceSession_ = nullptr;
+    throw;
   }
 }
 
@@ -244,6 +312,25 @@ auto QDMI_Device_impl_d::freeJob(QDMI_Job job) -> void {
 auto QDMI_Device_impl_d::queryDeviceProperty(QDMI_Device_Property prop,
                                              const size_t size, void* value,
                                              size_t* sizeRet) const -> int {
+  if (prop == QDMI_DEVICE_PROPERTY_CHILDDEVICES) {
+    if (childDevices_.empty()) {
+      return QDMI_ERROR_NOTSUPPORTED;
+    }
+    const auto requiredSize = childDevices_.size() * sizeof(QDMI_Device);
+    if (value != nullptr) {
+      if (size < requiredSize) {
+        return QDMI_ERROR_INVALIDARGUMENT;
+      }
+      auto* devices = static_cast<QDMI_Device*>(value);
+      std::ranges::transform(
+          childDevices_, devices,
+          [](const auto& child) -> QDMI_Device { return child.get(); });
+    }
+    if (sizeRet != nullptr) {
+      *sizeRet = requiredSize;
+    }
+    return QDMI_SUCCESS;
+  }
   return library_->device_session_query_device_property(deviceSession_, prop,
                                                         size, value, sizeRet);
 }
@@ -424,7 +511,7 @@ auto Driver::addDynamicDeviceLibrary(const std::string& libName,
                                      const DeviceSessionConfig& config)
     -> QDMI_Device {
   devices_.emplace_back(std::make_unique<QDMI_Device_impl_d>(
-      std::make_unique<DynamicDeviceLibrary>(libName, prefix), config));
+      std::make_shared<DynamicDeviceLibrary>(libName, prefix), config));
   return devices_.back().get();
 }
 

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -169,9 +169,10 @@ DynamicDeviceLibrary::~DynamicDeviceLibrary() {
 #undef DL_CLOSE
 } // namespace qdmi
 
-QDMI_Device_impl_d::QDMI_Device_impl_d(std::shared_ptr<qdmi::DeviceLibrary> lib,
-                                       const qdmi::DeviceSessionConfig& config,
-                                       const QDMI_Child_Device childDevice)
+QDMI_Device_impl_d::QDMI_Device_impl_d(
+    std::shared_ptr<qdmi::DeviceLibrary> lib,
+    const qdmi::DeviceSessionConfig& config,
+    QDMI_Child_Device_impl_d* const childDevice)
     : library_(std::move(lib)) {
   if (library_->device_session_alloc(&deviceSession_) != QDMI_SUCCESS) {
     throw std::runtime_error("Failed to allocate device session");
@@ -218,7 +219,7 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(std::shared_ptr<qdmi::DeviceLibrary> lib,
     const auto status =
         static_cast<QDMI_STATUS>(library_->device_session_set_parameter(
             deviceSession_, QDMI_DEVICE_SESSION_PARAMETER_CHILDDEVICE,
-            sizeof(childDevice), &childDevice));
+            sizeof(QDMI_Child_Device), static_cast<const void*>(&childDevice)));
     if (status != QDMI_SUCCESS) {
       library_->device_session_free(deviceSession_);
       deviceSession_ = nullptr;
@@ -264,7 +265,7 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(std::shared_ptr<qdmi::DeviceLibrary> lib,
     status =
         static_cast<QDMI_STATUS>(library_->device_session_query_device_property(
             deviceSession_, QDMI_DEVICE_PROPERTY_CHILDDEVICES, childrenSize,
-            children.data(), nullptr));
+            static_cast<void*>(children.data()), nullptr));
     if (status != QDMI_SUCCESS) {
       library_->device_session_free(deviceSession_);
       deviceSession_ = nullptr;
@@ -275,7 +276,7 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(std::shared_ptr<qdmi::DeviceLibrary> lib,
 
   try {
     childDevices_.reserve(children.size());
-    for (const auto child : children) {
+    for (auto* const child : children) {
       childDevices_.emplace_back(
           std::make_unique<QDMI_Device_impl_d>(library_, config, child));
     }

--- a/test/fomac/test_fomac.cpp
+++ b/test/fomac/test_fomac.cpp
@@ -440,6 +440,10 @@ TEST_P(DeviceTest, SupportedProgramFormats) {
   EXPECT_NO_THROW(std::ignore = device.getSupportedProgramFormats());
 }
 
+TEST_P(DeviceTest, ChildDevices) {
+  EXPECT_TRUE(device.getChildDevices().empty());
+}
+
 TEST_P(DeviceTest, UnsupportedCustomPropertyReturnsNullopt) {
   EXPECT_EQ(device.queryCustomProperty<std::vector<std::byte>>(
                 CustomProperty::Custom1),

--- a/test/python/fomac/test_fomac.py
+++ b/test/python/fomac/test_fomac.py
@@ -133,6 +133,13 @@ def test_device_operations(device: Device) -> None:
     assert all(isinstance(op, Device.Operation) for op in operations)
 
 
+def test_device_child_devices(device: Device) -> None:
+    """Test that devices without multicore support have no child devices."""
+    children = device.child_devices()
+    assert isinstance(children, list)
+    assert not children
+
+
 def test_device_coupling_map(device: Device) -> None:
     """Test that the device coupling map is a list of tuples of Device.Site objects."""
     cm = device.coupling_map()

--- a/test/qdmi/driver/CMakeLists.txt
+++ b/test/qdmi/driver/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TARGET_NAME mqt-core-qdmi-driver-test)
 
 if(TARGET MQT::CoreQDMIDriver)
   package_add_test(${TARGET_NAME} MQT::CoreQDMIDriver test_driver.cpp)
+  target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreFoMaC)
   target_compile_definitions(
     ${TARGET_NAME}
     PRIVATE

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -80,7 +81,7 @@ class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
     auto fakeSession =
         std::make_unique<Session>(Session{.library = activeLibrary});
     auto* const sessionPtr = fakeSession.get();
-    const auto sessionHandle =
+    auto* const sessionHandle =
         reinterpret_cast<QDMI_Device_Session>(sessionPtr);
     activeLibrary->sessions_.emplace(sessionHandle, std::move(fakeSession));
     ++activeLibrary->allocatedSessions;
@@ -198,7 +199,7 @@ public:
   bool malformedChildList = false;
   bool childDevicesNotSupported = false;
   bool childDeviceQueryFails = false;
-  std::vector<QDMI_Child_Device> selectedChildren{};
+  std::vector<QDMI_Child_Device> selectedChildren;
 
   ChildDeviceLibrary() {
     activeLibrary = this;
@@ -317,7 +318,7 @@ TEST(ChildDeviceTest, WrapsOpaqueHandlesInStableClientDevices) {
     std::array<QDMI_Device, 2> children{};
     ASSERT_EQ(QDMI_device_query_device_property(
                   &parent, QDMI_DEVICE_PROPERTY_CHILDDEVICES, size,
-                  children.data(), nullptr),
+                  static_cast<void*>(children.data()), nullptr),
               QDMI_SUCCESS);
     EXPECT_EQ(queryName(children[0]), "child-0");
     EXPECT_EQ(queryName(children[1]), "child-1");
@@ -331,7 +332,7 @@ TEST(ChildDeviceTest, WrapsOpaqueHandlesInStableClientDevices) {
     std::array<QDMI_Device, 2> repeatedQuery{};
     ASSERT_EQ(QDMI_device_query_device_property(
                   &parent, QDMI_DEVICE_PROPERTY_CHILDDEVICES, size,
-                  repeatedQuery.data(), nullptr),
+                  static_cast<void*>(repeatedQuery.data()), nullptr),
               QDMI_SUCCESS);
     EXPECT_EQ(repeatedQuery, children);
     EXPECT_EQ(library->selectedChildren,
@@ -341,7 +342,8 @@ TEST(ChildDeviceTest, WrapsOpaqueHandlesInStableClientDevices) {
 
     EXPECT_EQ(QDMI_device_query_device_property(
                   &parent, QDMI_DEVICE_PROPERTY_CHILDDEVICES,
-                  sizeof(QDMI_Device), children.data(), nullptr),
+                  sizeof(QDMI_Device), static_cast<void*>(children.data()),
+                  nullptr),
               QDMI_ERROR_INVALIDARGUMENT);
     EXPECT_EQ(QDMI_device_query_device_property(
                   children[0], QDMI_DEVICE_PROPERTY_CHILDDEVICES, 0, nullptr,
@@ -354,7 +356,7 @@ TEST(ChildDeviceTest, WrapsOpaqueHandlesInStableClientDevices) {
 TEST(ChildDeviceTest, CleansUpWhenSelectingAChildFails) {
   const auto library = std::make_shared<ChildDeviceLibrary>();
   library->rejectChildSelection = true;
-  EXPECT_THROW(QDMI_Device_impl_d parent(library), std::runtime_error);
+  EXPECT_THROW(QDMI_Device_impl_d{library}, std::runtime_error);
   EXPECT_EQ(library->allocatedSessions, 2);
   EXPECT_EQ(library->freedSessions, 2);
 }
@@ -362,7 +364,7 @@ TEST(ChildDeviceTest, CleansUpWhenSelectingAChildFails) {
 TEST(ChildDeviceTest, RejectsMalformedChildLists) {
   const auto library = std::make_shared<ChildDeviceLibrary>();
   library->malformedChildList = true;
-  EXPECT_THROW(QDMI_Device_impl_d parent(library), std::runtime_error);
+  EXPECT_THROW(QDMI_Device_impl_d{library}, std::runtime_error);
   EXPECT_EQ(library->allocatedSessions, 1);
   EXPECT_EQ(library->freedSessions, 1);
 }
@@ -385,7 +387,7 @@ TEST(ChildDeviceTest, SupportsDevicesWithoutChildDevices) {
 TEST(ChildDeviceTest, CleansUpWhenQueryingChildDevicesFails) {
   const auto library = std::make_shared<ChildDeviceLibrary>();
   library->childDeviceQueryFails = true;
-  EXPECT_THROW(QDMI_Device_impl_d parent(library), std::runtime_error);
+  EXPECT_THROW(QDMI_Device_impl_d{library}, std::runtime_error);
   EXPECT_EQ(library->allocatedSessions, 1);
   EXPECT_EQ(library->freedSessions, 1);
 }

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -14,6 +14,7 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <qdmi/client.h>
+#include <qdmi/device.h>
 
 #include <algorithm>
 #include <array>
@@ -58,15 +59,16 @@ class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
   };
 
   struct Session {
-    ChildDeviceLibrary* library;
+    ChildDeviceLibrary* library = nullptr;
     QDMI_Child_Device child = nullptr;
     bool initialized = false;
   };
 
   static inline ChildDeviceLibrary* activeLibrary = nullptr;
   std::array<Child, 2> children_{{{0}, {1}}};
+  std::unordered_map<QDMI_Device_Session, std::unique_ptr<Session>> sessions_;
 
-  [[nodiscard]] static auto asSession(const QDMI_Device_Session session)
+  [[nodiscard]] static auto asSession(QDMI_Device_Session_impl_d* const session)
       -> Session* {
     return reinterpret_cast<Session*>(session);
   }
@@ -75,9 +77,14 @@ class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
     if (session == nullptr || activeLibrary == nullptr) {
       return QDMI_ERROR_INVALIDARGUMENT;
     }
-    auto* const fakeSession = new Session{activeLibrary};
+    auto fakeSession =
+        std::make_unique<Session>(Session{.library = activeLibrary});
+    auto* const sessionPtr = fakeSession.get();
+    const auto sessionHandle =
+        reinterpret_cast<QDMI_Device_Session>(sessionPtr);
+    activeLibrary->sessions_.emplace(sessionHandle, std::move(fakeSession));
     ++activeLibrary->allocatedSessions;
-    *session = reinterpret_cast<QDMI_Device_Session>(fakeSession);
+    *session = sessionHandle;
     return QDMI_SUCCESS;
   }
 
@@ -87,7 +94,7 @@ class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
     }
     auto* const fakeSession = asSession(session);
     ++fakeSession->library->freedSessions;
-    delete fakeSession;
+    fakeSession->library->sessions_.erase(session);
   }
 
   static auto setParameter(QDMI_Device_Session session,
@@ -104,7 +111,8 @@ class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
         size != sizeof(QDMI_Child_Device)) {
       return QDMI_ERROR_NOTSUPPORTED;
     }
-    std::memcpy(&fakeSession->child, value, sizeof(fakeSession->child));
+    std::memcpy(static_cast<void*>(&fakeSession->child), value,
+                sizeof(QDMI_Child_Device));
     fakeSession->library->selectedChildren.emplace_back(fakeSession->child);
     return QDMI_SUCCESS;
   }
@@ -134,6 +142,12 @@ class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
         return QDMI_ERROR_NOTSUPPORTED;
       }
       auto* const library = fakeSession->library;
+      if (library->childDevicesNotSupported) {
+        return QDMI_ERROR_NOTSUPPORTED;
+      }
+      if (library->childDeviceQueryFails) {
+        return QDMI_ERROR_BADSTATE;
+      }
       const size_t requiredSize =
           library->malformedChildList
               ? sizeof(QDMI_Child_Device) + 1
@@ -150,7 +164,8 @@ class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
             library->children_, handles.begin(), [](Child& child) {
               return reinterpret_cast<QDMI_Child_Device>(&child);
             });
-        std::memcpy(value, handles.data(), requiredSize);
+        std::memcpy(value, static_cast<const void*>(handles.data()),
+                    requiredSize);
       }
       return QDMI_SUCCESS;
     }
@@ -158,8 +173,7 @@ class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
     if (property == QDMI_DEVICE_PROPERTY_NAME) {
       std::string name = "parent";
       if (fakeSession->child != nullptr) {
-        const auto* const child =
-            reinterpret_cast<const Child*>(fakeSession->child);
+        const auto* child = reinterpret_cast<const Child*>(fakeSession->child);
         name = "child-" + std::to_string(child->id);
       }
       const auto requiredSize = name.size() + 1;
@@ -182,7 +196,9 @@ public:
   size_t freedSessions = 0;
   bool rejectChildSelection = false;
   bool malformedChildList = false;
-  std::vector<QDMI_Child_Device> selectedChildren;
+  bool childDevicesNotSupported = false;
+  bool childDeviceQueryFails = false;
+  std::vector<QDMI_Child_Device> selectedChildren{};
 
   ChildDeviceLibrary() {
     activeLibrary = this;
@@ -200,7 +216,7 @@ public:
   }
 };
 
-[[nodiscard]] auto queryName(const QDMI_Device device) -> std::string {
+[[nodiscard]] auto queryName(QDMI_Device_impl_d* const device) -> std::string {
   size_t size = 0;
   EXPECT_EQ(QDMI_device_query_device_property(device, QDMI_DEVICE_PROPERTY_NAME,
                                               0, nullptr, &size),
@@ -346,6 +362,29 @@ TEST(ChildDeviceTest, CleansUpWhenSelectingAChildFails) {
 TEST(ChildDeviceTest, RejectsMalformedChildLists) {
   const auto library = std::make_shared<ChildDeviceLibrary>();
   library->malformedChildList = true;
+  EXPECT_THROW(QDMI_Device_impl_d parent(library), std::runtime_error);
+  EXPECT_EQ(library->allocatedSessions, 1);
+  EXPECT_EQ(library->freedSessions, 1);
+}
+
+TEST(ChildDeviceTest, SupportsDevicesWithoutChildDevices) {
+  const auto library = std::make_shared<ChildDeviceLibrary>();
+  library->childDevicesNotSupported = true;
+  {
+    QDMI_Device_impl_d parent(library);
+    size_t size = 0;
+    EXPECT_EQ(
+        QDMI_device_query_device_property(
+            &parent, QDMI_DEVICE_PROPERTY_CHILDDEVICES, 0, nullptr, &size),
+        QDMI_ERROR_NOTSUPPORTED);
+    EXPECT_EQ(library->allocatedSessions, 1);
+  }
+  EXPECT_EQ(library->freedSessions, 1);
+}
+
+TEST(ChildDeviceTest, CleansUpWhenQueryingChildDevicesFails) {
+  const auto library = std::make_shared<ChildDeviceLibrary>();
+  library->childDeviceQueryFails = true;
   EXPECT_THROW(QDMI_Device_impl_d parent(library), std::runtime_error);
   EXPECT_EQ(library->allocatedSessions, 1);
   EXPECT_EQ(library->freedSessions, 1);

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "fomac/FoMaC.hpp"
 #include "qdmi/driver/Driver.hpp"
 
 #include <gmock/gmock-matchers.h>
@@ -18,6 +19,8 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <memory>
 #include <random>
 #include <sstream>
 #include <stdexcept>
@@ -48,6 +51,166 @@ MATCHER_P2(IsBetween, a, b,
 namespace qc {
 
 namespace {
+
+class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
+  struct Child {
+    size_t id;
+  };
+
+  struct Session {
+    ChildDeviceLibrary* library;
+    QDMI_Child_Device child = nullptr;
+    bool initialized = false;
+  };
+
+  static inline ChildDeviceLibrary* activeLibrary = nullptr;
+  std::array<Child, 2> children_{{{0}, {1}}};
+
+  [[nodiscard]] static auto asSession(const QDMI_Device_Session session)
+      -> Session* {
+    return reinterpret_cast<Session*>(session);
+  }
+
+  static auto alloc(QDMI_Device_Session* session) -> int {
+    if (session == nullptr || activeLibrary == nullptr) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    auto* const fakeSession = new Session{activeLibrary};
+    ++activeLibrary->allocatedSessions;
+    *session = reinterpret_cast<QDMI_Device_Session>(fakeSession);
+    return QDMI_SUCCESS;
+  }
+
+  static void free(QDMI_Device_Session session) {
+    if (session == nullptr) {
+      return;
+    }
+    auto* const fakeSession = asSession(session);
+    ++fakeSession->library->freedSessions;
+    delete fakeSession;
+  }
+
+  static auto setParameter(QDMI_Device_Session session,
+                           const QDMI_Device_Session_Parameter parameter,
+                           const size_t size, const void* value) -> int {
+    if (session == nullptr || value == nullptr || size == 0) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    if (parameter != QDMI_DEVICE_SESSION_PARAMETER_CHILDDEVICE) {
+      return QDMI_ERROR_NOTSUPPORTED;
+    }
+    auto* const fakeSession = asSession(session);
+    if (fakeSession->library->rejectChildSelection ||
+        size != sizeof(QDMI_Child_Device)) {
+      return QDMI_ERROR_NOTSUPPORTED;
+    }
+    std::memcpy(&fakeSession->child, value, sizeof(fakeSession->child));
+    fakeSession->library->selectedChildren.emplace_back(fakeSession->child);
+    return QDMI_SUCCESS;
+  }
+
+  static auto init(QDMI_Device_Session session) -> int {
+    if (session == nullptr) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    asSession(session)->initialized = true;
+    return QDMI_SUCCESS;
+  }
+
+  static auto queryDeviceProperty(QDMI_Device_Session session,
+                                  const QDMI_Device_Property property,
+                                  const size_t size, void* value,
+                                  size_t* sizeRet) -> int {
+    if (session == nullptr || (value != nullptr && size == 0)) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    auto* const fakeSession = asSession(session);
+    if (!fakeSession->initialized) {
+      return QDMI_ERROR_BADSTATE;
+    }
+
+    if (property == QDMI_DEVICE_PROPERTY_CHILDDEVICES) {
+      if (fakeSession->child != nullptr) {
+        return QDMI_ERROR_NOTSUPPORTED;
+      }
+      auto* const library = fakeSession->library;
+      const size_t requiredSize =
+          library->malformedChildList
+              ? sizeof(QDMI_Child_Device) + 1
+              : library->children_.size() * sizeof(QDMI_Child_Device);
+      if (sizeRet != nullptr) {
+        *sizeRet = requiredSize;
+      }
+      if (value != nullptr) {
+        if (size < requiredSize || library->malformedChildList) {
+          return QDMI_ERROR_INVALIDARGUMENT;
+        }
+        std::array<QDMI_Child_Device, 2> handles{};
+        std::ranges::transform(
+            library->children_, handles.begin(), [](Child& child) {
+              return reinterpret_cast<QDMI_Child_Device>(&child);
+            });
+        std::memcpy(value, handles.data(), requiredSize);
+      }
+      return QDMI_SUCCESS;
+    }
+
+    if (property == QDMI_DEVICE_PROPERTY_NAME) {
+      std::string name = "parent";
+      if (fakeSession->child != nullptr) {
+        const auto* const child =
+            reinterpret_cast<const Child*>(fakeSession->child);
+        name = "child-" + std::to_string(child->id);
+      }
+      const auto requiredSize = name.size() + 1;
+      if (sizeRet != nullptr) {
+        *sizeRet = requiredSize;
+      }
+      if (value != nullptr) {
+        if (size < requiredSize) {
+          return QDMI_ERROR_INVALIDARGUMENT;
+        }
+        std::memcpy(value, name.c_str(), requiredSize);
+      }
+      return QDMI_SUCCESS;
+    }
+    return QDMI_ERROR_NOTSUPPORTED;
+  }
+
+public:
+  size_t allocatedSessions = 0;
+  size_t freedSessions = 0;
+  bool rejectChildSelection = false;
+  bool malformedChildList = false;
+  std::vector<QDMI_Child_Device> selectedChildren;
+
+  ChildDeviceLibrary() {
+    activeLibrary = this;
+    device_session_alloc = alloc;
+    device_session_free = free;
+    device_session_set_parameter = setParameter;
+    device_session_init = init;
+    device_session_query_device_property = queryDeviceProperty;
+  }
+
+  ~ChildDeviceLibrary() override { activeLibrary = nullptr; }
+
+  [[nodiscard]] auto childHandle(const size_t index) -> QDMI_Child_Device {
+    return reinterpret_cast<QDMI_Child_Device>(&children_.at(index));
+  }
+};
+
+[[nodiscard]] auto queryName(const QDMI_Device device) -> std::string {
+  size_t size = 0;
+  EXPECT_EQ(QDMI_device_query_device_property(device, QDMI_DEVICE_PROPERTY_NAME,
+                                              0, nullptr, &size),
+            QDMI_SUCCESS);
+  std::string name(size - 1, '\0');
+  EXPECT_EQ(QDMI_device_query_device_property(device, QDMI_DEVICE_PROPERTY_NAME,
+                                              size, name.data(), nullptr),
+            QDMI_SUCCESS);
+  return name;
+}
 
 class DriverTest : public testing::TestWithParam<const char*> {
 protected:
@@ -123,6 +286,70 @@ protected:
 };
 
 } // namespace
+
+TEST(ChildDeviceTest, WrapsOpaqueHandlesInStableClientDevices) {
+  const auto library = std::make_shared<ChildDeviceLibrary>();
+  {
+    QDMI_Device_impl_d parent(library);
+    size_t size = 0;
+    ASSERT_EQ(
+        QDMI_device_query_device_property(
+            &parent, QDMI_DEVICE_PROPERTY_CHILDDEVICES, 0, nullptr, &size),
+        QDMI_SUCCESS);
+    ASSERT_EQ(size, 2 * sizeof(QDMI_Device));
+
+    std::array<QDMI_Device, 2> children{};
+    ASSERT_EQ(QDMI_device_query_device_property(
+                  &parent, QDMI_DEVICE_PROPERTY_CHILDDEVICES, size,
+                  children.data(), nullptr),
+              QDMI_SUCCESS);
+    EXPECT_EQ(queryName(children[0]), "child-0");
+    EXPECT_EQ(queryName(children[1]), "child-1");
+
+    const auto fomacChildren =
+        fomac::Session::createSessionlessDevice(&parent).getChildDevices();
+    ASSERT_EQ(fomacChildren.size(), 2);
+    EXPECT_EQ(fomacChildren[0].getName(), "child-0");
+    EXPECT_EQ(fomacChildren[1].getName(), "child-1");
+
+    std::array<QDMI_Device, 2> repeatedQuery{};
+    ASSERT_EQ(QDMI_device_query_device_property(
+                  &parent, QDMI_DEVICE_PROPERTY_CHILDDEVICES, size,
+                  repeatedQuery.data(), nullptr),
+              QDMI_SUCCESS);
+    EXPECT_EQ(repeatedQuery, children);
+    EXPECT_EQ(library->selectedChildren,
+              (std::vector{library->childHandle(0), library->childHandle(1)}));
+    EXPECT_EQ(library->allocatedSessions, 3);
+    EXPECT_EQ(library->freedSessions, 0);
+
+    EXPECT_EQ(QDMI_device_query_device_property(
+                  &parent, QDMI_DEVICE_PROPERTY_CHILDDEVICES,
+                  sizeof(QDMI_Device), children.data(), nullptr),
+              QDMI_ERROR_INVALIDARGUMENT);
+    EXPECT_EQ(QDMI_device_query_device_property(
+                  children[0], QDMI_DEVICE_PROPERTY_CHILDDEVICES, 0, nullptr,
+                  nullptr),
+              QDMI_ERROR_NOTSUPPORTED);
+  }
+  EXPECT_EQ(library->freedSessions, 3);
+}
+
+TEST(ChildDeviceTest, CleansUpWhenSelectingAChildFails) {
+  const auto library = std::make_shared<ChildDeviceLibrary>();
+  library->rejectChildSelection = true;
+  EXPECT_THROW(QDMI_Device_impl_d parent(library), std::runtime_error);
+  EXPECT_EQ(library->allocatedSessions, 2);
+  EXPECT_EQ(library->freedSessions, 2);
+}
+
+TEST(ChildDeviceTest, RejectsMalformedChildLists) {
+  const auto library = std::make_shared<ChildDeviceLibrary>();
+  library->malformedChildList = true;
+  EXPECT_THROW(QDMI_Device_impl_d parent(library), std::runtime_error);
+  EXPECT_EQ(library->allocatedSessions, 1);
+  EXPECT_EQ(library->freedSessions, 1);
+}
 
 TEST_P(DriverTest, SessionSetParameter) {
   const std::string authFile = "authfile.txt";


### PR DESCRIPTION
## Description

This PR adds support for the newly introduced child device feature of QDMI v1.3.2 to the MQT Core Driver and the FoMaC libraries.

Assisted-by: gpt-5.6-sol via Codex CLI

@ystade FYI

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
