### PR TITLE
🐛 Fix `jeff` status return placement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
   change-detection:
     name: 🔍 Change
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@e7f84f39ce2d3b6c5d1d04526b8f94f98e455143 # v2.2.0
+    with:
+      additional-python-files: "mlir/**"
 
   cpp-tests-ubuntu:
     name: 🇨 Test 🐧

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -1157,6 +1157,7 @@ struct ConvertJeffMainToQCO final : OpConversionPattern<func::FuncOp> {
     if (needsStatusResult) {
       rewriter.setInsertionPointToStart(block);
       auto zero = arith::ConstantIntOp::create(rewriter, op.getLoc(), 0, 64);
+      rewriter.setInsertionPoint(returnOp);
       rewriter.replaceOpWithNewOp<func::ReturnOp>(returnOp, zero.getResult());
     }
 

--- a/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
+++ b/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
@@ -24,6 +24,7 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/DialectRegistry.h>
@@ -156,6 +157,38 @@ static LogicalResult convertJeffToQCO(ModuleOp module) {
   PassManager pm(module.getContext());
   pm.addPass(createJeffToQCO());
   return pm.run(module);
+}
+
+TEST(JeffRoundTripRegressionTest, RestoresStatusResultAtEndOfEntryPoint) {
+  DialectRegistry registry;
+  registry.insert<arith::ArithDialect, func::FuncDialect, jeff::JeffDialect,
+                  qco::QCODialect, scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  OpBuilder builder(&context);
+  auto loc = builder.getUnknownLoc();
+  auto program = ModuleOp::create(loc);
+  program->setAttr(
+      "jeff.entrypoint",
+      builder.getIntegerAttr(builder.getIntegerType(16, false), 0));
+  program->setAttr("jeff.strings",
+                   builder.getArrayAttr({builder.getStringAttr("main")}));
+
+  auto main = func::FuncOp::create(builder, loc, "main",
+                                   builder.getFunctionType({}, {}));
+  program.push_back(main);
+  auto* block = main.addEntryBlock();
+  builder.setInsertionPointToEnd(block);
+  arith::ConstantIntOp::create(builder, loc, 1, 1);
+  func::ReturnOp::create(builder, loc);
+
+  ASSERT_TRUE(succeeded(convertJeffToQCO(program)));
+  EXPECT_TRUE(succeeded(verify(program)));
+  EXPECT_EQ(main.getFunctionType(),
+            builder.getFunctionType({}, {builder.getI64Type()}));
+  auto returnOp = cast<func::ReturnOp>(block->getTerminator());
+  ASSERT_EQ(returnOp.getNumOperands(), 1);
+  EXPECT_TRUE(returnOp.getOperand(0).getType().isInteger(64));
 }
 
 TEST(JeffRoundTripRegressionTest, RestoresEntryPointWithObservableResults) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Insert the synthesized Jeff status return at the original terminator position.
- Add a regression for result-less Jeff entry points with operations in the body.
- Treat `mlir/**` changes as Python-relevant so binding-level tests and lint run on affected pull requests.

## Root cause

The entry-point restoration introduced in #1934 created the replacement `func.return` at the current rewriter insertion point, which remained near the start of the block after creating the zero status constant. Result-less Jeff programs therefore placed operations after the terminator and failed conversion.

The original pull request did not expose this through Python because the shared change detector did not classify `mlir/**` changes as Python-relevant, so all Python jobs were skipped.

## Impact

Serialized result-less Jeff programs can again be compiled through the Python `compile_program` entry point. Future MLIR changes will exercise the Python bindings in pull-request CI.

## Validation

- Jeff round-trip suite: 117 passed
- Jeff entry-point regressions: 2 passed
- Exact failing Python test: 1 passed
- Full Python suite: 394 passed, 3 skipped
- Repository lint and GitHub workflow validation: passed
- `git diff --check`: passed