### PR TITLE
⬆️ Update templates to v1.4.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,5 +29,5 @@ This checklist serves as a reminder of a couple of things that ensure your pull 
 
 - [ ] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
 - [ ] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
-- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
+- [ ] I have disclosed AI assistance in the PR description.
 - [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,72 +5,92 @@ name-template: "MQT Core $RESOLVED_VERSION Release"
 tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "⚛️ MQT Core IR"
-    labels:
-      - "Core"
+    when:
+      labels:
+        - "Core"
   - title: "⚖️ MQT Core DD Package"
-    labels:
-      - "DD"
+    when:
+      labels:
+        - "DD"
   - title: "🐉 MQT Core MLIR"
-    labels:
-      - "MLIR"
+    when:
+      labels:
+        - "MLIR"
   - title: "🐲 MQT Core QIR"
-    labels:
-      - "QIR"
+    when:
+      labels:
+        - "QIR"
   - title: "🔌 MQT Core QDMI"
-    labels:
-      - "QDMI"
+    when:
+      labels:
+        - "QDMI"
   - title: "🏼 MQT Core NA Package"
-    labels:
-      - "NA"
+    when:
+      labels:
+        - "NA"
   - title: "🕸️ MQT Core ZX Package"
-    labels:
-      - "ZX"
+    when:
+      labels:
+        - "ZX"
   - title: "🚀 Features and Enhancements"
-    labels:
-      - "enhancement"
-      - "feature"
-      - "refactor"
-      - "usability"
+    when:
+      labels:
+        - "enhancement"
+        - "feature"
+        - "refactor"
+        - "usability"
   - title: "🐛 Bug Fixes"
-    labels:
-      - "bug"
-      - "fix"
+    when:
+      labels:
+        - "bug"
+        - "fix"
   - title: "📄 Documentation"
-    labels:
-      - "documentation"
-  - title: "🤖 CI"
-    labels:
-      - "continuous integration"
+    when:
+      labels:
+        - "documentation"
+  - title: "🤖 CI & Tooling"
+    when:
+      labels:
+        - "continuous integration"
+        - "tooling"
   - title: "📦 Packaging"
-    labels:
-      - "packaging"
+    when:
+      labels:
+        - "packaging"
   - title: "🧹 Code Quality"
-    labels:
-      - "code quality"
+    when:
+      labels:
+        - "code quality"
   - title: "⬆️ Dependencies"
     collapse-after: 5
-    labels:
-      - "dependencies"
-      - "github-actions"
-      - "pre-commit"
-      - "submodules"
+    when:
+      labels:
+        - "dependencies"
+        - "github-actions"
+        - "pre-commit"
+        - "submodules"
+  - type: "pre-exclude"
+    when:
+      labels:
+        - "skip-changelog"
+        - "backport"
+        - "release-prep"
+  - type: "version-resolver"
+    semver-increment: "major"
+    when:
+      label: "major"
+  - type: "version-resolver"
+    semver-increment: "minor"
+    when:
+      label: "minor"
+  - type: "version-resolver"
+    semver-increment: "patch"
+    when:
+      label: "patch"
+  - type: "version-resolver"
+    semver-increment: "patch"
 change-template: "- $TITLE ([#$NUMBER]($URL)) (**@$AUTHOR**)"
 change-title-escapes: '\<*_&'
-exclude-labels:
-  - "skip-changelog"
-  - "backport"
-  - "release-prep"
-version-resolver:
-  major:
-    labels:
-      - "major"
-  minor:
-    labels:
-      - "minor"
-  patch:
-    labels:
-      - "patch"
-  default: patch
 
 template: |
   ## 👀 What Changed

--- a/.github/workflow_inputs/release_drafter_categories.json
+++ b/.github/workflow_inputs/release_drafter_categories.json
@@ -14,7 +14,7 @@
   ],
   "🐛 Bug Fixes": ["bug", "fix"],
   "📄 Documentation": ["documentation"],
-  "🤖 CI": ["continuous integration"],
+  "🤖 CI & Tooling": ["continuous integration", "tooling"],
   "📦 Packaging": ["packaging"],
   "🧹 Code Quality": ["code quality"],
   "⬆️ Dependencies": [

--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: munich-quantum-toolkit/templates@02460c7352d8d8a13414c9c082f062b33c3c5ecb # v1.4.1
+      - uses: munich-quantum-toolkit/templates@d0c5adb86d19a5095f871cb6184cfdab298e943c # v1.4.2
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: Core

--- a/docs/ai_usage.md
+++ b/docs/ai_usage.md
@@ -76,14 +76,16 @@ beginning of the edited field.
 Transparency helps the community understand the role of these tools and develop
 best practices.
 
-**You must disclose AI assistance.** This helps us understand how the tools are
-being used and identify potential issues. Disclose it in the following ways:
+**AI assistance must be disclosed in the PR description.** This helps reviewers
+understand how the tools were used and where human verification was applied.
 
-- **Commit Messages**: Add a trailer to your commit message in the form
-  `Assisted-by: [Model Name] via [Tool Name]` (example:
-  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`)
-- **Public issue and pull request text**: Use the visible disclosure required in
-  the [communication policy](#3-communication).
+- **PR Description**: Briefly state how AI tools materially assisted the
+  contribution. If an agent authored or edited the description, use the visible
+  disclosure required in the [communication policy](#3-communication).
+- **Commit Messages**: We recommend adding an
+  `Assisted-by: [Model Name] via [Tool Name]` trailer to commits prepared with
+  AI assistance. For example:
+  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`.
 
 ### 5. Licensing and Copyright
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -98,9 +98,10 @@ any AI-assisted contribution. In short:
 within an explicitly authorized scope, but you must review their work and remain
 accountable for the result. Every agent-authored or agent-edited public text
 body must begin with `🤖 *AI text below* 🤖`; issue and pull request titles are
-exempt. AI-assisted commits must include an
-`Assisted-by: [Model Name] via [Tool Name]` footer. AI assistance must not be
-used for contributions to issues labeled "good first issue".
+exempt. AI assistance must be disclosed in the PR description. Commit-level
+`Assisted-by: [Model Name] via [Tool Name]` trailers are recommended for commits
+prepared with AI assistance. AI assistance must not be used for contributions to
+issues labeled "good first issue".
 
 If you use an agent, it will automatically read the provided {code}`AGENTS.md`,
 which contains context and instructions to help the agent work on MQT Core. For


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- pin the templating workflow to the exact v1.4.2 release commit
- apply the generated Release Drafter schema migration and AI-disclosure policy updates
- rename the custom Core category to `CI & Tooling` and include the `tooling` label

This supersedes the stale v1.4.1-generated changes in #1963. In particular, rendering v1.4.2 no longer changes the MLIR dependency semantics in `docs/installation.md`.

## Validation

- `./.agent/run.sh uvx nox --non-interactive -s lint`
- `git diff --check`
- rendered from signed release commit `d0c5adb86d19a5095f871cb6184cfdab298e943c`

## AI assistance

GPT-5.6 via Codex rendered the released templates, prepared the rollout changes, and ran the validation. I reviewed the resulting diff and checks.