### PR TITLE
📝 Fix QCO pass diagram rendering

### DIFF
--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -168,6 +168,7 @@ def HadamardLifting : Pass<"hadamard-lifting", "mlir::ModuleOp"> {
     circuit, in order to improve the results provided by measurement lifting.
 
     Hadamard lifting uses the following commutation rules:
+    ```text
          ┌───┐ ┌───┐      ┌───┐ ┌───┐
         ─┤ X ├─┤ H ├─ => ─┤ H ├─┤ Z ├─
          └───┘ └───┘      └───┘ └───┘
@@ -177,26 +178,33 @@ def HadamardLifting : Pass<"hadamard-lifting", "mlir::ModuleOp"> {
          ┌───┐ ┌───┐      ┌───┐ ┌───┐                                ┌───────┐
         ─┤ Y ├─┤ H ├─ => ─┤ H ├─┤ Y ├─, while adding a global phase: │ G(pi) │
          └───┘ └───┘      └───┘ └───┘                                └───────┘
+    ```
+
     Hadamard lifting is only applied to commute Hadamard gates further in front in the circuit, not the other way
     around. A global phase is added if the Hadamard gate is commuted with a Pauli-Y gate, as YH = -HY.
 
     The routine is only applied to non-controlled Pauli and Hadamard gates.
 
     In order to reduce multi-qubit gates, a second transformation routine is applied. Using the commutation rule
+    ```text
                  ┌───┐┌───┐┌───┐
         ──■──    ┤ H ├┤ X ├┤ H ├
         ┌─┴─┐ => │───│└─┬─┘│───│
         ┤ X ├    ┤ H ├──■──┤ H ├
         └───┘    └───┘     └───┘
+    ```
+
     the following transformation is applied to circuits where a Hadamard gate follows a target gate of a controlled
     Pauli-X gate, which is followed by a measurement:
+    ```text
                               ┌───┐┌───┐┌───┐
         ──■─────────────      ┤ H ├┤ X ├┤ H ├──
         ┌─┴─┐┌───┐┌──────┐ => │───│└─┬─┘│───┘──┐
         ┤ X ├┤ H ├┤ Meas │    ┤ H ├──■──┤ Meas │
         └───┘└───┘└──────┘    └───┘     └──────┘
+    ```
 
-     Afterward the measurement lifting routine could transform the CNOT into a classically controlled Pauli-X.
+    Afterward the measurement lifting routine could transform the CNOT into a classically controlled Pauli-X.
 
   }];
 }
@@ -213,24 +221,30 @@ def MeasurementLifting : Pass<"measurement-lifting", "mlir::ModuleOp"> {
     circuit to reuse them and to potentially remove some quantum gates.
 
     Measurement lifting uses the following commutation rules:
-                 ┌──────┐             ┌──────┐
-            ──■──┤ Meas │──────      ─┤ Meas ├──■───
-              │  └──────┘             └──────┘  │
-            ┌─┴─┐                 =>          ┌─┴─┐
-            ┤ U ├────────────────    ─────────┤ U ├─
-            └───┘                             └───┘
-            (Where U is any (controlled) unitary gate)
+    ```text
+         ┌──────┐             ┌──────┐
+    ──■──┤ Meas │──────      ─┤ Meas ├──■───
+      │  └──────┘             └──────┘  │
+    ┌─┴─┐                 =>          ┌─┴─┐
+    ┤ U ├────────────────    ─────────┤ U ├─
+    └───┘                             └───┘
+    ```
+    Here, U is any (controlled) unitary gate.
 
-            ┌───┐┌──────┐    ┌──────┐┌───┐
-            ┤ P ├┤ Meas ├ => ┤ Meas ├┤ P ├
-            └───┘└──────┘    └──────┘└───┘
-            (Where P is any diagonal gate, e.g., `z`, `s`, ...)
+    ```text
+    ┌───┐┌──────┐    ┌──────┐┌───┐
+    ┤ P ├┤ Meas ├ => ┤ Meas ├┤ P ├
+    └───┘└──────┘    └──────┘└───┘
+    ```
+    Here, P is any diagonal gate, for example `z` or `s`.
 
-            ┌───┐┌──────┐    ┌───────┐┌───┐
-            ┤ X ├┤ Meas ├ => ┤ Meas* ├┤ X ├
-            └───┘└──────┘    └───────┘└───┘
-            (Where Meas* is a measurement after which the outcome is classically negated and X can be replaced by Y, which is also anti-diagonal)
-
+    ```text
+    ┌───┐┌──────┐    ┌───────┐┌───┐
+    ┤ X ├┤ Meas ├ => ┤ Meas* ├┤ X ├
+    └───┘└──────┘    └───────┘└───┘
+    ```
+    Here, Meas* is a measurement after which the outcome is classically negated. X can also be replaced by Y, which
+    is likewise anti-diagonal.
   }];
 }
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Preserve the layout of the circuit diagrams in the generated QCO pass
documentation by wrapping the diagrams in fenced `text` blocks in the
authoritative TableGen descriptions.

The diagrams were previously emitted as ordinary Markdown paragraphs. HTML
collapses whitespace in paragraph content, causing the circuit symbols to
appear inline. Fenced blocks make Sphinx render the diagrams as preformatted
content without changing the documentation-generation pipeline or editing
generated files.

The same rendering defect was present in the adjacent measurement-lifting
description, so its diagrams are covered by the same focused change. The
accompanying explanations remain regular prose, preserving inline formatting
for gate names.

Fixes #1958

## Validation

- Generated the pass documentation with `mlir-tblgen --gen-pass-doc`.
- Built the complete Sphinx documentation with warnings treated as errors using
  `uvx nox --non-interactive -s docs`.
- Confirmed that the generated HTML contains three `<pre>` blocks in each
  affected pass section.
- Ran `uvx nox -s lint`.
- Ran `git diff --check`.
- Independently reviewed the final change against the issue and generated HTML;
  no actionable findings remained.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to
  this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
  (The pass generator and complete documentation build exercise this
  documentation-only change.)
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions,
  changes, fixes, or removals. (No changelog entry is needed for this
  rendering-only correction.)
- [x] I have added migration instructions to the upgrade guide (if needed). (No
  migration is needed.)
- [x] The changes follow the project's style guidelines and introduce no new
  warnings.
- [x] The changes are fully tested and pass the CI checks. (Local checks pass;
  CI is pending.)
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly
  authorized for that scope, as required by our
  [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the
  visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]`
  footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated
  content, and accept full responsibility for it.
