### PR TITLE
♻️ Reuse MLIR modifier body helpers

### DIFF
--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -78,9 +78,11 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
           return utils::getValueFromBlockArgument(t, outerTargets);
         });
 
-    auto merged = CtrlOp::create(rewriter, op.getLoc(), controls, targets);
-    rewriter.inlineRegionBefore(innerCtrlOp.getRegion(), merged.getRegion(),
-                                merged.getRegion().end());
+    CtrlOp::create(rewriter, op.getLoc(), controls, targets,
+                   [&](ValueRange mergedTargets) {
+                     utils::inlineBodyReturningYields(*innerCtrlOp.getBody(),
+                                                      mergedTargets, rewriter);
+                   });
     rewriter.eraseOp(op);
     return success();
   }

--- a/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
@@ -70,10 +70,11 @@ struct MoveCtrlOutside final : OpRewritePattern<InvOp> {
 
     rewriter.replaceOpWithNewOp<CtrlOp>(
         op, controls, targets, [&](ValueRange targetArgs) {
-          auto innerInv = InvOp::create(rewriter, op.getLoc(), targetArgs);
-          rewriter.inlineRegionBefore(innerCtrlOp.getRegion(),
-                                      innerInv.getRegion(),
-                                      innerInv.getRegion().end());
+          InvOp::create(rewriter, op.getLoc(), targetArgs,
+                        [&](ValueRange invArgs) {
+                          utils::inlineBodyReturningYields(
+                              *innerCtrlOp.getBody(), invArgs, rewriter);
+                        });
         });
 
     return success();

--- a/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
@@ -244,11 +244,11 @@ struct MoveCtrlOutside final : OpRewritePattern<PowOp> {
 
     rewriter.replaceOpWithNewOp<CtrlOp>(
         op, controls, targets, [&](ValueRange targetArgs) {
-          auto innerPow = PowOp::create(rewriter, op.getLoc(), op.getExponent(),
-                                        targetArgs);
-          rewriter.inlineRegionBefore(innerCtrlOp.getRegion(),
-                                      innerPow.getRegion(),
-                                      innerPow.getRegion().end());
+          PowOp::create(rewriter, op.getLoc(), op.getExponent(), targetArgs,
+                        [&](ValueRange powArgs) {
+                          utils::inlineBodyReturningYields(
+                              *innerCtrlOp.getBody(), powArgs, rewriter);
+                        });
         });
 
     return success();

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -86,9 +86,12 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
       return utils::getValueFromBlockArgument(t, outerTargets);
     });
 
-    auto merged = CtrlOp::create(rewriter, op.getLoc(), controls, targets);
-    rewriter.inlineRegionBefore(innerCtrlOp.getRegion(), merged.getRegion(),
-                                merged.getRegion().end());
+    auto merged =
+        CtrlOp::create(rewriter, op.getLoc(), controls, targets,
+                       [&](ValueRange mergedTargets) -> SmallVector<Value> {
+                         return utils::inlineBodyReturningYields(
+                             *innerCtrlOp.getBody(), mergedTargets, rewriter);
+                       });
 
     // Every qubit output of the original control follows its input qubit to the
     // corresponding output of the merged control.
@@ -119,6 +122,8 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
     if (op.getNumControls() == 0 || isa<IdOp, BarrierOp>(innerOp)) {
       auto* body = op.getBody();
       auto* terminator = body->getTerminator();
+      // Controls are pass-through results outside the body yield, so the
+      // generic inlineModifierBody result mapping does not apply here.
       SmallVector<Value> outputs(op.getControlsIn());
       llvm::append_range(outputs, terminator->getOperands());
       rewriter.inlineBlockBefore(body, op, op.getTargetsIn());

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
@@ -75,15 +75,17 @@ struct MoveCtrlOutside final : OpRewritePattern<InvOp> {
           return utils::getValueFromBlockArgument(t, outerQubits);
         });
 
