### PR TITLE
🐛 Preserve QIR classical result order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ releases may include breaking changes.
 - ✨ Add and improve QIR generation support in the MQT Compiler Collection
   ([#1264], [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570],
   [#1572], [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751],
-  [#1755], [#1787], [#1815], [#1823], [#1830], [#1886], [#1933], [#1978], [#1979])
-  ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
+  [#1755], [#1787], [#1815], [#1823], [#1830], [#1886], [#1933], [#1978],
+  [#1979]) ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
   [**@li-mingbao**], [**@DRovara**], [**@MatthiasReumann**])
 - ✨ Add decision diagram-based construction and simulation of static unitary
   QCO functions ([#1915]) ([**@simon1hofmann**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ releases may include breaking changes.
 - ✨ Add and improve QIR generation support in the MQT Compiler Collection
   ([#1264], [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570],
   [#1572], [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751],
-  [#1755], [#1787], [#1815], [#1823], [#1830], [#1886], [#1933])
+  [#1755], [#1787], [#1815], [#1823], [#1830], [#1886], [#1933], [#1979])
   ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
   [**@li-mingbao**], [**@DRovara**], [**@MatthiasReumann**])
 - ✨ Add decision diagram-based construction and simulation of static unitary
@@ -692,6 +692,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1979]: https://github.com/munich-quantum-toolkit/core/pull/1979
 [#1967]: https://github.com/munich-quantum-toolkit/core/pull/1967
 [#1965]: https://github.com/munich-quantum-toolkit/core/pull/1965
 [#1961]: https://github.com/munich-quantum-toolkit/core/pull/1961

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRCommon/QIRCommon.h
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRCommon/QIRCommon.h
@@ -53,11 +53,17 @@ struct LoweringState {
   /// Cache qubit register sizes for reuse
   DenseMap<Value, Value> qregSizes;
 
-  /// Map from `memref::AllocOp` to `ClassicalRegister`
-  DenseMap<Operation*, qir::ClassicalRegister> cregs;
+  /// Classical registers owned by the lowering state.
+  SmallVector<qir::ClassicalRegister> cregs;
 
-  /// Destination of each measurement stored in a classical register.
-  DenseMap<Operation*, std::pair<Operation*, Value>> cregMeasurements;
+  /// Map from `memref::AllocOp` to its index in `cregs`.
+  DenseMap<Operation*, size_t> cregIndices;
+
+  /// Returned classical-register indices in function-result order.
+  SmallVector<size_t> returnedCregs;
+
+  /// Destination register index and bit index of each stored measurement.
+  DenseMap<Operation*, std::pair<size_t, Value>> cregMeasurements;
 
   /// Map from index to `StaticResult`
   DenseMap<int64_t, qir::StaticResult> staticResults;

--- a/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
@@ -57,8 +57,8 @@ static Value resolveRegisterMeasurement(LoweringState& state, Operation* op,
   if (it == state.cregMeasurements.end()) {
     return nullptr;
   }
-  const auto [allocOp, index] = it->second;
-  auto& reg = state.cregs[allocOp];
+  const auto [registerIndex, index] = it->second;
+  auto& reg = state.cregs[registerIndex];
   assert(reg.array && "result array must be allocated");
   auto loc = op->getLoc();
   auto ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
@@ -75,12 +75,12 @@ static Value resolveRegisterMeasurement(LoweringState& state, Operation* op,
 static LogicalResult convertClassicalBitMemRefAllocOp(
     memref::AllocOp op, memref::AllocOp::Adaptor adaptor, LoweringState& state,
     ConversionPatternRewriter& rewriter) {
-  const auto it = state.cregs.find(op.getOperation());
-  if (it == state.cregs.end()) {
+  const auto it = state.cregIndices.find(op.getOperation());
+  if (it == state.cregIndices.end()) {
     rewriter.eraseOp(op);
     return success();
   }
-  auto& reg = it->second;
+  auto& reg = state.cregs[it->second];
 
   auto loc = op.getLoc();
   auto* ctx = op.getContext();

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -64,14 +64,14 @@ static FailureOr<Value> resolveRegisterMeasurement(LoweringState& state,
   if (it == state.cregMeasurements.end()) {
     return Value{};
   }
-  const auto [allocOp, index] = it->second;
+  const auto [registerIndex, index] = it->second;
   const auto indexValue = getConstantIntValue(index);
   if (!indexValue) {
     op->emitError("QIR Base Profile requires constant classical-register "
                   "measurement indices");
     return failure();
   }
-  const auto& results = state.cregs.at(allocOp).results;
+  const auto& results = state.cregs[registerIndex].results;
   if (*indexValue < 0 || static_cast<size_t>(*indexValue) >= results.size()) {
     op->emitError("classical-register measurement index is out of bounds");
     return failure();
@@ -96,12 +96,12 @@ struct ConvertMemRefAllocOp final
   matchAndRewrite(memref::AllocOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
     auto& state = getState();
-    const auto it = state.cregs.find(op.getOperation());
-    if (it == state.cregs.end()) {
+    const auto it = state.cregIndices.find(op.getOperation());
+    if (it == state.cregIndices.end()) {
       rewriter.eraseOp(op);
       return success();
     }
-    auto& reg = it->second;
+    auto& reg = state.cregs[it->second];
     const auto* size = std::get_if<int64_t>(&reg.size);
     if (size == nullptr) {
       op.emitError(

--- a/mlir/lib/Conversion/QCToQIR/QIRCommon/QIRCommon.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRCommon/QIRCommon.cpp
@@ -412,9 +412,12 @@ void addOutputRecording(LLVM::LLVMFuncOp& main, MLIRContext* ctx,
                         LoweringState& state) {
   OpBuilder builder(ctx);
   builder.setInsertionPoint(&main.getBlocks().back().back());
-  emitOutputRecording(builder, main,
-                      llvm::to_vector(llvm::make_second_range(state.cregs)),
-                      state.staticResults);
+  SmallVector<qir::ClassicalRegister> returnedRegisters;
+  returnedRegisters.reserve(state.returnedCregs.size());
+  for (const auto registerIndex : state.returnedCregs) {
+    returnedRegisters.push_back(state.cregs[registerIndex]);
+  }
+  emitOutputRecording(builder, main, returnedRegisters, state.staticResults);
 }
 
 void populateQCToQIRPatterns(RewritePatternSet& patterns,
@@ -473,7 +476,12 @@ LogicalResult stripReturnedMeasurements(Operation* moduleOp,
         return;
       }
 
-      auto& reg = state.cregs.try_emplace(allocOp.getOperation()).first->second;
+      const auto [it, inserted] = state.cregIndices.try_emplace(
+          allocOp.getOperation(), state.cregs.size());
+      if (inserted) {
+        state.cregs.emplace_back();
+      }
+      auto& reg = state.cregs[it->second];
       reg.record = false;
       if (const auto name = allocOp->getAttrOfType<StringAttr>(
               utils::CLASSICAL_REGISTER_NAME_ATTR)) {
@@ -493,7 +501,7 @@ LogicalResult stripReturnedMeasurements(Operation* moduleOp,
       }
       auto allocOp = storeOp.getMemref().getDefiningOp<memref::AllocOp>();
       auto measureOp = storeOp.getValueToStore().getDefiningOp<MeasureOp>();
-      if (!allocOp || !state.cregs.contains(allocOp.getOperation()) ||
+      if (!allocOp || !state.cregIndices.contains(allocOp.getOperation()) ||
           !measureOp) {
         storeOp.emitError(
             "QIR conversion only supports storing direct measurement results "
@@ -501,8 +509,9 @@ LogicalResult stripReturnedMeasurements(Operation* moduleOp,
         hasInvalidMemory = true;
         return;
       }
-      const auto destination = std::pair<Operation*, Value>{
-          allocOp.getOperation(), storeOp.getIndices()[0]};
+      const auto destination =
+          std::pair<size_t, Value>{state.cregIndices.at(allocOp.getOperation()),
+                                   storeOp.getIndices()[0]};
       const auto [it, inserted] = state.cregMeasurements.try_emplace(
           measureOp.getOperation(), destination);
       if (!inserted && it->second != destination) {
@@ -513,16 +522,16 @@ LogicalResult stripReturnedMeasurements(Operation* moduleOp,
       }
     });
 
-    const auto markRegisterForRecording = [&](Operation* allocOp) {
-      auto& reg = state.cregs.at(allocOp);
+    const auto markRegisterForRecording = [&](const size_t registerIndex) {
+      auto& reg = state.cregs[registerIndex];
+      if (reg.record) {
+        return;
+      }
       if (reg.label.empty()) {
-        reg.label =
-            "c" +
-            std::to_string(llvm::count_if(state.cregs, [](const auto& entry) {
-              return entry.second.record;
-            }));
+        reg.label = "c" + std::to_string(state.returnedCregs.size());
       }
       reg.record = true;
+      state.returnedCregs.push_back(registerIndex);
     };
 
     funcOp.walk([&](func::ReturnOp returnOp) {
@@ -539,8 +548,10 @@ LogicalResult stripReturnedMeasurements(Operation* moduleOp,
             state.returnedStaticResults.insert(measureOp.getOperation());
           }
         } else if (auto allocOp = operand.getDefiningOp<memref::AllocOp>();
-                   allocOp && state.cregs.contains(allocOp.getOperation())) {
-          markRegisterForRecording(allocOp.getOperation());
+                   allocOp &&
+                   state.cregIndices.contains(allocOp.getOperation())) {
+          markRegisterForRecording(
+              state.cregIndices.at(allocOp.getOperation()));
         } else {
           keptOperands.push_back(operand);
           keptReturnTypes.push_back(operand.getType());

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
@@ -137,6 +137,40 @@ TEST(QCToQIRBaseNativeTest, RecordsReturnedRegisterMeasurement) {
       module->lookupSymbol<LLVM::GlobalOp>("qir.result_label_named_result"));
 }
 
+TEST(QCToQIRBaseNativeTest, RecordsReturnedRegistersInResultOrder) {
+  MLIRContext context;
+  context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
+                      LLVM::LLVMDialect, memref::MemRefDialect>();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  const auto firstQubit = builder.allocQubit();
+  const auto secondQubit = builder.allocQubit();
+  const auto firstRegister =
+      builder.allocClassicalBitRegister(1, "first_result");
+  const auto secondRegister =
+      builder.allocClassicalBitRegister(1, "second_result");
+  builder.measure(firstQubit, firstRegister, 0);
+  builder.measure(secondQubit, secondRegister, 0);
+  builder.retype({secondRegister.getType(), firstRegister.getType()});
+  auto module = builder.finalize({secondRegister, firstRegister});
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(runQCToQIRBaseConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  SmallVector<StringRef> recordedLabels;
+  module->walk([&](LLVM::CallOp call) {
+    if (call.getCallee() != qir::QIR_ARRAY_RECORD_OUTPUT) {
+      return;
+    }
+    auto address = call.getOperands().back().getDefiningOp<LLVM::AddressOfOp>();
+    ASSERT_TRUE(address);
+    recordedLabels.push_back(address.getGlobalName());
+  });
+  EXPECT_EQ(recordedLabels,
+            SmallVector<StringRef>({"qir.result_label_second_result",
+                                    "qir.result_label_first_result"}));
+}
+
 TEST(QCToQIRBaseNativeTest, RejectsNonMeasurementClassicalStore) {
   MLIRContext context;
   context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This extracts an independent QIR conversion fix found while working on the OpenQASM integration in #1910.

Returned classical registers are now recorded in function-result order instead of relying on `DenseMap` iteration. The lowering state owns the register descriptions and carries stable numeric indices across conversion phases, so final output recording does not retain or access erased MLIR operation pointers.

The native parser-independent regression returns two named registers in the reverse of their allocation order and verifies the resulting QIR output-recording order.

## Validation

- The new ordering regression fails on `main` before the fix
- QIR Base unit tests: 118/118 passed
- QIR Adaptive unit tests: 139/139 passed
- `clang-format --dry-run --Werror`: passed
- `git diff --check`: passed
- Independent exact-revision review: initial lifetime finding fixed; updated head has no actionable findings

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
