### PR TITLE
🔧 Scope the Rust build output ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,7 @@ docs/api/
 
 # PyBuilder
 .pybuilder/
-target/
+/target/
 
 # Jupyter Notebook
 .ipynb_checkpoints


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Anchor the Rust `target/` ignore rule at the repository root.
- Keep nested directories named `target` visible to Git.

## Context

This independent cleanup was found while working on the OpenQASM integration in #1910. It is unrelated to the OpenQASM frontend itself and has therefore been extracted into this focused PR.

The existing unanchored rule ignored any directory named `target`, including source or test fixture directories nested below the repository root. Cargo's repository-level build output remains ignored by `/target/`.

## Validation

- `uvx prek run --from-ref origin/main --to-ref HEAD`
- `git diff --check origin/main...HEAD`

No changelog entry is included because this only narrows a development-only ignore rule.