-    auto newCtrl = CtrlOp::create(
-        rewriter, op.getLoc(), controls, targets,
-        [&](ValueRange targetArgs) -> SmallVector<Value> {
-          auto innerInv = InvOp::create(rewriter, op.getLoc(), targetArgs);
-          rewriter.inlineRegionBefore(innerCtrlOp.getRegion(),
-                                      innerInv.getRegion(),
-                                      innerInv.getRegion().end());
-          return innerInv.getResults();
-        });
+    auto newCtrl =
+        CtrlOp::create(rewriter, op.getLoc(), controls, targets,
+                       [&](ValueRange targetArgs) -> SmallVector<Value> {
+                         auto innerInv = InvOp::create(
+                             rewriter, op.getLoc(), targetArgs,
+                             [&](ValueRange invArgs) -> SmallVector<Value> {
+                               return utils::inlineBodyReturningYields(
+                                   *innerCtrlOp.getBody(), invArgs, rewriter);
+                             });
+                         return innerInv.getResults();
+                       });
 
     // Each qubit output of the inverse modifier follows its input qubit to the
     // corresponding output of the new control modifier.

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
@@ -271,11 +271,12 @@ struct MoveCtrlOutside final : OpRewritePattern<PowOp> {
     auto newCtrl = CtrlOp::create(
         rewriter, op.getLoc(), controls, targets,
         [&](ValueRange targetArgs) -> SmallVector<Value> {
-          auto innerPow = PowOp::create(rewriter, op.getLoc(), targetArgs,
-                                        op.getExponent());
-          rewriter.inlineRegionBefore(innerCtrlOp.getRegion(),
-                                      innerPow.getRegion(),
-                                      innerPow.getRegion().end());
+          auto innerPow =
+              PowOp::create(rewriter, op.getLoc(), targetArgs, op.getExponent(),
+                            [&](ValueRange powArgs) -> SmallVector<Value> {
+                              return utils::inlineBodyReturningYields(
+                                  *innerCtrlOp.getBody(), powArgs, rewriter);
+                            });
           return innerPow.getResults();
         });
 
@@ -331,11 +332,9 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
       return failure();
     }
 
-    // Inline the body before op so all parameter-defining ops (constants,
-    // arithmetic) are in scope and survive op replacement.
-    rewriter.inlineBlockBefore(op.getBody(), op, op.getInputQubits());
-    rewriter.eraseOp(op->getPrevNode()); // erase the now-inlined YieldOp
-    rewriter.setInsertionPoint(op);
+    // Move supporting ops (constants, arithmetic) out of the body so their
+    // Values are accessible from outside and survive PowOp erasure.
+    utils::hoistSupportingOpsBefore(*op.getBody(), innerOp, op, rewriter);
 
     const LogicalResult result =
         TypeSwitch<Operation*, LogicalResult>(innerOp)
@@ -509,21 +508,23 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
             })
             // --- Hermitian gates (integer exponent): even => id, odd => gate
             // --- pow(n) { h } => id (n even) | h (n odd)
-            .Case<HOp>([&](auto gate) {
+            .Case<HOp>([&](auto) {
               if (utils::isEvenExponent(r)) {
                 // pow(even) { h } => identity: thread inputs to results.
                 rewriter.replaceOp(op, op.getQubitsIn());
               } else {
-                rewriter.replaceOp(op, gate->getResults());
+                utils::inlineModifierBody(op, *op.getBody(),
+                                          op.getInputQubits(), rewriter);
               }
               return success();
             })
             // pow(n) { ecr/rccx/swap } => id (n even) | gate (n odd)
-            .Case<ECROp, RCCXOp, SWAPOp>([&](auto gate) {
+            .Case<ECROp, RCCXOp, SWAPOp>([&](auto) {
               if (utils::isEvenExponent(r)) {
                 rewriter.replaceOp(op, op.getQubitsIn());
               } else {
-                rewriter.replaceOp(op, gate->getResults());
+                utils::inlineModifierBody(op, *op.getBody(),
+                                          op.getInputQubits(), rewriter);
               }
               return success();
             })
@@ -554,9 +555,6 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
               llvm_unreachable("unhandled gate type after pre-check");
               return failure(); // unreachable — satisfies compiler
             });
-    if (innerOp->use_empty()) {
-      rewriter.eraseOp(innerOp);
-    }
     return result;
   }
 };

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -195,7 +195,10 @@ INSTANTIATE_TEST_SUITE_P(
                    MQT_NAMED_BUILDER(doubleNestedCtrlTwoQubits),
                    MQT_NAMED_BUILDER(fourControlledRxx)},
         QCTestCase{"NestedCtrlTwo", MQT_NAMED_BUILDER(nestedCtrlTwo),
-                   MQT_NAMED_BUILDER(ctrlTwo)}));
+                   MQT_NAMED_BUILDER(ctrlTwo)},
+        QCTestCase{"ModifierBodyReuseReordered",
+                   MQT_NAMED_BUILDER(modifierBodyReuseReordered),
+                   MQT_NAMED_BUILDER(modifierBodyReuseReorderedRef)}));
 /// @}
 
 /// \name QC/Modifiers/PowOp.cpp

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -32,6 +32,7 @@
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
+#include <mlir/IR/Dominance.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Matchers.h>
 #include <mlir/IR/PatternMatch.h>
