### PR TITLE
💚 Fix Qiskit Upstream Tests Failure

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, macos-14, windows-2022]
+        runs-on: [ubuntu-24.04, macos-15, windows-2025]
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-qiskit-upstream-tests.yml@e7f84f39ce2d3b6c5d1d04526b8f94f98e455143 # v2.2.0
     with:
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -23,6 +23,8 @@ jobs:
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-z3: true
+      setup-mlir: true
+      llvm-version: "22.1.7"
 
   create-issue-on-failure:
     name: Create issue on failure


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

**TL;DR:** install MLIR in the Qiskit upstream tests workflow.

`upstream.yml` does not pass `setup-mlir: true` to the reusable workflow, so the `Set up MLIR` step is skipped. Since #1918, the wheel build needs MLIR (`BUILD_MQT_CORE_MLIR = "ON"` in `[tool.scikit-build.cmake.define]`, `mqt-core-mlir-bindings` in `build.targets`, MLIR install in `[tool.cibuildwheel.linux]`), so the CMake configure fails at `find_package(MLIR REQUIRED CONFIG)`. `ci.yml` was updated at the same time to pass `setup-mlir: true` and `llvm-version: 22.1.7` in every job; this brings `upstream.yml` in line.

`llvm-version` matters because the reusable workflow defaults to `21.1.8`, below `MQT_MLIR_MIN_VERSION = "22.1"` in `cmake/SetupMLIR.cmake`.

Fixes #1922

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.