### PR TITLE
Keep agent tool caches inside worktrees

### DIFF
--- a/.agent/clean-caches.sh
+++ b/.agent/clean-caches.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+# Clear only the mutable tool state belonging to this worktree.
+set -eu
+
+script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository_root=$(CDPATH= cd -- "${script_directory}/.." && pwd)
+cache_root="${repository_root}/.cache"
+uv_cache="${cache_root}/uv"
+uv_python="${cache_root}/uv-python"
+uv_tool_bin="${cache_root}/uv-bin"
+uv_tools="${cache_root}/uv-tools"
+ccache_cache="${cache_root}/ccache"
+sccache_cache="${cache_root}/sccache"
+sccache_socket="${cache_root}/sccache.sock"
+
+if [ -d "${uv_cache}" ]; then
+  if command -v uv >/dev/null 2>&1; then
+    UV_CACHE_DIR="${uv_cache}" uv cache clean
+  else
+    rm -rf -- "${uv_cache}"
+  fi
+fi
+
+rm -rf -- "${uv_python}" "${uv_tool_bin}" "${uv_tools}"
+
+if [ -d "${ccache_cache}" ]; then
+  if command -v ccache >/dev/null 2>&1; then
+    CCACHE_DIR="${ccache_cache}" ccache --clear
+  else
+    rm -rf -- "${ccache_cache}"
+  fi
+fi
+
+if [ -S "${sccache_socket}" ]; then
+  SCCACHE_DIR="${sccache_cache}" SCCACHE_SERVER_UDS="${sccache_socket}" \
+    sccache --stop-server
+fi
+
+rm -rf -- "${cache_root}"
+
+echo "Cleared worktree-local caches under ${cache_root}"

--- a/.agent/run.sh
+++ b/.agent/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+# Copyright (c) 2026 Chair for Design Automation, TUM
+# Copyright (c) 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+# Run a command with all mutable tool state kept inside this worktree.
+set -eu
+
+script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository_root=$(CDPATH= cd -- "${script_directory}/.." && pwd)
+cache_root="${repository_root}/.cache"
+
+export XDG_CACHE_HOME="${cache_root}/xdg"
+export PREK_HOME="${cache_root}/prek"
+export UV_CACHE_DIR="${cache_root}/uv"
+export UV_PYTHON_INSTALL_DIR="${cache_root}/uv-python"
+export UV_TOOL_BIN_DIR="${cache_root}/uv-bin"
+export UV_TOOL_DIR="${cache_root}/uv-tools"
+export CCACHE_DIR="${cache_root}/ccache"
+export CCACHE_MAXSIZE="4GiB"
+export CCACHE_TEMPDIR="${cache_root}/ccache/tmp"
+export SCCACHE_CACHE_SIZE="4G"
+export SCCACHE_DIR="${cache_root}/sccache"
+export SCCACHE_IDLE_TIMEOUT="60"
+
+case "$(uname -s)" in
+  Darwin | Linux)
+    export SCCACHE_SERVER_UDS="${cache_root}/sccache.sock"
+    ;;
+esac
+
+exec "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,9 @@ MQT Core. The project-wide policy for AI-assisted contributions is
 
 ### C++
 
-- Configure a release build with `cmake --preset release`.
-- Build it with `cmake --build --preset release`.
-- Run all configured C++ tests with `ctest --preset release`.
+- Configure a release build with `./.agent/run.sh cmake --preset release`.
+- Build it with `./.agent/run.sh cmake --build --preset release`.
+- Run all configured C++ tests with `./.agent/run.sh ctest --preset release`.
 - Run a component binary directly when iterating, for example
   `./build/release/test/ir/mqt-core-ir-test` or
   `./build/release/test/qdmi/driver/mqt-core-qdmi-driver-test`.
@@ -67,36 +67,65 @@ types such as `llvm::SmallVector` and `llvm::function_ref` where appropriate.
 ### Python and Bindings
 
 - Install build and test dependencies with
