### PR TITLE
🐛 Ignore classical loads in QC-to-QCO state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ releases may include breaking changes.
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
   [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938], [#1975],
-  [#1976]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**], 
+  [#1976]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
   [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
   [**@simon1hofmann**], [**@J4MMlE**])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ releases may include breaking changes.
   [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717],
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
-  [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938])
+  [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938], [#1976])
   ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**],
   [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
   [**@simon1hofmann**], [**@J4MMlE**])
@@ -692,6 +692,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1976]: https://github.com/munich-quantum-toolkit/core/pull/1976
 [#1967]: https://github.com/munich-quantum-toolkit/core/pull/1967
 [#1965]: https://github.com/munich-quantum-toolkit/core/pull/1965
 [#1961]: https://github.com/munich-quantum-toolkit/core/pull/1961

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -552,7 +552,9 @@ collectQubitValuesInsideSCFOps(Operation* op, LoweringState* state) {
       auto& qubitInfoMap = state->qubitInfoMap[&region];
       auto& regionRegisterMap = state->regionRegisterMap[op];
       // Track qubits from loadOp
-      if (auto loadOp = dyn_cast<memref::LoadOp>(operation)) {
+      if (auto loadOp = dyn_cast<memref::LoadOp>(operation);
+          loadOp &&
+          isa<qc::QubitType>(loadOp.getMemRefType().getElementType())) {
         QubitInfo info{.reg = loadOp.getMemRef(),
                        .index = loadOp.getIndices()[0]};
         qubitInfoMap.try_emplace(loadOp.getResult(), info);

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -207,6 +207,47 @@ module {
   EXPECT_TRUE(result.isOne());
 }
 
+TEST_F(QCToQCORegressionTest, IgnoresClassicalRegisterLoadsInWhileState) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() -> memref<1xi1>
+      attributes {passthrough = ["entry_point"]} {
+    %qc = qc.alloc : !qc.qubit
+    %c = memref.alloc() : memref<1xi1>
+    %c0 = arith.constant 0 : index
+    %true = arith.constant true
+    memref.store %true, %c[%c0] : memref<1xi1>
+    %result = scf.while (%running = %true) : (i1) -> i1 {
+      %condition = memref.load %c[%c0] : memref<1xi1>
+      scf.condition(%condition) %running : i1
+    } do {
+    ^bb0(%running: i1):
+      qc.x %qc : !qc.qubit
+      %false = arith.constant false
+      memref.store %false, %c[%c0] : memref<1xi1>
+      scf.yield %false : i1
+    }
+    qc.dealloc %qc : !qc.qubit
+    return %c : memref<1xi1>
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+  expectNoQCOperations(*module);
+
+  bool retainsClassicalRegister = false;
+  module->walk([&](memref::LoadOp op) {
+    retainsClassicalRegister |=
+        op.getMemRefType().getElementType().isInteger(1);
+  });
+  EXPECT_TRUE(retainsClassicalRegister);
+}
+
 TEST_F(QCToQCORegressionTest, ConvertsTypeChangingWhileWithQuantumState) {
   constexpr llvm::StringLiteral source = R"mlir(
 module {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This extracts an independent conversion fix found while working on the OpenQASM integration in #1910.

Structured-control-flow qubit tracking in the QC-to-QCO conversion now considers a `memref.load` quantum state only when the memref element type is `!qc.qubit`. Classical register loads therefore remain classical instead of entering the linear quantum state and causing a missing-register assertion.

The parser-independent native regression reproduces the assertion on `main` and verifies that a classical register load inside an `scf.while` containing a quantum operation converts successfully.

## Validation

- QC-to-QCO unit tests: 139/139 passed
- `git diff --check`: passed
- Independent exact-revision review: no actionable findings

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
