### PR TITLE
🐛 Preserve structured state in QC-to-QCO conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ releases may include breaking changes.
   [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717],
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
-  [#1886], [#1914], [#1925]) ([**@burgholzer**], [**@denialhaag**],
+  [#1886], [#1914], [#1925], [#1935]) ([**@burgholzer**], [**@denialhaag**],
   [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
   [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 
@@ -651,6 +651,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1935]: https://github.com/munich-quantum-toolkit/core/pull/1935
 [#1933]: https://github.com/munich-quantum-toolkit/core/pull/1933
 [#1925]: https://github.com/munich-quantum-toolkit/core/pull/1925
 [#1924]: https://github.com/munich-quantum-toolkit/core/pull/1924

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,9 @@ releases may include breaking changes.
   [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717],
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
-  [#1886], [#1914], [#1925], [#1935], [#1936]) ([**@burgholzer**], [**@denialhaag**],
-  [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
-  [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
+  [#1886], [#1914], [#1925], [#1935], [#1936]) ([**@burgholzer**],
+  [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**],
+  [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 
 ### Changed
 

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -20,7 +20,6 @@
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/TypeSwitch.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
@@ -526,13 +525,12 @@ static void extractQubitsAfterOp(LoweringState& state, Operation* target,
  * stack on every iteration. Each syntactic conditional gets distinct storage,
  * and structured control flow executes it sequentially.
  */
-[[nodiscard]] static FailureOr<SmallVector<Value>>
+[[nodiscard]] static SmallVector<Value>
 createHoistedScratchStorage(Operation* operation, TypeRange elementTypes,
                             ConversionPatternRewriter& rewriter) {
   auto function = operation->getParentOfType<func::FuncOp>();
-  if (!function || function.getBody().empty()) {
-    return failure();
-  }
+  assert(function && !function.getBody().empty() &&
+         "structured QC control flow must be nested in a function");
 
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToStart(&function.getBody().front());
@@ -1544,12 +1542,8 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
     // the IfOp
     insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
-    auto scratch =
+    const auto scratch =
         createHoistedScratchStorage(operation, op.getResultTypes(), rewriter);
-    if (failed(scratch)) {
-      return rewriter.notifyMatchFailure(
-          op, "result-bearing scf.if requires an automatic allocation scope");
-    }
 
     // Create the new IfOp
     auto newIfOp =
@@ -1581,10 +1575,10 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
     const auto spillResults = [&](Block* block) {
       auto yield = cast<scf::YieldOp>(block->getTerminator());
       rewriter.setInsertionPoint(yield);
-      if (!scratch->empty()) {
+      if (!scratch.empty()) {
         auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
         for (auto [value, storage] :
-             llvm::zip_equal(yield.getResults(), *scratch)) {
+             llvm::zip_equal(yield.getResults(), scratch)) {
           memref::StoreOp::create(rewriter, op.getLoc(), value, storage,
                                   ValueRange{index});
         }
@@ -1617,10 +1611,10 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
 
     rewriter.setInsertionPointAfter(newIfOp);
     SmallVector<Value> classicalResults;
-    classicalResults.reserve(scratch->size());
-    if (!scratch->empty()) {
+    classicalResults.reserve(scratch.size());
+    if (!scratch.empty()) {
       auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
-      for (auto storage : *scratch) {
+      for (auto storage : scratch) {
         classicalResults.push_back(memref::LoadOp::create(
             rewriter, op.getLoc(), storage, ValueRange{index}));
       }
@@ -1674,13 +1668,8 @@ struct ConvertSCFIndexSwitchOp final
     const auto targets = resolveAllValues(state, operation);
     const auto results = ValueRange(targets).getTypes();
     const SmallVector locs(targets.size(), op.getLoc());
-    auto scratch =
+    const auto scratch =
         createHoistedScratchStorage(operation, op.getResultTypes(), rewriter);
-    if (failed(scratch)) {
-      return rewriter.notifyMatchFailure(
-          op, "result-bearing scf.index_switch requires an automatic "
-              "allocation scope");
-    }
 
     auto newOp =
         IndexSwitchOp::create(rewriter, op.getLoc(), results, op.getArg(),
@@ -1709,10 +1698,10 @@ struct ConvertSCFIndexSwitchOp final
 
       auto yield = cast<scf::YieldOp>(newBlock->getTerminator());
       rewriter.setInsertionPoint(yield);
-      if (!scratch->empty()) {
+      if (!scratch.empty()) {
         auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
         for (auto [value, storage] :
-             llvm::zip_equal(yield.getResults(), *scratch)) {
+             llvm::zip_equal(yield.getResults(), scratch)) {
           memref::StoreOp::create(rewriter, op.getLoc(), value, storage,
                                   ValueRange{index});
         }
@@ -1732,10 +1721,10 @@ struct ConvertSCFIndexSwitchOp final
 
     rewriter.setInsertionPointAfter(newOp);
     SmallVector<Value> classicalResults;
-    classicalResults.reserve(scratch->size());
-    if (!scratch->empty()) {
+    classicalResults.reserve(scratch.size());
+    if (!scratch.empty()) {
       auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
-      for (auto storage : *scratch) {
+      for (auto storage : scratch) {
         classicalResults.push_back(memref::LoadOp::create(
             rewriter, op.getLoc(), storage, ValueRange{index}));
       }

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -116,6 +116,11 @@ struct LoweringState {
     DenseMap<Value, Value> currentRegisters;
   };
 
+  struct StructuredValues {
+    SmallVector<Value> qubits;
+    SmallVector<Value> memrefs;
+  };
+
   /// Per-region map from original QC qubit reference to its latest QCO SSA
   /// value.
   ///
@@ -138,6 +143,11 @@ struct LoweringState {
 
   /// Map from an operation to its used QC memrefs inside its regions
   DenseMap<Operation*, SetVector<Value>> regionRegisterMap;
+
+  /// Original QC value order for already-converted structured operations.
+  /// Kept separate from the legality maps above so converted SCF operations
+  /// remain legal.
+  DenseMap<Operation*, StructuredValues> structuredValues;
 
   /// Stack of active modifier regions
   SmallVector<ModifierFrame> modifierFrames;
@@ -367,29 +377,34 @@ static void pushModifierFrame(LoweringState& state, ValueRange qcTargets,
   }
 }
 
-/** @brief Pushes a new modifier frame seeded with aliased target values with
- * registers */
-static void pushModifierFrameWithRegisters(LoweringState& state,
-                                           ValueRange qcTargets,
-                                           ValueRange memrefs,
-                                           ValueRange qcoTargets,
-                                           ValueRange tensors) {
-  auto& [yieldOrder, registers, currentQubits, currentRegisters] =
-      state.modifierFrames.emplace_back();
-  llvm::append_range(yieldOrder, qcTargets);
-  for (auto [qcTarget, qcoTarget] : llvm::zip_equal(qcTargets, qcoTargets)) {
-    currentQubits.try_emplace(qcTarget, qcoTarget);
-  }
-  llvm::append_range(registers, memrefs);
-  for (auto [memref, tensor] : llvm::zip_equal(memrefs, tensors)) {
-    currentRegisters.try_emplace(memref, tensor);
-  }
-}
-
 /** @brief Pops the active modifier frame after lowering its yield. */
 static void popModifierFrame(LoweringState& state) {
   assert(isInsideModifier(state) && "expected active modifier frame");
   state.modifierFrames.pop_back();
+}
+
+/** @brief Returns the structured parent whose quantum values a terminator
+ * yields. */
+[[nodiscard]] static Operation* structuredValueOwner(Operation* operation) {
+  if (isa<scf::YieldOp, scf::ConditionOp>(operation)) {
+    return operation->getParentOp();
+  }
+  return operation;
+}
+
+/** @brief Seeds region-local QCO mappings for structured-control-flow block
+ * arguments. */
+static void seedRegionMappings(LoweringState& state, Region& region,
+                               ValueRange qcQubits, ValueRange memrefs,
+                               ValueRange qcoQubits, ValueRange tensors) {
+  auto& qubitMap = state.qubitMap[&region];
+  for (auto [qcQubit, qcoQubit] : llvm::zip_equal(qcQubits, qcoQubits)) {
+    qubitMap[qcQubit] = qcoQubit;
+  }
+  auto& tensorMap = state.tensorMap[&region];
+  for (auto [memref, tensor] : llvm::zip_equal(memrefs, tensors)) {
+    tensorMap[memref] = tensor;
+  }
 }
 
 /**
@@ -405,7 +420,13 @@ static void insertQubitsBeforeOp(LoweringState& state, Operation* target,
     memrefs = currentModifierFrame(state).memrefs;
     anchor = target->getParentOp();
   } else {
-    llvm::append_range(memrefs, state.regionRegisterMap[target]);
+    auto* owner = structuredValueOwner(target);
+    if (const auto it = state.structuredValues.find(owner);
+        it != state.structuredValues.end()) {
+      llvm::append_range(memrefs, it->second.memrefs);
+    } else {
+      llvm::append_range(memrefs, state.regionRegisterMap[owner]);
+    }
     anchor = target;
   }
 
@@ -478,8 +499,15 @@ static void extractQubitsAfterOp(LoweringState& state, Operation* target,
     memrefs = frame.memrefs;
     qcQubits = frame.qcQubits;
   } else {
-    llvm::append_range(memrefs, state.regionRegisterMap[anchor]);
-    llvm::append_range(qcQubits, state.regionQubitMap[anchor]);
+    auto* owner = structuredValueOwner(anchor);
+    if (const auto it = state.structuredValues.find(owner);
+        it != state.structuredValues.end()) {
+      llvm::append_range(memrefs, it->second.memrefs);
+      llvm::append_range(qcQubits, it->second.qubits);
+    } else {
+      llvm::append_range(memrefs, state.regionRegisterMap[owner]);
+      llvm::append_range(qcQubits, state.regionQubitMap[owner]);
+    }
   }
 
   SmallVector<Value> qcoTargets;
@@ -487,6 +515,34 @@ static void extractQubitsAfterOp(LoweringState& state, Operation* target,
   llvm::append_range(qcoTargets, resolveMappedTensors(state, anchor, memrefs));
   llvm::append_range(qcoTargets, resolveMappedQubits(state, anchor, qcQubits));
   return qcoTargets;
+}
+
+/**
+ * @brief Creates scalar scratch storage that is allocated once in the enclosing
+ * function.
+ *
+ * Hoisting the allocation outside enclosing loops lets result-bearing
+ * `scf.if` operations communicate classical branch results without growing the
+ * stack on every iteration. Each syntactic conditional gets distinct storage,
+ * and structured control flow executes it sequentially.
+ */
+[[nodiscard]] static FailureOr<SmallVector<Value>>
+createHoistedScratchStorage(Operation* operation, TypeRange elementTypes,
+                            ConversionPatternRewriter& rewriter) {
+  auto function = operation->getParentOfType<func::FuncOp>();
+  if (!function || function.getBody().empty()) {
+    return failure();
+  }
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(&function.getBody().front());
+  SmallVector<Value> storage;
+  storage.reserve(elementTypes.size());
+  for (auto type : elementTypes) {
+    storage.push_back(memref::AllocaOp::create(rewriter, operation->getLoc(),
+                                               MemRefType::get({1}, type)));
+  }
+  return storage;
 }
 
 /**
@@ -1288,38 +1344,47 @@ struct ConvertSCFForOp final : StatefulOpConversionPattern<scf::ForOp> {
     // the ForOp
     insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
+    const auto numOriginalResults = op.getNumResults();
+    SmallVector<Value> initArgs(op.getInitArgs());
+    llvm::append_range(initArgs, qcoTargets);
 
     // Create the new ForOp
     auto newForOp =
         scf::ForOp::create(rewriter, op.getLoc(), op.getLowerBound(),
-                           op.getUpperBound(), op.getStep(), qcoTargets);
+                           op.getUpperBound(), op.getStep(), initArgs);
 
     assignMappedTensors(state, op.getOperation(), registerMap,
-                        newForOp.getResults().take_front(numRegisters));
+                        newForOp.getResults()
+                            .drop_front(numOriginalResults)
+                            .take_front(numRegisters));
     assignMappedQubits(state, op.getOperation(), qubitMap,
                        newForOp->getResults().take_back(numQubits));
 
-    // Move the the contents from the old block into the new block
+    // Move the contents from the old block into the new block
     auto& srcBlock = op.getRegion().front();
     auto& dstBlock = newForOp.getRegion().front();
     dstBlock.getOperations().splice(dstBlock.end(), srcBlock.getOperations());
-    rewriter.replaceAllUsesWith(op.getInductionVar(),
-                                newForOp.getInductionVar());
+    for (auto [oldArgument, newArgument] : llvm::zip_equal(
+             srcBlock.getArguments(),
+             dstBlock.getArguments().take_front(srcBlock.getNumArguments()))) {
+      rewriter.replaceAllUsesWith(oldArgument, newArgument);
+    }
 
     // Extract all the previously inserted qubits again
     rewriter.setInsertionPointAfter(newForOp);
     extractQubitsAfterOp(state, operation, rewriter);
 
-    auto qubits = qubitMap.getArrayRef();
-    auto registers = registerMap.getArrayRef();
+    SmallVector<Value> qubits(qubitMap.begin(), qubitMap.end());
+    SmallVector<Value> memrefs(registerMap.begin(), registerMap.end());
+    state.structuredValues[newForOp] = {.qubits = qubits, .memrefs = memrefs};
+    seedRegionMappings(state, newForOp.getRegion(), qubits, memrefs,
+                       dstBlock.getArguments().take_back(numQubits),
+                       dstBlock.getArguments()
+                           .drop_front(1 + numOriginalResults)
+                           .take_front(numRegisters));
 
-    // Push a new frame to the stack
-    pushModifierFrameWithRegisters(
-        state, qubits, registers,
-        dstBlock.getArguments().drop_front(1).take_back(numQubits),
-        dstBlock.getArguments().drop_front(1).take_front(numRegisters));
-
-    rewriter.eraseOp(op);
+    rewriter.replaceOp(op,
+                       newForOp.getResults().take_front(numOriginalResults));
 
     return success();
   }
@@ -1368,49 +1433,77 @@ struct ConvertSCFWhileOp final : StatefulOpConversionPattern<scf::WhileOp> {
     // the WhileOp
     insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
+    const auto numOriginalInits = op.getInits().size();
+    const auto numOriginalResults = op.getNumResults();
+    SmallVector<Value> initArgs(op.getInits());
+    llvm::append_range(initArgs, qcoTargets);
+    SmallVector<Type> resultTypes(op.getResultTypes());
+    llvm::append_range(resultTypes,
+                       llvm::map_range(qcoTargets, [](Value value) {
+                         return value.getType();
+                       }));
 
     // Create the new WhileOp
-    auto newWhileOp = scf::WhileOp::create(
-        rewriter, op.getLoc(), TypeRange(qcoTargets), ValueRange(qcoTargets));
+    auto newWhileOp =
+        scf::WhileOp::create(rewriter, op.getLoc(), resultTypes, initArgs);
     assignMappedTensors(state, op.getOperation(), registerMap,
-                        newWhileOp.getResults().take_front(numRegisters));
+                        newWhileOp.getResults()
+                            .drop_front(numOriginalResults)
+                            .take_front(numRegisters));
     assignMappedQubits(state, op.getOperation(), qubitMap,
                        newWhileOp->getResults().take_back(numQubits));
 
     auto& newBeforeRegion = newWhileOp.getBefore();
     auto& newAfterRegion = newWhileOp.getAfter();
 
-    const SmallVector locs(qcoTargets.size(), op->getLoc());
+    const SmallVector beforeLocs(initArgs.size(), op->getLoc());
+    const SmallVector afterLocs(resultTypes.size(), op->getLoc());
 
     // Create the new blocks and move the contents from the old blocks into the
     // new ones
     auto* newBeforeBlock = rewriter.createBlock(
-        &newBeforeRegion, {}, newWhileOp->getResultTypes(), locs);
+        &newBeforeRegion, {}, ValueRange(initArgs).getTypes(), beforeLocs);
     auto* newAfterBlock = rewriter.createBlock(
-        &newAfterRegion, {}, newWhileOp->getResultTypes(), locs);
+        &newAfterRegion, {}, TypeRange(resultTypes), afterLocs);
+    auto* oldBeforeBlock = op.getBeforeBody();
+    auto* oldAfterBlock = op.getAfterBody();
     newBeforeBlock->getOperations().splice(newBeforeBlock->end(),
-                                           op.getBeforeBody()->getOperations());
+                                           oldBeforeBlock->getOperations());
     newAfterBlock->getOperations().splice(newAfterBlock->end(),
-                                          op.getAfterBody()->getOperations());
+                                          oldAfterBlock->getOperations());
+    for (auto [oldArgument, newArgument] :
+         llvm::zip_equal(oldBeforeBlock->getArguments(),
+                         newBeforeBlock->getArguments().take_front(
+                             oldBeforeBlock->getNumArguments()))) {
+      rewriter.replaceAllUsesWith(oldArgument, newArgument);
+    }
+    for (auto [oldArgument, newArgument] :
+         llvm::zip_equal(oldAfterBlock->getArguments(),
+                         newAfterBlock->getArguments().take_front(
+                             oldAfterBlock->getNumArguments()))) {
+      rewriter.replaceAllUsesWith(oldArgument, newArgument);
+    }
 
     // Extract all the previously inserted qubits again
     rewriter.setInsertionPointAfter(newWhileOp);
     extractQubitsAfterOp(state, operation, rewriter);
 
-    auto qubits = qubitMap.getArrayRef();
-    auto registers = registerMap.getArrayRef();
+    SmallVector<Value> qubits(qubitMap.begin(), qubitMap.end());
+    SmallVector<Value> memrefs(registerMap.begin(), registerMap.end());
+    state.structuredValues[newWhileOp] = {.qubits = qubits, .memrefs = memrefs};
+    seedRegionMappings(state, newWhileOp.getBefore(), qubits, memrefs,
+                       newBeforeBlock->getArguments().take_back(numQubits),
+                       newBeforeBlock->getArguments()
+                           .drop_front(numOriginalInits)
+                           .take_front(numRegisters));
+    seedRegionMappings(state, newWhileOp.getAfter(), qubits, memrefs,
+                       newAfterBlock->getArguments().take_back(numQubits),
+                       newAfterBlock->getArguments()
+                           .drop_front(numOriginalResults)
+                           .take_front(numRegisters));
 
-    // Push the frames for the before and after region to the stack
-    pushModifierFrameWithRegisters(
-        state, qubits, registers,
-        newAfterBlock->getArguments().take_back(numQubits),
-        newAfterBlock->getArguments().take_front(numRegisters));
-    pushModifierFrameWithRegisters(
-        state, qubits, registers,
-        newBeforeBlock->getArguments().take_back(numQubits),
-        newBeforeBlock->getArguments().take_front(numRegisters));
-
-    rewriter.eraseOp(op);
+    rewriter.replaceOp(op,
+                       newWhileOp.getResults().take_front(numOriginalResults));
     return success();
   }
 };
@@ -1451,6 +1544,12 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
     // the IfOp
     insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
+    auto scratch =
+        createHoistedScratchStorage(operation, op.getResultTypes(), rewriter);
+    if (failed(scratch)) {
+      return rewriter.notifyMatchFailure(
+          op, "result-bearing scf.if requires an automatic allocation scope");
+    }
 
     // Create the new IfOp
     auto newIfOp =
@@ -1479,16 +1578,32 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
     thenBlock->getOperations().splice(
         thenBlock->end(), op.getThenRegion().front().getOperations());
 
-    auto qubits = qubitMap.getArrayRef();
-    auto registers = registerMap.getArrayRef();
+    const auto spillResults = [&](Block* block) {
+      auto yield = cast<scf::YieldOp>(block->getTerminator());
+      rewriter.setInsertionPoint(yield);
+      if (!scratch->empty()) {
+        auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+        for (auto [value, storage] :
+             llvm::zip_equal(yield.getResults(), *scratch)) {
+          memref::StoreOp::create(rewriter, op.getLoc(), value, storage,
+                                  ValueRange{index});
+        }
+      }
+      rewriter.replaceOpWithNewOp<scf::YieldOp>(yield);
+    };
+    spillResults(thenBlock);
+
+    SmallVector<Value> qubits(qubitMap.begin(), qubitMap.end());
+    SmallVector<Value> memrefs(registerMap.begin(), registerMap.end());
+    state.structuredValues[newIfOp] = {.qubits = qubits, .memrefs = memrefs};
 
     if (!op.getElseRegion().empty()) {
       elseBlock->getOperations().splice(
           elseBlock->end(), op.getElseRegion().front().getOperations());
-      pushModifierFrameWithRegisters(
-          state, qubits, registers,
-          elseBlock->getArguments().take_back(numQubits),
-          elseBlock->getArguments().take_front(numRegisters));
+      spillResults(elseBlock);
+      seedRegionMappings(state, newIfOp.getElseRegion(), qubits, memrefs,
+                         elseBlock->getArguments().take_back(numQubits),
+                         elseBlock->getArguments().take_front(numRegisters));
 
     } else {
       // If the else block is empty, just create the new qco::YieldOp
@@ -1496,12 +1611,21 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
       qco::YieldOp::create(rewriter, op->getLoc(), elseBlock->getArguments());
     }
 
-    pushModifierFrameWithRegisters(
-        state, qubits, registers,
-        thenBlock->getArguments().take_back(numQubits),
-        thenBlock->getArguments().take_front(numRegisters));
+    seedRegionMappings(state, newIfOp.getThenRegion(), qubits, memrefs,
+                       thenBlock->getArguments().take_back(numQubits),
+                       thenBlock->getArguments().take_front(numRegisters));
 
-    rewriter.eraseOp(op);
+    rewriter.setInsertionPointAfter(newIfOp);
+    SmallVector<Value> classicalResults;
+    classicalResults.reserve(scratch->size());
+    if (!scratch->empty()) {
+      auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+      for (auto storage : *scratch) {
+        classicalResults.push_back(memref::LoadOp::create(
+            rewriter, op.getLoc(), storage, ValueRange{index}));
+      }
+    }
+    rewriter.replaceOp(op, classicalResults);
     return success();
   }
 };
@@ -1543,55 +1667,80 @@ struct ConvertSCFIndexSwitchOp final
     auto* operation = op.getOperation();
     auto& registerMap = state.regionRegisterMap[op];
     auto& qubitMap = state.regionQubitMap[op];
-
-    const auto qubits = qubitMap.getArrayRef();
-    const auto nqubits = qubits.size();
-    const auto registers = registerMap.getArrayRef();
-    const auto nregisters = registers.size();
+    const auto numRegisters = registerMap.size();
+    const auto numQubits = qubitMap.size();
 
     insertQubitsBeforeOp(state, operation, rewriter);
-
     const auto targets = resolveAllValues(state, operation);
     const auto results = ValueRange(targets).getTypes();
     const SmallVector locs(targets.size(), op.getLoc());
+    auto scratch =
+        createHoistedScratchStorage(operation, op.getResultTypes(), rewriter);
+    if (failed(scratch)) {
+      return rewriter.notifyMatchFailure(
+          op, "result-bearing scf.index_switch requires an automatic "
+              "allocation scope");
+    }
 
     auto newOp =
         IndexSwitchOp::create(rewriter, op.getLoc(), results, op.getArg(),
                               op.getCases(), targets, op.getNumCases());
 
     assignMappedTensors(state, op.getOperation(), registerMap,
-                        newOp.getResults().take_front(nregisters));
+                        newOp.getResults().take_front(numRegisters));
     assignMappedQubits(state, op.getOperation(), qubitMap,
-                       newOp.getResults().take_back(nqubits));
+                       newOp.getResults().take_back(numQubits));
 
     rewriter.setInsertionPointAfter(newOp);
     extractQubitsAfterOp(state, operation, rewriter);
 
+    SmallVector<Value> qubits(qubitMap.begin(), qubitMap.end());
+    SmallVector<Value> memrefs(registerMap.begin(), registerMap.end());
+    state.structuredValues[newOp] = {.qubits = qubits, .memrefs = memrefs};
+
     const auto newCaseRegions = newOp.getCaseRegions();
     const auto oldCaseRegions = op.getCaseRegions();
     const auto buildRegion = [&](Region& oldRegion, Region& newRegion) {
-      Block* const oldBlock = &(*oldRegion.begin());
-      Block* const newBlock =
+      auto* oldBlock = &oldRegion.front();
+      auto* newBlock =
           rewriter.createBlock(&newRegion, {}, newOp.getResultTypes(), locs);
-      rewriter.inlineBlockBefore(oldBlock, newBlock, newBlock->begin());
+      newBlock->getOperations().splice(newBlock->end(),
+                                       oldBlock->getOperations());
 
-      const auto args = newBlock->getArguments();
-      pushModifierFrameWithRegisters(state, qubits, registers,
-                                     args.take_back(nqubits),
-                                     args.take_front(nregisters));
+      auto yield = cast<scf::YieldOp>(newBlock->getTerminator());
+      rewriter.setInsertionPoint(yield);
+      if (!scratch->empty()) {
+        auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+        for (auto [value, storage] :
+             llvm::zip_equal(yield.getResults(), *scratch)) {
+          memref::StoreOp::create(rewriter, op.getLoc(), value, storage,
+                                  ValueRange{index});
+        }
+      }
+      rewriter.replaceOpWithNewOp<scf::YieldOp>(yield);
+
+      seedRegionMappings(state, newRegion, qubits, memrefs,
+                         newBlock->getArguments().take_back(numQubits),
+                         newBlock->getArguments().take_front(numRegisters));
     };
 
-    // Process regions and push frames in the correct order. The top-most stack
-    // element must be the default region (0th index) followed by the case
-    // regions.
-
-    for (size_t i = op.getNumCases(); i > 0; --i) {
-      buildRegion(oldCaseRegions[i - 1], newCaseRegions[i - 1]);
+    for (auto [oldRegion, newRegion] :
+         llvm::zip_equal(oldCaseRegions, newCaseRegions)) {
+      buildRegion(oldRegion, newRegion);
     }
     buildRegion(op.getDefaultRegion(), newOp.getDefaultRegion());
 
-    rewriter.eraseOp(op);
-
+    rewriter.setInsertionPointAfter(newOp);
+    SmallVector<Value> classicalResults;
+    classicalResults.reserve(scratch->size());
+    if (!scratch->empty()) {
+      auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+      for (auto storage : *scratch) {
+        classicalResults.push_back(memref::LoadOp::create(
+            rewriter, op.getLoc(), storage, ValueRange{index}));
+      }
+    }
+    rewriter.replaceOp(op, classicalResults);
     return success();
   }
 };
@@ -1620,15 +1769,14 @@ struct ConvertSCFYieldOp final : StatefulOpConversionPattern<scf::YieldOp> {
     auto* operation = op.getOperation();
 
     insertQubitsBeforeOp(state, op.getOperation(), rewriter);
-    SmallVector<Value> targets = resolveAllValues(state, operation);
+    SmallVector<Value> targets(op.getResults());
+    llvm::append_range(targets, resolveAllValues(state, operation));
 
     if (isa<IfOp, IndexSwitchOp>(op->getParentOp())) {
       rewriter.replaceOpWithNewOp<qco::YieldOp>(op, targets);
     } else {
       rewriter.replaceOpWithNewOp<scf::YieldOp>(op, targets);
     }
-
-    popModifierFrame(state);
 
     return success();
   }
@@ -1658,12 +1806,11 @@ struct ConvertSCFConditionOp final
     auto* operation = op.getOperation();
 
     insertQubitsBeforeOp(state, op.getOperation(), rewriter);
-    SmallVector<Value> targets = resolveAllValues(state, operation);
+    SmallVector<Value> targets(op.getArgs());
+    llvm::append_range(targets, resolveAllValues(state, operation));
 
     rewriter.replaceOpWithNewOp<scf::ConditionOp>(op, op.getCondition(),
                                                   targets);
-    popModifierFrame(state);
-
     return success();
   }
 };
@@ -1723,34 +1870,21 @@ protected:
       auto& regionTensorMap = state.regionRegisterMap[op];
       return regionQubitMap.empty() && regionTensorMap.empty();
     });
-    target.addDynamicallyLegalOp<scf::YieldOp, scf::ConditionOp>(
-        [](Operation* op) {
-          auto* parentOp = op->getParentOp();
-          auto isQCOType = [](Type t) {
-            return TypeSwitch<Type, bool>(t)
-                .Case<qco::QubitType>([](auto) { return true; })
-                .Case<RankedTensorType>([](RankedTensorType t) {
-                  return isa<qco::QubitType>(t.getElementType());
-                })
-                .Default([](auto) { return false; });
-          };
-
-          const auto parentHasQubitTypes =
-              llvm::any_of(parentOp->getOperandTypes(), isQCOType);
-          const auto terminatorHasQubitTypes =
-              llvm::any_of(op->getOperandTypes(), isQCOType);
-          return !parentHasQubitTypes || terminatorHasQubitTypes;
-        });
+    // Structured terminators are lowered in a second conversion phase. The
+    // first phase must finish converting every operation in a region so the
+    // region-local maps contain the final QCO values that the terminator has
+    // to yield. Converting terminators in the same worklist would make the
+    // result depend on dialect-conversion traversal order.
+    target.addLegalOp<scf::YieldOp, scf::ConditionOp>();
 
     // Register operation conversion patterns with state tracking.
-    patterns
-        .add<ConvertSCFForOp, ConvertSCFYieldOp, ConvertSCFWhileOp,
-             ConvertSCFIfOp, ConvertSCFIndexSwitchOp, ConvertSCFConditionOp,
-             ConvertMemRefAllocOp, ConvertMemRefLoadOp, ConvertMemRefDeallocOp,
-             ConvertQCAllocOp, ConvertQCDeallocOp, ConvertQCStaticOp,
-             ConvertQCMeasureOp, ConvertQCResetOp, ConvertQCBarrierOp,
-             ConvertQCCtrlOp, ConvertQCInvOp, ConvertQCPowOp, ConvertQCYieldOp>(
-            typeConverter, context, &state);
+    patterns.add<ConvertSCFForOp, ConvertSCFWhileOp, ConvertSCFIfOp,
+                 ConvertSCFIndexSwitchOp, ConvertMemRefAllocOp,
+                 ConvertMemRefLoadOp, ConvertMemRefDeallocOp, ConvertQCAllocOp,
+                 ConvertQCDeallocOp, ConvertQCStaticOp, ConvertQCMeasureOp,
+                 ConvertQCResetOp, ConvertQCBarrierOp, ConvertQCCtrlOp,
+                 ConvertQCInvOp, ConvertQCPowOp, ConvertQCYieldOp>(
+        typeConverter, context, &state);
 
     // Not part of the central gate table.
     patterns.add<ConvertQCGateToQCO<qc::GPhaseOp, qco::GPhaseOp, 0, 1>>(
@@ -1793,8 +1927,38 @@ protected:
     // Conversion of qc types in control-flow ops (e.g., cf.br, cf.cond_br)
     populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
 
-    // Apply the conversion
+    // Convert structured parents and their contents first.
     if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+
+    ConversionTarget terminatorTarget(*context);
+    terminatorTarget.markUnknownOpDynamicallyLegal(
+        [](Operation*) { return true; });
+    terminatorTarget.addDynamicallyLegalOp<scf::YieldOp, scf::ConditionOp>(
+        [&](Operation* op) {
+          auto* parentOp = op->getParentOp();
+          if (!state.structuredValues.contains(parentOp)) {
+            return true;
+          }
+
+          if (auto condition = dyn_cast<scf::ConditionOp>(op)) {
+            return llvm::equal(condition.getArgs().getTypes(),
+                               parentOp->getResultTypes());
+          }
+          if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
+            return llvm::equal(op->getOperandTypes(),
+                               whileOp.getInits().getTypes());
+          }
+          return llvm::equal(op->getOperandTypes(), parentOp->getResultTypes());
+        });
+
+    RewritePatternSet terminatorPatterns(context);
+    terminatorPatterns.add<ConvertSCFYieldOp, ConvertSCFConditionOp>(
+        typeConverter, context, &state);
+    if (failed(applyPartialConversion(module, terminatorTarget,
+                                      std::move(terminatorPatterns)))) {
       signalPassFailure();
     }
   }

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -517,33 +517,6 @@ static void extractQubitsAfterOp(LoweringState& state, Operation* target,
 }
 
 /**
- * @brief Creates scalar scratch storage that is allocated once in the enclosing
- * function.
- *
- * Hoisting the allocation outside enclosing loops lets result-bearing
- * `scf.if` operations communicate classical branch results without growing the
- * stack on every iteration. Each syntactic conditional gets distinct storage,
- * and structured control flow executes it sequentially.
- */
-[[nodiscard]] static SmallVector<Value>
-createHoistedScratchStorage(Operation* operation, TypeRange elementTypes,
-                            ConversionPatternRewriter& rewriter) {
-  auto function = operation->getParentOfType<func::FuncOp>();
-  assert(function && !function.getBody().empty() &&
-         "structured QC control flow must be nested in a function");
-
-  OpBuilder::InsertionGuard guard(rewriter);
-  rewriter.setInsertionPointToStart(&function.getBody().front());
-  SmallVector<Value> storage;
-  storage.reserve(elementTypes.size());
-  for (auto type : elementTypes) {
-    storage.push_back(memref::AllocaOp::create(rewriter, operation->getLoc(),
-                                               MemRefType::get({1}, type)));
-  }
-  return storage;
-}
-
-/**
  * @brief Collects all the QC qubit and memref references used by an scf
  * operation and stores them in the maps
  *
@@ -1542,8 +1515,6 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
     // the IfOp
     insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
-    const auto scratch =
-        createHoistedScratchStorage(operation, op.getResultTypes(), rewriter);
 
     // Create the new IfOp
     auto newIfOp =
@@ -1572,21 +1543,6 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
     thenBlock->getOperations().splice(
         thenBlock->end(), op.getThenRegion().front().getOperations());
 
-    const auto spillResults = [&](Block* block) {
-      auto yield = cast<scf::YieldOp>(block->getTerminator());
-      rewriter.setInsertionPoint(yield);
-      if (!scratch.empty()) {
-        auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
-        for (auto [value, storage] :
-             llvm::zip_equal(yield.getResults(), scratch)) {
-          memref::StoreOp::create(rewriter, op.getLoc(), value, storage,
-                                  ValueRange{index});
-        }
-      }
-      rewriter.replaceOpWithNewOp<scf::YieldOp>(yield);
-    };
-    spillResults(thenBlock);
-
     SmallVector<Value> qubits(qubitMap.begin(), qubitMap.end());
     SmallVector<Value> memrefs(registerMap.begin(), registerMap.end());
     state.structuredValues[newIfOp] = {.qubits = qubits, .memrefs = memrefs};
@@ -1594,7 +1550,6 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
     if (!op.getElseRegion().empty()) {
       elseBlock->getOperations().splice(
           elseBlock->end(), op.getElseRegion().front().getOperations());
-      spillResults(elseBlock);
       seedRegionMappings(state, newIfOp.getElseRegion(), qubits, memrefs,
                          elseBlock->getArguments().take_back(numQubits),
                          elseBlock->getArguments().take_front(numRegisters));
@@ -1609,17 +1564,7 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
                        thenBlock->getArguments().take_back(numQubits),
                        thenBlock->getArguments().take_front(numRegisters));
 
-    rewriter.setInsertionPointAfter(newIfOp);
-    SmallVector<Value> classicalResults;
-    classicalResults.reserve(scratch.size());
-    if (!scratch.empty()) {
-      auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
-      for (auto storage : scratch) {
-        classicalResults.push_back(memref::LoadOp::create(
-            rewriter, op.getLoc(), storage, ValueRange{index}));
-      }
-    }
-    rewriter.replaceOp(op, classicalResults);
+    rewriter.eraseOp(op);
     return success();
   }
 };
@@ -1668,8 +1613,6 @@ struct ConvertSCFIndexSwitchOp final
     const auto targets = resolveAllValues(state, operation);
     const auto results = ValueRange(targets).getTypes();
     const SmallVector locs(targets.size(), op.getLoc());
-    const auto scratch =
-        createHoistedScratchStorage(operation, op.getResultTypes(), rewriter);
 
     auto newOp =
         IndexSwitchOp::create(rewriter, op.getLoc(), results, op.getArg(),
@@ -1696,18 +1639,6 @@ struct ConvertSCFIndexSwitchOp final
       newBlock->getOperations().splice(newBlock->end(),
                                        oldBlock->getOperations());
 
-      auto yield = cast<scf::YieldOp>(newBlock->getTerminator());
-      rewriter.setInsertionPoint(yield);
-      if (!scratch.empty()) {
-        auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
-        for (auto [value, storage] :
-             llvm::zip_equal(yield.getResults(), scratch)) {
-          memref::StoreOp::create(rewriter, op.getLoc(), value, storage,
-                                  ValueRange{index});
-        }
-      }
-      rewriter.replaceOpWithNewOp<scf::YieldOp>(yield);
-
       seedRegionMappings(state, newRegion, qubits, memrefs,
                          newBlock->getArguments().take_back(numQubits),
                          newBlock->getArguments().take_front(numRegisters));
@@ -1719,17 +1650,7 @@ struct ConvertSCFIndexSwitchOp final
     }
     buildRegion(op.getDefaultRegion(), newOp.getDefaultRegion());
 
-    rewriter.setInsertionPointAfter(newOp);
-    SmallVector<Value> classicalResults;
-    classicalResults.reserve(scratch.size());
-    if (!scratch.empty()) {
-      auto index = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
-      for (auto storage : scratch) {
-        classicalResults.push_back(memref::LoadOp::create(
-            rewriter, op.getLoc(), storage, ValueRange{index}));
-      }
-    }
-    rewriter.replaceOp(op, classicalResults);
+    rewriter.eraseOp(op);
     return success();
   }
 };

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/QCO/Transforms/Mapping/Mapping.h"
 
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Utils/Drivers.h"

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -80,6 +80,12 @@ private:
 
   enum class RoutingMode : bool { Cold, Hot };
 
+  /// Return the qubit values in `values`, preserving their relative order.
+  static SmallVector<Value> getQubitValues(ValueRange values) {
+    return to_vector(llvm::make_filter_range(
+        values, [](Value value) { return isa<QubitType>(value.getType()); }));
+  }
+
   class AugmentedDevice {
   public:
     explicit AugmentedDevice(
@@ -466,11 +472,13 @@ private:
     auto newWhileOp =
         rewriter.create<scf::WhileOp>(whileOp.getLoc(), newTypes, newInits);
 
-    const SmallVector<Location> locs(newTypes.size(), whileOp.getLoc());
+    const SmallVector<Location> beforeLocs(newInits.size(), whileOp.getLoc());
+    const SmallVector<Location> afterLocs(newTypes.size(), whileOp.getLoc());
     Block* newBefBlock =
-        rewriter.createBlock(&newWhileOp.getBefore(), {}, newTypes, locs);
+        rewriter.createBlock(&newWhileOp.getBefore(), {},
+                             ValueRange(newInits).getTypes(), beforeLocs);
     Block* newAftBlock =
-        rewriter.createBlock(&newWhileOp.getAfter(), {}, newTypes, locs);
+        rewriter.createBlock(&newWhileOp.getAfter(), {}, newTypes, afterLocs);
 
     rewriter.mergeBlocks(oldBefBlock, newBefBlock,
                          newBefBlock->getArguments().take_front(oldBefNumArgs));
@@ -499,7 +507,7 @@ private:
 
     SmallVector<Value> newYieldArgs(yieldOp.getResults());
     llvm::append_range(newYieldArgs,
-                       newAftBlock->getArguments().drop_front(oldBefNumArgs));
+                       newAftBlock->getArguments().drop_front(oldAftNumArgs));
 
     rewriter.create<scf::YieldOp>(yieldOp.getLoc(), newYieldArgs);
     rewriter.eraseOp(yieldOp);
@@ -663,36 +671,43 @@ private:
             .Case<scf::ForOp>([&](scf::ForOp forOp) {
               assert(qubits.size() == layout.nqubits());
 
-              llvm::for_each(forOp.getInits(),
+              llvm::for_each(getQubitValues(forOp.getInits()),
                              [&](Value v) { qubits.erase(v); });
 
               auto newForOp = extend(forOp, to_vector(qubits), rewriter);
               for (const auto [init, result] : llvm::zip_equal(
                        newForOp.getInits(), *newForOp.getLoopResults())) {
-                qubits.insert(result);
-                qubits.erase(init);
+                if (isa<QubitType>(init.getType())) {
+                  qubits.insert(result);
+                  qubits.erase(init);
+                }
               }
 
+              const auto regionQubits =
+                  getQubitValues(newForOp.getRegionIterArgs());
               stack.emplace_back(
                   newForOp.getRegion(),
-                  DenseSet<Value>(newForOp.getRegionIterArgs().begin(),
-                                  newForOp.getRegionIterArgs().end()));
+                  DenseSet<Value>(regionQubits.begin(), regionQubits.end()));
             })
             .Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
               assert(qubits.size() == layout.nqubits());
 
-              llvm::for_each(whileOp.getInits(),
+              llvm::for_each(getQubitValues(whileOp.getInits()),
                              [&](Value v) { qubits.erase(v); });
 
               auto newWhileOp = extend(whileOp, to_vector(qubits), rewriter);
               for (const auto [init, result] : llvm::zip_equal(
                        newWhileOp.getInits(), newWhileOp.getResults())) {
-                qubits.insert(result);
-                qubits.erase(init);
+                if (isa<QubitType>(init.getType())) {
+                  qubits.insert(result);
+                  qubits.erase(init);
+                }
               }
 
-              const auto beforeArgs = newWhileOp.getBeforeArguments();
-              const auto afterArgs = newWhileOp.getAfterArguments();
+              const auto beforeArgs =
+                  getQubitValues(newWhileOp.getBeforeArguments());
+              const auto afterArgs =
+                  getQubitValues(newWhileOp.getAfterArguments());
               stack.emplace_back(
                   newWhileOp.getBefore(),
                   DenseSet<Value>(beforeArgs.begin(), beforeArgs.end()));
@@ -1148,13 +1163,11 @@ private:
     return stack;
   }
 
-  /// Helper function to realign a terminator operation based on a permutation
-  /// of hardware indices. This constructs a value map from the given bundle and
-  /// reorders the terminator's operands according to the permutation vector.
-  template <typename T, typename... Args>
-  static void realignTerminator(Operation* terminator, ArrayRef<size_t> perm,
-                                const RoutingBundle& bundle,
-                                IRRewriter& rewriter, Args&&... extraArgs) {
+  /// Return `values` with only the qubit entries realigned according to the
+  /// given permutation of hardware indices.
+  static SmallVector<Value> realignQubitValues(ValueRange values,
+                                               ArrayRef<size_t> perm,
+                                               const RoutingBundle& bundle) {
     // Map hardware indices to qubit values for the given bundle.
     DenseMap<size_t, Value> m(bundle.wires.size());
     for (size_t i = 0; i < bundle.wires.size(); ++i) {
@@ -1163,10 +1176,15 @@ private:
       m.try_emplace(hw, bundle.wires[i].qubit());
     }
 
-    rewriter.setInsertionPoint(terminator);
-    rewriter.replaceOpWithNewOp<T>(
-        terminator, std::forward<Args>(extraArgs)...,
-        to_vector(map_range(perm, [&](size_t hw) { return m.at(hw); })));
+    SmallVector<Value> realigned(values);
+    size_t qubitIndex = 0;
+    for (Value& value : realigned) {
+      if (isa<QubitType>(value.getType())) {
+        value = m.at(perm[qubitIndex++]);
+      }
+    }
+    assert(qubitIndex == perm.size());
+    return realigned;
   }
 
   /// Processes the recursive stack item by routing the nested operation and
@@ -1191,11 +1209,30 @@ private:
                   RoutingBundle{.layout = parent.layout}};
             });
 
+    SmallVector<std::optional<size_t>> resultToQubitIndex(op->getNumResults());
+    size_t numQubitResults = 0;
+    for (const auto [resultIndex, result] : llvm::enumerate(op->getResults())) {
+      if (isa<QubitType>(result.getType())) {
+        resultToQubitIndex[resultIndex] = numQubitResults++;
+      }
+    }
+    assert(numQubitResults == indices.size());
+
+    SmallVector<Value> whileBeforeQubits;
+    SmallVector<Value> whileConditionQubits;
+    if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+      whileBeforeQubits = getQubitValues(whileOp.getBeforeArguments());
+      whileConditionQubits = getQubitValues(
+          cast<scf::ConditionOp>(whileOp.getBeforeBody()->getTerminator())
+              .getArgs());
+    }
+
     for (size_t i : indices) {
       const auto prog = parent.infos.lookupProgram(i);
       const auto hw = parent.layout.getHardwareIndex(prog);
       const auto res = cast<OpResult>(parent.wires[i].qubit());
       const auto resNum = res.getResultNumber();
+      const auto qubitResNum = *resultToQubitIndex[resNum];
 
       TypeSwitch<Operation*>(op)
           .template Case<scf::ForOp>([&](scf::ForOp forOp) {
@@ -1209,16 +1246,14 @@ private:
               }
             }());
           })
-          .template Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+          .template Case<scf::WhileOp>([&](scf::WhileOp) {
             children[0].infos.insertOrUpdate(children[0].infos.size(), prog);
             children[0].wires.emplace_back([&] -> Value {
-              auto condOp = cast<scf::ConditionOp>(
-                  whileOp.getBeforeBody()->getTerminator());
-              const auto arg = whileOp.getBeforeArguments()[resNum];
+              const auto arg = whileBeforeQubits[qubitResNum];
               if constexpr (Direction == WireDirection::Forward) {
                 return arg;
               } else {
-                return condOp.getArgs()[resNum];
+                return whileConditionQubits[qubitResNum];
               }
             }());
           })
@@ -1245,7 +1280,7 @@ private:
             }
           });
 
-      permutation[resNum] = hw;
+      permutation[qubitResNum] = hw;
     }
 
     // Route each child branch and prepare the wire iterators for
@@ -1271,13 +1306,14 @@ private:
       children.emplace_back(RoutingBundle{.layout = children[0].layout});
       assert(children.size() == 2);
 
-      const auto rng = [&] -> ValueRange {
+      const auto values = [&] -> ValueRange {
         if constexpr (Direction == WireDirection::Forward) {
           return whileOp.getAfterArguments();
         }
         return cast<scf::YieldOp>(whileOp.getAfterBody()->getTerminator())
             .getResults();
       }();
+      const auto rng = getQubitValues(values);
 
       for (const auto& [i, arg] : llvm::enumerate(rng)) {
         const auto hw = permutation[i];
@@ -1338,20 +1374,27 @@ private:
           .template Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
             auto condOp = cast<scf::ConditionOp>(
                 whileOp.getBeforeBody()->getTerminator());
-            realignTerminator<scf::ConditionOp>(condOp, permutation,
-                                                children[0], *rewriter,
-                                                condOp.getCondition());
-            realignTerminator<scf::YieldOp>(
-                whileOp.getAfterBody()->getTerminator(), permutation,
-                children[1], *rewriter);
+            rewriter->setInsertionPoint(condOp);
+            rewriter->replaceOpWithNewOp<scf::ConditionOp>(
+                condOp, condOp.getCondition(),
+                realignQubitValues(condOp.getArgs(), permutation, children[0]));
+
+            auto yieldOp =
+                cast<scf::YieldOp>(whileOp.getAfterBody()->getTerminator());
+            rewriter->setInsertionPoint(yieldOp);
+            rewriter->replaceOpWithNewOp<scf::YieldOp>(
+                yieldOp, realignQubitValues(yieldOp.getResults(), permutation,
+                                            children[1]));
           })
           .template Case<IfOp>([&](IfOp ifOp) {
-            realignTerminator<YieldOp>(
-                ifOp.getThenRegion().front().getTerminator(), permutation,
-                children[0], *rewriter);
-            realignTerminator<YieldOp>(
-                ifOp.getElseRegion().front().getTerminator(), permutation,
-                children[1], *rewriter);
+            for (const auto [region, child] :
+                 llvm::zip_equal(ifOp->getRegions(), children)) {
+              auto yieldOp = cast<YieldOp>(region.front().getTerminator());
+              rewriter->setInsertionPoint(yieldOp);
+              rewriter->replaceOpWithNewOp<YieldOp>(
+                  yieldOp,
+                  realignQubitValues(yieldOp.getTargets(), permutation, child));
+            }
           });
 
       // Sort topologically to fix any occurring SSA dominance errors.

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -22,6 +22,7 @@
 #include "qco_programs.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -29,6 +30,7 @@
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Matchers.h>
+#include <mlir/IR/Region.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
@@ -108,27 +110,36 @@ protected:
     });
     EXPECT_FALSE(retainsQCOperations);
   }
+
+  static void expectReturnLoadedFromScratch(ModuleOp module) {
+    auto main = module.lookupSymbol<func::FuncOp>("main");
+    ASSERT_TRUE(main);
+    auto returnOp =
+        cast<func::ReturnOp>(main.getBody().front().getTerminator());
+    ASSERT_EQ(returnOp.getNumOperands(), 1);
+    auto load = returnOp.getOperand(0).getDefiningOp<memref::LoadOp>();
+    ASSERT_TRUE(load);
+    EXPECT_TRUE(load.getMemref().getDefiningOp<memref::AllocaOp>());
+  }
 };
 
 } // namespace
 
-TEST_F(QCToQCORegressionTest, ConvertsCompleteMixedSCFQuantumState) {
-
+TEST_F(QCToQCORegressionTest, PreservesForResultsWithQuantumState) {
   constexpr llvm::StringLiteral source = R"mlir(
 module {
-  func.func @main() attributes {passthrough = ["entry_point"]} {
-    %qco = qco.alloc : !qco.qubit
+  func.func @main() -> i1 attributes {passthrough = ["entry_point"]} {
     %qc = qc.alloc : !qc.qubit
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
+    %true = arith.constant true
     %loop = scf.for %i = %c0 to %c1 step %c1
-        iter_args(%qco_arg = %qco) -> (!qco.qubit) {
+        iter_args(%flag = %true) -> (i1) {
       qc.h %qc : !qc.qubit
-      scf.yield %qco_arg : !qco.qubit
+      scf.yield %flag : i1
     }
-    qco.sink %loop : !qco.qubit
     qc.dealloc %qc : !qc.qubit
-    return
+    return %loop : i1
   }
 }
 )mlir";
@@ -139,15 +150,17 @@ module {
   ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
   ASSERT_TRUE(succeeded(verify(*module)));
 
-  bool sawMixedLoop = false;
+  bool sawLoop = false;
   module->walk([&](scf::ForOp loop) {
-    sawMixedLoop = true;
+    sawLoop = true;
     EXPECT_EQ(loop.getNumResults(), 2);
+    EXPECT_TRUE(loop.getResult(0).getType().isInteger(1));
+    EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(1).getType()));
     auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
     EXPECT_EQ(yield.getNumOperands(), loop.getNumResults());
     EXPECT_TRUE(llvm::equal(yield.getOperandTypes(), loop.getResultTypes()));
   });
-  EXPECT_TRUE(sawMixedLoop);
+  EXPECT_TRUE(sawLoop);
 
   expectNoQCOperations(*module);
 }
@@ -183,6 +196,7 @@ module {
   ASSERT_EQ(main.getFunctionType().getNumResults(), 1);
   EXPECT_TRUE(main.getFunctionType().getResult(0).isInteger(1));
   expectNoQCOperations(*module);
+  expectReturnLoadedFromScratch(*module);
   qco::IfOp branch;
   module->walk([&](qco::IfOp candidate) { branch = candidate; });
   ASSERT_TRUE(branch);
@@ -207,22 +221,21 @@ TEST_F(QCToQCORegressionTest, PreservesWhileConditionArgumentsAndOrdering) {
   constexpr llvm::StringLiteral source = R"mlir(
 module {
   func.func @main() -> i1 attributes {passthrough = ["entry_point"]} {
-    %qco = qco.alloc : !qco.qubit
     %qc = qc.alloc : !qc.qubit
     %true = arith.constant true
-    %result:2 = scf.while (%flag = %true, %qco_arg = %qco)
-        : (i1, !qco.qubit) -> (i1, !qco.qubit) {
+    %zero = arith.constant 0 : i64
+    %result:2 = scf.while (%flag = %true, %count = %zero)
+        : (i1, i64) -> (i64, i1) {
       qc.h %qc : !qc.qubit
       %false = arith.constant false
-      scf.condition(%flag) %false, %qco_arg : i1, !qco.qubit
+      scf.condition(%false) %count, %flag : i64, i1
     } do {
-    ^bb0(%flag: i1, %qco_arg: !qco.qubit):
+    ^bb0(%count: i64, %flag: i1):
       qc.x %qc : !qc.qubit
-      scf.yield %flag, %qco_arg : i1, !qco.qubit
+      scf.yield %flag, %count : i1, i64
     }
-    qco.sink %result#1 : !qco.qubit
     qc.dealloc %qc : !qc.qubit
-    return %result#0 : i1
+    return %result#1 : i1
   }
 }
 )mlir";
@@ -236,15 +249,16 @@ module {
   module->walk([&](scf::WhileOp loop) {
     sawWhile = true;
     ASSERT_EQ(loop.getNumResults(), 3);
-    EXPECT_TRUE(loop.getResult(0).getType().isInteger(1));
-    EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(1).getType()));
+    EXPECT_TRUE(loop.getResult(0).getType().isInteger(64));
+    EXPECT_TRUE(loop.getResult(1).getType().isInteger(1));
     EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(2).getType()));
     auto condition =
         cast<scf::ConditionOp>(loop.getBeforeBody()->getTerminator());
     EXPECT_TRUE(
         llvm::equal(condition.getArgs().getTypes(), loop.getResultTypes()));
     auto yield = cast<scf::YieldOp>(loop.getAfterBody()->getTerminator());
-    EXPECT_TRUE(llvm::equal(yield.getOperandTypes(), loop.getResultTypes()));
+    EXPECT_TRUE(
+        llvm::equal(yield.getOperandTypes(), loop.getInits().getTypes()));
   });
   EXPECT_TRUE(sawWhile);
   expectNoQCOperations(*module);
@@ -254,7 +268,7 @@ module {
   auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
   APInt result;
   ASSERT_TRUE(matchPattern(returnOp.getOperand(0), m_ConstantInt(&result)));
-  EXPECT_TRUE(result.isZero());
+  EXPECT_TRUE(result.isOne());
 }
 
 TEST_F(QCToQCORegressionTest, ConvertsTypeChangingWhileWithQuantumState) {
@@ -290,7 +304,7 @@ module {
   module->walk([&](scf::WhileOp candidate) { loop = candidate; });
   ASSERT_TRUE(loop);
   ASSERT_EQ(loop.getInits().size(), 2);
-  EXPECT_TRUE(isa<Float32Type>(loop.getInits().front().getType()));
+  EXPECT_TRUE(loop.getInits().front().getType().isF32());
   EXPECT_TRUE(isa<qco::QubitType>(loop.getInits().back().getType()));
   ASSERT_EQ(loop.getNumResults(), 2);
   EXPECT_TRUE(loop.getResult(0).getType().isInteger(64));
@@ -347,19 +361,19 @@ module {
     EXPECT_TRUE(isa<qco::QubitType>(yield.getOperand(0).getType()));
   }
   expectNoQCOperations(*module);
+  expectReturnLoadedFromScratch(*module);
 }
 
 TEST_F(QCToQCORegressionTest, ConvertsNestedResultsAfterRegionContents) {
   constexpr llvm::StringLiteral source = R"mlir(
 module {
   func.func @main() -> i1 attributes {passthrough = ["entry_point"]} {
-    %qco = qco.alloc : !qco.qubit
     %qc = qc.alloc : !qc.qubit
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %true = arith.constant true
-    %loop:2 = scf.for %i = %c0 to %c1 step %c1
-        iter_args(%flag = %true, %qco_arg = %qco) -> (i1, !qco.qubit) {
+    %loop = scf.for %i = %c0 to %c1 step %c1
+        iter_args(%flag = %true) -> (i1) {
       %next = scf.if %flag -> i1 {
         qc.h %qc : !qc.qubit
         %value = arith.constant false
@@ -370,11 +384,10 @@ module {
         scf.yield %value : i1
       }
       qc.z %qc : !qc.qubit
-      scf.yield %next, %qco_arg : i1, !qco.qubit
+      scf.yield %next : i1
     }
-    qco.sink %loop#1 : !qco.qubit
     qc.dealloc %qc : !qc.qubit
-    return %loop#0 : i1
+    return %loop : i1
   }
 }
 )mlir";
@@ -387,13 +400,42 @@ module {
   bool sawLoop = false;
   module->walk([&](scf::ForOp loop) {
     sawLoop = true;
-    ASSERT_EQ(loop.getNumResults(), 3);
+    ASSERT_EQ(loop.getNumResults(), 2);
+    EXPECT_TRUE(loop.getResult(0).getType().isInteger(1));
+    EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(1).getType()));
     auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
     EXPECT_TRUE(llvm::equal(yield.getOperandTypes(), loop.getResultTypes()));
-    EXPECT_TRUE(llvm::none_of(loop.getBody()->getOps<memref::AllocaOp>(),
-                              [](auto) { return true; }));
+    EXPECT_TRUE(loop.getBody()->getOps<memref::AllocaOp>().empty());
   });
   EXPECT_TRUE(sawLoop);
+  expectNoQCOperations(*module);
+}
+
+TEST_F(QCToQCORegressionTest, LeavesUnrelatedSCFTerminatorsUntouched) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() -> i1 attributes {passthrough = ["entry_point"]} {
+    %qc = qc.alloc : !qc.qubit
+    qc.h %qc : !qc.qubit
+    %result = scf.execute_region -> i1 {
+      %true = arith.constant true
+      scf.yield %true : i1
+    }
+    qc.dealloc %qc : !qc.qubit
+    return %result : i1
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  bool sawExecuteRegion = false;
+  module->walk([&](scf::ExecuteRegionOp) { sawExecuteRegion = true; });
+  EXPECT_TRUE(sawExecuteRegion);
   expectNoQCOperations(*module);
 }
 

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
@@ -27,12 +28,15 @@
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 
@@ -79,6 +83,318 @@ static LogicalResult runQCToQCOConversion(ModuleOp module) {
   PassManager pm(module.getContext());
   pm.addPass(createQCToQCO());
   return pm.run(module);
+}
+
+namespace {
+
+class QCToQCORegressionTest : public testing::Test {
+protected:
+  MLIRContext context;
+
+  QCToQCORegressionTest() {
+    DialectRegistry registry;
+    registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
+                    arith::ArithDialect, func::FuncDialect,
+                    memref::MemRefDialect, scf::SCFDialect>();
+    context.appendDialectRegistry(registry);
+    context.loadAllAvailableDialects();
+  }
+
+  void expectNoQCOperations(ModuleOp module) {
+    bool retainsQCOperations = false;
+    module.walk([&](Operation* operation) {
+      retainsQCOperations |=
+          operation->getDialect() == context.getLoadedDialect<qc::QCDialect>();
+    });
+    EXPECT_FALSE(retainsQCOperations);
+  }
+};
+
+} // namespace
+
+TEST_F(QCToQCORegressionTest, ConvertsCompleteMixedSCFQuantumState) {
+
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %qco = qco.alloc : !qco.qubit
+    %qc = qc.alloc : !qc.qubit
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %loop = scf.for %i = %c0 to %c1 step %c1
+        iter_args(%qco_arg = %qco) -> (!qco.qubit) {
+      qc.h %qc : !qc.qubit
+      scf.yield %qco_arg : !qco.qubit
+    }
+    qco.sink %loop : !qco.qubit
+    qc.dealloc %qc : !qc.qubit
+    return
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  bool sawMixedLoop = false;
+  module->walk([&](scf::ForOp loop) {
+    sawMixedLoop = true;
+    EXPECT_EQ(loop.getNumResults(), 2);
+    auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
+    EXPECT_EQ(yield.getNumOperands(), loop.getNumResults());
+    EXPECT_TRUE(llvm::equal(yield.getOperandTypes(), loop.getResultTypes()));
+  });
+  EXPECT_TRUE(sawMixedLoop);
+
+  expectNoQCOperations(*module);
+}
+
+TEST_F(QCToQCORegressionTest, PreservesResultBearingIfValues) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() -> i1 attributes {passthrough = ["entry_point"]} {
+    %qc = qc.alloc : !qc.qubit
+    %condition = arith.constant true
+    %result = scf.if %condition -> i1 {
+      qc.h %qc : !qc.qubit
+      %value = arith.constant false
+      scf.yield %value : i1
+    } else {
+      qc.x %qc : !qc.qubit
+      %value = arith.constant true
+      scf.yield %value : i1
+    }
+    qc.dealloc %qc : !qc.qubit
+    return %result : i1
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  ASSERT_EQ(main.getFunctionType().getNumResults(), 1);
+  EXPECT_TRUE(main.getFunctionType().getResult(0).isInteger(1));
+  expectNoQCOperations(*module);
+  qco::IfOp branch;
+  module->walk([&](qco::IfOp candidate) { branch = candidate; });
+  ASSERT_TRUE(branch);
+  const auto storedResult = [](Region& region) -> std::optional<APInt> {
+    for (auto store : region.front().getOps<memref::StoreOp>()) {
+      APInt value;
+      if (matchPattern(store.getValue(), m_ConstantInt(&value))) {
+        return value;
+      }
+    }
+    return std::nullopt;
+  };
+  const auto thenResult = storedResult(branch.getThenRegion());
+  const auto elseResult = storedResult(branch.getElseRegion());
+  ASSERT_TRUE(thenResult);
+  ASSERT_TRUE(elseResult);
+  EXPECT_TRUE(thenResult->isZero());
+  EXPECT_TRUE(elseResult->isOne());
+}
+
+TEST_F(QCToQCORegressionTest, PreservesWhileConditionArgumentsAndOrdering) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() -> i1 attributes {passthrough = ["entry_point"]} {
+    %qco = qco.alloc : !qco.qubit
+    %qc = qc.alloc : !qc.qubit
+    %true = arith.constant true
+    %result:2 = scf.while (%flag = %true, %qco_arg = %qco)
+        : (i1, !qco.qubit) -> (i1, !qco.qubit) {
+      qc.h %qc : !qc.qubit
+      %false = arith.constant false
+      scf.condition(%flag) %false, %qco_arg : i1, !qco.qubit
+    } do {
+    ^bb0(%flag: i1, %qco_arg: !qco.qubit):
+      qc.x %qc : !qc.qubit
+      scf.yield %flag, %qco_arg : i1, !qco.qubit
+    }
+    qco.sink %result#1 : !qco.qubit
+    qc.dealloc %qc : !qc.qubit
+    return %result#0 : i1
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+  bool sawWhile = false;
+  module->walk([&](scf::WhileOp loop) {
+    sawWhile = true;
+    ASSERT_EQ(loop.getNumResults(), 3);
+    EXPECT_TRUE(loop.getResult(0).getType().isInteger(1));
+    EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(1).getType()));
+    EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(2).getType()));
+    auto condition =
+        cast<scf::ConditionOp>(loop.getBeforeBody()->getTerminator());
+    EXPECT_TRUE(
+        llvm::equal(condition.getArgs().getTypes(), loop.getResultTypes()));
+    auto yield = cast<scf::YieldOp>(loop.getAfterBody()->getTerminator());
+    EXPECT_TRUE(llvm::equal(yield.getOperandTypes(), loop.getResultTypes()));
+  });
+  EXPECT_TRUE(sawWhile);
+  expectNoQCOperations(*module);
+  ASSERT_TRUE(succeeded(runQCOCleanupPipeline(*module)));
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  APInt result;
+  ASSERT_TRUE(matchPattern(returnOp.getOperand(0), m_ConstantInt(&result)));
+  EXPECT_TRUE(result.isZero());
+}
+
+TEST_F(QCToQCORegressionTest, ConvertsTypeChangingWhileWithQuantumState) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() -> i64 attributes {passthrough = ["entry_point"]} {
+    %qc = qc.alloc : !qc.qubit
+    %initial = arith.constant 1.0 : f32
+    %result = scf.while (%input = %initial) : (f32) -> i64 {
+      qc.h %qc : !qc.qubit
+      %condition = arith.constant true
+      %next = arith.constant 7 : i64
+      scf.condition(%condition) %next : i64
+    } do {
+    ^bb0(%input: i64):
+      qc.x %qc : !qc.qubit
+      %next = arith.sitofp %input : i64 to f32
+      scf.yield %next : f32
+    }
+    qc.dealloc %qc : !qc.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::WhileOp loop;
+  module->walk([&](scf::WhileOp candidate) { loop = candidate; });
+  ASSERT_TRUE(loop);
+  ASSERT_EQ(loop.getInits().size(), 2);
+  EXPECT_TRUE(isa<Float32Type>(loop.getInits().front().getType()));
+  EXPECT_TRUE(isa<qco::QubitType>(loop.getInits().back().getType()));
+  ASSERT_EQ(loop.getNumResults(), 2);
+  EXPECT_TRUE(loop.getResult(0).getType().isInteger(64));
+  EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(1).getType()));
+
+  auto condition =
+      cast<scf::ConditionOp>(loop.getBeforeBody()->getTerminator());
+  EXPECT_TRUE(
+      llvm::equal(condition.getArgs().getTypes(), loop.getResultTypes()));
+  auto yield = cast<scf::YieldOp>(loop.getAfterBody()->getTerminator());
+  EXPECT_TRUE(llvm::equal(yield.getOperandTypes(), loop.getInits().getTypes()));
+  expectNoQCOperations(*module);
+}
+
+TEST_F(QCToQCORegressionTest, ConvertsIndexSwitchWithQuantumState) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() -> i64 attributes {passthrough = ["entry_point"]} {
+    %qc = qc.alloc : !qc.qubit
+    %selector = arith.constant 0 : index
+    %result = scf.index_switch %selector -> i64
+    case 0 {
+      qc.h %qc : !qc.qubit
+      %value = arith.constant 1 : i64
+      scf.yield %value : i64
+    }
+    default {
+      qc.x %qc : !qc.qubit
+      %value = arith.constant 2 : i64
+      scf.yield %value : i64
+    }
+    qc.dealloc %qc : !qc.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  qco::IndexSwitchOp indexSwitch;
+  module->walk([&](qco::IndexSwitchOp candidate) { indexSwitch = candidate; });
+  ASSERT_TRUE(indexSwitch);
+  ASSERT_EQ(indexSwitch.getNumResults(), 1);
+  EXPECT_TRUE(isa<qco::QubitType>(indexSwitch.getResult(0).getType()));
+  for (auto& region : indexSwitch->getRegions()) {
+    ASSERT_EQ(region.getNumArguments(), 1);
+    EXPECT_TRUE(isa<qco::QubitType>(region.getArgument(0).getType()));
+    auto yield = cast<qco::YieldOp>(region.front().getTerminator());
+    ASSERT_EQ(yield.getNumOperands(), 1);
+    EXPECT_TRUE(isa<qco::QubitType>(yield.getOperand(0).getType()));
+  }
+  expectNoQCOperations(*module);
+}
+
+TEST_F(QCToQCORegressionTest, ConvertsNestedResultsAfterRegionContents) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() -> i1 attributes {passthrough = ["entry_point"]} {
+    %qco = qco.alloc : !qco.qubit
+    %qc = qc.alloc : !qc.qubit
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %true = arith.constant true
+    %loop:2 = scf.for %i = %c0 to %c1 step %c1
+        iter_args(%flag = %true, %qco_arg = %qco) -> (i1, !qco.qubit) {
+      %next = scf.if %flag -> i1 {
+        qc.h %qc : !qc.qubit
+        %value = arith.constant false
+        scf.yield %value : i1
+      } else {
+        qc.x %qc : !qc.qubit
+        %value = arith.constant true
+        scf.yield %value : i1
+      }
+      qc.z %qc : !qc.qubit
+      scf.yield %next, %qco_arg : i1, !qco.qubit
+    }
+    qco.sink %loop#1 : !qco.qubit
+    qc.dealloc %qc : !qc.qubit
+    return %loop#0 : i1
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+  bool sawLoop = false;
+  module->walk([&](scf::ForOp loop) {
+    sawLoop = true;
+    ASSERT_EQ(loop.getNumResults(), 3);
+    auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
+    EXPECT_TRUE(llvm::equal(yield.getOperandTypes(), loop.getResultTypes()));
+    EXPECT_TRUE(llvm::none_of(loop.getBody()->getOps<memref::AllocaOp>(),
+                              [](auto) { return true; }));
+  });
+  EXPECT_TRUE(sawLoop);
+  expectNoQCOperations(*module);
 }
 
 TEST_P(QCToQCOTest, ProgramEquivalence) {

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -14,7 +14,6 @@
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
-#include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
@@ -30,7 +29,6 @@
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Matchers.h>
-#include <mlir/IR/Region.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
@@ -38,7 +36,6 @@
 #include <mlir/Support/LogicalResult.h>
 
 #include <memory>
-#include <optional>
 #include <ostream>
 #include <string>
 

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -110,17 +110,6 @@ protected:
     });
     EXPECT_FALSE(retainsQCOperations);
   }
-
-  static void expectReturnLoadedFromScratch(ModuleOp module) {
-    auto main = module.lookupSymbol<func::FuncOp>("main");
-    ASSERT_TRUE(main);
-    auto returnOp =
-        cast<func::ReturnOp>(main.getBody().front().getTerminator());
-    ASSERT_EQ(returnOp.getNumOperands(), 1);
-    auto load = returnOp.getOperand(0).getDefiningOp<memref::LoadOp>();
-    ASSERT_TRUE(load);
-    EXPECT_TRUE(load.getMemref().getDefiningOp<memref::AllocaOp>());
-  }
 };
 
 } // namespace
@@ -163,58 +152,6 @@ module {
   EXPECT_TRUE(sawLoop);
 
   expectNoQCOperations(*module);
-}
-
-TEST_F(QCToQCORegressionTest, PreservesResultBearingIfValues) {
-  constexpr llvm::StringLiteral source = R"mlir(
-module {
-  func.func @main() -> i1 attributes {passthrough = ["entry_point"]} {
-    %qc = qc.alloc : !qc.qubit
-    %condition = arith.constant true
-    %result = scf.if %condition -> i1 {
-      qc.h %qc : !qc.qubit
-      %value = arith.constant false
-      scf.yield %value : i1
-    } else {
-      qc.x %qc : !qc.qubit
-      %value = arith.constant true
-      scf.yield %value : i1
-    }
-    qc.dealloc %qc : !qc.qubit
-    return %result : i1
-  }
-}
-)mlir";
-
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
-  auto main = module->lookupSymbol<func::FuncOp>("main");
-  ASSERT_TRUE(main);
-  ASSERT_EQ(main.getFunctionType().getNumResults(), 1);
-  EXPECT_TRUE(main.getFunctionType().getResult(0).isInteger(1));
-  expectNoQCOperations(*module);
-  expectReturnLoadedFromScratch(*module);
-  qco::IfOp branch;
-  module->walk([&](qco::IfOp candidate) { branch = candidate; });
-  ASSERT_TRUE(branch);
-  const auto storedResult = [](Region& region) -> std::optional<APInt> {
-    for (auto store : region.front().getOps<memref::StoreOp>()) {
-      APInt value;
-      if (matchPattern(store.getValue(), m_ConstantInt(&value))) {
-        return value;
-      }
-    }
-    return std::nullopt;
-  };
-  const auto thenResult = storedResult(branch.getThenRegion());
-  const auto elseResult = storedResult(branch.getElseRegion());
-  ASSERT_TRUE(thenResult);
-  ASSERT_TRUE(elseResult);
-  EXPECT_TRUE(thenResult->isZero());
-  EXPECT_TRUE(elseResult->isOne());
 }
 
 TEST_F(QCToQCORegressionTest, PreservesWhileConditionArgumentsAndOrdering) {
@@ -316,98 +253,6 @@ module {
       llvm::equal(condition.getArgs().getTypes(), loop.getResultTypes()));
   auto yield = cast<scf::YieldOp>(loop.getAfterBody()->getTerminator());
   EXPECT_TRUE(llvm::equal(yield.getOperandTypes(), loop.getInits().getTypes()));
-  expectNoQCOperations(*module);
-}
-
-TEST_F(QCToQCORegressionTest, ConvertsIndexSwitchWithQuantumState) {
-  constexpr llvm::StringLiteral source = R"mlir(
-module {
-  func.func @main() -> i64 attributes {passthrough = ["entry_point"]} {
-    %qc = qc.alloc : !qc.qubit
-    %selector = arith.constant 0 : index
-    %result = scf.index_switch %selector -> i64
-    case 0 {
-      qc.h %qc : !qc.qubit
-      %value = arith.constant 1 : i64
-      scf.yield %value : i64
-    }
-    default {
-      qc.x %qc : !qc.qubit
-      %value = arith.constant 2 : i64
-      scf.yield %value : i64
-    }
-    qc.dealloc %qc : !qc.qubit
-    return %result : i64
-  }
-}
-)mlir";
-
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
-
-  qco::IndexSwitchOp indexSwitch;
-  module->walk([&](qco::IndexSwitchOp candidate) { indexSwitch = candidate; });
-  ASSERT_TRUE(indexSwitch);
-  ASSERT_EQ(indexSwitch.getNumResults(), 1);
-  EXPECT_TRUE(isa<qco::QubitType>(indexSwitch.getResult(0).getType()));
-  for (auto& region : indexSwitch->getRegions()) {
-    ASSERT_EQ(region.getNumArguments(), 1);
-    EXPECT_TRUE(isa<qco::QubitType>(region.getArgument(0).getType()));
-    auto yield = cast<qco::YieldOp>(region.front().getTerminator());
-    ASSERT_EQ(yield.getNumOperands(), 1);
-    EXPECT_TRUE(isa<qco::QubitType>(yield.getOperand(0).getType()));
-  }
-  expectNoQCOperations(*module);
-  expectReturnLoadedFromScratch(*module);
-}
-
-TEST_F(QCToQCORegressionTest, ConvertsNestedResultsAfterRegionContents) {
-  constexpr llvm::StringLiteral source = R"mlir(
-module {
-  func.func @main() -> i1 attributes {passthrough = ["entry_point"]} {
-    %qc = qc.alloc : !qc.qubit
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %true = arith.constant true
-    %loop = scf.for %i = %c0 to %c1 step %c1
-        iter_args(%flag = %true) -> (i1) {
-      %next = scf.if %flag -> i1 {
-        qc.h %qc : !qc.qubit
-        %value = arith.constant false
-        scf.yield %value : i1
-      } else {
-        qc.x %qc : !qc.qubit
-        %value = arith.constant true
-        scf.yield %value : i1
-      }
-      qc.z %qc : !qc.qubit
-      scf.yield %next : i1
-    }
-    qc.dealloc %qc : !qc.qubit
-    return %loop : i1
-  }
-}
-)mlir";
-
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
-  bool sawLoop = false;
-  module->walk([&](scf::ForOp loop) {
-    sawLoop = true;
-    ASSERT_EQ(loop.getNumResults(), 2);
-    EXPECT_TRUE(loop.getResult(0).getType().isInteger(1));
-    EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(1).getType()));
-    auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
-    EXPECT_TRUE(llvm::equal(yield.getOperandTypes(), loop.getResultTypes()));
-    EXPECT_TRUE(loop.getBody()->getOps<memref::AllocaOp>().empty());
-  });
-  EXPECT_TRUE(sawLoop);
   expectNoQCOperations(*module);
 }
 

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -56,7 +56,8 @@ struct Device {
   DenseSet<std::pair<size_t, size_t>> couplingSet;
 };
 
-static SmallVector<Value> getQubitValues(ValueRange values) {
+// NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
+SmallVector<Value> getQubitValues(ValueRange values) {
   return to_vector(llvm::make_filter_range(
       values, [](Value value) { return isa<QubitType>(value.getType()); }));
 }

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Transforms/Mapping/Mapping.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
+#include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <gtest/gtest.h>
@@ -32,6 +33,8 @@
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/Passes.h>
@@ -52,6 +55,11 @@ struct Device {
   size_t nqubits{};
   DenseSet<std::pair<size_t, size_t>> couplingSet;
 };
+
+static SmallVector<Value> getQubitValues(ValueRange values) {
+  return to_vector(llvm::make_filter_range(
+      values, [](Value value) { return isa<QubitType>(value.getType()); }));
+}
 } // namespace
 
 /// Return true, if the operations within a region fulfill the given coupling
@@ -111,8 +119,8 @@ isExecutable(Region& body, DenseMap<Value, size_t>& m,
                   [&](scf::ForOp forOp) { return forOp.getInits(); })
               .Default([](Operation*) -> ValueRange { return {}; });
 
-      const auto initialHardwareOrder =
-          to_vector(llvm::map_range(initArgs, [&](auto v) { return m.at(v); }));
+      const auto initialHardwareOrder = to_vector(llvm::map_range(
+          getQubitValues(initArgs), [&](auto v) { return m.at(v); }));
 
       const auto qubitArgs =
           llvm::make_filter_range(region.getArguments(), [](auto& arg) {
@@ -145,8 +153,9 @@ isExecutable(Region& body, DenseMap<Value, size_t>& m,
               })
               .Default([](Operation*) -> ValueRange { return {}; });
 
-      const auto finalOrder = to_vector(llvm::map_range(
-          finalOrderArgs, [&](auto v) { return localM.at(v); }));
+      const auto finalOrder =
+          to_vector(llvm::map_range(getQubitValues(finalOrderArgs),
+                                    [&](auto v) { return localM.at(v); }));
 
       if (finalOrder != initialHardwareOrder) {
         llvm::dbgs()
@@ -157,6 +166,9 @@ isExecutable(Region& body, DenseMap<Value, size_t>& m,
     }
 
     for (OpResult res : op.getResults()) {
+      if (!isa<QubitType>(res.getType())) {
+        continue;
+      }
       const Value init = TypeSwitch<Operation*, Value>(&op)
                              .Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
                                return whileOp.getInits()[res.getResultNumber()];
@@ -239,8 +251,8 @@ class MappingPassTest : public testing::Test,
 protected:
   void SetUp() override {
     DialectRegistry registry;
-    registry.insert<QCODialect, scf::SCFDialect, arith::ArithDialect,
-                    func::FuncDialect>();
+    registry.insert<QCODialect, qtensor::QTensorDialect, scf::SCFDialect,
+                    arith::ArithDialect, func::FuncDialect>();
     context = std::make_unique<MLIRContext>();
     context->appendDialectRegistry(registry);
     context->loadAllAvailableDialects();
@@ -567,6 +579,104 @@ TEST_P(MappingPassTest, MapParallelLoops) {
 
   ASSERT_TRUE(res.succeeded());
   EXPECT_TRUE(isExecutable(entry, device.couplingSet));
+}
+
+TEST_P(MappingPassTest, MapForWithClassicalIterArg) {
+  const auto& device = GetParam();
+  constexpr StringLiteral source = R"mlir(
+    module {
+      func.func @main() -> i64 attributes {passthrough = ["entry_point"]} {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %c2 = arith.constant 2 : index
+        %state = arith.constant 0 : i64
+        %one = arith.constant 1 : i64
+        %tensor0 = qtensor.alloc(%c2) : tensor<2x!qco.qubit>
+        %tensor1, %q0 = qtensor.extract %tensor0[%c0] : tensor<2x!qco.qubit>
+        %tensor2, %q1 = qtensor.extract %tensor1[%c1] : tensor<2x!qco.qubit>
+        %next_state, %next_q0, %next_q1 =
+            scf.for %iv = %c0 to %c2 step %c1
+                iter_args(%iter_state = %state, %iter_q0 = %q0,
+                          %iter_q1 = %q1)
+                -> (i64, !qco.qubit, !qco.qubit) {
+          %updated_state = arith.addi %iter_state, %one : i64
+          %updated_q0, %updated_q1 =
+              qco.swap %iter_q0, %iter_q1
+                  : !qco.qubit, !qco.qubit -> !qco.qubit, !qco.qubit
+          scf.yield %updated_state, %updated_q0, %updated_q1
+              : i64, !qco.qubit, !qco.qubit
+        }
+        %tensor3 = qtensor.insert %next_q0 into %tensor2[%c0]
+            : tensor<2x!qco.qubit>
+        %tensor4 = qtensor.insert %next_q1 into %tensor3[%c1]
+            : tensor<2x!qco.qubit>
+        qtensor.dealloc %tensor4 : tensor<2x!qco.qubit>
+        return %next_state : i64
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(verify(*module).succeeded());
+
+  ASSERT_TRUE(runPass(module.get(), device.couplingSet,
+                      MappingPassOptions{.ntrials = 1})
+                  .succeeded());
+  EXPECT_TRUE(verify(*module).succeeded());
+  EXPECT_TRUE(isExecutable(getEntryPoint(module.get()), device.couplingSet));
+}
+
+TEST_P(MappingPassTest, MapTypeChangingWhileWithClassicalState) {
+  const auto& device = GetParam();
+  constexpr StringLiteral source = R"mlir(
+    module {
+      func.func @main() -> i64 attributes {passthrough = ["entry_point"]} {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %c2 = arith.constant 2 : index
+        %false = arith.constant false
+        %state = arith.constant 0 : i32
+        %tensor0 = qtensor.alloc(%c2) : tensor<2x!qco.qubit>
+        %tensor1, %q0 = qtensor.extract %tensor0[%c0] : tensor<2x!qco.qubit>
+        %tensor2, %q1 = qtensor.extract %tensor1[%c1] : tensor<2x!qco.qubit>
+        %next_state, %next_q0, %next_q1 =
+            scf.while (%iter_state = %state, %iter_q0 = %q0,
+                       %iter_q1 = %q1)
+                : (i32, !qco.qubit, !qco.qubit)
+                  -> (i64, !qco.qubit, !qco.qubit) {
+          %extended_state = arith.extsi %iter_state : i32 to i64
+          %updated_q0, %updated_q1 =
+              qco.swap %iter_q0, %iter_q1
+                  : !qco.qubit, !qco.qubit -> !qco.qubit, !qco.qubit
+          scf.condition(%false) %extended_state, %updated_q0, %updated_q1
+              : i64, !qco.qubit, !qco.qubit
+        } do {
+        ^bb0(%after_state: i64, %after_q0: !qco.qubit,
+             %after_q1: !qco.qubit):
+          %truncated_state = arith.trunci %after_state : i64 to i32
+          scf.yield %truncated_state, %after_q0, %after_q1
+              : i32, !qco.qubit, !qco.qubit
+        }
+        %tensor3 = qtensor.insert %next_q0 into %tensor2[%c0]
+            : tensor<2x!qco.qubit>
+        %tensor4 = qtensor.insert %next_q1 into %tensor3[%c1]
+            : tensor<2x!qco.qubit>
+        qtensor.dealloc %tensor4 : tensor<2x!qco.qubit>
+        return %next_state : i64
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(verify(*module).succeeded());
+
+  ASSERT_TRUE(runPass(module.get(), device.couplingSet,
+                      MappingPassOptions{.ntrials = 1})
+                  .succeeded());
+  EXPECT_TRUE(verify(*module).succeeded());
+  EXPECT_TRUE(isExecutable(getEntryPoint(module.get()), device.couplingSet));
 }
 
 TEST_P(MappingPassTest, MapSABRECircuit) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Preserve existing classical iteration arguments and results when the QC-to-QCO conversion appends explicit QCO and QTensor state to `scf.for` and `scf.while`.
- Preserve the distinct input and result signatures of type-changing `scf.while` operations, including reordered `scf.condition` arguments.
- Lower affected structured terminators in a second conversion phase so their operands use the final region state instead of depending on dialect-conversion traversal order.
- Teach QCO mapping to distinguish classical loop state from qubit state, preserve classical terminator operands during hot routing, and extend type-changing `scf.while` regions with the correct before/after signatures.
- Add focused pure-QC conversion regressions and mixed-state mapping regressions for `for` and `while`.
- Add this general conversion fix to the existing MLIR infrastructure changelog entry.

## Context

This conversion gap was found while working on OpenQASM control flow in #1910. The fix is independent of that frontend: any QC producer can create valid `scf.for` or `scf.while` operations whose existing classical values must survive conversion while quantum state is made explicit.

## Scope

This PR is limited to stable `scf.for` and `scf.while` state preservation. It intentionally does not add classical results to `qco.if` or `qco.index_switch`, and it introduces no scratch allocations, stores, or loads. Classical `qco.if` results are being designed separately as an SSA-based extension.

## Validation

- QC-to-QCO conversion tests: 132 passed
- QCO mapping tests: 13 passed
- Focused structured-control-flow conversion regressions: 4 passed
- Focused mixed-state mapping regressions: 2 passed
- `uvx nox -s lint`
- `git diff --check`