@@ -1094,7 +1095,10 @@ INSTANTIATE_TEST_SUITE_P(
                     MQT_NAMED_BUILDER(doubleNestedCtrlTwoQubits),
                     MQT_NAMED_BUILDER(fourControlledRxx)},
         QCOTestCase{"NestedCtrlTwo", MQT_NAMED_BUILDER(nestedCtrlTwo),
-                    MQT_NAMED_BUILDER(ctrlTwo)}));
+                    MQT_NAMED_BUILDER(ctrlTwo)},
+        QCOTestCase{"ModifierBodyReuseReordered",
+                    MQT_NAMED_BUILDER(modifierBodyReuseReordered),
+                    MQT_NAMED_BUILDER(modifierBodyReuseReorderedRef)}));
 /// @}
 
 /// \name QCO/Modifiers/InvOp.cpp
@@ -1192,7 +1196,7 @@ TEST_F(QCOTest, NestedPowAcrossBranchCutDoesNotMerge) {
 }
 
 /// pow(rxx) folds the exponent into the rotation angle: pow(2){rxx(θ)} =>
-/// rxx(2θ). Verify that PowOp is folded away by the cleanup pipeline.
+/// rxx(2θ). Verify cleanup and the hoisted parameter's SSA dominance.
 TEST_F(QCOTest, PowRxxFold) {
   auto program =
       mqt::test::buildMLIRProgram(context.get(), MQT_NAMED_BUILDER(powRxx));
@@ -1201,9 +1205,22 @@ TEST_F(QCOTest, PowRxxFold) {
   EXPECT_TRUE(runQCOCleanupPipeline(program.get()).succeeded());
   EXPECT_TRUE(verify(*program).succeeded());
 
-  int powCount = 0;
+  std::size_t powCount = 0;
+  SmallVector<RXXOp> rxxOps;
   program->walk([&](PowOp) { ++powCount; });
+  program->walk([&](RXXOp op) { rxxOps.push_back(op); });
   EXPECT_EQ(powCount, 0) << "PowOp around rxx should be folded away";
+  ASSERT_EQ(rxxOps.size(), 1);
+
+  auto rxx = rxxOps.front();
+  FloatAttr angle;
+  ASSERT_TRUE(matchPattern(rxx.getTheta(), m_Constant(&angle)));
+  EXPECT_NEAR(angle.getValueAsDouble(), 0.246, 1e-12);
+
+  auto* parameterDef = rxx.getTheta().getDefiningOp();
+  ASSERT_NE(parameterDef, nullptr);
+  const DominanceInfo dominance(program.get());
+  EXPECT_TRUE(dominance.properlyDominates(parameterDef, rxx.getOperation()));
 }
 
 /// pow(-0.5) { h } cannot fold a negative fractional exponent

--- a/mlir/unittests/programs/qc_programs.cpp
+++ b/mlir/unittests/programs/qc_programs.cpp
@@ -2207,6 +2207,48 @@ Value ctrlInvTwo(QCProgramBuilder& b) {
   return measureAndReturn(b, q.qubits);
 }
 
+Value modifierBodyReuseReordered(QCProgramBuilder& b) {
+  auto q = b.allocQubitRegister(10);
+
+  b.ctrl({q[0]}, {q[1], q[2], q[3]}, [&](ValueRange outerTargets) {
+    b.ctrl({outerTargets[2]}, {outerTargets[1], outerTargets[0]},
+           [&](ValueRange innerTargets) {
+             b.rzx(0.123, innerTargets[0], innerTargets[1]);
+           });
+  });
+
+  b.inv({q[4], q[5], q[6]}, [&](ValueRange invArgs) {
+    b.ctrl({invArgs[2]}, {invArgs[1], invArgs[0]},
+           [&](ValueRange targets) { b.rzx(0.234, targets[0], targets[1]); });
+  });
+
+  b.pow(3.0, {q[7], q[8], q[9]}, [&](ValueRange powArgs) {
+    b.ctrl({powArgs[2]}, {powArgs[1], powArgs[0]},
+           [&](ValueRange targets) { b.rzx(0.345, targets[0], targets[1]); });
+  });
+
+  return measureAndReturn(b, q.qubits);
+}
+
+Value modifierBodyReuseReorderedRef(QCProgramBuilder& b) {
+  auto q = b.allocQubitRegister(10);
+
+  b.ctrl({q[0], q[3]}, {q[2], q[1]},
+         [&](ValueRange targets) { b.rzx(0.123, targets[0], targets[1]); });
+
+  b.ctrl({q[6]}, {q[5], q[4]}, [&](ValueRange targets) {
+    b.inv(targets,
+          [&](ValueRange invArgs) { b.rzx(0.234, invArgs[0], invArgs[1]); });
+  });
+
+  b.ctrl({q[9]}, {q[8], q[7]}, [&](ValueRange targets) {
+    b.pow(3.0, targets,
+          [&](ValueRange powArgs) { b.rzx(0.345, powArgs[0], powArgs[1]); });
+  });
+
+  return measureAndReturn(b, q.qubits);
+}
+
 Value emptyInv(QCProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
   b.rxx(0.123, q[0], q[1]);

--- a/mlir/unittests/programs/qc_programs.h
+++ b/mlir/unittests/programs/qc_programs.h
@@ -1084,6 +1084,12 @@ Value nestedCtrlTwo(QCProgramBuilder& b);
 /// applied to two gates.
 Value ctrlInvTwo(QCProgramBuilder& b);
 
+/// Exercises modifier-body reuse with reordered control and target aliases.
+Value modifierBodyReuseReordered(QCProgramBuilder& b);
+
+/// Canonical reference for modifierBodyReuseReordered.
+Value modifierBodyReuseReorderedRef(QCProgramBuilder& b);
+
 // --- InvOp ---------------------------------------------------------------- //
 
 /// Creates a circuit with an empty inverse modifier.

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -3663,6 +3663,93 @@ Value invCtrlTwo(QCOProgramBuilder& b) {
   return measureAndReturn(b, res);
 }
 
+Value modifierBodyReuseReordered(QCOProgramBuilder& b) {
+  auto q = b.allocQubitRegister(10);
+
+  const auto& [outerControlsOut, outerTargetsOut] =
+      b.ctrl({q[0]}, {q[1], q[2], q[3]}, [&](ValueRange outerTargets) {
+        const auto& [innerControlsOut, innerTargetsOut] =
+            b.ctrl({outerTargets[2]}, {outerTargets[1], outerTargets[0]},
+                   [&](ValueRange innerTargets) {
+                     auto [q0, q1] =
+                         b.rzx(0.123, innerTargets[0], innerTargets[1]);
+                     return SmallVector{q0, q1};
+                   });
+        return SmallVector{innerTargetsOut[1], innerTargetsOut[0],
+                           innerControlsOut[0]};
+      });
+  q[0] = outerControlsOut[0];
+  q[1] = outerTargetsOut[0];
+  q[2] = outerTargetsOut[1];
+  q[3] = outerTargetsOut[2];
+
+  auto invOut = b.inv({q[4], q[5], q[6]}, [&](ValueRange invArgs) {
+    const auto& [controlsOut, targetsOut] =
+        b.ctrl({invArgs[2]}, {invArgs[1], invArgs[0]}, [&](ValueRange targets) {
+          auto [q0, q1] = b.rzx(0.234, targets[0], targets[1]);
+          return SmallVector{q0, q1};
+        });
+    return SmallVector{targetsOut[1], targetsOut[0], controlsOut[0]};
+  });
+  q[4] = invOut[0];
+  q[5] = invOut[1];
+  q[6] = invOut[2];
+
+  auto powOut = b.pow(3.0, {q[7], q[8], q[9]}, [&](ValueRange powArgs) {
+    const auto& [controlsOut, targetsOut] =
+        b.ctrl({powArgs[2]}, {powArgs[1], powArgs[0]}, [&](ValueRange targets) {
+          auto [q0, q1] = b.rzx(0.345, targets[0], targets[1]);
+          return SmallVector{q0, q1};
+        });
+    return SmallVector{targetsOut[1], targetsOut[0], controlsOut[0]};
+  });
+  q[7] = powOut[0];
+  q[8] = powOut[1];
+  q[9] = powOut[2];
+
+  return measureAndReturn(b, q.qubits);
+}
+
+Value modifierBodyReuseReorderedRef(QCOProgramBuilder& b) {
+  auto q = b.allocQubitRegister(10);
+
+  const auto& [mergedControlsOut, mergedTargetsOut] =
+      b.ctrl({q[0], q[3]}, {q[2], q[1]}, [&](ValueRange targets) {
+        auto [q0, q1] = b.rzx(0.123, targets[0], targets[1]);
+        return SmallVector{q0, q1};
+      });
+  q[0] = mergedControlsOut[0];
+  q[3] = mergedControlsOut[1];
+  q[2] = mergedTargetsOut[0];
+  q[1] = mergedTargetsOut[1];
+
+  const auto& [invControlsOut, invTargetsOut] =
+      b.ctrl({q[6]}, {q[5], q[4]}, [&](ValueRange targets) {
+        auto inner = b.inv(targets, [&](ValueRange invArgs) {
+          auto [q0, q1] = b.rzx(0.234, invArgs[0], invArgs[1]);
+          return SmallVector{q0, q1};
+        });
+        return llvm::to_vector(inner);
+      });
+  q[6] = invControlsOut[0];
+  q[5] = invTargetsOut[0];
+  q[4] = invTargetsOut[1];
+
+  const auto& [powControlsOut, powTargetsOut] =
+      b.ctrl({q[9]}, {q[8], q[7]}, [&](ValueRange targets) {
+        auto inner = b.pow(3.0, targets, [&](ValueRange powArgs) {
+          auto [q0, q1] = b.rzx(0.345, powArgs[0], powArgs[1]);
+          return SmallVector{q0, q1};
+        });
+        return llvm::to_vector(inner);
+      });
+  q[9] = powControlsOut[0];
+  q[8] = powTargetsOut[0];
+  q[7] = powTargetsOut[1];
+
+  return measureAndReturn(b, q.qubits);
+}
+
 Value pow1Inline(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(1);
   const auto powOut = b.pow(1.0, q[0], [&](Value qubits) {

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -1289,6 +1289,12 @@ Value powTwo(QCOProgramBuilder& b);
 /// applied to two gates.
 Value invCtrlTwo(QCOProgramBuilder& b);
 
+/// Exercises modifier-body reuse with reordered control and target aliases.
+Value modifierBodyReuseReordered(QCOProgramBuilder& b);
+
+/// Canonical reference for modifierBodyReuseReordered.
+Value modifierBodyReuseReorderedRef(QCOProgramBuilder& b);
+
 // --- PowOp ---------------------------------------------------------------- //
 
 /// Creates a circuit with pow(1.0) modifier (should inline to just the gate).


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Reuse the existing QC and QCO modifier body helpers in same-dialect canonicalizations while preserving explicit block-argument and QCO result remapping.

This also aligns QCO power folding with the QC operation-lifetime model, keeps supporting scalar operations in dominating scope, and documents why QCO `ReduceCtrl` retains its specialized replacement path.

Focused reordered-alias tests make incorrect block-argument or result mapping observable, and the QCO `PowRxxFold` test now verifies cleanup, scaling, and SSA dominance.

No public APIs, operation definitions, conversion contracts, helper signatures, or canonicalization behavior change.

Fixes #1929

## Validation

- `mqt-core-mlir-unittest-qc-ir`: 311/311 passed
- `mqt-core-mlir-unittest-qco-ir`: 453/453 passed
- `mqt-core-mlir-unittest-qc-to-qco`: 139/139 passed
- `mqt-core-mlir-unittest-qco-to-qc`: 137/137 passed
- `mqt-mlir-unittests`: 2765/2765 passed
- `prek run --all-files`
- `git diff --check`
- Fresh exact-revision review of `ddb35476f8dc17121cdab962215f5ace22f7102f`: no actionable findings

## AI assistance

AI assistance was used for implementation, tests, review, and validation. A human maintainer remains responsible for reviewing and accepting the contribution.
