### PR TITLE
✨ Support classical results in QCO conditionals

### DIFF
--- a/.agent/plans/qco-if-classical-results.md
+++ b/.agent/plans/qco-if-classical-results.md
@@ -63,10 +63,10 @@ their consumers while QCO's explicit single-use quantum flow remains intact.
 - [x] (2026-07-24 22:47Z) Move the QC-to-QCO-to-QC composition regressions into
       a dedicated round-trip test target so each directional conversion test
       links only its own conversion library.
-- [ ] Rebuild the affected targets, run focused suites and repository lint,
-      independently verify the follow-up, and record the final evidence
-      (completed: 718 affected tests, changed-source clang-tidy, repository
-      lint, and `git diff --check`; remaining: independent verification).
+- [x] (2026-07-24 22:53Z) Rebuild the affected targets, pass 718 affected tests,
+      pass changed-source clang-tidy and repository lint, run
+      `git diff --check`, and complete an independent read-only verification of
+      the follow-up.
 
 ## Surprises & Discoveries
 
@@ -204,8 +204,10 @@ regressions and a dedicated two-test QC/QCO round-trip target preserve both
 layers of coverage. The affected debug suites pass 451 QCO IR, 131 QCO-to-QC,
 134 QC-to-QCO, and 2 round-trip tests. LLVM 22.1.8 clang-tidy reports no
 diagnostics in the changed source files, repository lint passes, and
-`git diff --check` is clean. Independent verification of this follow-up remains
-before publication.
+`git diff --check` is clean. Independent read-only verification confirmed that
+the patterns preserve the quantum bundle and result-segment metadata, that no
+generic region-branch patterns are registered, and that each directional test
+target now owns only its conversion dependency.
 
 ## Context and Orientation
 

--- a/.agent/plans/qco-if-classical-results.md
+++ b/.agent/plans/qco-if-classical-results.md
@@ -67,6 +67,9 @@ their consumers while QCO's explicit single-use quantum flow remains intact.
       pass changed-source clang-tidy and repository lint, run
       `git diff --check`, and complete an independent read-only verification of
       the follow-up.
+- [x] (2026-07-24 23:19Z) Merge current `origin/main` after PR #1939, preserve
+      both Jeff round-trip regression families, pass 836 affected tests and
+      repository lint, and prepare the exact merged head for publication.
 
 ## Surprises & Discoveries
 
@@ -127,6 +130,10 @@ their consumers while QCO's explicit single-use quantum flow remains intact.
   suite now starts from QCO text for both conditional forms, while
   `mlir/unittests/Conversion/QCQCORoundTrip/` explicitly owns the two-pass tests
   and their intentional two-library dependency.
+- Observation: PR #1939 touched the same Jeff round-trip test file but a
+  different contract. Git merged its entry-point return-placement regression
+  cleanly alongside this change's precise rejection test for classical
+  conditional results, and the complete 118-test Jeff round-trip suite passes.
 
 ## Decision Log
 
@@ -208,6 +215,11 @@ diagnostics in the changed source files, repository lint passes, and
 the patterns preserve the quantum bundle and result-segment metadata, that no
 generic region-branch patterns are registered, and that each directional test
 target now owns only its conversion dependency.
+
+After merging `origin/main` at `013aef0de`, the complete QCO IR, QCO-to-QC,
+QC-to-QCO, QC/QCO round-trip, and Jeff round-trip suites pass 836 tests in
+total. Repository lint and both working-tree and branch diff checks pass on the
+merged exact head.
 
 ## Context and Orientation
 

--- a/.agent/plans/qco-if-classical-results.md
+++ b/.agent/plans/qco-if-classical-results.md
@@ -9,14 +9,14 @@ repository root.
 
 ## Purpose / Big Picture
 
-After this change, a QC program can use an `scf.if` to compute ordinary
-classical values while also updating quantum state, convert to QCO, and convert
-back to QC without allocating scratch memory or losing either kind of result.
-The QCO dialect will represent that behavior directly: a `qco.if` returns an
-ordinary SSA-value prefix followed by the existing linear quantum-value suffix.
-Focused dialect, conversion, mapping, and round-trip tests will demonstrate that
-the classical value remains connected to its consumer while QCO's explicit
-single-use quantum flow remains intact.
+After this change, a QC program can use an `scf.if` or `scf.index_switch` to
+compute ordinary classical values while also updating quantum state, convert to
+QCO, and convert back to QC without allocating scratch memory or losing either
+kind of result. The QCO dialect will represent that behavior directly: `qco.if`
+and `qco.index_switch` return an ordinary SSA-value prefix followed by the
+existing linear quantum-value suffix. Focused dialect, conversion, mapping, and
+round-trip tests will demonstrate that classical values remain connected to
+their consumers while QCO's explicit single-use quantum flow remains intact.
 
 ## Progress
 
@@ -38,9 +38,24 @@ single-use quantum flow remains intact.
       diagnostic regressions.
 - [x] (2026-07-24 19:42Z) Build the affected targets, run focused and complete
       suites, run `uvx nox -s lint`, and record the evidence here.
-- [ ] Keep the branch local until the prerequisite structured-loop PR is merged;
-      rebase then prepare it for human review without opening a PR
-      automatically.
+- [x] (2026-07-24 21:08Z) Rebase the two local commits onto the merge of the
+      prerequisite structured-loop PR #1935 without replaying its historical
+      commits.
+- [x] (2026-07-24 21:34Z) Extend `qco.index_switch`, its parser, printer,
+      verifier, tied-value helpers, target extension, region-branch interface,
+      builders, and equivalence support for mixed classical and linear results.
+- [x] (2026-07-24 21:34Z) Preserve classical `scf.index_switch` results through
+      QC-to-QCO and QCO-to-QC without scratch storage and add focused round-trip
+      regressions.
+- [x] (2026-07-24 22:07Z) Extend mapping, tensor traversal, and module
+      equivalence to distinguish each conditional's classical prefix from its
+      tied linear suffix.
+- [x] (2026-07-24 22:21Z) Rebuild all affected targets, pass 932 focused tests,
+      pass repository lint and changed-source clang-tidy, and run
+      `git diff --check`.
+- [x] (2026-07-24 23:31Z) Complete an independent read-only review, fix its
+      positional-classical-yield equivalence finding, rerun validation, and keep
+      the branch local for human inspection.
 
 ## Surprises & Discoveries
 
@@ -66,6 +81,29 @@ single-use quantum flow remains intact.
 - Observation: the MLIR parser verifies operations before returning a module.
   Invalid mixed yields are therefore rejected during `parseSourceString`,
   allowing tests to assert the precise `qco.yield` diagnostic directly.
+- Observation: GitHub merged PR #1935 as one commit, so a plain rebase tried to
+  replay its historical commits. Rebasing only the two commits after `cc5b3ed46`
+  moved the local plan and feature cleanly onto merge commit `745149687`.
+- Observation: `qco.index_switch` used the full result list to infer the types
+  of its region arguments. Once classical results are added, the assignment list
+  itself must define the number of trailing linear result types. The parser now
+  uses that count consistently for every case and the default.
+- Observation: QCO's module-equivalence and tensor-iterator utilities assumed
+  all conditional results were linear. Mixed results exposed incorrect result
+  indexing for both `qco.if` and `qco.index_switch`; the utilities now map the
+  classical prefix positionally and traverse only the tied linear suffix.
+- Observation: mapping had recursive handling for `qco.if` but no equivalent
+  handling for the already-existing `qco.index_switch`. Supporting mixed index
+  switches therefore also required making every case and the default region a
+  routing child, extending their explicit targets, and realigning only their
+  yielded linear suffixes. The focused mapping regression exercises two cases, a
+  default, one classical result, and two quantum wires.
+- Observation: the independent review found that module equivalence still
+  compared every `qco.yield` operand as a permutation, even though the new
+  classical result prefixes are positional. The comparison now checks the
+  classical prefix through `IRMapping` in order and permits permutation only for
+  the tied linear suffix. Regressions cover swapped and duplicate classical
+  values for both conditional operation forms.
 
 ## Decision Log
 
@@ -81,10 +119,11 @@ single-use quantum flow remains intact.
   a parent-aware verifier. Rationale: one terminator can then express mixed
   conditional results without weakening modifier or index-switch semantics.
   Date/Author: 2026-07-24, Codex.
-- Decision: Do not add classical results to `qco.index_switch` in this change.
-  Rationale: its parser, result layout, mapping, and both conversions form a
-  separate reviewable surface. QC-to-QCO must diagnose that case explicitly
-  rather than use scratch memory. Date/Author: 2026-07-24, Codex.
+- Decision: Add classical results to `qco.index_switch` in the same change,
+  superseding the earlier decision to defer them. Rationale: the user requested
+  one coherent conditional-result contract, and index switches can use the exact
+  same classical-prefix, linear-suffix representation without scratch memory or
+  a separate abstraction. Date/Author: 2026-07-24, Codex.
 - Decision: Jeff conversion may reject classical-result `qco.if` with a precise
   capability diagnostic. Rationale: QC to QCO to QC to QIR is the primary
   pipeline; Jeff limitations must be explicit but must not constrain valid QCO
@@ -93,21 +132,33 @@ single-use quantum flow remains intact.
   `qco.if` until it can preserve `resultSegmentSizes`. Rationale: retaining the
   QCO-specific patterns is both smaller and correct for mixed results.
   Date/Author: 2026-07-24, Codex.
+- Decision: Restore every mapped `qco.index_switch` region to the parent layout
+  before joining instead of attempting pairwise branch convergence. Rationale:
+  an index switch has an arbitrary number of regions, and a single explicit
+  parent-layout invariant is simpler, deterministic, and reuses the existing
+  `qco.if` yield-realignment machinery. Date/Author: 2026-07-24, Codex.
 
 ## Outcomes & Retrospective
 
-The implementation avoids runtime memory operations and limits the dialect
-change to one conditional operation plus its shared terminator. Focused tests
-demonstrate textual round-tripping, verifier diagnostics, constant folding,
-QC-to-QCO and QCO-to-QC conversion, a composed round trip, mapping, and the
-intentional Jeff and index-switch capability diagnostics.
+The implementation avoids runtime memory operations and gives both QCO
+conditional operations the same explicit contract: ordinary classical SSA
+results followed by tied linear quantum results. The index-switch extension
+removes its former conversion rejection and covers parser/printer behavior,
+verification, region-branch and tied-value interfaces, builders, module
+equivalence, tensor traversal, mapping, and both conversion directions.
 
-All affected suites pass: 447 QCO IR tests, 134 QC-to-QCO tests, 131 QCO-to-QC
-tests, 14 mapping tests, 82 QCO utility tests, and 117 Jeff round-trip tests.
-The changed C++ files produce no local clang-tidy 22 warnings. Targeted
-repository hooks, `uvx nox -s lint`, and `git diff --check` pass. The branch
-remains local on top of the reduced structured-loop PR and awaits that PR's
-merge before rebasing and publication.
+After rebuilding the affected targets, the complete focused suites passed: 450
+QCO IR tests, 134 QC-to-QCO tests, 132 QCO-to-QC tests, 82 QCO utility tests, 3
+QTensor utility tests, 15 mapping tests, and 117 Jeff round-trip tests, for 933
+tests in total. Repository lint and changed-source clang-tidy also passed; the
+only direct clang-tidy diagnostics outside the filtered source lines were known
+generated-MLIR warnings and an analyzer warning in MLIR's
+`OperationState::getOrAddProperties`.
+
+The independent read-only review passed the IR design, conversions, mapping,
+tensor traversal, performance, compatibility, tests, and scope after identifying
+one module-equivalence correctness issue and one documentation mismatch. Both
+were fixed and revalidated. The branch remains local.
 
 ## Context and Orientation
 
@@ -119,12 +170,14 @@ consumes a quantum value and produces its successor. The conversion in
 an SCF region and appends explicit state. The reverse conversion lives in
 `mlir/lib/Conversion/QCOToQC/QCOToQC.cpp`.
 
-`qco.if` is declared in `mlir/include/mlir/Dialect/QCO/IR/QCOOps.td`, with
-hand-written parsing, printing, verification, tied-value helpers, and
-replacement helpers in `mlir/lib/Dialect/QCO/IR/QCOOps.cpp`. Its regions receive
-only linear quantum block arguments and end in `qco.yield`. `qco.yield` is also
-used by `qco.index_switch`, `qco.ctrl`, `qco.inv`, and `qco.pow`, so changes to
-its ODS type constraint must be paired with parent-specific verification.
+`qco.if` and `qco.index_switch` are declared in
+`mlir/include/mlir/Dialect/QCO/IR/QCOOps.td`, with hand-written parsing,
+printing, verification, tied-value helpers, and replacement helpers in
+`mlir/lib/Dialect/QCO/IR/QCOOps.cpp` and `mlir/lib/Dialect/QCO/IR/SCF/`. Their
+regions receive only linear quantum block arguments and end in `qco.yield`.
+`qco.yield` is also used by `qco.ctrl`, `qco.inv`, and `qco.pow`, so its
+generalized ODS type constraint must remain paired with parent-specific
+verification.
 
 QCO mapping in `mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp` extends
 structured operations with all physical qubits and may reorder yielded quantum
@@ -169,26 +222,31 @@ classical segment and discovered quantum targets as its linear segment. Move the
 regions, let the existing second terminator-conversion phase yield original
 classical values followed by resolved quantum values, replace the original SCF
 results with `getClassicalResults()`, and update quantum mappings from
-`getLinearResults()`. Leave an `scf.if` with no quantum state unchanged. Reject
-a result-bearing `scf.index_switch` with a precise unsupported-feature
-diagnostic.
+`getLinearResults()`. Leave an `scf.if` with no quantum state unchanged. Apply
+the same segmentation to `scf.index_switch`: preserve its original results as
+the classical prefix, append discovered quantum state as the linear suffix, and
+give each new QCO region only linear block arguments.
 
 In QCO-to-QC, create an `scf.if` that returns only the converted classical
 types. Replace its linear block arguments with QC references when inlining the
 regions, lower each `qco.yield` to an `scf.yield` containing only its classical
 prefix, and replace the QCO operation with the new classical SCF results plus
 the corresponding QC references for its linear results. Preserve an else region
-whenever classical results exist. In QCO-to-Jeff, reject a classical-result
-`qco.if` with a feature-specific message before generic conversion fails.
+whenever classical results exist. Lower `qco.index_switch` identically to a
+result-bearing `scf.index_switch`, retaining the classical yield prefix and
+replacing only its linear results with QC references. In QCO-to-Jeff, reject a
+classical-result `qco.if` with a feature-specific message before generic
+conversion fails.
 
 Add tests close to each contract. Dialect tests must cover textual round-trip,
 invalid segment and yield signatures, tied-value offsets, region-branch
 relationships, and constant-condition canonicalization. Conversion tests must
-cover QC-to-QCO, QCO-to-QC, nested conditionals in loops, and a full
-QC-to-QCO-to-QC round trip while asserting that no `memref.alloca`, store, or
-load exists. Mapping tests must force quantum permutation and prove the
-classical yield remains connected. Jeff and index-switch tests must check their
-specific diagnostics. Existing quantum-only suites must continue to pass.
+cover QC-to-QCO, QCO-to-QC, both conditional operation forms, nested
+conditionals in loops, and a full QC-to-QCO-to-QC round trip while asserting
+that no `memref.alloca`, store, or load exists. Mapping tests must force quantum
+permutation and prove the classical yield remains connected. Jeff tests must
+check the target-specific diagnostic. Existing quantum-only suites must continue
+to pass.
 
 ## Concrete Steps
 
@@ -216,24 +274,25 @@ unsupported behavior.
 
 ## Validation and Acceptance
 
-A parsed and verified `qco.if` with one `i1` result and one `!qco.qubit` result
-must print and parse again with the same two result segments. Each branch must
-yield exactly `i1, !qco.qubit`; placing a qubit in the classical segment or
-yielding a classical value from a modifier must fail verification with a
-specific diagnostic.
+A parsed and verified `qco.if` or `qco.index_switch` with one `i1` result and
+one `!qco.qubit` result must print and parse again with the same two result
+segments. Each region must yield exactly `i1, !qco.qubit`; placing a qubit in
+the classical segment or yielding a classical value from a modifier must fail
+verification with a specific diagnostic.
 
-A QC module containing a result-bearing `scf.if` and quantum operations in both
-branches must convert to a verified QCO module containing a mixed-result
-`qco.if`. Its classical result must feed the original consumer, and the module
-must contain no scratch allocation, store, or load. Converting that module back
-to QC must produce a verified result-bearing `scf.if`; an end-to-end round-trip
-test must preserve the observable classical return value.
+A QC module containing a result-bearing `scf.if` or `scf.index_switch` and
+quantum operations in every region must convert to a verified QCO module
+containing the corresponding mixed-result operation. Its classical result must
+feed the original consumer, and the module must contain no scratch allocation,
+store, or load. Converting that module back to QC must reproduce the
+result-bearing SCF operation; end-to-end round-trip tests must preserve the
+observable classical return value.
 
-The QCO mapping pass must succeed on a mixed-result `qco.if`, leave the module
-verified, preserve the classical yield values, and produce executable two-qubit
-operations for the test device. A classical-result `qco.if` sent to Jeff and a
-result-bearing `scf.index_switch` sent to QC-to-QCO must fail with their named
-capability diagnostics rather than crash or silently lower incorrectly.
+The QCO mapping pass must succeed on mixed-result `qco.if` and
+`qco.index_switch` operations, leave the module verified, preserve the classical
+yield values, and produce executable two-qubit operations for the test device. A
+classical-result `qco.if` sent to Jeff must fail with its named capability
+diagnostic rather than crash or silently lower incorrectly.
 
 All existing quantum-only QCO IR, builder, utility, mapping, QC-to-QCO,
 QCO-to-QC, and Jeff tests must pass. The final repository-wide lint session and
@@ -250,8 +309,8 @@ explicit capability diagnostic before proceeding; do not introduce scratch
 memory as a fallback.
 
 Keep all work confined to this task worktree. Preserve unrelated changes and do
-not alter the prerequisite worktree. This branch must remain local until its
-base PR is merged; rebasing and publication require a separate human decision.
+not alter any other task worktree. The prerequisite PR is merged and this branch
+is rebased; publication remains a separate human decision.
 
 ## Artifacts and Notes
 
@@ -275,6 +334,12 @@ remain source compatible. Its tied-value helpers accept only linear results and
 map them to the corresponding quantum operand and branch argument after
 subtracting the classical prefix.
 
+`qco::IndexSwitchOp` must expose the same two result accessors and retain its
+existing index, cases, targets, and region APIs. Its parser derives the number
+of linear results from the `args(...)` assignments, and all cases plus the
+default must use the same explicit target list. Its tied-value helpers and
+target-extension helper operate only on the linear suffix.
+
 `qco::YieldOp::verify()` must derive its expected operand types from one of
 `qco::IfOp`, `qco::IndexSwitchOp`, `qco::CtrlOp`, `qco::InvOp`, or `qco::PowOp`.
 No new runtime library or third-party dependency is required. Builtin MLIR
@@ -284,3 +349,14 @@ Revision note (2026-07-24): Initial plan created from the independent design
 review and the reduced structured-loop prerequisite. It records the SSA result
 segmentation, consumer audit, explicit target diagnostics, and local-only
 publication boundary.
+
+Revision note (2026-07-24): Rebased onto merged PR #1935 and expanded the single
+conditional-result contract to `qco.index_switch` at the user's request. The
+earlier deferral decision is explicitly superseded, and the plan now covers the
+parser, verifier, tied-value, conversion, equivalence, and test surfaces for
+both conditional operation forms.
+
+Revision note (2026-07-24): Recorded the completed independent review and its
+remediation. Classical yield values are now compared positionally while the
+linear suffix remains permutation-aware, with swapped-value and duplicate-value
+regressions for both conditional operation forms.

--- a/.agent/plans/qco-if-classical-results.md
+++ b/.agent/plans/qco-if-classical-results.md
@@ -56,6 +56,17 @@ their consumers while QCO's explicit single-use quantum flow remains intact.
 - [x] (2026-07-24 23:31Z) Complete an independent read-only review, fix its
       positional-classical-yield equivalence finding, rerun validation, and keep
       the branch local for human inspection.
+- [x] (2026-07-24 22:47Z) Add QCO-specific `qco.if` canonicalization patterns
+      that forward equal classical yields, coalesce duplicate classical result
+      columns, and remove unused classical results without changing the tied
+      linear suffix.
+- [x] (2026-07-24 22:47Z) Move the QC-to-QCO-to-QC composition regressions into
+      a dedicated round-trip test target so each directional conversion test
+      links only its own conversion library.
+- [ ] Rebuild the affected targets, run focused suites and repository lint,
+      independently verify the follow-up, and record the final evidence
+      (completed: 718 affected tests, changed-source clang-tidy, repository
+      lint, and `git diff --check`; remaining: independent verification).
 
 ## Surprises & Discoveries
 
