### PR TITLE
📝 Record v3.8.0 release on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,6 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Add binary-safe QDMI program submission and retrieval to FoMaC ([#1957])
-  ([**@burgholzer**])
-- ✨ Add versioned, relocatable configuration and stable-ID registration for
-  QDMI device libraries, including disabled-ID reservations, fresh device
-  sessions, idempotent registration, and external-device target metadata
-  ([#1912]) ([**@burgholzer**])
 - ✨ Add and improve QIR generation support in the MQT Compiler Collection
   ([#1264], [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570],
   [#1572], [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751],
@@ -32,19 +26,8 @@ releases may include breaking changes.
 - ✨ Add a `decompose-multi-controlled` pass for decomposing controlled X, Z,
   RCCX, and constant-angle phase gates with a configurable `min-controls`
   threshold ([#1810]) ([**@simon1hofmann**])
-- ✨ Add native relative-phase CCX (`rccx`) support across the IR, DD package,
-  ZX diagrams, OpenQASM import/export, and Python/Qiskit bindings ([#1886],
-  [#1950]) ([**@simon1hofmann**])
 - ✨ Add Python bindings for the MQT Compiler Collection ([#1815])
   ([**@burgholzer**], [**@denialhaag**])
-- ✨ Add support for QDMI child devices to the driver and FoMaC libraries
-  ([#1897], [#1952]) ([**@burgholzer**])
-- ✨ Add typed custom property and result queries to the C++ and Python FoMaC
-  libraries ([#1895]) ([**@burgholzer**])
-- ✨ Add support for custom job parameters to C++ and Python FoMaC library
-  ([#1887]) ([**@flowerthrower**], [**@burgholzer**])
-- ✨ Add QIR Output Schemas support to the QIR runtime ([#1877])
-  ([**@rturrado**])
 - ✨ Add support for IQM's `move` gate in the QDMI Qiskit backend converter
   ([#1844], [#1848]) ([**@burgholzer**], [**@marcelwa**])
 - 🚸 Add `const` version of the `CompoundOperation`'s `getOps()` function
@@ -58,8 +41,6 @@ releases may include breaking changes.
 - ✨ Add a `fuse-single-qubit-unitary-runs` pass for fusing compile-time
   single-qubit unitary runs via Euler resynthesis ([#1672])
   ([**@simon1hofmann**], [**@burgholzer**])
-- ✨ Add QIR program format support to the DDSIM QDMI Device ([#1766], [#1815])
-  ([**@rturrado**], [**@burgholzer**])
 - ✨ Add a `quantum-loop-unroll` pass for unrolling for-loop operations
   containing quantum operations ([#1718]) ([**@MatthiasReumann**])
 - ✨ Add a `hadamard-lifting` pass for lifting Hadamard gates above Pauli gates
@@ -93,8 +74,6 @@ releases may include breaking changes.
 
 - 💥 Require LLVM/MLIR and QIR support in every MQT Core build and remove the
   corresponding build options ([#1953]) ([**@burgholzer**])
-- ⬆️ Raise the minimum supported QDMI version to 1.3.2 ([#1897])
-  ([**@burgholzer**])
 - ⬆️ Require LLVM 22.1 for C++ library builds ([#1549]) ([**@burgholzer**],
   [**@denialhaag**])
 - 📦 Build MLIR by default for C++ library builds ([#1356]) ([**@burgholzer**],
@@ -102,13 +81,50 @@ releases may include breaking changes.
 
 ### Removed
 
-- 🔥 Replace the unstable C++ `Driver::addDynamicDeviceLibrary` and Python
-  `add_dynamic_device_library` APIs with definition registration and stable-ID
-  opening ([#1912]) ([**@burgholzer**])
 - 🔥 Remove the density matrix support from the MQT Core DD package ([#1466])
   ([**@burgholzer**])
 - 🔥 Remove `datastructures` (`ds`) (sub)library from MQT Core ([#1458])
   ([**@burgholzer**])
+
+## [3.8.0] - 2026-07-30
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#380)._
+
+### Added
+
+- ✨ Add binary-safe QDMI program submission and retrieval to FoMaC, including
+  explicit text and exact-byte APIs and all standard QDMI program formats
+  ([#1957]) ([**@burgholzer**])
+- ✨ Add versioned, relocatable configuration and stable-ID registration for
+  QDMI device libraries, including disabled-ID reservations, fresh device
+  sessions, idempotent registration, and external-device target metadata
+  ([#1912]) ([**@burgholzer**])
+- ✨ Add native relative-phase CCX (`rccx`) support across the IR, DD package,
+  ZX diagrams, OpenQASM import/export, and Python/Qiskit bindings ([#1886],
+  [#1950]) ([**@simon1hofmann**])
+- ✨ Add support for QDMI child devices to the driver and FoMaC libraries
+  ([#1897], [#1952]) ([**@burgholzer**])
+- ✨ Add typed custom property and result queries to the C++ and Python FoMaC
+  libraries ([#1895]) ([**@burgholzer**])
+- ✨ Add support for custom job parameters to C++ and Python FoMaC library
+  ([#1887]) ([**@flowerthrower**], [**@burgholzer**])
+- ✨ Add labeled and ordered output schemas to the QIR runtime ([#1877])
+  ([**@rturrado**])
+- ✨ Add boolean, integer, floating-point, tuple, and array record output
+  functions to the QIR runtime ([#1799]) ([**@rturrado**])
+- ✨ Add the reusable in-process `MQT::CoreQIRJIT` library and QIR program
+  format support to the DDSIM QDMI device ([#1766]) ([**@rturrado**])
+
+### Changed
+
+- ⬆️ Raise the minimum supported QDMI version to 1.3.2 ([#1897])
+  ([**@burgholzer**])
+
+### Removed
+
+- 🔥 Replace the unstable C++ `Driver::addDynamicDeviceLibrary` and Python
+  `add_dynamic_device_library` APIs with definition registration and stable-ID
+  opening ([#1912]) ([**@burgholzer**])
 
 ### Fixed
 
@@ -650,7 +666,8 @@ changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.7.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.8.0...HEAD
+[3.8.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.8.0
 [3.7.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.7.0
 [3.6.1]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.6.1
 [3.6.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.6.0
@@ -723,6 +740,7 @@ changelogs._
 [#1805]: https://github.com/munich-quantum-toolkit/core/pull/1805
 [#1803]: https://github.com/munich-quantum-toolkit/core/pull/1803
 [#1802]: https://github.com/munich-quantum-toolkit/core/pull/1802
+[#1799]: https://github.com/munich-quantum-toolkit/core/pull/1799
 [#1787]: https://github.com/munich-quantum-toolkit/core/pull/1787
 [#1786]: https://github.com/munich-quantum-toolkit/core/pull/1786
 [#1782]: https://github.com/munich-quantum-toolkit/core/pull/1782

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,16 +6,6 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
-### Bundled QDMI devices in embedded builds
-
-The bundled QDMI devices now have individual CMake options:
-`BUILD_MQT_CORE_QDMI_DDSIM_DEVICE`, `BUILD_MQT_CORE_QDMI_NA_DEVICE`, and
-`BUILD_MQT_CORE_QDMI_SC_DEVICE`. All three remain enabled by default in a
-standalone MQT Core build. They default to disabled when MQT Core is consumed
-through CMake's `FetchContent` or `add_subdirectory`; embedded consumers can
-enable only the devices they need before making MQT Core available. The QDMI
-driver and FoMaC libraries remain available independently.
-
 ### LLVM/MLIR required for all source builds
 
 MQT Core now builds its MLIR-based compiler infrastructure unconditionally. LLVM
@@ -45,6 +35,53 @@ Known limitations:
   compiler.
 - AppleClang 17+ is required to build MQT Core due to some C++20 features that
   are not yet properly supported by older versions.
+
+### Removal of the density matrix support from the DD package
+
+The density matrix support within the DD package has been removed. This change
+was made to reduce the maintenance burden of the package. Any libraries that
+depend on the density matrix functionality, such as [MQT DDSIM], need to
+implement it on their own or use an alternative solution. In a related fashion,
+this PR also removes the noise operations from the MQT Core IR as they no longer
+serve a purpose.
+
+### Removal of the `datastructures` (sub)library
+
+The `datastructures` (sub)library has been removed from the MQT Core repository.
+Its functionality has only ever been used in [MQT QMAP] since its inception. As
+a consequence, the code shall be moved to [MQT QMAP] once QMAP adopts an MQT
+Core version that includes this change.
+
+### Dev container
+
+A [dev container](https://containers.dev/) configuration is available to provide
+a consistent local development environment. Common IDEs like
+[CLion](https://www.jetbrains.com/help/clion/dev-containers-starting-page.html)
+and [VS Code](https://code.visualstudio.com/docs/devcontainers/containers) can
+open the repository directly inside the container. If you are on Windows, we
+recommend using Docker Desktop with the WSL 2 backend.
+
+## [3.8.0]
+
+The shared library ABI version (`SOVERSION`) is increased from `3.7` to `3.8`.
+Thus, consuming libraries need to update their wheel repair configuration for
+`cibuildwheel` to ensure the `mqt-core` libraries are properly skipped in the
+wheel repair step.
+
+### QDMI updated to version 1.3.2
+
+MQT Core already bundled QDMI 1.3.2 in the previous release, but now also
+requires at least that version when using a system-provided QDMI installation.
+
+### Bundled QDMI devices in embedded builds
+
+The bundled QDMI devices now have individual CMake options:
+`BUILD_MQT_CORE_QDMI_DDSIM_DEVICE`, `BUILD_MQT_CORE_QDMI_NA_DEVICE`, and
+`BUILD_MQT_CORE_QDMI_SC_DEVICE`. All three remain enabled by default in a
+standalone MQT Core build. They default to disabled when MQT Core is consumed
+through CMake's `FetchContent` or `add_subdirectory`; embedded consumers can
+enable only the devices they need before making MQT Core available. The QDMI
+driver and FoMaC libraries remain available independently.
 
 ### QDMI runtime device registration
 
@@ -83,30 +120,24 @@ an unknown or disabled ID fails. `fomac::Session::openDevice` creates a fresh
 owned session on every call. `qdmi::Driver::open(id)` retains its cached-device
 behavior for client callers.
 
-### Removal of the density matrix support from the DD package
+See the [QDMI device configuration guide](docs/qdmi/configuration.md) for the
+versioned JSON and TOML formats, configuration precedence, and relocatable
+device manifests.
 
-The density matrix support within the DD package has been removed. This change
-was made to reduce the maintenance burden of the package. Any libraries that
-depend on the density matrix functionality, such as [MQT DDSIM], need to
-implement it on their own or use an alternative solution. In a related fashion,
-this PR also removes the noise operations from the MQT Core IR as they no longer
-serve a purpose.
+### FoMaC program payload handling
 
-### Removal of the `datastructures` (sub)library
+FoMaC now distinguishes textual programs from exact binary payloads. In C++, use
+`Device::submitJob(const std::string&, ...)` for text formats and
+`Device::submitJob(std::span<const std::byte>, ...)` for binary formats. In
+Python, pass `str` for text and `bytes` for binary payloads. In particular, QIR
+`*_STRING` formats are text, while QIR `*_MODULE` formats are LLVM bitcode and
+must be submitted as bytes.
 
-The `datastructures` (sub)library has been removed from the MQT Core repository.
-Its functionality has only ever been used in [MQT QMAP] since its inception. As
-a consequence, the code shall be moved to [MQT QMAP] once QMAP adopts an MQT
-Core version that includes this change.
-
-### Dev container
-
-A [dev container](https://containers.dev/) configuration is available to provide
-a consistent local development environment. Common IDEs like
-[CLion](https://www.jetbrains.com/help/clion/dev-containers-starting-page.html)
-and [VS Code](https://code.visualstudio.com/docs/devcontainers/containers) can
-open the repository directly inside the container. If you are on Windows, we
-recommend using Docker Desktop with the WSL 2 backend.
+`Job::getProgram()` and Python's `Job.program` remain the textual accessors and
+now reject binary or non-null-terminated payloads. Use `Job::getProgramBytes()`
+or `Job.program_bytes` to retrieve the exact submitted bytes. Calibration and
+batch-job formats cannot be submitted through these generic program APIs because
+their QDMI payloads have specialized representations.
 
 ### QDMI child devices
 
@@ -449,7 +480,8 @@ It also requires the `uv` library version 0.5.20 or higher.
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.7.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.8.0...HEAD
+[3.8.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.5.1...v3.6.0
 [3.5.1]: https://github.com/munich-quantum-toolkit/core/compare/v3.5.0...v3.5.1


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This PR back-backports the v3.8.0 release changelog and upgrade guide from
`v3.x` to `main` after the release of MQT Core 3.8.0.

It moves the changes shipped in 3.8.0 from the unreleased sections into
dedicated 3.8.0 sections, preserves the main-only v4 entries under Unreleased,
and updates the comparison links to start at `v3.8.0`. The resulting 3.8.0
sections match the released `v3.8.0` tag.

## Validation

- `./.agent/run.sh prek run --files CHANGELOG.md UPGRADING.md`
- `./.agent/run.sh uvx nox -s lint`
- `git diff --check`
- Exact section comparison against the `v3.8.0` tag

## AI assistance

Codex helped compare the release and main branches, curate the document split,
and run the validation checks.
