### PR TITLE
🐛 Lower control-flow assertions to QIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -728,6 +728,7 @@ changelogs._
 [#1662]: https://github.com/munich-quantum-toolkit/core/pull/1662
 [#1660]: https://github.com/munich-quantum-toolkit/core/pull/1660
 [#1652]: https://github.com/munich-quantum-toolkit/core/pull/1652
+[#1648]: https://github.com/munich-quantum-toolkit/core/pull/1648
 [#1638]: https://github.com/munich-quantum-toolkit/core/pull/1638
 [#1637]: https://github.com/munich-quantum-toolkit/core/pull/1637
 [#1635]: https://github.com/munich-quantum-toolkit/core/pull/1635

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add and improve QIR generation support in the MQT Compiler Collection
+  ([#1264], [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570],
+  [#1572], [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751],
+  [#1755], [#1787], [#1815], [#1823], [#1830], [#1886], [#1933])
+  ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
+  [**@li-mingbao**], [**@DRovara**], [**@MatthiasReumann**])
 - ✨ Add decision diagram-based construction and simulation of static unitary
   QCO functions ([#1915]) ([**@simon1hofmann**])
 - ✨ Add native relative-phase CCX (`rccx`) support across the IR, DD package,
@@ -63,13 +69,12 @@ releases may include breaking changes.
   [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510],
   [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569],
   [#1570], [#1572], [#1573], [#1580], [#1602], [#1603], [#1620], [#1623],
-  [#1624], [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700],
-  [#1710], [#1717], [#1728], [#1730], [#1749], [#1751], [#1762], [#1765],
-  [#1780], [#1781], [#1782], [#1787], [#1806], [#1807], [#1815], [#1808],
-  [#1823], [#1824], [#1830], [#1869], [#1872], [#1886], [#1914], [#1925])
-  ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**],
-  [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
-  [**@simon1hofmann**], [**@J4MMlE**])
+  [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717],
+  [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
+  [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
+  [#1886], [#1914], [#1925]) ([**@burgholzer**], [**@denialhaag**],
+  [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
+  [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 
 ### Changed
 
@@ -646,6 +651,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1933]: https://github.com/munich-quantum-toolkit/core/pull/1933
 [#1925]: https://github.com/munich-quantum-toolkit/core/pull/1925
 [#1924]: https://github.com/munich-quantum-toolkit/core/pull/1924
 [#1915]: https://github.com/munich-quantum-toolkit/core/pull/1915

--- a/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
@@ -685,6 +685,7 @@ protected:
 
       cf::populateControlFlowToLLVMConversionPatterns(typeConverter,
                                                       stdPatterns);
+      cf::populateAssertToLLVMConversionPattern(typeConverter, stdPatterns);
       arith::populateArithToLLVMConversionPatterns(typeConverter, stdPatterns);
 
       if (applyPartialConversion(moduleOp, target, std::move(stdPatterns))

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -467,6 +467,7 @@ protected:
 
       cf::populateControlFlowToLLVMConversionPatterns(typeConverter,
                                                       stdPatterns);
+      cf::populateAssertToLLVMConversionPattern(typeConverter, stdPatterns);
       arith::populateArithToLLVMConversionPatterns(typeConverter, stdPatterns);
 
       if (applyPartialConversion(moduleOp, target, std::move(stdPatterns))

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
+#include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -81,6 +82,37 @@ static LogicalResult runQCToQIRAdaptiveConversion(ModuleOp module) {
   PassManager pm(module.getContext());
   pm.addPass(createQCToQIRAdaptive());
   return pm.run(module);
+}
+
+TEST(QCToQIRAdaptiveNativeTest, LowersControlFlowAssertions) {
+  MLIRContext context;
+  context
+      .loadDialect<qc::QCDialect, arith::ArithDialect, cf::ControlFlowDialect,
+                   func::FuncDialect, LLVM::LLVMDialect>();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  auto condition = LLVM::UndefOp::create(builder, builder.getI1Type());
+  cf::AssertOp::create(builder, condition, "runtime precondition");
+  auto module = builder.finalize();
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQIRAdaptiveConversion(*module)));
+  EXPECT_TRUE(succeeded(verify(*module)));
+
+  EXPECT_TRUE(module->lookupSymbol<LLVM::LLVMFuncOp>("abort"));
+  EXPECT_TRUE(module->lookupSymbol<LLVM::LLVMFuncOp>("puts"));
+  EXPECT_TRUE(module->lookupSymbol<LLVM::GlobalOp>("assert_msg"));
+  bool retainsAssertion = false;
+  bool hasConditionalBranch = false;
+  bool hasUnreachableFailure = false;
+  module->walk([&](Operation* operation) {
+    retainsAssertion |= isa<cf::AssertOp>(operation);
+    hasConditionalBranch |= isa<LLVM::CondBrOp>(operation);
+    hasUnreachableFailure |= isa<LLVM::UnreachableOp>(operation);
+  });
+  EXPECT_FALSE(retainsAssertion);
+  EXPECT_TRUE(hasConditionalBranch);
+  EXPECT_TRUE(hasUnreachableFailure);
 }
 
 TEST_P(QCToQIRAdaptiveTest, ProgramEquivalence) {

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
+#include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -79,6 +80,37 @@ static LogicalResult runQCToQIRBaseConversion(ModuleOp module) {
   PassManager pm(module.getContext());
   pm.addPass(createQCToQIRBase());
   return pm.run(module);
+}
+
+TEST(QCToQIRBaseNativeTest, LowersControlFlowAssertions) {
+  MLIRContext context;
+  context
+      .loadDialect<qc::QCDialect, arith::ArithDialect, cf::ControlFlowDialect,
+                   func::FuncDialect, LLVM::LLVMDialect>();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  auto condition = LLVM::UndefOp::create(builder, builder.getI1Type());
+  cf::AssertOp::create(builder, condition, "runtime precondition");
+  auto module = builder.finalize();
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQIRBaseConversion(*module)));
+  EXPECT_TRUE(succeeded(verify(*module)));
+
+  EXPECT_TRUE(module->lookupSymbol<LLVM::LLVMFuncOp>("abort"));
+  EXPECT_TRUE(module->lookupSymbol<LLVM::LLVMFuncOp>("puts"));
+  EXPECT_TRUE(module->lookupSymbol<LLVM::GlobalOp>("assert_msg"));
+  bool retainsAssertion = false;
+  bool hasConditionalBranch = false;
+  bool hasUnreachableFailure = false;
+  module->walk([&](Operation* operation) {
+    retainsAssertion |= isa<cf::AssertOp>(operation);
+    hasConditionalBranch |= isa<LLVM::CondBrOp>(operation);
+    hasUnreachableFailure |= isa<LLVM::UnreachableOp>(operation);
+  });
+  EXPECT_FALSE(retainsAssertion);
+  EXPECT_TRUE(hasConditionalBranch);
+  EXPECT_TRUE(hasUnreachableFailure);
 }
 
 TEST_P(QCToQIRBaseTest, ProgramEquivalence) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Register MLIR's canonical `cf.assert`-to-LLVM conversion in both QIR profiles.
- Cover Base and Adaptive QIR lowering with native assertion regression tests.
- Split compiler QIR work into a dedicated changelog entry and remove QIR-only
  PRs from the generic QC/QCO infrastructure entry.

## Context

This general QIR gap was found while working on the OpenQASM integration in
#1910. OpenQASM runtime preconditions can be represented as `cf.assert`; the
standard QC → QCO → QC → QIR pipeline should lower those assertions instead of
rejecting otherwise valid IR. The fix uses MLIR's existing conversion rather
than introducing OpenQASM-specific handling.

The changelog entry collects the compiler QIR work that was previously mixed
into the generic infrastructure entry. PRs that also affected QC, QCO, Jeff, or
broader compiler infrastructure remain listed in both relevant entries;
QIR-only PRs are moved to the QIR entry.

## Validation

- QIR Base conversion tests: 111 passed
- QIR Adaptive conversion tests: 129 passed
- `uvx prek run --from-ref origin/main --to-ref HEAD`
- `git diff --check origin/main...HEAD`
