### PR TITLE
🐛 Preserve classical loop state in QCO-to-QC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ releases may include breaking changes.
   [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717],
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
-  [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938])
+  [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938], [#1975])
   ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**],
   [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
   [**@simon1hofmann**], [**@J4MMlE**])
@@ -692,6 +692,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1975]: https://github.com/munich-quantum-toolkit/core/pull/1975
 [#1967]: https://github.com/munich-quantum-toolkit/core/pull/1967
 [#1965]: https://github.com/munich-quantum-toolkit/core/pull/1965
 [#1961]: https://github.com/munich-quantum-toolkit/core/pull/1961

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -138,6 +138,80 @@ static void inlineRegion(Region& sourceRegion, Region& targetRegion,
   block.eraseArguments(offset, replacementValues.size());
 }
 
+[[nodiscard]] static bool isQuantumStateType(const Type type) {
+  if (isa<qco::QubitType, qc::QubitType>(type)) {
+    return true;
+  }
+  if (const auto tensor = dyn_cast<RankedTensorType>(type)) {
+    return isa<qco::QubitType>(tensor.getElementType());
+  }
+  const auto memref = dyn_cast<MemRefType>(type);
+  return memref && isa<qc::QubitType>(memref.getElementType());
+}
+
+[[nodiscard]] static SmallVector<Value>
+selectConvertedState(ValueRange originalValues, ValueRange convertedValues,
+                     const bool selectQuantum) {
+  assert(originalValues.size() == convertedValues.size());
+  SmallVector<Value> selected;
+  for (const auto [original, converted] :
+       llvm::zip_equal(originalValues, convertedValues)) {
+    if (isQuantumStateType(original.getType()) == selectQuantum) {
+      selected.push_back(converted);
+    }
+  }
+  return selected;
+}
+
+static void inlineSCFRegion(Region& sourceRegion, Region& targetRegion,
+                            const unsigned int offset, ValueRange originalState,
+                            ValueRange quantumReplacements,
+                            ConversionPatternRewriter& rewriter) {
+  rewriter.inlineRegionBefore(sourceRegion, targetRegion, targetRegion.end());
+  auto& block = targetRegion.front();
+  assert(block.getNumArguments() == offset + originalState.size() &&
+         "region arguments must match the original loop state");
+
+  SmallVector<unsigned int> quantumArguments;
+  size_t quantumIndex = 0;
+  for (const auto [index, original] : llvm::enumerate(originalState)) {
+    if (!isQuantumStateType(original.getType())) {
+      continue;
+    }
+    assert(quantumIndex < quantumReplacements.size() &&
+           "missing replacement for quantum loop state");
+    block.getArgument(offset + index)
+        .replaceAllUsesWith(quantumReplacements[quantumIndex++]);
+    quantumArguments.push_back(static_cast<unsigned int>(offset + index));
+  }
+  assert(quantumIndex == quantumReplacements.size() &&
+         "unused replacement for quantum loop state");
+  for (const auto argument : llvm::reverse(quantumArguments)) {
+    block.eraseArgument(argument);
+  }
+}
+
+[[nodiscard]] static SmallVector<Value>
+combineConvertedResults(TypeRange originalTypes, ValueRange classicalResults,
+                        ValueRange quantumReplacements) {
+  SmallVector<Value> replacements;
+  replacements.reserve(originalTypes.size());
+  size_t classicalIndex = 0;
+  size_t quantumIndex = 0;
+  for (const auto type : originalTypes) {
+    if (isQuantumStateType(type)) {
+      assert(quantumIndex < quantumReplacements.size());
+      replacements.push_back(quantumReplacements[quantumIndex++]);
+    } else {
+      assert(classicalIndex < classicalResults.size());
+      replacements.push_back(classicalResults[classicalIndex++]);
+    }
+  }
+  assert(classicalIndex == classicalResults.size());
+  assert(quantumIndex == quantumReplacements.size());
+  return replacements;
+}
+
 #define GEN_PASS_DEF_QCOTOQC
 #include "mlir/Conversion/QCOToQC/QCOToQC.h.inc"
 
@@ -766,8 +840,7 @@ struct ConvertQCOYieldOp final : OpConversionPattern<qco::YieldOp> {
 
 /**
  * @brief Converts scf.for with value semantics to scf.for with memory
- * semantics for qubit values. This currently assumes only qubit types as return
- * values.
+ * semantics for qubit values while preserving classical loop-carried state.
  *
  * @par Example:
  * ```mlir
@@ -793,17 +866,24 @@ struct ConvertQCOSCFForOp final : OpConversionPattern<scf::ForOp> {
   LogicalResult
   matchAndRewrite(scf::ForOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
+    const auto classicalInits =
+        selectConvertedState(op.getInitArgs(), adaptor.getInitArgs(), false);
+    const auto quantumInits =
+        selectConvertedState(op.getInitArgs(), adaptor.getInitArgs(), true);
     auto newFor = scf::ForOp::create(
         rewriter, op.getLoc(), adaptor.getLowerBound(), adaptor.getUpperBound(),
-        adaptor.getStep(), ValueRange{});
+        adaptor.getStep(), classicalInits);
     // Erase default block
     rewriter.eraseBlock(&newFor.getRegion().front());
 
-    // Inline the region and replace the block arguments
-    inlineRegion(op.getRegion(), newFor.getRegion(), 1, adaptor.getInitArgs(),
-                 rewriter);
+    // Inline the region, retaining classical state as block arguments and
+    // replacing quantum state with the reference-semantic QC values.
+    inlineSCFRegion(op.getRegion(), newFor.getRegion(), 1, op.getInitArgs(),
+                    quantumInits, rewriter);
 
-    rewriter.replaceOp(op, adaptor.getInitArgs());
+    rewriter.replaceOp(op, combineConvertedResults(op.getResultTypes(),
+                                                   newFor.getResults(),
+                                                   quantumInits));
 
     return success();
   }
@@ -811,8 +891,7 @@ struct ConvertQCOSCFForOp final : OpConversionPattern<scf::ForOp> {
 
 /**
  * @brief Converts scf.while with value semantics to scf.while with memory
- * semantics for qubit values. This currently assumes only qubit types as return
- * values.
+ * semantics for qubit values while preserving classical loop-carried state.
  *
  * @par Example:
  * ```mlir
@@ -842,16 +921,30 @@ struct ConvertQCOSCFWhileOp final : OpConversionPattern<scf::WhileOp> {
   LogicalResult
   matchAndRewrite(scf::WhileOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
-    auto newWhileOp =
-        scf::WhileOp::create(rewriter, op->getLoc(), TypeRange{}, ValueRange{});
+    const auto classicalInits =
+        selectConvertedState(op.getInits(), adaptor.getInits(), false);
+    const auto quantumInits =
+        selectConvertedState(op.getInits(), adaptor.getInits(), true);
+    SmallVector<Type> classicalResultTypes;
+    for (const auto type : op.getResultTypes()) {
+      if (!isQuantumStateType(type)) {
+        classicalResultTypes.push_back(type);
+      }
+    }
+    auto newWhileOp = scf::WhileOp::create(
+        rewriter, op->getLoc(), classicalResultTypes, classicalInits);
 
-    // Inline the regions and replace the block arguments
-    inlineRegion(op.getBefore(), newWhileOp.getBefore(), 0, adaptor.getInits(),
-                 rewriter);
-    inlineRegion(op.getAfter(), newWhileOp.getAfter(), 0, adaptor.getInits(),
-                 rewriter);
+    // The before region receives initial-state types, while the after region
+    // receives result-state types. Quantum state in both regions maps back to
+    // the same reference-semantic QC values.
+    inlineSCFRegion(op.getBefore(), newWhileOp.getBefore(), 0, op.getInits(),
+                    quantumInits, rewriter);
+    inlineSCFRegion(op.getAfter(), newWhileOp.getAfter(), 0, op.getResults(),
+                    quantumInits, rewriter);
 
-    rewriter.replaceOp(op, adaptor.getInits());
+    rewriter.replaceOp(op, combineConvertedResults(op.getResultTypes(),
+                                                   newWhileOp.getResults(),
+                                                   quantumInits));
 
     return success();
   }
@@ -980,8 +1073,7 @@ struct ConvertQCOIndexSwitchOp final : OpConversionPattern<IndexSwitchOp> {
 
 /**
  * @brief Converts scf.yield with value semantics to scf.yield with memory
- * semantics for qubit values. This currently assumes no mixed types as yielded
- * values.
+ * semantics for qubit values while retaining classical yielded values.
  *
  * @par Example:
  * ```mlir
@@ -996,16 +1088,17 @@ struct ConvertQCOSCFYieldOp final : OpConversionPattern<scf::YieldOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(scf::YieldOp op, OpAdaptor /*adaptor*/,
+  matchAndRewrite(scf::YieldOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
-    rewriter.replaceOpWithNewOp<scf::YieldOp>(op);
+    rewriter.replaceOpWithNewOp<scf::YieldOp>(
+        op, selectConvertedState(op.getResults(), adaptor.getResults(), false));
     return success();
   }
 };
 
 /**
  * @brief Converts scf.condition with value semantics to scf.condition with
- * memory semantics for qubit values
+ * memory semantics for qubit values while retaining classical state
  *
  * @par Example:
  * ```mlir
@@ -1022,8 +1115,9 @@ struct ConvertQCOSCFConditionOp final : OpConversionPattern<scf::ConditionOp> {
   LogicalResult
   matchAndRewrite(scf::ConditionOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
-    rewriter.replaceOpWithNewOp<scf::ConditionOp>(op, adaptor.getCondition(),
-                                                  ValueRange{});
+    rewriter.replaceOpWithNewOp<scf::ConditionOp>(
+        op, adaptor.getCondition(),
+        selectConvertedState(op.getArgs(), adaptor.getArgs(), false));
 
     return success();
   }

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -192,6 +192,106 @@ module {
   EXPECT_FALSE(containsQCOOperations);
 }
 
+TEST(QCOToQCRegressionTest, PreservesClassicalForLoopState) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
+                  arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
+                  scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() -> i64 attributes {passthrough = ["entry_point"]} {
+    %q0 = qco.alloc : !qco.qubit
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 2 : index
+    %step = arith.constant 1 : index
+    %initial = arith.constant 0 : i64
+    %one = arith.constant 1 : i64
+    %result, %q1 = scf.for %iv = %lb to %ub step %step
+        iter_args(%value = %initial, %q = %q0) -> (i64, !qco.qubit) {
+      %next = arith.addi %value, %one : i64
+      %q2 = qco.h %q : !qco.qubit -> !qco.qubit
+      scf.yield %next, %q2 : i64, !qco.qubit
+    }
+    qco.sink %q1 : !qco.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCOToQCConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::ForOp loop;
+  module->walk([&](scf::ForOp candidate) { loop = candidate; });
+  ASSERT_TRUE(loop);
+  ASSERT_EQ(loop.getInitArgs().size(), 1);
+  EXPECT_TRUE(loop.getInitArgs().front().getType().isInteger(64));
+  ASSERT_EQ(loop.getNumResults(), 1);
+  EXPECT_TRUE(loop.getResult(0).getType().isInteger(64));
+  auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
+  ASSERT_EQ(yield.getNumOperands(), 1);
+  EXPECT_TRUE(yield.getOperand(0).getType().isInteger(64));
+}
+
+TEST(QCOToQCRegressionTest, PreservesTypeChangingClassicalWhileState) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
+                  arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
+                  scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() -> i64 attributes {passthrough = ["entry_point"]} {
+    %q0 = qco.alloc : !qco.qubit
+    %initial = arith.constant 1.0 : f32
+    %result, %q1 = scf.while (%input = %initial, %q = %q0)
+        : (f32, !qco.qubit) -> (i64, !qco.qubit) {
+      %q2 = qco.h %q : !qco.qubit -> !qco.qubit
+      %condition = arith.constant false
+      %next = arith.constant 7 : i64
+      scf.condition(%condition) %next, %q2 : i64, !qco.qubit
+    } do {
+    ^bb0(%input: i64, %q: !qco.qubit):
+      %q2 = qco.x %q : !qco.qubit -> !qco.qubit
+      %next = arith.sitofp %input : i64 to f32
+      scf.yield %next, %q2 : f32, !qco.qubit
+    }
+    qco.sink %q1 : !qco.qubit
+    return %result : i64
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCOToQCConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::WhileOp loop;
+  module->walk([&](scf::WhileOp candidate) { loop = candidate; });
+  ASSERT_TRUE(loop);
+  ASSERT_EQ(loop.getInits().size(), 1);
+  EXPECT_TRUE(loop.getInits().front().getType().isF32());
+  ASSERT_EQ(loop.getNumResults(), 1);
+  EXPECT_TRUE(loop.getResult(0).getType().isInteger(64));
+  auto condition =
+      cast<scf::ConditionOp>(loop.getBeforeBody()->getTerminator());
+  ASSERT_EQ(condition.getArgs().size(), 1);
+  EXPECT_TRUE(condition.getArgs().front().getType().isInteger(64));
+  auto yield = cast<scf::YieldOp>(loop.getAfterBody()->getTerminator());
+  ASSERT_EQ(yield.getNumOperands(), 1);
+  EXPECT_TRUE(yield.getOperand(0).getType().isF32());
+}
+
 TEST_P(QCOToQCTest, ProgramEquivalence) {
   const auto& [nameStr, programBuilder, referenceBuilder] = GetParam();
   const auto name = " (" + nameStr + ")";


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This extracts an independent conversion fix found while working on the OpenQASM integration in #1910.

The QCO-to-QC conversion now preserves classical `scf.for` and `scf.while` operands, results, and terminator values while continuing to map quantum loop state to stable QC references. This prevents classical loop-carried state from being dropped and supports type-changing `scf.while` signatures.

The change is parser-independent and contains native conversion regressions for mixed classical/quantum `for` loops and type-changing `while` loops.

## Validation

- QCO-to-QC unit tests: 137/137 passed
- `git diff --check`: passed
- Independent exact-revision review: no actionable findings

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
