### PR TITLE
🐛 Keep GoogleTest discovery artifacts in the build tree

### DIFF
--- a/cmake/PackageAddTest.cmake
+++ b/cmake/PackageAddTest.cmake
@@ -19,8 +19,10 @@ macro(PACKAGE_ADD_TEST testname linklibs)
     # discover tests
     gtest_discover_tests(
       ${testname}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" DISCOVERY_TIMEOUT 60)
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      # Defer the property name so it is not parsed as the discovery working directory.
+      PROPERTIES "$<1:WORKING_DIRECTORY>" "${CMAKE_CURRENT_SOURCE_DIR}"
+                 VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" DISCOVERY_TIMEOUT 60)
     set_target_properties(${testname} PROPERTIES FOLDER tests)
 
     # Set c++ standard
@@ -40,8 +42,10 @@ macro(PACKAGE_ADD_TEST_WITH_WORKING_DIR testname linklibs test_working_directory
     # discover tests
     gtest_discover_tests(
       ${testname}
-      WORKING_DIRECTORY ${test_working_directory}
-      PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${test_working_directory}" DISCOVERY_TIMEOUT 60)
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      # Defer the property name so it is not parsed as the discovery working directory.
+      PROPERTIES "$<1:WORKING_DIRECTORY>" "${test_working_directory}" VS_DEBUGGER_WORKING_DIRECTORY
+                 "${test_working_directory}" DISCOVERY_TIMEOUT 60)
     set_target_properties(${testname} PROPERTIES FOLDER tests)
 
     # Set c++ standard


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

CMake 4.3 writes a `cmake_test_discovery_*.json` bookkeeping file to the directory passed to `gtest_discover_tests(WORKING_DIRECTORY ...)`. Our test helpers passed source directories there because the same argument also controls the runtime working directory of each discovered test. As a result, configuring and building tests could dirty the source tree.

Run GoogleTest discovery from the current binary directory so the bookkeeping file remains a build artifact. Preserve the existing runtime working directory by setting the discovered tests' `WORKING_DIRECTORY` property separately. The property name is deferred through a generator expression so CMake's argument parser does not interpret it as a second discovery option.

This is extracted from #1912 because it is independent of the QDMI configuration work.

## Validation

- Configured and built representative targets with CMake 4.3.2.
- Confirmed that no `cmake_test_discovery_*.json` files appear outside `build/`.
- Confirmed that the ordinary helper still runs a FoMaC test from its source directory.
- Confirmed that the custom-working-directory helper still runs an IR test from its configured build directory.
- `uvx nox -s lint`
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality. (Existing tests exercise both helper variants.)
- [x] I have updated the documentation to reflect these changes. (No user-facing documentation change is needed.)
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals. (Not user-facing.)
- [x] I have added migration instructions to the upgrade guide (if needed). (No migration is needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks. (Local checks pass; CI is pending.)
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
