### PR TITLE
:sparkles: Map `scf::WhileOp`s using the restore strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ releases may include breaking changes.
   [#1676], [#1706], [#1776], [#1836]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add a `place-and-route` pass for mapping circuits to architectures with
   restricted topologies ([#1537], [#1547], [#1568], [#1581], [#1583], [#1588],
-  [#1600], [#1664], [#1709], [#1716], [#1748], [#1805], [#1870], [#1904])
+  [#1600], [#1664], [#1709], [#1716], [#1748], [#1805], [#1870], [#1904], [#1911])
   ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add initial infrastructure for new QC and QCO MLIR dialects ([#1264],
   [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464],
@@ -638,6 +638,7 @@ changelogs._
 <!-- PR links -->
 
 [#1914]: https://github.com/munich-quantum-toolkit/core/pull/1914
+[#1911]: https://github.com/munich-quantum-toolkit/core/pull/1911
 [#1904]: https://github.com/munich-quantum-toolkit/core/pull/1904
 [#1897]: https://github.com/munich-quantum-toolkit/core/pull/1897
 [#1895]: https://github.com/munich-quantum-toolkit/core/pull/1895

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@ releases may include breaking changes.
   [#1676], [#1706], [#1776], [#1836]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add a `place-and-route` pass for mapping circuits to architectures with
   restricted topologies ([#1537], [#1547], [#1568], [#1581], [#1583], [#1588],
-  [#1600], [#1664], [#1709], [#1716], [#1748], [#1805], [#1870], [#1904], [#1911])
-  ([**@MatthiasReumann**], [**@burgholzer**])
+  [#1600], [#1664], [#1709], [#1716], [#1748], [#1805], [#1870], [#1904],
+  [#1911]) ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add initial infrastructure for new QC and QCO MLIR dialects ([#1264],
   [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464],
   [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@ releases may include breaking changes.
   [#1676], [#1706], [#1776], [#1836]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add a `place-and-route` pass for mapping circuits to architectures with
   restricted topologies ([#1537], [#1547], [#1568], [#1581], [#1583], [#1588],
-  [#1600], [#1664], [#1709], [#1716], [#1748], [#1805], [#1870], [#1904], [#1911])
-  ([**@MatthiasReumann**], [**@burgholzer**])
+  [#1600], [#1664], [#1709], [#1716], [#1748], [#1805], [#1870], [#1904],
+  [#1911]) ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add a pass for qubit reuse in quantum programs, as well as related
   auxiliary passes and patterns ([#1705], [#1755]) ([**@DRovara**])
 - ✨ Add initial infrastructure for new QC and QCO MLIR dialects ([#1264],

--- a/mlir/include/mlir/Dialect/QCO/Utils/Drivers.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/Drivers.h
@@ -124,13 +124,13 @@ LogicalResult walkProgramGraph(MutableArrayRef<WireIterator> wires,
       while (Traits::isActive(it)) {
 
         // For source-like (AllocOp, StaticOp, qtensor::ExtractOp),
-        // sink-like (SinkOp, YieldOp, qtensor::InsertOp, scf::YieldOp), and
-        // one-qubit non-unitary (ResetOp, MeasureOp) operations, simply advance
-        // the iterator.
+        // sink-like (SinkOp, YieldOp, qtensor::InsertOp, scf::YieldOp,
+        // scf::ConditionOp), and one-qubit non-unitary (ResetOp, MeasureOp)
+        // operations, simply advance the iterator.
 
         if (isa<AllocOp, StaticOp, ResetOp, MeasureOp, SinkOp, YieldOp,
-                qtensor::ExtractOp, qtensor::InsertOp, scf::YieldOp>(
-                it.operation())) {
+                qtensor::ExtractOp, qtensor::InsertOp, scf::YieldOp,
+                scf::ConditionOp>(it.operation())) {
           std::ranges::advance(it, Traits::stride());
           continue;
         }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -135,7 +135,7 @@ private:
 
     /// Bidirectionally map a wire index to a program index.
     /// Overwrites existing mappings.
-    void map(const size_t index, const size_t prog) {
+    void insertOrUpdate(const size_t index, const size_t prog) {
       if (index >= indexToProgram_.size()) {
         indexToProgram_.resize(index + 1);
       }
@@ -153,6 +153,9 @@ private:
       std::swap(programToIndex_[prog0], programToIndex_[prog1]);
       std::swap(indexToProgram_[i0], indexToProgram_[i1]);
     }
+
+    /// Return the number of index-wire mappings.
+    [[nodiscard]] size_t size() const { return indexToProgram_.size(); }
 
   private:
     /// Maps the i-th wire index to a program index.
@@ -177,6 +180,12 @@ private:
     Wires wires;
     WireInfos infos;
     Layout layout;
+  };
+
+  /// A routing trial used for parallelization.
+  struct Trial : RoutingBundle {
+    Statistics stats{};
+    bool success{false};
   };
 
   /// Describes a node in the A* search graph.
@@ -552,7 +561,7 @@ private:
           const auto index = wires.size();
 
           wires.emplace_back(qubit);
-          infos.map(index, index);
+          infos.insertOrUpdate(index, index);
 
           continue;
         }
@@ -610,7 +619,7 @@ private:
               rewriter.eraseOp(op);
 
               wires.emplace_back(qubit);
-              infos.map(prog, prog);
+              infos.insertOrUpdate(prog, prog);
             })
             .Case<InsertOp>([&](auto op) {
               rewriter.setInsertionPointAfter(op);
@@ -632,7 +641,7 @@ private:
       const auto qubit = staticOps[hw].getQubit();
 
       wires.emplace_back(qubit);
-      infos.map(prog, prog);
+      infos.insertOrUpdate(prog, prog);
 
       SinkOp::create(rewriter, body.getLoc(), qubit);
     }
@@ -744,12 +753,6 @@ private:
   FailureOr<Layout> generateLayout(const Wires& wires, const WireInfos& infos) {
     std::mt19937_64 rng{seed};
 
-    struct Trial {
-      RoutingBundle bundle;
-      Statistics stats{};
-      bool success{false};
-    };
-
     SmallVector<Trial, 0> trials;
     trials.reserve(ntrials);
     for (size_t i = 0; i < ntrials; ++i) {
@@ -761,11 +764,11 @@ private:
 
     parallelForEach(&getContext(), trials, [&, this](Trial& t) {
       for (size_t i = 0; i < niterations; ++i) {
-        if (route<WireDirection::Forward>(t.bundle, t.stats).failed()) {
+        if (route<WireDirection::Forward>(t, t.stats).failed()) {
           return;
         }
         t.stats.nswaps = 0;
-        if (route<WireDirection::Backward>(t.bundle, t.stats).failed()) {
+        if (route<WireDirection::Backward>(t, t.stats).failed()) {
           return;
         }
       }
@@ -785,7 +788,7 @@ private:
       return failure();
     }
 
-    return best->bundle.layout;
+    return best->layout;
   }
 
   /// Perform A* search to find a sequence of SWAPs that makes all two-qubit ops
@@ -1175,264 +1178,207 @@ private:
                          IRRewriter* rewriter = nullptr) {
     const auto& [op, indices] = item;
 
-    const LogicalResult res =
-        TypeSwitch<Operation*, LogicalResult>(op)
-            .template Case<scf::ForOp>([&](scf::ForOp forOp) {
-              RoutingBundle child{.layout = parent.layout};
-
-              // Construct child bundle. Particularly, find the iteration
-              // argument (block-argument, forward) or yielded result (backward)
-              // for each result qubit the selected (via indices) iterators
-              // point at.
-
-              for (size_t i : indices) {
-                const auto prog = parent.infos.lookupProgram(i);
-                const auto res = cast<OpResult>(parent.wires[i].qubit());
-                const auto arg = forOp.getTiedLoopRegionIterArg(res);
-                const auto index = child.wires.size();
-
-                if constexpr (Direction == WireDirection::Forward) {
-                  child.wires.emplace_back(arg);
-                } else {
-                  const auto yield = forOp.getTiedLoopYieldedValue(arg)->get();
-                  child.wires.emplace_back(yield);
-                }
-                child.infos.map(index, prog);
-              }
-
-              // Route the child body and prepare the wire iterators for
-              // epilogue SWAP insertion, i.e., point each iterator at the final
-              // qubit op (note: might be a measurement) before the yield:
-              // Because "route" moves each iterator to the default sentinel,
-              // decrement twice: sentinel → yield → unitary/block arg.
-
-              if (failed(route<Direction, Mode>(child, stats, rewriter))) {
-                return failure();
-              }
-
-              if constexpr (Mode == RoutingMode::Hot) {
-                for_each(child.wires, [](auto& it) { std::advance(it, -2); });
-              }
-
-              // Find (insert) the epilogue SWAP sequence for (into) the child
-              // body using the "restore" strategy. Because this restores the
-              // parent's layout, we don't have to update the infos.
-
-              const auto swaps = restore(child.layout, parent.layout);
-              insertSWAPs<Mode>(swaps, child, stats, rewriter);
-
-              // Sort topologically to fix any occurring SSA dominance errors.
-
-              if constexpr (Mode == RoutingMode::Hot) {
-                sortTopologically(forOp.getBody());
-              }
-
-              return success();
+    SmallVector<size_t> permutation(indices.size());
+    SmallVector<RoutingBundle, 2> children =
+        TypeSwitch<Operation*, SmallVector<RoutingBundle, 2>>(op)
+            .template Case<scf::ForOp, scf::WhileOp>([&](auto) {
+              return SmallVector<RoutingBundle, 2>{
+                  RoutingBundle{.layout = parent.layout}};
             })
-            .template Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+            .template Case<IfOp>([&](IfOp) {
+              return SmallVector<RoutingBundle, 2>{
+                  RoutingBundle{.layout = parent.layout},
+                  RoutingBundle{.layout = parent.layout}};
+            });
+
+    for (size_t i : indices) {
+      const auto prog = parent.infos.lookupProgram(i);
+      const auto hw = parent.layout.getHardwareIndex(prog);
+      const auto res = cast<OpResult>(parent.wires[i].qubit());
+      const auto resNum = res.getResultNumber();
+
+      TypeSwitch<Operation*>(op)
+          .template Case<scf::ForOp>([&](scf::ForOp forOp) {
+            children[0].infos.insertOrUpdate(children[0].infos.size(), prog);
+            children[0].wires.emplace_back([&] -> Value {
+              const auto arg = forOp.getTiedLoopRegionIterArg(res);
+              if constexpr (Direction == WireDirection::Forward) {
+                return arg;
+              } else {
+                return forOp.getTiedLoopYieldedValue(arg)->get();
+              }
+            }());
+          })
+          .template Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+            children[0].infos.insertOrUpdate(children[0].infos.size(), prog);
+            children[0].wires.emplace_back([&] -> Value {
               auto condOp = cast<scf::ConditionOp>(
                   whileOp.getBeforeBody()->getTerminator());
-              auto yieldOp =
-                  cast<scf::YieldOp>(whileOp.getAfterBody()->getTerminator());
+              const auto arg = whileOp.getBeforeArguments()[resNum];
+              if constexpr (Direction == WireDirection::Forward) {
+                return arg;
+              } else {
+                return condOp.getArgs()[resNum];
+              }
+            }());
+          })
+          .template Case<IfOp>([&](IfOp ifOp) {
+            assert(ifOp.getNumRegions() == 2);
 
-              // Construct "before" child bundle. Particularly, find the
-              // block-argument (forward) or condition-yielded value (backward)
-              // for each result qubit the selected (via indices) iterators
-              // point at.
+            OpOperand* const qubit = ifOp.getTiedQubit(res);
+            for (size_t i = 0; i < 2; ++i) {
+              Region& region = ifOp.getRegion(i);
 
-              SmallVector<size_t> perm(indices.size());
-              RoutingBundle befChild{.layout = parent.layout};
-
-              for (size_t i : indices) {
-                const auto prog = parent.infos.lookupProgram(i);
-                const auto res = cast<OpResult>(parent.wires[i].qubit());
-                const auto resNum = res.getResultNumber();
-                const auto arg = whileOp.getBeforeArguments()[resNum];
-                const auto index = befChild.wires.size();
-
-                perm[res.getResultNumber()] =
-                    parent.layout.getHardwareIndex(prog);
-
+              const auto arg = region.getRegionNumber() == 0
+                                   ? ifOp.getTiedThenBlockArgument(qubit)
+                                   : ifOp.getTiedElseBlockArgument(qubit);
+              children[i].infos.insertOrUpdate(children[i].infos.size(), prog);
+              children[i].wires.emplace_back([&] -> Value {
                 if constexpr (Direction == WireDirection::Forward) {
-                  befChild.wires.emplace_back(arg);
+                  return arg;
                 } else {
-                  befChild.wires.emplace_back(condOp.getArgs()[resNum]);
+                  return region.getRegionNumber() == 0
+                             ? ifOp.getTiedThenYieldedValue(arg)->get()
+                             : ifOp.getTiedElseYieldedValue(arg)->get();
                 }
+              }());
+            }
+          });
 
-                befChild.infos.map(index, prog);
-              }
+      permutation[resNum] = hw;
+    }
 
-              if (failed(route<Direction, Mode>(befChild, stats, rewriter))) {
-                return failure();
-              }
+    // Route each child branch and prepare the wire iterators for
+    // epilogue SWAP insertion, i.e., point each iterator at the final
+    // qubit op (note: might be a measurement) before the yield.
+    // TODO: Parallelize multiple children, if possible.
 
-              if constexpr (Mode == RoutingMode::Hot) {
-                for_each(befChild.wires,
-                         [](auto& it) { std::advance(it, -2); });
+    for (auto& child : children) {
+      if (failed(route<Direction, Mode>(child, stats, rewriter))) {
+        return failure();
+      }
 
-                realignTerminator<scf::ConditionOp>(
-                    whileOp.getBeforeBody()->getTerminator(), perm, befChild,
-                    *rewriter, condOp.getCondition());
-                sortTopologically(whileOp.getBeforeBody());
-              }
+      if constexpr (Mode == RoutingMode::Hot) {
+        for_each(child.wires, [](auto& it) { std::advance(it, -2); });
+      }
+    }
 
-              RoutingBundle aftChild{.layout = befChild.layout};
+    // Exception: The layout of the "after" region depends on the final layout
+    // of the before region. Thus, create / route the second child region /
+    // bundle here.
 
-              const auto rng = [&] -> ValueRange {
-                if constexpr (Direction == WireDirection::Forward) {
-                  return whileOp.getAfterArguments();
-                }
+    if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+      children.emplace_back(RoutingBundle{.layout = children[0].layout});
+      assert(children.size() == 2);
 
-                return yieldOp.getResults();
-              }();
+      const auto rng = [&] -> ValueRange {
+        if constexpr (Direction == WireDirection::Forward) {
+          return whileOp.getAfterArguments();
+        }
+        return cast<scf::YieldOp>(whileOp.getAfterBody()->getTerminator())
+            .getResults();
+      }();
 
-              for (const auto& [i, arg] : llvm::enumerate(rng)) {
-                const auto hw = perm[i];
-                const auto prog = befChild.layout.getProgramIndex(hw);
-                aftChild.wires.emplace_back(arg);
-                aftChild.infos.map(i, prog);
-              }
+      for (const auto& [i, arg] : llvm::enumerate(rng)) {
+        const auto hw = permutation[i];
+        const auto prog = children[0].layout.getProgramIndex(hw);
+        children[1].wires.emplace_back(arg);
+        children[1].infos.insertOrUpdate(i, prog);
+      }
 
-              if (failed(route<Direction, Mode>(aftChild, stats, rewriter))) {
-                return failure();
-              }
+      if (failed(route<Direction, Mode>(children[1], stats, rewriter))) {
+        return failure();
+      }
 
-              if constexpr (Mode == RoutingMode::Hot) {
-                for_each(aftChild.wires,
-                         [](auto& it) { std::advance(it, -2); });
-              }
+      if constexpr (Mode == RoutingMode::Hot) {
+        for_each(children[1].wires, [](auto& it) { std::advance(it, -2); });
+      }
+    }
 
-              const auto swaps = restore(aftChild.layout, parent.layout);
-              insertSWAPs<Mode>(swaps, aftChild, stats, rewriter);
+    const Layout exit =
+        TypeSwitch<Operation*, Layout>(op)
+            .Case<scf::ForOp>([&](scf::ForOp) {
+              // Find (insert) the epilogue SWAP sequence for (into) the child
+              // region using the restore strategy.
 
-              // Re-order the targets of the yield operation, to match the input
-              // order of hardware indices and ensure qubits[i] = yield[i] and
-              // sort topologically to fix any occurring SSA dominance errors.
-
-              if constexpr (Mode == RoutingMode::Hot) {
-                realignTerminator<scf::YieldOp>(
-                    whileOp.getAfterBody()->getTerminator(), perm, aftChild,
-                    *rewriter);
-                sortTopologically(whileOp.getAfterBody());
-              }
-
-              // Propagate the correct layout and index-to-program mapping to
-              // the parent.
-
-              WireInfos realigendInfos;
-              for (size_t i = 0; i < parent.wires.size(); ++i) {
-                const auto oldProg = parent.infos.lookupProgram(i);
-                const auto oldHw = parent.layout.getHardwareIndex(oldProg);
-                const auto newProg = befChild.layout.getProgramIndex(oldHw);
-                realigendInfos.map(i, newProg);
-              }
-
-              parent.layout = befChild.layout;
-              parent.infos = std::move(realigendInfos);
-
-              return success();
+              const auto swaps = restore(children[0].layout, parent.layout);
+              insertSWAPs<Mode>(swaps, children[0], stats, rewriter);
+              return parent.layout;
             })
-            .template Case<IfOp>([&](IfOp ifOp) {
-              const std::array bodies{
-                  &ifOp.getThenRegion().getBlocks().front(),
-                  &ifOp.getElseRegion().getBlocks().front(),
-              };
+            .template Case<scf::WhileOp>([&](scf::WhileOp) {
+              // Find (insert) the epilogue SWAP sequence for (into) the after
+              // region using the restore strategy.
 
-              // Construct child bundles for each branch. Particularly, find the
-              // block-argument (forward) or yielded result (backward) for each
-              // result qubit the selected (via indices) iterators point at.
+              const auto swaps = restore(children[1].layout, parent.layout);
+              insertSWAPs<Mode>(swaps, children[1], stats, rewriter);
 
-              SmallVector<size_t> perm(indices.size());
-              std::array children{RoutingBundle{.layout = parent.layout},
-                                  RoutingBundle{.layout = parent.layout}};
-
-              for (size_t i : indices) {
-                const auto prog = parent.infos.lookupProgram(i);
-                const auto res = cast<OpResult>(parent.wires[i].qubit());
-                const auto index = children[0].wires.size();
-
-                OpOperand* qubit = ifOp.getTiedQubit(res);
-                const std::array args{ifOp.getTiedThenBlockArgument(qubit),
-                                      ifOp.getTiedElseBlockArgument(qubit)};
-
-                perm[res.getResultNumber()] =
-                    parent.layout.getHardwareIndex(prog);
-
-                if constexpr (Direction == WireDirection::Forward) {
-                  for (size_t j = 0; j < children.size(); ++j) {
-                    children[j].wires.emplace_back(args[j]);
-                    children[j].infos.map(index, prog);
-                  }
-                } else {
-                  const std::array yields{
-                      ifOp.getTiedThenYieldedValue(args[0])->get(),
-                      ifOp.getTiedElseYieldedValue(args[1])->get()};
-                  for (size_t j = 0; j < children.size(); ++j) {
-                    children[j].wires.emplace_back(yields[j]);
-                    children[j].infos.map(index, prog);
-                  }
-                }
-              }
-
-              // Route each child branch and prepare the wire iterators for
-              // epilogue SWAP insertion, i.e., point each iterator at the final
-              // qubit op (note: might be a measurement) before the yield.
-
-              for (auto& child : children) {
-                if (failed(route<Direction, Mode>(child, stats, rewriter))) {
-                  return failure();
-                }
-
-                if constexpr (Mode == RoutingMode::Hot) {
-                  for_each(child.wires, [](auto& it) { std::advance(it, -2); });
-                }
-              }
-
+              // The scf::YieldOp is the terminator in the before region and
+              // thus determines the final output layout.
+              return children[0].layout;
+            })
+            .template Case<IfOp>([&](IfOp) {
               // Find (insert) the epilogue SWAP sequence for (into) each child
               // branch using the "converge" strategy.
 
               const auto [convergedLayout, fst, snd] =
                   converge(children[0].layout, children[1].layout);
-
               insertSWAPs<Mode>(fst, children[0], stats, rewriter);
               insertSWAPs<Mode>(snd, children[1], stats, rewriter);
+              return convergedLayout;
+            });
 
-              // Re-order the targets of a yield operation to match the input
-              // order of hardware indices and ensure qubits[i] = yield[i] and
-              // sort topologically to fix any occurring SSA dominance errors.
+    if constexpr (Mode == RoutingMode::Hot) {
 
-              if constexpr (Mode == RoutingMode::Hot) {
+      // Realign terminator values to ensure that i-th input qubit and the i-th
+      // output qubit represent the equivalent hardware qubit. Note: Because
+      // we restore the layout at the end of the scf::ForOp, we don't require
+      // this procedure.
 
-                for (const auto& [child, body] :
-                     llvm::zip_equal(children, bodies)) {
+      TypeSwitch<Operation*>(op)
+          .template Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+            auto condOp = cast<scf::ConditionOp>(
+                whileOp.getBeforeBody()->getTerminator());
+            realignTerminator<scf::ConditionOp>(condOp, permutation,
+                                                children[0], *rewriter,
+                                                condOp.getCondition());
+            realignTerminator<scf::YieldOp>(
+                whileOp.getAfterBody()->getTerminator(), permutation,
+                children[1], *rewriter);
+          })
+          .template Case<IfOp>([&](IfOp ifOp) {
+            realignTerminator<YieldOp>(
+                ifOp.getThenRegion().front().getTerminator(), permutation,
+                children[0], *rewriter);
+            realignTerminator<YieldOp>(
+                ifOp.getElseRegion().front().getTerminator(), permutation,
+                children[1], *rewriter);
+          });
 
-                  assert(all_of(child.wires, [&](auto& it) {
-                    return isa<qco::YieldOp>(std::next(it).operation());
-                  }));
+      // Sort topologically to fix any occurring SSA dominance errors.
 
-                  realignTerminator<YieldOp>(body->getTerminator(), perm, child,
-                                             *rewriter);
+      for (Region& region : op->getRegions()) {
+        assert(region.hasOneBlock());
+        sortTopologically(&region.front());
+      }
+    }
 
-                  sortTopologically(body);
-                }
-              }
+    // If the operation is a scf::ForOp, where the parent.layout = child.layout,
+    // we are done. Otherwise, propagate the final layout and index-to-program
+    // mapping to the parent.
 
-              // Propagate the correct layout and index-to-program mapping to
-              // the parent.
+    if (!isa<scf::ForOp>(op)) {
 
-              WireInfos realigendInfos;
-              for (size_t i = 0; i < parent.wires.size(); ++i) {
-                const auto oldProg = parent.infos.lookupProgram(i);
-                const auto oldHw = parent.layout.getHardwareIndex(oldProg);
-                const auto newProg = convergedLayout.getProgramIndex(oldHw);
-                realigendInfos.map(i, newProg);
-              }
+      WireInfos realigendInfos;
+      for (size_t i = 0; i < parent.wires.size(); ++i) {
+        const auto oldProg = parent.infos.lookupProgram(i);
+        const auto oldHw = parent.layout.getHardwareIndex(oldProg);
+        const auto newProg = exit.getProgramIndex(oldHw);
+        realigendInfos.insertOrUpdate(i, newProg);
+      }
 
-              parent.layout = convergedLayout;
-              parent.infos = std::move(realigendInfos);
-              return success();
-            })
-            .Default([](Operation*) { return failure(); });
+      parent.layout = exit;
+      parent.infos = std::move(realigendInfos);
+    }
 
     // Finally, move past the operation with nested regions by
     // incrementing the respective global wires.
@@ -1441,7 +1387,7 @@ private:
       std::advance(parent.wires[i], WireTraversalTraits<Direction>::stride());
     });
 
-    return res;
+    return success();
   }
 
   /// Iterates over a dynamically computed window of layers and uses A* search

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -437,6 +437,83 @@ private:
     return newIfOp;
   }
 
+  /// Extend the arguments of an `scf::WhileOp` by adding a given range of
+  /// additional SSA values. Replaces the existing operation and returns the
+  /// newly created one.
+  static scf::WhileOp extend(scf::WhileOp whileOp, ValueRange addons,
+                             IRRewriter& rewriter) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(whileOp);
+
+    Block* oldBefBlock = whileOp.getBeforeBody();
+    Block* oldAftBlock = whileOp.getAfterBody();
+
+    const auto oldBefNumArgs = oldBefBlock->getNumArguments();
+    const auto oldAftNumArgs = oldAftBlock->getNumArguments();
+
+    // Create a new while op at the same location as the old one with the
+    // additional arguments.
+
+    SmallVector<Value> newInits(whileOp.getInits());
+    newInits.append(addons.begin(), addons.end());
+
+    SmallVector<Type> newTypes(whileOp.getResultTypes());
+    newTypes.append(addons.getTypes().begin(), addons.getTypes().end());
+
+    auto newWhileOp =
+        rewriter.create<scf::WhileOp>(whileOp.getLoc(), newTypes, newInits);
+
+    const SmallVector<Location> locs(newTypes.size(), whileOp.getLoc());
+    Block* newBefBlock =
+        rewriter.createBlock(&newWhileOp.getBefore(), {}, newTypes, locs);
+    Block* newAftBlock =
+        rewriter.createBlock(&newWhileOp.getAfter(), {}, newTypes, locs);
+
+    rewriter.mergeBlocks(oldBefBlock, newBefBlock,
+                         newBefBlock->getArguments().take_front(oldBefNumArgs));
+    rewriter.mergeBlocks(oldAftBlock, newAftBlock,
+                         newAftBlock->getArguments().take_front(oldAftNumArgs));
+
+    auto conditionOp = cast<scf::ConditionOp>(newBefBlock->getTerminator());
+    rewriter.setInsertionPoint(conditionOp);
+
+    // Replace the old condition operation with one that includes the new
+    // "before" block arguments.
+
+    SmallVector<Value> newConditionArgs(conditionOp.getArgs());
+    llvm::append_range(newConditionArgs,
+                       newBefBlock->getArguments().drop_front(oldBefNumArgs));
+
+    rewriter.create<scf::ConditionOp>(
+        conditionOp.getLoc(), conditionOp.getCondition(), newConditionArgs);
+    rewriter.eraseOp(conditionOp);
+
+    // Replace the old yield operation with one that includes the new "after"
+    // block arguments.
+
+    auto yieldOp = cast<scf::YieldOp>(newAftBlock->getTerminator());
+    rewriter.setInsertionPoint(yieldOp);
+
+    SmallVector<Value> newYieldArgs(yieldOp.getResults());
+    llvm::append_range(newYieldArgs,
+                       newAftBlock->getArguments().drop_front(oldBefNumArgs));
+
+    rewriter.create<scf::YieldOp>(yieldOp.getLoc(), newYieldArgs);
+    rewriter.eraseOp(yieldOp);
+
+    // Finally, replace the old while operation with the new one.
+
+    rewriter.replaceOp(
+        whileOp, newWhileOp.getResults().take_front(whileOp.getNumResults()));
+
+    for (const auto [before, after] : llvm::zip_equal(
+             addons, newWhileOp->getResults().take_back(addons.size()))) {
+      rewriter.replaceAllUsesExcept(before, after, newWhileOp);
+    }
+
+    return newWhileOp;
+  }
+
   /// Return the wires of a dynamic computation.
   /// The mapping pass currently assumes that
   /// - there are no `qco.alloc` operation
@@ -597,6 +674,28 @@ private:
                   newForOp.getRegion(),
                   DenseSet<Value>(newForOp.getRegionIterArgs().begin(),
                                   newForOp.getRegionIterArgs().end()));
+            })
+            .Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+              assert(qubits.size() == layout.nqubits());
+
+              llvm::for_each(whileOp.getInits(),
+                             [&](Value v) { qubits.erase(v); });
+
+              auto newWhileOp = extend(whileOp, to_vector(qubits), rewriter);
+              for (const auto [init, result] : llvm::zip_equal(
+                       newWhileOp.getInits(), newWhileOp.getResults())) {
+                qubits.insert(result);
+                qubits.erase(init);
+              }
+
+              const auto beforeArgs = newWhileOp.getBeforeArguments();
+              const auto afterArgs = newWhileOp.getAfterArguments();
+              stack.emplace_back(
+                  newWhileOp.getBefore(),
+                  DenseSet<Value>(beforeArgs.begin(), beforeArgs.end()));
+              stack.emplace_back(
+                  newWhileOp.getAfter(),
+                  DenseSet<Value>(afterArgs.begin(), afterArgs.end()));
             })
             .Case<IfOp>([&](IfOp ifOp) {
               assert(qubits.size() == layout.nqubits());
@@ -1032,7 +1131,7 @@ private:
                     released.emplace_back(op);
                   }
                 })
-                .template Case<scf::ForOp, IfOp>(
+                .template Case<scf::ForOp, scf::WhileOp, IfOp>(
                     [&](auto op) { stack.emplace_back(op, indices); });
           }
 
@@ -1054,6 +1153,17 @@ private:
                          RoutingBundle& parent, Statistics& stats,
                          IRRewriter* rewriter = nullptr) {
     const auto& [op, indices] = item;
+
+    const auto constructMap = [](const RoutingBundle& bundle) {
+      DenseMap<size_t, Value> curr(bundle.wires.size());
+      for (size_t i = 0; i < bundle.wires.size(); ++i) {
+        const auto prog = bundle.infos.lookupProgram(i);
+        const auto hw = bundle.layout.getHardwareIndex(prog);
+        curr.try_emplace(hw, bundle.wires[i].qubit());
+      }
+      return curr;
+    };
+
     const LogicalResult res =
         TypeSwitch<Operation*, LogicalResult>(op)
             .template Case<scf::ForOp>([&](scf::ForOp forOp) {
@@ -1105,6 +1215,115 @@ private:
               if constexpr (Mode == RoutingMode::Hot) {
                 sortTopologically(forOp.getBody());
               }
+
+              return success();
+            })
+            .template Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+              auto condOp = cast<scf::ConditionOp>(
+                  whileOp.getBeforeBody()->getTerminator());
+              auto yieldOp =
+                  cast<scf::YieldOp>(whileOp.getAfterBody()->getTerminator());
+
+              // Construct "before" child bundle. Particularly, find the
+              // block-argument (forward) or condition-yielded value (backward)
+              // for each result qubit the selected (via indices) iterators
+              // point at.
+
+              SmallVector<size_t> perm(indices.size());
+              RoutingBundle befChild{.layout = parent.layout};
+
+              for (size_t i : indices) {
+                const auto prog = parent.infos.lookupProgram(i);
+                const auto res = cast<OpResult>(parent.wires[i].qubit());
+                const auto resNum = res.getResultNumber();
+                const auto arg = whileOp.getBeforeArguments()[resNum];
+                const auto index = befChild.wires.size();
+
+                perm[res.getResultNumber()] =
+                    parent.layout.getHardwareIndex(prog);
+
+                if constexpr (Direction == WireDirection::Forward) {
+                  befChild.wires.emplace_back(arg);
+                } else {
+                  befChild.wires.emplace_back(condOp.getArgs()[resNum]);
+                }
+
+                befChild.infos.map(index, prog);
+              }
+
+              if (failed(route<Direction, Mode>(befChild, stats, rewriter))) {
+                return failure();
+              }
+
+              if constexpr (Mode == RoutingMode::Hot) {
+                for_each(befChild.wires,
+                         [](auto& it) { std::advance(it, -2); });
+
+                const auto m = constructMap(befChild);
+                rewriter->setInsertionPoint(condOp);
+                rewriter->replaceOpWithNewOp<scf::ConditionOp>(
+                    condOp, condOp.getCondition(),
+                    to_vector(
+                        map_range(perm, [&](size_t hw) { return m.at(hw); })));
+                sortTopologically(whileOp.getBeforeBody());
+              }
+
+              RoutingBundle aftChild{.layout = befChild.layout};
+
+              const auto rng = [&] -> ValueRange {
+                if constexpr (Direction == WireDirection::Forward) {
+                  return whileOp.getAfterArguments();
+                }
+
+                return yieldOp.getResults();
+              }();
+
+              for (const auto& [i, arg] : llvm::enumerate(rng)) {
+                const auto hw = perm[i];
+                const auto prog = befChild.layout.getProgramIndex(hw);
+                aftChild.wires.emplace_back(arg);
+                aftChild.infos.map(i, prog);
+              }
+
+              if (failed(route<Direction, Mode>(aftChild, stats, rewriter))) {
+                return failure();
+              }
+
+              if constexpr (Mode == RoutingMode::Hot) {
+                for_each(aftChild.wires,
+                         [](auto& it) { std::advance(it, -2); });
+              }
+
+              const auto swaps = restore(aftChild.layout, parent.layout);
+              insertSWAPs<Mode>(swaps, aftChild, stats, rewriter);
+
+              // Re-order the targets of the yield operation, to match the input
+              // order of hardware indices and ensure qubits[i] = yield[i] and
+              // sort topologically to fix any occurring SSA dominance errors.
+
+              if constexpr (Mode == RoutingMode::Hot) {
+                const auto m = constructMap(aftChild);
+                rewriter->setInsertionPoint(yieldOp);
+                rewriter->replaceOpWithNewOp<scf::YieldOp>(
+                    yieldOp, to_vector(map_range(
+                                 perm, [&](size_t hw) { return m.at(hw); })));
+
+                sortTopologically(whileOp.getAfterBody());
+              }
+
+              // Propagate the correct layout and index-to-program mapping to
+              // the parent.
+
+              WireInfos realigendInfos;
+              for (size_t i = 0; i < parent.wires.size(); ++i) {
+                const auto oldProg = parent.infos.lookupProgram(i);
+                const auto oldHw = parent.layout.getHardwareIndex(oldProg);
+                const auto newProg = befChild.layout.getProgramIndex(oldHw);
+                realigendInfos.map(i, newProg);
+              }
+
+              parent.layout = befChild.layout;
+              parent.infos = std::move(realigendInfos);
 
               return success();
             })
@@ -1186,18 +1405,15 @@ private:
                     return isa<qco::YieldOp>(std::next(it).operation());
                   }));
 
-                  DenseMap<size_t, Value> curr(child.wires.size());
-                  for (size_t i = 0; i < child.wires.size(); ++i) {
-                    const auto prog = child.infos.lookupProgram(i);
-                    const auto hw = child.layout.getHardwareIndex(prog);
-                    curr.try_emplace(hw, child.wires[i].qubit());
-                  }
+                  const auto m = constructMap(child);
 
                   auto yieldOp = cast<YieldOp>(body->getTerminator());
                   const SmallVector<Value> targets(
-                      map_range(perm, [&](size_t hw) { return curr.at(hw); }));
+                      map_range(perm, [&](size_t hw) { return m.at(hw); }));
                   rewriter->setInsertionPoint(yieldOp);
-                  rewriter->replaceOpWithNewOp<qco::YieldOp>(yieldOp, targets);
+                  rewriter->replaceOpWithNewOp<YieldOp>(
+                      yieldOp, to_vector(map_range(
+                                   perm, [&](size_t hw) { return m.at(hw); })));
 
                   sortTopologically(body);
                 }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -182,12 +182,6 @@ private:
     Layout layout;
   };
 
-  /// A routing trial used for parallelization.
-  struct Trial : RoutingBundle {
-    Statistics stats{};
-    bool success{false};
-  };
-
   /// Describes a node in the A* search graph.
   struct Node {
     struct ComparePointer {
@@ -753,6 +747,12 @@ private:
   FailureOr<Layout> generateLayout(const Wires& wires, const WireInfos& infos) {
     std::mt19937_64 rng{seed};
 
+    struct Trial {
+      RoutingBundle bundle;
+      Statistics stats{};
+      bool success{false};
+    };
+
     SmallVector<Trial, 0> trials;
     trials.reserve(ntrials);
     for (size_t i = 0; i < ntrials; ++i) {
@@ -764,11 +764,11 @@ private:
 
     parallelForEach(&getContext(), trials, [&, this](Trial& t) {
       for (size_t i = 0; i < niterations; ++i) {
-        if (route<WireDirection::Forward>(t, t.stats).failed()) {
+        if (route<WireDirection::Forward>(t.bundle, t.stats).failed()) {
           return;
         }
         t.stats.nswaps = 0;
-        if (route<WireDirection::Backward>(t, t.stats).failed()) {
+        if (route<WireDirection::Backward>(t.bundle, t.stats).failed()) {
           return;
         }
       }
@@ -788,7 +788,7 @@ private:
       return failure();
     }
 
-    return best->layout;
+    return best->bundle.layout;
   }
 
   /// Perform A* search to find a sequence of SWAPs that makes all two-qubit ops

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1145,6 +1145,27 @@ private:
     return stack;
   }
 
+  /// Helper function to realign a terminator operation based on a permutation
+  /// of hardware indices. This constructs a value map from the given bundle and
+  /// reorders the terminator's operands according to the permutation vector.
+  template <typename T, typename... Args>
+  static void realignTerminator(Operation* terminator, ArrayRef<size_t> perm,
+                                const RoutingBundle& bundle,
+                                IRRewriter& rewriter, Args&&... extraArgs) {
+    // Map hardware indices to qubit values for the given bundle.
+    DenseMap<size_t, Value> m(bundle.wires.size());
+    for (size_t i = 0; i < bundle.wires.size(); ++i) {
+      const auto prog = bundle.infos.lookupProgram(i);
+      const auto hw = bundle.layout.getHardwareIndex(prog);
+      m.try_emplace(hw, bundle.wires[i].qubit());
+    }
+
+    rewriter.setInsertionPoint(terminator);
+    rewriter.replaceOpWithNewOp<T>(
+        terminator, std::forward<Args>(extraArgs)...,
+        to_vector(map_range(perm, [&](size_t hw) { return m.at(hw); })));
+  }
+
   /// Processes the recursive stack item by routing the nested operation and
   /// inserting epilogue SWAPs.
   template <WireDirection Direction, RoutingMode Mode = RoutingMode::Cold>
@@ -1153,16 +1174,6 @@ private:
                          RoutingBundle& parent, Statistics& stats,
                          IRRewriter* rewriter = nullptr) {
     const auto& [op, indices] = item;
-
-    const auto constructMap = [](const RoutingBundle& bundle) {
-      DenseMap<size_t, Value> curr(bundle.wires.size());
-      for (size_t i = 0; i < bundle.wires.size(); ++i) {
-        const auto prog = bundle.infos.lookupProgram(i);
-        const auto hw = bundle.layout.getHardwareIndex(prog);
-        curr.try_emplace(hw, bundle.wires[i].qubit());
-      }
-      return curr;
-    };
 
     const LogicalResult res =
         TypeSwitch<Operation*, LogicalResult>(op)
@@ -1259,12 +1270,9 @@ private:
                 for_each(befChild.wires,
                          [](auto& it) { std::advance(it, -2); });
 
-                const auto m = constructMap(befChild);
-                rewriter->setInsertionPoint(condOp);
-                rewriter->replaceOpWithNewOp<scf::ConditionOp>(
-                    condOp, condOp.getCondition(),
-                    to_vector(
-                        map_range(perm, [&](size_t hw) { return m.at(hw); })));
+                realignTerminator<scf::ConditionOp>(
+                    whileOp.getBeforeBody()->getTerminator(), perm, befChild,
+                    *rewriter, condOp.getCondition());
                 sortTopologically(whileOp.getBeforeBody());
               }
 
@@ -1302,12 +1310,9 @@ private:
               // sort topologically to fix any occurring SSA dominance errors.
 
               if constexpr (Mode == RoutingMode::Hot) {
-                const auto m = constructMap(aftChild);
-                rewriter->setInsertionPoint(yieldOp);
-                rewriter->replaceOpWithNewOp<scf::YieldOp>(
-                    yieldOp, to_vector(map_range(
-                                 perm, [&](size_t hw) { return m.at(hw); })));
-
+                realignTerminator<scf::YieldOp>(
+                    whileOp.getAfterBody()->getTerminator(), perm, aftChild,
+                    *rewriter);
                 sortTopologically(whileOp.getAfterBody());
               }
 
@@ -1405,15 +1410,8 @@ private:
                     return isa<qco::YieldOp>(std::next(it).operation());
                   }));
 
-                  const auto m = constructMap(child);
-
-                  auto yieldOp = cast<YieldOp>(body->getTerminator());
-                  const SmallVector<Value> targets(
-                      map_range(perm, [&](size_t hw) { return m.at(hw); }));
-                  rewriter->setInsertionPoint(yieldOp);
-                  rewriter->replaceOpWithNewOp<YieldOp>(
-                      yieldOp, to_vector(map_range(
-                                   perm, [&](size_t hw) { return m.at(hw); })));
+                  realignTerminator<YieldOp>(body->getTerminator(), perm, child,
+                                             *rewriter);
 
                   sortTopologically(body);
                 }

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -137,7 +137,7 @@ void WireIterator::backward() {
         // Because the scf::WhileOp doesn't implement "getLoopResults", we
         // have to fallback to the following instead of using
         // "getTiedLoopInit".
-        
+
         if (auto result = dyn_cast<OpResult>(qubit_)) {
           qubit_ = op.getInits()[result.getResultNumber()];
           return;

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -28,7 +28,8 @@
 namespace mlir::qco {
 
 bool WireIterator::isSinkLikeOperation(Operation* op) {
-  return isa<SinkOp, YieldOp, qtensor::InsertOp, scf::YieldOp>(op);
+  return isa<SinkOp, YieldOp, qtensor::InsertOp, scf::ConditionOp,
+             scf::YieldOp>(op);
 }
 
 bool WireIterator::isSourceLikeOperation(Operation* op) {
@@ -72,8 +73,16 @@ void WireIterator::forward() {
         })
         .Case<MeasureOp>([&](MeasureOp op) { qubit_ = op.getQubitOut(); })
         .Case<ResetOp>([&](ResetOp op) { qubit_ = op.getQubitOut(); })
-        .Case<scf::ForOp, scf::WhileOp>([&](auto op) {
-          qubit_ = op.getTiedLoopResult(&*(qubit_.use_begin()));
+        .Case<scf::ForOp>([&](scf::ForOp op) {
+          qubit_ = op.getTiedLoopResult(qubit_.use_begin().getOperand());
+        })
+        .Case<scf::WhileOp>([&](scf::WhileOp op) {
+          // Because the scf::WhileOp doesn't implement "getLoopResults", we
+          // have to fallback to the following instead of using
+          // "getTiedLoopResult".
+
+          OpOperand* operand = qubit_.use_begin().getOperand();
+          qubit_ = op->getResult(operand->getOperandNumber());
         })
         .Case<IfOp>(
             [&](IfOp op) { qubit_ = op.getTiedResult(&(*qubit_.use_begin())); })
@@ -117,11 +126,23 @@ void WireIterator::backward() {
           [&](UnitaryOpInterface op) { qubit_ = op.getInputForOutput(qubit_); })
       .Case<MeasureOp>([&](MeasureOp op) { qubit_ = op.getQubitIn(); })
       .Case<ResetOp>([&](ResetOp op) { qubit_ = op.getQubitIn(); })
-      .Case<scf::ForOp, scf::WhileOp>([&](auto op) {
+      .Case<scf::ForOp>([&](scf::ForOp op) {
         if (auto result = dyn_cast<OpResult>(qubit_)) {
           qubit_ = op.getTiedLoopInit(result)->get();
           return;
         }
+        llvm::reportFatalInternalError("expected result lookup");
+      })
+      .Case<scf::WhileOp>([&](scf::WhileOp op) {
+        // Because the scf::WhileOp doesn't implement "getLoopResults", we
+        // have to fallback to the following instead of using
+        // "getTiedLoopInit".
+        
+        if (auto result = dyn_cast<OpResult>(qubit_)) {
+          qubit_ = op.getInits()[result.getResultNumber()];
+          return;
+        }
+
         llvm::reportFatalInternalError("expected result lookup");
       })
       .Case<IfOp>([&](IfOp op) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -93,22 +93,78 @@ isExecutable(Region& body, DenseMap<Value, size_t>& m,
 
               return true;
             })
-            .Case<scf::ForOp>([&](scf::ForOp forOp) {
-              DenseMap<Value, size_t> bodyM;
-              for (const auto [init, arg] : llvm::zip_equal(
-                       forOp.getInits(), forOp.getRegionIterArgs())) {
-                const auto hw = m.at(init);
-                bodyM.try_emplace(arg, hw);
-              }
+            .Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+              const auto inits = whileOp.getInitsMutable();
+
+              DenseMap<Value, size_t> beforeM;
+              DenseMap<Value, size_t> afterM;
 
               SmallVector<size_t> initialHardwareOrder;
-              initialHardwareOrder.reserve(forOp.getInits().size());
+              initialHardwareOrder.reserve(inits.size());
 
-              for (OpOperand& operand : forOp.getInitsMutable()) {
-                const auto pred = operand.get();
-                const auto succ = forOp.getTiedLoopResult(&operand);
+              for (const auto [init, beforeArg, afterArg] :
+                   llvm::zip_equal(inits, whileOp.getBeforeArguments(),
+                                   whileOp.getAfterArguments())) {
+                const auto pred = init.get();
+                const auto hw = m.at(pred);
+                const auto succ = whileOp->getResult(init.getOperandNumber());
+
+                beforeM.try_emplace(beforeArg, hw);
+                afterM.try_emplace(afterArg, hw);
+                m.try_emplace(succ, hw);
+                initialHardwareOrder.emplace_back(hw);
+              }
+
+              if (!isExecutable(whileOp.getBefore(), beforeM, couplingSet)) {
+                return false;
+              }
+
+              if (!isExecutable(whileOp.getAfter(), afterM, couplingSet)) {
+                return false;
+              }
+
+              auto condOp = cast<scf::ConditionOp>(
+                  whileOp.getBeforeBody()->getTerminator());
+              auto yieldOp =
+                  cast<scf::YieldOp>(whileOp.getAfterBody()->getTerminator());
+
+              const auto beforeHardwareOrder = to_vector(llvm::map_range(
+                  condOp.getArgs(), [&](auto v) { return beforeM.at(v); }));
+              const auto afterHardwareOrder = to_vector(llvm::map_range(
+                  yieldOp.getResults(), [&](auto v) { return afterM.at(v); }));
+
+              if (beforeHardwareOrder != initialHardwareOrder) {
+                llvm::dbgs()
+                    << "The hardware indices of the condition argument qubit "
+                       "values must be in the same order as the scf::WhileOp's "
+                       "input qubit values!\n";
+                return false;
+              }
+
+              if (afterHardwareOrder != initialHardwareOrder) {
+                llvm::dbgs()
+                    << "The hardware indices of the yielded qubit values "
+                       "values must be in the same order as the scf::WhileOp's "
+                       "input qubit values!\n";
+                return false;
+              }
+
+              return true;
+            })
+            .Case<scf::ForOp>([&](scf::ForOp forOp) {
+              const auto inits = forOp.getInitsMutable();
+
+              DenseMap<Value, size_t> bodyM;
+              SmallVector<size_t> initialHardwareOrder;
+              initialHardwareOrder.reserve(inits.size());
+
+              for (const auto [init, arg] :
+                   llvm::zip_equal(inits, forOp.getRegionIterArgs())) {
+                const auto pred = init.get();
+                const auto succ = forOp.getTiedLoopResult(&init);
                 const auto hw = m.at(pred);
 
+                bodyM.try_emplace(arg, hw);
                 m.try_emplace(succ, hw);
                 initialHardwareOrder.emplace_back(hw);
               }
@@ -119,7 +175,7 @@ isExecutable(Region& body, DenseMap<Value, size_t>& m,
 
               auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
 
-              const SmallVector<size_t> bodyHardwareOrder(llvm::map_range(
+              const auto bodyHardwareOrder = to_vector(llvm::map_range(
                   yield.getResults(), [&](auto v) { return bodyM.at(v); }));
 
               if (bodyHardwareOrder != initialHardwareOrder) {
@@ -133,23 +189,24 @@ isExecutable(Region& body, DenseMap<Value, size_t>& m,
               return true;
             })
             .Case<qco::IfOp>([&](qco::IfOp ifOp) {
-              std::array mappings{DenseMap<Value, size_t>{},
-                                  DenseMap<Value, size_t>{}};
-
+              const auto qubits = ifOp.getQubitsMutable();
               const std::array regions{&ifOp.getThenRegion(),
                                        &ifOp.getElseRegion()};
 
+              std::array mappings{DenseMap<Value, size_t>{},
+                                  DenseMap<Value, size_t>{}};
+
+              SmallVector<size_t> initialHardwareOrder;
+              initialHardwareOrder.reserve(qubits.size());
+
               for (size_t i = 0; i < 2; ++i) {
-                for (const auto [init, arg] : llvm::zip_equal(
-                         ifOp.getQubits(), regions[i]->getArguments())) {
-                  mappings[i].try_emplace(arg, /*hw = */ m.at(init));
+                for (const auto [qubit, arg] :
+                     llvm::zip_equal(qubits, regions[i]->getArguments())) {
+                  mappings[i].try_emplace(arg, /*hw = */ m.at(qubit.get()));
                 }
               }
 
-              SmallVector<size_t> initialHardwareOrder;
-              initialHardwareOrder.reserve(ifOp.getQubits().size());
-
-              for (OpOperand& operand : ifOp.getQubitsMutable()) {
+              for (OpOperand& operand : qubits) {
                 const auto pred = operand.get();
                 const auto succ = ifOp.getTiedResult(&operand);
                 const auto hw = m.at(pred);
@@ -714,6 +771,65 @@ TEST_P(MappingPassTest, MapBranchingGHZ) {
   builder.qtensorDealloc(tensor);
 
   auto m = builder.finalize(bits);
+  auto res =
+      runPass(m.get(), device.couplingSet, MappingPassOptions{.ntrials = 1});
+  auto entry = getEntryPoint(m.get());
+
+  ASSERT_TRUE(res.succeeded());
+  EXPECT_TRUE(isExecutable(entry, device.couplingSet));
+}
+
+TEST_P(MappingPassTest, MapDoUntil) {
+  const auto& device = GetParam();
+  const auto size = 4;
+
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  Value tensor = builder.qtensorAlloc(size);
+  SmallVector<Value> qubits(size);
+
+  for (int64_t i = 0; i < size; ++i) {
+    std::tie(tensor, qubits[i]) = builder.qtensorExtract(tensor, i);
+  }
+
+  qubits = builder.scfWhile(
+      qubits,
+      [&](ValueRange args) {
+        SmallVector<Value> beforeArgs(args);
+        SmallVector<Value> beforeBits(args);
+
+        flatGHZ(builder, beforeArgs);
+
+        beforeArgs = builder.barrier(beforeArgs);
+
+        for (int64_t i = 0; i < size; ++i) {
+          std::tie(beforeArgs[i], beforeBits[i]) =
+              builder.measure(beforeArgs[i]);
+        }
+
+        for (int64_t i = 0; i < size - 1; ++i) {
+          beforeBits[i + 1] =
+              arith::AndIOp::create(builder, beforeBits[i], beforeBits[i + 1])
+                  .getResult();
+        }
+
+        builder.scfCondition(beforeBits[size - 1], beforeArgs);
+        return beforeArgs;
+      },
+      [&](ValueRange args) { return args; });
+
+  flatGHZ(builder, qubits);
+
+  qubits = builder.barrier(qubits);
+
+  for (int64_t i = 0; i < size; ++i) {
+    tensor = builder.qtensorInsert(qubits[i], tensor, i);
+  }
+
+  builder.qtensorDealloc(tensor);
+
+  auto m = builder.finalize();
   auto res =
       runPass(m.get(), device.couplingSet, MappingPassOptions{.ntrials = 1});
   auto entry = getEntryPoint(m.get());

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -21,6 +21,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Debug.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/LogicalResult.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -31,6 +32,7 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/Passes.h>
@@ -59,199 +61,116 @@ struct Device {
 static bool
 isExecutable(Region& body, DenseMap<Value, size_t>& m,
              const DenseSet<std::pair<size_t, size_t>>& couplingSet) {
-  for (Operation& rop : body.getOps()) {
-    const bool executable =
-        TypeSwitch<Operation*, bool>(&rop)
-            .Case<StaticOp>([&](StaticOp op) {
-              m.try_emplace(op.getQubit(), op.getIndex());
-              return true;
-            })
-            .Case<BarrierOp>([&](BarrierOp op) {
-              for (const auto [pred, succ] :
-                   llvm::zip_equal(op.getInputQubits(), op.getOutputQubits())) {
-                m.try_emplace(succ, /*hw= */ m.at(pred));
-              }
-              return true;
-            })
-            .Case<UnitaryOpInterface>([&](UnitaryOpInterface& op) {
-              assert(op.getNumQubits() <= 2 && "expected two-qubit decomp.");
+  for (Operation& op : body.getOps()) {
+    if (auto staticOp = dyn_cast<StaticOp>(op)) {
+      m.try_emplace(staticOp.getQubit(), staticOp.getIndex());
+      continue;
+    }
 
-              if (op.getNumQubits() > 1) {
-                const auto hwA = m.at(op.getInputQubit(0));
-                const auto hwB = m.at(op.getInputQubit(1));
-                if (!couplingSet.contains(std::make_pair(hwA, hwB))) {
-                  llvm::dbgs() << "The two-qubit gate (" << hwA << ", " << hwB
-                               << ") is not executable: \n";
-                  op->dump();
-                  return false;
-                }
-              }
+    if (auto unitaryOp = dyn_cast<UnitaryOpInterface>(op)) {
+      if (!isa<BarrierOp>(op) && unitaryOp.getNumQubits() > 1) {
+        assert(unitaryOp.getNumQubits() <= 2 && "expected two-qubit decomp.");
 
-              for (const auto [pred, succ] :
-                   llvm::zip_equal(op.getInputQubits(), op.getOutputQubits())) {
-                m.try_emplace(succ, /*hw= */ m.at(pred));
-              }
+        const auto hwA = m.at(unitaryOp.getInputQubit(0));
+        const auto hwB = m.at(unitaryOp.getInputQubit(1));
+        if (!couplingSet.contains(std::make_pair(hwA, hwB))) {
+          llvm::dbgs() << "The two-qubit gate (" << hwA << ", " << hwB
+                       << ") is not executable: \n";
+          unitaryOp->dump();
+          return false;
+        }
+      }
 
-              return true;
-            })
-            .Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
-              const auto inits = whileOp.getInitsMutable();
+      for (const auto [pred, succ] : llvm::zip_equal(
+               unitaryOp.getInputQubits(), unitaryOp.getOutputQubits())) {
+        m.try_emplace(succ, m.at(pred));
+      }
 
-              DenseMap<Value, size_t> beforeM;
-              DenseMap<Value, size_t> afterM;
+      continue;
+    }
 
-              SmallVector<size_t> initialHardwareOrder;
-              initialHardwareOrder.reserve(inits.size());
+    if (auto resetOp = dyn_cast<ResetOp>(op)) {
+      m.try_emplace(resetOp.getQubitOut(), m.at(resetOp.getQubitIn()));
+      continue;
+    }
 
-              for (const auto [init, beforeArg, afterArg] :
-                   llvm::zip_equal(inits, whileOp.getBeforeArguments(),
-                                   whileOp.getAfterArguments())) {
-                const auto pred = init.get();
-                const auto hw = m.at(pred);
-                const auto succ = whileOp->getResult(init.getOperandNumber());
+    if (auto measOp = dyn_cast<MeasureOp>(op)) {
+      m.try_emplace(measOp.getQubitOut(), m.at(measOp.getQubitIn()));
+      continue;
+    }
 
-                beforeM.try_emplace(beforeArg, hw);
-                afterM.try_emplace(afterArg, hw);
-                m.try_emplace(succ, hw);
-                initialHardwareOrder.emplace_back(hw);
-              }
+    if (!isa<scf::ForOp, scf::WhileOp, qco::IfOp>(op)) {
+      continue;
+    }
 
-              if (!isExecutable(whileOp.getBefore(), beforeM, couplingSet)) {
-                return false;
-              }
+    for (Region& region : op.getRegions()) {
+      const ValueRange initArgs =
+          TypeSwitch<Operation*, ValueRange>(region.getParentOp())
+              .Case<qco::IfOp>([&](qco::IfOp ifOp) { return ifOp.getQubits(); })
+              .Case<scf::WhileOp>(
+                  [&](scf::WhileOp whileOp) { return whileOp.getInits(); })
+              .Case<scf::ForOp>(
+                  [&](scf::ForOp forOp) { return forOp.getInits(); })
+              .Default([](Operation*) -> ValueRange { return {}; });
 
-              if (!isExecutable(whileOp.getAfter(), afterM, couplingSet)) {
-                return false;
-              }
+      const auto initialHardwareOrder =
+          to_vector(llvm::map_range(initArgs, [&](auto v) { return m.at(v); }));
 
-              auto condOp = cast<scf::ConditionOp>(
-                  whileOp.getBeforeBody()->getTerminator());
-              auto yieldOp =
-                  cast<scf::YieldOp>(whileOp.getAfterBody()->getTerminator());
+      const auto qubitArgs =
+          llvm::make_filter_range(region.getArguments(), [](auto& arg) {
+            return isa<QubitType>(arg.getType());
+          });
 
-              const auto beforeHardwareOrder = to_vector(llvm::map_range(
-                  condOp.getArgs(), [&](auto v) { return beforeM.at(v); }));
-              const auto afterHardwareOrder = to_vector(llvm::map_range(
-                  yieldOp.getResults(), [&](auto v) { return afterM.at(v); }));
+      DenseMap<Value, size_t> localM;
+      for (const auto [i, arg] : llvm::enumerate(qubitArgs)) {
+        localM.try_emplace(arg, initialHardwareOrder[i]);
+      }
 
-              if (beforeHardwareOrder != initialHardwareOrder) {
-                llvm::dbgs()
-                    << "The hardware indices of the condition argument qubit "
-                       "values must be in the same order as the scf::WhileOp's "
-                       "input qubit values!\n";
-                return false;
-              }
+      if (!isExecutable(region, localM, couplingSet)) {
+        return false;
+      }
 
-              if (afterHardwareOrder != initialHardwareOrder) {
-                llvm::dbgs()
-                    << "The hardware indices of the yielded qubit values "
-                       "values must be in the same order as the scf::WhileOp's "
-                       "input qubit values!\n";
-                return false;
-              }
+      Operation* terminator = region.front().getTerminator();
+      const ValueRange finalOrderArgs =
+          TypeSwitch<Operation*, ValueRange>(region.getParentOp())
+              .Case<qco::IfOp>([&](qco::IfOp) {
+                return cast<qco::YieldOp>(terminator).getTargets();
+              })
+              .Case<scf::WhileOp>([&](auto) {
+                // Choose between "before" and "after" terminator.
+                return region.getRegionNumber() == 0
+                           ? cast<scf::ConditionOp>(terminator).getArgs()
+                           : cast<scf::YieldOp>(terminator).getResults();
+              })
+              .Case<scf::ForOp>([&](scf::ForOp) {
+                return cast<scf::YieldOp>(terminator).getResults();
+              })
+              .Default([](Operation*) -> ValueRange { return {}; });
 
-              return true;
-            })
-            .Case<scf::ForOp>([&](scf::ForOp forOp) {
-              const auto inits = forOp.getInitsMutable();
+      const auto finalOrder = to_vector(llvm::map_range(
+          finalOrderArgs, [&](auto v) { return localM.at(v); }));
 
-              DenseMap<Value, size_t> bodyM;
-              SmallVector<size_t> initialHardwareOrder;
-              initialHardwareOrder.reserve(inits.size());
+      if (finalOrder != initialHardwareOrder) {
+        llvm::dbgs()
+            << "The hardware indices of the yielded terminator qubit values "
+               "must "
+               "be in the same order as parent's op input qubit values!\n";
+        return false;
+      }
+    }
 
-              for (const auto [init, arg] :
-                   llvm::zip_equal(inits, forOp.getRegionIterArgs())) {
-                const auto pred = init.get();
-                const auto succ = forOp.getTiedLoopResult(&init);
-                const auto hw = m.at(pred);
-
-                bodyM.try_emplace(arg, hw);
-                m.try_emplace(succ, hw);
-                initialHardwareOrder.emplace_back(hw);
-              }
-
-              if (!isExecutable(forOp.getRegion(), bodyM, couplingSet)) {
-                return false;
-              }
-
-              auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-
-              const auto bodyHardwareOrder = to_vector(llvm::map_range(
-                  yield.getResults(), [&](auto v) { return bodyM.at(v); }));
-
-              if (bodyHardwareOrder != initialHardwareOrder) {
-                llvm::dbgs()
-                    << "The hardware indices of the yielded qubit values "
-                       "must be in the same order as the scf::ForOp's "
-                       "iteration qubit values!\n";
-                return false;
-              }
-
-              return true;
-            })
-            .Case<qco::IfOp>([&](qco::IfOp ifOp) {
-              const auto qubits = ifOp.getQubitsMutable();
-              const std::array regions{&ifOp.getThenRegion(),
-                                       &ifOp.getElseRegion()};
-
-              std::array mappings{DenseMap<Value, size_t>{},
-                                  DenseMap<Value, size_t>{}};
-
-              SmallVector<size_t> initialHardwareOrder;
-              initialHardwareOrder.reserve(qubits.size());
-
-              for (size_t i = 0; i < 2; ++i) {
-                for (const auto [qubit, arg] :
-                     llvm::zip_equal(qubits, regions[i]->getArguments())) {
-                  mappings[i].try_emplace(arg, /*hw = */ m.at(qubit.get()));
-                }
-              }
-
-              for (OpOperand& operand : qubits) {
-                const auto pred = operand.get();
-                const auto succ = ifOp.getTiedResult(&operand);
-                const auto hw = m.at(pred);
-
-                m.try_emplace(succ, hw);
-                initialHardwareOrder.emplace_back(hw);
-              }
-
-              for (const auto [body, mapping] :
-                   llvm::zip_equal(regions, mappings)) {
-                if (!isExecutable(*body, mapping, couplingSet)) {
-                  llvm::dbgs()
-                      << "One of the qco::IfOp's branches is not executable!\n";
-                  return false;
-                }
-
-                auto& block = body->getBlocks().front();
-                auto yield = cast<qco::YieldOp>(block.getTerminator());
-
-                const SmallVector<size_t> branchHardwareOrder(llvm::map_range(
-                    yield.getTargets(), [&](auto v) { return mapping.at(v); }));
-
-                if (branchHardwareOrder != initialHardwareOrder) {
-                  llvm::dbgs()
-                      << "The hardware indices of the yielded qubit values "
-                         "must be in the same order as the qco::IfOp's input "
-                         "qubit "
-                         "values! This ensures that qco::IfOp's act like a "
-                         "large, program-to-hardware mapping change, "
-                         "unitary.\n";
-                  return false;
-                }
-              }
-
-              return true;
-            })
-            .Case<ResetOp, MeasureOp>([&](auto op) {
-              m.try_emplace(op.getQubitOut(), /*hw= */ m.at(op.getQubitIn()));
-              return true;
-            })
-            .Default([](Operation*) { return true; });
-
-    if (!executable) {
-      return false;
+    for (OpResult res : op.getResults()) {
+      const Value init = TypeSwitch<Operation*, Value>(&op)
+                             .Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+                               return whileOp.getInits()[res.getResultNumber()];
+                             })
+                             .Case<scf::ForOp>([&](scf::ForOp forOp) {
+                               return forOp.getTiedLoopInit(res)->get();
+                             })
+                             .Case<qco::IfOp>([&](qco::IfOp ifOp) {
+                               return ifOp.getTiedQubit(res)->get();
+                             });
+      m.try_emplace(res, m.at(init));
     }
   }
 
@@ -275,8 +194,8 @@ static Device getNineQubitSquareGrid() {
                           {5, 8}, {8, 5}, {6, 7}, {7, 6}, {7, 8}, {8, 7}}};
 }
 
-/// Creates an N-qubit GHZ state, where N = `qubits.size()` using straight-line
-/// programming.
+/// Creates an N-qubit GHZ state, where N = `qubits.size()` using
+/// straight-line programming.
 static void flatGHZ(QCOProgramBuilder& builder, SmallVector<Value>& qubits) {
   qubits[0] = builder.h(qubits[0]);
   for (size_t i = 1; i < qubits.size(); ++i) {
@@ -637,7 +556,6 @@ TEST_P(MappingPassTest, MapParallelLoops) {
 
   for (int64_t i = 0; i < size; ++i) {
     std::tie(qubits[i], bits[i]) = builder.measure(qubits[i]);
-    qubits[i] = builder.h(qubits[i]);
   }
 
   for (int64_t i = 0; i < size; ++i) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -153,8 +153,7 @@ isExecutable(Region& body, DenseMap<Value, size_t>& m,
       if (finalOrder != initialHardwareOrder) {
         llvm::dbgs()
             << "The hardware indices of the yielded terminator qubit values "
-               "must "
-               "be in the same order as parent's op input qubit values!\n";
+               "must be in the same order as parent's op input qubit values!\n";
         return false;
       }
     }

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -733,7 +733,11 @@ TEST_P(MappingPassTest, MapDoUntil) {
         builder.scfCondition(beforeBits[size - 1], beforeArgs);
         return beforeArgs;
       },
-      [&](ValueRange args) { return args; });
+      [&](ValueRange args) {
+        SmallVector<Value> afterArgs(args);
+        flatGHZ(builder, afterArgs);
+        return afterArgs;
+      });
 
   flatGHZ(builder, qubits);
 

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/LogicalResult.h>

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -21,7 +21,6 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Debug.h>
-#include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/LogicalResult.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -37,7 +36,6 @@
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/Passes.h>
 
-#include <array>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
## Description

This pull request adds mapping support for the `scf::WhileOp`.

- ✨ Add `scf::WhileOp` to supported SCF ops in `Mapping.cpp`
- 🐛 Fix WireIterator for `scf::WhileOp`
- ♻️ Simplify `isExecutable` function in `test_mapping.cpp`
- ♻️ Simplify `dispatch` function in `Mapping.cpp` 

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
