### PR TITLE
🐛 Traverse reordered while tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ releases may include breaking changes.
   [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717],
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
-  [#1886], [#1914], [#1925]) ([**@burgholzer**], [**@denialhaag**],
+  [#1886], [#1914], [#1925], [#1936]) ([**@burgholzer**], [**@denialhaag**],
   [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
   [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 
@@ -651,6 +651,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1936]: https://github.com/munich-quantum-toolkit/core/pull/1936
 [#1933]: https://github.com/munich-quantum-toolkit/core/pull/1933
 [#1925]: https://github.com/munich-quantum-toolkit/core/pull/1925
 [#1924]: https://github.com/munich-quantum-toolkit/core/pull/1924

--- a/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
+++ b/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
@@ -34,6 +34,51 @@ TypedValue<RankedTensorType> TensorIterator::tensor() const {
   return tensor_;
 }
 
+[[nodiscard]] static TypedValue<RankedTensorType>
+whileResultForInit(scf::WhileOp op, OpOperand& init) {
+  auto current = cast<TypedValue<RankedTensorType>>(
+      op.getBeforeBody()->getArgument(init.getOperandNumber()));
+  TensorIterator iterator(current);
+  while (true) {
+    assert(current.hasOneUse() && "expected linear typing");
+    auto* user = *current.user_begin();
+    if (auto condition = dyn_cast<scf::ConditionOp>(user)) {
+      const auto result = llvm::find(condition.getArgs(), current);
+      if (result == condition.getArgs().end()) {
+        llvm::reportFatalInternalError(
+            "expected scf.while tensor in condition arguments");
+      }
+      const auto resultNumber = static_cast<size_t>(
+          std::distance(condition.getArgs().begin(), result));
+      return cast<TypedValue<RankedTensorType>>(op.getResult(resultNumber));
+    }
+    ++iterator;
+    if (iterator == std::default_sentinel) {
+      llvm::reportFatalInternalError(
+          "expected scf.while tensor to reach its condition");
+    }
+    current = iterator.tensor();
+  }
+}
+
+[[nodiscard]] static TypedValue<RankedTensorType>
+whileInitForResult(scf::WhileOp op, const OpResult result) {
+  auto condition = cast<scf::ConditionOp>(op.getBeforeBody()->getTerminator());
+  auto current = cast<TypedValue<RankedTensorType>>(
+      condition.getArgs()[result.getResultNumber()]);
+  TensorIterator iterator(current);
+  while (iterator.operation() != nullptr) {
+    --iterator;
+  }
+  auto argument = dyn_cast<BlockArgument>(iterator.tensor());
+  if (!argument || argument.getOwner() != op.getBeforeBody()) {
+    llvm::reportFatalInternalError(
+        "expected scf.while tensor to originate from a before-region argument");
+  }
+  return cast<TypedValue<RankedTensorType>>(
+      op.getInits()[argument.getArgNumber()]);
+}
+
 void TensorIterator::forward() {
   // If the iterator is a sentinel already, there is nothing to do.
   if (isSentinel_) {
@@ -64,6 +109,9 @@ void TensorIterator::forward() {
         .Case<scf::ForOp>([&](scf::ForOp op) {
           tensor_ = cast<TypedValue<RankedTensorType>>(
               op.getTiedLoopResult(&*(tensor_.use_begin())));
+        })
+        .Case<scf::WhileOp>([&](scf::WhileOp op) {
+          tensor_ = whileResultForInit(op, *tensor_.use_begin().getOperand());
         })
         .Case<qco::IfOp>([&](qco::IfOp op) {
           auto it = llvm::find(op.getQubits(), tensor_);
@@ -122,6 +170,15 @@ void TensorIterator::backward() {
 
         llvm::reportFatalInternalError(
             "expected scf.for result for tied init lookup");
+      })
+      .Case<scf::WhileOp>([&](scf::WhileOp op) {
+        if (auto result = dyn_cast<OpResult>(tensor_)) {
+          tensor_ = whileInitForResult(op, result);
+          return;
+        }
+
+        llvm::reportFatalInternalError(
+            "expected scf.while result for tied init lookup");
       })
       .Case<qco::IfOp>([&](qco::IfOp op) {
         if (auto res = dyn_cast<OpResult>(tensor_)) {

--- a/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
+++ b/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
@@ -22,6 +22,7 @@
 #include <mlir/Support/LLVM.h>
 
 #include <cassert>
+#include <cstddef>
 #include <iterator>
 
 namespace mlir::qtensor {
@@ -48,7 +49,7 @@ whileResultForInit(scf::WhileOp op, OpOperand& init) {
         llvm::reportFatalInternalError(
             "expected scf.while tensor in condition arguments");
       }
-      const auto resultNumber = static_cast<size_t>(
+      const auto resultNumber = static_cast<std::size_t>(
           std::distance(condition.getArgs().begin(), result));
       return cast<TypedValue<RankedTensorType>>(op.getResult(resultNumber));
     }

--- a/mlir/unittests/Dialect/QTensor/Utils/test_tensoriterator.cpp
+++ b/mlir/unittests/Dialect/QTensor/Utils/test_tensoriterator.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
+#include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/QTensor/Utils/TensorIterator.h"
 
 #include <gtest/gtest.h>
@@ -24,6 +25,7 @@
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/Verifier.h>
 #include <mlir/Support/LLVM.h>
 
 #include <cstdint>
@@ -255,4 +257,74 @@ TEST_F(TensorIteratorTest, Traversal) {
   --recIt;
   ASSERT_EQ(recIt.operation(), nullptr);
   ASSERT_EQ(recIt.tensor(), tensorElse0);
+}
+
+TEST_F(TensorIteratorTest, TraversesWhileCarriedTensors) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  auto scalar0 = builder.floatConstant(1.0);
+  auto tensor0 = builder.qtensorAlloc(2);
+  auto tensor1 = builder.qtensorAlloc(3);
+  auto loop = scf::WhileOp::create(
+      builder, builder.getLoc(),
+      TypeRange{builder.getI64Type(), tensor1.getType(), tensor0.getType()},
+      ValueRange{scalar0, tensor0, tensor1});
+  const SmallVector locations(3, builder.getLoc());
+  auto* before = builder.createBlock(
+      &loop.getBefore(), {}, ValueRange{scalar0, tensor0, tensor1}.getTypes(),
+      locations);
+  builder.setInsertionPointToStart(before);
+  auto scalar1 = builder.intConstant(1);
+  scf::ConditionOp::create(
+      builder, builder.getLoc(), builder.boolConstant(false),
+      ValueRange{scalar1, before->getArgument(2), before->getArgument(1)});
+  auto* after = builder.createBlock(&loop.getAfter(), {}, loop.getResultTypes(),
+                                    locations);
+  builder.setInsertionPointToStart(after);
+  scf::YieldOp::create(builder, builder.getLoc(),
+                       ValueRange{builder.floatConstant(2.0),
+                                  after->getArgument(2),
+                                  after->getArgument(1)});
+  builder.setInsertionPointAfter(loop);
+  auto tensor0Result = loop.getResult(2);
+  auto tensor1Result = loop.getResult(1);
+  qtensor::DeallocOp::create(builder, builder.getLoc(), tensor0Result);
+  qtensor::DeallocOp::create(builder, builder.getLoc(), tensor1Result);
+  ASSERT_TRUE(succeeded(verify(loop)));
+
+  TensorIterator iterator(cast<TypedValue<RankedTensorType>>(tensor0));
+  ASSERT_EQ(iterator.operation(), tensor0.getDefiningOp());
+  ASSERT_EQ(iterator.tensor(), tensor0);
+
+  ++iterator;
+  ASSERT_TRUE(isa<scf::WhileOp>(iterator.operation()));
+  ASSERT_EQ(iterator.tensor(), tensor0Result);
+
+  ++iterator;
+  ASSERT_TRUE(isa<qtensor::DeallocOp>(iterator.operation()));
+  ASSERT_EQ(iterator.tensor(), nullptr);
+
+  ++iterator;
+  ASSERT_EQ(iterator, std::default_sentinel);
+
+  --iterator;
+  ASSERT_TRUE(isa<qtensor::DeallocOp>(iterator.operation()));
+  ASSERT_EQ(iterator.tensor(), nullptr);
+
+  --iterator;
+  ASSERT_TRUE(isa<scf::WhileOp>(iterator.operation()));
+  ASSERT_EQ(iterator.tensor(), tensor0Result);
+
+  --iterator;
+  ASSERT_EQ(iterator.operation(), tensor0.getDefiningOp());
+  ASSERT_EQ(iterator.tensor(), tensor0);
+
+  TensorIterator swapped(cast<TypedValue<RankedTensorType>>(tensor1));
+  ++swapped;
+  ASSERT_TRUE(isa<scf::WhileOp>(swapped.operation()));
+  ASSERT_EQ(swapped.tensor(), tensor1Result);
+  --swapped;
+  ASSERT_EQ(swapped.operation(), tensor1.getDefiningOp());
+  ASSERT_EQ(swapped.tensor(), tensor1);
 }


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Teach `TensorIterator` to follow tensor values through `scf.while`.
- Resolve the actual before-region argument → condition operand → result mapping
  instead of assuming positional identity.
- Support backward traversal from a while result to its corresponding init
  value.
- Add a regression test with reordered classical and tensor values.
- Add this general SCF/QTensor fix to the existing MLIR infrastructure changelog
  entry.

## Context

This general SCF/QTensor issue was found while working on loop lowering for the
OpenQASM integration in #1910. It is independent of the frontend and applies to
any pipeline that carries linearly typed quantum tensors through `scf.while`.

## Validation

- QTensor utility tests: 2 passed
- `uvx prek run --from-ref origin/main --to-ref HEAD`
- `git diff --check origin/main...HEAD`