-  `uv sync --inexact --only-group build --only-group test`.
+  `./.agent/run.sh uv sync --inexact --only-group build --only-group test`.
 - Install the package for fast local rebuilds with
-  `uv sync --inexact --no-dev --no-build-isolation-package mqt-core`.
-- Run the Python tests with `uv run --no-sync pytest`; pass a file or `-k`
-  expression while iterating.
-- Run the supported test sessions with `uvx nox -s tests` and
-  `uvx nox -s minimums`. Python 3.14 variants are `tests-3.14` and
-  `minimums-3.14`.
+  `./.agent/run.sh uv sync --inexact --no-dev --no-build-isolation-package mqt-core`.
+- Run the Python tests with `./.agent/run.sh uv run --no-sync pytest`; pass a
+  file or `-k` expression while iterating.
+- Run the supported test sessions with `./.agent/run.sh uvx nox -s tests` and
+  `./.agent/run.sh uvx nox -s minimums`. Python 3.14 variants are `tests-3.14`
+  and `minimums-3.14`.
 - If a file in `bindings/` is added or changed, regenerate type stubs with
-  `uvx nox -s stubs`. Never edit generated `.pyi` files in `python/mqt/core/`
-  manually.
+  `./.agent/run.sh uvx nox -s stubs`. Never edit generated `.pyi` files in
+  `python/mqt/core/` manually.
 
 Use Google-style Python docstrings. Prefer fixing diagnostics from `ruff` and
 `ty` over suppressing them; document suppressions that are genuinely required.
 
+### Worktree-Local Tool Caches
+
+- Run cache-producing commands through `.agent/run.sh`. It derives the
+  repository root from its own location, so it works from any directory in the
+  worktree and exports worktree-local cache paths before executing the requested
+  command. In addition to the download cache, this localizes `uv` tool
+  environments, tool binaries, and managed Python installations. It also
+  supplies a local XDG cache root and `PREK_HOME` so other cache-aware
+  development tools stay within the worktree.
+- The wrapper configures `uv` and `uvx` to use `.cache/uv`. The CMake presets
+  configure `ccache` and `sccache` to use `.cache/ccache` and `.cache/sccache`,
+  respectively. These paths are ignored by Git. Outside agent-driven work,
+  contributors remain free to use their preferred cache configuration.
+- Do not redirect these tools to a user-level or shared cache outside the
+  worktree. In particular, do not work around sandbox failures by requesting
+  access to a cache under a home directory.
+- Use the CMake presets for configuration, builds, and tests so the compiler
+  cache environment is applied consistently. The compiler caches are capped at 4
+  GiB per worktree and clean up automatically as they reach that limit.
+- If invoking `ccache` or `sccache` outside a CMake preset, set `CCACHE_DIR` or
+  `SCCACHE_DIR` to the corresponding repository-local path first.
+- After a significant batch of work, and only once no `uv`, build, or compiler
+  cache process is running, run `./.agent/clean-caches.sh`. This clears only the
+  current worktree's local caches. Do not remove cache contents manually while
+  another process may be using them.
+
 ### MLIR and Documentation
 
 - Build the MLIR documentation with
-  `cmake --build --preset release --target mlir-doc`.
+  `./.agent/run.sh cmake --build --preset release --target mlir-doc`.
 - A real focused MLIR test binary is
   `./build/release/mlir/unittests/Compiler/mqt-core-mlir-unittests-compiler`.
-- Build the complete documentation with `uvx nox --non-interactive -s docs`.
-- Check documentation links with `uvx nox -s docs -- -b linkcheck`.
+- Build the complete documentation with
+  `./.agent/run.sh uvx nox --non-interactive -s docs`.
+- Check documentation links with
+  `./.agent/run.sh uvx nox -s docs -- -b linkcheck`.
 
 ## Generated Files and Validation
 
 - Do not hand-edit generated stubs, rendered documentation, CMake-generated
   files, or template-managed files.