@@ -104,6 +115,18 @@ their consumers while QCO's explicit single-use quantum flow remains intact.
   classical prefix through `IRMapping` in order and permits permutation only for
   the tied linear suffix. Regressions cover swapped and duplicate classical
   values for both conditional operation forms.
+- Observation: `PatternRewriter::eraseOpResults` safely rebuilds a
+  result-bearing operation and transfers its regions, but it copies QCO's
+  result-segment property unchanged. The dedicated dead-classical-result pattern
+  therefore removes the matching yield operands and immediately updates the
+  replacement `qco.if` property. Evidence: the canonicalization regression
+  reduces four classical results to one, retains the linear result and both
+  linear yields, and verifies the resulting module.
+- Observation: the former QCO-to-QC round-trip tests conflated two contracts:
+  direct reverse conversion and composition of both conversions. The direct
+  suite now starts from QCO text for both conditional forms, while
+  `mlir/unittests/Conversion/QCQCORoundTrip/` explicitly owns the two-pass tests
+  and their intentional two-library dependency.
 
 ## Decision Log
 
@@ -132,6 +155,17 @@ their consumers while QCO's explicit single-use quantum flow remains intact.
   `qco.if` until it can preserve `resultSegmentSizes`. Rationale: retaining the
   QCO-specific patterns is both smaller and correct for mixed results.
   Date/Author: 2026-07-24, Codex.
+- Decision: Reproduce the useful classical-result subset of MLIR's `scf.if`
+  canonicalization patterns in QCO-specific patterns while leaving the linear
+  suffix untouched. Rationale: equal and duplicate classical yields and dead
+  classical results can be simplified safely, whereas the generic region-branch
+  patterns cannot express QCO's atomic quantum input/argument/yield/result
+  bundle. Date/Author: 2026-07-24, Codex.
+- Decision: Test bidirectional QC/QCO composition in a dedicated round-trip
+  target. Rationale: the QCO-to-QC unit-test target should not depend on the
+  reverse conversion merely to construct its inputs; direct tests cover each
+  conversion independently, while the separate target names and owns the
+  intentional two-way dependency. Date/Author: 2026-07-24, Codex.
 - Decision: Restore every mapped `qco.index_switch` region to the parent layout
   before joining instead of attempting pairwise branch convergence. Rationale:
   an index switch has an arbitrary number of regions, and a single explicit
@@ -155,10 +189,23 @@ only direct clang-tidy diagnostics outside the filtered source lines were known
 generated-MLIR warnings and an analyzer warning in MLIR's
 `OperationState::getOrAddProperties`.
 
-The independent read-only review passed the IR design, conversions, mapping,
-tensor traversal, performance, compatibility, tests, and scope after identifying
-one module-equivalence correctness issue and one documentation mismatch. Both
-were fixed and revalidated. The branch remains local.
+The earlier independent read-only review passed the IR design, conversions,
+mapping, tensor traversal, performance, compatibility, tests, and scope after
+identifying one module-equivalence correctness issue and one documentation
+mismatch. Both were fixed and revalidated. The feature is under review in a
+draft pull request.
+
+The follow-up adds classical-only `qco.if` simplification without registering
+MLIR's unsafe generic region-branch pattern bundle. Equal branch yields are
+forwarded, duplicate classical result columns are coalesced, and dead classical
+results are removed together with the matching yield operands and segment
+metadata. The QCO-to-QC target no longer links QC-to-QCO; two direct QCO-to-QC
+regressions and a dedicated two-test QC/QCO round-trip target preserve both
+layers of coverage. The affected debug suites pass 451 QCO IR, 131 QCO-to-QC,
+134 QC-to-QCO, and 2 round-trip tests. LLVM 22.1.8 clang-tidy reports no
+diagnostics in the changed source files, repository lint passes, and
+`git diff --check` is clean. Independent verification of this follow-up remains
+before publication.
 
 ## Context and Orientation
 
@@ -217,6 +264,15 @@ uses with the generated linear-result accessor. When mapping rewrites a
 When a dead conditional has classical results, erase it only if those results
 are unused; replace only linear result uses with their tied inputs.
 
+Add QCO-specific `IfOp` canonicalization patterns in
+`mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp`. One pattern forwards an ordinary
+classical result when both branches yield the same value and coalesces two
+classical result positions when both corresponding branch yields are identical.
+A second pattern removes unused classical result positions from the operation
+and both `qco.yield` terminators, updating `resultSegmentSizes` at the same
+time. These patterns must never inspect or erase linear results, qubit operands,
+branch arguments, or the linear yield suffix.
+
 In QC-to-QCO, create `qco.if` with the original `scf.if` result types as its
 classical segment and discovered quantum targets as its linear segment. Move the
 regions, let the existing second terminator-conversion phase yield original
@@ -240,13 +296,15 @@ conversion fails.
 
 Add tests close to each contract. Dialect tests must cover textual round-trip,
 invalid segment and yield signatures, tied-value offsets, region-branch
-relationships, and constant-condition canonicalization. Conversion tests must
-cover QC-to-QCO, QCO-to-QC, both conditional operation forms, nested
-conditionals in loops, and a full QC-to-QCO-to-QC round trip while asserting
-that no `memref.alloca`, store, or load exists. Mapping tests must force quantum
-permutation and prove the classical yield remains connected. Jeff tests must
-check the target-specific diagnostic. Existing quantum-only suites must continue
-to pass.
+relationships, constant-condition canonicalization, equal classical-yield
+forwarding, duplicate classical-result coalescing, dead classical-result
+removal, and preservation of the complete linear suffix. Conversion tests must
+cover QC-to-QCO and QCO-to-QC directly for both conditional operation forms and
+nested conditionals in loops. A dedicated QC/QCO round-trip target must own the
+full two-pass composition regressions and assert that no `memref.alloca`, store,
+or load exists. Mapping tests must force quantum permutation and prove the
+classical yield remains connected. Jeff tests must check the target-specific
+diagnostic. Existing quantum-only suites must continue to pass.
 
 ## Concrete Steps
 
@@ -262,8 +320,8 @@ Configure and build with the repository's debug preset if needed:
 
 Run the focused dialect and conversion binaries discovered under
 `build/debug/mlir/unittests`, including the QCO IR, QC-to-QCO, QCO-to-QC,
-round-trip, mapping, and Jeff conversion targets. Each must report all tests
-passed. Then run:
+dedicated QC/QCO round-trip, mapping, and Jeff conversion targets. Each must
+report all tests passed. Then run:
 
     .agent/run.sh uvx nox -s lint
     git diff --check
@@ -295,8 +353,10 @@ classical-result `qco.if` sent to Jeff must fail with its named capability
 diagnostic rather than crash or silently lower incorrectly.
 
 All existing quantum-only QCO IR, builder, utility, mapping, QC-to-QCO,
-QCO-to-QC, and Jeff tests must pass. The final repository-wide lint session and
-`git diff --check` must pass without modifying files.
+QCO-to-QC, QC/QCO round-trip, and Jeff tests must pass. The QCO-to-QC test
+target must not link `MLIRQCToQCO`; only the dedicated round-trip target may
+link both directional conversion libraries. The final repository-wide lint
+session and `git diff --check` must pass without modifying files.
 
 ## Idempotence and Recovery
 
@@ -360,3 +420,7 @@ Revision note (2026-07-24): Recorded the completed independent review and its
 remediation. Classical yield values are now compared positionally while the
 linear suffix remains permutation-aware, with swapped-value and duplicate-value
 regressions for both conditional operation forms.
+
+Revision note (2026-07-24): Added the follow-up milestone for QCO-specific
+classical `qco.if` canonicalization patterns and separated bidirectional
+conversion regressions from the directional QCO-to-QC test target.

