### PR TITLE
🐛 Complete QDMI child-device string conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ releases may include breaking changes.
 - ✨ Add Python bindings for the MQT Compiler Collection ([#1815])
   ([**@burgholzer**], [**@denialhaag**])
 - ✨ Add support for QDMI child devices to the driver and FoMaC libraries
-  ([#1897]) ([**@burgholzer**])
+  ([#1897], [#1952]) ([**@burgholzer**])
 - ✨ Add typed custom property and result queries to the C++ and Python FoMaC
   libraries ([#1895]) ([**@burgholzer**])
 - ✨ Add support for custom job parameters to C++ and Python FoMaC library
@@ -652,6 +652,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1952]: https://github.com/munich-quantum-toolkit/core/pull/1952
 [#1938]: https://github.com/munich-quantum-toolkit/core/pull/1938
 [#1936]: https://github.com/munich-quantum-toolkit/core/pull/1936
 [#1935]: https://github.com/munich-quantum-toolkit/core/pull/1935

--- a/include/mqt-core/qdmi/common/Common.hpp
+++ b/include/mqt-core/qdmi/common/Common.hpp
@@ -249,6 +249,8 @@ constexpr auto toString(const QDMI_Device_Session_Parameter param) -> const
     return "USERNAME";
   case QDMI_DEVICE_SESSION_PARAMETER_PASSWORD:
     return "PASSWORD";
+  case QDMI_DEVICE_SESSION_PARAMETER_CHILDDEVICE:
+    return "CHILD DEVICE";
   case QDMI_DEVICE_SESSION_PARAMETER_MAX:
     return "MAX";
   case QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1:
@@ -386,6 +388,8 @@ constexpr auto toString(const QDMI_Device_Property prop) -> const char* {
     return "PULSE SUPPORT";
   case QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS:
     return "SUPPORTED PROGRAM FORMATS";
+  case QDMI_DEVICE_PROPERTY_CHILDDEVICES:
+    return "CHILD DEVICES";
   case QDMI_DEVICE_PROPERTY_MAX:
     return "MAX";
   case QDMI_DEVICE_PROPERTY_CUSTOM1:

--- a/test/fomac/test_fomac.cpp
+++ b/test/fomac/test_fomac.cpp
@@ -346,6 +346,8 @@ TEST(FoMaCTest, DevicePropertyToString) {
                "MIN ATOM DISTANCE");
   EXPECT_STREQ(qdmi::toString(QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS),
                "SUPPORTED PROGRAM FORMATS");
+  EXPECT_STREQ(qdmi::toString(QDMI_DEVICE_PROPERTY_CHILDDEVICES),
+               "CHILD DEVICES");
   EXPECT_STREQ(qdmi::toString(QDMI_DEVICE_PROPERTY_MAX), "MAX");
   EXPECT_STREQ(qdmi::toString(QDMI_DEVICE_PROPERTY_CUSTOM1), "CUSTOM1");
   EXPECT_STREQ(qdmi::toString(QDMI_DEVICE_PROPERTY_CUSTOM2), "CUSTOM2");
@@ -356,6 +358,11 @@ TEST(FoMaCTest, DevicePropertyToString) {
 
 TEST(FoMaCTest, SessionPropertyToString) {
   EXPECT_STREQ(qdmi::toString(QDMI_SESSION_PROPERTY_DEVICES), "DEVICES");
+}
+
+TEST(FoMaCTest, DeviceSessionParameterToString) {
+  EXPECT_STREQ(qdmi::toString(QDMI_DEVICE_SESSION_PARAMETER_CHILDDEVICE),
+               "CHILD DEVICE");
 }
 
 TEST(FoMaCTest, ThrowIfError) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Complete the public `qdmi::toString` mappings for the child-device session parameter and device property introduced with child-device support. This keeps diagnostics and property-name formatting exhaustive for the current QDMI enum surface.

This small fix was identified while reviewing #1912 and is extracted because it has no dependency on configurable device discovery. The existing child-device changelog entry now also attributes this follow-up to #1952 and retains the original human author attribution.

## Validation

- Focused child-device string-conversion tests: 2 passed
- Complete FoMaC C++ test binary: 171 passed
- `uvx nox -s lint`
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the changed functionality.
- [x] Documentation and migration guidance are not needed for this diagnostic-string completion.
- [x] The existing changelog entry includes this PR and all human authors.
- [x] The change follows the project's style guidelines and introduces no new warnings.
- [x] The changes are fully tested and pass the relevant local checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