-- Run `uvx nox -s lint` after each completed batch of changes. It runs the full
-  `prek` hook set, including formatting, spelling, type, and metadata checks.
+- Run `./.agent/run.sh uvx nox -s lint` after each completed batch of changes.
+  It runs the full `prek` hook set, including formatting, spelling, type, and
+  metadata checks.
 - Inspect the final diff and working-tree status. Report every check run and
   clearly distinguish passes, failures, and checks that could not be run.
 
@@ -131,7 +160,7 @@ task's decisions and progress.
 
 - The diff is focused and follows neighboring code conventions.
 - Behavioral changes have automated test coverage, and targeted tests pass.
-- `uvx nox -s lint` passes.
+- `./.agent/run.sh uvx nox -s lint` passes.
 - Binding changes have regenerated stubs.
 - User-facing changes update `CHANGELOG.md` and `UPGRADING.md` when appropriate.
 - Generated, template-managed, secret, and unrelated files are absent from the

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,6 +7,13 @@
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
         "MLIR_DIR": "$env{MLIR_DIR}"
+      },
+      "environment": {
+        "CCACHE_DIR": "${sourceDir}/.cache/ccache",
+        "CCACHE_MAXSIZE": "4GiB",
+        "CCACHE_TEMPDIR": "${sourceDir}/.cache/ccache/tmp",
+        "SCCACHE_CACHE_SIZE": "4G",
+        "SCCACHE_DIR": "${sourceDir}/.cache/sccache"
       }
     },
     {
@@ -19,7 +26,10 @@
         "list": ["Linux", "Darwin"]
       },
       "description": "Default configuration for Linux and macOS builds. Uses the Ninja generator",
-      "generator": "Ninja"
+      "generator": "Ninja",
+      "environment": {
+        "SCCACHE_SERVER_UDS": "${sourceDir}/.cache/sccache.sock"
+      }
     },
     {
       "name": "base-windows",


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Keep cache-producing agent workflows self-contained in each MQT Core worktree.
This avoids sandbox failures when `uv`, `uvx`, `ccache`, or `sccache` attempt to
access cache directories outside the active workspace, while leaving ordinary
contributors free to configure their own caches.

This pull request:

- adds `.agent/run.sh` to run agent commands with worktree-local `uv`, tool,
  XDG, `prek`, `ccache`, and `sccache` state;
- adds `.agent/clean-caches.sh` for explicit cleanup after a significant batch
  of work;
- configures the CMake presets to use worktree-local compiler caches capped at
  4 GiB each;
- updates `AGENTS.md` to require the wrapper for cache-producing agent commands
  and document cleanup expectations;
- deliberately does not set `tool.uv.cache-dir` in `pyproject.toml`, so
  non-agent workflows retain their preferred cache configuration.

The cleanup helper targets only the worktree-local `.cache` directory and leaves
build trees and other worktree state intact.

## Validation

- `./.agent/run.sh prek run --files AGENTS.md CMakePresets.json .agent/run.sh
  .agent/clean-caches.sh pyproject.toml`
- `./.agent/run.sh uvx nox -s lint`
- shell syntax checks for both helper scripts
- CMake preset discovery
- local `uv` and `ccache` configuration checks
- focused CMake configure and build using the localized compiler cache
- cleanup verification confirming that build output remains intact
- `git diff --check origin/main...HEAD`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to
  this change.
- [x] I have added appropriate tests that cover the new/changed functionality,
  or documented why automated tests are not needed.
- [x] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new
  warnings.
- [x] The changes are fully tested and pass the relevant checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly
  authorized for that scope, as required by our AI Usage Guidelines.
- [x] Every agent-authored or agent-edited public text body begins with the
  visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an
  `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated
  content, and accept full responsibility for it.
