### PR TITLE
🐛 Preserve `jeff` entry-point results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ releases may include breaking changes.
   rotation gates using quaternions ([#1407], [#1674]) ([**@J4MMlE**],
   [**@denialhaag**], [**@MatthiasReumann**])
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637],
-  [#1676], [#1706], [#1776], [#1836]) ([**@denialhaag**], [**@burgholzer**])
+  [#1676], [#1706], [#1776], [#1836], [#1934]) ([**@denialhaag**],
+  [**@burgholzer**])
 - ✨ Add a `place-and-route` pass for mapping circuits to architectures with
   restricted topologies ([#1537], [#1547], [#1568], [#1581], [#1583], [#1588],
   [#1600], [#1664], [#1709], [#1716], [#1748], [#1805], [#1870], [#1904],
@@ -651,6 +652,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1934]: https://github.com/munich-quantum-toolkit/core/pull/1934
 [#1933]: https://github.com/munich-quantum-toolkit/core/pull/1933
 [#1925]: https://github.com/munich-quantum-toolkit/core/pull/1925
 [#1924]: https://github.com/munich-quantum-toolkit/core/pull/1924

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -1142,23 +1142,27 @@ struct ConvertJeffMainToQCO final : OpConversionPattern<func::FuncOp> {
       return failure();
     }
 
-    // Update function signature and add passthrough attribute
+    // Restore the compiler entry-point marker. Jeff functions may retain
+    // observable classical results, so only synthesize the legacy i64 status
+    // result for a result-less entry point.
     rewriter.startOpModification(op);
     auto* ctx = rewriter.getContext();
-    op.setType(FunctionType::get(ctx, {}, {rewriter.getI64Type()}));
     auto entryPointAttr = StringAttr::get(ctx, "entry_point");
     op->setAttr("passthrough", ArrayAttr::get(ctx, {entryPointAttr}));
+    const bool needsStatusResult = op.getFunctionType().getResults().empty();
+    if (needsStatusResult) {
+      op.setType(FunctionType::get(ctx, {}, {rewriter.getI64Type()}));
+    }
     rewriter.finalizeOpModification(op);
 
-    // Replace return operation
-    rewriter.setInsertionPointToStart(block);
-    auto constOp = arith::ConstantOp::create(rewriter, op.getLoc(),
-                                             rewriter.getI64IntegerAttr(0));
-
-    rewriter.setInsertionPointToEnd(block);
-    func::ReturnOp::create(rewriter, op.getLoc(), constOp.getResult());
-
-    rewriter.eraseOp(returnOp);
+    if (needsStatusResult) {
+      rewriter.setInsertionPointToStart(block);
+      auto constOp = arith::ConstantOp::create(rewriter, op.getLoc(),
+                                               rewriter.getI64IntegerAttr(0));
+      rewriter.setInsertionPointToEnd(block);
+      func::ReturnOp::create(rewriter, op.getLoc(), constOp.getResult());
+      rewriter.eraseOp(returnOp);
+    }
 
     return success();
   }
@@ -1209,8 +1213,8 @@ protected:
                            tensor::TensorDialect, scf::SCFDialect>();
 
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
-      return !(op.getSymName() == getEntryPointName(module) &&
-               op.getFunctionType().getResults().empty());
+      return op.getSymName() != getEntryPointName(module) ||
+             op->hasAttr("passthrough");
     });
     target.addLegalOp<func::ReturnOp>();
 

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -1137,31 +1137,27 @@ struct ConvertJeffMainToQCO final : OpConversionPattern<func::FuncOp> {
     }
     auto* block = &op.getBlocks().front();
 
-    auto* returnOp = block->getTerminator();
-    if (!isa<func::ReturnOp>(returnOp)) {
+    auto returnOp = dyn_cast<func::ReturnOp>(block->getTerminator());
+    if (!returnOp) {
       return failure();
     }
 
     // Restore the compiler entry-point marker. Jeff functions may retain
     // observable classical results, so only synthesize the legacy i64 status
     // result for a result-less entry point.
-    rewriter.startOpModification(op);
-    auto* ctx = rewriter.getContext();
-    auto entryPointAttr = StringAttr::get(ctx, "entry_point");
-    op->setAttr("passthrough", ArrayAttr::get(ctx, {entryPointAttr}));
     const bool needsStatusResult = op.getFunctionType().getResults().empty();
-    if (needsStatusResult) {
-      op.setType(FunctionType::get(ctx, {}, {rewriter.getI64Type()}));
-    }
-    rewriter.finalizeOpModification(op);
+    rewriter.modifyOpInPlace(op, [&] {
+      op->setAttr("passthrough", rewriter.getArrayAttr(
+                                     {rewriter.getStringAttr("entry_point")}));
+      if (needsStatusResult) {
+        op.setType(rewriter.getFunctionType({}, {rewriter.getI64Type()}));
+      }
+    });
 
     if (needsStatusResult) {
       rewriter.setInsertionPointToStart(block);
-      auto constOp = arith::ConstantOp::create(rewriter, op.getLoc(),
-                                               rewriter.getI64IntegerAttr(0));
-      rewriter.setInsertionPointToEnd(block);
-      func::ReturnOp::create(rewriter, op.getLoc(), constOp.getResult());
-      rewriter.eraseOp(returnOp);
+      auto zero = arith::ConstantIntOp::create(rewriter, op.getLoc(), 0, 64);
+      rewriter.replaceOpWithNewOp<func::ReturnOp>(returnOp, zero.getResult());
     }
 
     return success();

--- a/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
+++ b/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
@@ -157,6 +157,27 @@ static LogicalResult convertJeffToQCO(ModuleOp module) {
   return pm.run(module);
 }
 
+TEST(JeffRoundTripRegressionTest, RestoresEntryPointWithObservableResults) {
+  DialectRegistry registry;
+  registry.insert<arith::ArithDialect, func::FuncDialect, jeff::JeffDialect,
+                  qco::QCODialect, scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  auto program = mqt::test::buildMLIRProgram(
+      &context, MQT_NAMED_BUILDER(qco::singleMeasurementToSingleBit));
+  ASSERT_TRUE(program);
+  ASSERT_TRUE(succeeded(convertQCOToJeff(*program)));
+  ASSERT_TRUE(succeeded(convertJeffToQCO(*program)));
+  auto main = program->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto passthrough = main->getAttrOfType<ArrayAttr>("passthrough");
+  ASSERT_TRUE(passthrough);
+  EXPECT_TRUE(llvm::is_contained(passthrough,
+                                 StringAttr::get(&context, "entry_point")));
+  ASSERT_EQ(main.getFunctionType().getNumResults(), 1);
+  EXPECT_TRUE(main.getFunctionType().getResult(0).isInteger(1));
+}
+
 TEST_P(JeffRoundTripTest, ProgramEquivalence) {
   const auto& [nameStr, programBuilder, referenceBuilder] = GetParam();
   const auto name = " (" + nameStr + ")";

--- a/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
+++ b/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
@@ -24,6 +24,7 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/OwningOpRef.h>
@@ -170,12 +171,14 @@ TEST(JeffRoundTripRegressionTest, RestoresEntryPointWithObservableResults) {
   ASSERT_TRUE(succeeded(convertJeffToQCO(*program)));
   auto main = program->lookupSymbol<func::FuncOp>("main");
   ASSERT_TRUE(main);
-  auto passthrough = main->getAttrOfType<ArrayAttr>("passthrough");
-  ASSERT_TRUE(passthrough);
-  EXPECT_TRUE(llvm::is_contained(passthrough,
-                                 StringAttr::get(&context, "entry_point")));
+  EXPECT_EQ(
+      main->getAttrOfType<ArrayAttr>("passthrough"),
+      ArrayAttr::get(&context, {StringAttr::get(&context, "entry_point")}));
   ASSERT_EQ(main.getFunctionType().getNumResults(), 1);
   EXPECT_TRUE(main.getFunctionType().getResult(0).isInteger(1));
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  ASSERT_EQ(returnOp.getNumOperands(), 1);
+  EXPECT_TRUE(returnOp.getOperand(0).getType().isInteger(1));
 }
 
 TEST_P(JeffRoundTripTest, ProgramEquivalence) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Preserve observable classical result types and returns when converting a Jeff
  entry point back to QCO.
- Synthesize the legacy `i64` status result only for result-less entry points.
- Add a measurement-result round-trip regression test.
- Add this fix to the existing Jeff conversion changelog entry.

## Context

This independent Jeff conversion issue was found while exercising programs from
the OpenQASM integration in #1910. Jeff compatibility is not a prerequisite for
accepting an OpenQASM program, but when a supported program is converted through
Jeff, the conversion must not silently replace its observable result.

## Validation

- Jeff round-trip conversion tests: 116 passed
- `uvx prek run --from-ref origin/main --to-ref HEAD`
- `git diff --check origin/main...HEAD`