--- a/.agent/plans/qco-if-classical-results.md
+++ b/.agent/plans/qco-if-classical-results.md
@@ -1,0 +1,286 @@
+# Add SSA classical results to QCO conditionals
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+After this change, a QC program can use an `scf.if` to compute ordinary
+classical values while also updating quantum state, convert to QCO, and convert
+back to QC without allocating scratch memory or losing either kind of result.
+The QCO dialect will represent that behavior directly: a `qco.if` returns an
+ordinary SSA-value prefix followed by the existing linear quantum-value suffix.
+Focused dialect, conversion, mapping, and round-trip tests will demonstrate that
+the classical value remains connected to its consumer while QCO's explicit
+single-use quantum flow remains intact.
+
+## Progress
+
+- [x] (2026-07-24 19:05Z) Create this work on top of the reduced structured
+  `for`/`while` conversion fix.
+- [x] (2026-07-24 19:05Z) Compare SSA-based `qco.if` results, retained `scf.if`,
+      and scratch-memory alternatives with an independent design review.
+- [x] (2026-07-24 19:38Z) Extend `qco.if`, `qco.yield`, their verifiers,
+      parser/printer, builders, tied-value helpers, and region-branch interface
+      for mixed results.
+- [x] (2026-07-24 19:38Z) Update QCO consumers, canonicalization, dead-gate
+      handling, and mapping so only the linear suffix participates in quantum
+      dataflow and routing.
+- [x] (2026-07-24 19:38Z) Add QC-to-QCO and QCO-to-QC lowering for classical
+      conditional results.
+- [x] (2026-07-24 19:38Z) Add a feature-specific QCO-to-Jeff diagnostic and
+      explicitly reject result-bearing `scf.index_switch` in QC-to-QCO.
+- [x] (2026-07-24 19:38Z) Add dialect, conversion, round-trip, mapping, and
+      diagnostic regressions.
+- [x] (2026-07-24 19:42Z) Build the affected targets, run focused and complete
+      suites, run `uvx nox -s lint`, and record the evidence here.
+- [ ] Keep the branch local until the prerequisite structured-loop PR is merged;
+      rebase then prepare it for human review without opening a PR
+      automatically.
+
+## Surprises & Discoveries
+
+- Observation: `scf.if` can return arbitrary types but has no explicit quantum
+  input-to-block-argument ties. Reusing it with QCO linear values would weaken
+  the representation relied on by `WireIterator`, mapping, and dead-gate
+  analysis. Evidence: `qco.if` exposes custom tied-value helpers in
+  `mlir/include/mlir/Dialect/QCO/IR/QCOOps.h`, while `scf.if` captures values
+  from above its regions.
+- Observation: `qco.yield` is shared by conditionals, index switches, and gate
+  modifiers. Relaxing its generated operand constraint requires a parent-aware
+  verifier so modifier and index-switch invariants do not regress. Evidence: all
+  five parent operations terminate their regions with the same `qco::YieldOp`.
+- Observation: mapping previously treated every SCF loop result as a qubit. The
+  prerequisite branch now filters mixed loop state and preserves classical
+  terminator operands, which provides the routing pattern needed for mixed
+  `qco.if` yields.
+- Observation: MLIR's generic region-branch canonicalization rebuilds this
+  result-segmented custom operation without preserving its segment property.
+  Registering that pattern changed a mixed `qco.if` into an invalid operation.
+  The existing QCO-specific constant-condition and condition-propagation
+  patterns cover the useful folds, so the generic pattern remains unregistered.
+- Observation: the MLIR parser verifies operations before returning a module.
+  Invalid mixed yields are therefore rejected during `parseSourceString`,
+  allowing tests to assert the precise `qco.yield` diagnostic directly.
+
+## Decision Log
+
+- Decision: Give `qco.if` two result segments ordered as classical values first
+  and linear values second. Rationale: this keeps classical computation in
+  ordinary SSA, preserves the existing explicit QCO quantum-flow contract, and
+  matches QC-to-QCO's convention of appending quantum state to existing SCF
+  state. Date/Author: 2026-07-24, Codex after independent design review.
+- Decision: Keep operands and branch block arguments linear-only. Rationale:
+  classical inputs can be captured normally, while quantum inputs need explicit
+  ties to enforce single-use flow. Date/Author: 2026-07-24, Codex.
+- Decision: Generalize `qco.yield` syntactically but recover strict typing with
+  a parent-aware verifier. Rationale: one terminator can then express mixed
+  conditional results without weakening modifier or index-switch semantics.
+  Date/Author: 2026-07-24, Codex.
+- Decision: Do not add classical results to `qco.index_switch` in this change.
+  Rationale: its parser, result layout, mapping, and both conversions form a
+  separate reviewable surface. QC-to-QCO must diagnose that case explicitly
+  rather than use scratch memory. Date/Author: 2026-07-24, Codex.
+- Decision: Jeff conversion may reject classical-result `qco.if` with a precise
+  capability diagnostic. Rationale: QC to QCO to QC to QIR is the primary
+  pipeline; Jeff limitations must be explicit but must not constrain valid QCO
+  representation. Date/Author: 2026-07-24, Codex.
+- Decision: Do not register MLIR's generic region-branch canonicalization for
+  `qco.if` until it can preserve `resultSegmentSizes`. Rationale: retaining the
+  QCO-specific patterns is both smaller and correct for mixed results.
+  Date/Author: 2026-07-24, Codex.
+
+## Outcomes & Retrospective
+
+The implementation avoids runtime memory operations and limits the dialect
+change to one conditional operation plus its shared terminator. Focused tests
+demonstrate textual round-tripping, verifier diagnostics, constant folding,
+QC-to-QCO and QCO-to-QC conversion, a composed round trip, mapping, and the
+intentional Jeff and index-switch capability diagnostics.
+
+All affected suites pass: 447 QCO IR tests, 134 QC-to-QCO tests, 131 QCO-to-QC
+tests, 14 mapping tests, 82 QCO utility tests, and 117 Jeff round-trip tests.
+The changed C++ files produce no local clang-tidy 22 warnings. Targeted
+repository hooks, `uvx nox -s lint`, and `git diff --check` pass. The branch
+remains local on top of the reduced structured-loop PR and awaits that PR's
+merge before rebasing and publication.
+
+## Context and Orientation
+
+QC is the reference-style quantum dialect: quantum operations mutate logical
+references and SCF operations carry classical SSA values. QCO is the explicit
+linear-value form used for analyses and transformations: each quantum operation
+consumes a quantum value and produces its successor. The conversion in
+`mlir/lib/Conversion/QCToQCO/QCToQCO.cpp` discovers which quantum values cross
+an SCF region and appends explicit state. The reverse conversion lives in
+`mlir/lib/Conversion/QCOToQC/QCOToQC.cpp`.
+
+`qco.if` is declared in `mlir/include/mlir/Dialect/QCO/IR/QCOOps.td`, with
+hand-written parsing, printing, verification, tied-value helpers, and
+replacement helpers in `mlir/lib/Dialect/QCO/IR/QCOOps.cpp`. Its regions receive
+only linear quantum block arguments and end in `qco.yield`. `qco.yield` is also
+used by `qco.index_switch`, `qco.ctrl`, `qco.inv`, and `qco.pow`, so changes to
+its ODS type constraint must be paired with parent-specific verification.
+
+QCO mapping in `mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp` extends
+structured operations with all physical qubits and may reorder yielded quantum
+values during routing. Utilities under `mlir/lib/Dialect/QCO/Utils/` follow tied
+quantum values and remove dead gates. These consumers must use the linear result
+segment, never the complete mixed result range.
+
+Generated TableGen files and generated dialect documentation are build outputs.
+Do not edit or commit them. Follow `AGENTS.md` and `docs/ai_usage.md`; this plan
+does not authorize pushing the branch or opening a pull request.
+
+## Plan of Work
+
+First change `IfOp` in `QCOOps.td` so it has an `AnyType` classical-result
+segment followed by its existing `LinearType` result segment, guarded by
+`AttrSizedResultSegments`. Keep condition and quantum operands unchanged. Change
+`YieldOp` to accept arbitrary operands and constrain its valid parents with
+`ParentOneOf`. In `QCOOps.cpp`, teach the custom parser to infer the split: the
+number of trailing linear results equals the number of `args(...)` assignments,
+and all earlier result types are classical. Emit parse errors for inconsistent
+counts or non-linear trailing types. Keep the existing textual shape for
+quantum-only programs.
+
+Add verification that the classical segment contains no QCO linear type, the
+linear segment matches the quantum operands, region arguments match those
+operands, and both yields match the complete result signature. Add a
+parent-aware `YieldOp::verify()` that compares its operands with the relevant
+parent result types; for `qco.ctrl`, compare only the target outputs. Update all
+`IfOp` tied-value methods so classical results are never treated as quantum
+results. Complete `RegionBranchOpInterface` operand-to-region and
+region-to-parent mappings while this contract is explicit.
+
+Audit builders, canonicalization, `ReplaceClassicalControls`, mapping,
+`WireIterator`, and QCO dead-gate elimination. Replace ambiguous whole-result
+uses with the generated linear-result accessor. When mapping rewrites a
+`qco.yield`, retain the classical prefix and permute only its linear suffix.
+When a dead conditional has classical results, erase it only if those results
+are unused; replace only linear result uses with their tied inputs.
+
+In QC-to-QCO, create `qco.if` with the original `scf.if` result types as its
+classical segment and discovered quantum targets as its linear segment. Move the
+regions, let the existing second terminator-conversion phase yield original
+classical values followed by resolved quantum values, replace the original SCF
+results with `getClassicalResults()`, and update quantum mappings from
+`getLinearResults()`. Leave an `scf.if` with no quantum state unchanged. Reject
+a result-bearing `scf.index_switch` with a precise unsupported-feature
+diagnostic.
+
+In QCO-to-QC, create an `scf.if` that returns only the converted classical
+types. Replace its linear block arguments with QC references when inlining the
+regions, lower each `qco.yield` to an `scf.yield` containing only its classical
+prefix, and replace the QCO operation with the new classical SCF results plus
+the corresponding QC references for its linear results. Preserve an else region
+whenever classical results exist. In QCO-to-Jeff, reject a classical-result
+`qco.if` with a feature-specific message before generic conversion fails.
+
+Add tests close to each contract. Dialect tests must cover textual round-trip,
+invalid segment and yield signatures, tied-value offsets, region-branch
+relationships, and constant-condition canonicalization. Conversion tests must
+cover QC-to-QCO, QCO-to-QC, nested conditionals in loops, and a full
+QC-to-QCO-to-QC round trip while asserting that no `memref.alloca`, store, or
+load exists. Mapping tests must force quantum permutation and prove the
+classical yield remains connected. Jeff and index-switch tests must check their
+specific diagnostics. Existing quantum-only suites must continue to pass.
+
+## Concrete Steps
+
+From the repository root, inspect definitions and consumers before editing:
+
+    rg -n "IfOp|YieldOp|getResults\\(\\)|getTied" \
+      mlir/include/mlir/Dialect/QCO mlir/lib mlir/unittests
+
+Configure and build with the repository's debug preset if needed:
+
+    .agent/run.sh cmake --preset debug
+    .agent/run.sh cmake --build build/debug -j 4
+
+Run the focused dialect and conversion binaries discovered under
+`build/debug/mlir/unittests`, including the QCO IR, QC-to-QCO, QCO-to-QC,
+round-trip, mapping, and Jeff conversion targets. Each must report all tests
+passed. Then run:
+
+    .agent/run.sh uvx nox -s lint
+    git diff --check
+
+Update `Progress`, `Surprises & Discoveries`, and `Outcomes & Retrospective`
+after each milestone, recording exact test counts and any intentionally
+unsupported behavior.
+
+## Validation and Acceptance
+
+A parsed and verified `qco.if` with one `i1` result and one `!qco.qubit` result
+must print and parse again with the same two result segments. Each branch must
+yield exactly `i1, !qco.qubit`; placing a qubit in the classical segment or
+yielding a classical value from a modifier must fail verification with a
+specific diagnostic.
+
+A QC module containing a result-bearing `scf.if` and quantum operations in both
+branches must convert to a verified QCO module containing a mixed-result
+`qco.if`. Its classical result must feed the original consumer, and the module
+must contain no scratch allocation, store, or load. Converting that module back
+to QC must produce a verified result-bearing `scf.if`; an end-to-end round-trip
+test must preserve the observable classical return value.
+
+The QCO mapping pass must succeed on a mixed-result `qco.if`, leave the module
+verified, preserve the classical yield values, and produce executable two-qubit
+operations for the test device. A classical-result `qco.if` sent to Jeff and a
+result-bearing `scf.index_switch` sent to QC-to-QCO must fail with their named
+capability diagnostics rather than crash or silently lower incorrectly.
+
+All existing quantum-only QCO IR, builder, utility, mapping, QC-to-QCO,
+QCO-to-QC, and Jeff tests must pass. The final repository-wide lint session and
+`git diff --check` must pass without modifying files.
+
+## Idempotence and Recovery
+
+Build, test, format, and lint commands are repeatable. TableGen regeneration is
+performed by CMake into the build directory and must never be copied into the
+source tree. If a verifier or parser change breaks existing quantum-only text,
+restore compatibility in the custom parser rather than updating unrelated test
+fixtures. If a consumer cannot safely handle the classical segment, add an
+explicit capability diagnostic before proceeding; do not introduce scratch
+memory as a fallback.
+
+Keep all work confined to this task worktree. Preserve unrelated changes and do
+not alter the prerequisite worktree. This branch must remain local until its
+base PR is merged; rebasing and publication require a separate human decision.
+
+## Artifacts and Notes
+
+The target textual shape is:
+
+    %flag, %q1 = qco.if %cond args(%arg = %q0)
+        -> (i1, !qco.qubit) {
+      qco.yield %true, %arg : i1, !qco.qubit
+    } else args(%arg = %q0) {
+      qco.yield %false, %arg : i1, !qco.qubit
+    }
+
+The result ordering is a stable internal contract: original classical SCF
+results remain first, and conversion-generated QCO linear state is appended.
+
+## Interfaces and Dependencies
+
+`qco::IfOp` must expose generated `getClassicalResults()` and
+`getLinearResults()` accessors. Its condition and quantum operand accessors
+remain source compatible. Its tied-value helpers accept only linear results and
+map them to the corresponding quantum operand and branch argument after
+subtracting the classical prefix.
+
+`qco::YieldOp::verify()` must derive its expected operand types from one of
+`qco::IfOp`, `qco::IndexSwitchOp`, `qco::CtrlOp`, `qco::InvOp`, or `qco::PowOp`.
+No new runtime library or third-party dependency is required. Builtin MLIR
+`scf.if` remains the classical control-flow representation on the QC side.
+
+Revision note (2026-07-24): Initial plan created from the independent design
+review and the reduced structured-loop prerequisite. It records the SSA result
+segmentation, consumer audit, explicit target diagnostics, and local-only
+publication boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ releases may include breaking changes.
   [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717],
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
-  [#1886], [#1914], [#1925], [#1935], [#1936]) ([**@burgholzer**],
+  [#1886], [#1914], [#1925], [#1935], [#1936], [#1938]) ([**@burgholzer**],
   [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**],
   [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 
@@ -652,6 +652,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1938]: https://github.com/munich-quantum-toolkit/core/pull/1938
 [#1936]: https://github.com/munich-quantum-toolkit/core/pull/1936
 [#1935]: https://github.com/munich-quantum-toolkit/core/pull/1935
 [#1934]: https://github.com/munich-quantum-toolkit/core/pull/1934

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1103,8 +1103,8 @@ def YieldOp
                                             "InvOp", "PowOp"]>]> {
   let summary = "Yield values from a QCO region";
   let description = [{
-        Terminates a QCO region. Modifier and index-switch regions yield their
-        transformed linear values. Conditional regions may additionally yield
+        Terminates a QCO region. Modifier regions yield their transformed linear
+        values. `qco.if` and `qco.index_switch` regions may additionally yield
         ordinary classical SSA values before their transformed linear values.
         The operands must match the expected output signature of the parent
         operation.
@@ -1520,18 +1520,21 @@ def IndexSwitchOp
           "index_switch",
           traits = [DeclareOpInterfaceMethods<
                         RegionBranchOpInterface, ["getRegionInvocationBounds",
-                                                  "getEntrySuccessorRegions"]>,
+                                                  "getEntrySuccessorRegions",
+                                                  "getEntrySuccessorOperands"]>,
                     SingleBlockImplicitTerminator<"YieldOp">, Pure,
-                    RecursiveMemoryEffects]> {
+                    RecursiveMemoryEffects, AttrSizedResultSegments]> {
 
-  let summary = "Index-based switch operation for linear (qubit) types";
+  let summary =
+      "Index-based switch operation with classical and linear results";
   let description = [{
         The `qco.index_switch` operation provides multi-way branching based on an index
         value, analogous to `scf.index_switch`. In addition to the index, the operation
         takes a variadic number of qubits and qtensors as inputs that are required in all
         case branches. These values are passed down to each case region as block arguments.
-        The number of results and the type of the results must be equivalent to the number
-        and types of the input qubit and qtensor values.
+        The operation may additionally return ordinary classical SSA values.
+        Classical results precede the linear results. The number and types of
+        the linear results must match the input qubit and qtensor values.
 
         The operation has one region for each case value plus a default region. Each region
         must terminate with a `qco.yield` operation that yields values matching the operation's
@@ -1539,32 +1542,63 @@ def IndexSwitchOp
 
         Example:
         ```mlir
-        %result = qco.index_switch %index -> !qco.qubit
+        %flag, %result = qco.index_switch %index -> (i1, !qco.qubit)
         case 0 args(%arg0 = %q0) {
           %q1 = qco.h %arg0 : !qco.qubit -> !qco.qubit
-          qco.yield %q1 : !qco.qubit
+          qco.yield %true, %q1 : i1, !qco.qubit
         }
         case 1 args(%arg0 = %q0) {
           %q1 = qco.x %arg0 : !qco.qubit -> !qco.qubit
-          qco.yield %q1 : !qco.qubit
+          qco.yield %false, %q1 : i1, !qco.qubit
         }
         default args(%arg0 = %q0) {
-          qco.yield %arg0 : !qco.qubit
+          qco.yield %false, %arg0 : i1, !qco.qubit
         }
         ```
     }];
 
   let arguments = (ins Index:$arg, DenseI64ArrayAttr:$cases,
       Variadic<LinearType>:$targets);
-  let results = (outs Variadic<LinearType>:$results);
+  let results = (outs Variadic<AnyType>:$classicalResults,
+      Variadic<LinearType>:$linearResults);
   let regions = (region SizedRegion<1>:$defaultRegion,
       VariadicRegion<SizedRegion<1>>:$caseRegions);
   let hasCustomAssemblyFormat = 1;
+  let skipDefaultBuilders = 1;
 
-  let builders = [OpBuilder<(ins "Value":$arg, "Value":$target,
-      "ArrayRef<int64_t>":$cases,
-      "ArrayRef<function_ref<Value(Value)>>":$caseBuilders,
-      "function_ref<Value(Value)>":$defaultBuilder)>];
+  let builders =
+      [OpBuilder<(ins "TypeRange":$classicalResultTypes,
+                     "TypeRange":$linearResultTypes, "Value":$arg,
+                     "ArrayRef<int64_t>":$cases, "ValueRange":$targets,
+                     "unsigned":$numCaseRegions),
+                 [{
+          $_state.addOperands(arg);
+          $_state.addOperands(targets);
+          $_state.addAttribute(
+              "cases", $_builder.getDenseI64ArrayAttr(cases));
+          (void)$_state.addRegion();
+          for (unsigned i = 0; i < numCaseRegions; ++i) {
+            (void)$_state.addRegion();
+          }
+          $_state.addTypes(classicalResultTypes);
+          $_state.addTypes(linearResultTypes);
+          ::llvm::copy(
+              ::llvm::ArrayRef<int32_t>({
+                  static_cast<int32_t>(classicalResultTypes.size()),
+                  static_cast<int32_t>(linearResultTypes.size())}),
+              $_state.getOrAddProperties<Properties>()
+                  .resultSegmentSizes.begin());
+        }]>,
+       OpBuilder<(ins "TypeRange":$linearResultTypes, "Value":$arg,
+                     "ArrayRef<int64_t>":$cases, "ValueRange":$targets,
+                     "unsigned":$numCaseRegions),
+                 [{
+          build($_builder, $_state, TypeRange{}, linearResultTypes, arg, cases,
+                targets, numCaseRegions);
+        }]>,
+       OpBuilder<(ins "Value":$arg, "Value":$target, "ArrayRef<int64_t>":$cases,
+           "ArrayRef<function_ref<Value(Value)>>":$caseBuilders,
+           "function_ref<Value(Value)>":$defaultBuilder)>];
 
   let extraClassDeclaration = [{
         /// Return the number of case regions

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1097,11 +1097,17 @@ def BarrierOp : QCOOp<"barrier", traits = [UnitaryOpInterface, Pure]> {
 // Modifiers
 //===----------------------------------------------------------------------===//
 
-def YieldOp : QCOOp<"yield", traits = [Terminator, ReturnLike, Pure]> {
-  let summary = "Yield from a modifier region";
+def YieldOp
+    : QCOOp<"yield", traits = [Terminator, ReturnLike, Pure,
+                               ParentOneOf<["CtrlOp", "IfOp", "IndexSwitchOp",
+                                            "InvOp", "PowOp"]>]> {
+  let summary = "Yield values from a QCO region";
   let description = [{
-        Terminates a modifier region, yielding the transformed target qubit and qtensor values back to the enclosing modifier operation.
-        The targets must match the expected output signature of the modifier region.
+        Terminates a QCO region. Modifier and index-switch regions yield their
+        transformed linear values. Conditional regions may additionally yield
+        ordinary classical SSA values before their transformed linear values.
+        The operands must match the expected output signature of the parent
+        operation.
 
         Example:
         ```mlir
@@ -1112,8 +1118,9 @@ def YieldOp : QCOOp<"yield", traits = [Terminator, ReturnLike, Pure]> {
         ```
     }];
 
-  let arguments = (ins Variadic<LinearType>:$targets);
+  let arguments = (ins Variadic<AnyType>:$targets);
   let assemblyFormat = "attr-dict ($targets^ `:` type($targets))?";
+  let hasVerifier = 1;
 }
 
 def CtrlOp : QCOOp<"ctrl",
@@ -1377,37 +1384,61 @@ def IfOp
           traits = [DeclareOpInterfaceMethods<
                         RegionBranchOpInterface, ["getNumRegionInvocations",
                                                   "getRegionInvocationBounds",
-                                                  "getEntrySuccessorRegions"]>,
+                                                  "getEntrySuccessorRegions",
+                                                  "getEntrySuccessorOperands"]>,
                     SingleBlock, SingleBlockImplicitTerminator<"YieldOp">, Pure,
-                    RecursiveMemoryEffects]> {
+                    RecursiveMemoryEffects, AttrSizedResultSegments]> {
 
-  let summary = "If-then-else operation for linear (qubit) types";
+  let summary = "If-then-else operation with classical and linear results";
   let description = [{
         The `qco.if` operation is an if-then-else construct similar to the standard scf.if operation.
         In addition to the condition, the operation takes a variadic number of qubits and qtensors as inputs that are
         required in the bodies of both branches. These values are passed down to the individual regions
-        as block arguments. The number of results and the type of the results must be equivalent to the
-        number and types of the input qubit and qtensor values.
+        as block arguments. The operation may additionally return ordinary
+        classical SSA values. Classical results precede the linear results.
+        The number and types of the linear results must match the input qubit
+        and qtensor values.
 
         Example:
         ```mlir
-        %result = qco.if %condition args(%arg0 = %q0) {
+        %flag, %result = qco.if %condition args(%arg0 = %q0)
+            -> (i1, !qco.qubit) {
             %q1 = qco.h %arg0 : !qco.qubit -> !qco.qubit
-            qco.yield %q1 : !qco.qubit
+            qco.yield %true, %q1 : i1, !qco.qubit
          } else args(%arg0 = %q0) {
-            qco.yield %arg0 : !qco.qubit
-        } : {i1, !qco.qubit} -> {!qco.qubit}
+            qco.yield %false, %arg0 : i1, !qco.qubit
+        }
         ```
     }];
 
   let arguments = (ins I1:$condition, Variadic<LinearType>:$qubits);
-  let results = (outs Variadic<LinearType>:$results);
+  let results = (outs Variadic<AnyType>:$classicalResults,
+      Variadic<LinearType>:$linearResults);
   let regions = (region SizedRegion<1>:$thenRegion, SizedRegion<1>:$elseRegion);
   let hasCustomAssemblyFormat = 1;
+  let skipDefaultBuilders = 1;
 
   let builders =
-      [OpBuilder<(ins "Value":$condition, "ValueRange":$qubits), [{
-           build($_builder, $_state, qubits.getTypes(), condition, qubits);
+      [OpBuilder<(ins "TypeRange":$classicalResultTypes,
+                     "TypeRange":$linearResultTypes, "Value":$condition,
+                     "ValueRange":$qubits),
+                 [{
+           $_state.addOperands(condition);
+           $_state.addOperands(qubits);
+           (void)$_state.addRegion();
+           (void)$_state.addRegion();
+           $_state.addTypes(classicalResultTypes);
+           $_state.addTypes(linearResultTypes);
+           ::llvm::copy(
+               ::llvm::ArrayRef<int32_t>({
+                   static_cast<int32_t>(classicalResultTypes.size()),
+                   static_cast<int32_t>(linearResultTypes.size())}),
+               $_state.getOrAddProperties<Properties>()
+                   .resultSegmentSizes.begin());
+        }]>,
+       OpBuilder<(ins "Value":$condition, "ValueRange":$qubits), [{
+           build($_builder, $_state, TypeRange{}, qubits.getTypes(), condition,
+                 qubits);
         }]>,
        OpBuilder<(ins "Value":$condition, "ValueRange":$qubits,
            "function_ref<SmallVector<Value>(ValueRange)"

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -338,7 +338,9 @@ inline LogicalResult tryEliminateDeadGateValue(Value qubit,
             .Case<IfOp>([&](auto ifOp) {
               auto* tiedQubit = ifOp.getTiedQubit(cast<OpResult>(qubit));
               auto newValue = tiedQubit->get();
-              rewriter.replaceOp(ifOp, ifOp.getQubits());
+              rewriter.replaceAllUsesWith(ifOp.getLinearResults(),
+                                          ifOp.getQubits());
+              rewriter.eraseOp(ifOp);
               return newValue;
             })
             .Case<ResetOp>([&](auto resetOp) {

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -1069,6 +1069,12 @@ struct ConvertQCOIfOpToJeff final : StatefulOpConversionPattern<IfOp> {
   LogicalResult
   matchAndRewrite(IfOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
+    if (!op.getClassicalResults().empty()) {
+      op.emitError("classical qco.if results are not supported by the "
+                   "QCO-to-Jeff conversion");
+      return failure();
+    }
+
     auto loc = op.getLoc();
 
     SetVector<Value> aboveValues;
@@ -1079,8 +1085,8 @@ struct ConvertQCOIfOpToJeff final : StatefulOpConversionPattern<IfOp> {
     llvm::append_range(initArgs, adaptor.getQubits());
 
     SmallVector<Type> outTypes;
-    if (failed(
-            getTypeConverter()->convertTypes(op.getResultTypes(), outTypes))) {
+    if (failed(getTypeConverter()->convertTypes(
+            op.getLinearResults().getTypes(), outTypes))) {
       return failure();
     }
 

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -752,9 +752,12 @@ struct ConvertQCOYieldOp final : OpConversionPattern<qco::YieldOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(qco::YieldOp op, OpAdaptor /*adaptor*/,
+  matchAndRewrite(qco::YieldOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
-    if (isa<scf::IfOp, scf::IndexSwitchOp>(op->getParentOp())) {
+    if (auto ifOp = dyn_cast<scf::IfOp>(op->getParentOp())) {
+      rewriter.replaceOpWithNewOp<scf::YieldOp>(
+          op, adaptor.getTargets().take_front(ifOp.getNumResults()));
+    } else if (isa<scf::IndexSwitchOp>(op->getParentOp())) {
       rewriter.replaceOpWithNewOp<scf::YieldOp>(op);
     } else {
       rewriter.replaceOpWithNewOp<qc::YieldOp>(op);
@@ -882,26 +885,38 @@ struct ConvertQCOIfOp final : OpConversionPattern<IfOp> {
   LogicalResult
   matchAndRewrite(IfOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
+    SmallVector<Type> classicalResultTypes;
+    if (failed(getTypeConverter()->convertTypes(
+            op.getClassicalResults().getTypes(), classicalResultTypes))) {
+      return failure();
+    }
+    const bool keepElseRegion =
+        !classicalResultTypes.empty() ||
+        op.getElseRegion().front().getOperations().size() > 1;
+
     // Create the new if operation
-    auto newIf = scf::IfOp::create(rewriter, op.getLoc(), TypeRange{},
-                                   adaptor.getCondition(), false);
+    auto newIf = scf::IfOp::create(rewriter, op.getLoc(), classicalResultTypes,
+                                   adaptor.getCondition(), keepElseRegion);
     auto& newThenRegion = newIf.getThenRegion();
     auto& oldElseRegion = op.getElseRegion();
     // Erase the default empty then block
     rewriter.eraseBlock(&newThenRegion.front());
 
     // Inline the region and replace the block arguments
-    inlineRegion(op.getThenRegion(), newThenRegion, 0,
-                 adaptor.getOperands().drop_front(1), rewriter);
+    inlineRegion(op.getThenRegion(), newThenRegion, 0, adaptor.getQubits(),
+                 rewriter);
 
-    // Inline the else block if it has more than just the yield operation
-    if (oldElseRegion.front().getOperations().size() > 1) {
-      inlineRegion(oldElseRegion, newIf.getElseRegion(), 0,
-                   adaptor.getOperands().drop_front(1), rewriter);
+    // Inline the else block when it has observable operations or must produce
+    // classical results.
+    if (keepElseRegion) {
+      rewriter.eraseBlock(&newIf.getElseRegion().front());
+      inlineRegion(oldElseRegion, newIf.getElseRegion(), 0, adaptor.getQubits(),
+                   rewriter);
     }
 
-    // Replace the qco results with the input qc values except the condition
-    rewriter.replaceOp(op, adaptor.getOperands().drop_front(1));
+    SmallVector<Value> replacements(newIf.getResults());
+    llvm::append_range(replacements, adaptor.getQubits());
+    rewriter.replaceOp(op, replacements);
 
     return success();
   }

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -757,8 +757,10 @@ struct ConvertQCOYieldOp final : OpConversionPattern<qco::YieldOp> {
     if (auto ifOp = dyn_cast<scf::IfOp>(op->getParentOp())) {
       rewriter.replaceOpWithNewOp<scf::YieldOp>(
           op, adaptor.getTargets().take_front(ifOp.getNumResults()));
-    } else if (isa<scf::IndexSwitchOp>(op->getParentOp())) {
-      rewriter.replaceOpWithNewOp<scf::YieldOp>(op);
+    } else if (auto switchOp =
+                   dyn_cast<scf::IndexSwitchOp>(op->getParentOp())) {
+      rewriter.replaceOpWithNewOp<scf::YieldOp>(
+          op, adaptor.getTargets().take_front(switchOp.getNumResults()));
     } else {
       rewriter.replaceOpWithNewOp<qc::YieldOp>(op);
     }
@@ -954,22 +956,28 @@ struct ConvertQCOIndexSwitchOp final : OpConversionPattern<IndexSwitchOp> {
   LogicalResult
   matchAndRewrite(IndexSwitchOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
-    auto newOp =
-        scf::IndexSwitchOp::create(rewriter, op.getLoc(), {}, adaptor.getArg(),
-                                   adaptor.getCases(), op.getNumCases());
+    SmallVector<Type> classicalResultTypes;
+    if (failed(getTypeConverter()->convertTypes(
+            op.getClassicalResults().getTypes(), classicalResultTypes))) {
+      return failure();
+    }
+    auto newOp = scf::IndexSwitchOp::create(
+        rewriter, op.getLoc(), classicalResultTypes, adaptor.getArg(),
+        adaptor.getCases(), op.getNumCases());
 
     const auto oldRegions = op.getCaseRegions();
     const auto newCaseRegions = newOp.getCaseRegions();
     for (size_t i = 0; i < op.getNumCases(); ++i) {
-      inlineRegion(oldRegions[i], newCaseRegions[i], 0,
-                   adaptor.getOperands().drop_front(1), rewriter);
+      inlineRegion(oldRegions[i], newCaseRegions[i], 0, adaptor.getTargets(),
+                   rewriter);
     }
 
     inlineRegion(op.getDefaultRegion(), newOp.getDefaultRegion(), 0,
-                 adaptor.getOperands().drop_front(1), rewriter);
+                 adaptor.getTargets(), rewriter);
 
-    // Replace the qco results with the input qc values except the condition
-    rewriter.replaceOp(op, adaptor.getOperands().drop_front(1));
+    SmallVector<Value> replacements(newOp.getResults());
+    llvm::append_range(replacements, adaptor.getTargets());
+    rewriter.replaceOp(op, replacements);
 
     return success();
   }

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -1604,12 +1604,6 @@ struct ConvertSCFIndexSwitchOp final
   LogicalResult
   matchAndRewrite(scf::IndexSwitchOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
-    if (op.getNumResults() != 0) {
-      op.emitError("classical scf.index_switch results are not supported by "
-                   "the QC-to-QCO conversion");
-      return failure();
-    }
-
     auto& state = getState();
     auto* operation = op.getOperation();
     auto& registerMap = state.regionRegisterMap[op];
@@ -1619,17 +1613,17 @@ struct ConvertSCFIndexSwitchOp final
 
     insertQubitsBeforeOp(state, operation, rewriter);
     const auto targets = resolveAllValues(state, operation);
-    const auto results = ValueRange(targets).getTypes();
+    const auto linearResultTypes = ValueRange(targets).getTypes();
     const SmallVector locs(targets.size(), op.getLoc());
 
-    auto newOp =
-        IndexSwitchOp::create(rewriter, op.getLoc(), results, op.getArg(),
-                              op.getCases(), targets, op.getNumCases());
+    auto newOp = IndexSwitchOp::create(
+        rewriter, op.getLoc(), op.getResultTypes(), linearResultTypes,
+        op.getArg(), op.getCases(), targets, op.getNumCases());
 
     assignMappedTensors(state, op.getOperation(), registerMap,
-                        newOp.getResults().take_front(numRegisters));
+                        newOp.getLinearResults().take_front(numRegisters));
     assignMappedQubits(state, op.getOperation(), qubitMap,
-                       newOp.getResults().take_back(numQubits));
+                       newOp.getLinearResults().take_back(numQubits));
 
     rewriter.setInsertionPointAfter(newOp);
     extractQubitsAfterOp(state, operation, rewriter);
@@ -1642,8 +1636,8 @@ struct ConvertSCFIndexSwitchOp final
     const auto oldCaseRegions = op.getCaseRegions();
     const auto buildRegion = [&](Region& oldRegion, Region& newRegion) {
       auto* oldBlock = &oldRegion.front();
-      auto* newBlock =
-          rewriter.createBlock(&newRegion, {}, newOp.getResultTypes(), locs);
+      auto* newBlock = rewriter.createBlock(
+          &newRegion, {}, newOp.getLinearResults().getTypes(), locs);
       newBlock->getOperations().splice(newBlock->end(),
                                        oldBlock->getOperations());
 
@@ -1658,7 +1652,7 @@ struct ConvertSCFIndexSwitchOp final
     }
     buildRegion(op.getDefaultRegion(), newOp.getDefaultRegion());
 
-    rewriter.eraseOp(op);
+    rewriter.replaceOp(op, newOp.getClassicalResults());
     return success();
   }
 };

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -1517,12 +1517,13 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
     auto qcoTargets = resolveAllValues(state, operation);
 
     // Create the new IfOp
-    auto newIfOp =
-        IfOp::create(rewriter, op.getLoc(), op.getCondition(), qcoTargets);
+    auto newIfOp = IfOp::create(rewriter, op.getLoc(), op.getResultTypes(),
+                                ValueRange(qcoTargets).getTypes(),
+                                op.getCondition(), qcoTargets);
     assignMappedTensors(state, op.getOperation(), registerMap,
-                        newIfOp.getResults().take_front(numRegisters));
+                        newIfOp.getLinearResults().take_front(numRegisters));
     assignMappedQubits(state, op.getOperation(), qubitMap,
-                       newIfOp.getResults().take_back(numQubits));
+                       newIfOp.getLinearResults().take_back(numQubits));
 
     // Extract all the previously inserted qubits again
     rewriter.setInsertionPointAfter(newIfOp);
@@ -1535,10 +1536,11 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
 
     // Create the new blocks and move the contents from the old blocks into the
     // new ones
+    const auto qcoTargetTypes = ValueRange(qcoTargets).getTypes();
     auto* thenBlock =
-        rewriter.createBlock(&thenRegion, {}, newIfOp->getResultTypes(), locs);
+        rewriter.createBlock(&thenRegion, {}, qcoTargetTypes, locs);
     auto* elseBlock =
-        rewriter.createBlock(&elseRegion, {}, newIfOp->getResultTypes(), locs);
+        rewriter.createBlock(&elseRegion, {}, qcoTargetTypes, locs);
 
     thenBlock->getOperations().splice(
         thenBlock->end(), op.getThenRegion().front().getOperations());
@@ -1564,7 +1566,7 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
                        thenBlock->getArguments().take_back(numQubits),
                        thenBlock->getArguments().take_front(numRegisters));
 
-    rewriter.eraseOp(op);
+    rewriter.replaceOp(op, newIfOp.getClassicalResults());
     return success();
   }
 };
@@ -1602,6 +1604,12 @@ struct ConvertSCFIndexSwitchOp final
   LogicalResult
   matchAndRewrite(scf::IndexSwitchOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
+    if (op.getNumResults() != 0) {
+      op.emitError("classical scf.index_switch results are not supported by "
+                   "the QC-to-QCO conversion");
+      return failure();
+    }
+
     auto& state = getState();
     auto* operation = op.getOperation();
     auto& registerMap = state.regionRegisterMap[op];

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -1263,9 +1263,9 @@ ValueRange QCOProgramBuilder::qcoIndexSwitch(
   }
 
   buildRegion(switchOp.getDefaultRegion(), prev, defaultBody);
-  updateQubitValueTracking(prev, switchOp.getResults());
+  updateQubitValueTracking(prev, switchOp.getLinearResults());
 
-  return switchOp.getResults();
+  return switchOp.getLinearResults();
 }
 
 Value QCOProgramBuilder::qcoIndexSwitch(
@@ -1302,8 +1302,8 @@ Value QCOProgramBuilder::qcoIndexSwitch(
     previous = buildRegion(region, previous, body);
   }
   previous = buildRegion(switchOp.getDefaultRegion(), previous, defaultBody);
-  updateQubitValueTracking(previous, switchOp.getResult(0));
-  return switchOp.getResult(0);
+  updateQubitValueTracking(previous, switchOp.getLinearResults().front());
+  return switchOp.getLinearResults().front();
 }
 
 Value QCOProgramBuilder::qcoIf(const std::variant<bool, Value>& condition,

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -1206,13 +1206,13 @@ ValueRange QCOProgramBuilder::qcoIf(
           "Else body must return exactly one value per input value");
     }
     YieldOp::create(*this, elseResult);
-    updateQubitValueTracking(elseResult, ifOp.getResults());
+    updateQubitValueTracking(elseResult, ifOp.getLinearResults());
   } else {
     YieldOp::create(*this, elseArgs);
-    updateQubitValueTracking(thenResult, ifOp.getResults());
+    updateQubitValueTracking(thenResult, ifOp.getLinearResults());
   }
 
-  return ifOp.getResults();
+  return ifOp.getLinearResults();
 }
 
 ValueRange QCOProgramBuilder::qcoIndexSwitch(
@@ -1328,13 +1328,13 @@ Value QCOProgramBuilder::qcoIf(const std::variant<bool, Value>& condition,
                                elseResult = elseBody(arg);
                                return elseResult;
                              });
-    updateQubitValueTracking(elseResult, ifOp.getResult(0));
-    return ifOp.getResult(0);
+    updateQubitValueTracking(elseResult, ifOp.getLinearResults().front());
+    return ifOp.getLinearResults().front();
   }
 
   auto ifOp = IfOp::create(*this, conditionValue, updatedArg, trackedThenBody);
-  updateQubitValueTracking(thenResult, ifOp.getResult(0));
-  return ifOp.getResult(0);
+  updateQubitValueTracking(thenResult, ifOp.getLinearResults().front());
+  return ifOp.getLinearResults().front();
 }
 
 QCOProgramBuilder& QCOProgramBuilder::scfCondition(Value condition,

--- a/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
@@ -35,6 +35,15 @@
 using namespace mlir;
 using namespace mlir::qco;
 
+static bool isQCOLinearType(Type type) {
+  if (isa<QubitType>(type)) {
+    return true;
+  }
+  const auto tensorType = dyn_cast<RankedTensorType>(type);
+  return tensorType && tensorType.getRank() == 1 &&
+         isa<QubitType>(tensorType.getElementType());
+}
+
 //===----------------------------------------------------------------------===//
 // Custom Parsers
 //===----------------------------------------------------------------------===//
@@ -77,14 +86,29 @@ ParseResult IfOp::parse(::mlir::OpAsmParser& parser,
   if (parser.parseArrowTypeList(result.types)) {
     return failure();
   }
+  const auto numLinearResults = thenOperands.size();
+  if (result.types.size() < numLinearResults) {
+    return parser.emitError(
+        parser.getCurrentLocation(),
+        "expected at least one linear result type per assigned argument");
+  }
+  const auto numClassicalResults = result.types.size() - numLinearResults;
+  const auto linearResultTypes =
+      ArrayRef(result.types).take_back(numLinearResults);
+  if (llvm::any_of(linearResultTypes,
+                   [](Type type) { return !isQCOLinearType(type); })) {
+    return parser.emitError(parser.getCurrentLocation(),
+                            "assigned arguments must correspond to trailing "
+                            "linear result types");
+  }
   // Resolve the operands
-  if (failed(parser.resolveOperands(thenOperands, result.types,
+  if (failed(parser.resolveOperands(thenOperands, linearResultTypes,
                                     parser.getCurrentLocation(),
                                     result.operands))) {
     return failure();
   }
   // Set the argument types
-  for (auto [iterArg, type] : llvm::zip_equal(thenArgs, result.types)) {
+  for (auto [iterArg, type] : llvm::zip_equal(thenArgs, linearResultTypes)) {
     iterArg.type = type;
   }
   // Parse the then region
@@ -102,11 +126,16 @@ ParseResult IfOp::parse(::mlir::OpAsmParser& parser,
   if (parser.parseAssignmentList(elseRegionArgs, elseOperands)) {
     return failure();
   }
+  if (elseOperands.size() != numLinearResults) {
+    return parser.emitError(
+        parser.getCurrentLocation(),
+        "expected the same number of linear arguments in both branches");
+  }
 
   SmallVector<Value> resolvedElseOperands;
   // Also resolve the else operands to check if they are the same as the
   // previous operands
-  if (failed(parser.resolveOperands(elseOperands, result.types,
+  if (failed(parser.resolveOperands(elseOperands, linearResultTypes,
                                     parser.getCurrentLocation(),
                                     resolvedElseOperands))) {
     return failure();
@@ -122,7 +151,8 @@ ParseResult IfOp::parse(::mlir::OpAsmParser& parser,
   }
 
   // Set the argument types
-  for (auto [iterArg, type] : llvm::zip_equal(elseRegionArgs, result.types)) {
+  for (auto [iterArg, type] :
+       llvm::zip_equal(elseRegionArgs, linearResultTypes)) {
     iterArg.type = type;
   }
   // Parse the else region
@@ -135,6 +165,11 @@ ParseResult IfOp::parse(::mlir::OpAsmParser& parser,
   if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
   }
+
+  llvm::copy(
+      ArrayRef<int32_t>({static_cast<int32_t>(numClassicalResults),
+                         static_cast<int32_t>(numLinearResults)}),
+      result.getOrAddProperties<IfOp::Properties>().resultSegmentSizes.begin());
 
   return success();
 }
@@ -170,7 +205,39 @@ void IfOp::print(OpAsmPrinter& p) {
   printQubitsBlock(getElseRegion(), getQubits());
   p.printRegion(getElseRegion(), /*printEntryBlockArgs=*/false);
 
-  p.printOptionalAttrDict((*this)->getAttrs());
+  p.printOptionalAttrDict((*this)->getAttrs(), {"resultSegmentSizes"});
+}
+
+LogicalResult YieldOp::verify() {
+  SmallVector<Type> expectedTypes;
+  bool validParent = true;
+  TypeSwitch<Operation*>(getOperation()->getParentOp())
+      .Case<IfOp, IndexSwitchOp, InvOp, PowOp>([&](auto parent) {
+        llvm::append_range(expectedTypes, parent.getResultTypes());
+      })
+      .Case<CtrlOp>([&](CtrlOp parent) {
+        llvm::append_range(expectedTypes, parent.getTargetsOut().getTypes());
+      })
+      .Default([&](Operation*) { validParent = false; });
+  if (!validParent) {
+    return emitOpError("has an unsupported parent operation");
+  }
+
+  if (getTargets().size() != expectedTypes.size()) {
+    return emitOpError() << "must yield " << expectedTypes.size()
+                         << " values for parent operation but yields "
+                         << getTargets().size();
+  }
+
+  for (const auto [index, types] : llvm::enumerate(llvm::zip_equal(
+           getTargets().getTypes(), TypeRange(expectedTypes)))) {
+    const auto [actual, expected] = types;
+    if (actual != expected) {
+      return emitOpError() << "operand " << index << " has type " << actual
+                           << " but parent operation expects " << expected;
+    }
+  }
+  return success();
 }
 
 ParseResult IndexSwitchOp::parse(::mlir::OpAsmParser& parser,

--- a/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOOps.cpp
@@ -264,6 +264,38 @@ ParseResult IndexSwitchOp::parse(::mlir::OpAsmParser& parser,
   SmallVector<int64_t> caseValues;
   SmallVector<OpAsmParser::Argument> regionArgs;
   SmallVector<OpAsmParser::UnresolvedOperand> regionOperands;
+  SmallVector<Type> linearResultTypes;
+  bool initializedResultSegments = false;
+
+  const auto initializeResultSegments =
+      [&](const size_t numLinearResults) -> ParseResult {
+    if (initializedResultSegments) {
+      if (linearResultTypes.size() != numLinearResults) {
+        return parser.emitError(
+            parser.getCurrentLocation(),
+            "all cases and the default region must use the same number of "
+            "linear arguments");
+      }
+      return success();
+    }
+    if (result.types.size() < numLinearResults) {
+      return parser.emitError(
+          parser.getCurrentLocation(),
+          "expected at least one linear result type per assigned argument");
+    }
+
+    const auto trailingTypes =
+        ArrayRef(result.types).take_back(numLinearResults);
+    if (llvm::any_of(trailingTypes,
+                     [](Type type) { return !isQCOLinearType(type); })) {
+      return parser.emitError(parser.getCurrentLocation(),
+                              "assigned arguments must correspond to trailing "
+                              "linear result types");
+    }
+    llvm::append_range(linearResultTypes, trailingTypes);
+    initializedResultSegments = true;
+    return success();
+  };
 
   while (succeeded(parser.parseOptionalKeyword("case"))) {
     int64_t caseValue = 0;
@@ -280,12 +312,15 @@ ParseResult IndexSwitchOp::parse(::mlir::OpAsmParser& parser,
     if (parser.parseAssignmentList(regionArgs, regionOperands)) {
       return failure();
     }
+    if (failed(initializeResultSegments(regionOperands.size()))) {
+      return failure();
+    }
 
     if (caseValues.size() == 1) {
 
       // Resolve the operands into the result for the very first case.
 
-      if (parser.resolveOperands(regionOperands, result.types,
+      if (parser.resolveOperands(regionOperands, linearResultTypes,
                                  parser.getCurrentLocation(),
                                  result.operands)) {
         return failure();
@@ -296,7 +331,7 @@ ParseResult IndexSwitchOp::parse(::mlir::OpAsmParser& parser,
       // the case-value) as the first one.
 
       SmallVector<Value> operands;
-      if (parser.resolveOperands(regionOperands, result.types,
+      if (parser.resolveOperands(regionOperands, linearResultTypes,
                                  parser.getCurrentLocation(), operands)) {
         return failure();
       }
@@ -311,7 +346,7 @@ ParseResult IndexSwitchOp::parse(::mlir::OpAsmParser& parser,
       }
     }
 
-    for (auto [arg, type] : llvm::zip_equal(regionArgs, result.types)) {
+    for (auto [arg, type] : llvm::zip_equal(regionArgs, linearResultTypes)) {
       arg.type = type;
     }
 
@@ -341,11 +376,14 @@ ParseResult IndexSwitchOp::parse(::mlir::OpAsmParser& parser,
   if (parser.parseAssignmentList(regionArgs, regionOperands)) {
     return failure();
   }
+  if (failed(initializeResultSegments(regionOperands.size()))) {
+    return failure();
+  }
 
   // Otherwise, verify if the other cases use the equivalent operands (minus
   // the case-value) for all other cases.
 
-  if (parser.resolveOperands(regionOperands, result.types,
+  if (parser.resolveOperands(regionOperands, linearResultTypes,
                              parser.getCurrentLocation(), operands)) {
     return failure();
   }
@@ -363,13 +401,20 @@ ParseResult IndexSwitchOp::parse(::mlir::OpAsmParser& parser,
     }
   }
 
-  for (auto [args, type] : llvm::zip_equal(regionArgs, result.types)) {
+  for (auto [args, type] : llvm::zip_equal(regionArgs, linearResultTypes)) {
     args.type = type;
   }
 
   if (parser.parseRegion(*defaultRegion, regionArgs)) {
     return failure();
   }
+
+  const auto numLinearResults = linearResultTypes.size();
+  const auto numClassicalResults = result.types.size() - numLinearResults;
+  llvm::copy(ArrayRef<int32_t>({static_cast<int32_t>(numClassicalResults),
+                                static_cast<int32_t>(numLinearResults)}),
+             result.getOrAddProperties<IndexSwitchOp::Properties>()
+                 .resultSegmentSizes.begin());
 
   return success();
 }
@@ -378,15 +423,12 @@ void IndexSwitchOp::print(OpAsmPrinter& p) {
   p << " ";
   p.printOperand(getArg());
 
-  // Print result types if present
-  if (!getResults().empty()) {
-    p << " -> ";
-    llvm::interleaveComma(getResultTypes(), p);
-  }
+  p.printOptionalArrowTypeList(getResultTypes());
 
   // Print attributes (excluding cases which we handle specially)
-  p.printOptionalAttrDictWithKeyword(getOperation()->getAttrs(),
-                                     /*elidedAttrs=*/{"cases"});
+  p.printOptionalAttrDictWithKeyword(
+      getOperation()->getAttrs(),
+      /*elidedAttrs=*/{"cases", "resultSegmentSizes"});
 
   // Print case regions
   const auto cases = getCases();

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -11,8 +11,10 @@
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
+#include <llvm/ADT/BitVector.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/Sequence.h>
 #include <llvm/ADT/SmallVector.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Attributes.h>
@@ -29,6 +31,7 @@
 #include <mlir/Support/LLVM.h>
 
 #include <cassert>
+#include <cstdint>
 
 using namespace mlir;
 using namespace mlir::qco;
@@ -272,11 +275,111 @@ struct ConditionPropagation : public OpRewritePattern<IfOp> {
     return success(changed);
   }
 };
+
+/**
+ * @brief Forward redundant classical results
+ *
+ * @details
+ * Replaces a classical result with a value yielded by both branches or with an
+ * earlier classical result whose pair of yielded values is identical. A
+ * separate pattern removes the result and its yield operands once they become
+ * unused. Linear results are intentionally excluded because their explicit
+ * branch threading is part of QCO's quantum dataflow.
+ */
+struct ForwardClassicalResults : public OpRewritePattern<IfOp> {
+  using OpRewritePattern<IfOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IfOp op,
+                                PatternRewriter& rewriter) const override {
+    const auto classicalResults = op.getClassicalResults();
+    if (classicalResults.empty()) {
+      return failure();
+    }
+
+    const auto thenValues =
+        op.thenYield().getTargets().take_front(classicalResults.size());
+    const auto elseValues =
+        op.elseYield().getTargets().take_front(classicalResults.size());
+
+    bool changed = false;
+    for (const auto [index, result] : llvm::enumerate(classicalResults)) {
+      Value replacement;
+      if (thenValues[index] == elseValues[index]) {
+        replacement = thenValues[index];
+      } else {
+        for (const auto candidate : llvm::seq(index)) {
+          if (thenValues[candidate] == thenValues[index] &&
+              elseValues[candidate] == elseValues[index]) {
+            replacement = classicalResults[candidate];
+            break;
+          }
+        }
+      }
+
+      if (replacement && !result.use_empty()) {
+        rewriter.replaceAllUsesWith(result, replacement);
+        changed = true;
+      }
+    }
+    return success(changed);
+  }
+};
+
+/**
+ * @brief Remove unused classical results
+ *
+ * @details
+ * Removes unused classical results and the corresponding operands from both
+ * branch terminators. The result segment property is updated on the replacement
+ * operation. The linear result suffix and all quantum dataflow remain intact.
+ */
+struct RemoveUnusedClassicalResults : public OpRewritePattern<IfOp> {
+  using OpRewritePattern<IfOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IfOp op,
+                                PatternRewriter& rewriter) const override {
+    llvm::BitVector resultsToErase(op.getNumResults());
+    for (const OpResult result : op.getClassicalResults()) {
+      if (result.use_empty()) {
+        resultsToErase.set(result.getResultNumber());
+      }
+    }
+    if (resultsToErase.none()) {
+      return failure();
+    }
+
+    const auto numLinearResults = op.getLinearResults().size();
+    const auto numClassicalResults =
+        op.getClassicalResults().size() - resultsToErase.count();
+
+    llvm::BitVector yieldOperandsToErase(op.thenYield().getNumOperands());
+    for (const auto result : op.getClassicalResults()) {
+      if (resultsToErase.test(result.getResultNumber())) {
+        yieldOperandsToErase.set(result.getResultNumber());
+      }
+    }
+    rewriter.modifyOpInPlace(op.thenYield(), [&]() {
+      op.thenYield()->eraseOperands(yieldOperandsToErase);
+    });
+    rewriter.modifyOpInPlace(op.elseYield(), [&]() {
+      op.elseYield()->eraseOperands(yieldOperandsToErase);
+    });
+
+    auto replacement = cast<IfOp>(rewriter.eraseOpResults(op, resultsToErase));
+    rewriter.modifyOpInPlace(replacement, [&]() {
+      replacement.getProperties().setResultSegmentSizes(
+          ArrayRef<int32_t>({static_cast<int32_t>(numClassicalResults),
+                             static_cast<int32_t>(numLinearResults)}));
+    });
+    return success();
+  }
+};
 } // namespace
 
 void IfOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                        MLIRContext* context) {
-  results.add<RemoveStaticCondition, ConditionPropagation>(context);
+  results.add<RemoveStaticCondition, ConditionPropagation,
+              ForwardClassicalResults, RemoveUnusedClassicalResults>(context);
 }
 
 LogicalResult IfOp::verify() {

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
 #include <llvm/ADT/STLExtras.h>
@@ -32,12 +33,22 @@
 using namespace mlir;
 using namespace mlir::qco;
 
+static bool isLinearType(Type type) {
+  if (isa<QubitType>(type)) {
+    return true;
+  }
+  const auto tensorType = dyn_cast<RankedTensorType>(type);
+  return tensorType && tensorType.getRank() == 1 &&
+         isa<QubitType>(tensorType.getElementType());
+}
+
 void IfOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                  Value condition, ValueRange qubits,
                  function_ref<SmallVector<Value>(ValueRange)> thenBuilder,
                  function_ref<SmallVector<Value>(ValueRange)> elseBuilder) {
   // Build the empty operation
-  build(odsBuilder, odsState, qubits.getTypes(), condition, qubits);
+  build(odsBuilder, odsState, TypeRange{}, qubits.getTypes(), condition,
+        qubits);
 
   // Add the blocks to the regions
   auto& thenBlock = odsState.regions.front()->emplaceBlock();
@@ -65,7 +76,8 @@ void IfOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                  Value condition, Value input,
                  function_ref<Value(Value)> thenBuilder,
                  function_ref<Value(Value)> elseBuilder) {
-  build(odsBuilder, odsState, input.getType(), condition, input);
+  const SmallVector<Type> linearResultTypes{input.getType()};
+  build(odsBuilder, odsState, TypeRange{}, linearResultTypes, condition, input);
 
   auto& thenBlock = odsState.regions.front()->emplaceBlock();
   auto& elseBlock = odsState.regions.back()->emplaceBlock();
@@ -94,7 +106,8 @@ void IfOp::getSuccessorRegions(RegionBranchPoint point,
     return;
   }
 
-  regions.push_back(RegionSuccessor(&getThenRegion()));
+  regions.push_back(
+      RegionSuccessor(&getThenRegion(), getThenRegion().getArguments()));
 
   // If the else region is empty, execution continues after the parent op.
   Region* elseRegion = &getElseRegion();
@@ -102,7 +115,7 @@ void IfOp::getSuccessorRegions(RegionBranchPoint point,
     regions.push_back(
         RegionSuccessor(getOperation(), getOperation()->getResults()));
   } else {
-    regions.push_back(RegionSuccessor(elseRegion));
+    regions.push_back(RegionSuccessor(elseRegion, elseRegion->getArguments()));
   }
 }
 
@@ -111,17 +124,21 @@ void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
   FoldAdaptor adaptor(operands, *this);
   auto boolAttr = dyn_cast_or_null<BoolAttr>(adaptor.getCondition());
   if (!boolAttr || boolAttr.getValue()) {
-    regions.emplace_back(&getThenRegion());
+    regions.emplace_back(&getThenRegion(), getThenRegion().getArguments());
   }
 
   // If the else region is empty, execution continues after the parent op.
   if (!boolAttr || !boolAttr.getValue()) {
     if (!getElseRegion().empty()) {
-      regions.emplace_back(&getElseRegion());
+      regions.emplace_back(&getElseRegion(), getElseRegion().getArguments());
     } else {
       regions.emplace_back(getOperation(), getResults());
     }
   }
+}
+
+OperandRange IfOp::getEntrySuccessorOperands(RegionSuccessor /*successor*/) {
+  return getQubits();
 }
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void IfOp::getRegionInvocationBounds(
@@ -260,14 +277,12 @@ struct ConditionPropagation : public OpRewritePattern<IfOp> {
 void IfOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                        MLIRContext* context) {
   results.add<RemoveStaticCondition, ConditionPropagation>(context);
-  populateRegionBranchOpInterfaceCanonicalizationPatterns(
-      results, IfOp::getOperationName());
 }
 
 LogicalResult IfOp::verify() {
   const auto& inputQubits = getQubits();
   const auto numInputQubits = inputQubits.size();
-  const auto& outputQubits = getResults();
+  const auto& outputQubits = getLinearResults();
   const auto numOutputQubits = outputQubits.size();
 
   const auto numThenArgs = thenBlock()->getNumArguments();
@@ -285,11 +300,24 @@ LogicalResult IfOp::verify() {
     return emitOpError("Operation must return the same number of qubits as the "
                        "number of input qubits.");
   }
+  for (Type type : getClassicalResults().getTypes()) {
+    if (isLinearType(type)) {
+      return emitOpError("classical results must not use QCO linear types");
+    }
+  }
   for (auto [inputQubitType, outputQubitType] :
        llvm::zip_equal(inputQubits.getTypes(), outputQubits.getTypes())) {
     if (inputQubitType != outputQubitType) {
       return emitOpError("Operation must return the same qubit types as its "
                          "input qubit types.");
+    }
+  }
+  for (const auto [inputType, thenType, elseType] :
+       llvm::zip_equal(inputQubits.getTypes(), thenBlock()->getArgumentTypes(),
+                       elseBlock()->getArgumentTypes())) {
+    if (inputType != thenType || inputType != elseType) {
+      return emitOpError(
+          "branch argument types must match the input qubit types");
     }
   }
   SmallPtrSet<Value, 4> uniqueQubitsIn;
@@ -303,22 +331,26 @@ LogicalResult IfOp::verify() {
 }
 
 OpResult IfOp::getTiedResult(OpOperand* qubit) {
-  if (qubit->getOwner() != getOperation()) {
+  if (qubit->getOwner() != getOperation() || qubit->getOperandNumber() == 0) {
     return {};
   }
   // Because the first operand is the if-condition, subtract one.
-  return getResults()[qubit->getOperandNumber() - 1];
+  return getLinearResults()[qubit->getOperandNumber() - 1];
 }
 
 OpOperand* IfOp::getTiedQubit(OpResult result) {
   if (result.getDefiningOp() != getOperation()) {
     return nullptr;
   }
-  return &getQubitsMutable()[result.getResultNumber()];
+  const auto numClassicalResults = getClassicalResults().size();
+  if (result.getResultNumber() < numClassicalResults) {
+    return nullptr;
+  }
+  return &getQubitsMutable()[result.getResultNumber() - numClassicalResults];
 }
 
 BlockArgument IfOp::getTiedThenBlockArgument(OpOperand* qubit) {
-  if (qubit->getOwner() != getOperation()) {
+  if (qubit->getOwner() != getOperation() || qubit->getOperandNumber() == 0) {
     return {};
   }
   // Because the first operand is the if-condition, subtract one.
@@ -326,7 +358,7 @@ BlockArgument IfOp::getTiedThenBlockArgument(OpOperand* qubit) {
 }
 
 BlockArgument IfOp::getTiedElseBlockArgument(OpOperand* qubit) {
-  if (qubit->getOwner() != getOperation()) {
+  if (qubit->getOwner() != getOperation() || qubit->getOperandNumber() == 0) {
     return {};
   }
   // Because the first operand is the if-condition, subtract one.
@@ -334,17 +366,19 @@ BlockArgument IfOp::getTiedElseBlockArgument(OpOperand* qubit) {
 }
 
 OpOperand* IfOp::getTiedThenYieldedValue(BlockArgument bbArg) {
-  if (bbArg.getOwner()->getParentOp() != getOperation()) {
+  if (bbArg.getOwner() != thenBlock()) {
     return nullptr;
   }
-  return &thenYield().getTargetsMutable()[bbArg.getArgNumber()];
+  return &thenYield().getTargetsMutable()[getClassicalResults().size() +
+                                          bbArg.getArgNumber()];
 }
 
 OpOperand* IfOp::getTiedElseYieldedValue(BlockArgument bbArg) {
-  if (bbArg.getOwner()->getParentOp() != getOperation()) {
+  if (bbArg.getOwner() != elseBlock()) {
     return nullptr;
   }
-  return &elseYield().getTargetsMutable()[bbArg.getArgNumber()];
+  return &elseYield().getTargetsMutable()[getClassicalResults().size() +
+                                          bbArg.getArgNumber()];
 }
 
 IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
@@ -361,7 +395,9 @@ IfOp IfOp::replaceWithAdditionalQubits(RewriterBase& rewriter,
   newQubits.append(addons.begin(), addons.end());
   const auto allQubitTypes = ValueRange(newQubits).getTypes();
 
-  auto newIfOp = create(rewriter, getLoc(), getCondition(), newQubits);
+  auto newIfOp =
+      create(rewriter, getLoc(), getClassicalResults().getTypes(),
+             ValueRange(newQubits).getTypes(), getCondition(), newQubits);
 
   const auto rewriteRegion = [&](Region& oldRegion, Region& newRegion) {
     auto* oldBlock = &oldRegion.front();

--- a/mlir/lib/Dialect/QCO/IR/SCF/IndexSwitchOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IndexSwitchOp.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
 #include <llvm/ADT/DenseSet.h>
@@ -32,6 +33,15 @@
 using namespace mlir;
 using namespace mlir::qco;
 
+static bool isLinearType(Type type) {
+  if (isa<QubitType>(type)) {
+    return true;
+  }
+  const auto tensorType = dyn_cast<RankedTensorType>(type);
+  return tensorType && tensorType.getRank() == 1 &&
+         isa<QubitType>(tensorType.getElementType());
+}
+
 void IndexSwitchOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                           Value arg, Value target, ArrayRef<int64_t> cases,
                           ArrayRef<function_ref<Value(Value)>> caseBuilders,
@@ -41,7 +51,8 @@ void IndexSwitchOp::build(OpBuilder& odsBuilder, OperationState& odsState,
         "Each case must have a corresponding case body function");
   }
 
-  build(odsBuilder, odsState, target.getType(), arg, cases, target,
+  const SmallVector<Type> linearResultTypes{target.getType()};
+  build(odsBuilder, odsState, linearResultTypes, arg, cases, target,
         cases.size());
 
   const OpBuilder::InsertionGuard guard(odsBuilder);
@@ -70,7 +81,9 @@ void IndexSwitchOp::getSuccessorRegions(
     return;
   }
 
-  llvm::append_range(regions, getRegions());
+  for (Region* region : getRegions()) {
+    regions.emplace_back(region, region->getArguments());
+  }
 }
 
 void IndexSwitchOp::getRegionInvocationBounds(
@@ -108,7 +121,9 @@ void IndexSwitchOp::getEntrySuccessorRegions(
   // If a constant was not provided, all regions are possible successors.
   auto arg = dyn_cast_or_null<IntegerAttr>(adaptor.getArg());
   if (!arg) {
-    llvm::append_range(regions, getRegions());
+    for (Region* region : getRegions()) {
+      regions.emplace_back(region, region->getArguments());
+    }
     return;
   }
 
@@ -117,12 +132,19 @@ void IndexSwitchOp::getEntrySuccessorRegions(
 
   const auto* it = llvm::find(getCases(), arg.getInt());
   if (it == getCases().end()) {
-    regions.emplace_back(&getDefaultRegion());
+    regions.emplace_back(&getDefaultRegion(),
+                         getDefaultRegion().getArguments());
     return;
   }
 
   const auto caseIndex = std::distance(getCases().begin(), it);
-  regions.emplace_back(&getCaseRegions()[caseIndex]);
+  auto& caseRegion = getCaseRegions()[caseIndex];
+  regions.emplace_back(&caseRegion, caseRegion.getArguments());
+}
+
+OperandRange
+IndexSwitchOp::getEntrySuccessorOperands(RegionSuccessor /*successor*/) {
+  return getTargets();
 }
 
 LogicalResult IndexSwitchOp::verify() {
@@ -140,7 +162,7 @@ LogicalResult IndexSwitchOp::verify() {
 
   const auto targets = getTargets();
   const auto ntargets = targets.size();
-  const auto results = getResults();
+  const auto results = getLinearResults();
   const auto nresults = results.size();
 
   for (Region* region : getRegions()) {
@@ -148,6 +170,15 @@ LogicalResult IndexSwitchOp::verify() {
       return emitOpError(
           "Region " + Twine(region->getRegionNumber()) +
           " must have the same number of arguments as the number of targets");
+    }
+    if (!llvm::equal(region->getArgumentTypes(), targets.getTypes())) {
+      return emitOpError("region argument types must match the target types");
+    }
+  }
+
+  for (Type type : getClassicalResults().getTypes()) {
+    if (isLinearType(type)) {
+      return emitOpError("classical results must not use QCO linear types");
     }
   }
 
@@ -175,23 +206,28 @@ LogicalResult IndexSwitchOp::verify() {
 }
 
 OpResult IndexSwitchOp::getTiedResult(OpOperand* target) {
-  if (target->getOwner() != getOperation()) {
+  if (target->getOwner() != getOperation() || target->getOperandNumber() == 0) {
     return {};
   }
   // Because the first operand is the index, subtract one.
-  return getResults()[target->getOperandNumber() - 1];
+  return getLinearResults()[target->getOperandNumber() - 1];
 }
 
 OpOperand* IndexSwitchOp::getTiedTarget(OpResult result) {
   if (result.getDefiningOp() != getOperation()) {
     return nullptr;
   }
-  return &getTargetsMutable()[result.getResultNumber()];
+  const auto numClassicalResults = getClassicalResults().size();
+  if (result.getResultNumber() < numClassicalResults) {
+    return nullptr;
+  }
+  return &getTargetsMutable()[result.getResultNumber() - numClassicalResults];
 }
 
 BlockArgument IndexSwitchOp::getTiedCaseBlockArgument(OpOperand* target,
                                                       size_t i) {
-  if (target->getOwner() != getOperation() || i >= getNumCases()) {
+  if (target->getOwner() != getOperation() || target->getOperandNumber() == 0 ||
+      i >= getNumCases()) {
     return {};
   }
 
@@ -204,11 +240,12 @@ OpOperand* IndexSwitchOp::getTiedCaseYieldedValue(BlockArgument bbArg,
     return nullptr;
   }
 
-  return &getCaseYield(i).getTargetsMutable()[bbArg.getArgNumber()];
+  return &getCaseYield(i).getTargetsMutable()[getClassicalResults().size() +
+                                              bbArg.getArgNumber()];
 }
 
 BlockArgument IndexSwitchOp::getTiedDefaultBlockArgument(OpOperand* target) {
-  if (target->getOwner() != getOperation()) {
+  if (target->getOwner() != getOperation() || target->getOperandNumber() == 0) {
     return {};
   }
 
@@ -220,7 +257,8 @@ OpOperand* IndexSwitchOp::getTiedDefaultYieldedValue(BlockArgument bbArg) {
     return nullptr;
   }
 
-  return &getDefaultYield().getTargetsMutable()[bbArg.getArgNumber()];
+  return &getDefaultYield().getTargetsMutable()[getClassicalResults().size() +
+                                                bbArg.getArgNumber()];
 }
 
 IndexSwitchOp
@@ -239,8 +277,9 @@ IndexSwitchOp::replaceWithAdditionalTargets(RewriterBase& rewriter,
   newTargets.append(addons.begin(), addons.end());
   const auto newTargetTypes = ValueRange(newTargets).getTypes();
 
-  auto newSwitchOp = create(rewriter, getLoc(), newTargetTypes, getArg(),
-                            getCases(), newTargets, getNumCases());
+  auto newSwitchOp =
+      create(rewriter, getLoc(), getClassicalResults().getTypes(),
+             newTargetTypes, getArg(), getCases(), newTargets, getNumCases());
 
   const auto rewriteRegion = [&](Region& oldRegion, Region& newRegion) {
     auto* oldBlock = &oldRegion.front();

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -724,8 +724,8 @@ private:
 
               auto newIfOp = extend(ifOp, to_vector(qubits), rewriter);
 
-              for (const auto [qubit, result] :
-                   llvm::zip_equal(newIfOp.getQubits(), newIfOp.getResults())) {
+              for (const auto [qubit, result] : llvm::zip_equal(
+                       newIfOp.getQubits(), newIfOp.getLinearResults())) {
                 qubits.insert(result);
                 qubits.erase(qubit);
               }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -447,6 +447,22 @@ private:
     return newIfOp;
   }
 
+  /// Extend the target arguments of an `IndexSwitchOp` by adding a given range
+  /// of additional SSA values. Replaces the existing operation and returns the
+  /// newly created one.
+  static IndexSwitchOp extend(IndexSwitchOp switchOp, ValueRange addons,
+                              IRRewriter& rewriter) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(switchOp);
+
+    auto newSwitchOp = switchOp.replaceWithAdditionalTargets(rewriter, addons);
+    for (const auto [before, after] : llvm::zip_equal(
+             addons, newSwitchOp.getLinearResults().take_back(addons.size()))) {
+      rewriter.replaceAllUsesExcept(before, after, newSwitchOp);
+    }
+    return newSwitchOp;
+  }
+
   /// Extend the arguments of an `scf::WhileOp` by adding a given range of
   /// additional SSA values. Replaces the existing operation and returns the
   /// newly created one.
@@ -738,6 +754,26 @@ private:
               stack.emplace_back(
                   newIfOp.getElseRegion(),
                   DenseSet<Value>(elseArgs.begin(), elseArgs.end()));
+            })
+            .Case<IndexSwitchOp>([&](IndexSwitchOp switchOp) {
+              assert(qubits.size() == layout.nqubits());
+
+              llvm::for_each(switchOp.getTargets(),
+                             [&](Value value) { qubits.erase(value); });
+
+              auto newSwitchOp = extend(switchOp, to_vector(qubits), rewriter);
+              for (const auto [target, result] :
+                   llvm::zip_equal(newSwitchOp.getTargets(),
+                                   newSwitchOp.getLinearResults())) {
+                qubits.insert(result);
+                qubits.erase(target);
+              }
+
+              for (Region* region : newSwitchOp.getRegions()) {
+                const auto args = region->getArguments();
+                stack.emplace_back(*region,
+                                   DenseSet<Value>(args.begin(), args.end()));
+              }
             })
             .Case<ResetOp, MeasureOp>([&](auto resetOp) {
               qubits.insert(resetOp.getQubitOut());
@@ -1150,7 +1186,7 @@ private:
                     released.emplace_back(op);
                   }
                 })
-                .template Case<scf::ForOp, scf::WhileOp, IfOp>(
+                .template Case<scf::ForOp, scf::WhileOp, IfOp, IndexSwitchOp>(
                     [&](auto op) { stack.emplace_back(op, indices); });
           }
 
@@ -1208,6 +1244,11 @@ private:
               return SmallVector<RoutingBundle, 2>{
                   RoutingBundle{.layout = parent.layout},
                   RoutingBundle{.layout = parent.layout}};
+            })
+            .template Case<IndexSwitchOp>([&](IndexSwitchOp switchOp) {
+              return SmallVector<RoutingBundle, 2>(
+                  switchOp.getNumRegions(),
+                  RoutingBundle{.layout = parent.layout});
             });
 
     SmallVector<std::optional<size_t>> resultToQubitIndex(op->getNumResults());
@@ -1277,6 +1318,29 @@ private:
                              ? ifOp.getTiedThenYieldedValue(arg)->get()
                              : ifOp.getTiedElseYieldedValue(arg)->get();
                 }
+              }());
+            }
+          })
+          .template Case<IndexSwitchOp>([&](IndexSwitchOp switchOp) {
+            OpOperand* const target = switchOp.getTiedTarget(res);
+            for (Region* region : switchOp.getRegions()) {
+              const auto regionNumber = region->getRegionNumber();
+              const auto arg =
+                  regionNumber == 0
+                      ? switchOp.getTiedDefaultBlockArgument(target)
+                      : switchOp.getTiedCaseBlockArgument(target,
+                                                          regionNumber - 1);
+              auto& child = children[regionNumber];
+              child.infos.insertOrUpdate(child.infos.size(), prog);
+              child.wires.emplace_back([&] -> Value {
+                if constexpr (Direction == WireDirection::Forward) {
+                  return arg;
+                }
+                return regionNumber == 0
+                           ? switchOp.getTiedDefaultYieldedValue(arg)->get()
+                           : switchOp
+                                 .getTiedCaseYieldedValue(arg, regionNumber - 1)
+                                 ->get();
               }());
             }
           });
@@ -1362,6 +1426,13 @@ private:
               insertSWAPs<Mode>(fst, children[0], stats, rewriter);
               insertSWAPs<Mode>(snd, children[1], stats, rewriter);
               return convergedLayout;
+            })
+            .template Case<IndexSwitchOp>([&](IndexSwitchOp) {
+              for (auto& child : children) {
+                const auto swaps = restore(child.layout, parent.layout);
+                insertSWAPs<Mode>(swaps, child, stats, rewriter);
+              }
+              return parent.layout;
             });
 
     if constexpr (Mode == RoutingMode::Hot) {
@@ -1387,9 +1458,9 @@ private:
                 yieldOp, realignQubitValues(yieldOp.getResults(), permutation,
                                             children[1]));
           })
-          .template Case<IfOp>([&](IfOp ifOp) {
+          .template Case<IfOp, IndexSwitchOp>([&](auto branchOp) {
             for (const auto [region, child] :
-                 llvm::zip_equal(ifOp->getRegions(), children)) {
+                 llvm::zip_equal(branchOp->getRegions(), children)) {
               auto yieldOp = cast<YieldOp>(region.front().getTerminator());
               rewriter->setInsertionPoint(yieldOp);
               rewriter->replaceOpWithNewOp<YieldOp>(

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/ReplaceClassicalControls.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/ReplaceClassicalControls.cpp
@@ -165,7 +165,7 @@ struct ReplaceBasisStateControlsWithIfPattern final
           return newCtrl.getOutputQubits();
         });
 
-    rewriter.replaceAllUsesWith(oldOutputs, ifOp.getResults());
+    rewriter.replaceAllUsesWith(oldOutputs, ifOp.getLinearResults());
     rewriter.eraseOp(ctrlOp);
 
     return success();

--- a/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
+++ b/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
@@ -115,10 +115,8 @@ void TensorIterator::forward() {
           tensor_ = whileResultForInit(op, *tensor_.use_begin().getOperand());
         })
         .Case<qco::IfOp>([&](qco::IfOp op) {
-          auto it = llvm::find(op.getQubits(), tensor_);
-          assert(it != op.getQubits().end());
-          const auto idx = std::distance(op.getQubits().begin(), it);
-          tensor_ = cast<TypedValue<RankedTensorType>>(op.getResults()[idx]);
+          tensor_ = cast<TypedValue<RankedTensorType>>(
+              op.getTiedResult(&(*tensor_.use_begin())));
         })
         .Case<qco::IndexSwitchOp>([&](qco::IndexSwitchOp op) {
           tensor_ = cast<TypedValue<RankedTensorType>>(
@@ -183,10 +181,8 @@ void TensorIterator::backward() {
       })
       .Case<qco::IfOp>([&](qco::IfOp op) {
         if (auto res = dyn_cast<OpResult>(tensor_)) {
-          auto it = llvm::find(op.getResults(), res);
-          assert(it != op->result_end());
-          const auto idx = std::distance(op.result_begin(), it);
-          tensor_ = cast<TypedValue<RankedTensorType>>(op.getQubits()[idx]);
+          tensor_ =
+              cast<TypedValue<RankedTensorType>>(op.getTiedQubit(res)->get());
           return;
         }
 

--- a/mlir/lib/Support/IRVerification.cpp
+++ b/mlir/lib/Support/IRVerification.cpp
@@ -31,6 +31,7 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Region.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
 
 #include <cassert>
@@ -153,6 +154,22 @@ static void mapResults(Operation* lhs, Operation* rhs,
                        ArrayRef<size_t> permutation, IRMapping& m) {
   for (const auto& [i, lhsResult] : llvm::enumerate(lhs->getResults())) {
     m.map(lhsResult, rhs->getResult(permutation[i]));
+  }
+}
+
+/// Map a classical result prefix positionally and a linear result suffix using
+/// the given permutation.
+static void mapSegmentedResults(ValueRange lhsClassical,
+                                ValueRange rhsClassical, ValueRange lhsLinear,
+                                ValueRange rhsLinear,
+                                ArrayRef<size_t> linearPermutation,
+                                IRMapping& mapping) {
+  for (const auto [lhsResult, rhsResult] :
+       llvm::zip_equal(lhsClassical, rhsClassical)) {
+    mapping.map(lhsResult, rhsResult);
+  }
+  for (const auto [index, lhsResult] : llvm::enumerate(lhsLinear)) {
+    mapping.map(lhsResult, rhsLinear[linearPermutation[index]]);
   }
 }
 
@@ -416,8 +433,27 @@ static bool compareOperations(Operation* lhs, Operation* rhs,
     }
   } else if (isa<qco::YieldOp>(lhs)) {
     assert(isa<qco::YieldOp>(rhs));
-    if (!compareValueLists(cast<qco::YieldOp>(lhs).getTargets(),
-                           cast<qco::YieldOp>(rhs).getTargets(), m, tm)) {
+    auto lhsYield = cast<qco::YieldOp>(lhs);
+    auto rhsYield = cast<qco::YieldOp>(rhs);
+
+    size_t numClassicalResults = 0;
+    if (auto ifOp = dyn_cast<qco::IfOp>(lhs->getParentOp())) {
+      numClassicalResults = ifOp.getClassicalResults().size();
+    } else if (auto switchOp =
+                   dyn_cast<qco::IndexSwitchOp>(lhs->getParentOp())) {
+      numClassicalResults = switchOp.getClassicalResults().size();
+    }
+
+    for (const auto [lhsValue, rhsValue] : llvm::zip_equal(
+             lhsYield.getTargets().take_front(numClassicalResults),
+             rhsYield.getTargets().take_front(numClassicalResults))) {
+      if (m.lookup(lhsValue) != rhsValue) {
+        return false;
+      }
+    }
+    if (!compareValueLists(
+            lhsYield.getTargets().drop_front(numClassicalResults),
+            rhsYield.getTargets().drop_front(numClassicalResults), m, tm)) {
       return false;
     }
   } else {
@@ -658,7 +694,10 @@ static bool compareBlocks(Block& lhs, Block& rhs,
             if (failed(permutation)) {
               return false;
             }
-            mapResults(lhsIf, rhsIf, *permutation, m);
+            mapSegmentedResults(lhsIf.getClassicalResults(),
+                                rhsIf.getClassicalResults(),
+                                lhsIf.getLinearResults(),
+                                rhsIf.getLinearResults(), *permutation, m);
           } else if (isa<qco::IndexSwitchOp>(lhsOp)) {
             assert(isa<qco::IndexSwitchOp>(rhsOp));
             auto lhsSwitch = cast<qco::IndexSwitchOp>(lhsOp);
@@ -668,7 +707,10 @@ static bool compareBlocks(Block& lhs, Block& rhs,
             if (failed(permutation)) {
               return false;
             }
-            mapResults(lhsSwitch, rhsSwitch, *permutation, m);
+            mapSegmentedResults(lhsSwitch.getClassicalResults(),
+                                rhsSwitch.getClassicalResults(),
+                                lhsSwitch.getLinearResults(),
+                                rhsSwitch.getLinearResults(), *permutation, m);
           } else if (isa<qtensor::AllocOp>(lhsOp)) {
             assert(isa<qtensor::AllocOp>(rhsOp));
             auto lhsAlloc = cast<qtensor::AllocOp>(lhsOp);

--- a/mlir/unittests/Conversion/CMakeLists.txt
+++ b/mlir/unittests/Conversion/CMakeLists.txt
@@ -9,4 +9,5 @@
 add_subdirectory(QCToQCO)
 add_subdirectory(QCToQIR)
 add_subdirectory(QCOToQC)
+add_subdirectory(QCQCORoundTrip)
 add_subdirectory(JeffRoundTrip)

--- a/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
+++ b/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
@@ -21,15 +21,18 @@
 #include <jeff/IR/JeffDialect.h>
 #include <jeff/Translation/Deserialize.hpp>
 #include <jeff/Translation/Serialize.hpp>
+#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
@@ -179,6 +182,50 @@ TEST(JeffRoundTripRegressionTest, RestoresEntryPointWithObservableResults) {
   auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
   ASSERT_EQ(returnOp.getNumOperands(), 1);
   EXPECT_TRUE(returnOp.getOperand(0).getType().isInteger(1));
+}
+
+TEST(JeffRoundTripRegressionTest, RejectsClassicalIfResultsPrecisely) {
+  DialectRegistry registry;
+  registry.insert<arith::ArithDialect, func::FuncDialect, jeff::JeffDialect,
+                  qco::QCODialect, scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%condition: i1) -> i64
+      attributes {passthrough = ["entry_point"]} {
+    %q0 = qco.alloc : !qco.qubit
+    %then = arith.constant 1 : i64
+    %else = arith.constant 2 : i64
+    %result, %q1 = qco.if %condition args(%arg = %q0)
+        -> (i64, !qco.qubit) {
+      qco.yield %then, %arg : i64, !qco.qubit
+    } else args(%arg = %q0) {
+      qco.yield %else, %arg : i64, !qco.qubit
+    }
+    qco.sink %q1 : !qco.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    std::string message;
+    llvm::raw_string_ostream stream(message);
+    diagnostic.print(stream);
+    sawExpectedDiagnostic |= StringRef(message).contains(
+        "classical qco.if results are not supported by the QCO-to-Jeff "
+        "conversion");
+    return success();
+  });
+  EXPECT_TRUE(failed(convertQCOToJeff(*module)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
 }
 
 TEST_P(JeffRoundTripTest, ProgramEquivalence) {

--- a/mlir/unittests/Conversion/QCOToQC/CMakeLists.txt
+++ b/mlir/unittests/Conversion/QCOToQC/CMakeLists.txt
@@ -18,7 +18,8 @@ target_link_libraries(
           MLIRQCOProgramBuilder
           MLIRQCPrograms
           MLIRQCOPrograms
-          MLIRQCOToQC)
+          MLIRQCOToQC
+          MLIRQCToQCO)
 
 mqt_mlir_configure_unittest_target(${target_name})
 

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -10,6 +10,7 @@
 
 #include "TestCaseUtils.h"
 #include "mlir/Conversion/QCOToQC/QCOToQC.h"
+#include "mlir/Conversion/QCToQCO/QCToQCO.h"
 #include "mlir/Dialect/QC/Builder/QCProgramBuilder.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
@@ -28,6 +29,7 @@
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
@@ -79,6 +81,115 @@ static LogicalResult runQCOToQCConversion(ModuleOp module) {
   PassManager pm(module.getContext());
   pm.addPass(createQCOToQC());
   return pm.run(module);
+}
+
+TEST(QCOToQCRegressionTest, PreservesClassicalIfResult) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
+                  arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
+                  scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%condition: i1) -> i64
+      attributes {passthrough = ["entry_point"]} {
+    %q0 = qco.alloc : !qco.qubit
+    %then = arith.constant 1 : i64
+    %else = arith.constant 2 : i64
+    %result, %q1 = qco.if %condition args(%arg = %q0)
+        -> (i64, !qco.qubit) {
+      %q2 = qco.h %arg : !qco.qubit -> !qco.qubit
+      qco.yield %then, %q2 : i64, !qco.qubit
+    } else args(%arg = %q0) {
+      %q2 = qco.x %arg : !qco.qubit -> !qco.qubit
+      qco.yield %else, %q2 : i64, !qco.qubit
+    }
+    qco.sink %q1 : !qco.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCOToQCConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::IfOp ifOp;
+  module->walk([&](scf::IfOp candidate) { ifOp = candidate; });
+  ASSERT_TRUE(ifOp);
+  ASSERT_EQ(ifOp.getNumResults(), 1);
+  EXPECT_TRUE(ifOp.getResult(0).getType().isInteger(64));
+
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  EXPECT_EQ(returnOp.getOperand(0), ifOp.getResult(0));
+
+  bool containsQCOOperations = false;
+  module->walk([&](Operation* operation) {
+    containsQCOOperations |=
+        operation->getDialect() == context.getLoadedDialect<qco::QCODialect>();
+  });
+  EXPECT_FALSE(containsQCOOperations);
+}
+
+TEST(QCOToQCRegressionTest, RoundTripsClassicalIfResultWithoutScratch) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
+                  arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
+                  scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%condition: i1) -> i64
+      attributes {passthrough = ["entry_point"]} {
+    %q = qc.alloc : !qc.qubit
+    %result = scf.if %condition -> i64 {
+      qc.h %q : !qc.qubit
+      %then = arith.constant 1 : i64
+      scf.yield %then : i64
+    } else {
+      qc.x %q : !qc.qubit
+      %else = arith.constant 2 : i64
+      scf.yield %else : i64
+    }
+    qc.dealloc %q : !qc.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  PassManager pm(&context);
+  pm.addPass(createQCToQCO());
+  pm.addPass(createQCOToQC());
+  ASSERT_TRUE(succeeded(pm.run(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::IfOp ifOp;
+  module->walk([&](scf::IfOp candidate) { ifOp = candidate; });
+  ASSERT_TRUE(ifOp);
+  ASSERT_EQ(ifOp.getNumResults(), 1);
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  EXPECT_EQ(returnOp.getOperand(0), ifOp.getResult(0));
+
+  bool containsScratchStorage = false;
+  module->walk([&](Operation* operation) {
+    containsScratchStorage |=
+        isa<memref::AllocaOp, memref::LoadOp, memref::StoreOp>(operation);
+  });
+  EXPECT_FALSE(containsScratchStorage);
 }
 
 TEST_P(QCOToQCTest, ProgramEquivalence) {

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -10,7 +10,6 @@
 
 #include "TestCaseUtils.h"
 #include "mlir/Conversion/QCOToQC/QCOToQC.h"
-#include "mlir/Conversion/QCToQCO/QCToQCO.h"
 #include "mlir/Dialect/QC/Builder/QCProgramBuilder.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
@@ -137,63 +136,7 @@ module {
   EXPECT_FALSE(containsQCOOperations);
 }
 
-TEST(QCOToQCRegressionTest, RoundTripsClassicalIfResultWithoutScratch) {
-  DialectRegistry registry;
-  registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
-                  arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
-                  scf::SCFDialect>();
-  MLIRContext context(registry);
-  context.loadAllAvailableDialects();
-
-  constexpr llvm::StringLiteral source = R"mlir(
-module {
-  func.func @main(%condition: i1) -> i64
-      attributes {passthrough = ["entry_point"]} {
-    %q = qc.alloc : !qc.qubit
-    %result = scf.if %condition -> i64 {
-      qc.h %q : !qc.qubit
-      %then = arith.constant 1 : i64
-      scf.yield %then : i64
-    } else {
-      qc.x %q : !qc.qubit
-      %else = arith.constant 2 : i64
-      scf.yield %else : i64
-    }
-    qc.dealloc %q : !qc.qubit
-    return %result : i64
-  }
-}
-)mlir";
-
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-
-  PassManager pm(&context);
-  pm.addPass(createQCToQCO());
-  pm.addPass(createQCOToQC());
-  ASSERT_TRUE(succeeded(pm.run(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
-
-  scf::IfOp ifOp;
-  module->walk([&](scf::IfOp candidate) { ifOp = candidate; });
-  ASSERT_TRUE(ifOp);
-  ASSERT_EQ(ifOp.getNumResults(), 1);
-  auto main = module->lookupSymbol<func::FuncOp>("main");
-  ASSERT_TRUE(main);
-  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
-  EXPECT_EQ(returnOp.getOperand(0), ifOp.getResult(0));
-
-  bool containsScratchStorage = false;
-  module->walk([&](Operation* operation) {
-    containsScratchStorage |=
-        isa<memref::AllocaOp, memref::LoadOp, memref::StoreOp>(operation);
-  });
-  EXPECT_FALSE(containsScratchStorage);
-}
-
-TEST(QCOToQCRegressionTest,
-     RoundTripsClassicalIndexSwitchResultWithoutScratch) {
+TEST(QCOToQCRegressionTest, PreservesClassicalIndexSwitchResult) {
   DialectRegistry registry;
   registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
                   arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
@@ -205,19 +148,19 @@ TEST(QCOToQCRegressionTest,
 module {
   func.func @main(%index: index) -> i64
       attributes {passthrough = ["entry_point"]} {
-    %q = qc.alloc : !qc.qubit
-    %result = scf.index_switch %index -> i64
-    case 0 {
-      qc.h %q : !qc.qubit
+    %q0 = qco.alloc : !qco.qubit
+    %result, %q1 = qco.index_switch %index -> (i64, !qco.qubit)
+    case 0 args(%arg0 = %q0) {
+      %q2 = qco.h %arg0 : !qco.qubit -> !qco.qubit
       %case = arith.constant 1 : i64
-      scf.yield %case : i64
+      qco.yield %case, %q2 : i64, !qco.qubit
     }
-    default {
-      qc.x %q : !qc.qubit
+    default args(%arg0 = %q0) {
+      %q2 = qco.x %arg0 : !qco.qubit -> !qco.qubit
       %default = arith.constant 2 : i64
-      scf.yield %default : i64
+      qco.yield %default, %q2 : i64, !qco.qubit
     }
-    qc.dealloc %q : !qc.qubit
+    qco.sink %q1 : !qco.qubit
     return %result : i64
   }
 }
@@ -227,10 +170,7 @@ module {
   ASSERT_TRUE(module);
   ASSERT_TRUE(succeeded(verify(*module)));
 
-  PassManager pm(&context);
-  pm.addPass(createQCToQCO());
-  pm.addPass(createQCOToQC());
-  ASSERT_TRUE(succeeded(pm.run(*module)));
+  ASSERT_TRUE(succeeded(runQCOToQCConversion(*module)));
   ASSERT_TRUE(succeeded(verify(*module)));
 
   scf::IndexSwitchOp switchOp;
@@ -238,17 +178,18 @@ module {
   ASSERT_TRUE(switchOp);
   ASSERT_EQ(switchOp.getNumResults(), 1);
   EXPECT_TRUE(switchOp.getResult(0).getType().isInteger(64));
+
   auto main = module->lookupSymbol<func::FuncOp>("main");
   ASSERT_TRUE(main);
   auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
   EXPECT_EQ(returnOp.getOperand(0), switchOp.getResult(0));
 
-  bool containsScratchStorage = false;
+  bool containsQCOOperations = false;
   module->walk([&](Operation* operation) {
-    containsScratchStorage |=
-        isa<memref::AllocaOp, memref::LoadOp, memref::StoreOp>(operation);
+    containsQCOOperations |=
+        operation->getDialect() == context.getLoadedDialect<qco::QCODialect>();
   });
-  EXPECT_FALSE(containsScratchStorage);
+  EXPECT_FALSE(containsQCOOperations);
 }
 
 TEST_P(QCOToQCTest, ProgramEquivalence) {

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -192,6 +192,65 @@ module {
   EXPECT_FALSE(containsScratchStorage);
 }
 
+TEST(QCOToQCRegressionTest,
+     RoundTripsClassicalIndexSwitchResultWithoutScratch) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
+                  arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
+                  scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%index: index) -> i64
+      attributes {passthrough = ["entry_point"]} {
+    %q = qc.alloc : !qc.qubit
+    %result = scf.index_switch %index -> i64
+    case 0 {
+      qc.h %q : !qc.qubit
+      %case = arith.constant 1 : i64
+      scf.yield %case : i64
+    }
+    default {
+      qc.x %q : !qc.qubit
+      %default = arith.constant 2 : i64
+      scf.yield %default : i64
+    }
+    qc.dealloc %q : !qc.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  PassManager pm(&context);
+  pm.addPass(createQCToQCO());
+  pm.addPass(createQCOToQC());
+  ASSERT_TRUE(succeeded(pm.run(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::IndexSwitchOp switchOp;
+  module->walk([&](scf::IndexSwitchOp candidate) { switchOp = candidate; });
+  ASSERT_TRUE(switchOp);
+  ASSERT_EQ(switchOp.getNumResults(), 1);
+  EXPECT_TRUE(switchOp.getResult(0).getType().isInteger(64));
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  EXPECT_EQ(returnOp.getOperand(0), switchOp.getResult(0));
+
+  bool containsScratchStorage = false;
+  module->walk([&](Operation* operation) {
+    containsScratchStorage |=
+        isa<memref::AllocaOp, memref::LoadOp, memref::StoreOp>(operation);
+  });
+  EXPECT_FALSE(containsScratchStorage);
+}
+
 TEST_P(QCOToQCTest, ProgramEquivalence) {
   const auto& [nameStr, programBuilder, referenceBuilder] = GetParam();
   const auto name = " (" + nameStr + ")";

--- a/mlir/unittests/Conversion/QCQCORoundTrip/CMakeLists.txt
+++ b/mlir/unittests/Conversion/QCQCORoundTrip/CMakeLists.txt
@@ -6,18 +6,23 @@
 #
 # Licensed under the MIT License
 
-set(target_name mqt-core-mlir-unittest-qco-to-qc)
-add_executable(${target_name} test_qco_to_qc.cpp)
+set(target_name mqt-core-mlir-unittest-qc-qco-round-trip)
+add_executable(${target_name} test_qc_qco_round_trip.cpp)
 
 target_link_libraries(
   ${target_name}
-  PRIVATE MLIRParser
+  PRIVATE GTest::gtest_main
+          MLIRArithDialect
+          MLIRFuncDialect
+          MLIRMemRefDialect
+          MLIRParser
+          MLIRPass
+          MLIRQCDialect
+          MLIRQCODialect
+          MLIRSCFDialect
           MLIRSupportMQT
-          GTest::gtest_main
-          MLIRQCProgramBuilder
-          MLIRQCOProgramBuilder
-          MLIRQCPrograms
-          MLIRQCOPrograms
+          MLIRTransforms
+          MLIRQCToQCO
           MLIRQCOToQC)
 
 mqt_mlir_configure_unittest_target(${target_name})

--- a/mlir/unittests/Conversion/QCQCORoundTrip/test_qc_qco_round_trip.cpp
+++ b/mlir/unittests/Conversion/QCQCORoundTrip/test_qc_qco_round_trip.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Conversion/QCOToQC/QCOToQC.h"
+#include "mlir/Conversion/QCToQCO/QCToQCO.h"
+#include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+
+#include <gtest/gtest.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/DialectRegistry.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+
+using namespace mlir;
+
+namespace {
+
+class QCQCORoundTripTest : public testing::Test {
+protected:
+  MLIRContext context;
+
+  QCQCORoundTripTest() {
+    DialectRegistry registry;
+    registry
+        .insert<qc::QCDialect, qco::QCODialect, arith::ArithDialect,
+                func::FuncDialect, memref::MemRefDialect, scf::SCFDialect>();
+    context.appendDialectRegistry(registry);
+    context.loadAllAvailableDialects();
+  }
+
+  [[nodiscard]] LogicalResult runRoundTrip(ModuleOp module) {
+    PassManager pm(&context);
+    pm.addPass(createQCToQCO());
+    pm.addPass(createQCOToQC());
+    return pm.run(module);
+  }
+
+  static void expectNoScratchStorage(ModuleOp module) {
+    bool containsScratchStorage = false;
+    module.walk([&](Operation* operation) {
+      containsScratchStorage |=
+          isa<memref::AllocaOp, memref::LoadOp, memref::StoreOp>(operation);
+    });
+    EXPECT_FALSE(containsScratchStorage);
+  }
+};
+
+} // namespace
+
+TEST_F(QCQCORoundTripTest, PreservesClassicalIfResultWithoutScratch) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%condition: i1) -> i64
+      attributes {passthrough = ["entry_point"]} {
+    %q = qc.alloc : !qc.qubit
+    %result = scf.if %condition -> i64 {
+      qc.h %q : !qc.qubit
+      %then = arith.constant 1 : i64
+      scf.yield %then : i64
+    } else {
+      qc.x %q : !qc.qubit
+      %else = arith.constant 2 : i64
+      scf.yield %else : i64
+    }
+    qc.dealloc %q : !qc.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runRoundTrip(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::IfOp ifOp;
+  module->walk([&](scf::IfOp candidate) { ifOp = candidate; });
+  ASSERT_TRUE(ifOp);
+  ASSERT_EQ(ifOp.getNumResults(), 1);
+
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  EXPECT_EQ(returnOp.getOperand(0), ifOp.getResult(0));
+  expectNoScratchStorage(*module);
+}
+
+TEST_F(QCQCORoundTripTest, PreservesClassicalIndexSwitchResultWithoutScratch) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%index: index) -> i64
+      attributes {passthrough = ["entry_point"]} {
+    %q = qc.alloc : !qc.qubit
+    %result = scf.index_switch %index -> i64
+    case 0 {
+      qc.h %q : !qc.qubit
+      %case = arith.constant 1 : i64
+      scf.yield %case : i64
+    }
+    default {
+      qc.x %q : !qc.qubit
+      %default = arith.constant 2 : i64
+      scf.yield %default : i64
+    }
+    qc.dealloc %q : !qc.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runRoundTrip(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::IndexSwitchOp switchOp;
+  module->walk([&](scf::IndexSwitchOp candidate) { switchOp = candidate; });
+  ASSERT_TRUE(switchOp);
+  ASSERT_EQ(switchOp.getNumResults(), 1);
+
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  EXPECT_EQ(returnOp.getOperand(0), switchOp.getResult(0));
+  expectNoScratchStorage(*module);
+}

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -23,7 +23,6 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -338,7 +337,8 @@ module {
   expectNoQCOperations(*module);
 }
 
-TEST_F(QCToQCORegressionTest, RejectsClassicalIndexSwitchResultsPrecisely) {
+TEST_F(QCToQCORegressionTest,
+       PreservesIndexSwitchClassicalResultsWithoutScratch) {
   constexpr llvm::StringLiteral source = R"mlir(
 module {
   func.func @main(%index: index) -> i64
@@ -364,19 +364,36 @@ module {
   auto module = parseSourceString<ModuleOp>(source, &context);
   ASSERT_TRUE(module);
   ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
 
-  bool sawExpectedDiagnostic = false;
-  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
-    std::string message;
-    llvm::raw_string_ostream stream(message);
-    diagnostic.print(stream);
-    sawExpectedDiagnostic |= StringRef(message).contains(
-        "classical scf.index_switch results are not supported by the "
-        "QC-to-QCO conversion");
-    return success();
+  qco::IndexSwitchOp switchOp;
+  module->walk([&](qco::IndexSwitchOp candidate) { switchOp = candidate; });
+  ASSERT_TRUE(switchOp);
+  ASSERT_EQ(switchOp.getClassicalResults().size(), 1);
+  EXPECT_TRUE(switchOp.getClassicalResults().front().getType().isInteger(64));
+  ASSERT_EQ(switchOp.getLinearResults().size(), 1);
+  EXPECT_TRUE(
+      isa<qco::QubitType>(switchOp.getLinearResults().front().getType()));
+  for (Region* region : switchOp.getRegions()) {
+    auto yield = cast<qco::YieldOp>(region->front().getTerminator());
+    ASSERT_EQ(yield.getNumOperands(), 2);
+    EXPECT_TRUE(yield.getOperand(0).getType().isInteger(64));
+    EXPECT_TRUE(isa<qco::QubitType>(yield.getOperand(1).getType()));
+  }
+
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  EXPECT_EQ(returnOp.getOperand(0), switchOp.getClassicalResults().front());
+
+  bool containsScratchStorage = false;
+  module->walk([&](Operation* operation) {
+    containsScratchStorage |=
+        isa<memref::AllocaOp, memref::LoadOp, memref::StoreOp>(operation);
   });
-  EXPECT_TRUE(failed(runQCToQCOConversion(*module)));
-  EXPECT_TRUE(sawExpectedDiagnostic);
+  EXPECT_FALSE(containsScratchStorage);
+  expectNoQCOperations(*module);
 }
 
 TEST_P(QCToQCOTest, ProgramEquivalence) {

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
@@ -22,10 +23,12 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Matchers.h>
@@ -279,6 +282,101 @@ module {
   module->walk([&](scf::ExecuteRegionOp) { sawExecuteRegion = true; });
   EXPECT_TRUE(sawExecuteRegion);
   expectNoQCOperations(*module);
+}
+
+TEST_F(QCToQCORegressionTest, PreservesIfClassicalResultsWithoutScratch) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%condition: i1) -> i64
+      attributes {passthrough = ["entry_point"]} {
+    %qc = qc.alloc : !qc.qubit
+    %result = scf.if %condition -> i64 {
+      qc.h %qc : !qc.qubit
+      %then = arith.constant 1 : i64
+      scf.yield %then : i64
+    } else {
+      qc.x %qc : !qc.qubit
+      %else = arith.constant 2 : i64
+      scf.yield %else : i64
+    }
+    qc.dealloc %qc : !qc.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  qco::IfOp ifOp;
+  module->walk([&](qco::IfOp candidate) { ifOp = candidate; });
+  ASSERT_TRUE(ifOp);
+  ASSERT_EQ(ifOp.getClassicalResults().size(), 1);
+  EXPECT_TRUE(ifOp.getClassicalResults().front().getType().isInteger(64));
+  ASSERT_EQ(ifOp.getLinearResults().size(), 1);
+  EXPECT_TRUE(isa<qco::QubitType>(ifOp.getLinearResults().front().getType()));
+  for (qco::YieldOp yield : {ifOp.thenYield(), ifOp.elseYield()}) {
+    ASSERT_EQ(yield.getNumOperands(), 2);
+    EXPECT_TRUE(yield.getOperand(0).getType().isInteger(64));
+    EXPECT_TRUE(isa<qco::QubitType>(yield.getOperand(1).getType()));
+  }
+
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  EXPECT_EQ(returnOp.getOperand(0), ifOp.getClassicalResults().front());
+
+  bool containsScratchStorage = false;
+  module->walk([&](Operation* operation) {
+    containsScratchStorage |=
+        isa<memref::AllocaOp, memref::LoadOp, memref::StoreOp>(operation);
+  });
+  EXPECT_FALSE(containsScratchStorage);
+  expectNoQCOperations(*module);
+}
+
+TEST_F(QCToQCORegressionTest, RejectsClassicalIndexSwitchResultsPrecisely) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%index: index) -> i64
+      attributes {passthrough = ["entry_point"]} {
+    %qc = qc.alloc : !qc.qubit
+    %result = scf.index_switch %index -> i64
+    case 0 {
+      qc.h %qc : !qc.qubit
+      %case = arith.constant 1 : i64
+      scf.yield %case : i64
+    }
+    default {
+      qc.x %qc : !qc.qubit
+      %default = arith.constant 2 : i64
+      scf.yield %default : i64
+    }
+    qc.dealloc %qc : !qc.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    std::string message;
+    llvm::raw_string_ostream stream(message);
+    diagnostic.print(stream);
+    sawExpectedDiagnostic |= StringRef(message).contains(
+        "classical scf.index_switch results are not supported by the "
+        "QC-to-QCO conversion");
+    return success();
+  });
+  EXPECT_TRUE(failed(runQCToQCOConversion(*module)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
 }
 
 TEST_P(QCToQCOTest, ProgramEquivalence) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -31,6 +31,7 @@
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
@@ -338,6 +339,163 @@ TEST_F(QCOTest, IfOpParser) {
 
   EXPECT_TRUE(areModulesEquivalentWithPermutations(parsedSourceModule.get(),
                                                    refBuilder.get()));
+}
+
+TEST_F(QCOTest, IfOpWithClassicalResultRoundTripsAndPreservesTies) {
+  constexpr StringLiteral mlirCode = R"mlir(
+    module {
+      func.func @main(%condition: i1) -> i1 {
+        %q0 = qco.alloc : !qco.qubit
+        %true = arith.constant true
+        %false = arith.constant false
+        %flag, %q1 = qco.if %condition args(%arg0 = %q0)
+            -> (i1, !qco.qubit) {
+          %q2 = qco.h %arg0 : !qco.qubit -> !qco.qubit
+          qco.yield %true, %q2 : i1, !qco.qubit
+        } else args(%arg0 = %q0) {
+          qco.yield %false, %arg0 : i1, !qco.qubit
+        }
+        qco.sink %q1 : !qco.qubit
+        return %flag : i1
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(mlirCode, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  IfOp ifOp;
+  module->walk([&](IfOp candidate) { ifOp = candidate; });
+  ASSERT_TRUE(ifOp);
+  ASSERT_EQ(ifOp.getClassicalResults().size(), 1);
+  ASSERT_EQ(ifOp.getLinearResults().size(), 1);
+  EXPECT_TRUE(ifOp.getClassicalResults().front().getType().isInteger(1));
+  EXPECT_TRUE(isa<QubitType>(ifOp.getLinearResults().front().getType()));
+
+  auto* conditionOperand = &ifOp->getOpOperand(0);
+  auto* qubitOperand = &ifOp->getOpOperand(1);
+  EXPECT_FALSE(ifOp.getTiedResult(conditionOperand));
+  EXPECT_FALSE(ifOp.getTiedThenBlockArgument(conditionOperand));
+  EXPECT_FALSE(ifOp.getTiedElseBlockArgument(conditionOperand));
+  EXPECT_EQ(ifOp.getTiedResult(qubitOperand), ifOp.getLinearResults().front());
+  EXPECT_EQ(
+      ifOp.getTiedQubit(cast<OpResult>(ifOp.getClassicalResults().front())),
+      nullptr);
+  EXPECT_EQ(ifOp.getTiedQubit(cast<OpResult>(ifOp.getLinearResults().front())),
+            qubitOperand);
+  EXPECT_EQ(
+      ifOp.getTiedThenYieldedValue(ifOp.thenBlock()->getArgument(0))->get(),
+      ifOp.thenYield().getTargets().back());
+  EXPECT_EQ(
+      ifOp.getTiedElseYieldedValue(ifOp.elseBlock()->getArgument(0))->get(),
+      ifOp.elseYield().getTargets().back());
+  EXPECT_EQ(ifOp.getTiedThenYieldedValue(ifOp.elseBlock()->getArgument(0)),
+            nullptr);
+  EXPECT_EQ(ifOp.getTiedElseYieldedValue(ifOp.thenBlock()->getArgument(0)),
+            nullptr);
+
+  std::string printed;
+  llvm::raw_string_ostream stream(printed);
+  module->print(stream);
+  stream.flush();
+  auto reparsedModule = parseSourceString<ModuleOp>(printed, context.get());
+  ASSERT_TRUE(reparsedModule);
+  EXPECT_TRUE(succeeded(verify(*reparsedModule)));
+}
+
+TEST_F(QCOTest, IfOpRejectsMismatchedClassicalYield) {
+  constexpr StringLiteral mlirCode = R"mlir(
+    module {
+      func.func @main(%condition: i1) -> i1 {
+        %q0 = qco.alloc : !qco.qubit
+        %true = arith.constant true
+        %flag, %q1 = qco.if %condition args(%arg0 = %q0)
+            -> (i1, !qco.qubit) {
+          qco.yield %arg0 : !qco.qubit
+        } else args(%arg0 = %q0) {
+          qco.yield %true, %arg0 : i1, !qco.qubit
+        }
+        qco.sink %q1 : !qco.qubit
+        return %flag : i1
+      }
+    }
+  )mlir";
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(context.get(), [&](Diagnostic& diagnostic) {
+    sawExpectedDiagnostic |= StringRef(diagnostic.str())
+                                 .contains("must yield 2 values for parent "
+                                           "operation but yields 1");
+    return success();
+  });
+  EXPECT_FALSE(parseSourceString<ModuleOp>(mlirCode, context.get()));
+  EXPECT_TRUE(sawExpectedDiagnostic);
+}
+
+TEST_F(QCOTest, ModifierYieldStillRejectsClassicalValues) {
+  constexpr StringLiteral mlirCode = R"mlir(
+    module {
+      func.func @main() {
+        %q0 = qco.alloc : !qco.qubit
+        %true = arith.constant true
+        %q1 = qco.inv (%arg = %q0) {
+          qco.yield %true : i1
+        } : {!qco.qubit} -> {!qco.qubit}
+        qco.sink %q1 : !qco.qubit
+        return
+      }
+    }
+  )mlir";
+
+  std::string diagnosticMessage;
+  ScopedDiagnosticHandler handler(context.get(), [&](Diagnostic& diagnostic) {
+    diagnosticMessage += diagnostic.str();
+    return success();
+  });
+  EXPECT_FALSE(parseSourceString<ModuleOp>(mlirCode, context.get()));
+  EXPECT_TRUE(StringRef(diagnosticMessage)
+                  .contains("'qco.yield' op operand 0 has type 'i1' but parent "
+                            "operation expects '!qco.qubit'"))
+      << diagnosticMessage;
+}
+
+TEST_F(QCOTest, CanonicalizesConstantIfWithClassicalResult) {
+  constexpr StringLiteral mlirCode = R"mlir(
+    module {
+      func.func @main() -> i1 {
+        %condition = arith.constant true
+        %q0 = qco.alloc : !qco.qubit
+        %true = arith.constant true
+        %false = arith.constant false
+        %flag, %q1 = qco.if %condition args(%arg0 = %q0)
+            -> (i1, !qco.qubit) {
+          %q2 = qco.h %arg0 : !qco.qubit -> !qco.qubit
+          qco.yield %true, %q2 : i1, !qco.qubit
+        } else args(%arg0 = %q0) {
+          qco.yield %false, %arg0 : i1, !qco.qubit
+        }
+        qco.sink %q1 : !qco.qubit
+        return %flag : i1
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(mlirCode, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCOCleanupPipeline(module.get())));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  bool containsIf = false;
+  module->walk([&](IfOp) { containsIf = true; });
+  EXPECT_FALSE(containsIf);
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  APInt result;
+  ASSERT_TRUE(matchPattern(returnOp.getOperand(0), m_ConstantInt(&result)));
+  EXPECT_TRUE(result.isOne());
 }
 
 TEST_F(QCOTest, IndexSwitchParser) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -501,6 +501,62 @@ TEST_F(QCOTest, CanonicalizesConstantIfWithClassicalResult) {
   EXPECT_TRUE(result.isOne());
 }
 
+TEST_F(QCOTest, CanonicalizesRedundantClassicalIfResults) {
+  constexpr StringLiteral mlirCode = R"mlir(
+    module {
+      func.func @main(%condition: i1, %shared: i64) -> (i64, i64, i64) {
+        %q0 = qco.alloc : !qco.qubit
+        %same, %first, %duplicate, %unused, %q1 =
+            qco.if %condition args(%arg0 = %q0)
+                -> (i64, i64, i64, i64, !qco.qubit) {
+          %value = arith.constant 1 : i64
+          %dead = arith.constant 3 : i64
+          %q2 = qco.h %arg0 : !qco.qubit -> !qco.qubit
+          qco.yield %shared, %value, %value, %dead, %q2
+              : i64, i64, i64, i64, !qco.qubit
+        } else args(%arg0 = %q0) {
+          %value = arith.constant 2 : i64
+          %dead = arith.constant 4 : i64
+          %q2 = qco.x %arg0 : !qco.qubit -> !qco.qubit
+          qco.yield %shared, %value, %value, %dead, %q2
+              : i64, i64, i64, i64, !qco.qubit
+        }
+        qco.sink %q1 : !qco.qubit
+        return %same, %first, %duplicate : i64, i64, i64
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(mlirCode, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCOCleanupPipeline(module.get())));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  IfOp ifOp;
+  module->walk([&](IfOp candidate) { ifOp = candidate; });
+  ASSERT_TRUE(ifOp);
+  ASSERT_EQ(ifOp.getClassicalResults().size(), 1);
+  ASSERT_EQ(ifOp.getLinearResults().size(), 1);
+  EXPECT_EQ(ifOp.getProperties().getResultSegmentSizes(),
+            ArrayRef<int32_t>({1, 1}));
+  for (YieldOp yield : {ifOp.thenYield(), ifOp.elseYield()}) {
+    ASSERT_EQ(yield.getTargets().size(), 2);
+    EXPECT_EQ(yield.getTargets().front().getType(),
+              ifOp.getClassicalResults().front().getType());
+    EXPECT_EQ(yield.getTargets().back().getType(),
+              ifOp.getLinearResults().front().getType());
+  }
+
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
+  ASSERT_EQ(returnOp.getNumOperands(), 3);
+  EXPECT_EQ(returnOp.getOperand(0), main.getArgument(1));
+  EXPECT_EQ(returnOp.getOperand(1), ifOp.getClassicalResults().front());
+  EXPECT_EQ(returnOp.getOperand(2), returnOp.getOperand(1));
+}
+
 TEST_F(QCOTest, IndexSwitchParser) {
   // Test IndexSwitch parser
   const char* mlirCode = R"(

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -45,6 +45,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <utility>
 
 using namespace mlir;
 using namespace mlir::qco;
@@ -402,6 +403,8 @@ TEST_F(QCOTest, IfOpWithClassicalResultRoundTripsAndPreservesTies) {
   auto reparsedModule = parseSourceString<ModuleOp>(printed, context.get());
   ASSERT_TRUE(reparsedModule);
   EXPECT_TRUE(succeeded(verify(*reparsedModule)));
+  EXPECT_TRUE(
+      areModulesEquivalentWithPermutations(module.get(), reparsedModule.get()));
 }
 
 TEST_F(QCOTest, IfOpRejectsMismatchedClassicalYield) {
@@ -590,6 +593,216 @@ TEST_F(QCOTest, DefaultOnlyIndexSwitchParser) {
   auto reparsedModule = parseSourceString<ModuleOp>(printed, context.get());
   ASSERT_TRUE(reparsedModule);
   EXPECT_TRUE(verify(*reparsedModule).succeeded());
+}
+
+TEST_F(QCOTest, IndexSwitchWithClassicalResultRoundTripsAndPreservesTies) {
+  constexpr StringLiteral mlirCode = R"mlir(
+    module {
+      func.func @main(%index: index) -> i64 {
+        %q0 = qco.alloc : !qco.qubit
+        %state, %q1 = qco.index_switch %index -> (i64, !qco.qubit)
+        case 0 args(%arg0 = %q0) {
+          %q2 = qco.h %arg0 : !qco.qubit -> !qco.qubit
+          %case = arith.constant 1 : i64
+          qco.yield %case, %q2 : i64, !qco.qubit
+        }
+        default args(%arg0 = %q0) {
+          %default = arith.constant 2 : i64
+          qco.yield %default, %arg0 : i64, !qco.qubit
+        }
+        qco.sink %q1 : !qco.qubit
+        return %state : i64
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(mlirCode, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  IndexSwitchOp switchOp;
+  module->walk([&](IndexSwitchOp candidate) { switchOp = candidate; });
+  ASSERT_TRUE(switchOp);
+  ASSERT_EQ(switchOp.getClassicalResults().size(), 1);
+  ASSERT_EQ(switchOp.getLinearResults().size(), 1);
+  EXPECT_TRUE(switchOp.getClassicalResults().front().getType().isInteger(64));
+  EXPECT_TRUE(isa<QubitType>(switchOp.getLinearResults().front().getType()));
+
+  auto* targetOperand = &switchOp->getOpOperand(1);
+  auto* indexOperand = &switchOp->getOpOperand(0);
+  EXPECT_FALSE(switchOp.getTiedResult(indexOperand));
+  EXPECT_FALSE(switchOp.getTiedCaseBlockArgument(indexOperand, 0));
+  EXPECT_FALSE(switchOp.getTiedDefaultBlockArgument(indexOperand));
+  EXPECT_EQ(switchOp.getTiedResult(targetOperand),
+            switchOp.getLinearResults().front());
+  EXPECT_EQ(switchOp.getTiedTarget(
+                cast<OpResult>(switchOp.getClassicalResults().front())),
+            nullptr);
+  EXPECT_EQ(switchOp.getTiedTarget(
+                cast<OpResult>(switchOp.getLinearResults().front())),
+            targetOperand);
+  EXPECT_EQ(
+      switchOp
+          .getTiedCaseYieldedValue(switchOp.getCaseBlock(0)->getArgument(0), 0)
+          ->get(),
+      switchOp.getCaseYield(0).getTargets().back());
+  EXPECT_EQ(switchOp
+                .getTiedDefaultYieldedValue(
+                    switchOp.getDefaultBlock()->getArgument(0))
+                ->get(),
+            switchOp.getDefaultYield().getTargets().back());
+
+  SmallVector<Attribute> operands(switchOp->getNumOperands());
+  SmallVector<RegionSuccessor> successors;
+  switchOp.getEntrySuccessorRegions(operands, successors);
+  ASSERT_EQ(successors.size(), 2);
+  for (const RegionSuccessor successor : successors) {
+    ASSERT_EQ(successor.getSuccessorInputs().size(), 1);
+    EXPECT_EQ(switchOp.getEntrySuccessorOperands(successor).front(),
+              switchOp.getTargets().front());
+  }
+
+  std::string printed;
+  llvm::raw_string_ostream stream(printed);
+  module->print(stream);
+  stream.flush();
+  auto reparsedModule = parseSourceString<ModuleOp>(printed, context.get());
+  ASSERT_TRUE(reparsedModule);
+  EXPECT_TRUE(succeeded(verify(*reparsedModule)));
+  EXPECT_TRUE(
+      areModulesEquivalentWithPermutations(module.get(), reparsedModule.get()));
+}
+
+TEST_F(QCOTest, ClassicalYieldOrderAffectsConditionalEquivalence) {
+  constexpr StringLiteral ifSource = R"mlir(
+    module {
+      func.func @main(%condition: i1) -> (i64, i64) {
+        %q0 = qco.alloc : !qco.qubit
+        %first, %second, %q1 = qco.if %condition args(%arg0 = %q0)
+            -> (i64, i64, !qco.qubit) {
+          %one = arith.constant 1 : i64
+          %two = arith.constant 2 : i64
+          qco.yield %one, %two, %arg0 : i64, i64, !qco.qubit
+        } else args(%arg0 = %q0) {
+          %one = arith.constant 1 : i64
+          %two = arith.constant 2 : i64
+          qco.yield %one, %two, %arg0 : i64, i64, !qco.qubit
+        }
+        qco.sink %q1 : !qco.qubit
+        return %first, %second : i64, i64
+      }
+    }
+  )mlir";
+  constexpr StringLiteral switchSource = R"mlir(
+    module {
+      func.func @main(%index: index) -> (i64, i64) {
+        %q0 = qco.alloc : !qco.qubit
+        %first, %second, %q1 = qco.index_switch %index
+            -> (i64, i64, !qco.qubit)
+        case 0 args(%arg0 = %q0) {
+          %one = arith.constant 1 : i64
+          %two = arith.constant 2 : i64
+          qco.yield %one, %two, %arg0 : i64, i64, !qco.qubit
+        }
+        default args(%arg0 = %q0) {
+          %one = arith.constant 1 : i64
+          %two = arith.constant 2 : i64
+          qco.yield %one, %two, %arg0 : i64, i64, !qco.qubit
+        }
+        qco.sink %q1 : !qco.qubit
+        return %first, %second : i64, i64
+      }
+    }
+  )mlir";
+
+  for (const StringRef source : {ifSource, switchSource}) {
+    auto lhs = parseSourceString<ModuleOp>(source, context.get());
+    auto rhs = parseSourceString<ModuleOp>(source, context.get());
+    ASSERT_TRUE(lhs);
+    ASSERT_TRUE(rhs);
+
+    const auto findFirstYield = [](ModuleOp module) {
+      YieldOp result;
+      module.walk([&](YieldOp candidate) {
+        if (!result) {
+          result = candidate;
+        }
+      });
+      return result;
+    };
+
+    auto rhsYield = findFirstYield(*rhs);
+    ASSERT_TRUE(rhsYield);
+    SmallVector<Value> operands(rhsYield.getTargets());
+    ASSERT_GE(operands.size(), 2);
+    std::swap(operands[0], operands[1]);
+    rhsYield->setOperands(operands);
+    ASSERT_TRUE(succeeded(verify(*rhs)));
+
+    EXPECT_FALSE(areModulesEquivalentWithPermutations(lhs.get(), rhs.get()));
+
+    auto duplicateLhs = parseSourceString<ModuleOp>(source, context.get());
+    auto duplicateRhs = parseSourceString<ModuleOp>(source, context.get());
+    ASSERT_TRUE(duplicateLhs);
+    ASSERT_TRUE(duplicateRhs);
+    for (ModuleOp module : {*duplicateLhs, *duplicateRhs}) {
+      auto yield = findFirstYield(module);
+      ASSERT_TRUE(yield);
+      SmallVector<Value> duplicateOperands(yield.getTargets());
+      ASSERT_GE(duplicateOperands.size(), 2);
+      duplicateOperands[1] = duplicateOperands[0];
+      yield->setOperands(duplicateOperands);
+      ASSERT_TRUE(succeeded(verify(module)));
+    }
+    EXPECT_TRUE(areModulesEquivalentWithPermutations(duplicateLhs.get(),
+                                                     duplicateRhs.get()));
+  }
+}
+
+TEST_F(QCOTest, ExtendsMixedResultIndexSwitchTargets) {
+  constexpr StringLiteral mlirCode = R"mlir(
+    module {
+      func.func @main(%index: index) -> i64 {
+        %q0 = qco.alloc : !qco.qubit
+        %state, %q1 = qco.index_switch %index -> (i64, !qco.qubit)
+        case 0 args(%arg0 = %q0) {
+          %case = arith.constant 1 : i64
+          qco.yield %case, %arg0 : i64, !qco.qubit
+        }
+        default args(%arg0 = %q0) {
+          %default = arith.constant 2 : i64
+          qco.yield %default, %arg0 : i64, !qco.qubit
+        }
+        qco.sink %q1 : !qco.qubit
+        return %state : i64
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(mlirCode, context.get());
+  ASSERT_TRUE(module);
+  IndexSwitchOp switchOp;
+  module->walk([&](IndexSwitchOp candidate) { switchOp = candidate; });
+  ASSERT_TRUE(switchOp);
+
+  IRRewriter rewriter(context.get());
+  rewriter.setInsertionPoint(switchOp);
+  auto addon = AllocOp::create(rewriter, switchOp.getLoc());
+  auto extended =
+      switchOp.replaceWithAdditionalTargets(rewriter, addon.getResult());
+  rewriter.setInsertionPointAfter(extended);
+  SinkOp::create(rewriter, extended.getLoc(),
+                 extended.getLinearResults().back());
+
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_EQ(extended.getClassicalResults().size(), 1);
+  ASSERT_EQ(extended.getLinearResults().size(), 2);
+  for (Region* region : extended.getRegions()) {
+    ASSERT_EQ(region->getNumArguments(), 2);
+    auto yield = cast<YieldOp>(region->front().getTerminator());
+    ASSERT_EQ(yield.getNumOperands(), 3);
+    EXPECT_TRUE(yield.getOperand(0).getType().isInteger(64));
+  }
 }
 
 TEST_F(QCOTest, EquivalentTensorIndexSwitches) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -680,6 +680,65 @@ TEST_P(MappingPassTest, MapTypeChangingWhileWithClassicalState) {
   EXPECT_TRUE(isExecutable(getEntryPoint(module.get()), device.couplingSet));
 }
 
+TEST_P(MappingPassTest, MapIfWithClassicalResult) {
+  const auto& device = GetParam();
+  constexpr StringLiteral source = R"mlir(
+    module {
+      func.func @main() -> i64 attributes {passthrough = ["entry_point"]} {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %c2 = arith.constant 2 : index
+        %tensor0 = qtensor.alloc(%c2) : tensor<2x!qco.qubit>
+        %tensor1, %q0 = qtensor.extract %tensor0[%c0]
+            : tensor<2x!qco.qubit>
+        %tensor2, %q1 = qtensor.extract %tensor1[%c1]
+            : tensor<2x!qco.qubit>
+        %q2 = qco.h %q0 : !qco.qubit -> !qco.qubit
+        %q3, %condition = qco.measure %q2 : !qco.qubit
+        %state, %q4, %q5 = qco.if %condition
+            args(%arg0 = %q3, %arg1 = %q1)
+            -> (i64, !qco.qubit, !qco.qubit) {
+          %next0, %next1 = qco.swap %arg0, %arg1
+              : !qco.qubit, !qco.qubit -> !qco.qubit, !qco.qubit
+          %then = arith.constant 1 : i64
+          qco.yield %then, %next0, %next1
+              : i64, !qco.qubit, !qco.qubit
+        } else args(%arg0 = %q3, %arg1 = %q1) {
+          %else = arith.constant 2 : i64
+          qco.yield %else, %arg0, %arg1
+              : i64, !qco.qubit, !qco.qubit
+        }
+        %tensor3 = qtensor.insert %q4 into %tensor2[%c0]
+            : tensor<2x!qco.qubit>
+        %tensor4 = qtensor.insert %q5 into %tensor3[%c1]
+            : tensor<2x!qco.qubit>
+        qtensor.dealloc %tensor4 : tensor<2x!qco.qubit>
+        return %state : i64
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  ASSERT_TRUE(runPass(module.get(), device.couplingSet,
+                      MappingPassOptions{.ntrials = 1})
+                  .succeeded());
+  ASSERT_TRUE(succeeded(verify(*module)));
+  EXPECT_TRUE(isExecutable(getEntryPoint(module.get()), device.couplingSet));
+
+  IfOp ifOp;
+  module->walk([&](IfOp candidate) { ifOp = candidate; });
+  ASSERT_TRUE(ifOp);
+  ASSERT_EQ(ifOp.getClassicalResults().size(), 1);
+  EXPECT_TRUE(ifOp.getClassicalResults().front().getType().isInteger(64));
+  for (YieldOp yield : {ifOp.thenYield(), ifOp.elseYield()}) {
+    ASSERT_EQ(yield.getNumOperands(), ifOp.getNumResults());
+    EXPECT_TRUE(yield.getOperand(0).getType().isInteger(64));
+  }
+}
+
 TEST_P(MappingPassTest, MapSABRECircuit) {
   const auto& device = GetParam();
   constexpr int64_t size = 6;

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -739,6 +739,73 @@ TEST_P(MappingPassTest, MapIfWithClassicalResult) {
   }
 }
 
+TEST_P(MappingPassTest, MapIndexSwitchWithClassicalResult) {
+  const auto& device = GetParam();
+  constexpr StringLiteral source = R"mlir(
+    module {
+      func.func @main(%selector: index) -> i64
+          attributes {passthrough = ["entry_point"]} {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %c2 = arith.constant 2 : index
+        %tensor0 = qtensor.alloc(%c2) : tensor<2x!qco.qubit>
+        %tensor1, %q0 = qtensor.extract %tensor0[%c0]
+            : tensor<2x!qco.qubit>
+        %tensor2, %q1 = qtensor.extract %tensor1[%c1]
+            : tensor<2x!qco.qubit>
+        %state, %q2, %q3 = qco.index_switch %selector
+            -> (i64, !qco.qubit, !qco.qubit)
+        case 0 args(%arg0 = %q0, %arg1 = %q1) {
+          %next0, %next1 = qco.swap %arg0, %arg1
+              : !qco.qubit, !qco.qubit -> !qco.qubit, !qco.qubit
+          %case = arith.constant 1 : i64
+          qco.yield %case, %next0, %next1
+              : i64, !qco.qubit, !qco.qubit
+        }
+        case 1 args(%arg0 = %q0, %arg1 = %q1) {
+          %next0, %next1 = qco.swap %arg0, %arg1
+              : !qco.qubit, !qco.qubit -> !qco.qubit, !qco.qubit
+          %case = arith.constant 2 : i64
+          qco.yield %case, %next0, %next1
+              : i64, !qco.qubit, !qco.qubit
+        }
+        default args(%arg0 = %q0, %arg1 = %q1) {
+          %default = arith.constant 3 : i64
+          qco.yield %default, %arg0, %arg1
+              : i64, !qco.qubit, !qco.qubit
+        }
+        %tensor3 = qtensor.insert %q2 into %tensor2[%c0]
+            : tensor<2x!qco.qubit>
+        %tensor4 = qtensor.insert %q3 into %tensor3[%c1]
+            : tensor<2x!qco.qubit>
+        qtensor.dealloc %tensor4 : tensor<2x!qco.qubit>
+        return %state : i64
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  ASSERT_TRUE(runPass(module.get(), device.couplingSet,
+                      MappingPassOptions{.ntrials = 1})
+                  .succeeded());
+  ASSERT_TRUE(succeeded(verify(*module)));
+  EXPECT_TRUE(isExecutable(getEntryPoint(module.get()), device.couplingSet));
+
+  IndexSwitchOp switchOp;
+  module->walk([&](IndexSwitchOp candidate) { switchOp = candidate; });
+  ASSERT_TRUE(switchOp);
+  ASSERT_EQ(switchOp.getClassicalResults().size(), 1);
+  EXPECT_TRUE(switchOp.getClassicalResults().front().getType().isInteger(64));
+  for (Region* region : switchOp.getRegions()) {
+    auto yield = cast<YieldOp>(region->front().getTerminator());
+    ASSERT_EQ(yield.getNumOperands(), switchOp.getNumResults());
+    EXPECT_TRUE(yield.getOperand(0).getType().isInteger(64));
+  }
+}
+
 TEST_P(MappingPassTest, MapSABRECircuit) {
   const auto& device = GetParam();
   constexpr int64_t size = 6;

--- a/mlir/unittests/Dialect/QTensor/Utils/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QTensor/Utils/CMakeLists.txt
@@ -8,8 +8,9 @@
 
 set(qtensor_utils_target mqt-core-mlir-unittest-qtensor-utils)
 add_executable(${qtensor_utils_target} test_tensoriterator.cpp)
-target_link_libraries(${qtensor_utils_target} PRIVATE GTest::gtest_main MLIRQTensorDialect
-                                                      MLIRQTensorUtils MLIRQCOProgramBuilder)
+target_link_libraries(
+  ${qtensor_utils_target} PRIVATE GTest::gtest_main MLIRQTensorDialect MLIRQTensorUtils
+                                  MLIRQCOProgramBuilder MLIRParser)
 mqt_mlir_configure_unittest_target(${qtensor_utils_target})
 
 gtest_discover_tests(${qtensor_utils_target} PROPERTIES LABELS mqt-mlir-unittests DISCOVERY_TIMEOUT

--- a/mlir/unittests/Dialect/QTensor/Utils/test_tensoriterator.cpp
+++ b/mlir/unittests/Dialect/QTensor/Utils/test_tensoriterator.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/QTensor/Utils/TensorIterator.h"
@@ -26,6 +27,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
 #include <mlir/Support/LLVM.h>
 
 #include <cstdint>
@@ -257,6 +259,68 @@ TEST_F(TensorIteratorTest, Traversal) {
   --recIt;
   ASSERT_EQ(recIt.operation(), nullptr);
   ASSERT_EQ(recIt.tensor(), tensorElse0);
+}
+
+TEST_F(TensorIteratorTest, TraversesMixedResultConditionals) {
+  constexpr StringLiteral source = R"mlir(
+    module {
+      func.func @main(%condition: i1, %selector: index) -> i64 {
+        %c1 = arith.constant 1 : index
+        %tensor0 = qtensor.alloc(%c1) : tensor<1x!qco.qubit>
+        %if_state, %tensor1 = qco.if %condition
+            args(%arg0 = %tensor0) -> (i64, tensor<1x!qco.qubit>) {
+          %then = arith.constant 1 : i64
+          qco.yield %then, %arg0 : i64, tensor<1x!qco.qubit>
+        } else args(%arg0 = %tensor0) {
+          %else = arith.constant 2 : i64
+          qco.yield %else, %arg0 : i64, tensor<1x!qco.qubit>
+        }
+        %switch_state, %tensor2 = qco.index_switch %selector
+            -> (i64, tensor<1x!qco.qubit>)
+        case 0 args(%arg0 = %tensor1) {
+          qco.yield %if_state, %arg0 : i64, tensor<1x!qco.qubit>
+        }
+        default args(%arg0 = %tensor1) {
+          %default = arith.constant 3 : i64
+          qco.yield %default, %arg0 : i64, tensor<1x!qco.qubit>
+        }
+        qtensor.dealloc %tensor2 : tensor<1x!qco.qubit>
+        return %switch_state : i64
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  qtensor::AllocOp alloc;
+  module->walk([&](qtensor::AllocOp candidate) { alloc = candidate; });
+  ASSERT_TRUE(alloc);
+
+  TensorIterator iterator(alloc.getResult());
+  EXPECT_EQ(iterator.operation(), alloc.getOperation());
+  ++iterator;
+  ASSERT_TRUE(isa<qco::IfOp>(iterator.operation()));
+  auto ifOp = cast<qco::IfOp>(iterator.operation());
+  EXPECT_EQ(iterator.tensor(), ifOp.getLinearResults().front());
+  ++iterator;
+  ASSERT_TRUE(isa<qco::IndexSwitchOp>(iterator.operation()));
+  auto switchOp = cast<qco::IndexSwitchOp>(iterator.operation());
+  EXPECT_EQ(iterator.tensor(), switchOp.getLinearResults().front());
+  ++iterator;
+  EXPECT_TRUE(isa<qtensor::DeallocOp>(iterator.operation()));
+  EXPECT_EQ(iterator.tensor(), nullptr);
+
+  --iterator;
+  EXPECT_EQ(iterator.operation(), switchOp.getOperation());
+  EXPECT_EQ(iterator.tensor(), switchOp.getLinearResults().front());
+  --iterator;
+  EXPECT_EQ(iterator.operation(), ifOp.getOperation());
+  EXPECT_EQ(iterator.tensor(), ifOp.getLinearResults().front());
+  --iterator;
+  EXPECT_EQ(iterator.operation(), alloc.getOperation());
+  EXPECT_EQ(iterator.tensor(), alloc.getResult());
 }
 
 TEST_F(TensorIteratorTest, TraversesWhileCarriedTensors) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Allow `qco.if` and `qco.index_switch` to return ordinary classical SSA values
  before their existing linear quantum results.
- Preserve result-bearing `scf.if` and `scf.index_switch` operations through
  QC-to-QCO and QCO-to-QC conversion without introducing scratch memory.
- Update verification, parsing and printing, RegionBranch interfaces,
  tied-value helpers, builders, mapping, tensor traversal, module equivalence,
  and affected optimizations for the segmented result model.
- Keep unsupported Jeff lowering explicit without constraining the standard
  QC → QCO → QC → QIR pipeline.

## Motivation

This capability was identified while working on the OpenQASM integration in
#1910 and while reducing the structured-control-flow fixes that became #1935.
QCO conditionals previously represented only linear quantum results. Preserving
classical SCF results therefore required either rejecting otherwise valid
programs or lowering classical state through temporary memory.

The new representation keeps classical values in ordinary SSA form while
retaining QCO's explicit single-use quantum flow:

1. classical result prefix;
2. tied linear quantum result suffix.

Conditional region arguments remain linear-only. Classical inputs continue to
use normal SSA capture, while `qco.yield` returns the complete
classical-plus-linear result signature.

## Implementation notes

- Both conditional operations use `AttrSizedResultSegments` and expose explicit
  classical and linear result accessors.
- Custom parsers infer the linear suffix from the `args(...)` assignments and
  retain quantum-only textual compatibility.
- Parent-aware `qco.yield` verification preserves the stricter modifier
  contracts.
- QC↔QCO conversions retain classical def-use chains directly and replace only
  linear results with QC references on the QC side.
- Mapping handles every index-switch case and the default region, preserving
  classical yield operands while realigning only quantum values.
- Module equivalence compares classical yield prefixes positionally while
  keeping the linear suffix permutation-aware.

## Validation

All affected targets build successfully. The focused suites pass 933 tests in
total:

- 450 QCO IR tests
- 134 QC-to-QCO tests
- 132 QCO-to-QC tests
- 82 QCO utility tests
- 3 QTensor utility tests
- 15 mapping tests
- 117 Jeff round-trip tests

Repository lint, changed-source `clang-tidy`, and `git diff --check` pass. Two
independent read-only reviews were performed; the final review found no
remaining actionable issues.
