### PR TITLE
✨ Expose registered QDMI device IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Expose registered QDMI device IDs without loading device libraries
+  ([#1972]) ([**@burgholzer**])
 - ✨ Add typed runtime configuration transport and relocatable assets for QDMI
   device descriptions ([#1967]) ([**@burgholzer**])
 - ✨ Add and improve QIR generation support in the MQT Compiler Collection
@@ -692,6 +694,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1972]: https://github.com/munich-quantum-toolkit/core/pull/1972
 [#1967]: https://github.com/munich-quantum-toolkit/core/pull/1967
 [#1965]: https://github.com/munich-quantum-toolkit/core/pull/1965
 [#1961]: https://github.com/munich-quantum-toolkit/core/pull/1961

--- a/bindings/fomac/fomac.cpp
+++ b/bindings/fomac/fomac.cpp
@@ -753,6 +753,14 @@ Raises:
     ValueError: If the definition is invalid.)pb");
 
   m.def(
+      "registered_device_ids",
+      [] { return qdmi::Driver::get().registeredDeviceIds(); },
+      R"pb(Return registered, enabled QDMI device IDs in registration order.
+
+This includes devices registered at runtime and does not load native device
+libraries or expose their definitions.)pb");
+
+  m.def(
       "open_device",
       [](const std::string& deviceId, std::optional<std::string> baseUrl,
          std::optional<std::string> token,

--- a/docs/qdmi/configuration.md
+++ b/docs/qdmi/configuration.md
@@ -140,9 +140,14 @@ Code paths that may be imported more than once can use
 inserted and ignores an existing or explicitly disabled stable ID; malformed
 definitions still raise an error.
 
+Use `registered_device_ids()` to inspect the enabled stable IDs in deterministic
+registration order. This includes runtime registrations without loading native
+device libraries or exposing their paths, prefixes, or session configuration.
+
 The equivalent C++ registration operation is `qdmi::Driver::registerDevice`.
 Duplicate IDs are rejected unless `replace` is true, and an opened definition
-cannot be replaced. `qdmi::Driver::open(id)` returns the cached device.
+cannot be replaced. `qdmi::Driver::registeredDeviceIds()` provides the same
+load-free enumeration, and `qdmi::Driver::open(id)` returns the cached device.
 `fomac::Session::openDevice(id, overrides)` returns a fresh device session and
 does not add it to the QDMI client catalog. Runtime registrations and explicit
 opens are not added to that catalog.

--- a/include/mqt-core/qdmi/driver/Driver.hpp
+++ b/include/mqt-core/qdmi/driver/Driver.hpp
@@ -505,6 +505,14 @@ public:
   auto registerDeviceIfAbsent(DeviceDefinition definition) -> bool;
 
   /**
+   * @brief Lists the stable IDs of all registered devices.
+   * @returns The enabled device IDs in deterministic registration order.
+   * @details This query includes runtime registrations and does not load device
+   * libraries or expose their definitions.
+   */
+  [[nodiscard]] auto registeredDeviceIds() const -> std::vector<std::string>;
+
+  /**
    * @brief Opens the registered device with the given stable ID.
    * @returns The existing device handle when the ID is already open.
    * @throws std::out_of_range If the ID is unknown.

--- a/python/mqt/core/fomac.pyi
+++ b/python/mqt/core/fomac.pyi
@@ -619,6 +619,13 @@ def register_device_if_absent(definition: DeviceDefinition) -> bool:
         ValueError: If the definition is invalid.
     """
 
+def registered_device_ids() -> list[str]:
+    """Return registered, enabled QDMI device IDs in registration order.
+
+    This includes devices registered at runtime and does not load native device
+    libraries or expose their definitions.
+    """
+
 def open_device(
     device_id: str,
     *,

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -673,6 +673,14 @@ auto Driver::registerDeviceIfAbsent(DeviceDefinition definition) -> bool {
   return true;
 }
 
+auto Driver::registeredDeviceIds() const -> std::vector<std::string> {
+  std::vector<std::string> ids;
+  ids.reserve(definitions_.size());
+  std::ranges::transform(definitions_, std::back_inserter(ids),
+                         &DeviceDefinition::id);
+  return ids;
+}
+
 auto Driver::open(const std::string_view id) -> QDMI_Device {
   if (disabledDeviceIds_.contains(std::string(id))) {
     throw std::runtime_error("QDMI device ID '" + std::string(id) +

--- a/test/python/fomac/test_fomac.py
+++ b/test/python/fomac/test_fomac.py
@@ -26,6 +26,7 @@ from mqt.core.fomac import (
     open_device,
     register_device,
     register_device_if_absent,
+    registered_device_ids,
 )
 
 CustomValueType = type[str] | type[bool] | type[int] | type[float] | type[bytes]
@@ -977,6 +978,19 @@ def test_register_device_if_absent_only_ignores_existing_id() -> None:
     assert not register_device_if_absent(definition)
     with pytest.raises(ValueError, match="library must not be empty"):
         register_device_if_absent(DeviceDefinition("python.if-absent", "", "PREFIX"))
+
+
+def test_registered_device_ids_include_runtime_registrations_in_order() -> None:
+    """Stable-ID enumeration is ordered and does not load native libraries."""
+    ids_before = registered_device_ids()
+    register_device(DeviceDefinition("python.enumeration.first", "/nonexistent/first.so", "FIRST"))
+    register_device(DeviceDefinition("python.enumeration.second", "/nonexistent/second.so", "SECOND"))
+
+    assert registered_device_ids() == [
+        *ids_before,
+        "python.enumeration.first",
+        "python.enumeration.second",
+    ]
 
 
 def test_open_device_rejects_unknown_id() -> None:

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -937,6 +937,28 @@ TEST(DeviceRegistrationTest, RegistrationDoesNotLoadLibraries) {
                std::runtime_error);
 }
 
+TEST(DeviceRegistrationTest,
+     EnumeratesEnabledIdsInOrderWithoutLoadingLibraries) {
+  auto& driver = qdmi::Driver::get();
+  const auto idsBefore = driver.registeredDeviceIds();
+  driver.registerDevice({.id = "test.enumeration.first",
+                         .library = "/nonexistent/first-device-library",
+                         .prefix = "MISSING_FIRST"});
+  driver.registerDevice({.id = "test.enumeration.second",
+                         .library = "/nonexistent/second-device-library",
+                         .prefix = "MISSING_SECOND"});
+
+  const auto idsAfter = driver.registeredDeviceIds();
+  ASSERT_EQ(idsAfter.size(), idsBefore.size() + 2);
+  EXPECT_TRUE(std::equal(idsBefore.begin(), idsBefore.end(), idsAfter.begin()));
+  EXPECT_EQ(idsAfter[idsBefore.size()], "test.enumeration.first");
+  EXPECT_EQ(idsAfter[idsBefore.size() + 1], "test.enumeration.second");
+  EXPECT_THAT(idsAfter, testing::Not(testing::Contains("test.disabled")));
+
+  EXPECT_THROW(static_cast<void>(driver.open("test.enumeration.first")),
+               std::runtime_error);
+}
+
 TEST(DeviceRegistrationTest, SynthesizesManifestForMetadataOnlyTarget) {
   std::ifstream manifest(MQT_CORE_QDMI_METADATA_MANIFEST);
   ASSERT_TRUE(manifest);


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This PR builds on the typed QDMI device-configuration transport merged in #1967 and exposes the enabled QDMI device IDs already registered with the Driver. It enables integrations to discover stable IDs without opening devices, loading native libraries, or receiving paths, prefixes, credentials, or session configuration.

The change adds:

- `Driver::registeredDeviceIds()` in C++, preserving deterministic registration order;
- `registered_device_ids()` in the FoMaC Python API;
- documentation for the load-free enumeration contract; and
- C++ and Python tests covering runtime registrations, ordering, disabled IDs, and the absence of eager library loading.

AI assistance was used to implement the API, tests, documentation, and validation. A human maintainer remains responsible for reviewing and accepting the contribution.

## Validation

- Full release build
- QDMI Driver tests: 112/112
- Python FoMaC tests: 185/185
- Python stub regeneration
- Full repository lint session
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added the assigned pull request number to the changelog.
- [x] The changes follow the project style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope.
- [x] Every agent-authored public text body begins with the required visible disclosure.
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
