### PR TITLE
🎨 Support alias-safe repeated qubit loads

### DIFF
--- a/.agent/plans/alias-safe-repeated-qubit-loads.md
+++ b/.agent/plans/alias-safe-repeated-qubit-loads.md
@@ -83,8 +83,36 @@ width-dependent `scf.index_switch`.
 - [x] (2026-08-02) Integrate current `origin/main`
       `ae7aff283c0c06da5e01e53349a3eaec8b322c1e` with a signed merge, then rerun
       all repository hooks and the full Python 3.13 test session.
-- [ ] Obtain a fresh independent read-only review of the final exact source
-      revision.
+- [x] (2026-08-02) Integrate the subsequently advanced `origin/main`
+      `1f9fd7ebfa085bd57e7224caac8ab3a73df36981` with signed merge `d8cb2b315`,
+      including the compiler-wide global-phase normalization.
+- [x] (2026-08-02) Address independent-review finding MF-07 by rejecting
+      implicit standalone and register-backed qubit captures in every QC
+      modifier verifier and in the verifier-independent QC-to-QCO preflight. Add
+      direct/nested coverage for all three modifiers and positive classical
+      capture coverage.
+- [x] (2026-08-02) Address the final quality findings by adding the Unreleased
+      changelog entry, adopting the live `moduleOp` naming policy, and
+      documenting the current review and validation state.
+- [x] (2026-08-02) Complete the exact-base release build and all 4,467 CTest
+      cases, every repository hook, LLVM 22.1.8 changed-line clang-tidy, the
+      affected MLIR suites, Python 3.10 (417 passed, three configured skips),
+      and compact QC/QCO/QIR `mqt-cc` smokes. The remaining Python-version
+      repetitions were intentionally omitted at the user's request after the
+      broad native validation was green.
+- [x] (2026-08-02) Address final independent-review robustness findings by
+      validating quantum SSA sources before mutation. Ranked and unranked qubit
+      memrefs, non-one-dimensional or derived register storage, unsupported
+      quantum block arguments/results, and quantum captures through unsupported
+      region-bearing operations now receive diagnostics instead of reaching an
+      assertion or invalid dominance state.
+- [x] (2026-08-02) Pass all 165 QC-to-QCO tests, including the six
+      verifier-disabled `PreflightRejects*` regressions, and rerun changed-line
+      clang-tidy and formatting for the final remediation.
+- [x] (2026-08-02) Obtain a fresh independent read-only review of exact source
+      revision `252010af9d58bea0371aede7a86880b9d74eba49`; no actionable
+      correctness, conversion-legality, C++20/LLVM 22 idiom, performance, or
+      test-coverage findings remain.
 
 ## Surprises & Discoveries
 
@@ -147,6 +175,29 @@ width-dependent `scf.index_switch`.
   eagerly extracts its element and returns the residual tensor plus a standalone
   qubit. The corresponding QC APIs now document the same storage-only versus
   eager-reference distinction.
+- Observation: QC modifier verification previously allowed a qubit from an
+  enclosing region to be used without appearing among the modifier operands.
+  QC-to-QCO maps only the aliased modifier block arguments, so such a capture
+  reached an assertion when pass verification was disabled. MLIR
+  `getUsedValuesDefinedAbove` provides the exact capture query needed by both
+  the verifier and conversion preflight while leaving classical captures valid.
+- Observation: Collecting load provenance must not assume that the source memref
+  is rank one. Rank-zero `memref<!qc.qubit>` is valid MLIR, and calling
+  `front()` on its empty index range asserted. The preflight now validates
+  storage shape and value origin before recording provenance.
+- Observation: `BaseMemRefType`, rather than `MemRefType`, is required when
+  classifying unsupported quantum storage. Otherwise unranked
+  `memref<*x!qc.qubit>` block arguments and operations can remain dynamically
+  legal and escape conversion unchanged.
+- Observation: Only `scf.for`, `scf.while`, `scf.if`, and `scf.index_switch`
+  participate in QC-to-QCO's explicit quantum-state threading. Capturing quantum
+  values through another region-bearing operation, such as `scf.execute_region`,
+  must be diagnosed before rewriting; purely classical uses of those operations
+  remain legal.
+- Observation: QIR Base intentionally requires single-block straight-line QC
+  input and does not lower SCF. Dynamic loop programs therefore target the
+  Adaptive profile; the Base-profile dynamic-loop failure is not caused by this
+  change, and the QC-to-QIR implementations remain untouched.
 
 ## Decision Log
 
@@ -195,6 +246,24 @@ width-dependent `scf.index_switch`.
   public documentation and use storage-only APIs whenever complete tensor state
   is required. Rationale: Collapsing the APIs would either hide linear
   extraction or break source compatibility. Date/Author: 2026-08-02, Codex.
+- Decision: Reject implicit qubit captures in QC modifiers at both operation
+  verification and conversion preflight. Rationale: Modifier bodies may capture
+  classical parameters, but every quantum value must enter through an aliased
+  modifier block argument so the QCO linear mapping is complete. Date/Author:
+  2026-08-02, Codex.
+- Decision: Centralize the supported QC quantum-value-source contract in a
+  read-only preflight using MLIR `BaseMemRefType` and
+  `getUsedValuesDefinedAbove`. Rationale: The lowering state can map only
+  `qc.alloc`, `qc.static`, direct rank-one register loads, QC modifier qubit
+  arguments, and captures through the four explicitly converted SCF operations;
+  diagnosing every other source before dialect conversion prevents assertion and
+  dominance failures without adding alias analysis. Date/Author: 2026-08-02,
+  Codex.
+- Decision: After the complete release build, CTest matrix, hooks, and one
+  Python session passed, limit the final iterations to the affected conversion
+  binary, changed-line clang-tidy, and compiler smokes. Rationale: The user
+  explicitly requested shorter iterations once the broad validation was working.
+  Date/Author: 2026-08-02, Codex.
 
 ## Outcomes & Retrospective
 
@@ -215,27 +284,38 @@ provably invalid simultaneous register operands, shallow structured test
 oracles, a custom translation-test IR rewriter, ambiguous eager builder usage,
 and quadratic barrier bookkeeping.
 
-The final remediation uses MLIR `RegionUtils`, removes the dead state and all
-new void casts, rejects statically proven simultaneous aliases before mutation,
-compares translation fixtures after the production QC-to-QCO pass, and verifies
-that every register access is an operation-local extract/use/insert triple.
-Structured tests now require complete tensor operands, region arguments, and
+The completed remediation uses MLIR `RegionUtils`, removes the dead state and
+all new void casts, rejects statically proven simultaneous aliases before
+mutation, compares translation fixtures after the production QC-to-QCO pass, and
+verifies that every register access is an operation-local extract/use/insert
+triple. Structured tests require complete tensor operands, region arguments, and
 results. OpenQASM emission counts and emits only pairs that may alias; a
 10,000-element static barrier emits no runtime alias checks and lowers in linear
 time.
 
-The final release build completed all 434 steps. All 4,409 configured CTest
-cases passed, with the two existing QDMI job-ID skips. The full Python 3.13
-session passed 416 tests with three expected Qiskit compatibility skips. LLVM
-22.1.8 clang-tidy reported no diagnostics in the changed translation units,
-every repository hook passed, and `mqt-cc` emitted QC MLIR, QCO, and base QIR
-for repeated dynamic accesses into a 99,999-qubit register.
+The final scrutiny rounds also closed the entire preflight contract. Modifier
+verifiers and conversion preflight reject implicit quantum captures while
+allowing classical captures. A centralized source validator uses
+`BaseMemRefType` and MLIR region-capture discovery to accept only the quantum
+SSA sources and region operations the lowering maps. Rank-zero, unranked,
+derived, block-argument, and unsupported-region inputs now fail with diagnostics
+before any delayed conversion state is created.
+
+After integrating the current base, the release build completed and all 4,467
+configured CTest cases passed, with the two existing QDMI job-ID skips. Every
+repository hook passed. Python 3.10 passed 417 tests with three expected Qiskit
+compatibility skips; the user requested that the remaining interpreter
+repetitions be skipped. LLVM 22.1.8 changed-line clang-tidy reported no
+diagnostics, the final QC-to-QCO suite passed all 165 tests, and compact
+`mqt-cc` smokes emitted direct-load QC, operation-local QCO, Adaptive QIR for
+dynamic SCF, and Base QIR for straight-line input.
 
 No dialect operation, type, pass, command-line option, or external dependency
 was added. Direct QC-to-QIR conversion remains unchanged. The current base is
-`ae7aff283c0c06da5e01e53349a3eaec8b322c1e`; its maintenance-only changes do not
-overlap the MLIR implementation. A final independent exact-revision review is
-pending.
+`1f9fd7ebfa085bd57e7224caac8ab3a73df36981`. A final independent review of exact
+source revision `252010af9d58bea0371aede7a86880b9d74eba49` reported no remaining
+findings. The remote PR still points to the older `004511d` revision, so its
+existing green checks do not validate these local commits.
 
 ## Context and Orientation
 
@@ -410,6 +490,9 @@ The final validated base also includes:
     ae7aff283c0c06da5e01e53349a3eaec8b322c1e
     🔧 Maintenance round (#1989)
 
+    1f9fd7ebfa085bd57e7224caac8ab3a73df36981
+    ✨ Normalize compiler-wide global phases (#1986)
+
 Issue #1893 is an enhancement/MLIR issue and is not labeled `good first issue`.
 No external GitHub mutation is authorized by this plan.
 
@@ -452,3 +535,9 @@ exact-revision review reported no actionable findings.
 Revision note (2026-08-02, Codex): Reopened and updated the plan for the two
 subsequent exhaustive remediation rounds, current-base integration, and final
 validation. A fresh exact-revision review remains pending.
+
+Revision note (2026-08-02, Codex): Closed the plan after integrating `1f9fd7eb`,
+fixing implicit modifier captures and the complete quantum-value preflight
+contract, recording the shortened final validation requested by the user, and
+receiving a clean independent review of exact source revision
+`252010af9d58bea0371aede7a86880b9d74eba49`.

--- a/.agent/plans/alias-safe-repeated-qubit-loads.md
+++ b/.agent/plans/alias-safe-repeated-qubit-loads.md
@@ -113,6 +113,26 @@ width-dependent `scf.index_switch`.
       revision `252010af9d58bea0371aede7a86880b9d74eba49`; no actionable
       correctness, conversion-legality, C++20/LLVM 22 idiom, performance, or
       test-coverage findings remain.
+- [x] (2026-08-05) Rebase the 12 signed feature and remediation commits linearly
+      from boundary `1f9fd7ebfa085bd57e7224caac8ab3a73df36981` onto refreshed
+      `origin/main` `ecd32f734212b6f622927626a215f2ea31335759`; discard the
+      three obsolete merge-main commits and preserve the concurrent
+      compiler-target, QDMI, OpenQASM, Jeff, mapping, and Python changes.
+- [x] (2026-08-05) Resolve the rebase semantically by retaining upstream
+      `compileForTarget`, moving the existing QCO cleanup pipeline to the start
+      of target compilation while retaining post-mapping cleanup, preserving
+      both sets of `Utils.h` dependencies, and merging every changelog entry.
+- [x] (2026-08-05) Validate the rebased series with `git range-diff`, signed
+      commit verification, 1,390 focused MLIR tests, four target compiler
+      checks, 29 Python MLIR tests, direct-load QC/QCO/QIR `mqt-cc` smokes,
+      changed-file hooks, LLVM 22.1.8 changed-line clang-tidy, and
+      `git diff --check`.
+- [x] (2026-08-05) Address independent-review finding Q-01 by replacing the
+      skipped nested `scf.for`/`scf.while` reference comparison with an
+      independently built complete-QTensor reference. Extend the existing
+      QTensor iterator and IR-equivalence grouping to model `scf.condition` and
+      both `scf.while` regions; all 165 QC-to-QCO and three QTensor iterator
+      tests pass.
 
 ## Surprises & Discoveries
 
@@ -198,6 +218,13 @@ width-dependent `scf.index_switch`.
   input and does not lower SCF. Dynamic loop programs therefore target the
   Adaptive profile; the Base-profile dynamic-loop failure is not caused by this
   change, and the QC-to-QIR implementations remain untouched.
+- Observation: The nested `scf.for`/`scf.while` conversion test originally
+  skipped reference equivalence because the QTensor iterator did not recognize
+  `scf.condition` as a linear-chain terminator and IR equivalence did not assign
+  the loop's before- and after-region tensor values to the allocation's
+  equivalence group. Modeling those standard SCF edges removes the test
+  exception and lets the existing permutation-aware oracle compare the complete
+  structured state.
 
 ## Decision Log
 
@@ -264,6 +291,17 @@ width-dependent `scf.index_switch`.
   binary, changed-line clang-tidy, and compiler smokes. Rationale: The user
   explicitly requested shorter iterations once the broad validation was working.
   Date/Author: 2026-08-02, Codex.
+- Decision: Keep both pre- and post-mapping QCO cleanup in target compilation.
+  Rationale: The existing cleanup canonicalizes operation-local QTensor access
+  into the mapper's supported form without adding a bespoke transformation,
+  while the later cleanup preserves established post-mapping normalization.
+  Date/Author: 2026-08-05, Codex.
+- Decision: Close Q-01 through the existing permutation-aware equivalence
+  infrastructure rather than adding a one-off comparison path. Rationale:
+  `scf.condition` and the two `scf.while` regions are standard parts of the
+  QTensor def-use graph, and supporting them centrally strengthens every
+  equivalence user while keeping the production conversion unchanged.
+  Date/Author: 2026-08-05, Codex.
 
 ## Outcomes & Retrospective
 
@@ -312,10 +350,10 @@ dynamic SCF, and Base QIR for straight-line input.
 
 No dialect operation, type, pass, command-line option, or external dependency
 was added. Direct QC-to-QIR conversion remains unchanged. The current base is
-`1f9fd7ebfa085bd57e7224caac8ab3a73df36981`. A final independent review of exact
-source revision `252010af9d58bea0371aede7a86880b9d74eba49` reported no remaining
-findings. The remote PR still points to the older `004511d` revision, so its
-existing green checks do not validate these local commits.
+`ecd32f734212b6f622927626a215f2ea31335759`. The rebased series retained 12
+signed feature/remediation commits; Q-01 adds one separately reviewable test
+oracle remediation commit. The remote PR still points to the older `004511d`
+revision, so its existing green checks do not validate these local commits.
 
 ## Context and Orientation
 
@@ -493,8 +531,12 @@ The final validated base also includes:
     1f9fd7ebfa085bd57e7224caac8ab3a73df36981
     ✨ Normalize compiler-wide global phases (#1986)
 
+    ecd32f734212b6f622927626a215f2ea31335759
+    Refreshed main used for the linear PR #1987 rebase
+
 Issue #1893 is an enhancement/MLIR issue and is not labeled `good first issue`.
-No external GitHub mutation is authorized by this plan.
+The user authorized updating PR #1987 with an explicit force-with-lease after
+final exact-head validation.
 
 ## Interfaces and Dependencies
 
@@ -541,3 +583,8 @@ fixing implicit modifier captures and the complete quantum-value preflight
 contract, recording the shortened final validation requested by the user, and
 receiving a clean independent review of exact source revision
 `252010af9d58bea0371aede7a86880b9d74eba49`.
+
+Revision note (2026-08-05, Codex): Reopened the plan for the signed linear
+rebase onto `ecd32f734`, recorded the semantic conflict resolutions and focused
+validation, and closed independent-review finding Q-01 with a complete-QTensor
+`scf.while` reference oracle.

--- a/.agent/plans/alias-safe-repeated-qubit-loads.md
+++ b/.agent/plans/alias-safe-repeated-qubit-loads.md
@@ -36,12 +36,33 @@ width-dependent `scf.index_switch`.
 - [x] (2026-08-01 12:40Z) Add focused Stage 1 regression tests and verify the
       raw conversion without relying on cleanup. The QC IR (311 tests), QTensor
       IR (29 tests), and QC-to-QCO (141 tests) suites pass.
-- [ ] Commit Stage 1 as one signed, AI-attributed commit.
-- [ ] Implement Stage 2 direct OpenQASM register loads.
-- [ ] Add focused Stage 2 translation and end-to-end tests.
-- [ ] Commit Stage 2 as one signed, AI-attributed commit.
-- [ ] Integrate the refreshed `origin/main` tip and rerun affected validation.
-- [ ] Run repository lint and an independent exact-revision review.
+- [x] (2026-08-01 12:48Z) Commit Stage 1 as the signed, AI-attributed
+      `🐛 Make repeated qubit loads alias-safe` commit.
+- [x] (2026-08-01 14:05Z) Implement Stage 2 direct OpenQASM register loads.
+- [x] (2026-08-01 14:10Z) Add focused Stage 2 translation and end-to-end tests.
+      The OpenQASM target (71 tests), QC IR (312 tests), and selected OpenQASM
+      compiler pipeline (14 tests) suites pass. `mqt-cc` also emits verified QC,
+      operation-local QCO extract/use/insert sequences, and Adaptive QIR for a
+      combined dynamic gate/measurement/reset/barrier program.
+- [x] (2026-08-01 14:15Z) Commit Stage 2 as the signed, AI-attributed
+      `✨ Emit direct OpenQASM qubit register loads` commit.
+- [x] (2026-08-01 14:20Z) Rebase the two commits onto refreshed `origin/main`,
+      initially at `a5757fe95af7d5f7ba85471c27d8d294afc0b894`.
+- [x] (2026-08-01 15:10Z) Run the release build, all 4,401 CTest tests, focused
+      MLIR suites, compiler and `mqt-cc` smoke tests, and repository lint.
+- [x] (2026-08-01) Address independent-review finding MF-01 by applying the same
+      runtime distinctness checks to dynamic barrier operands, rejecting exact
+      duplicate barrier references during semantic analysis, and adding focused
+      frontend/emitter regressions.
+- [x] (2026-08-01) Rebuild all affected release targets and rerun the complete
+      post-review CTest matrix: all 4,402 tests pass, with the same two
+      configured QDMI skips.
+- [x] (2026-08-01) Rebase both signed commits again after `origin/main` advanced
+      to `618c37fa4d5d15be282117d2c12f26a3b6e3dd75`, then complete a clean
+      434-step release rebuild and pass all 4,404 exact-base CTest cases with
+      the same two configured QDMI skips.
+- [x] (2026-08-01) Complete a fresh independent review of exact source revision
+      `7a84fdf22de840efa423164cb967d5da10ecebf7`; no actionable findings remain.
 
 ## Surprises & Discoveries
 
@@ -63,6 +84,28 @@ width-dependent `scf.index_switch`.
   Keeping such a range in a local variable produced a dangling view during the
   first conversion prototype. Single-qubit helper calls now use owned
   `SmallVector<Value, 1>` storage.
+- Observation: Once quantum dispatch is removed, the existing emission budget
+  correctly accepts registers that were previously rejected solely because their
+  widths were multiplied into projected operation counts. Large and small
+  registers now produce identical operation counts for the same dynamic source
+  access.
+- Observation: The QCO mapping pass intentionally expects a canonical
+  all-extracts-before-all-inserts tensor shape. The public place-and-route API
+  now composes the existing QCO cleanup pipeline before mapping, which restores
+  that supported shape for statically addressable programs without weakening the
+  operation-local conversion invariant.
+- Observation: Several direct-QCO test fixtures encoded the old partially
+  extracted structured state. Rewriting those fixtures to allocate complete
+  QTensors directly exposed and verified the new region-boundary invariant while
+  preserving direct QC-to-QIR behavior.
+- Observation: The aggregate lint cache contained incomplete hook environments
+  from an interrupted provisioning run. Moving only the generated cache aside
+  and allowing `prek` to recreate it produced a clean all-files lint run.
+- Observation: Gates already rejected exact duplicate qubits during semantic
+  analysis and asserted potentially aliasing dynamic operands at runtime, but
+  barriers originally did neither. Reusing the runtime assertion path for
+  barriers and using an ordered set for exact semantic duplicates preserves the
+  linear QCO contract without quadratic checks over expanded whole registers.
 
 ## Decision Log
 
@@ -91,11 +134,50 @@ width-dependent `scf.index_switch`.
   references encode the representation Stage 1 intentionally removes and are no
   longer valid structural references for those cases. Date/Author: 2026-08-01,
   Codex.
+- Decision: Treat barriers as simultaneous multi-qubit operations for alias
+  validation. Rationale: A QCO barrier consumes its operands linearly just like
+  a multi-qubit gate; exact duplicates should fail in semantic analysis, while
+  potentially equal runtime indices need `cf.assert`. Date/Author: 2026-08-01,
+  Codex.
 
 ## Outcomes & Retrospective
 
-Implementation is in progress. This section will record final behavior, commit
-identifiers, validation results, remaining limitations, and lessons learned.
+The implementation now has the intended two-commit shape. Stage 1 makes
+`memref.load` a stable QC register-access marker, lowers every quantum use to an
+operation-local QTensor extract/use/reverse-insert sequence, carries complete
+QTensor state through structured control flow, rejects unsupported escaping
+references before mutation, and restricts QTensor rewrites to local, alias-safe
+cases. Stage 2 adds storage-only register allocation and makes the typed
+OpenQASM emitter produce checked point-of-use loads without quantum
+`scf.index_switch` expansion.
+
+The release build completed successfully. All 4,401 CTest tests passed; the two
+QDMI job-ID tests were reported as skipped by their existing test configuration.
+Focused QC, QCO, QTensor, QC-to-QCO, QCO-to-QC, Jeff round-trip, OpenQASM
+translation, and compiler suites pass. `mqt-cc` successfully emitted QC,
+operation-local QCO, and Adaptive QIR for dynamic gate, modifier, measurement,
+reset, and barrier access. The all-files nox lint session passed every
+configured hook.
+
+Independent review found one barrier-specific alias gap in Stage 2. The
+remediation centralizes dynamic distinctness assertions across gates and
+barriers, accounts for those assertions in the emission budget, and rejects
+exact duplicate scalar, static-register, and hardware barrier operands during
+semantic analysis. The focused OpenQASM target suite has 145 passing tests, and
+a barrier-only `mqt-cc --emit=qco` smoke test verifies the assertion followed by
+extract/barrier/reverse-insert. After rebuilding all affected dependents, the
+post-review full CTest matrix passes all 4,402 tests with the same two
+configured QDMI skips.
+
+During finalization, `origin/main` advanced once more with modifier-body helper
+reuse. Both commits rebased cleanly onto
+`618c37fa4d5d15be282117d2c12f26a3b6e3dd75`; the overlapping QC/QCO modifier
+fixtures rebuilt without conflict, and all 4,404 tests on that base pass.
+
+No dialect operation, type, pass, command-line option, or external dependency
+was added. Direct QC-to-QIR conversion remains unchanged. A fresh independent
+exact-revision review found no remaining correctness, MLIR-legality, lifetime,
+alias-safety, SCF, QTensor-fold, direct-QIR, or emission-budget defect.
 
 ## Context and Orientation
 
@@ -252,10 +334,16 @@ The selected implementation base is:
 
     e772dba5ce1c51cc7b8931b8a5031a826040f3d5
 
-At worktree allocation time the live base was one unrelated commit newer:
+At final validation the live base included three subsequent commits:
 
     a4293f1473f4a716aec81707d3cbe01cd1a1b83a
     ✨ Expose DD serialization in Python (#1983)
+
+    a5757fe95af7d5f7ba85471c27d8d294afc0b894
+    🚀 Improve ZX MCX decomposition complexity (#1984)
+
+    618c37fa4d5d15be282117d2c12f26a3b6e3dd75
+    ♻️ Reuse MLIR modifier body helpers (#1985)
 
 Issue #1893 is an enhancement/MLIR issue and is not labeled `good first issue`.
 No external GitHub mutation is authorized by this plan.
@@ -278,3 +366,20 @@ pass, or command-line option.
 
 Revision note (2026-08-01, Codex): Created the living plan from the approved
 two-stage design and recorded the refreshed-base boundary before implementation.
+
+Revision note (2026-08-01, Codex): Recorded the completed two-stage
+implementation, live-base integration, full validation, fixture migrations, and
+lint-cache recovery before independent review.
+
+Revision note (2026-08-01, Codex): Refreshed the final base to include the
+subsequent ZX functionality commit and recorded the exact-head 4,401-test
+validation.
+
+Revision note (2026-08-01, Codex): Recorded the independent-review barrier
+finding, its semantic and runtime remediation, and focused validation.
+
+Revision note (2026-08-01, Codex): Integrated the final modifier-helper base
+commit and recorded the exact-base release rebuild and 4,404-test result.
+
+Revision note (2026-08-01, Codex): Closed the plan after a fresh independent
+exact-revision review reported no actionable findings.

--- a/.agent/plans/alias-safe-repeated-qubit-loads.md
+++ b/.agent/plans/alias-safe-repeated-qubit-loads.md
@@ -143,6 +143,9 @@ width-dependent `scf.index_switch`.
       `077b73f802c408b036453fce9d597e52db70e8c7`. Preserve the newly merged
       PennyLane/QDMI implementation and place #1987 above #2005 in the
       merge-time-ordered changelog.
+- [x] (2026-08-05) Address final maintainer feedback by folding #1987 into the
+      staged OpenQASM changelog entry and removing overly specific agent
+      guidance.
 
 ## Surprises & Discoveries
 
@@ -608,3 +611,6 @@ validation, and closed independent-review finding Q-01 with a complete-QTensor
 Revision note (2026-08-05, Codex): Rebased again onto `077b73f80` after main
 advanced during replacement CI, preserved the PennyLane/QDMI additions, and
 recorded the QCO-to-QC fixture compatibility correction.
+
+Revision note (2026-08-05, Codex): Recorded the final changelog and agent-guide
+review corrections.

--- a/.agent/plans/alias-safe-repeated-qubit-loads.md
+++ b/.agent/plans/alias-safe-repeated-qubit-loads.md
@@ -152,6 +152,13 @@ width-dependent `scf.index_switch`.
       switch and multi-label emission-budget tests alongside the branch's
       width-independent register-access expectations. Validate 1,153 focused
       MLIR tests and 44 Python MLIR tests.
+- [x] (2026-08-05) Diagnose the replacement CI failures on every C++ platform as
+      one shared QCO cleanup convergence issue. Configure the production cleanup
+      canonicalizer to reach its fixed point, make the mapping regression
+      exercise that pipeline directly, and require an allocation to have no use
+      besides its deallocation before removing the pair. The complete QTensor IR
+      (29 tests), mapping (78 tests), and compiler (229 tests) suites pass
+      locally.
 
 ## Surprises & Discoveries
 
@@ -183,6 +190,12 @@ width-dependent `scf.index_switch`.
   now composes the existing QCO cleanup pipeline before mapping, which restores
   that supported shape for statically addressable programs without weakening the
   operation-local conversion invariant.
+- Observation: MLIR 22's canonicalizer defaults to ten outer greedy iterations.
+  Commuting an insertion through an arbitrarily long unrolled register-access
+  chain may require more iterations, leaving 16- and 100-qubit mapping inputs
+  only partially normalized. Requesting convergence also exposed that the
+  existing allocation/deallocation fold did not check for other allocation uses
+  before erasing the allocation.
 - Observation: Several direct-QCO test fixtures encoded the old partially
   extracted structured state. Rewriting those fixtures to allocate complete
   QTensors directly exposed and verified the new region-boundary invariant while
@@ -319,6 +332,13 @@ width-dependent `scf.index_switch`.
   into the mapper's supported form without adding a bespoke transformation,
   while the later cleanup preserves established post-mapping normalization.
   Date/Author: 2026-08-05, Codex.
+- Decision: Let the QCO cleanup canonicalizer run to convergence and preserve
+  the standard MLIR greedy driver rather than adding a tensor-size-dependent
+  pass loop or a larger arbitrary cap. Rationale: complete QTensor normalization
+  is a mapping precondition and OpenQASM registers have no fixed width limit;
+  QTensor rewrite patterns are local and monotonic. Guard the pre-existing
+  allocation/deallocation rewrite with `hasOneUse()` so the stronger cleanup
+  cannot erase a still-used allocation. Date/Author: 2026-08-05, Codex.
 - Decision: Close Q-01 through the existing permutation-aware equivalence
   infrastructure rather than adding a one-off comparison path. Rationale:
   `scf.condition` and the two `scf.while` regions are standard parts of the
@@ -625,3 +645,7 @@ Revision note (2026-08-05, Codex): Rebased the final 16-commit series onto
 `2b977fbf2`, preserving the newly merged OpenQASM emission coverage while
 retaining direct dynamic qubit access, and recorded focused post-rebase
 validation.
+
+Revision note (2026-08-05, Codex): Recorded the cross-platform CI convergence
+failure, the MLIR greedy-driver configuration and allocation/deallocation
+linearity guard that correct it, and the production-pipeline mapping regression.

--- a/.agent/plans/alias-safe-repeated-qubit-loads.md
+++ b/.agent/plans/alias-safe-repeated-qubit-loads.md
@@ -133,6 +133,16 @@ width-dependent `scf.index_switch`.
       QTensor iterator and IR-equivalence grouping to model `scf.condition` and
       both `scf.while` regions; all 165 QC-to-QCO and three QTensor iterator
       tests pass.
+- [x] (2026-08-05) Repair the replacement CI debug-build failure by preserving
+      the established partially extracted `nestedForLoopWhileOp` fixture for
+      QCO-to-QC tests and adding the complete-QTensor fixture separately. The
+      focused nested-loop checks and the complete 137-test QCO-to-QC and
+      165-test QC-to-QCO suites pass.
+- [x] (2026-08-05) Rebase the 14 signed commits again after `origin/main`
+      advanced during replacement CI to
+      `077b73f802c408b036453fce9d597e52db70e8c7`. Preserve the newly merged
+      PennyLane/QDMI implementation and place #1987 above #2005 in the
+      merge-time-ordered changelog.
 
 ## Surprises & Discoveries
 
@@ -225,6 +235,10 @@ width-dependent `scf.index_switch`.
   equivalence group. Modeling those standard SCF edges removes the test
   exception and lets the existing permutation-aware oracle compare the complete
   structured state.
+- Observation: QCO-to-QC intentionally exercises the older partially extracted
+  QTensor fixture, whereas Q-01 needs a complete-QTensor QC-to-QCO reference.
+  These are distinct conversion inputs rather than interchangeable names, so
+  both test builders must remain available.
 
 ## Decision Log
 
@@ -350,10 +364,9 @@ dynamic SCF, and Base QIR for straight-line input.
 
 No dialect operation, type, pass, command-line option, or external dependency
 was added. Direct QC-to-QIR conversion remains unchanged. The current base is
-`ecd32f734212b6f622927626a215f2ea31335759`. The rebased series retained 12
+`077b73f802c408b036453fce9d597e52db70e8c7`. The rebased series retained 12
 signed feature/remediation commits; Q-01 adds one separately reviewable test
-oracle remediation commit. The remote PR still points to the older `004511d`
-revision, so its existing green checks do not validate these local commits.
+oracle remediation commit and its CI correction adds one signed follow-up.
 
 ## Context and Orientation
 
@@ -534,6 +547,9 @@ The final validated base also includes:
     ecd32f734212b6f622927626a215f2ea31335759
     Refreshed main used for the linear PR #1987 rebase
 
+    077b73f802c408b036453fce9d597e52db70e8c7
+    ✨ Add PennyLane support for QDMI devices (#2005)
+
 Issue #1893 is an enhancement/MLIR issue and is not labeled `good first issue`.
 The user authorized updating PR #1987 with an explicit force-with-lease after
 final exact-head validation.
@@ -588,3 +604,7 @@ Revision note (2026-08-05, Codex): Reopened the plan for the signed linear
 rebase onto `ecd32f734`, recorded the semantic conflict resolutions and focused
 validation, and closed independent-review finding Q-01 with a complete-QTensor
 `scf.while` reference oracle.
+
+Revision note (2026-08-05, Codex): Rebased again onto `077b73f80` after main
+advanced during replacement CI, preserved the PennyLane/QDMI additions, and
+recorded the QCO-to-QC fixture compatibility correction.

--- a/.agent/plans/alias-safe-repeated-qubit-loads.md
+++ b/.agent/plans/alias-safe-repeated-qubit-loads.md
@@ -1,0 +1,280 @@
+# Implement alias-safe repeated qubit loads
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+MQT Core's QC builder currently rejects repeated loads of a qubit-register
+element, and the typed OpenQASM frontend expands every runtime qubit index into
+an `scf.index_switch` with one case per register element. After this change,
+ordinary `memref.load` operations may name the same register element repeatedly,
+including from the entry block, and QC-to-QCO conversion remains correct even
+when two sequential runtime indices happen to alias. OpenQASM programs with
+runtime qubit indices lower to a fixed-size load/use sequence instead of code
+whose size grows with the register width.
+
+The observable proof is twofold. A raw QC module containing repeated qubit loads
+converts to verified QCO in which each register operand is extracted immediately
+before its quantum operation and inserted immediately afterward. An OpenQASM
+program containing `x q[i];` emits a checked `memref.load` and no
+width-dependent `scf.index_switch`.
+
+## Progress
+
+- [x] (2026-08-01 11:00Z) Investigated issue #1893 against the typed OpenQASM
+  frontend and LLVM/MLIR 22 behavior.
+- [x] (2026-08-01 11:00Z) Allocated a clean task worktree at the selected
+  `e772dba5ce1c51cc7b8931b8a5031a826040f3d5` revision and read repository
+  policy.
+- [x] (2026-08-01 12:25Z) Implement Stage 1 builder, QC-to-QCO, and QTensor
+  behavior.
+- [x] (2026-08-01 12:40Z) Add focused Stage 1 regression tests and verify the
+      raw conversion without relying on cleanup. The QC IR (311 tests), QTensor
+      IR (29 tests), and QC-to-QCO (141 tests) suites pass.
+- [ ] Commit Stage 1 as one signed, AI-attributed commit.
+- [ ] Implement Stage 2 direct OpenQASM register loads.
+- [ ] Add focused Stage 2 translation and end-to-end tests.
+- [ ] Commit Stage 2 as one signed, AI-attributed commit.
+- [ ] Integrate the refreshed `origin/main` tip and rerun affected validation.
+- [ ] Run repository lint and an independent exact-revision review.
+
+## Surprises & Discoveries
+
+- Observation: MLIR's LLVM 22 CSE cannot be the correctness mechanism. QC
+  quantum operations declare memory writes, so an intervening gate prevents CSE
+  from reusing a prior `memref.load`.
+- Observation: The current OpenQASM frontend no longer emits dynamic loads. It
+  selects eagerly loaded references through nested `scf.index_switch`
+  operations, making emitted operation count depend on register widths.
+- Observation: Existing QTensor canonicalizers scan only constant-index tensor
+  chains. Dynamic indices can alias unless they are the exact same SSA value, so
+  only adjacent exact-index folds are safe without an alias analysis.
+- Observation: The old tensor-chain search can cross a structured QCO operation.
+  Once structured regions carry complete tensors, folding an insert against an
+  extract on the far side of that operation bypasses region-local quantum
+  updates. The replacement canonicalizers therefore use direct SSA
+  producer/consumer relationships only.
+- Observation: `ValueRange{value}` does not own its initializer-list storage.
+  Keeping such a range in a local variable produced a dangling view during the
+  first conversion prototype. Single-qubit helper calls now use owned
+  `SmallVector<Value, 1>` storage.
+
+## Decision Log
+
+- Decision: Implement two dependent commits, with the core conversion preceding
+  the OpenQASM migration. Rationale: The raw conversion becomes independently
+  useful and Stage 2 never lands on an unsafe converter. Date/Author:
+  2026-08-01, Codex.
+- Decision: Treat qubit `memref.load` as reference provenance and materialize
+  QCO values around each consuming quantum operation. Rationale: This supports
+  arbitrary sequential runtime aliasing without adding an analysis, dialect
+  type, or operation. Date/Author: 2026-08-01, Codex.
+- Decision: Keep simultaneous operands subject to the existing distinct-qubit
+  contract and preserve OpenQASM runtime assertions. Rationale: A multi-qubit
+  QCO operation cannot extract the same linear qubit twice. Date/Author:
+  2026-08-01, Codex.
+- Decision: Preserve the public eager `allocQubitRegister` API and add a
+  storage-only primitive for the frontend. Rationale: Existing builders and
+  fixtures remain source-compatible. Date/Author: 2026-08-01, Codex.
+- Decision: Start from the user-selected revision, then integrate the one newer
+  live-base commit before final verification. Rationale: This preserves exact
+  implementation scope and satisfies the repository's live-base handoff rule.
+  Date/Author: 2026-08-01, Codex.
+- Decision: Preserve exact QCO reference comparison where representation is
+  unchanged, and assert operation-local extract/insert linearity plus complete
+  tensor state for structured-register cases. Rationale: Eagerly extracted QCO
+  references encode the representation Stage 1 intentionally removes and are no
+  longer valid structural references for those cases. Date/Author: 2026-08-01,
+  Codex.
+
+## Outcomes & Retrospective
+
+Implementation is in progress. This section will record final behavior, commit
+identifiers, validation results, remaining limitations, and lessons learned.
+
+## Context and Orientation
+
+The QC dialect models `!qc.qubit` as a reference. A QC gate mutates that
+reference in place. The QCO dialect models `!qco.qubit` linearly: an operation
+consumes an input SSA value and produces the next value. A QTensor is a
+one-dimensional `tensor<...x!qco.qubit>` whose `qtensor.extract` removes one
+qubit and whose `qtensor.insert` returns it.
+
+`mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h` and
+`mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp` own the public builder.
+`allocQubitRegister` currently allocates a qubit memref and eagerly loads every
+constant element. `loadQubit` rejects entry-block and repeated loads using
+per-region maps.
+
+`mlir/lib/Conversion/QCToQCO/QCToQCO.cpp` converts QC reference semantics to QCO
+value semantics. Its current load pattern extracts a qubit when the load is
+converted and keeps it live until a structured boundary or register
+deallocation. That is unsafe when another load may name the same element.
+
+`mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp` and `InsertOp.cpp` own
+local tensor-chain canonicalization. They use constant-index equality when
+searching through a chain.
+
+`mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp` emits QC from the
+typed OpenQASM frontend. Non-scalar declarations currently retain vectors of
+eagerly loaded values. Dynamic references recursively construct
+`scf.index_switch` operations over those vectors.
+
+Tests belong under `mlir/unittests/Conversion/QCToQCO/`,
+`mlir/unittests/Dialect/QC/IR/`, `mlir/unittests/Dialect/QTensor/IR/`, and
+`mlir/unittests/Dialect/QC/Translation/`. Production tools are not test
+locations.
+
+## Plan of Work
+
+First, simplify the builder. Add
+`Value QCProgramBuilder::allocQubitRegisterStorage(int64_t size)`, which
+validates the size, selects dynamic allocation mode, allocates
+`memref<sizex!qc.qubit>`, and registers it for automatic deallocation. Implement
+the existing eager allocator in terms of this function. Make `loadQubit` emit an
+ordinary `memref.load` at any valid insertion point and remove all region
+tracking.
+
+Second, refactor QC-to-QCO state. Before conversion, collect every qubit
+`memref.load` into owned register-access records containing the original memref
+and index. Reject uses that escape through unsupported calls, returns, stores,
+or general block arguments before changing IR. Replace the current persistent
+extraction maps with central materialize and commit helpers. Materialization
+extracts register-backed operands in operand order from the latest mapped
+QTensor; standalone references resolve through the existing qubit map. Commit
+updates standalone mappings or reinserts register outputs in reverse order.
+Measurement, reset, gates, barriers, and modifiers all use these helpers.
+
+Qubit load conversion then erases only the reference marker. Register
+deallocation consumes the already-complete mapped tensor. Structured control
+flow carries QTensor values for used registers and QCO values only for
+standalone qubits. The existing terminator phase yields those values, but no
+insert-before or re-extract-after bookkeeping remains. Transient provenance must
+be discarded before later conversion phases; no erased `Operation*` may survive
+in state.
+
+Third, add adjacent QTensor folds that use LLVM 22 `isEqualConstantIntOrValue`.
+An extract immediately consuming an insert result at the same exact dynamic or
+constant index forwards the inserted scalar and original destination. An insert
+immediately consuming an extract result at the same index forwards the original
+tensor. Existing non-adjacent patterns remain constant-only and must not cross a
+potentially aliasing dynamic index.
+
+After Stage 1 tests pass, commit it. Then migrate the OpenQASM emitter.
+Represent every non-scalar qubit declaration with storage allocated through the
+new builder method. Resolve static register indices with a constant index load.
+Evaluate and bounds-check dynamic indices once, cast them to MLIR `index`, and
+load directly. Scalar qubits, gate arguments, and hardware qubits retain their
+existing representations.
+
+Remove only quantum dynamic-dispatch construction and its projected width
+accounting. Measurement, reset, barrier, and modifier emission use the directly
+resolved values. Keep classical dynamic indexing and general construction budget
+checks. Preserve signed negative-index wrapping, bounds assertions, and pairwise
+runtime assertions for possibly identical gate operands.
+
+Finally, add behavioral tests, integrate current `origin/main`, run focused and
+broad validation, update this plan, and obtain an independent read-only review.
+Do not push, open a pull request, post GitHub text, or modify issue state.
+
+## Concrete Steps
+
+Run all commands from the repository root.
+
+Inspect changes continuously with:
+
+    git status --short
+    git diff --check
+    git diff --stat
+
+Configure and build the MLIR-enabled release tree with the repository wrapper:
+
+    ./.agent/run.sh cmake --preset release
+    ./.agent/run.sh cmake --build --preset release
+
+During Stage 1, run the focused conversion and dialect binaries discovered in
+the generated build tree. At minimum, run the QC-to-QCO, QC IR, and QTensor IR
+test suites with GoogleTest filters for the new cases.
+
+During Stage 2, run the OpenQASM QC translation tests and compiler pipeline
+tests. Exercise `mqt-cc` on a small OpenQASM input containing a dynamic qubit
+index and inspect emitted QC/QCO for successful verification and absence of
+quantum width-expanded switches.
+
+After integrating the live base, rerun the affected tests, then:
+
+    ./.agent/run.sh uvx nox -s lint
+    git diff --check
+    git status --short
+
+## Validation and Acceptance
+
+Stage 1 is accepted when builder tests can emit repeated identical loads in the
+entry block and nested SCF, and raw `createQCToQCO()` conversion verifies
+without first running canonicalization or CSE. Tests must cover constant and
+dynamic indices, repeated sequential use, an eager constant reference followed
+by a possibly aliasing dynamic reference, structured control flow, measurement,
+reset, barriers, and modifiers. The resulting QCO must contain complete tensors
+at structured boundaries and register deallocation.
+
+QTensor canonicalization is accepted when adjacent operations at the same
+constant or exact dynamic SSA index fold, while adjacent operations at distinct
+dynamic SSA indices remain unchanged.
+
+Stage 2 is accepted when OpenQASM dynamic quantum operations emit direct
+register loads and no quantum-selection `scf.index_switch`. A large register
+must emit approximately the same number of operations as a small register for
+the same source operation. Existing index bounds, negative-index, and
+same-qubit-operand failures must remain observable.
+
+The complete change is accepted when focused tests, affected compiler tests, the
+release build, repository lint, `git diff --check`, and independent review pass.
+Any environment-limited check must be recorded with exact evidence rather than
+weakened.
+
+## Idempotence and Recovery
+
+All build and test commands are repeatable and keep caches inside this worktree.
+Edits are confined to this task worktree. If a conversion experiment fails,
+preserve the failing test and adjust the implementation; do not reset, clean, or
+modify another worktree. Integrating `origin/main` is postponed until the two
+selected commits exist, so conflicts can be resolved against clear atomic
+history.
+
+## Artifacts and Notes
+
+The selected implementation base is:
+
+    e772dba5ce1c51cc7b8931b8a5031a826040f3d5
+
+At worktree allocation time the live base was one unrelated commit newer:
+
+    a4293f1473f4a716aec81707d3cbe01cd1a1b83a
+    ✨ Expose DD serialization in Python (#1983)
+
+Issue #1893 is an enhancement/MLIR issue and is not labeled `good first issue`.
+No external GitHub mutation is authorized by this plan.
+
+## Interfaces and Dependencies
+
+The only new public C++ interface is:
+
+    Value QCProgramBuilder::allocQubitRegisterStorage(int64_t size);
+
+`QCProgramBuilder::allocQubitRegister(int64_t)` remains source-compatible.
+`QCProgramBuilder::loadQubit(Value memref, Value index)` retains its signature
+but permits repeated and entry-region loads.
+
+The implementation uses existing MLIR 22 APIs: `memref::LoadOp`,
+`qtensor::ExtractOp`, `qtensor::InsertOp`, `isEqualConstantIntOrValue`, dialect
+conversion patterns, SCF iter arguments, and the repository's existing LLVM
+containers. It adds no external dependency, dialect operation, dialect type,
+pass, or command-line option.
+
+Revision note (2026-08-01, Codex): Created the living plan from the approved
+two-stage design and recorded the refreshed-base boundary before implementation.

--- a/.agent/plans/alias-safe-repeated-qubit-loads.md
+++ b/.agent/plans/alias-safe-repeated-qubit-loads.md
@@ -145,7 +145,13 @@ width-dependent `scf.index_switch`.
       merge-time-ordered changelog.
 - [x] (2026-08-05) Address final maintainer feedback by folding #1987 into the
       staged OpenQASM changelog entry and removing overly specific agent
-      guidance.
+      guidance. Localize the one-use modifier-body operation query instead of
+      adding it to the shared dialect utilities.
+- [x] (2026-08-05) Rebase the 16 signed commits onto `origin/main` at
+      `2b977fbf2a3e4d5d935f0b001e8415683a4b5ac5`. Preserve upstream's native
+      switch and multi-label emission-budget tests alongside the branch's
+      width-independent register-access expectations. Validate 1,153 focused
+      MLIR tests and 44 Python MLIR tests.
 
 ## Surprises & Discoveries
 
@@ -612,5 +618,10 @@ Revision note (2026-08-05, Codex): Rebased again onto `077b73f80` after main
 advanced during replacement CI, preserved the PennyLane/QDMI additions, and
 recorded the QCO-to-QC fixture compatibility correction.
 
-Revision note (2026-08-05, Codex): Recorded the final changelog and agent-guide
-review corrections.
+Revision note (2026-08-05, Codex): Recorded the final changelog, agent-guide,
+and shared-utility review corrections.
+
+Revision note (2026-08-05, Codex): Rebased the final 16-commit series onto
+`2b977fbf2`, preserving the newly merged OpenQASM emission coverage while
+retaining direct dynamic qubit access, and recorded focused post-rebase
+validation.

--- a/.agent/plans/alias-safe-repeated-qubit-loads.md
+++ b/.agent/plans/alias-safe-repeated-qubit-loads.md
@@ -63,6 +63,28 @@ width-dependent `scf.index_switch`.
       the same two configured QDMI skips.
 - [x] (2026-08-01) Complete a fresh independent review of exact source revision
       `7a84fdf22de840efa423164cb967d5da10ecebf7`; no actionable findings remain.
+- [x] (2026-08-02) Address the subsequent exhaustive-review findings: replace
+      custom recursive SCF capture discovery with MLIR `RegionUtils`, remove
+      dead modifier register state and void casts, diagnose provably duplicate
+      simultaneous register operands, and distinguish intact tensor/storage
+      allocation from eager element extraction in the builder documentation.
+- [x] (2026-08-02) Replace the translation test's custom mutating IR normalizer
+      with the production QC-to-QCO conversion and strengthen structured
+      conversion checks to prove operation-local extract/use/insert linearity
+      and complete QTensor state.
+- [x] (2026-08-02) Make OpenQASM alias accounting and assertion emission sparse
+      by register, replace ordered barrier deduplication with LLVM dense
+      containers, and reject unavoidable whole-register/dynamic barrier aliases
+      during semantic analysis.
+- [x] (2026-08-02) Validate the remediation with LLVM 22.1.8 clang-tidy, every
+      repository hook, a complete 434-step release build, all 4,409 configured
+      CTest cases, all 419 Python tests (416 passed, three configured skips),
+      and QC/QCO/QIR `mqt-cc` smoke tests on a 99,999-qubit dynamic program.
+- [x] (2026-08-02) Integrate current `origin/main`
+      `ae7aff283c0c06da5e01e53349a3eaec8b322c1e` with a signed merge, then rerun
+      all repository hooks and the full Python 3.13 test session.
+- [ ] Obtain a fresh independent read-only review of the final exact source
+      revision.
 
 ## Surprises & Discoveries
 
@@ -104,8 +126,27 @@ width-dependent `scf.index_switch`.
 - Observation: Gates already rejected exact duplicate qubits during semantic
   analysis and asserted potentially aliasing dynamic operands at runtime, but
   barriers originally did neither. Reusing the runtime assertion path for
-  barriers and using an ordered set for exact semantic duplicates preserves the
-  linear QCO contract without quadratic checks over expanded whole registers.
+  barriers preserves the linear QCO contract. Grouping accesses by register and
+  using LLVM dense containers avoids quadratic scans over expanded whole
+  registers when all indices are statically distinct.
+- Observation: MLIR already provides `getUsedValuesDefinedAbove` for region
+  capture discovery. Using it for each supported SCF operation avoids
+  recursively interpreting block locality and correctly distinguishes values
+  captured from enclosing regions from qubits allocated inside a structured
+  region.
+- Observation: The QC modifier verifiers already reject register loads inside
+  modifier bodies. Register-specific modifier maps were therefore dead state;
+  modifier operands need only the existing standalone SSA alias mapping.
+- Observation: The legacy OpenQASM translation reference test repaired eager
+  register fixtures with a custom, order-sensitive IR mutation. Lowering both
+  modules through the production QC-to-QCO pass yields a stronger semantic
+  comparison and deletes that bespoke normalizer.
+- Observation: `QCOProgramBuilder::qtensorAlloc(1)` and
+  `QCOProgramBuilder::allocQubitRegister(1)` have intentionally different
+  linear-state results. The first returns one intact tensor, while the second
+  eagerly extracts its element and returns the residual tensor plus a standalone
+  qubit. The corresponding QC APIs now document the same storage-only versus
+  eager-reference distinction.
 
 ## Decision Log
 
@@ -139,10 +180,25 @@ width-dependent `scf.index_switch`.
   a multi-qubit gate; exact duplicates should fail in semantic analysis, while
   potentially equal runtime indices need `cf.assert`. Date/Author: 2026-08-01,
   Codex.
+- Decision: Use MLIR `RegionUtils` to discover structured captures and keep the
+  conversion's custom logic limited to classifying captured quantum values as
+  standalone qubits or register provenance. Rationale: Region ownership and
+  nested block locality are standard MLIR concerns and should not be
+  reimplemented recursively. Date/Author: 2026-08-02, Codex.
+- Decision: Reject only simultaneous register operands whose equality is
+  statically proven by identical SSA values or equal integer constants.
+  Rationale: QCO linearity makes those operations invalid, while distinct
+  dynamic values may alias only at runtime and remain the source frontend's
+  responsibility to guard. Date/Author: 2026-08-02, Codex.
+- Decision: Keep `qtensorAlloc`/storage-only allocation distinct from
+  `allocQubitRegister` eager extraction, but make the distinction explicit in
+  public documentation and use storage-only APIs whenever complete tensor state
+  is required. Rationale: Collapsing the APIs would either hide linear
+  extraction or break source compatibility. Date/Author: 2026-08-02, Codex.
 
 ## Outcomes & Retrospective
 
-The implementation now has the intended two-commit shape. Stage 1 makes
+The core implementation retains the intended two-stage shape. Stage 1 makes
 `memref.load` a stable QC register-access marker, lowers every quantum use to an
 operation-local QTensor extract/use/reverse-insert sequence, carries complete
 QTensor state through structured control flow, rejects unsupported escaping
@@ -151,33 +207,35 @@ cases. Stage 2 adds storage-only register allocation and makes the typed
 OpenQASM emitter produce checked point-of-use loads without quantum
 `scf.index_switch` expansion.
 
-The release build completed successfully. All 4,401 CTest tests passed; the two
-QDMI job-ID tests were reported as skipped by their existing test configuration.
-Focused QC, QCO, QTensor, QC-to-QCO, QCO-to-QC, Jeff round-trip, OpenQASM
-translation, and compiler suites pass. `mqt-cc` successfully emitted QC,
-operation-local QCO, and Adaptive QIR for dynamic gate, modifier, measurement,
-reset, and barrier access. The all-files nox lint session passed every
-configured hook.
+Independent review first found a barrier-specific alias gap in Stage 2. The
+initial remediation centralized runtime distinctness assertions across gates and
+barriers and rejected exact duplicate barrier operands. Two later scrutiny
+rounds then identified custom SCF capture discovery, redundant modifier state,
+provably invalid simultaneous register operands, shallow structured test
+oracles, a custom translation-test IR rewriter, ambiguous eager builder usage,
+and quadratic barrier bookkeeping.
 
-Independent review found one barrier-specific alias gap in Stage 2. The
-remediation centralizes dynamic distinctness assertions across gates and
-barriers, accounts for those assertions in the emission budget, and rejects
-exact duplicate scalar, static-register, and hardware barrier operands during
-semantic analysis. The focused OpenQASM target suite has 145 passing tests, and
-a barrier-only `mqt-cc --emit=qco` smoke test verifies the assertion followed by
-extract/barrier/reverse-insert. After rebuilding all affected dependents, the
-post-review full CTest matrix passes all 4,402 tests with the same two
-configured QDMI skips.
+The final remediation uses MLIR `RegionUtils`, removes the dead state and all
+new void casts, rejects statically proven simultaneous aliases before mutation,
+compares translation fixtures after the production QC-to-QCO pass, and verifies
+that every register access is an operation-local extract/use/insert triple.
+Structured tests now require complete tensor operands, region arguments, and
+results. OpenQASM emission counts and emits only pairs that may alias; a
+10,000-element static barrier emits no runtime alias checks and lowers in linear
+time.
 
-During finalization, `origin/main` advanced once more with modifier-body helper
-reuse. Both commits rebased cleanly onto
-`618c37fa4d5d15be282117d2c12f26a3b6e3dd75`; the overlapping QC/QCO modifier
-fixtures rebuilt without conflict, and all 4,404 tests on that base pass.
+The final release build completed all 434 steps. All 4,409 configured CTest
+cases passed, with the two existing QDMI job-ID skips. The full Python 3.13
+session passed 416 tests with three expected Qiskit compatibility skips. LLVM
+22.1.8 clang-tidy reported no diagnostics in the changed translation units,
+every repository hook passed, and `mqt-cc` emitted QC MLIR, QCO, and base QIR
+for repeated dynamic accesses into a 99,999-qubit register.
 
 No dialect operation, type, pass, command-line option, or external dependency
-was added. Direct QC-to-QIR conversion remains unchanged. A fresh independent
-exact-revision review found no remaining correctness, MLIR-legality, lifetime,
-alias-safety, SCF, QTensor-fold, direct-QIR, or emission-budget defect.
+was added. Direct QC-to-QIR conversion remains unchanged. The current base is
+`ae7aff283c0c06da5e01e53349a3eaec8b322c1e`; its maintenance-only changes do not
+overlap the MLIR implementation. A final independent exact-revision review is
+pending.
 
 ## Context and Orientation
 
@@ -189,22 +247,23 @@ qubit and whose `qtensor.insert` returns it.
 
 `mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h` and
 `mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp` own the public builder.
-`allocQubitRegister` currently allocates a qubit memref and eagerly loads every
-constant element. `loadQubit` rejects entry-block and repeated loads using
-per-region maps.
+Before this work, `allocQubitRegister` allocated a qubit memref and eagerly
+loaded every constant element, while `loadQubit` rejected entry-block and
+repeated loads using per-region maps.
 
 `mlir/lib/Conversion/QCToQCO/QCToQCO.cpp` converts QC reference semantics to QCO
-value semantics. Its current load pattern extracts a qubit when the load is
-converted and keeps it live until a structured boundary or register
-deallocation. That is unsafe when another load may name the same element.
+value semantics. Its previous load pattern extracted a qubit when the load was
+converted and kept it live until a structured boundary or register deallocation.
+That was unsafe when another load could name the same element.
 
 `mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp` and `InsertOp.cpp` own
-local tensor-chain canonicalization. They use constant-index equality when
-searching through a chain.
+local tensor-chain canonicalization. The former implementations searched
+constant-index chains; the replacements fold only direct producer/consumer pairs
+whose indices are equal by MLIR's standard value-or-constant utility.
 
 `mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp` emits QC from the
-typed OpenQASM frontend. Non-scalar declarations currently retain vectors of
-eagerly loaded values. Dynamic references recursively construct
+typed OpenQASM frontend. Before Stage 2, non-scalar declarations retained
+vectors of eagerly loaded values and dynamic references recursively constructed
 `scf.index_switch` operations over those vectors.
 
 Tests belong under `mlir/unittests/Conversion/QCToQCO/`,
@@ -334,7 +393,7 @@ The selected implementation base is:
 
     e772dba5ce1c51cc7b8931b8a5031a826040f3d5
 
-At final validation the live base included three subsequent commits:
+The final validated base also includes:
 
     a4293f1473f4a716aec81707d3cbe01cd1a1b83a
     ✨ Expose DD serialization in Python (#1983)
@@ -344,6 +403,12 @@ At final validation the live base included three subsequent commits:
 
     618c37fa4d5d15be282117d2c12f26a3b6e3dd75
     ♻️ Reuse MLIR modifier body helpers (#1985)
+
+    907e30c1dc11d47ef0c2fe14659e8c7ac2c297ae
+    ⚡ Speed up documentation builds (#1988)
+
+    ae7aff283c0c06da5e01e53349a3eaec8b322c1e
+    🔧 Maintenance round (#1989)
 
 Issue #1893 is an enhancement/MLIR issue and is not labeled `good first issue`.
 No external GitHub mutation is authorized by this plan.
@@ -383,3 +448,7 @@ commit and recorded the exact-base release rebuild and 4,404-test result.
 
 Revision note (2026-08-01, Codex): Closed the plan after a fresh independent
 exact-revision review reported no actionable findings.
+
+Revision note (2026-08-02, Codex): Reopened and updated the plan for the two
+subsequent exhaustive remediation rounds, current-base integration, and final
+validation. A fresh exact-revision review remains pending.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,9 @@ Use Google-style Python docstrings. Prefer fixing diagnostics from `ruff` and
   and descriptions aligned with the implementation's actual scope, defaults,
   supported operation shapes, compile-time or runtime limitations, failure
   modes, and deliberately out-of-scope behavior.
+- Treat `scf.condition` as the linear terminator of an `scf.while` before
+  region. QTensor traversal and equivalence utilities must account for both the
+  before- and after-region block arguments when following loop-carried tensors.
 
 ## Generated Files and Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,9 +139,6 @@ Use Google-style Python docstrings. Prefer fixing diagnostics from `ruff` and
   and descriptions aligned with the implementation's actual scope, defaults,
   supported operation shapes, compile-time or runtime limitations, failure
   modes, and deliberately out-of-scope behavior.
-- Treat `scf.condition` as the linear terminator of an `scf.while` before
-  region. QTensor traversal and equivalence utilities must account for both the
-  before- and after-region block arguments when following loop-carried tensors.
 
 ## Generated Files and Validation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add storage-only qubit-register allocation and alias-safe point-of-use
+  access in QC-to-QCO and typed OpenQASM lowering ([#1987]) ([**@burgholzer**])
 - ✨ Add PennyLane support for gate-based QDMI devices ([#2005])
   ([**@burgholzer**])
 - ✨ Integrate QDMI devices as MLIR compiler targets across C++, Python, and
@@ -735,6 +737,7 @@ for previous changelogs._
 [#1994]: https://github.com/munich-quantum-toolkit/core/pull/1994
 [#1993]: https://github.com/munich-quantum-toolkit/core/pull/1993
 [#1992]: https://github.com/munich-quantum-toolkit/core/pull/1992
+[#1987]: https://github.com/munich-quantum-toolkit/core/pull/1987
 [#1986]: https://github.com/munich-quantum-toolkit/core/pull/1986
 [#1984]: https://github.com/munich-quantum-toolkit/core/pull/1984
 [#1983]: https://github.com/munich-quantum-toolkit/core/pull/1983

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Add storage-only qubit-register allocation and alias-safe point-of-use
-  access in QC-to-QCO and typed OpenQASM lowering ([#1987]) ([**@burgholzer**])
 - ✨ Add PennyLane support for gate-based QDMI devices ([#2005])
   ([**@burgholzer**])
 - ✨ Integrate QDMI devices as MLIR compiler targets across C++, Python, and
@@ -52,8 +50,8 @@ releases may include breaking changes.
   ([**@simon1hofmann**])
 - ✨ Add an LLVM-native staged OpenQASM frontend with typed semantic analysis
   and direct QC emission, including lexical scope, assignment, inclusive ranges,
-  and structured control flow ([#1910], [#1994]) ([**@burgholzer**],
-  [**@denialhaag**])
+  structured control flow, and alias-safe qubit-register access ([#1910],
+  [#1987], [#1994]) ([**@burgholzer**], [**@denialhaag**])
 - ✨ Add Python bindings for the MQT Compiler Collection ([#1815])
   ([**@burgholzer**], [**@denialhaag**])
 - ✨ Add support for IQM's `move` gate in the QDMI Qiskit backend converter

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -207,11 +207,6 @@ public:
   /**
    * @brief Explicitly loads a qubit from a memref
    *
-   * @details Explicitly loads a qubit from a memref at the given index. This
-   * builder should only be called in a nested region inside the main function.
-   * The same index cannot be used to load a value multiple times in the same
-   * nested region.
-   *
    * @param memref Source memref
    * @param index The index from where the qubit is loaded
    * @return The loaded qubit
@@ -1370,12 +1365,6 @@ private:
 
   /// Track allocated memrefs for automatic deallocation
   DenseSet<Value> allocatedQregs;
-
-  /// Per-region map of memrefs and their loaded indices
-  DenseMap<Region*, DenseMap<Value, DenseSet<Value>>> loadedQubits;
-
-  /// Stack of the nested regions where the insertion point of the builder is
-  SmallVector<Region*> regionStack;
 
   /// Check if the builder has been finalized
   void checkFinalized() const;

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -205,6 +205,16 @@ public:
   QubitRegister allocQubitRegister(int64_t size);
 
   /**
+   * @brief Allocate storage for a qubit register without loading its elements
+   * @param size Number of qubits (must be positive)
+   * @return The memref value representing the qubit register
+   *
+   * @details The register is tracked for automatic deallocation. Use
+   * `loadQubit` to obtain references to individual elements.
+   */
+  Value allocQubitRegisterStorage(int64_t size);
+
+  /**
    * @brief Explicitly loads a qubit from a memref
    *
    * @param memref Source memref

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -187,9 +187,10 @@ public:
   Value staticQubit(uint64_t index);
 
   /**
-   * @brief Allocate a qubit register
+   * @brief Allocate a qubit register and eagerly load every element
    * @param size Number of qubits (must be positive)
-   * @return A `QubitRegister` structure
+   * @return A `QubitRegister` containing the backing memref and one reference
+   * for every eagerly loaded element
    *
    * @par Example:
    * ```c++
@@ -209,8 +210,9 @@ public:
    * @param size Number of qubits (must be positive)
    * @return The memref value representing the qubit register
    *
-   * @details The register is tracked for automatic deallocation. Use
-   * `loadQubit` to obtain references to individual elements.
+   * @details The register is tracked for automatic deallocation and remains
+   * intact until an element is loaded. Use `loadQubit` to obtain references at
+   * their points of use.
    */
   Value allocQubitRegisterStorage(int64_t size);
 

--- a/mlir/include/mlir/Dialect/QC/IR/QCOps.td
+++ b/mlir/include/mlir/Dialect/QC/IR/QCOps.td
@@ -939,6 +939,9 @@ def CtrlOp
         However, the `controls` argument is marked with `MemWrite` to ensure correct dependency tracking in MLIR.
 
         The body region may contain an arbitrary amount of unitary and classical operations.
+        Classical SSA values may be captured from above, but every qubit used
+        in the body must be passed through a modifier operand and accessed via
+        its aliased block argument.
         Non-unitary operations, such as `AllocOp` and `MeasureOp`, are not allowed.
 
         Example:
@@ -999,6 +1002,9 @@ def InvOp : QCOp<"inv",
         A modifier operation that inverts the gates defined in its body region.
 
         The body region may contain an arbitrary amount of unitary and classical operations.
+        Classical SSA values may be captured from above, but every qubit used
+        in the body must be passed through a modifier operand and accessed via
+        its aliased block argument.
         Non-unitary operations, such as `AllocOp` and `MeasureOp`, are not allowed.
 
         Example:
@@ -1060,6 +1066,9 @@ def PowOp : QCOp<"pow",
           - r < 0: equivalent to inv @ pow(-r) @ g.
 
           The body region may contain an arbitrary amount of unitary and classical operations.
+          Classical SSA values may be captured from above, but every qubit used
+          in the body must be passed through a modifier operand and accessed via
+          its aliased block argument.
           Non-unitary operations, such as `AllocOp` and `MeasureOp`, are not allowed.
 
           Example:

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -210,9 +210,10 @@ public:
   Value staticQubit(uint64_t index);
 
   /**
-   * @brief Allocate a qubit register
+   * @brief Allocate a qubit tensor and eagerly extract every element
    * @param size Number of qubits (must be positive)
-   * @return A `QubitRegister` structure
+   * @return A `QubitRegister` containing the residual tensor and one standalone
+   * qubit value for every eagerly extracted element
    *
    * @par Example:
    * ```c++
@@ -254,11 +255,10 @@ public:
   /**
    * @brief Allocate a qubit tensor
    *
-   * @details
-   * Allocates a one-dimensional tensor of !qco.qubit types with the given size
-   * if the size is a constant, otherwise the tensor has dynamic size. The
-   * qubits are initialized in the |0> state. The resulting tensor is added to
-   * the tracking.
+   * @details Allocates and returns one intact, one-dimensional tensor of
+   * `!qco.qubit` values. No elements are extracted. If the size is a constant,
+   * the tensor has static size; otherwise it has dynamic size. Its qubits are
+   * initialized in the |0> state, and the tensor is tracked automatically.
    *
    * @param size Number of qubits (must be positive)
    * @return The allocated tensor

--- a/mlir/include/mlir/Dialect/Utils/Utils.h
+++ b/mlir/include/mlir/Dialect/Utils/Utils.h
@@ -29,7 +29,6 @@
 #include <mlir/IR/Value.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Support/LLVM.h>
-#include <mlir/Support/WalkResult.h>
 
 #include <cassert>
 #include <cmath>
@@ -391,20 +390,6 @@ template <typename UnitaryInterface>
     return {};
   }
   return unitary;
-}
-
-/**
- * @brief Returns whether @p block or any nested region contains one of the
- * requested operation types.
- */
-template <typename... OpTypes>
-[[nodiscard]] bool containsOperationOfType(Block& block) {
-  return block
-      .walk([](Operation* operation) {
-        return isa<OpTypes...>(operation) ? WalkResult::interrupt()
-                                          : WalkResult::advance();
-      })
-      .wasInterrupted();
 }
 
 /**

--- a/mlir/include/mlir/Dialect/Utils/Utils.h
+++ b/mlir/include/mlir/Dialect/Utils/Utils.h
@@ -29,6 +29,7 @@
 #include <mlir/IR/Value.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Support/WalkResult.h>
 
 #include <cassert>
 #include <cmath>
@@ -390,6 +391,20 @@ template <typename UnitaryInterface>
     return {};
   }
   return unitary;
+}
+
+/**
+ * @brief Returns whether @p block or any nested region contains one of the
+ * requested operation types.
+ */
+template <typename... OpTypes>
+[[nodiscard]] bool containsOperationOfType(Block& block) {
+  return block
+      .walk([](Operation* operation) {
+        return isa<OpTypes...>(operation) ? WalkResult::interrupt()
+                                          : WalkResult::advance();
+      })
+      .wasInterrupted();
 }
 
 /**

--- a/mlir/lib/Compiler/TargetCompilation.cpp
+++ b/mlir/lib/Compiler/TargetCompilation.cpp
@@ -22,6 +22,7 @@ namespace mlir {
 
 void populateTargetCompilationPipeline(OpPassManager& pm,
                                        const CompilerTarget& target) {
+  populateQCOCleanupPipeline(pm);
   populateDecomposeMultiControlledPipeline(pm, 3);
   populateDefaultQCOOptimizationPipeline(pm);
   pm.addPass(qco::createFuseTwoQubitGates());

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -454,16 +454,49 @@ static void commitQubits(LoweringState& state, Operation* anchor,
 /** @brief Collects stable register identifiers and load provenance. */
 [[nodiscard]] static LogicalResult
 collectRegisterAccesses(Operation* root, LoweringState& state) {
-  root->walk([&](memref::AllocOp op) {
-    if (isa<qc::QubitType>(op.getType().getElementType())) {
-      const auto reg = state.registerIds.size();
-      state.registerIds.try_emplace(op.getResult(), reg);
+  const auto allocationResult = root->walk([&](memref::AllocOp op) {
+    if (!isa<qc::QubitType>(op.getType().getElementType())) {
+      return WalkResult::advance();
     }
+
+    if (op.getType().getRank() != 1) {
+      op.emitOpError("requires one-dimensional qubit register storage");
+      return WalkResult::interrupt();
+    }
+
+    const auto reg = state.registerIds.size();
+    state.registerIds.try_emplace(op.getResult(), reg);
+    return WalkResult::advance();
   });
+  if (allocationResult.wasInterrupted()) {
+    return failure();
+  }
+
+  const auto registerUseResult = root->walk([&](Operation* operation) {
+    for (const auto operand : operation->getOperands()) {
+      const auto type = dyn_cast<MemRefType>(operand.getType());
+      if (!type || !isa<qc::QubitType>(type.getElementType()) ||
+          state.registerIds.contains(operand)) {
+        continue;
+      }
+
+      operation->emitOpError("requires a directly allocated qubit register");
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  if (registerUseResult.wasInterrupted()) {
+    return failure();
+  }
 
   const auto result = root->walk([&](memref::LoadOp op) {
     if (!isa<qc::QubitType>(op.getMemRefType().getElementType())) {
       return WalkResult::advance();
+    }
+
+    if (op.getMemRefType().getRank() != 1 || op.getIndices().size() != 1) {
+      op.emitOpError("requires one-dimensional qubit register storage");
+      return WalkResult::interrupt();
     }
 
     const auto regIt = state.registerIds.find(op.getMemref());

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -538,9 +538,22 @@ collectRegisterAccesses(Operation* root, LoweringState& state) {
   return success(!distinctResult.wasInterrupted());
 }
 
-/** @brief Rejects forbidden operations recursively nested in QC modifiers. */
+/** @brief Rejects unsupported operations and qubit captures in QC modifiers. */
 [[nodiscard]] static LogicalResult validateModifierBodies(Operation* root) {
   const auto result = root->walk([&](Operation* operation) {
+    if (isa<qc::InvOp, qc::CtrlOp, qc::PowOp>(operation)) {
+      SetVector<Value> captures;
+      getUsedValuesDefinedAbove(operation->getRegions(), captures);
+      if (llvm::any_of(captures, [](const Value value) {
+            return isa<qc::QubitType>(value.getType());
+          })) {
+        operation->emitOpError(
+            "body must not capture qubits from above; use only its aliased "
+            "block arguments");
+        return WalkResult::interrupt();
+      }
+    }
+
     if (!isa<qc::AllocOp, qc::DeallocOp, qc::MeasureOp, qc::ResetOp,
              memref::LoadOp, memref::StoreOp>(operation)) {
       return WalkResult::advance();
@@ -1751,7 +1764,7 @@ struct QCToQCO final : impl::QCToQCOBase<QCToQCO> {
 protected:
   void runOnOperation() override {
     MLIRContext* context = &getContext();
-    auto* module = getOperation();
+    auto* moduleOp = getOperation();
 
     // Create state object to track qubit value flow
     LoweringState state;
@@ -1760,14 +1773,14 @@ protected:
     RewritePatternSet patterns(context);
     QCToQCOTypeConverter typeConverter(context);
 
-    if (failed(validateModifierBodies(module)) ||
-        failed(collectRegisterAccesses(module, state))) {
+    if (failed(validateModifierBodies(moduleOp)) ||
+        failed(collectRegisterAccesses(moduleOp, state))) {
       signalPassFailure();
       return;
     }
 
     // Get the quantum values captured by structured control-flow regions.
-    collectStructuredCaptures(module, state);
+    collectStructuredCaptures(moduleOp, state);
 
     // Configure conversion target
     target.addIllegalDialect<QCDialect>();
@@ -1846,7 +1859,7 @@ protected:
     populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
 
     // Convert structured parents and their contents first.
-    if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
+    if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
       signalPassFailure();
       return;
     }
@@ -1884,7 +1897,7 @@ protected:
     RewritePatternSet terminatorPatterns(context);
     terminatorPatterns.add<ConvertSCFYieldOp, ConvertSCFConditionOp>(
         typeConverter, context, &state);
-    if (failed(applyPartialConversion(module, terminatorTarget,
+    if (failed(applyPartialConversion(moduleOp, terminatorTarget,
                                       std::move(terminatorPatterns)))) {
       signalPassFailure();
     }

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -41,6 +41,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <utility>
 
 namespace mlir {
@@ -53,12 +54,14 @@ using namespace qc;
 
 namespace {
 
+using RegisterId = std::size_t;
+
 /**
- * @brief Information about a qubit
+ * @brief Provenance for a register-backed QC qubit reference
  */
-struct QubitInfo {
-  /// Register the qubit belongs to
-  Value reg;
+struct RegisterAccess {
+  /// Stable identifier of the register the qubit belongs to
+  RegisterId reg;
   /// Index of the qubit within its register
   Value index;
 };
@@ -103,21 +106,22 @@ struct LoweringState {
     /// QC qubits yielded from the current modifier region, in yield order.
     SmallVector<Value> qcQubits;
 
-    /// QC memrefs yielded from the current modifier region, in yield order.
-    SmallVector<Value> memrefs;
+    /// Qubit registers yielded from the current modifier region, in yield
+    /// order.
+    SmallVector<RegisterId> registers;
 
     /// Latest QCO SSA values for QC qubits that are remapped inside the
     /// modifier region.
     DenseMap<Value, Value> currentQubits;
 
-    /// Latest QCO SSA values for QC memrefs that are remapped inside the
+    /// Latest QTensor SSA values for registers that are remapped inside the
     /// modifier region.
-    DenseMap<Value, Value> currentRegisters;
+    DenseMap<RegisterId, Value> currentRegisters;
   };
 
   struct StructuredValues {
     SmallVector<Value> qubits;
-    SmallVector<Value> memrefs;
+    SmallVector<RegisterId> registers;
   };
 
   /// Per-region map from original QC qubit reference to its latest QCO SSA
@@ -127,21 +131,21 @@ struct LoweringState {
   /// (typically a `func.func` body or a modifier region).
   DenseMap<Region*, DenseMap<Value, Value>> qubitMap;
 
-  /// Per-region map from original QC register to its latest QTensor SSA value
-  DenseMap<Region*, DenseMap<Value, Value>> tensorMap;
+  /// Per-region map from stable register identifiers to their latest QTensor
+  /// SSA values.
+  DenseMap<Region*, DenseMap<RegisterId, Value>> tensorMap;
 
-  /// Per-region map from original QC qubit reference to its register
-  /// information
-  DenseMap<Region*, DenseMap<Value, QubitInfo>> qubitInfoMap;
+  /// Transient map from source QC register values to stable identifiers.
+  DenseMap<Value, RegisterId> registerIds;
 
-  /// Per-region map from original QC register to its extracted QC qubits
-  DenseMap<Region*, DenseMap<Value, SetVector<Value>>> extractedQubits;
+  /// Transient provenance for register-backed QC qubit references.
+  DenseMap<Value, RegisterAccess> registerAccesses;
 
   /// Map from an operation to its used QC qubits inside its regions
   DenseMap<Operation*, SetVector<Value>> regionQubitMap;
 
-  /// Map from an operation to its used QC memrefs inside its regions
-  DenseMap<Operation*, SetVector<Value>> regionRegisterMap;
+  /// Map from an operation to the registers used inside its regions.
+  DenseMap<Operation*, SetVector<RegisterId>> regionRegisterMap;
 
   /// Original QC value order for already-converted structured operations.
   /// Kept separate from the legality maps above so converted SCF operations
@@ -212,14 +216,23 @@ currentModifierFrame(LoweringState& state) {
   return state.modifierFrames.back();
 }
 
+/** @brief Resolves the stable identifier for a source QC register value. */
+[[nodiscard]] static RegisterId lookupRegisterId(const LoweringState& state,
+                                                 const Value memref) {
+  const auto it = state.registerIds.find(memref);
+  assert(it != state.registerIds.end() && "QC register not found");
+  return it->second;
+}
+
 /**
  * @brief Finds the nearest region-local map containing @p reference and
  * returns the pair containing the map and a mutable reference to the value in
  * the map.
  */
-[[nodiscard]] static std::pair<DenseMap<Value, Value>*, Value*>
-findRegionLocalMap(DenseMap<Region*, DenseMap<Value, Value>>& map,
-                   Operation* anchor, Value reference) {
+template <typename Key>
+[[nodiscard]] static std::pair<DenseMap<Key, Value>*, Value*>
+findRegionLocalMap(DenseMap<Region*, DenseMap<Key, Value>>& map,
+                   Operation* anchor, const Key reference) {
   for (auto* current = anchor->getParentRegion(); current != nullptr;
        current = current->getParentRegion()) {
     if (auto it = map.find(current); it != map.end()) {
@@ -253,17 +266,18 @@ findRegionLocalMap(DenseMap<Region*, DenseMap<Value, Value>>& map,
 
 /** @brief Resolves the latest QTensor SSA value for a QC register. */
 [[nodiscard]] static Value lookupMappedTensor(LoweringState& state,
-                                              Operation* anchor, Value memref) {
+                                              Operation* anchor,
+                                              const RegisterId reg) {
 
   if (isInsideModifier(state)) {
     auto& frame = currentModifierFrame(state);
-    if (auto it = frame.currentRegisters.find(memref);
+    if (auto it = frame.currentRegisters.find(reg);
         it != frame.currentRegisters.end()) {
       return it->second;
     }
   }
   const auto& [tensorMap, tensorValue] =
-      findRegionLocalMap(state.tensorMap, anchor, memref);
+      findRegionLocalMap(state.tensorMap, anchor, reg);
   assert(tensorMap != nullptr && tensorValue != nullptr &&
          "QC register not found");
   return *tensorValue;
@@ -299,30 +313,30 @@ static void assignMappedQubit(LoweringState& state, Operation* anchor,
 
 /** @brief Updates the latest QTensor SSA value for a QC register. */
 static void assignMappedTensor(LoweringState& state, Operation* anchor,
-                               Value memref, Value tensor) {
+                               const RegisterId reg, Value tensor) {
   if (isInsideModifier(state)) {
     auto& frame = currentModifierFrame(state);
-    if (auto it = frame.currentRegisters.find(memref);
+    if (auto it = frame.currentRegisters.find(reg);
         it != frame.currentRegisters.end()) {
       it->second = tensor;
       return;
     }
-    frame.currentRegisters.try_emplace(memref, tensor);
+    frame.currentRegisters.try_emplace(reg, tensor);
     return;
   }
 
   auto [tensorMap, tensorValue] =
-      findRegionLocalMap(state.tensorMap, anchor, memref);
+      findRegionLocalMap(state.tensorMap, anchor, reg);
 
   if (tensorValue != nullptr) {
     *tensorValue = tensor;
     return;
   }
   if (tensorMap != nullptr) {
-    (*tensorMap)[memref] = tensor;
+    (*tensorMap)[reg] = tensor;
     return;
   }
-  state.tensorMap[anchor->getParentRegion()][memref] = tensor;
+  state.tensorMap[anchor->getParentRegion()][reg] = tensor;
 }
 
 /** @brief Resolves a range of QC qubits to their latest QCO values. */
@@ -339,9 +353,9 @@ resolveMappedQubits(LoweringState& state, Operation* anchor,
 template <typename Range>
 [[nodiscard]] static SmallVector<Value>
 resolveMappedTensors(LoweringState& state, Operation* anchor,
-                     const Range& memrefs) {
-  return llvm::to_vector(llvm::map_range(memrefs, [&](Value memref) {
-    return lookupMappedTensor(state, anchor, memref);
+                     const Range& registers) {
+  return llvm::to_vector(llvm::map_range(registers, [&](RegisterId reg) {
+    return lookupMappedTensor(state, anchor, reg);
   }));
 }
 
@@ -358,10 +372,10 @@ static void assignMappedQubits(LoweringState& state, Operation* anchor,
 /** @brief Updates mappings for matching QC memref and QTensor ranges. */
 template <typename QcRange, typename QcoRange>
 static void assignMappedTensors(LoweringState& state, Operation* anchor,
-                                const QcRange& memrefs,
+                                const QcRange& registers,
                                 const QcoRange& tensors) {
-  for (auto [memref, tensor] : llvm::zip_equal(memrefs, tensors)) {
-    assignMappedTensor(state, anchor, memref, tensor);
+  for (auto [reg, tensor] : llvm::zip_equal(registers, tensors)) {
+    assignMappedTensor(state, anchor, reg, tensor);
   }
 }
 
@@ -370,6 +384,8 @@ static void pushModifierFrame(LoweringState& state, ValueRange qcTargets,
                               ValueRange qcoTargets) {
   auto& [yieldOrder, registers, currentQubits, currentRegisters] =
       state.modifierFrames.emplace_back();
+  static_cast<void>(registers);
+  static_cast<void>(currentRegisters);
   llvm::append_range(yieldOrder, qcTargets);
   for (auto [qcTarget, qcoTarget] : llvm::zip_equal(qcTargets, qcoTargets)) {
     currentQubits.try_emplace(qcTarget, qcoTarget);
@@ -394,138 +410,153 @@ static void popModifierFrame(LoweringState& state) {
 /** @brief Seeds region-local QCO mappings for structured-control-flow block
  * arguments. */
 static void seedRegionMappings(LoweringState& state, Region& region,
-                               ValueRange qcQubits, ValueRange memrefs,
+                               ValueRange qcQubits,
+                               ArrayRef<RegisterId> registers,
                                ValueRange qcoQubits, ValueRange tensors) {
   auto& qubitMap = state.qubitMap[&region];
   for (auto [qcQubit, qcoQubit] : llvm::zip_equal(qcQubits, qcoQubits)) {
     qubitMap[qcQubit] = qcoQubit;
   }
   auto& tensorMap = state.tensorMap[&region];
-  for (auto [memref, tensor] : llvm::zip_equal(memrefs, tensors)) {
-    tensorMap[memref] = tensor;
+  for (auto [reg, tensor] : llvm::zip_equal(registers, tensors)) {
+    tensorMap[reg] = tensor;
   }
+}
+
+/** @brief QCO operands and register provenance materialized for a QC op. */
+struct MaterializedQubits {
+  SmallVector<Value> values;
+  SmallVector<std::optional<RegisterAccess>> accesses;
+};
+
+/**
+ * @brief Materializes register-backed qubits immediately before a quantum op.
+ */
+[[nodiscard]] static MaterializedQubits
+materializeQubits(LoweringState& state, Operation* anchor,
+                  const ValueRange qcQubits, PatternRewriter& rewriter) {
+  MaterializedQubits materialized;
+  materialized.values.reserve(qcQubits.size());
+  materialized.accesses.reserve(qcQubits.size());
+
+  for (const auto qcQubit : qcQubits) {
+    const auto accessIt = state.registerAccesses.find(qcQubit);
+    if (accessIt == state.registerAccesses.end()) {
+      materialized.values.push_back(lookupMappedQubit(state, anchor, qcQubit));
+      materialized.accesses.emplace_back();
+      continue;
+    }
+
+    const auto access = accessIt->second;
+    const auto tensor = lookupMappedTensor(state, anchor, access.reg);
+    auto extract = qtensor::ExtractOp::create(rewriter, anchor->getLoc(),
+                                              tensor, access.index);
+    assignMappedTensor(state, anchor, access.reg, extract.getOutTensor());
+    materialized.values.push_back(extract.getResult());
+    materialized.accesses.emplace_back(access);
+  }
+
+  return materialized;
 }
 
 /**
- * @brief Inserts extracted qubits that are not required by @p target back into
- * their tensors.
+ * @brief Commits quantum-operation results to standalone mappings or QTensor.
  */
-static void insertQubitsBeforeOp(LoweringState& state, Operation* target,
-                                 PatternRewriter& rewriter) {
-  auto* region = target->getParentRegion();
-  Operation* anchor = nullptr;
-  SmallVector<Value> memrefs;
-  if (isInsideModifier(state) && target->getNumRegions() == 0) {
-    memrefs = currentModifierFrame(state).memrefs;
-    anchor = target->getParentOp();
-  } else {
-    auto* owner = structuredValueOwner(target);
-    if (const auto it = state.structuredValues.find(owner);
-        it != state.structuredValues.end()) {
-      llvm::append_range(memrefs, it->second.memrefs);
-    } else {
-      llvm::append_range(memrefs, state.regionRegisterMap[owner]);
-    }
-    anchor = target;
-  }
+static void commitQubits(LoweringState& state, Operation* anchor,
+                         const ValueRange qcQubits, const ValueRange qcoQubits,
+                         const MaterializedQubits& materialized,
+                         PatternRewriter& rewriter) {
+  assert(qcQubits.size() == qcoQubits.size());
+  assert(qcQubits.size() == materialized.accesses.size());
 
-  // Iterate over all used memrefs
-  auto& qubitsFromRegion = state.extractedQubits[region];
-  auto& qubitInfoFromRegion = state.qubitInfoMap[region];
-  for (auto memref : memrefs) {
-    auto& extractedQubits = qubitsFromRegion[memref];
-    // Insert all extracted qubits that are not required by the target
-    for (auto qubit : extractedQubits) {
-      if (state.regionQubitMap[target].contains(qubit)) {
-        continue;
-      }
-      auto tensor = lookupMappedTensor(state, anchor, memref);
-      auto qcoQubit = lookupMappedQubit(state, anchor, qubit);
-      auto index = qubitInfoFromRegion[qubit].index;
-      auto insertOp = qtensor::InsertOp::create(rewriter, target->getLoc(),
-                                                qcoQubit, tensor, index);
-      // Update the tensor
-      assignMappedTensor(state, anchor, memref, insertOp.getResult());
+  for (std::size_t i = qcQubits.size(); i > 0; --i) {
+    const auto position = i - 1;
+    const auto& access = materialized.accesses[position];
+    if (!access) {
+      assignMappedQubit(state, anchor, qcQubits[position], qcoQubits[position]);
+      continue;
     }
+
+    const auto tensor = lookupMappedTensor(state, anchor, access->reg);
+    auto insert = qtensor::InsertOp::create(
+        rewriter, anchor->getLoc(), qcoQubits[position], tensor, access->index);
+    assignMappedTensor(state, anchor, access->reg, insert.getResult());
   }
 }
 
-/**
- * @brief Re-extracts qubits from their tensors after @p target has been
- * processed.
- */
-static void extractQubitsAfterOp(LoweringState& state, Operation* target,
-                                 PatternRewriter& rewriter) {
-  auto* region = target->getParentRegion();
-  Operation* anchor = nullptr;
-  SmallVector<Value> memrefs;
-  if (isInsideModifier(state) && target->getNumRegions() == 0) {
-    memrefs = currentModifierFrame(state).memrefs;
-    anchor = target->getParentOp();
-  } else {
-    llvm::append_range(memrefs, state.regionRegisterMap[target]);
-    anchor = target;
-  }
-  // Iterate over all used memrefs
-  auto& qubitsFromRegion = state.extractedQubits[region];
-  auto& qubitInfoFromRegion = state.qubitInfoMap[region];
-  for (auto& memref : memrefs) {
-    auto& extractedQubits = qubitsFromRegion[memref];
-    // Extract the previously extracted qubits
-    for (auto qubit : extractedQubits) {
-      if (state.regionQubitMap[target].contains(qubit)) {
-        continue;
-      }
-      auto tensor = lookupMappedTensor(state, anchor, memref);
-      auto index = qubitInfoFromRegion[qubit].index;
-      auto insertOp =
-          qtensor::ExtractOp::create(rewriter, target->getLoc(), tensor, index);
-      assignMappedTensor(state, anchor, memref, insertOp.getOutTensor());
-      assignMappedQubit(state, anchor, qubit, insertOp.getResult());
-    }
-  }
-}
-
-/** @brief Resolves all QC qubit and memref values to their
- * latest QCO and QTensor values.
- **/
+/** @brief Resolves all structured QC state to QCO and QTensor values. */
 [[nodiscard]] static SmallVector<Value> resolveAllValues(LoweringState& state,
                                                          Operation* anchor) {
-  SmallVector<Value> memrefs;
+  SmallVector<RegisterId> registers;
   SmallVector<Value> qcQubits;
   if (isInsideModifier(state) && anchor->getNumRegions() == 0) {
     auto& frame = currentModifierFrame(state);
-    memrefs = frame.memrefs;
+    registers = frame.registers;
     qcQubits = frame.qcQubits;
   } else {
     auto* owner = structuredValueOwner(anchor);
     if (const auto it = state.structuredValues.find(owner);
         it != state.structuredValues.end()) {
-      llvm::append_range(memrefs, it->second.memrefs);
+      llvm::append_range(registers, it->second.registers);
       llvm::append_range(qcQubits, it->second.qubits);
     } else {
-      llvm::append_range(memrefs, state.regionRegisterMap[owner]);
+      llvm::append_range(registers, state.regionRegisterMap[owner]);
       llvm::append_range(qcQubits, state.regionQubitMap[owner]);
     }
   }
 
   SmallVector<Value> qcoTargets;
-  qcoTargets.reserve(memrefs.size() + qcQubits.size());
-  llvm::append_range(qcoTargets, resolveMappedTensors(state, anchor, memrefs));
+  qcoTargets.reserve(registers.size() + qcQubits.size());
+  llvm::append_range(qcoTargets,
+                     resolveMappedTensors(state, anchor, registers));
   llvm::append_range(qcoTargets, resolveMappedQubits(state, anchor, qcQubits));
   return qcoTargets;
 }
 
+/** @brief Collects stable register identifiers and load provenance. */
+[[nodiscard]] static LogicalResult
+collectRegisterAccesses(Operation* root, LoweringState& state) {
+  root->walk([&](memref::AllocOp op) {
+    if (isa<qc::QubitType>(op.getType().getElementType())) {
+      const auto reg = state.registerIds.size();
+      state.registerIds.try_emplace(op.getResult(), reg);
+    }
+  });
+
+  const auto result = root->walk([&](memref::LoadOp op) {
+    if (!isa<qc::QubitType>(op.getMemRefType().getElementType())) {
+      return WalkResult::advance();
+    }
+
+    const auto regIt = state.registerIds.find(op.getMemref());
+    if (regIt == state.registerIds.end()) {
+      op.emitOpError("requires a directly allocated qubit register");
+      return WalkResult::interrupt();
+    }
+
+    state.registerAccesses.try_emplace(
+        op.getResult(),
+        RegisterAccess{.reg = regIt->second, .index = op.getIndices().front()});
+
+    for (Operation* user : op.getResult().getUsers()) {
+      if (isa<qc::UnitaryOpInterface, qc::MeasureOp, qc::ResetOp>(user)) {
+        continue;
+      }
+      user->emitOpError(
+          "cannot consume a register-backed qubit reference; only QC quantum "
+          "operations support register-backed qubits");
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  return success(!result.wasInterrupted());
+}
+
 /**
- * @brief Collects all the QC qubit and memref references used by an scf
- * operation and stores them in the maps
- *
- * @param op The operation that is currently traversed
- * @param state The lowering state
- * @return Pair of SetVector<Value> of unique QC qubits and memref
- * references
+ * @brief Collects standalone qubits and registers used by structured control.
  */
-static std::pair<SetVector<Value>, SetVector<Value>>
+static std::pair<SetVector<Value>, SetVector<RegisterId>>
 collectQubitValuesInsideSCFOps(Operation* op, LoweringState* state) {
   for (auto& region : op->getRegions()) {
     // Skip empty regions e.g. empty else region of an If operation
@@ -542,36 +573,30 @@ collectQubitValuesInsideSCFOps(Operation* op, LoweringState* state) {
         auto [qubits, registers] =
             collectQubitValuesInsideSCFOps(&operation, state);
         auto& regionQubitMap = state->regionQubitMap[op];
-        auto& qubitInfoMap = state->qubitInfoMap[&region];
         regionQubitMap.set_union(qubits);
-        // Remove duplicate qubits
-        regionQubitMap.remove_if(
-            [&](Value qubit) { return qubitInfoMap.contains(qubit); });
         state->regionRegisterMap[op].set_union(registers);
       }
-      auto& qubitInfoMap = state->qubitInfoMap[&region];
       auto& regionRegisterMap = state->regionRegisterMap[op];
-      // Track qubits from loadOp
       if (auto loadOp = dyn_cast<memref::LoadOp>(operation);
           loadOp &&
           isa<qc::QubitType>(loadOp.getMemRefType().getElementType())) {
-        QubitInfo info{.reg = loadOp.getMemRef(),
-                       .index = loadOp.getIndices()[0]};
-        qubitInfoMap.try_emplace(loadOp.getResult(), info);
-        regionRegisterMap.insert(loadOp.getMemRef());
+        regionRegisterMap.insert(
+            state->registerAccesses.find(loadOp.getResult())->second.reg);
         continue;
       }
       auto& regionQubitMap = state->regionQubitMap[op];
-      // Add the QC qubit and memref operands to the maps
       for (const auto& operand : operation.getOperands()) {
         if (isa<qc::QubitType>(operand.getType())) {
-          if (!qubitInfoMap.contains(operand)) {
+          if (const auto access = state->registerAccesses.find(operand);
+              access != state->registerAccesses.end()) {
+            regionRegisterMap.insert(access->second.reg);
+          } else {
             regionQubitMap.insert(operand);
           }
         }
         if (auto memref = dyn_cast<MemRefType>(operand.getType())) {
           if (isa<qc::QubitType>(memref.getElementType())) {
-            regionRegisterMap.insert(operand);
+            regionRegisterMap.insert(lookupRegisterId(*state, operand));
           }
         }
       }
@@ -702,23 +727,22 @@ struct ConvertMemRefAllocOp final
 
     auto& state = getState();
     auto memref = op.getResult();
-    assignMappedTensor(state, qtensor.getDefiningOp(), memref, qtensor);
+    assignMappedTensor(state, qtensor.getDefiningOp(),
+                       lookupRegisterId(state, memref), qtensor);
 
     return success();
   }
 };
 
 /**
- * @brief Converts memref.load to qtensor.extract
+ * @brief Erases a qubit memref.load after recording its converted index
  *
  * @par Example:
  * ```mlir
  * %q = memref.load %memref[%c0] : memref<3x!qc.qubit>
  * ```
- * is converted to
- * ```mlir
- * %tensor_out, %q = qtensor.extract %tensor_in[%c0]: tensor<3x!qco.qubit>
- * ```
+ * The consuming quantum operation materializes and commits the referenced
+ * qubit locally.
  */
 struct ConvertMemRefLoadOp final : StatefulOpConversionPattern<memref::LoadOp> {
   using StatefulOpConversionPattern::StatefulOpConversionPattern;
@@ -726,37 +750,15 @@ struct ConvertMemRefLoadOp final : StatefulOpConversionPattern<memref::LoadOp> {
   LogicalResult
   matchAndRewrite(memref::LoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
-    auto memref = op.getMemref();
-    if (!isa<qc::QubitType>(memref.getType().getElementType())) {
+    if (!isa<qc::QubitType>(op.getMemRefType().getElementType())) {
       return failure();
     }
 
     auto& state = getState();
-    auto& qubitInfoMap = state.qubitInfoMap;
-    auto* operation = op.getOperation();
-
-    // Look up latest QTensor value for this QC register
-    auto qtensor = lookupMappedTensor(state, operation, memref);
-
-    auto index = adaptor.getIndices()[0];
-    auto extract =
-        qtensor::ExtractOp::create(rewriter, op.getLoc(), qtensor, index);
-
-    auto qcQubit = op.getResult();
-    auto qcoQubit = extract.getResult();
-
-    assignMappedQubit(state, operation, qcQubit, qcoQubit);
-    assignMappedTensor(state, operation, memref, extract.getOutTensor());
-
-    QubitInfo info{.reg = memref, .index = index};
-    auto* parentRegion = operation->getParentRegion();
-    if (auto it = qubitInfoMap.find(parentRegion); it != qubitInfoMap.end()) {
-      it->second[qcQubit] = info;
-    } else {
-      qubitInfoMap[parentRegion][qcQubit] = info;
-    }
-
-    state.extractedQubits[parentRegion][memref].insert(qcQubit);
+    const auto accessIt = state.registerAccesses.find(op.getResult());
+    assert(accessIt != state.registerAccesses.end() &&
+           "qubit load provenance not found");
+    accessIt->second.index = adaptor.getIndices().front();
 
     rewriter.eraseOp(op);
 
@@ -767,20 +769,13 @@ struct ConvertMemRefLoadOp final : StatefulOpConversionPattern<memref::LoadOp> {
 /**
  * @brief Converts memref.dealloc to qtensor.dealloc
  *
- * @details
- * Before deallocating the tensor, all qubits are inserted back into it at their
- * original location.
- *
  * @par Example:
  * ```mlir
  * memref.dealloc %memref : memref<3x!qc.qubit>
  * ```
  * is converted to
  * ```mlir
- * %t1 = qtensor.insert %q0 into %t0[%c0] : tensor<3x!qco.qubit>
- * %t2 = qtensor.insert %q1 into %t1[%c1] : tensor<3x!qco.qubit>
- * %t3 = qtensor.insert %q2 into %t2[%c2] : tensor<3x!qco.qubit>
- * qtensor.dealloc %t3 : tensor<3x!qco.qubit>
+ * qtensor.dealloc %tensor : tensor<3x!qco.qubit>
  * ```
  */
 struct ConvertMemRefDeallocOp final
@@ -796,36 +791,10 @@ struct ConvertMemRefDeallocOp final
     }
 
     auto& state = getState();
-    auto& qubitMap = state.qubitMap[op->getParentRegion()];
     auto& tensorMap = state.tensorMap[op->getParentRegion()];
-    auto& qubitInfoMap = state.qubitInfoMap[op->getParentRegion()];
-
-    // Look up latest QTensor value for this QC register
-    auto qtensor = lookupMappedTensor(state, op.getOperation(), memref);
-
-    // Filter out qubits belonging to this tensor
-    for (auto it = qubitMap.begin(); it != qubitMap.end();) {
-      auto current = it++;
-      auto qcQubit = current->first;
-      auto qcoQubit = current->second;
-
-      auto infoIt = qubitInfoMap.find(qcQubit);
-      if (infoIt == qubitInfoMap.end()) {
-        continue;
-      }
-
-      auto& [reg, index] = infoIt->second;
-      if (reg != memref) {
-        continue;
-      }
-
-      qtensor = qtensor::InsertOp::create(rewriter, op.getLoc(), qcoQubit,
-                                          qtensor, index)
-                    .getResult();
-      qubitMap.erase(current);
-      qubitInfoMap.erase(infoIt);
-    }
-    tensorMap.erase(memref);
+    const auto reg = lookupRegisterId(state, memref);
+    auto qtensor = lookupMappedTensor(state, op.getOperation(), reg);
+    tensorMap.erase(reg);
 
     rewriter.replaceOpWithNewOp<qtensor::DeallocOp>(op, qtensor);
     return success();
@@ -970,13 +939,15 @@ struct ConvertQCMeasureOp final : StatefulOpConversionPattern<qc::MeasureOp> {
     auto& state = getState();
     auto* operation = op.getOperation();
     auto qcQubit = op.getQubit();
-    auto qcoQubit = lookupMappedQubit(state, operation, qcQubit);
+    const SmallVector<Value, 1> qcQubits{qcQubit};
+    auto materialized = materializeQubits(state, operation, qcQubits, rewriter);
 
     // Create qco.measure (returns both output qubit and bit result)
-    auto qcoOp = qco::MeasureOp::create(rewriter, op.getLoc(), qcoQubit);
+    auto qcoOp =
+        qco::MeasureOp::create(rewriter, op.getLoc(), materialized.values[0]);
 
-    // Update mapping: the QC qubit now corresponds to the output qubit
-    assignMappedQubit(state, operation, qcQubit, qcoOp.getQubitOut());
+    const SmallVector<Value, 1> qcoQubits{qcoOp.getQubitOut()};
+    commitQubits(state, operation, qcQubits, qcoQubits, materialized, rewriter);
 
     // Replace the QC operation's bit result with the QCO bit result
     rewriter.replaceOp(op, qcoOp.getResult());
@@ -1014,13 +985,15 @@ struct ConvertQCResetOp final : StatefulOpConversionPattern<qc::ResetOp> {
     auto& state = getState();
     auto* operation = op.getOperation();
     auto qcQubit = op.getQubit();
-    auto qcoQubit = lookupMappedQubit(state, operation, qcQubit);
+    const SmallVector<Value, 1> qcQubits{qcQubit};
+    auto materialized = materializeQubits(state, operation, qcQubits, rewriter);
 
     // Create qco.reset (consumes input, produces output)
-    auto qcoOp = qco::ResetOp::create(rewriter, op.getLoc(), qcoQubit);
+    auto qcoOp =
+        qco::ResetOp::create(rewriter, op.getLoc(), materialized.values[0]);
 
-    // Update mapping: the QC qubit now corresponds to the reset output
-    assignMappedQubit(state, operation, qcQubit, qcoOp.getQubitOut());
+    const SmallVector<Value, 1> qcoQubits{qcoOp.getQubitOut()};
+    commitQubits(state, operation, qcQubits, qcoQubits, materialized, rewriter);
 
     // Erase the old (it has no results to replace)
     rewriter.eraseOp(op);
@@ -1036,14 +1009,13 @@ struct ConvertQCGateToQCO final : StatefulOpConversionPattern<QCOpType> {
 
   template <std::size_t... TargetIndices, std::size_t... ParamIndices>
   auto createGate(ConversionPatternRewriter& rewriter, QCOpType op,
+                  const ValueRange qcoTargets,
                   std::index_sequence<TargetIndices...> /*targets*/,
                   std::index_sequence<ParamIndices...> /*params*/) const {
     auto params = op.getParameters();
-    auto& state = this->getState();
-    return QCOOpType::create(
-        rewriter, op.getLoc(),
-        lookupMappedQubit(state, op, op.getTargets()[TargetIndices])...,
-        params[ParamIndices]...);
+    return QCOOpType::create(rewriter, op.getLoc(),
+                             qcoTargets[TargetIndices]...,
+                             params[ParamIndices]...);
   }
 
   LogicalResult
@@ -1051,11 +1023,13 @@ struct ConvertQCGateToQCO final : StatefulOpConversionPattern<QCOpType> {
                   ConversionPatternRewriter& rewriter) const override {
     auto& state = this->getState();
     const auto qcTargets = op.getTargets();
-    auto qcoOp =
-        createGate(rewriter, op, std::make_index_sequence<NumTargets>{},
-                   std::make_index_sequence<NumParams>{});
+    auto materialized = materializeQubits(state, op, qcTargets, rewriter);
+    auto qcoOp = createGate(rewriter, op, materialized.values,
+                            std::make_index_sequence<NumTargets>{},
+                            std::make_index_sequence<NumParams>{});
 
-    assignMappedQubits(state, op, qcTargets, qcoOp.getOutputTargets());
+    commitQubits(state, op, qcTargets, qcoOp.getOutputTargets(), materialized,
+                 rewriter);
 
     rewriter.eraseOp(op);
 
@@ -1085,12 +1059,14 @@ struct ConvertQCBarrierOp final : StatefulOpConversionPattern<qc::BarrierOp> {
     auto& state = getState();
     auto* operation = op.getOperation();
     auto qcQubits = op.getQubits();
-    auto qcoQubits = resolveMappedQubits(state, operation, qcQubits);
+    auto materialized = materializeQubits(state, operation, qcQubits, rewriter);
 
     // Create qco.barrier
-    auto qcoOp = qco::BarrierOp::create(rewriter, op.getLoc(), qcoQubits);
+    auto qcoOp =
+        qco::BarrierOp::create(rewriter, op.getLoc(), materialized.values);
 
-    assignMappedQubits(state, operation, qcQubits, qcoOp.getQubitsOut());
+    commitQubits(state, operation, qcQubits, qcoOp.getQubitsOut(), materialized,
+                 rewriter);
 
     rewriter.eraseOp(op);
     return success();
@@ -1124,15 +1100,21 @@ struct ConvertQCCtrlOp final : StatefulOpConversionPattern<qc::CtrlOp> {
     auto* operation = op.getOperation();
     const auto qcControls = op.getControls();
     const auto qcTargets = op.getTargets();
-    auto qcoControls = resolveMappedQubits(state, operation, qcControls);
-    auto qcoTargets = resolveMappedQubits(state, operation, qcTargets);
+    const auto qcQubits = op.getQubits();
+    auto materialized = materializeQubits(state, operation, qcQubits, rewriter);
+    const auto qcoControls =
+        ValueRange(materialized.values).take_front(qcControls.size());
+    const auto qcoTargets =
+        ValueRange(materialized.values).drop_front(qcControls.size());
 
     // Create qco.ctrl
     auto qcoOp =
         qco::CtrlOp::create(rewriter, op.getLoc(), qcoControls, qcoTargets);
 
-    assignMappedQubits(state, operation, qcControls, qcoOp.getControlsOut());
-    assignMappedQubits(state, operation, qcTargets, qcoOp.getTargetsOut());
+    SmallVector<Value> qcoQubits;
+    llvm::append_range(qcoQubits, qcoOp.getControlsOut());
+    llvm::append_range(qcoQubits, qcoOp.getTargetsOut());
+    commitQubits(state, operation, qcQubits, qcoQubits, materialized, rewriter);
 
     auto qcArgs = op.getRegion().front().getArguments();
 
@@ -1175,12 +1157,14 @@ struct ConvertQCInvOp final : StatefulOpConversionPattern<qc::InvOp> {
     auto& state = getState();
     auto* operation = op.getOperation();
     const auto qcTargets = op.getTargets();
-    auto qcoTargets = resolveMappedQubits(state, operation, qcTargets);
+    auto materialized =
+        materializeQubits(state, operation, qcTargets, rewriter);
 
     // Create qco.inv
-    auto qcoOp = qco::InvOp::create(rewriter, op.getLoc(), qcoTargets);
+    auto qcoOp = qco::InvOp::create(rewriter, op.getLoc(), materialized.values);
 
-    assignMappedQubits(state, operation, qcTargets, qcoOp.getOutputTargets());
+    commitQubits(state, operation, qcTargets, qcoOp.getOutputTargets(),
+                 materialized, rewriter);
 
     auto qcArgs = op.getRegion().front().getArguments();
 
@@ -1223,13 +1207,15 @@ struct ConvertQCPowOp final : StatefulOpConversionPattern<qc::PowOp> {
     auto& state = getState();
     auto* operation = op.getOperation();
     const auto qcTargets = op.getTargets();
-    auto qcoTargets = resolveMappedQubits(state, operation, qcTargets);
+    auto materialized =
+        materializeQubits(state, operation, qcTargets, rewriter);
 
     // Create qco.pow with exponent.
-    auto qcoOp =
-        qco::PowOp::create(rewriter, op.getLoc(), qcoTargets, op.getExponent());
+    auto qcoOp = qco::PowOp::create(rewriter, op.getLoc(), materialized.values,
+                                    op.getExponent());
 
-    assignMappedQubits(state, operation, qcTargets, qcoOp.getQubitsOut());
+    commitQubits(state, operation, qcTargets, qcoOp.getQubitsOut(),
+                 materialized, rewriter);
 
     auto qcArgs = op.getRegion().front().getArguments();
 
@@ -1309,9 +1295,6 @@ struct ConvertSCFForOp final : StatefulOpConversionPattern<scf::ForOp> {
     const auto numRegisters = registerMap.size();
     const auto numQubits = qubitMap.size();
 
-    // Insert the extracted qubits back to the registers that are used inside
-    // the ForOp
-    insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
     const auto numOriginalResults = op.getNumResults();
     SmallVector<Value> initArgs(op.getInitArgs());
@@ -1339,14 +1322,11 @@ struct ConvertSCFForOp final : StatefulOpConversionPattern<scf::ForOp> {
       rewriter.replaceAllUsesWith(oldArgument, newArgument);
     }
 
-    // Extract all the previously inserted qubits again
-    rewriter.setInsertionPointAfter(newForOp);
-    extractQubitsAfterOp(state, operation, rewriter);
-
     SmallVector<Value> qubits(qubitMap.begin(), qubitMap.end());
-    SmallVector<Value> memrefs(registerMap.begin(), registerMap.end());
-    state.structuredValues[newForOp] = {.qubits = qubits, .memrefs = memrefs};
-    seedRegionMappings(state, newForOp.getRegion(), qubits, memrefs,
+    SmallVector<RegisterId> registers(registerMap.begin(), registerMap.end());
+    state.structuredValues[newForOp] = {.qubits = qubits,
+                                        .registers = registers};
+    seedRegionMappings(state, newForOp.getRegion(), qubits, registers,
                        dstBlock.getArguments().take_back(numQubits),
                        dstBlock.getArguments()
                            .drop_front(1 + numOriginalResults)
@@ -1398,9 +1378,6 @@ struct ConvertSCFWhileOp final : StatefulOpConversionPattern<scf::WhileOp> {
     const auto numRegisters = registerMap.size();
     const auto numQubits = qubitMap.size();
 
-    // Insert the extracted qubits back to the registers that are used inside
-    // the WhileOp
-    insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
     const auto numOriginalInits = op.getInits().size();
     const auto numOriginalResults = op.getNumResults();
@@ -1453,19 +1430,16 @@ struct ConvertSCFWhileOp final : StatefulOpConversionPattern<scf::WhileOp> {
       rewriter.replaceAllUsesWith(oldArgument, newArgument);
     }
 
-    // Extract all the previously inserted qubits again
-    rewriter.setInsertionPointAfter(newWhileOp);
-    extractQubitsAfterOp(state, operation, rewriter);
-
     SmallVector<Value> qubits(qubitMap.begin(), qubitMap.end());
-    SmallVector<Value> memrefs(registerMap.begin(), registerMap.end());
-    state.structuredValues[newWhileOp] = {.qubits = qubits, .memrefs = memrefs};
-    seedRegionMappings(state, newWhileOp.getBefore(), qubits, memrefs,
+    SmallVector<RegisterId> registers(registerMap.begin(), registerMap.end());
+    state.structuredValues[newWhileOp] = {.qubits = qubits,
+                                          .registers = registers};
+    seedRegionMappings(state, newWhileOp.getBefore(), qubits, registers,
                        newBeforeBlock->getArguments().take_back(numQubits),
                        newBeforeBlock->getArguments()
                            .drop_front(numOriginalInits)
                            .take_front(numRegisters));
-    seedRegionMappings(state, newWhileOp.getAfter(), qubits, memrefs,
+    seedRegionMappings(state, newWhileOp.getAfter(), qubits, registers,
                        newAfterBlock->getArguments().take_back(numQubits),
                        newAfterBlock->getArguments()
                            .drop_front(numOriginalResults)
@@ -1509,9 +1483,6 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
     const auto numRegisters = registerMap.size();
     const auto numQubits = qubitMap.size();
 
-    // Insert the extracted qubits back to the registers that are used inside
-    // the IfOp
-    insertQubitsBeforeOp(state, operation, rewriter);
     auto qcoTargets = resolveAllValues(state, operation);
 
     // Create the new IfOp
@@ -1522,10 +1493,6 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
                         newIfOp.getLinearResults().take_front(numRegisters));
     assignMappedQubits(state, op.getOperation(), qubitMap,
                        newIfOp.getLinearResults().take_back(numQubits));
-
-    // Extract all the previously inserted qubits again
-    rewriter.setInsertionPointAfter(newIfOp);
-    extractQubitsAfterOp(state, operation, rewriter);
 
     auto& thenRegion = newIfOp.getThenRegion();
     auto& elseRegion = newIfOp.getElseRegion();
@@ -1544,13 +1511,14 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
         thenBlock->end(), op.getThenRegion().front().getOperations());
 
     SmallVector<Value> qubits(qubitMap.begin(), qubitMap.end());
-    SmallVector<Value> memrefs(registerMap.begin(), registerMap.end());
-    state.structuredValues[newIfOp] = {.qubits = qubits, .memrefs = memrefs};
+    SmallVector<RegisterId> registers(registerMap.begin(), registerMap.end());
+    state.structuredValues[newIfOp] = {.qubits = qubits,
+                                       .registers = registers};
 
     if (!op.getElseRegion().empty()) {
       elseBlock->getOperations().splice(
           elseBlock->end(), op.getElseRegion().front().getOperations());
-      seedRegionMappings(state, newIfOp.getElseRegion(), qubits, memrefs,
+      seedRegionMappings(state, newIfOp.getElseRegion(), qubits, registers,
                          elseBlock->getArguments().take_back(numQubits),
                          elseBlock->getArguments().take_front(numRegisters));
 
@@ -1560,7 +1528,7 @@ struct ConvertSCFIfOp final : StatefulOpConversionPattern<scf::IfOp> {
       qco::YieldOp::create(rewriter, op->getLoc(), elseBlock->getArguments());
     }
 
-    seedRegionMappings(state, newIfOp.getThenRegion(), qubits, memrefs,
+    seedRegionMappings(state, newIfOp.getThenRegion(), qubits, registers,
                        thenBlock->getArguments().take_back(numQubits),
                        thenBlock->getArguments().take_front(numRegisters));
 
@@ -1609,7 +1577,6 @@ struct ConvertSCFIndexSwitchOp final
     const auto numRegisters = registerMap.size();
     const auto numQubits = qubitMap.size();
 
-    insertQubitsBeforeOp(state, operation, rewriter);
     const auto targets = resolveAllValues(state, operation);
     const auto linearResultTypes = ValueRange(targets).getTypes();
     const SmallVector locs(targets.size(), op.getLoc());
@@ -1623,12 +1590,9 @@ struct ConvertSCFIndexSwitchOp final
     assignMappedQubits(state, op.getOperation(), qubitMap,
                        newOp.getLinearResults().take_back(numQubits));
 
-    rewriter.setInsertionPointAfter(newOp);
-    extractQubitsAfterOp(state, operation, rewriter);
-
     SmallVector<Value> qubits(qubitMap.begin(), qubitMap.end());
-    SmallVector<Value> memrefs(registerMap.begin(), registerMap.end());
-    state.structuredValues[newOp] = {.qubits = qubits, .memrefs = memrefs};
+    SmallVector<RegisterId> registers(registerMap.begin(), registerMap.end());
+    state.structuredValues[newOp] = {.qubits = qubits, .registers = registers};
 
     const auto newCaseRegions = newOp.getCaseRegions();
     const auto oldCaseRegions = op.getCaseRegions();
@@ -1639,7 +1603,7 @@ struct ConvertSCFIndexSwitchOp final
       newBlock->getOperations().splice(newBlock->end(),
                                        oldBlock->getOperations());
 
-      seedRegionMappings(state, newRegion, qubits, memrefs,
+      seedRegionMappings(state, newRegion, qubits, registers,
                          newBlock->getArguments().take_back(numQubits),
                          newBlock->getArguments().take_front(numRegisters));
     };
@@ -1678,7 +1642,6 @@ struct ConvertSCFYieldOp final : StatefulOpConversionPattern<scf::YieldOp> {
     auto& state = getState();
     auto* operation = op.getOperation();
 
-    insertQubitsBeforeOp(state, op.getOperation(), rewriter);
     SmallVector<Value> targets(op.getResults());
     llvm::append_range(targets, resolveAllValues(state, operation));
 
@@ -1715,7 +1678,6 @@ struct ConvertSCFConditionOp final
     auto& state = getState();
     auto* operation = op.getOperation();
 
-    insertQubitsBeforeOp(state, op.getOperation(), rewriter);
     SmallVector<Value> targets(op.getArgs());
     llvm::append_range(targets, resolveAllValues(state, operation));
 
@@ -1758,7 +1720,12 @@ protected:
     RewritePatternSet patterns(context);
     QCToQCOTypeConverter typeConverter(context);
 
-    // Get the qubit values inside the scf ops
+    if (failed(collectRegisterAccesses(module, state))) {
+      signalPassFailure();
+      return;
+    }
+
+    // Get the qubit values and registers used inside the scf ops.
     collectQubitValuesInsideSCFOps(module, &state);
 
     // Configure conversion target
@@ -1842,6 +1809,14 @@ protected:
       signalPassFailure();
       return;
     }
+
+    // Source register values and loaded qubit references have been erased.
+    // Structured conversion state uses stable register identifiers from here
+    // on.
+    state.registerIds.clear();
+    state.registerAccesses.clear();
+    state.regionQubitMap.clear();
+    state.regionRegisterMap.clear();
 
     ConversionTarget terminatorTarget(*context);
     terminatorTarget.markUnknownOpDynamicallyLegal(

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Conversion/ConversionUtils.h"
 #include "mlir/Conversion/GateTable.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
@@ -36,6 +37,7 @@
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/WalkResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 
 #include <cassert>
@@ -424,10 +426,12 @@ static void seedRegionMappings(LoweringState& state, Region& region,
 }
 
 /** @brief QCO operands and register provenance materialized for a QC op. */
+namespace {
 struct MaterializedQubits {
   SmallVector<Value> values;
   SmallVector<std::optional<RegisterAccess>> accesses;
 };
+} // namespace
 
 /**
  * @brief Materializes register-backed qubits immediately before a quantum op.
@@ -1099,7 +1103,6 @@ struct ConvertQCCtrlOp final : StatefulOpConversionPattern<qc::CtrlOp> {
     auto& state = getState();
     auto* operation = op.getOperation();
     const auto qcControls = op.getControls();
-    const auto qcTargets = op.getTargets();
     const auto qcQubits = op.getQubits();
     auto materialized = materializeQubits(state, operation, qcQubits, rewriter);
     const auto qcoControls =

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -113,15 +113,6 @@ enum class AllocationMode : std::uint8_t {
  * - %q2 after the X gate
  */
 struct LoweringState {
-  struct ModifierFrame {
-    /// QC qubits yielded from the current modifier region, in yield order.
-    SmallVector<Value> qcQubits;
-
-    /// Latest QCO SSA values for QC qubits that are remapped inside the
-    /// modifier region.
-    DenseMap<Value, Value> currentQubits;
-  };
-
   struct StructuredValues {
     SmallVector<Value> qubits;
     SmallVector<RegisterId> registers;
@@ -144,6 +135,10 @@ struct LoweringState {
   /// Transient provenance for register-backed QC qubit references.
   DenseMap<Value, RegisterAccess> registerAccesses;
 
+  /// Transient canonical keys for modifier block arguments replaced by
+  /// dialect-conversion signature conversion.
+  DenseMap<Value, Value> convertedQubitAliases;
+
   /// Map from an operation to its used QC qubits inside its regions
   DenseMap<Operation*, SetVector<Value>> regionQubitMap;
 
@@ -155,8 +150,8 @@ struct LoweringState {
   /// remain legal.
   DenseMap<Operation*, StructuredValues> structuredValues;
 
-  /// Stack of active modifier regions
-  SmallVector<ModifierFrame> modifierFrames;
+  /// Qubit keys yielded by converted modifier regions, in yield order.
+  DenseMap<Region*, SmallVector<Value>> modifierRegionQubits;
 
   /// The qubit allocation mode used in the module
   AllocationMode allocationMode = AllocationMode::Unset;
@@ -207,18 +202,6 @@ private:
 };
 } // namespace
 
-/** @brief Returns whether lowering currently processes a modifier body. */
-[[nodiscard]] static bool isInsideModifier(const LoweringState& state) {
-  return !state.modifierFrames.empty();
-}
-
-/** @brief Returns the active modifier frame. */
-[[nodiscard]] static LoweringState::ModifierFrame&
-currentModifierFrame(LoweringState& state) {
-  assert(isInsideModifier(state) && "expected active modifier frame");
-  return state.modifierFrames.back();
-}
-
 /** @brief Resolves the stable identifier for a source QC register value. */
 [[nodiscard]] static RegisterId lookupRegisterId(const LoweringState& state,
                                                  const Value memref) {
@@ -250,17 +233,21 @@ findRegionLocalMap(DenseMap<Region*, DenseMap<Key, Value>>& map,
   return {nullptr, nullptr};
 }
 
+/** @brief Canonicalizes a source qubit key after block signature conversion. */
+[[nodiscard]] static Value canonicalQubitKey(const LoweringState& state,
+                                             Value qubit) {
+  for (auto alias = state.convertedQubitAliases.find(qubit);
+       alias != state.convertedQubitAliases.end();
+       alias = state.convertedQubitAliases.find(qubit)) {
+    qubit = alias->second;
+  }
+  return qubit;
+}
+
 /** @brief Resolves the latest QCO SSA value for a QC qubit reference. */
 [[nodiscard]] static Value lookupMappedQubit(LoweringState& state,
                                              Operation* anchor, Value qcQubit) {
-  if (isInsideModifier(state)) {
-    auto& frame = currentModifierFrame(state);
-    if (auto it = frame.currentQubits.find(qcQubit);
-        it != frame.currentQubits.end()) {
-      return it->second;
-    }
-  }
-
+  qcQubit = canonicalQubitKey(state, qcQubit);
   const auto& [qubitMap, qubitValue] =
       findRegionLocalMap(state.qubitMap, anchor, qcQubit);
   assert(qubitMap != nullptr && qubitValue != nullptr && "QC qubit not found");
@@ -281,17 +268,7 @@ findRegionLocalMap(DenseMap<Region*, DenseMap<Key, Value>>& map,
 /** @brief Updates the latest QCO SSA value for a QC qubit reference. */
 static void assignMappedQubit(LoweringState& state, Operation* anchor,
                               Value qcQubit, Value qcoQubit) {
-  if (isInsideModifier(state)) {
-    auto& frame = currentModifierFrame(state);
-    if (auto it = frame.currentQubits.find(qcQubit);
-        it != frame.currentQubits.end()) {
-      it->second = qcoQubit;
-      return;
-    }
-    frame.currentQubits.try_emplace(qcQubit, qcoQubit);
-    return;
-  }
-
+  qcQubit = canonicalQubitKey(state, qcQubit);
   auto [qubitMap, qubitValue] =
       findRegionLocalMap(state.qubitMap, anchor, qcQubit);
   if (qubitValue != nullptr) {
@@ -363,22 +340,6 @@ static void assignMappedTensors(LoweringState& state, Operation* anchor,
   }
 }
 
-/** @brief Pushes a new modifier frame seeded with aliased target values. */
-static void pushModifierFrame(LoweringState& state, ValueRange qcTargets,
-                              ValueRange qcoTargets) {
-  auto& frame = state.modifierFrames.emplace_back();
-  llvm::append_range(frame.qcQubits, qcTargets);
-  for (auto [qcTarget, qcoTarget] : llvm::zip_equal(qcTargets, qcoTargets)) {
-    frame.currentQubits.try_emplace(qcTarget, qcoTarget);
-  }
-}
-
-/** @brief Pops the active modifier frame after lowering its yield. */
-static void popModifierFrame(LoweringState& state) {
-  assert(isInsideModifier(state) && "expected active modifier frame");
-  state.modifierFrames.pop_back();
-}
-
 /** @brief Returns the structured parent whose quantum values a terminator
  * yields. */
 [[nodiscard]] static Operation* structuredValueOwner(Operation* operation) {
@@ -396,7 +357,7 @@ static void seedRegionMappings(LoweringState& state, Region& region,
                                ValueRange qcoQubits, ValueRange tensors) {
   auto& qubitMap = state.qubitMap[&region];
   for (auto [qcQubit, qcoQubit] : llvm::zip_equal(qcQubits, qcoQubits)) {
-    qubitMap[qcQubit] = qcoQubit;
+    qubitMap[canonicalQubitKey(state, qcQubit)] = qcoQubit;
   }
   auto& tensorMap = state.tensorMap[&region];
   for (auto [reg, tensor] : llvm::zip_equal(registers, tensors)) {
@@ -577,6 +538,29 @@ collectRegisterAccesses(Operation* root, LoweringState& state) {
   return success(!distinctResult.wasInterrupted());
 }
 
+/** @brief Rejects forbidden operations recursively nested in QC modifiers. */
+[[nodiscard]] static LogicalResult validateModifierBodies(Operation* root) {
+  const auto result = root->walk([&](Operation* operation) {
+    if (!isa<qc::AllocOp, qc::DeallocOp, qc::MeasureOp, qc::ResetOp,
+             memref::LoadOp, memref::StoreOp>(operation)) {
+      return WalkResult::advance();
+    }
+
+    for (auto* parent = operation->getParentOp(); parent != nullptr;
+         parent = parent->getParentOp()) {
+      if (!isa<qc::InvOp, qc::CtrlOp, qc::PowOp>(parent)) {
+        continue;
+      }
+      parent->emitOpError(
+          "body must not contain non-unitary quantum operations or modify a "
+          "quantum register");
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return success(!result.wasInterrupted());
+}
+
 /** @brief Collects values captured by supported structured control flow. */
 static void collectStructuredCaptures(Operation* root, LoweringState& state) {
   root->walk([&](Operation* operation) {
@@ -590,6 +574,8 @@ static void collectStructuredCaptures(Operation* root, LoweringState& state) {
 
     auto& qubits = state.regionQubitMap[operation];
     auto& registers = state.regionRegisterMap[operation];
+    qubits.clear();
+    registers.clear();
     for (const auto value : captures) {
       if (const auto access = state.registerAccesses.find(value);
           access != state.registerAccesses.end()) {
@@ -606,6 +592,50 @@ static void collectStructuredCaptures(Operation* root, LoweringState& state) {
       }
     }
   });
+}
+
+/**
+ * @brief Canonicalizes preserved SCF capture keys after signature conversion.
+ */
+static void remapStructuredCaptures(Operation* root, LoweringState& state) {
+  root->walk([&](Operation* operation) {
+    if (!isa<scf::ForOp, scf::WhileOp, scf::IfOp, scf::IndexSwitchOp>(
+            operation)) {
+      return;
+    }
+
+    const auto captures = state.regionQubitMap.find(operation);
+    if (captures == state.regionQubitMap.end()) {
+      return;
+    }
+
+    SetVector<Value> remapped;
+    for (const auto qubit : captures->second) {
+      remapped.insert(canonicalQubitKey(state, qubit));
+    }
+    captures->second = std::move(remapped);
+  });
+}
+
+/** @brief Seeds region-owned modifier state after signature conversion. */
+static void initializeModifierRegionState(Operation* modifier,
+                                          ValueRange sourceArguments,
+                                          LoweringState& state) {
+  auto& region = modifier->getRegion(0);
+  const auto convertedArguments = region.front().getArguments();
+  for (auto [source, converted] :
+       llvm::zip_equal(sourceArguments, convertedArguments)) {
+    state.convertedQubitAliases[source] = converted;
+  }
+  state.modifierRegionQubits[&region] =
+      SmallVector<Value>(convertedArguments.begin(), convertedArguments.end());
+  seedRegionMappings(state, region, convertedArguments, {}, convertedArguments,
+                     {});
+
+  // Signature conversion replaces modifier block arguments. Refresh nested
+  // structured captures so they refer to the converted arguments owned by the
+  // moved region rather than source conversion keys.
+  remapStructuredCaptures(modifier, state);
 }
 
 namespace {
@@ -1117,7 +1147,8 @@ struct ConvertQCCtrlOp final : StatefulOpConversionPattern<qc::CtrlOp> {
     llvm::append_range(qcoQubits, qcoOp.getTargetsOut());
     commitQubits(state, operation, qcQubits, qcoQubits, materialized, rewriter);
 
-    auto qcArgs = op.getRegion().front().getArguments();
+    const SmallVector<Value> sourceArguments(
+        op.getRegion().front().getArguments());
 
     // Inline region and convert the block signature to QCO types.
     if (failed(moveRegion(op.getRegion(), qcoOp.getRegion(), rewriter,
@@ -1125,7 +1156,7 @@ struct ConvertQCCtrlOp final : StatefulOpConversionPattern<qc::CtrlOp> {
       return failure();
     }
 
-    pushModifierFrame(state, qcArgs, qcoOp.getRegion().front().getArguments());
+    initializeModifierRegionState(qcoOp, sourceArguments, state);
 
     rewriter.eraseOp(op);
     return success();
@@ -1167,7 +1198,8 @@ struct ConvertQCInvOp final : StatefulOpConversionPattern<qc::InvOp> {
     commitQubits(state, operation, qcTargets, qcoOp.getOutputTargets(),
                  materialized, rewriter);
 
-    auto qcArgs = op.getRegion().front().getArguments();
+    const SmallVector<Value> sourceArguments(
+        op.getRegion().front().getArguments());
 
     // Inline region and convert the block signature to QCO types.
     if (failed(moveRegion(op.getRegion(), qcoOp.getRegion(), rewriter,
@@ -1175,7 +1207,7 @@ struct ConvertQCInvOp final : StatefulOpConversionPattern<qc::InvOp> {
       return failure();
     }
 
-    pushModifierFrame(state, qcArgs, qcoOp.getRegion().front().getArguments());
+    initializeModifierRegionState(qcoOp, sourceArguments, state);
 
     rewriter.eraseOp(op);
     return success();
@@ -1218,7 +1250,8 @@ struct ConvertQCPowOp final : StatefulOpConversionPattern<qc::PowOp> {
     commitQubits(state, operation, qcTargets, qcoOp.getQubitsOut(),
                  materialized, rewriter);
 
-    auto qcArgs = op.getRegion().front().getArguments();
+    const SmallVector<Value> sourceArguments(
+        op.getRegion().front().getArguments());
 
     // Inline region and convert the block signature to QCO types.
     if (failed(moveRegion(op.getRegion(), qcoOp.getRegion(), rewriter,
@@ -1226,7 +1259,7 @@ struct ConvertQCPowOp final : StatefulOpConversionPattern<qc::PowOp> {
       return failure();
     }
 
-    pushModifierFrame(state, qcArgs, qcoOp.getRegion().front().getArguments());
+    initializeModifierRegionState(qcoOp, sourceArguments, state);
 
     rewriter.eraseOp(op);
     return success();
@@ -1253,10 +1286,16 @@ struct ConvertQCYieldOp final : StatefulOpConversionPattern<qc::YieldOp> {
                   ConversionPatternRewriter& rewriter) const override {
     auto& state = getState();
     auto* operation = op.getOperation();
-    auto& frame = currentModifierFrame(state);
-    auto targets = resolveMappedQubits(state, operation, frame.qcQubits);
+    auto* region = op->getParentRegion();
+    const auto frame = state.modifierRegionQubits.find(region);
+    if (frame == state.modifierRegionQubits.end()) {
+      return rewriter.notifyMatchFailure(op, "missing modifier region state");
+    }
+
+    auto targets = resolveMappedQubits(state, operation, frame->second);
     rewriter.replaceOpWithNewOp<qco::YieldOp>(op, targets);
-    popModifierFrame(state);
+    state.qubitMap.erase(region);
+    state.modifierRegionQubits.erase(frame);
     return success();
   }
 };
@@ -1721,7 +1760,8 @@ protected:
     RewritePatternSet patterns(context);
     QCToQCOTypeConverter typeConverter(context);
 
-    if (failed(collectRegisterAccesses(module, state))) {
+    if (failed(validateModifierBodies(module)) ||
+        failed(collectRegisterAccesses(module, state))) {
       signalPassFailure();
       return;
     }
@@ -1816,6 +1856,7 @@ protected:
     // on.
     state.registerIds.clear();
     state.registerAccesses.clear();
+    state.convertedQubitAliases.clear();
     state.regionQubitMap.clear();
     state.regionRegisterMap.clear();
 

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -20,12 +20,14 @@
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/BuiltinTypes.h>
@@ -39,6 +41,7 @@
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Support/WalkResult.h>
 #include <mlir/Transforms/DialectConversion.h>
+#include <mlir/Transforms/RegionUtils.h>
 
 #include <cassert>
 #include <cstddef>
@@ -66,6 +69,12 @@ struct RegisterAccess {
   RegisterId reg;
   /// Index of the qubit within its register
   Value index;
+};
+
+/** @brief Indices already used for one register by a quantum operation. */
+struct SeenRegisterIndices {
+  DenseMap<int64_t, Value> constants;
+  llvm::SmallDenseSet<Value, 4> dynamicValues;
 };
 
 /** @brief Qubit allocation mode */
@@ -108,17 +117,9 @@ struct LoweringState {
     /// QC qubits yielded from the current modifier region, in yield order.
     SmallVector<Value> qcQubits;
 
-    /// Qubit registers yielded from the current modifier region, in yield
-    /// order.
-    SmallVector<RegisterId> registers;
-
     /// Latest QCO SSA values for QC qubits that are remapped inside the
     /// modifier region.
     DenseMap<Value, Value> currentQubits;
-
-    /// Latest QTensor SSA values for registers that are remapped inside the
-    /// modifier region.
-    DenseMap<RegisterId, Value> currentRegisters;
   };
 
   struct StructuredValues {
@@ -270,14 +271,6 @@ findRegionLocalMap(DenseMap<Region*, DenseMap<Key, Value>>& map,
 [[nodiscard]] static Value lookupMappedTensor(LoweringState& state,
                                               Operation* anchor,
                                               const RegisterId reg) {
-
-  if (isInsideModifier(state)) {
-    auto& frame = currentModifierFrame(state);
-    if (auto it = frame.currentRegisters.find(reg);
-        it != frame.currentRegisters.end()) {
-      return it->second;
-    }
-  }
   const auto& [tensorMap, tensorValue] =
       findRegionLocalMap(state.tensorMap, anchor, reg);
   assert(tensorMap != nullptr && tensorValue != nullptr &&
@@ -316,17 +309,6 @@ static void assignMappedQubit(LoweringState& state, Operation* anchor,
 /** @brief Updates the latest QTensor SSA value for a QC register. */
 static void assignMappedTensor(LoweringState& state, Operation* anchor,
                                const RegisterId reg, Value tensor) {
-  if (isInsideModifier(state)) {
-    auto& frame = currentModifierFrame(state);
-    if (auto it = frame.currentRegisters.find(reg);
-        it != frame.currentRegisters.end()) {
-      it->second = tensor;
-      return;
-    }
-    frame.currentRegisters.try_emplace(reg, tensor);
-    return;
-  }
-
   auto [tensorMap, tensorValue] =
       findRegionLocalMap(state.tensorMap, anchor, reg);
 
@@ -384,13 +366,10 @@ static void assignMappedTensors(LoweringState& state, Operation* anchor,
 /** @brief Pushes a new modifier frame seeded with aliased target values. */
 static void pushModifierFrame(LoweringState& state, ValueRange qcTargets,
                               ValueRange qcoTargets) {
-  auto& [yieldOrder, registers, currentQubits, currentRegisters] =
-      state.modifierFrames.emplace_back();
-  static_cast<void>(registers);
-  static_cast<void>(currentRegisters);
-  llvm::append_range(yieldOrder, qcTargets);
+  auto& frame = state.modifierFrames.emplace_back();
+  llvm::append_range(frame.qcQubits, qcTargets);
   for (auto [qcTarget, qcoTarget] : llvm::zip_equal(qcTargets, qcoTargets)) {
-    currentQubits.try_emplace(qcTarget, qcoTarget);
+    frame.currentQubits.try_emplace(qcTarget, qcoTarget);
   }
 }
 
@@ -493,20 +472,14 @@ static void commitQubits(LoweringState& state, Operation* anchor,
                                                          Operation* anchor) {
   SmallVector<RegisterId> registers;
   SmallVector<Value> qcQubits;
-  if (isInsideModifier(state) && anchor->getNumRegions() == 0) {
-    auto& frame = currentModifierFrame(state);
-    registers = frame.registers;
-    qcQubits = frame.qcQubits;
+  auto* owner = structuredValueOwner(anchor);
+  if (const auto it = state.structuredValues.find(owner);
+      it != state.structuredValues.end()) {
+    llvm::append_range(registers, it->second.registers);
+    llvm::append_range(qcQubits, it->second.qubits);
   } else {
-    auto* owner = structuredValueOwner(anchor);
-    if (const auto it = state.structuredValues.find(owner);
-        it != state.structuredValues.end()) {
-      llvm::append_range(registers, it->second.registers);
-      llvm::append_range(qcQubits, it->second.qubits);
-    } else {
-      llvm::append_range(registers, state.regionRegisterMap[owner]);
-      llvm::append_range(qcQubits, state.regionQubitMap[owner]);
-    }
+    llvm::append_range(registers, state.regionRegisterMap[owner]);
+    llvm::append_range(qcQubits, state.regionQubitMap[owner]);
   }
 
   SmallVector<Value> qcoTargets;
@@ -554,60 +527,85 @@ collectRegisterAccesses(Operation* root, LoweringState& state) {
     return WalkResult::advance();
   });
 
-  return success(!result.wasInterrupted());
-}
-
-/**
- * @brief Collects standalone qubits and registers used by structured control.
- */
-static std::pair<SetVector<Value>, SetVector<RegisterId>>
-collectQubitValuesInsideSCFOps(Operation* op, LoweringState* state) {
-  for (auto& region : op->getRegions()) {
-    // Skip empty regions e.g. empty else region of an If operation
-    if (region.empty()) {
-      continue;
-    }
-    // Check that the region has only one block
-    assert(region.hasOneBlock() && "Expected single-block region");
-    // Iterate through all operations of the current region
-    for (auto& operation : region.front().getOperations()) {
-      // Recursively walk through nested regions
-      if (operation.getNumRegions() > 0 &&
-          !isa<qc::CtrlOp, qc::InvOp>(operation)) {
-        auto [qubits, registers] =
-            collectQubitValuesInsideSCFOps(&operation, state);
-        auto& regionQubitMap = state->regionQubitMap[op];
-        regionQubitMap.set_union(qubits);
-        state->regionRegisterMap[op].set_union(registers);
-      }
-      auto& regionRegisterMap = state->regionRegisterMap[op];
-      if (auto loadOp = dyn_cast<memref::LoadOp>(operation);
-          loadOp &&
-          isa<qc::QubitType>(loadOp.getMemRefType().getElementType())) {
-        regionRegisterMap.insert(
-            state->registerAccesses.find(loadOp.getResult())->second.reg);
-        continue;
-      }
-      auto& regionQubitMap = state->regionQubitMap[op];
-      for (const auto& operand : operation.getOperands()) {
-        if (isa<qc::QubitType>(operand.getType())) {
-          if (const auto access = state->registerAccesses.find(operand);
-              access != state->registerAccesses.end()) {
-            regionRegisterMap.insert(access->second.reg);
-          } else {
-            regionQubitMap.insert(operand);
-          }
-        }
-        if (auto memref = dyn_cast<MemRefType>(operand.getType())) {
-          if (isa<qc::QubitType>(memref.getElementType())) {
-            regionRegisterMap.insert(lookupRegisterId(*state, operand));
-          }
-        }
-      }
-    }
+  if (result.wasInterrupted()) {
+    return failure();
   }
 
-  return {state->regionQubitMap[op], state->regionRegisterMap[op]};
+  const auto distinctResult = root->walk([&](Operation* operation) {
+    auto unitary = dyn_cast<qc::UnitaryOpInterface>(operation);
+    if (!unitary || unitary.getNumQubits() < 2) {
+      return WalkResult::advance();
+    }
+
+    llvm::SmallDenseSet<Value, 4> qubits;
+    DenseMap<RegisterId, SeenRegisterIndices> registerIndices;
+    for (const auto qubit : unitary.getQubits()) {
+      if (!qubits.insert(qubit).second) {
+        operation->emitOpError("requires distinct qubit operands");
+        return WalkResult::interrupt();
+      }
+
+      const auto access = state.registerAccesses.find(qubit);
+      if (access == state.registerAccesses.end()) {
+        continue;
+      }
+
+      auto& seen = registerIndices[access->second.reg];
+      if (const auto constant = getConstantIntValue(access->second.index)) {
+        const auto [it, inserted] =
+            seen.constants.try_emplace(*constant, access->second.index);
+        if (!inserted &&
+            isEqualConstantIntOrValue(it->second, access->second.index)) {
+          operation->emitOpError(
+              "requires distinct qubit operands; register-backed operands "
+              "have the same constant index");
+          return WalkResult::interrupt();
+        }
+        continue;
+      }
+
+      if (!seen.dynamicValues.insert(access->second.index).second) {
+        operation->emitOpError(
+            "requires distinct qubit operands; register-backed operands use "
+            "the same dynamic index");
+        return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+
+  return success(!distinctResult.wasInterrupted());
+}
+
+/** @brief Collects values captured by supported structured control flow. */
+static void collectStructuredCaptures(Operation* root, LoweringState& state) {
+  root->walk([&](Operation* operation) {
+    if (!isa<scf::ForOp, scf::WhileOp, scf::IfOp, scf::IndexSwitchOp>(
+            operation)) {
+      return;
+    }
+
+    SetVector<Value> captures;
+    getUsedValuesDefinedAbove(operation->getRegions(), captures);
+
+    auto& qubits = state.regionQubitMap[operation];
+    auto& registers = state.regionRegisterMap[operation];
+    for (const auto value : captures) {
+      if (const auto access = state.registerAccesses.find(value);
+          access != state.registerAccesses.end()) {
+        registers.insert(access->second.reg);
+        continue;
+      }
+      if (isa<qc::QubitType>(value.getType())) {
+        qubits.insert(value);
+        continue;
+      }
+      if (const auto type = dyn_cast<MemRefType>(value.getType());
+          type && isa<qc::QubitType>(type.getElementType())) {
+        registers.insert(lookupRegisterId(state, value));
+      }
+    }
+  });
 }
 
 namespace {
@@ -1728,8 +1726,8 @@ protected:
       return;
     }
 
-    // Get the qubit values and registers used inside the scf ops.
-    collectQubitValuesInsideSCFOps(module, &state);
+    // Get the quantum values captured by structured control-flow regions.
+    collectStructuredCaptures(module, state);
 
     // Configure conversion target
     target.addIllegalDialect<QCDialect>();

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -28,6 +28,7 @@
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
+#include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/BuiltinTypes.h>
@@ -201,6 +202,12 @@ private:
   LoweringState* state_;
 };
 } // namespace
+
+/** @brief Returns whether a type is ranked or unranked QC qubit storage. */
+[[nodiscard]] static bool isQubitMemrefType(const Type type) {
+  const auto memref = dyn_cast<BaseMemRefType>(type);
+  return memref && isa<qc::QubitType>(memref.getElementType());
+}
 
 /** @brief Resolves the stable identifier for a source QC register value. */
 [[nodiscard]] static RegisterId lookupRegisterId(const LoweringState& state,
@@ -451,43 +458,83 @@ static void commitQubits(LoweringState& state, Operation* anchor,
   return qcoTargets;
 }
 
-/** @brief Collects stable register identifiers and load provenance. */
+/** @brief Rejects quantum SSA sources unsupported by the lowering state. */
 [[nodiscard]] static LogicalResult
-collectRegisterAccesses(Operation* root, LoweringState& state) {
-  const auto allocationResult = root->walk([&](memref::AllocOp op) {
-    if (!isa<qc::QubitType>(op.getType().getElementType())) {
-      return WalkResult::advance();
+validateQuantumValueSources(Operation* root) {
+  const auto result = root->walk([&](Operation* operation) {
+    const bool isModifier = isa<qc::InvOp, qc::CtrlOp, qc::PowOp>(operation);
+    for (Region& region : operation->getRegions()) {
+      for (Block& block : region) {
+        for (const auto argument : block.getArguments()) {
+          const bool isQubit = isa<qc::QubitType>(argument.getType());
+          if ((!isQubit && !isQubitMemrefType(argument.getType())) ||
+              (isModifier && isQubit)) {
+            continue;
+          }
+
+          operation->emitOpError(
+              "cannot convert arbitrary qubit or qubit-register block "
+              "arguments; only QC modifier qubit arguments are supported");
+          return WalkResult::interrupt();
+        }
+      }
     }
 
-    if (op.getType().getRank() != 1) {
-      op.emitOpError("requires one-dimensional qubit register storage");
-      return WalkResult::interrupt();
-    }
-
-    const auto reg = state.registerIds.size();
-    state.registerIds.try_emplace(op.getResult(), reg);
-    return WalkResult::advance();
-  });
-  if (allocationResult.wasInterrupted()) {
-    return failure();
-  }
-
-  const auto registerUseResult = root->walk([&](Operation* operation) {
-    for (const auto operand : operation->getOperands()) {
-      const auto type = dyn_cast<MemRefType>(operand.getType());
-      if (!type || !isa<qc::QubitType>(type.getElementType()) ||
-          state.registerIds.contains(operand)) {
+    for (const auto value : operation->getResults()) {
+      if (isQubitMemrefType(value.getType())) {
+        auto allocation = dyn_cast<memref::AllocOp>(operation);
+        if (!allocation) {
+          operation->emitOpError(
+              "requires a directly allocated qubit register");
+          return WalkResult::interrupt();
+        }
+        if (allocation.getType().getRank() != 1) {
+          operation->emitOpError(
+              "requires one-dimensional qubit register storage");
+          return WalkResult::interrupt();
+        }
         continue;
       }
 
-      operation->emitOpError("requires a directly allocated qubit register");
-      return WalkResult::interrupt();
+      if (isa<qc::QubitType>(value.getType()) &&
+          !isa<qc::AllocOp, qc::StaticOp, memref::LoadOp>(operation)) {
+        operation->emitOpError(
+            "produces an unsupported qubit reference; use qc.alloc, "
+            "qc.static, a qubit-register load, or a QC modifier argument");
+        return WalkResult::interrupt();
+      }
+    }
+
+    const bool supportsQuantumCaptures =
+        isModifier ||
+        isa<scf::ForOp, scf::WhileOp, scf::IfOp, scf::IndexSwitchOp>(operation);
+    if (!supportsQuantumCaptures && operation->getNumRegions() != 0) {
+      SetVector<Value> captures;
+      getUsedValuesDefinedAbove(operation->getRegions(), captures);
+      if (llvm::any_of(captures, [](const Value value) {
+            return isa<qc::QubitType>(value.getType()) ||
+                   isQubitMemrefType(value.getType());
+          })) {
+        operation->emitOpError(
+            "cannot capture quantum values in an unsupported region-bearing "
+            "operation; use scf.for, scf.while, scf.if, or scf.index_switch");
+        return WalkResult::interrupt();
+      }
     }
     return WalkResult::advance();
   });
-  if (registerUseResult.wasInterrupted()) {
-    return failure();
-  }
+  return success(!result.wasInterrupted());
+}
+
+/** @brief Collects stable register identifiers and load provenance. */
+[[nodiscard]] static LogicalResult
+collectRegisterAccesses(Operation* root, LoweringState& state) {
+  root->walk([&](memref::AllocOp op) {
+    if (isa<qc::QubitType>(op.getType().getElementType())) {
+      const auto reg = state.registerIds.size();
+      state.registerIds.try_emplace(op.getResult(), reg);
+    }
+  });
 
   const auto result = root->walk([&](memref::LoadOp op) {
     if (!isa<qc::QubitType>(op.getMemRefType().getElementType())) {
@@ -632,8 +679,7 @@ static void collectStructuredCaptures(Operation* root, LoweringState& state) {
         qubits.insert(value);
         continue;
       }
-      if (const auto type = dyn_cast<MemRefType>(value.getType());
-          type && isa<qc::QubitType>(type.getElementType())) {
+      if (isQubitMemrefType(value.getType())) {
         registers.insert(lookupRegisterId(state, value));
       }
     }
@@ -1807,6 +1853,7 @@ protected:
     QCToQCOTypeConverter typeConverter(context);
 
     if (failed(validateModifierBodies(moduleOp)) ||
+        failed(validateQuantumValueSources(moduleOp)) ||
         failed(collectRegisterAccesses(moduleOp, state))) {
       signalPassFailure();
       return;
@@ -1821,12 +1868,8 @@ protected:
                            qtensor::QTensorDialect>();
 
     target.addDynamicallyLegalDialect<memref::MemRefDialect>([](Operation* op) {
-      auto isQubitMemref = [](Type t) {
-        auto mt = dyn_cast<MemRefType>(t);
-        return mt && isa<qc::QubitType>(mt.getElementType());
-      };
-      return llvm::none_of(op->getOperandTypes(), isQubitMemref) &&
-             llvm::none_of(op->getResultTypes(), isQubitMemref);
+      return llvm::none_of(op->getOperandTypes(), isQubitMemrefType) &&
+             llvm::none_of(op->getResultTypes(), isQubitMemrefType);
     });
 
     target.addDynamicallyLegalDialect<scf::SCFDialect>([&](Operation* op) {

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -65,7 +65,6 @@ void QCProgramBuilder::initialize(TypeRange returnTypes) {
   // Create entry block and set insertion point
   auto& entryBlock = mainFunc.getBody().emplaceBlock();
   setInsertionPointToStart(&entryBlock);
-  regionStack.emplace_back(entryBlock.getParent());
 }
 
 void QCProgramBuilder::retype(TypeRange returnTypes) {
@@ -127,20 +126,16 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
   }
 
   auto memrefType = MemRefType::get({size}, QubitType::get(ctx));
-  auto allocOp = memref::AllocOp::create(*this, memrefType);
-  auto memref = allocOp.getResult();
+  auto memref = memref::AllocOp::create(*this, memrefType).getResult();
   allocatedQregs.insert(memref);
 
   SmallVector<Value> qubits;
   qubits.reserve(size);
-  auto& loadedQubitsForRegion =
-      loadedQubits[allocOp->getParentRegion()][memref];
   for (int64_t i = 0; i < size; ++i) {
     auto index = arith::ConstantIndexOp::create(*this, i);
     auto load = memref::LoadOp::create(*this, memref, index.getResult());
     const auto& qubit = qubits.emplace_back(load.getResult());
     allocatedQubits.insert(qubit);
-    loadedQubitsForRegion.insert(index);
   }
 
   return {.value = memref, .qubits = std::move(qubits)};
@@ -148,23 +143,7 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
 
 Value QCProgramBuilder::loadQubit(Value memref, Value index) {
   checkFinalized();
-
-  auto* region = getInsertionBlock()->getParent();
-
-  if (regionStack.size() == 1) {
-    llvm::reportFatalUsageError(
-        "Qubit cannot be loaded in the main function region");
-  }
-  for (Region* curr : regionStack) {
-    if (loadedQubits[curr][memref].contains(index)) {
-      llvm::reportFatalUsageError("Qubit already loaded in enclosing region");
-    }
-  }
-
-  auto loadOp = memref::LoadOp::create(*this, memref, index);
-  loadedQubits[region][memref].insert(index);
-
-  return loadOp.getResult();
+  return memref::LoadOp::create(*this, memref, index).getResult();
 }
 
 Value QCProgramBuilder::allocClassicalBitRegister(const int64_t size,
@@ -576,11 +555,8 @@ QCProgramBuilder::scfFor(const std::variant<int64_t, Value>& lowerbound,
 
   scf::ForOp::create(*this, lb, ub, stepSize, ValueRange{},
                      [&](OpBuilder& b, Location l, Value iv, ValueRange) {
-                       regionStack.emplace_back(
-                           b.getInsertionBlock()->getParent());
                        body(iv);
                        scf::YieldOp::create(b, l);
-                       regionStack.pop_back();
                      });
   return *this;
 }
@@ -594,20 +570,16 @@ QCProgramBuilder::scfWhile(const function_ref<void()>& beforeBody,
       *this, TypeRange{}, ValueRange{},
       [&](OpBuilder& b, Location, ValueRange) {
         auto* insertionBlock = b.getInsertionBlock();
-        regionStack.emplace_back(insertionBlock->getParent());
         beforeBody();
         if (!isa_and_nonnull<scf::ConditionOp>(
                 insertionBlock->getTerminator())) {
           llvm::reportFatalUsageError(
               "scf.while beforeBody must terminate with scf.condition");
         }
-        regionStack.pop_back();
       },
       [&](OpBuilder& b, Location loc, ValueRange) {
-        regionStack.emplace_back(b.getInsertionBlock()->getParent());
         afterBody();
         scf::YieldOp::create(b, loc);
-        regionStack.pop_back();
       });
 
   return *this;
@@ -623,10 +595,8 @@ QCProgramBuilder::scfIf(const std::variant<bool, Value>& cond,
 
   auto buildRegion = [&](const function_ref<void()>& body) {
     return [&, body](OpBuilder& b, Location loc) {
-      regionStack.emplace_back(b.getInsertionBlock()->getParent());
       body();
       scf::YieldOp::create(b, loc);
-      regionStack.pop_back();
     };
   };
 
@@ -670,10 +640,8 @@ QCProgramBuilder::scfIndexSwitch(const std::variant<int64_t, Value>& arg,
   const InsertionGuard guard(*this);
   const auto buildRegion = [&](Region& region, const function_ref<void()>& f) {
     Block* block = createBlock(&region); // Implicitly sets the insertion point.
-    regionStack.emplace_back(&region);
     f();
     scf::YieldOp::create(*this, getLoc());
-    regionStack.pop_back();
   };
 
   for (auto [region, f] :

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -124,9 +124,7 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
   qubits.reserve(size);
   for (int64_t i = 0; i < size; ++i) {
     auto index = arith::ConstantIndexOp::create(*this, i);
-    auto load = memref::LoadOp::create(*this, memref, index.getResult());
-    const auto& qubit = qubits.emplace_back(load.getResult());
-    allocatedQubits.insert(qubit);
+    qubits.emplace_back(loadQubit(memref, index));
   }
 
   return {.value = memref, .qubits = std::move(qubits)};
@@ -760,9 +758,7 @@ OwningOpRef<ModuleOp> QCProgramBuilder::finalize(ValueRange returnValues) {
   }
 
   for (auto qubit : allocatedQubits) {
-    if (!isa<memref::LoadOp>(qubit.getDefiningOp())) {
-      DeallocOp::create(*this, qubit);
-    }
+    DeallocOp::create(*this, qubit);
   }
   allocatedQubits.clear();
 

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -118,16 +118,7 @@ Value QCProgramBuilder::staticQubit(const uint64_t index) {
 
 QCProgramBuilder::QubitRegister
 QCProgramBuilder::allocQubitRegister(const int64_t size) {
-  checkFinalized();
-  ensureAllocationMode(AllocationMode::Dynamic);
-
-  if (size <= 0) {
-    llvm::reportFatalUsageError("Size must be positive");
-  }
-
-  auto memrefType = MemRefType::get({size}, QubitType::get(ctx));
-  auto memref = memref::AllocOp::create(*this, memrefType).getResult();
-  allocatedQregs.insert(memref);
+  auto memref = allocQubitRegisterStorage(size);
 
   SmallVector<Value> qubits;
   qubits.reserve(size);
@@ -139,6 +130,20 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
   }
 
   return {.value = memref, .qubits = std::move(qubits)};
+}
+
+Value QCProgramBuilder::allocQubitRegisterStorage(const int64_t size) {
+  checkFinalized();
+  ensureAllocationMode(AllocationMode::Dynamic);
+
+  if (size <= 0) {
+    llvm::reportFatalUsageError("Size must be positive");
+  }
+
+  auto memrefType = MemRefType::get({size}, QubitType::get(ctx));
+  auto memref = memref::AllocOp::create(*this, memrefType).getResult();
+  allocatedQregs.insert(memref);
+  return memref;
 }
 
 Value QCProgramBuilder::loadQubit(Value memref, Value index) {

--- a/mlir/lib/Dialect/QC/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/QC/IR/CMakeLists.txt
@@ -25,7 +25,8 @@ add_mlir_dialect_library(
   PRIVATE
   MLIRIR
   MLIRInferTypeOpInterface
-  MLIRSideEffectInterfaces)
+  MLIRSideEffectInterfaces
+  MLIRTransformUtils)
 
 mqt_mlir_target_use_project_options(MLIRQCDialect)
 

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "ModifierUtils.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
@@ -15,7 +16,6 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVectorExtras.h>
-#include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -226,11 +226,8 @@ void CtrlOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult CtrlOp::verify() {
-  if (utils::containsOperationOfType<AllocOp, DeallocOp, MeasureOp, ResetOp,
-                                     memref::LoadOp, memref::StoreOp>(
-          *getBody())) {
-    return emitOpError("body must not contain non-unitary quantum operations "
-                       "or modify a quantum register");
+  if (failed(detail::verifyModifierBody(getOperation(), *getBody()))) {
+    return failure();
   }
 
   SmallPtrSet<Value, 4> uniqueQubits;

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -226,10 +226,9 @@ void CtrlOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult CtrlOp::verify() {
-  if (llvm::any_of(*getBody(), [](Operation& op) {
-        return isa<AllocOp, DeallocOp, MeasureOp, ResetOp, memref::LoadOp,
-                   memref::StoreOp>(op);
-      })) {
+  if (utils::containsOperationOfType<AllocOp, DeallocOp, MeasureOp, ResetOp,
+                                     memref::LoadOp, memref::StoreOp>(
+          *getBody())) {
     return emitOpError("body must not contain non-unitary quantum operations "
                        "or modify a quantum register");
   }

--- a/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/Utils/Utils.h"
 
-#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -395,10 +394,9 @@ void InvOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubit,
 }
 
 LogicalResult InvOp::verify() {
-  if (llvm::any_of(*getBody(), [](Operation& op) {
-        return isa<AllocOp, DeallocOp, MeasureOp, ResetOp, memref::LoadOp,
-                   memref::StoreOp>(op);
-      })) {
+  if (utils::containsOperationOfType<AllocOp, DeallocOp, MeasureOp, ResetOp,
+                                     memref::LoadOp, memref::StoreOp>(
+          *getBody())) {
     return emitOpError("body must not contain non-unitary quantum operations "
                        "or modify a quantum register");
   }

--- a/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "ModifierUtils.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
@@ -16,7 +17,6 @@
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
-#include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -394,13 +394,7 @@ void InvOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubit,
 }
 
 LogicalResult InvOp::verify() {
-  if (utils::containsOperationOfType<AllocOp, DeallocOp, MeasureOp, ResetOp,
-                                     memref::LoadOp, memref::StoreOp>(
-          *getBody())) {
-    return emitOpError("body must not contain non-unitary quantum operations "
-                       "or modify a quantum register");
-  }
-  return success();
+  return detail::verifyModifierBody(getOperation(), *getBody());
 }
 
 void InvOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.cpp
@@ -12,7 +12,6 @@
 
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
-#include "mlir/Dialect/Utils/Utils.h"
 
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -21,13 +20,21 @@
 #include <mlir/IR/Value.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
+#include <mlir/Support/WalkResult.h>
 #include <mlir/Transforms/RegionUtils.h>
 
 namespace mlir::qc::detail {
 
 LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
-  if (utils::containsOperationOfType<AllocOp, DeallocOp, MeasureOp, ResetOp,
-                                     memref::LoadOp, memref::StoreOp>(body)) {
+  const auto hasNonUnitaryOperation =
+      body.walk([](Operation* operation) {
+            return isa<AllocOp, DeallocOp, MeasureOp, ResetOp, memref::LoadOp,
+                       memref::StoreOp>(operation)
+                       ? WalkResult::interrupt()
+                       : WalkResult::advance();
+          })
+          .wasInterrupted();
+  if (hasNonUnitaryOperation) {
     return modifierOp->emitOpError(
         "body must not contain non-unitary quantum operations or modify a "
         "quantum register");

--- a/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "ModifierUtils.h"
+
+#include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/Dialect/Utils/Utils.h"
+
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/IR/Block.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/Value.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/RegionUtils.h>
+
+namespace mlir::qc::detail {
+
+LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
+  if (utils::containsOperationOfType<AllocOp, DeallocOp, MeasureOp, ResetOp,
+                                     memref::LoadOp, memref::StoreOp>(body)) {
+    return modifierOp->emitOpError(
+        "body must not contain non-unitary quantum operations or modify a "
+        "quantum register");
+  }
+
+  SetVector<Value> captures;
+  getUsedValuesDefinedAbove(modifierOp->getRegions(), captures);
+  if (llvm::any_of(captures, [](const Value value) {
+        return isa<QubitType>(value.getType());
+      })) {
+    return modifierOp->emitOpError(
+        "body must not capture qubits from above; use only its aliased block "
+        "arguments");
+  }
+
+  return success();
+}
+
+} // namespace mlir::qc::detail

--- a/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.h
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include <mlir/Support/LogicalResult.h>
+
+namespace mlir {
+
+class Block;
+class Operation;
+
+namespace qc::detail {
+
+/**
+ * @brief Verify the operations and SSA captures in a QC modifier body.
+ */
+[[nodiscard]] LogicalResult verifyModifierBody(Operation* modifierOp,
+                                               Block& body);
+
+} // namespace qc::detail
+
+} // namespace mlir

--- a/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/Utils/Utils.h"
 
-#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
@@ -595,10 +594,9 @@ void PowOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult PowOp::verify() {
-  if (llvm::any_of(*getBody(), [](Operation& op) {
-        return isa<AllocOp, DeallocOp, MeasureOp, ResetOp, memref::LoadOp,
-                   memref::StoreOp>(op);
-      })) {
+  if (utils::containsOperationOfType<AllocOp, DeallocOp, MeasureOp, ResetOp,
+                                     memref::LoadOp, memref::StoreOp>(
+          *getBody())) {
     return emitOpError("body must not contain non-unitary quantum operations "
                        "or modify a quantum register");
   }

--- a/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "ModifierUtils.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
@@ -17,7 +18,6 @@
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
-#include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
@@ -594,13 +594,7 @@ void PowOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 }
 
 LogicalResult PowOp::verify() {
-  if (utils::containsOperationOfType<AllocOp, DeallocOp, MeasureOp, ResetOp,
-                                     memref::LoadOp, memref::StoreOp>(
-          *getBody())) {
-    return emitOpError("body must not contain non-unitary quantum operations "
-                       "or modify a quantum register");
-  }
-  return success();
+  return detail::verifyModifierBody(getOperation(), *getBody());
 }
 
 void PowOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -112,7 +112,7 @@ public:
   OpenQASMToQCEmitter(const oq3::frontend::TypedProgram& typedProgram,
                       MLIRContext& mlirContext)
       : program(typedProgram), context(mlirContext), emissionBudget(context),
-        builder(&context), registerValues(program.registers.size()),
+        builder(&context), qubitValues(program.registers.size()),
         classicalRegisters(program.registers.size()),
         outputBitRegisters(program.registers.size(), false),
         bitValues(program.registers.size()),
@@ -201,7 +201,7 @@ private:
       context; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
   EmissionBudget emissionBudget;
   qc::QCProgramBuilder builder;
-  std::vector<SmallVector<Value>> registerValues;
+  std::vector<Value> qubitValues;
   std::vector<Value> classicalRegisters;
   std::vector<bool> outputBitRegisters;
   std::vector<SmallVector<Value>> bitValues;
@@ -312,26 +312,6 @@ private:
         << "OpenQASM QC emission error: projected emitted operation count "
            "exceeds the safe lowering limit";
     return false;
-  }
-
-  [[nodiscard]] bool
-  projectedMultiplicity(const ArrayRef<frontend::QubitReference> references,
-                        const size_t parentMultiplicity,
-                        const oq3::frontend::SourceLocation& source,
-                        size_t& result) const {
-    result = parentMultiplicity;
-    for (const auto& reference : references) {
-      if (!reference.dynamicIndex) {
-        continue;
-      }
-      const auto width =
-          static_cast<size_t>(program.registers.at(reference.symbol).width);
-      if (width != 0 && result > PROJECTED_EMISSION_LIMIT / width) {
-        return reportProjectedEmissionLimit(source);
-      }
-      result *= width;
-    }
-    return true;
   }
 
   [[nodiscard]] bool
@@ -495,30 +475,44 @@ private:
   }
 
   [[nodiscard]] bool
-  chargeDynamicDispatch(const ArrayRef<frontend::QubitReference> references,
-                        const size_t parentMultiplicity,
-                        size_t& projectedEmission,
-                        const oq3::frontend::SourceLocation& source) const {
-    auto switchMultiplicity = parentMultiplicity;
+  chargeQubitAccesses(const ArrayRef<frontend::QubitReference> references,
+                      const size_t multiplicity, size_t& projectedEmission,
+                      const oq3::frontend::SourceLocation& source) const {
     for (const auto& reference : references) {
-      if (!reference.dynamicIndex) {
+      if (reference.kind != frontend::QubitReferenceKind::Register ||
+          program.registers.at(reference.symbol).isScalar) {
         continue;
       }
-      const auto width =
-          static_cast<size_t>(program.registers.at(reference.symbol).width);
-      // Checked-index normalization plus the index cast and switch operation.
-      if (!chargeExpressionEmission(*reference.dynamicIndex, switchMultiplicity,
-                                    projectedEmission, source) ||
-          !chargeScaledEmission(9, switchMultiplicity, projectedEmission,
-                                source) ||
-          !chargeScaledEmission(width, switchMultiplicity, projectedEmission,
+
+      if (reference.dynamicIndex &&
+          !chargeExpressionEmission(*reference.dynamicIndex, multiplicity,
+                                    projectedEmission, source)) {
+        return false;
+      }
+      // A static access emits a constant index and a load. A checked dynamic
+      // access additionally normalizes signed negative indices, verifies the
+      // bounds, and casts to the MLIR index type.
+      const size_t accessCost = reference.dynamicIndex ? 12 : 2;
+      if (!chargeScaledEmission(accessCost, multiplicity, projectedEmission,
                                 source)) {
         return false;
       }
-      if (width != 0 && switchMultiplicity > PROJECTED_EMISSION_LIMIT / width) {
-        return reportProjectedEmissionLimit(source);
+    }
+
+    for (const auto [position, reference] : llvm::enumerate(references)) {
+      if (reference.kind != frontend::QubitReferenceKind::Register) {
+        continue;
       }
-      switchMultiplicity *= width;
+      for (const auto& previous : ArrayRef(references).take_front(position)) {
+        if (previous.kind != frontend::QubitReferenceKind::Register ||
+            previous.symbol != reference.symbol ||
+            (!previous.dynamicIndex && !reference.dynamicIndex)) {
+          continue;
+        }
+        if (!chargeScaledEmission(2, multiplicity, projectedEmission, source)) {
+          return false;
+        }
+      }
     }
     return true;
   }
@@ -561,13 +555,9 @@ private:
                           const oq3::frontend::SourceLocation& source) const {
     const auto& condition = program.conditions.at(id);
     if (condition.kind == frontend::ConditionKind::Measurement) {
-      size_t operationMultiplicity = 0;
-      return chargeDynamicDispatch({condition.measurement}, multiplicity,
-                                   projectedEmission, source) &&
-             projectedMultiplicity({condition.measurement}, multiplicity,
-                                   source, operationMultiplicity) &&
-             chargeProjectedEmission(operationMultiplicity, projectedEmission,
-                                     source);
+      return chargeQubitAccesses({condition.measurement}, multiplicity,
+                                 projectedEmission, source) &&
+             chargeScaledEmission(1, multiplicity, projectedEmission, source);
     }
     if (condition.kind == frontend::ConditionKind::Literal) {
       return chargeScaledEmission(1, multiplicity, projectedEmission, source);
@@ -748,15 +738,9 @@ private:
                   multiplicity, projectedEmission, statement.location)) {
             return false;
           }
-        } else if (const auto* declaration =
-                       std::get_if<frontend::DeclarationStatement>(
-                           &statement.data)) {
-          const auto& reg = program.registers.at(declaration->reg);
-          size_t cost = 1;
-          if (reg.kind == frontend::RegisterKind::Qubit && !reg.isScalar) {
-            cost += 2 * static_cast<size_t>(reg.width);
-          }
-          if (!chargeScaledEmission(cost, multiplicity, projectedEmission,
+        } else if (std::holds_alternative<frontend::DeclarationStatement>(
+                       statement.data)) {
+          if (!chargeScaledEmission(1, multiplicity, projectedEmission,
                                     statement.location)) {
             return false;
           }
@@ -764,15 +748,10 @@ private:
                        std::get_if<frontend::MeasurementStatement>(
                            &statement.data)) {
           for (const auto& qubit : measurement->qubits) {
-            size_t operationMultiplicity = 0;
-            if (!chargeDynamicDispatch({qubit}, multiplicity, projectedEmission,
-                                       statement.location) ||
-                !projectedMultiplicity({qubit}, multiplicity,
-                                       statement.location,
-                                       operationMultiplicity) ||
-                !chargeProjectedEmission(operationMultiplicity,
-                                         projectedEmission,
-                                         statement.location)) {
+            if (!chargeQubitAccesses({qubit}, multiplicity, projectedEmission,
+                                     statement.location) ||
+                !chargeScaledEmission(1, multiplicity, projectedEmission,
+                                      statement.location)) {
               return false;
             }
           }
@@ -793,29 +772,20 @@ private:
         } else if (const auto* reset =
                        std::get_if<frontend::ResetStatement>(&statement.data)) {
           for (const auto& qubit : reset->qubits) {
-            size_t operationMultiplicity = 0;
-            if (!chargeDynamicDispatch({qubit}, multiplicity, projectedEmission,
-                                       statement.location) ||
-                !projectedMultiplicity({qubit}, multiplicity,
-                                       statement.location,
-                                       operationMultiplicity) ||
-                !chargeProjectedEmission(operationMultiplicity,
-                                         projectedEmission,
-                                         statement.location)) {
+            if (!chargeQubitAccesses({qubit}, multiplicity, projectedEmission,
+                                     statement.location) ||
+                !chargeScaledEmission(1, multiplicity, projectedEmission,
+                                      statement.location)) {
               return false;
             }
           }
         } else if (const auto* barrier =
                        std::get_if<frontend::BarrierStatement>(
                            &statement.data)) {
-          size_t operationMultiplicity = 0;
-          if (!chargeDynamicDispatch(barrier->qubits, multiplicity,
-                                     projectedEmission, statement.location) ||
-              !projectedMultiplicity(barrier->qubits, multiplicity,
-                                     statement.location,
-                                     operationMultiplicity) ||
-              !chargeProjectedEmission(operationMultiplicity, projectedEmission,
-                                       statement.location)) {
+          if (!chargeQubitAccesses(barrier->qubits, multiplicity,
+                                   projectedEmission, statement.location) ||
+              !chargeScaledEmission(1, multiplicity, projectedEmission,
+                                    statement.location)) {
             return false;
           }
         }
@@ -844,11 +814,8 @@ private:
           return false;
         }
       }
-      size_t operationMultiplicity = 0;
-      if (!projectedMultiplicity(application->qubits, multiplicity,
-                                 statement.location, operationMultiplicity) ||
-          !chargeDynamicDispatch(application->qubits, multiplicity,
-                                 projectedEmission, statement.location)) {
+      if (!chargeQubitAccesses(application->qubits, multiplicity,
+                               projectedEmission, statement.location)) {
         return false;
       }
       const auto* gate = findCustomGate(application->callee);
@@ -869,14 +836,14 @@ private:
             leafCost += 3;
           }
         }
-        if (!chargeScaledEmission(leafCost, operationMultiplicity,
-                                  projectedEmission, statement.location)) {
+        if (!chargeScaledEmission(leafCost, multiplicity, projectedEmission,
+                                  statement.location)) {
           return false;
         }
         continue;
       }
       if (!chargeScaledEmission(modifierEmissionCost(*application),
-                                operationMultiplicity, projectedEmission,
+                                multiplicity, projectedEmission,
                                 statement.location)) {
         return false;
       }
@@ -887,8 +854,7 @@ private:
                "structured control flow are not supported by the QC dialect";
         return false;
       }
-      if (!preflightStatements(gate->body, projectedEmission,
-                               operationMultiplicity)) {
+      if (!preflightStatements(gate->body, projectedEmission, multiplicity)) {
         return false;
       }
     }
@@ -1469,12 +1435,15 @@ private:
   }
 
   Value resolveQubit(const frontend::QubitReference& reference,
-                     ValueRange gateQubits) {
+                     ValueRange gateQubits, const Value index = {}) {
     switch (reference.kind) {
     case frontend::QubitReferenceKind::Register: {
-      assert(!reference.dynamicIndex &&
-             "dynamic qubit references require structured dispatch");
-      return registerValues.at(reference.symbol)[reference.index];
+      const auto& declaration = program.registers.at(reference.symbol);
+      if (declaration.isScalar) {
+        return qubitValues.at(reference.symbol);
+      }
+      assert(index && "register qubit references require an index");
+      return builder.loadQubit(qubitValues.at(reference.symbol), index);
     }
     case frontend::QubitReferenceKind::GateArgument:
       return gateQubits[reference.symbol];
@@ -1485,102 +1454,69 @@ private:
   }
 
   [[nodiscard]] SmallVector<Value>
-  emitDynamicQubitIndices(ArrayRef<frontend::QubitReference> references) {
+  emitQubitIndices(ArrayRef<frontend::QubitReference> references) {
     SmallVector<Value> indices(references.size());
     for (const auto [position, reference] : llvm::enumerate(references)) {
+      if (reference.kind != frontend::QubitReferenceKind::Register ||
+          program.registers.at(reference.symbol).isScalar) {
+        continue;
+      }
       if (!reference.dynamicIndex) {
+        indices[position] = arith::ConstantIndexOp::create(
+            builder, static_cast<int64_t>(reference.index));
         continue;
       }
       const auto width =
           static_cast<int64_t>(program.registers.at(reference.symbol).width);
-      indices[position] = emitCheckedIndex(*reference.dynamicIndex, width,
-                                           "dynamic qubit index out of bounds");
+      auto checked = emitCheckedIndex(*reference.dynamicIndex, width,
+                                      "dynamic qubit index out of bounds");
+      indices[position] =
+          arith::IndexCastOp::create(builder, builder.getIndexType(), checked);
     }
     return indices;
   }
 
   void
-  dispatchQubits(ArrayRef<frontend::QubitReference> references,
-                 ValueRange gateQubits, ValueRange dynamicIndices,
-                 llvm::function_ref<void(ValueRange)> emitResolvedOperation) {
-    SmallVector<Value> resolved(references.size());
-    const auto resolveAt = [&](auto&& self, const size_t position) -> void {
-      if (position == references.size()) {
-        emitResolvedOperation(resolved);
-        return;
+  emitDistinctQubitAssertions(ArrayRef<frontend::QubitReference> references,
+                              ValueRange indices, const StringRef message) {
+    for (const auto [position, reference] : llvm::enumerate(references)) {
+      if (reference.kind != frontend::QubitReferenceKind::Register) {
+        continue;
       }
+      for (const auto [previousPosition, previous] :
+           llvm::enumerate(ArrayRef(references).take_front(position))) {
+        if (previous.kind != frontend::QubitReferenceKind::Register ||
+            previous.symbol != reference.symbol ||
+            (!previous.dynamicIndex && !reference.dynamicIndex)) {
+          continue;
+        }
+        auto distinct =
+            arith::CmpIOp::create(builder, arith::CmpIPredicate::ne,
+                                  indices[previousPosition], indices[position]);
+        cf::AssertOp::create(builder, distinct, message);
+      }
+    }
+  }
 
-      const auto& reference = references[position];
-      if (!reference.dynamicIndex) {
-        resolved[position] = resolveQubit(reference, gateQubits);
-        self(self, position + 1);
-        return;
-      }
-
-      const auto& qubits = registerValues.at(reference.symbol);
-      if (!emissionBudget.canConstruct(qubits.size() + 2)) {
-        return;
-      }
-      SmallVector<int64_t> cases;
-      cases.reserve(qubits.size() - 1);
-      for (size_t candidate = 0; candidate + 1 < qubits.size(); ++candidate) {
-        cases.push_back(static_cast<int64_t>(candidate));
-      }
-      auto selector = arith::IndexCastOp::create(
-          builder, builder.getIndexType(), dynamicIndices[position]);
-      auto switchOp = scf::IndexSwitchOp::create(builder, TypeRange{}, selector,
-                                                 cases, cases.size());
-      OpBuilder::InsertionGuard guard(builder);
-      const auto emitCase = [&](Region& region, const size_t candidate) {
-        auto& block = region.emplaceBlock();
-        builder.setInsertionPointToEnd(&block);
-        resolved[position] = qubits[candidate];
-        self(self, position + 1);
-        scf::YieldOp::create(builder);
-      };
-      for (const auto [candidate, region] :
-           llvm::enumerate(switchOp.getCaseRegions())) {
-        emitCase(region, candidate);
-      }
-      emitCase(switchOp.getDefaultRegion(), qubits.size() - 1);
-    };
-    resolveAt(resolveAt, 0);
+  [[nodiscard]] SmallVector<Value>
+  resolveQubits(ArrayRef<frontend::QubitReference> references,
+                ValueRange gateQubits, ValueRange indices) {
+    SmallVector<Value> resolved;
+    resolved.reserve(references.size());
+    for (const auto [position, reference] : llvm::enumerate(references)) {
+      resolved.push_back(
+          resolveQubit(reference, gateQubits, indices[position]));
+    }
+    return resolved;
   }
 
   [[nodiscard]] Value
   emitQubitOperation(const frontend::QubitReference& reference,
                      ValueRange gateQubits,
                      llvm::function_ref<Value(Value)> emitResolvedOperation) {
-    if (!reference.dynamicIndex) {
-      return emitResolvedOperation(resolveQubit(reference, gateQubits));
-    }
-
-    const auto dynamicIndex = emitDynamicQubitIndices({reference}).front();
-    const auto& qubits = registerValues.at(reference.symbol);
-    if (!emissionBudget.canConstruct(qubits.size() + 2)) {
-      return {};
-    }
-    SmallVector<int64_t> cases;
-    cases.reserve(qubits.size() - 1);
-    for (size_t candidate = 0; candidate + 1 < qubits.size(); ++candidate) {
-      cases.push_back(static_cast<int64_t>(candidate));
-    }
-    auto selector = arith::IndexCastOp::create(builder, builder.getIndexType(),
-                                               dynamicIndex);
-    auto switchOp = scf::IndexSwitchOp::create(builder, builder.getI1Type(),
-                                               selector, cases, cases.size());
-    OpBuilder::InsertionGuard guard(builder);
-    const auto emitCase = [&](Region& region, const size_t candidate) {
-      auto& block = region.emplaceBlock();
-      builder.setInsertionPointToEnd(&block);
-      scf::YieldOp::create(builder, emitResolvedOperation(qubits[candidate]));
-    };
-    for (const auto [candidate, region] :
-         llvm::enumerate(switchOp.getCaseRegions())) {
-      emitCase(region, candidate);
-    }
-    emitCase(switchOp.getDefaultRegion(), qubits.size() - 1);
-    return switchOp.getResult(0);
+    const auto indices = emitQubitIndices({reference});
+    return emitResolvedOperation(
+        resolveQubit(reference, gateQubits, indices.front()));
   }
 
   static LogicalResult emitPrimitive(OpBuilder& opBuilder, const Location loc,
@@ -1877,33 +1813,10 @@ private:
       }
       parameters.push_back(parameter);
     }
-    const auto dynamicIndices = emitDynamicQubitIndices(application.qubits);
-    for (const auto [position, reference] :
-         llvm::enumerate(application.qubits)) {
-      if (reference.kind != frontend::QubitReferenceKind::Register) {
-        continue;
-      }
-      for (const auto [previousPosition, previous] :
-           llvm::enumerate(ArrayRef(application.qubits).take_front(position))) {
-        if (previous.kind != frontend::QubitReferenceKind::Register ||
-            previous.symbol != reference.symbol ||
-            (!previous.dynamicIndex && !reference.dynamicIndex)) {
-          continue;
-        }
-        auto previousIndex =
-            previous.dynamicIndex
-                ? dynamicIndices[previousPosition]
-                : builder.intConstant(static_cast<int64_t>(previous.index));
-        auto currentIndex =
-            reference.dynamicIndex
-                ? dynamicIndices[position]
-                : builder.intConstant(static_cast<int64_t>(reference.index));
-        auto distinct = arith::CmpIOp::create(builder, arith::CmpIPredicate::ne,
-                                              previousIndex, currentIndex);
-        cf::AssertOp::create(builder, distinct,
-                             "gate operands must not reference the same qubit");
-      }
-    }
+    const auto qubitIndices = emitQubitIndices(application.qubits);
+    emitDistinctQubitAssertions(
+        application.qubits, qubitIndices,
+        "gate operands must not reference the same qubit");
     SmallVector<int64_t> controlCounts(application.modifiers.size(), 0);
     SmallVector<std::variant<double, Value>> modifierOperands(
         application.modifiers.size());
@@ -1961,50 +1874,45 @@ private:
       controlCounts[position] = count;
     }
 
-    dispatchQubits(
-        application.qubits, gateQubits, dynamicIndices, [&](ValueRange qubits) {
-          llvm::DenseSet<Value> distinctQubits(qubits.begin(), qubits.end());
-          if (distinctQubits.size() != qubits.size()) {
-            return;
+    const auto qubits =
+        resolveQubits(application.qubits, gateQubits, qubitIndices);
+    size_t negativeOffset = 0;
+    for (const auto [position, modifier] :
+         llvm::enumerate(application.modifiers)) {
+      if (modifier.kind == frontend::ModifierKind::Ctrl ||
+          modifier.kind == frontend::ModifierKind::NegCtrl) {
+        if (modifier.kind == frontend::ModifierKind::NegCtrl) {
+          for (auto control : ValueRange(qubits).slice(
+                   negativeOffset, controlCounts[position])) {
+            qc::XOp::create(opBuilder, loc, control);
           }
-          size_t negativeOffset = 0;
-          for (const auto [position, modifier] :
-               llvm::enumerate(application.modifiers)) {
-            if (modifier.kind == frontend::ModifierKind::Ctrl ||
-                modifier.kind == frontend::ModifierKind::NegCtrl) {
-              if (modifier.kind == frontend::ModifierKind::NegCtrl) {
-                for (auto control :
-                     qubits.slice(negativeOffset, controlCounts[position])) {
-                  qc::XOp::create(opBuilder, loc, control);
-                }
-              }
-              negativeOffset += static_cast<size_t>(controlCounts[position]);
-            }
+        }
+        negativeOffset += static_cast<size_t>(controlCounts[position]);
+      }
+    }
+    const auto result =
+        emitModifiers(opBuilder, application, loc, parameters, controlCounts,
+                      modifierOperands, 0, qubits);
+    negativeOffset = 0;
+    for (const auto [position, modifier] :
+         llvm::enumerate(application.modifiers)) {
+      if (modifier.kind == frontend::ModifierKind::Ctrl ||
+          modifier.kind == frontend::ModifierKind::NegCtrl) {
+        if (modifier.kind == frontend::ModifierKind::NegCtrl) {
+          for (auto control : ValueRange(qubits).slice(
+                   negativeOffset, controlCounts[position])) {
+            qc::XOp::create(opBuilder, loc, control);
           }
-          const auto result =
-              emitModifiers(opBuilder, application, loc, parameters,
-                            controlCounts, modifierOperands, 0, qubits);
-          negativeOffset = 0;
-          for (const auto [position, modifier] :
-               llvm::enumerate(application.modifiers)) {
-            if (modifier.kind == frontend::ModifierKind::Ctrl ||
-                modifier.kind == frontend::ModifierKind::NegCtrl) {
-              if (modifier.kind == frontend::ModifierKind::NegCtrl) {
-                for (auto control :
-                     qubits.slice(negativeOffset, controlCounts[position])) {
-                  qc::XOp::create(opBuilder, loc, control);
-                }
-              }
-              negativeOffset += static_cast<size_t>(controlCounts[position]);
-            }
-          }
-          if (failed(result)) {
-            emissionFailed = true;
-            emitError(loc) << "OpenQASM QC emission error: gate '"
-                           << application.callee
-                           << "' has no lowering to the QC dialect";
-          }
-        });
+        }
+        negativeOffset += static_cast<size_t>(controlCounts[position]);
+      }
+    }
+    if (failed(result)) {
+      emissionFailed = true;
+      emitError(loc) << "OpenQASM QC emission error: gate '"
+                     << application.callee
+                     << "' has no lowering to the QC dialect";
+    }
   }
 
   [[nodiscard]] static Value emitScalarCast(OpBuilder& opBuilder,
@@ -2386,16 +2294,15 @@ private:
             emitMeasurement(data, gateQubits);
           } else if constexpr (std::is_same_v<T, frontend::ResetStatement>) {
             for (const auto& qubit : data.qubits) {
-              const auto indices = emitDynamicQubitIndices({qubit});
-              dispatchQubits({qubit}, gateQubits, indices,
-                             [&](ValueRange resolved) {
-                               builder.reset(resolved.front());
-                             });
+              const auto indices = emitQubitIndices({qubit});
+              builder.reset(resolveQubit(qubit, gateQubits, indices.front()));
             }
           } else if constexpr (std::is_same_v<T, frontend::BarrierStatement>) {
-            const auto indices = emitDynamicQubitIndices(data.qubits);
-            dispatchQubits(data.qubits, gateQubits, indices,
-                           [&](ValueRange qubits) { builder.barrier(qubits); });
+            const auto indices = emitQubitIndices(data.qubits);
+            emitDistinctQubitAssertions(
+                data.qubits, indices,
+                "barrier operands must not reference the same qubit");
+            builder.barrier(resolveQubits(data.qubits, gateQubits, indices));
           } else if constexpr (std::is_same_v<T, frontend::IfStatement>) {
             emitIf(data, gateParameters, gateQubits);
           } else if constexpr (std::is_same_v<T, frontend::ForStatement>) {
@@ -2455,16 +2362,14 @@ private:
         if (!emissionBudget.canConstruct(1)) {
           return;
         }
-        registerValues[statement.reg] = {builder.allocQubit()};
+        qubitValues[statement.reg] = builder.allocQubit();
         return;
       }
-      const auto width = static_cast<size_t>(declaration.width);
-      if (!emissionBudget.canConstruct(1 + (2 * width))) {
+      if (!emissionBudget.canConstruct(1)) {
         return;
       }
-      auto allocation =
-          builder.allocQubitRegister(static_cast<int64_t>(declaration.width));
-      registerValues[statement.reg] = std::move(allocation.qubits);
+      qubitValues[statement.reg] = builder.allocQubitRegisterStorage(
+          static_cast<int64_t>(declaration.width));
       return;
     }
     if (outputBitRegisters[statement.reg]) {
@@ -2534,10 +2439,9 @@ private:
                        ValueRange gateQubits) {
     if (measurement.targets.empty()) {
       for (const auto& qubit : measurement.qubits) {
-        const auto indices = emitDynamicQubitIndices({qubit});
-        dispatchQubits({qubit}, gateQubits, indices, [&](ValueRange resolved) {
-          std::ignore = builder.measure(resolved.front());
-        });
+        const auto indices = emitQubitIndices({qubit});
+        std::ignore =
+            builder.measure(resolveQubit(qubit, gateQubits, indices.front()));
       }
       return;
     }

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -474,6 +474,19 @@ private:
                                 projectedEmission, source);
   }
 
+  [[nodiscard]] static llvm::SmallDenseSet<frontend::RegisterId, 4>
+  collectDynamicallyIndexedRegisters(
+      const ArrayRef<frontend::QubitReference> references) {
+    llvm::SmallDenseSet<frontend::RegisterId, 4> registers;
+    for (const auto& reference : references) {
+      if (reference.kind == frontend::QubitReferenceKind::Register &&
+          reference.dynamicIndex) {
+        registers.insert(reference.symbol);
+      }
+    }
+    return registers;
+  }
+
   [[nodiscard]] bool
   chargeQubitAccesses(const ArrayRef<frontend::QubitReference> references,
                       const size_t multiplicity, size_t& projectedEmission,
@@ -482,6 +495,8 @@ private:
       size_t total = 0;
       size_t dynamic = 0;
     };
+    const auto dynamicallyIndexedRegisters =
+        collectDynamicallyIndexedRegisters(references);
     llvm::DenseMap<frontend::RegisterId, RegisterAccessCounts> priorAccesses;
 
     for (const auto& reference : references) {
@@ -504,6 +519,9 @@ private:
         return false;
       }
 
+      if (!dynamicallyIndexedRegisters.contains(reference.symbol)) {
+        continue;
+      }
       auto& accesses = priorAccesses[reference.symbol];
       const auto comparisons =
           reference.dynamicIndex ? accesses.total : accesses.dynamic;
@@ -1484,6 +1502,12 @@ private:
   void
   emitDistinctQubitAssertions(ArrayRef<frontend::QubitReference> references,
                               ValueRange indices, const StringRef message) {
+    const auto dynamicallyIndexedRegisters =
+        collectDynamicallyIndexedRegisters(references);
+    if (dynamicallyIndexedRegisters.empty()) {
+      return;
+    }
+
     struct PriorRegisterAccesses {
       SmallVector<size_t> all;
       SmallVector<size_t> dynamic;
@@ -1492,7 +1516,8 @@ private:
 
     for (const auto [position, reference] : llvm::enumerate(references)) {
       if (reference.kind != frontend::QubitReferenceKind::Register ||
-          program.registers.at(reference.symbol).isScalar) {
+          program.registers.at(reference.symbol).isScalar ||
+          !dynamicallyIndexedRegisters.contains(reference.symbol)) {
         continue;
       }
       auto& accesses = priorAccesses[reference.symbol];

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -478,6 +478,12 @@ private:
   chargeQubitAccesses(const ArrayRef<frontend::QubitReference> references,
                       const size_t multiplicity, size_t& projectedEmission,
                       const oq3::frontend::SourceLocation& source) const {
+    struct RegisterAccessCounts {
+      size_t total = 0;
+      size_t dynamic = 0;
+    };
+    llvm::DenseMap<frontend::RegisterId, RegisterAccessCounts> priorAccesses;
+
     for (const auto& reference : references) {
       if (reference.kind != frontend::QubitReferenceKind::Register ||
           program.registers.at(reference.symbol).isScalar) {
@@ -497,21 +503,20 @@ private:
                                 source)) {
         return false;
       }
-    }
 
-    for (const auto [position, reference] : llvm::enumerate(references)) {
-      if (reference.kind != frontend::QubitReferenceKind::Register) {
-        continue;
+      auto& accesses = priorAccesses[reference.symbol];
+      const auto comparisons =
+          reference.dynamicIndex ? accesses.total : accesses.dynamic;
+      if (comparisons > PROJECTED_EMISSION_LIMIT / 2) {
+        return reportProjectedEmissionLimit(source);
       }
-      for (const auto& previous : ArrayRef(references).take_front(position)) {
-        if (previous.kind != frontend::QubitReferenceKind::Register ||
-            previous.symbol != reference.symbol ||
-            (!previous.dynamicIndex && !reference.dynamicIndex)) {
-          continue;
-        }
-        if (!chargeScaledEmission(2, multiplicity, projectedEmission, source)) {
-          return false;
-        }
+      if (!chargeScaledEmission(2 * comparisons, multiplicity,
+                                projectedEmission, source)) {
+        return false;
+      }
+      ++accesses.total;
+      if (reference.dynamicIndex) {
+        ++accesses.dynamic;
       }
     }
     return true;
@@ -1479,21 +1484,29 @@ private:
   void
   emitDistinctQubitAssertions(ArrayRef<frontend::QubitReference> references,
                               ValueRange indices, const StringRef message) {
+    struct PriorRegisterAccesses {
+      SmallVector<size_t> all;
+      SmallVector<size_t> dynamic;
+    };
+    llvm::DenseMap<frontend::RegisterId, PriorRegisterAccesses> priorAccesses;
+
     for (const auto [position, reference] : llvm::enumerate(references)) {
-      if (reference.kind != frontend::QubitReferenceKind::Register) {
+      if (reference.kind != frontend::QubitReferenceKind::Register ||
+          program.registers.at(reference.symbol).isScalar) {
         continue;
       }
-      for (const auto [previousPosition, previous] :
-           llvm::enumerate(ArrayRef(references).take_front(position))) {
-        if (previous.kind != frontend::QubitReferenceKind::Register ||
-            previous.symbol != reference.symbol ||
-            (!previous.dynamicIndex && !reference.dynamicIndex)) {
-          continue;
-        }
+      auto& accesses = priorAccesses[reference.symbol];
+      const ArrayRef<size_t> possibleAliases =
+          reference.dynamicIndex ? accesses.all : accesses.dynamic;
+      for (const auto previousPosition : possibleAliases) {
         auto distinct =
             arith::CmpIOp::create(builder, arith::CmpIPredicate::ne,
                                   indices[previousPosition], indices[position]);
         cf::AssertOp::create(builder, distinct, message);
+      }
+      accesses.all.push_back(position);
+      if (reference.dynamicIndex) {
+        accesses.dynamic.push_back(position);
       }
     }
   }

--- a/mlir/lib/Dialect/QTensor/IR/Operations/DeallocOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/DeallocOp.cpp
@@ -28,10 +28,11 @@ struct RemoveAllocDeallocPair final : OpRewritePattern<DeallocOp> {
 
   LogicalResult matchAndRewrite(DeallocOp op,
                                 PatternRewriter& rewriter) const override {
-    // Check whether the tensor is directly defined by a qtensor::AllocOp.
+    // Check whether the tensor is directly defined by an otherwise unused
+    // qtensor::AllocOp.
     auto tensor = op.getTensor();
     auto allocOp = tensor.getDefiningOp<AllocOp>();
-    if (!allocOp) {
+    if (!allocOp || !allocOp->hasOneUse()) {
       return failure();
     }
 

--- a/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
@@ -9,8 +9,6 @@
  */
 
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
-#include "mlir/Dialect/QTensor/IR/QTensorUtils.h"
-#include "mlir/Dialect/QTensor/Utils/TensorIterator.h"
 
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
@@ -18,67 +16,30 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Support/LLVM.h>
 
-#include <iterator>
-
 using namespace mlir;
 using namespace mlir::qtensor;
 
 namespace {
 /**
- * @brief Remove an (extract, insert) pair when the extracted qubit is
- * reinserted unchanged at the same constant index.
+ * @brief Fold an insert followed immediately by an extract at the same index.
  */
-struct RemoveExtractInsertPairPattern final : OpRewritePattern<ExtractOp> {
+struct FoldExtractAfterInsertPattern final : OpRewritePattern<ExtractOp> {
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(ExtractOp extract,
                                 PatternRewriter& rewriter) const override {
-    // Check: Extract has constant index.
-    if (!getConstantIntValue(extract.getIndex())) {
+    auto insert = extract.getTensor().getDefiningOp<InsertOp>();
+    if (!insert || !insert->hasOneUse() ||
+        !isEqualConstantIntOrValue(insert.getIndex(), extract.getIndex())) {
       return failure();
     }
 
-    // Search for an insert operation on the tensor-chain with the same constant
-    // index as the matched extract operation.
-    TensorIterator it(extract.getOutTensor());
-    for (; it != std::default_sentinel; ++it) {
-      if (!isa<InsertOp>(it.operation())) {
-        continue;
-      }
-
-      auto insert = cast<InsertOp>(it.operation());
-
-      // Check: Insert has constant index.
-      if (!getConstantIntValue(insert.getIndex())) {
-        return failure();
-      }
-
-      // Check: Same constant index.
-      if (!areEquivalentIndices(insert.getIndex(), extract.getIndex())) {
-        continue;
-      }
-
-      // Check: The inserted qubit value is the extracted one. If so, the
-      // qubit has not been used and both operations can be safely removed.
-
-      if (extract.getResult() == insert.getScalar()) {
-
-        //              ┌──────────┐         ┌─────────┐
-        // ... ─tensor─▶│extract(i)│─▶ ... ─▶│insert(i)│─▶result─▶ ...
-        //              └────┬─────┘         └────▲────┘
-        //                   └──result = scalar───┘
-        // ------------------- ⬇ (transformed) ⬇ -------------------
-        // ... ─tensor = result─▶ ...
-
-        rewriter.replaceOp(insert, insert.getDest());
-        rewriter.replaceOp(extract, {extract.getTensor(), nullptr});
-        return success();
-      }
-    }
-
-    return failure();
+    rewriter.replaceOp(extract, {insert.getDest(), insert.getScalar()});
+    rewriter.eraseOp(insert);
+    return success();
   }
 };
+
 } // namespace
 
 LogicalResult ExtractOp::verify() {
@@ -98,5 +59,5 @@ LogicalResult ExtractOp::verify() {
 
 void ExtractOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                             MLIRContext* context) {
-  results.add<RemoveExtractInsertPairPattern>(context);
+  results.add<FoldExtractAfterInsertPattern>(context);
 }

--- a/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
@@ -9,8 +9,6 @@
  */
 
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
-#include "mlir/Dialect/QTensor/IR/QTensorUtils.h"
-#include "mlir/Dialect/QTensor/Utils/TensorIterator.h"
 
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
@@ -20,8 +18,6 @@
 #include <mlir/IR/Value.h>
 #include <mlir/Support/LLVM.h>
 
-#include <iterator>
-
 using namespace mlir;
 using namespace mlir::qtensor;
 
@@ -30,7 +26,7 @@ using namespace mlir::qtensor;
  */
 static bool isRemovableExtractInsertPair(InsertOp insert, ExtractOp extract) {
   return insert.getScalar() == extract.getResult() &&
-         areEquivalentIndices(insert.getIndex(), extract.getIndex());
+         isEqualConstantIntOrValue(insert.getIndex(), extract.getIndex());
 }
 
 /**
@@ -56,109 +52,40 @@ static Value foldInsertAfterExtract(InsertOp insert) {
 
 namespace {
 /**
- * @brief Remove an (insert, extract) pair when the inserted qubit has been
- * extracted previously with the same constant index.
- * @pre Assumes each qubit is extracted and inserted with the same index.
+ * @brief Commutes a directly chained insert and extract at provably distinct
+ * constant indices.
  */
-struct RemoveInsertExtractPairPattern final : OpRewritePattern<InsertOp> {
+struct CommuteAdjacentInsertExtractPattern final : OpRewritePattern<InsertOp> {
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(InsertOp insert,
                                 PatternRewriter& rewriter) const override {
-    // Check: Insert has constant index.
-    if (!getConstantIntValue(insert.getIndex())) {
+    if (!insert.getResult().hasOneUse()) {
+      return failure();
+    }
+    auto extract = dyn_cast<ExtractOp>(*insert.getResult().getUsers().begin());
+    if (!extract || insert->getBlock() != extract->getBlock()) {
       return failure();
     }
 
-    // Search for an extract operation on the tensor-chain with the same
-    // constant index as the matched insert operation.
-    TensorIterator it(insert.getResult());
-    for (; it != std::default_sentinel; ++it) {
-      if (!isa<ExtractOp>(it.operation())) {
-        continue;
-      }
-
-      auto extract = cast<ExtractOp>(it.operation());
-
-      // Check: Extract has constant index.
-      if (!getConstantIntValue(extract.getIndex())) {
-        return failure();
-      }
-
-      // Check: Same constant index.
-      if (!areEquivalentIndices(extract.getIndex(), insert.getIndex())) {
-        continue;
-      }
-
-      //                 ┌─────────┐                 ┌──────────┐
-      // ... ─t = dest──▶│insert(i)│─▶ ... ─▶tensor─▶│extract(i)│─outTensor─▶...
-      //                 └────▲────┘                 └────┬─────┘
-      //          ... ─scalar─┘                           └result─▶ ...
-      // ------------------------- ⬇ (transformed) ⬇ -------------------------
-      // ... ─t = outTensor─▶ ...
-      // ... ─scalar = result─▶ ... (Assumption applied.)
-
-      rewriter.replaceOp(extract, {extract.getTensor(), insert.getScalar()});
-      rewriter.replaceOp(insert, insert.getDest());
-
-      return success();
-    }
-
-    return failure();
-  }
-};
-
-/**
- * @brief If possible, move insert after extract in tensor chain.
- * @pre Assumes that the extract and insertion index of any qubit is equivalent.
- */
-struct BubbleDownInsertPattern final : OpRewritePattern<InsertOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(InsertOp insert,
-                                PatternRewriter& rewriter) const override {
-    if (!getConstantIntValue(insert.getIndex())) {
+    const auto insertIndex = getConstantIntValue(insert.getIndex());
+    const auto extractIndex = getConstantIntValue(extract.getIndex());
+    if (!insertIndex || !extractIndex || insertIndex == extractIndex) {
       return failure();
     }
 
-    auto next = std::next(TensorIterator(insert.getResult()));
-    if (next == std::default_sentinel) {
-      return failure();
-    }
-
-    if (!isa<ExtractOp>(next.operation())) {
-      return failure();
-    }
-
-    auto extract = cast<ExtractOp>(next.operation());
-    if (!getConstantIntValue(extract.getIndex())) {
-      return failure();
-    }
-
-    if (areEquivalentIndices(extract.getIndex(), insert.getIndex())) {
-      return failure();
-    }
-
-    // i != j
-    //                ┌─────────┐                  ┌──────────┐
-    // ... ─t = dest─▶│insert(i)│─result = tensor─▶│extract(j)│─outTensor─▶ ...
-    //                └─────────┘                  └──────────┘
-    // -------------------------- ⬇ (transformed) ⬇ --------------------------
-    //                  ┌──────────┐                   ┌─────────┐
-    // ... ─t = tensor─▶│extract(j)│─outTensor = dest─▶│insert(i)│─result─▶ ...
-    //                  └──────────┘                   └─────────┘
-
-    const Value t = insert.getDest();
-    const Value outTensor = extract.getOutTensor();
-    const Value result = insert.getResult();
+    const Value tensorBeforeInsert = insert.getDest();
+    const Value tensorAfterExtract = extract.getOutTensor();
+    const Value tensorAfterInsert = insert.getResult();
 
     rewriter.moveOpAfter(insert, extract);
-    rewriter.modifyOpInPlace(extract,
-                             [&] { extract.getTensorMutable().assign(t); });
+    rewriter.modifyOpInPlace(extract, [&] {
+      extract.getTensorMutable().assign(tensorBeforeInsert);
+    });
     rewriter.modifyOpInPlace(
-        insert, [&] { insert.getDestMutable().assign(outTensor); });
-    rewriter.replaceAllUsesExcept(outTensor, result, insert);
-
+        insert, [&] { insert.getDestMutable().assign(tensorAfterExtract); });
+    rewriter.replaceAllUsesExcept(tensorAfterExtract, tensorAfterInsert,
+                                  insert);
     return success();
   }
 };
@@ -189,5 +116,5 @@ OpFoldResult InsertOp::fold(FoldAdaptor /*adaptor*/) {
 
 void InsertOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                            MLIRContext* context) {
-  results.add<RemoveInsertExtractPairPattern, BubbleDownInsertPattern>(context);
+  results.add<CommuteAdjacentInsertExtractPattern>(context);
 }

--- a/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
+++ b/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
@@ -28,7 +28,8 @@
 namespace mlir::qtensor {
 TypedValue<RankedTensorType> TensorIterator::tensor() const {
   // The following operations don't have an OpResult.
-  if (op_ != nullptr && isa<DeallocOp, scf::YieldOp, qco::YieldOp>(op_)) {
+  if (op_ != nullptr &&
+      isa<DeallocOp, scf::YieldOp, scf::ConditionOp, qco::YieldOp>(op_)) {
     return nullptr;
   }
 
@@ -97,7 +98,7 @@ void TensorIterator::forward() {
   op_ = *(tensor_.user_begin());
 
   // The following operations define the end of the tensor's life-chain.
-  if (isa<DeallocOp, scf::YieldOp, qco::YieldOp>(op_)) {
+  if (isa<DeallocOp, scf::YieldOp, scf::ConditionOp, qco::YieldOp>(op_)) {
     isFinal_ = true;
     return;
   }
@@ -144,7 +145,7 @@ void TensorIterator::backward() {
   }
 
   // For these operations, tensor_ is an OpOperand. Hence, only get the def-op.
-  if (isa<DeallocOp, scf::YieldOp, qco::YieldOp>(op_)) {
+  if (isa<DeallocOp, scf::YieldOp, scf::ConditionOp, qco::YieldOp>(op_)) {
     op_ = tensor_.getDefiningOp();
     isFinal_ = false;
     return;

--- a/mlir/lib/Support/IRVerification.cpp
+++ b/mlir/lib/Support/IRVerification.cpp
@@ -124,6 +124,21 @@ static void initEquivGroup(TypedValue<RankedTensorType> v, size_t id,
       const auto& arg =
           forOp.getTiedLoopRegionIterArg(cast<OpResult>(it.tensor()));
       initEquivGroup(cast<TypedValue<RankedTensorType>>(arg), id, group);
+    } else if (auto whileOp = dyn_cast<scf::WhileOp>(it.operation())) {
+      const auto previous = std::prev(it);
+      const auto init = llvm::find(whileOp.getInits(), previous.tensor());
+      assert(init != whileOp.getInits().end());
+      const auto initNumber = static_cast<unsigned>(
+          std::distance(whileOp.getInits().begin(), init));
+      initEquivGroup(cast<TypedValue<RankedTensorType>>(
+                         whileOp.getBeforeBody()->getArgument(initNumber)),
+                     id, group);
+
+      const auto result = cast<OpResult>(it.tensor());
+      initEquivGroup(
+          cast<TypedValue<RankedTensorType>>(
+              whileOp.getAfterBody()->getArgument(result.getResultNumber())),
+          id, group);
     }
   }
 }

--- a/mlir/lib/Support/Passes.cpp
+++ b/mlir/lib/Support/Passes.cpp
@@ -22,6 +22,7 @@
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Pass/PassRegistry.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 #include <mlir/Transforms/Passes.h>
 
 #include <cstdint>
@@ -118,7 +119,8 @@ void populateQCCleanupPipeline(OpPassManager& pm) {
 }
 
 void populateQCOCleanupPipeline(OpPassManager& pm) {
-  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCanonicalizerPass(
+      GreedyRewriteConfig{}.setMaxIterations(GreedyRewriteConfig::kNoLimit)));
   pm.addPass(mlir::mqt::createNormalizeGlobalPhases());
   pm.addPass(createCSEPass());
   pm.addPass(qtensor::createShrinkQTensorToFitPass());

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -2243,6 +2243,21 @@ private:
       auto selection = resolveQubitOperand(operand);
       qubits.insert(qubits.end(), selection.begin(), selection.end());
     }
+
+    std::set<std::tuple<QubitReferenceKind, uint32_t, uint64_t,
+                        std::optional<ExpressionId>>>
+        uniqueQubits;
+    for (const auto& qubit : qubits) {
+      if (!uniqueQubits
+               .emplace(qubit.kind, qubit.symbol, qubit.index,
+                        qubit.dynamicIndex)
+               .second) {
+        fail(location,
+             "barrier operands must not reference the same qubit more than "
+             "once");
+      }
+    }
+
     return addStatement(location,
                         BarrierStatement{.qubits = std::move(qubits)});
   }

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -2245,7 +2245,7 @@ private:
       qubits.insert(qubits.end(), selection.begin(), selection.end());
     }
 
-    if (!barrier.operands.empty()) {
+    if (barrier.operands.size() > 1) {
       llvm::DenseSet<std::pair<RegisterId, uint64_t>> staticRegisterQubits;
       llvm::DenseSet<std::pair<RegisterId, ExpressionId>> dynamicRegisterQubits;
       llvm::DenseSet<uint32_t> gateArguments;

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -17,6 +17,8 @@
 
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/StringMap.h>
@@ -40,7 +42,6 @@
 #include <set>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -2244,17 +2245,51 @@ private:
       qubits.insert(qubits.end(), selection.begin(), selection.end());
     }
 
-    std::set<std::tuple<QubitReferenceKind, uint32_t, uint64_t,
-                        std::optional<ExpressionId>>>
-        uniqueQubits;
-    for (const auto& qubit : qubits) {
-      if (!uniqueQubits
-               .emplace(qubit.kind, qubit.symbol, qubit.index,
-                        qubit.dynamicIndex)
-               .second) {
-        fail(location,
-             "barrier operands must not reference the same qubit more than "
-             "once");
+    if (!barrier.operands.empty()) {
+      llvm::DenseSet<std::pair<RegisterId, uint64_t>> staticRegisterQubits;
+      llvm::DenseSet<std::pair<RegisterId, ExpressionId>> dynamicRegisterQubits;
+      llvm::DenseSet<uint32_t> gateArguments;
+      llvm::DenseSet<uint64_t> hardwareQubitOperands;
+      llvm::DenseMap<RegisterId, size_t> staticRegisterQubitCounts;
+
+      for (const auto& qubit : qubits) {
+        bool inserted = false;
+        switch (qubit.kind) {
+        case QubitReferenceKind::Register:
+          if (qubit.dynamicIndex) {
+            inserted = dynamicRegisterQubits
+                           .insert({qubit.symbol, *qubit.dynamicIndex})
+                           .second;
+          } else {
+            inserted =
+                staticRegisterQubits.insert({qubit.symbol, qubit.index}).second;
+            if (inserted) {
+              ++staticRegisterQubitCounts[qubit.symbol];
+            }
+          }
+          break;
+        case QubitReferenceKind::GateArgument:
+          inserted = gateArguments.insert(qubit.symbol).second;
+          break;
+        case QubitReferenceKind::Hardware:
+          inserted = hardwareQubitOperands.insert(qubit.index).second;
+          break;
+        }
+        if (!inserted) {
+          fail(location,
+               "barrier operands must not reference the same qubit more than "
+               "once");
+        }
+      }
+
+      for (const auto& dynamicRegisterQubit : dynamicRegisterQubits) {
+        const auto reg = dynamicRegisterQubit.first;
+        if (staticRegisterQubitCounts.lookup(reg) ==
+            program.registers.at(reg).width) {
+          fail(location,
+               "barrier operands must not reference the same qubit more than "
+               "once");
+        }
       }
     }
 

--- a/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
+++ b/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
@@ -173,8 +173,8 @@ static Value ifWithAngle(qco::QCOProgramBuilder& b) {
 
 static Value forLoopWithAngle(qco::QCOProgramBuilder& b) {
   auto theta = b.floatConstant(0.123);
-  auto reg = b.allocQubitRegister(2);
-  auto res = b.scfFor(0, 2, 1, {reg.value}, [&](Value iv, ValueRange iterArgs) {
+  auto reg = b.qtensorAlloc(2);
+  auto res = b.scfFor(0, 2, 1, {reg}, [&](Value iv, ValueRange iterArgs) {
     auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
     auto q1 = b.rx(theta, q0);
     auto insert = b.qtensorInsert(q1, t0, iv);
@@ -187,12 +187,12 @@ static Value forLoopWithAngle(qco::QCOProgramBuilder& b) {
 static Value nestedIfOpForLoopWithAngle(qco::QCOProgramBuilder& b) {
   auto theta1 = b.floatConstant(0.123);
   auto theta2 = b.floatConstant(0.456);
-  auto reg = b.allocQubitRegister(3);
+  auto reg = b.qtensorAlloc(3);
   auto q0 = b.allocQubit();
   auto q1 = b.h(q0);
   auto [q2, cond] = b.measure(q1);
   auto res = b.qcoIf(
-      cond, {reg.value, q2},
+      cond, {reg, q2},
       [&](ValueRange args) {
         auto q3 = b.rx(theta1, args[1]);
         return SmallVector{args[0], q3};

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -27,6 +27,7 @@
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -82,6 +82,22 @@ static LogicalResult runQCOToQCConversion(ModuleOp module) {
   return pm.run(module);
 }
 
+static Value
+aliasSafeNestedForLoopCtrlOpWithExtractedQubit(qc::QCProgramBuilder& b) {
+  auto reg = b.allocQubitRegister(4);
+  auto c0 = arith::ConstantIndexOp::create(b, 0);
+  auto control = b.loadQubit(reg.value, c0);
+  b.h(control);
+  b.scfFor(1, 4, 1, [&](Value iv) {
+    auto target = b.loadQubit(reg.value, iv);
+    b.h(target);
+    b.cx(b.loadQubit(reg.value, c0), target);
+  });
+  auto result = b.allocClassicalBitRegister(1);
+  b.measure(control, result, 0);
+  return result;
+}
+
 TEST(QCOToQCRegressionTest, PreservesClassicalIfResult) {
   DialectRegistry registry;
   registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
@@ -965,5 +981,6 @@ INSTANTIATE_TEST_SUITE_P(
         QCOToQCTestCase{
             "NestedForLoopCtrlOpWithExtractedQubit",
             MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithExtractedQubit),
-            MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOpWithExtractedQubit)}));
+            MQT_NAMED_BUILDER(
+                aliasSafeNestedForLoopCtrlOpWithExtractedQubit)}));
 /// @}

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -127,23 +127,23 @@ protected:
   }
 
 public:
-  static void expectOperationLocalRegisterAccesses(ModuleOp module) {
+  static void expectOperationLocalRegisterAccesses(ModuleOp moduleOp) {
     std::size_t extracts = 0;
     std::size_t inserts = 0;
     llvm::DenseSet<Operation*> committedExtracts;
-    module.walk([&](qtensor::ExtractOp extract) {
+    moduleOp.walk([&](qtensor::ExtractOp extract) {
       ++extracts;
       ASSERT_TRUE(extract.getResult().hasOneUse());
       auto* user = *extract.getResult().getUsers().begin();
       EXPECT_EQ(user->getDialect(),
-                module.getContext()->getOrLoadDialect<qco::QCODialect>());
+                moduleOp.getContext()->getOrLoadDialect<qco::QCODialect>());
     });
-    module.walk([&](qtensor::InsertOp insert) {
+    moduleOp.walk([&](qtensor::InsertOp insert) {
       ++inserts;
       auto* producer = insert.getScalar().getDefiningOp();
       ASSERT_NE(producer, nullptr);
       EXPECT_EQ(producer->getDialect(),
-                module.getContext()->getOrLoadDialect<qco::QCODialect>());
+                moduleOp.getContext()->getOrLoadDialect<qco::QCODialect>());
 
       Value input;
       if (auto unitary = dyn_cast<qco::UnitaryOpInterface>(producer)) {
@@ -171,14 +171,14 @@ public:
     EXPECT_EQ(extracts, inserts);
     EXPECT_EQ(committedExtracts.size(), extracts);
 
-    module.walk([&](memref::LoadOp load) {
+    moduleOp.walk([&](memref::LoadOp load) {
       EXPECT_FALSE(isa<qc::QubitType>(load.getMemRefType().getElementType()));
     });
   }
 
-  static void expectStructuredStateUsesCompleteTensors(ModuleOp module) {
+  static void expectStructuredStateUsesCompleteTensors(ModuleOp moduleOp) {
     bool sawStructuredQuantumState = false;
-    module.walk([&](Operation* operation) {
+    moduleOp.walk([&](Operation* operation) {
       if (!isa<qco::IfOp, qco::IndexSwitchOp, scf::ForOp, scf::WhileOp>(
               operation)) {
         return;
@@ -568,19 +568,19 @@ module {
 }
 )mlir";
 
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
-  expectOperationLocalRegisterAccesses(*module);
-  expectNoQCOperations(*module);
+  expectOperationLocalRegisterAccesses(*moduleOp);
+  expectNoQCOperations(*moduleOp);
 
   std::size_t allocations = 0;
   std::size_t deallocations = 0;
-  module->walk([&](qtensor::AllocOp) { ++allocations; });
-  module->walk([&](qtensor::DeallocOp) { ++deallocations; });
+  moduleOp->walk([&](qtensor::AllocOp) { ++allocations; });
+  moduleOp->walk([&](qtensor::DeallocOp) { ++deallocations; });
   EXPECT_EQ(allocations, 1U);
   EXPECT_EQ(deallocations, 1U);
 }
@@ -600,9 +600,9 @@ module {
 }
 )mlir";
 
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
   bool sawExpectedDiagnostic = false;
   ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
@@ -611,7 +611,7 @@ module {
             .contains("cannot consume a register-backed qubit reference");
     return success();
   });
-  EXPECT_TRUE(failed(runQCToQCOConversion(*module)));
+  EXPECT_TRUE(failed(runQCToQCOConversion(*moduleOp)));
   EXPECT_TRUE(sawExpectedDiagnostic);
 }
 
@@ -635,19 +635,19 @@ module {
 }
 )mlir";
 
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
   scf::ForOp loop;
-  module->walk([&](scf::ForOp candidate) { loop = candidate; });
+  moduleOp->walk([&](scf::ForOp candidate) { loop = candidate; });
   ASSERT_TRUE(loop);
   ASSERT_EQ(loop.getNumResults(), 1);
   EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(0).getType()));
   EXPECT_FALSE(loop.getBody()->getOps<qco::PowOp>().empty());
-  expectNoQCOperations(*module);
+  expectNoQCOperations(*moduleOp);
 }
 
 namespace {
@@ -737,15 +737,15 @@ class NestedModifierConversionTest
 TEST_P(NestedModifierConversionTest, CarriesQubitThroughStructuredOperation) {
   for (const bool registerBacked : {false, true}) {
     SCOPED_TRACE(testing::Message() << "register_backed=" << registerBacked);
-    auto module =
+    auto moduleOp =
         buildNestedModifierProgram(&context, GetParam(), registerBacked);
-    ASSERT_TRUE(module);
-    ASSERT_TRUE(succeeded(verify(*module)));
-    ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
-    ASSERT_TRUE(succeeded(verify(*module)));
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
     qco::YieldOp modifierYield;
-    module->walk([&](qco::YieldOp yield) {
+    moduleOp->walk([&](qco::YieldOp yield) {
       if (isa<qco::InvOp, qco::CtrlOp, qco::PowOp>(yield->getParentOp())) {
         modifierYield = yield;
       }
@@ -756,20 +756,20 @@ TEST_P(NestedModifierConversionTest, CarriesQubitThroughStructuredOperation) {
     Value structuredResult;
     switch (GetParam().structured) {
     case StructuredKind::For:
-      module->walk(
+      moduleOp->walk(
           [&](scf::ForOp op) { structuredResult = op.getResults().back(); });
       break;
     case StructuredKind::While:
-      module->walk(
+      moduleOp->walk(
           [&](scf::WhileOp op) { structuredResult = op.getResults().back(); });
       break;
     case StructuredKind::If:
-      module->walk([&](qco::IfOp op) {
+      moduleOp->walk([&](qco::IfOp op) {
         structuredResult = op.getLinearResults().back();
       });
       break;
     case StructuredKind::IndexSwitch:
-      module->walk([&](qco::IndexSwitchOp op) {
+      moduleOp->walk([&](qco::IndexSwitchOp op) {
         structuredResult = op.getLinearResults().back();
       });
       break;
@@ -778,9 +778,9 @@ TEST_P(NestedModifierConversionTest, CarriesQubitThroughStructuredOperation) {
     ASSERT_TRUE(structuredResult);
     EXPECT_EQ(modifierYield.getOperand(0), structuredResult);
     if (registerBacked) {
-      expectOperationLocalRegisterAccesses(*module);
+      expectOperationLocalRegisterAccesses(*moduleOp);
     }
-    expectNoQCOperations(*module);
+    expectNoQCOperations(*moduleOp);
   }
 }
 
@@ -833,8 +833,8 @@ TEST_F(QCToQCORegressionTest,
   for (const auto modifier : modifiers) {
     SCOPED_TRACE(testing::Message()
                  << "modifier=" << modifierName(modifier).str());
-    auto module = buildInvalidNestedRegisterLoadProgram(&context, modifier);
-    ASSERT_TRUE(module);
+    auto moduleOp = buildInvalidNestedRegisterLoadProgram(&context, modifier);
+    ASSERT_TRUE(moduleOp);
 
     bool sawExpectedDiagnostic = false;
     ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
@@ -848,8 +848,126 @@ TEST_F(QCToQCORegressionTest,
     PassManager pm(&context);
     pm.enableVerifier(false);
     pm.addPass(createQCToQCO());
-    EXPECT_TRUE(failed(pm.run(*module)));
+    EXPECT_TRUE(failed(pm.run(*moduleOp)));
     EXPECT_TRUE(sawExpectedDiagnostic);
+  }
+}
+
+static OwningOpRef<ModuleOp> buildInvalidModifierCaptureProgram(
+    MLIRContext* context, const ModifierKind modifier,
+    const bool registerBacked, const bool nested) {
+  qc::QCProgramBuilder builder(context);
+  builder.initialize();
+
+  Value target;
+  Value captured;
+  if (registerBacked) {
+    const auto reg = builder.allocQubitRegisterStorage(2);
+    auto targetIndex = arith::ConstantIndexOp::create(builder, 0);
+    auto capturedIndex = arith::ConstantIndexOp::create(builder, 1);
+    target = builder.loadQubit(reg, targetIndex.getResult());
+    captured = builder.loadQubit(reg, capturedIndex.getResult());
+  } else {
+    target = builder.allocQubit();
+    captured = builder.allocQubit();
+  }
+
+  const auto modifierBody = [&](const Value) {
+    if (nested) {
+      builder.scfIf(true, [&] { builder.x(captured); });
+      return;
+    }
+    builder.x(captured);
+  };
+  switch (modifier) {
+  case ModifierKind::Inv:
+    builder.inv(target, modifierBody);
+    break;
+  case ModifierKind::Ctrl:
+    builder.ctrl(builder.allocQubit(), target, modifierBody);
+    break;
+  case ModifierKind::Pow:
+    builder.pow(2.0, target, modifierBody);
+    break;
+  }
+  return builder.finalize();
+}
+
+TEST_F(QCToQCORegressionTest,
+       PreflightRejectsEveryUnsupportedModifierQubitCapture) {
+  constexpr std::array modifiers{ModifierKind::Inv, ModifierKind::Ctrl,
+                                 ModifierKind::Pow};
+
+  for (const auto modifier : modifiers) {
+    for (const bool registerBacked : {false, true}) {
+      for (const bool nested : {false, true}) {
+        SCOPED_TRACE(testing::Message()
+                     << "modifier=" << modifierName(modifier).str()
+                     << ", register_backed=" << registerBacked
+                     << ", nested=" << nested);
+        auto moduleOp = buildInvalidModifierCaptureProgram(
+            &context, modifier, registerBacked, nested);
+        ASSERT_TRUE(moduleOp);
+
+        bool sawExpectedDiagnostic = false;
+        ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+          sawExpectedDiagnostic |=
+              StringRef(diagnostic.str())
+                  .contains("body must not capture qubits from above; use only "
+                            "its aliased block arguments");
+          return success();
+        });
+
+        PassManager pm(&context);
+        pm.enableVerifier(false);
+        pm.addPass(createQCToQCO());
+        EXPECT_TRUE(failed(pm.run(*moduleOp)));
+        EXPECT_TRUE(sawExpectedDiagnostic);
+      }
+    }
+  }
+}
+
+static OwningOpRef<ModuleOp>
+buildClassicalCaptureProgram(MLIRContext* context,
+                             const ModifierKind modifier) {
+  qc::QCProgramBuilder builder(context);
+  builder.initialize();
+  const auto target = builder.allocQubit();
+  const auto theta =
+      arith::ConstantOp::create(builder, builder.getF64FloatAttr(0.75))
+          .getResult();
+  const auto modifierBody = [&](const Value argument) {
+    builder.rx(theta, argument);
+  };
+
+  switch (modifier) {
+  case ModifierKind::Inv:
+    builder.inv(target, modifierBody);
+    break;
+  case ModifierKind::Ctrl:
+    builder.ctrl(builder.allocQubit(), target, modifierBody);
+    break;
+  case ModifierKind::Pow:
+    builder.pow(2.0, target, modifierBody);
+    break;
+  }
+  return builder.finalize();
+}
+
+TEST_F(QCToQCORegressionTest, ModifiersPermitClassicalCaptures) {
+  constexpr std::array modifiers{ModifierKind::Inv, ModifierKind::Ctrl,
+                                 ModifierKind::Pow};
+
+  for (const auto modifier : modifiers) {
+    SCOPED_TRACE(testing::Message()
+                 << "modifier=" << modifierName(modifier).str());
+    auto moduleOp = buildClassicalCaptureProgram(&context, modifier);
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    expectNoQCOperations(*moduleOp);
   }
 }
 
@@ -864,18 +982,18 @@ TEST_F(QCToQCORegressionTest,
     });
   });
 
-  auto module = builder.finalize();
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
   qco::InvOp inv;
   qco::PowOp pow;
   scf::ForOp loop;
-  module->walk([&](qco::InvOp op) { inv = op; });
-  module->walk([&](qco::PowOp op) { pow = op; });
-  module->walk([&](scf::ForOp op) { loop = op; });
+  moduleOp->walk([&](qco::InvOp op) { inv = op; });
+  moduleOp->walk([&](qco::PowOp op) { pow = op; });
+  moduleOp->walk([&](scf::ForOp op) { loop = op; });
   ASSERT_TRUE(inv);
   ASSERT_TRUE(pow);
   ASSERT_TRUE(loop);
@@ -886,7 +1004,7 @@ TEST_F(QCToQCORegressionTest,
   ASSERT_EQ(powYield.getNumOperands(), 1);
   EXPECT_EQ(invYield.getOperand(0), pow.getQubitsOut().front());
   EXPECT_EQ(powYield.getOperand(0), loop.getResults().back());
-  expectNoQCOperations(*module);
+  expectNoQCOperations(*moduleOp);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -929,20 +1047,20 @@ module {
 }
 )mlir";
 
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
   scf::IfOp ifOp;
-  module->walk([&](scf::IfOp candidate) { ifOp = candidate; });
+  moduleOp->walk([&](scf::IfOp candidate) { ifOp = candidate; });
   ASSERT_TRUE(ifOp);
   EXPECT_EQ(ifOp.getNumResults(), 0);
   std::size_t allocations = 0;
   ifOp.getThenRegion().walk([&](qco::AllocOp) { ++allocations; });
   EXPECT_EQ(allocations, 1);
-  expectNoQCOperations(*module);
+  expectNoQCOperations(*moduleOp);
 }
 
 TEST_F(QCToQCORegressionTest,
@@ -960,9 +1078,9 @@ module {
 }
 )mlir";
 
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
   bool sawExpectedDiagnostic = false;
   ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
@@ -970,7 +1088,7 @@ module {
         StringRef(diagnostic.str()).contains("use the same dynamic index");
     return success();
   });
-  EXPECT_TRUE(failed(runQCToQCOConversion(*module)));
+  EXPECT_TRUE(failed(runQCToQCOConversion(*moduleOp)));
   EXPECT_TRUE(sawExpectedDiagnostic);
 }
 
@@ -991,9 +1109,9 @@ module {
 }
 )mlir";
 
-  auto module = parseSourceString<ModuleOp>(source, &context);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
   bool sawExpectedDiagnostic = false;
   ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
@@ -1001,7 +1119,7 @@ module {
         StringRef(diagnostic.str()).contains("same constant index");
     return success();
   });
-  EXPECT_TRUE(failed(runQCToQCOConversion(*module)));
+  EXPECT_TRUE(failed(runQCToQCOConversion(*moduleOp)));
   EXPECT_TRUE(sawExpectedDiagnostic);
 }
 

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -647,13 +647,13 @@ module {
   EXPECT_TRUE(sawExpectedDiagnostic);
 }
 
-TEST_F(QCToQCORegressionTest,
-       PreflightRejectsNonAllocatedQubitRegisterBlockArguments) {
+TEST_F(QCToQCORegressionTest, PreflightRejectsDerivedQubitRegisterValues) {
   constexpr llvm::StringLiteral source = R"mlir(
 module {
-  func.func @main(%reg: memref<1x!qc.qubit>)
-      attributes {passthrough = ["entry_point"]} {
-    memref.dealloc %reg : memref<1x!qc.qubit>
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %reg = memref.alloc() : memref<1x!qc.qubit>
+    %cast = memref.cast %reg : memref<1x!qc.qubit> to memref<?x!qc.qubit>
+    memref.dealloc %cast : memref<?x!qc.qubit>
     return
   }
 }
@@ -676,6 +676,116 @@ module {
   pm.addPass(createQCToQCO());
   EXPECT_TRUE(failed(pm.run(*moduleOp)));
   EXPECT_TRUE(sawExpectedDiagnostic);
+}
+
+TEST_F(QCToQCORegressionTest,
+       PreflightRejectsUnsupportedQuantumBlockArguments) {
+  constexpr auto sources = std::to_array<llvm::StringLiteral>({
+      R"mlir(
+module {
+  func.func @main(%q: !qc.qubit)
+      attributes {passthrough = ["entry_point"]} {
+    qc.x %q : !qc.qubit
+    return
+  }
+}
+)mlir",
+      R"mlir(
+module {
+  func.func @main(%reg: memref<1x!qc.qubit>)
+      attributes {passthrough = ["entry_point"]} {
+    return
+  }
+}
+)mlir",
+      R"mlir(
+module {
+  func.func @main(%reg: memref<*x!qc.qubit>)
+      attributes {passthrough = ["entry_point"]} {
+    return
+  }
+}
+)mlir",
+  });
+
+  for (const auto source : sources) {
+    SCOPED_TRACE(source.str());
+    auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+    bool sawExpectedDiagnostic = false;
+    ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+      sawExpectedDiagnostic |=
+          StringRef(diagnostic.str())
+              .contains("cannot convert arbitrary qubit or qubit-register "
+                        "block arguments; only QC modifier qubit arguments are "
+                        "supported");
+      return success();
+    });
+
+    PassManager pm(&context);
+    pm.enableVerifier(false);
+    pm.addPass(createQCToQCO());
+    EXPECT_TRUE(failed(pm.run(*moduleOp)));
+    EXPECT_TRUE(sawExpectedDiagnostic);
+  }
+}
+
+TEST_F(QCToQCORegressionTest,
+       PreflightRejectsUnsupportedQuantumRegionCaptures) {
+  constexpr auto sources = std::to_array<llvm::StringLiteral>({
+      R"mlir(
+module {
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %q = qc.alloc : !qc.qubit
+    scf.execute_region {
+      qc.x %q : !qc.qubit
+      scf.yield
+    }
+    qc.dealloc %q : !qc.qubit
+    return
+  }
+}
+)mlir",
+      R"mlir(
+module {
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %reg = memref.alloc() : memref<1x!qc.qubit>
+    %c0 = arith.constant 0 : index
+    %q = memref.load %reg[%c0] : memref<1x!qc.qubit>
+    scf.execute_region {
+      qc.x %q : !qc.qubit
+      scf.yield
+    }
+    memref.dealloc %reg : memref<1x!qc.qubit>
+    return
+  }
+}
+)mlir",
+  });
+
+  for (const auto source : sources) {
+    SCOPED_TRACE(source.str());
+    auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+    bool sawExpectedDiagnostic = false;
+    ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+      sawExpectedDiagnostic |=
+          StringRef(diagnostic.str())
+              .contains("cannot capture quantum values in an unsupported "
+                        "region-bearing operation");
+      return success();
+    });
+
+    PassManager pm(&context);
+    pm.enableVerifier(false);
+    pm.addPass(createQCToQCO());
+    EXPECT_TRUE(failed(pm.run(*moduleOp)));
+    EXPECT_TRUE(sawExpectedDiagnostic);
+  }
 }
 
 TEST_F(QCToQCORegressionTest, CapturesQubitsUsedByPowInsideFor) {

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -615,6 +615,69 @@ module {
   EXPECT_TRUE(sawExpectedDiagnostic);
 }
 
+TEST_F(QCToQCORegressionTest, PreflightRejectsNonOneDimensionalQubitRegisters) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %reg = memref.alloc() : memref<!qc.qubit>
+    %q = memref.load %reg[] : memref<!qc.qubit>
+    qc.x %q : !qc.qubit
+    memref.dealloc %reg : memref<!qc.qubit>
+    return
+  }
+}
+)mlir";
+
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    sawExpectedDiagnostic |=
+        StringRef(diagnostic.str())
+            .contains("requires one-dimensional qubit register storage");
+    return success();
+  });
+
+  PassManager pm(&context);
+  pm.enableVerifier(false);
+  pm.addPass(createQCToQCO());
+  EXPECT_TRUE(failed(pm.run(*moduleOp)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
+}
+
+TEST_F(QCToQCORegressionTest,
+       PreflightRejectsNonAllocatedQubitRegisterBlockArguments) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%reg: memref<1x!qc.qubit>)
+      attributes {passthrough = ["entry_point"]} {
+    memref.dealloc %reg : memref<1x!qc.qubit>
+    return
+  }
+}
+)mlir";
+
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    sawExpectedDiagnostic |=
+        StringRef(diagnostic.str())
+            .contains("requires a directly allocated qubit register");
+    return success();
+  });
+
+  PassManager pm(&context);
+  pm.enableVerifier(false);
+  pm.addPass(createQCToQCO());
+  EXPECT_TRUE(failed(pm.run(*moduleOp)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
+}
+
 TEST_F(QCToQCORegressionTest, CapturesQubitsUsedByPowInsideFor) {
   constexpr llvm::StringLiteral source = R"mlir(
 module {

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -1976,7 +1976,8 @@ INSTANTIATE_TEST_SUITE_P(
                         MQT_NAMED_BUILDER(qco::nestedForLoopIfOp), true},
         QCToQCOTestCase{
             "NestedForLoopWhileOp", MQT_NAMED_BUILDER(qc::nestedForLoopWhileOp),
-            MQT_NAMED_BUILDER(qco::nestedForLoopWhileOp), true, true},
+            MQT_NAMED_BUILDER(qco::nestedForLoopWhileOpCompleteTensorState),
+            true},
         QCToQCOTestCase{
             "NestedForLoopSwitchOp",
             MQT_NAMED_BUILDER(qc::nestedForLoopSwitchOp),

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
@@ -23,16 +24,20 @@
 #include "qco_programs.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Matchers.h>
+#include <mlir/IR/Region.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
@@ -53,6 +58,7 @@ struct QCToQCOTestCase {
   mqt::test::NamedMLIRBuilder<qc::QCProgramBuilder> programBuilder;
   mqt::test::NamedMLIRBuilder<qco::QCOProgramBuilder> referenceBuilder;
   bool expectsCompleteTensorState = false;
+  bool skipReferenceComparison = false;
 
   friend std::ostream& operator<<(std::ostream& os,
                                   const QCToQCOTestCase& info);
@@ -118,6 +124,7 @@ public:
   static void expectOperationLocalRegisterAccesses(ModuleOp module) {
     std::size_t extracts = 0;
     std::size_t inserts = 0;
+    llvm::DenseSet<Operation*> committedExtracts;
     module.walk([&](qtensor::ExtractOp extract) {
       ++extracts;
       ASSERT_TRUE(extract.getResult().hasOneUse());
@@ -131,9 +138,32 @@ public:
       ASSERT_NE(producer, nullptr);
       EXPECT_EQ(producer->getDialect(),
                 module.getContext()->getOrLoadDialect<qco::QCODialect>());
+
+      Value input;
+      if (auto unitary = dyn_cast<qco::UnitaryOpInterface>(producer)) {
+        input = unitary.getInputForOutput(insert.getScalar());
+      } else if (auto measure = dyn_cast<qco::MeasureOp>(producer)) {
+        EXPECT_EQ(insert.getScalar(), measure.getQubitOut());
+        input = measure.getQubitIn();
+      } else if (auto reset = dyn_cast<qco::ResetOp>(producer)) {
+        EXPECT_EQ(insert.getScalar(), reset.getQubitOut());
+        input = reset.getQubitIn();
+      }
+      ASSERT_TRUE(input);
+
+      auto extract = input.getDefiningOp<qtensor::ExtractOp>();
+      ASSERT_TRUE(extract);
+      EXPECT_TRUE(
+          isEqualConstantIntOrValue(extract.getIndex(), insert.getIndex()));
+      EXPECT_EQ(extract->getBlock(), producer->getBlock());
+      EXPECT_EQ(producer->getBlock(), insert->getBlock());
+      EXPECT_TRUE(extract->isBeforeInBlock(producer));
+      EXPECT_TRUE(producer->isBeforeInBlock(insert));
+      committedExtracts.insert(extract);
     });
     EXPECT_GT(extracts, 0U);
     EXPECT_EQ(extracts, inserts);
+    EXPECT_EQ(committedExtracts.size(), extracts);
 
     module.walk([&](memref::LoadOp load) {
       EXPECT_FALSE(isa<qc::QubitType>(load.getMemRefType().getElementType()));
@@ -157,6 +187,19 @@ public:
           llvm::any_of(operation->getResultTypes(), isQubitTensor);
       EXPECT_TRUE(hasTensorOperand);
       EXPECT_TRUE(hasTensorResult);
+      const auto tensorOperands = llvm::to_vector(
+          llvm::make_filter_range(operation->getOperandTypes(), isQubitTensor));
+      const auto tensorResults = llvm::to_vector(
+          llvm::make_filter_range(operation->getResultTypes(), isQubitTensor));
+      EXPECT_EQ(tensorOperands, tensorResults);
+      for (Region& region : operation->getRegions()) {
+        if (region.empty()) {
+          continue;
+        }
+        const auto tensorArguments = llvm::to_vector(llvm::make_filter_range(
+            region.front().getArgumentTypes(), isQubitTensor));
+        EXPECT_EQ(tensorArguments, tensorResults);
+      }
       sawStructuredQuantumState = true;
     });
     EXPECT_TRUE(sawStructuredQuantumState);
@@ -566,9 +609,135 @@ module {
   EXPECT_TRUE(sawExpectedDiagnostic);
 }
 
+TEST_F(QCToQCORegressionTest, CapturesQubitsUsedByPowInsideFor) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %q = qc.alloc : !qc.qubit
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %exponent = arith.constant 2.0 : f64
+    scf.for %i = %c0 to %c1 step %c1 {
+      qc.pow(%exponent) (%arg0 = %q) {
+        qc.x %arg0 : !qc.qubit
+        qc.yield
+      } : !qc.qubit
+    }
+    qc.dealloc %q : !qc.qubit
+    return
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::ForOp loop;
+  module->walk([&](scf::ForOp candidate) { loop = candidate; });
+  ASSERT_TRUE(loop);
+  ASSERT_EQ(loop.getNumResults(), 1);
+  EXPECT_TRUE(isa<qco::QubitType>(loop.getResult(0).getType()));
+  EXPECT_FALSE(loop.getBody()->getOps<qco::PowOp>().empty());
+  expectNoQCOperations(*module);
+}
+
+TEST_F(QCToQCORegressionTest, DoesNotCaptureQubitsAllocatedInsideIf) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%condition: i1)
+      attributes {passthrough = ["entry_point"]} {
+    scf.if %condition {
+      %q = qc.alloc : !qc.qubit
+      qc.h %q : !qc.qubit
+      qc.dealloc %q : !qc.qubit
+    }
+    return
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  scf::IfOp ifOp;
+  module->walk([&](scf::IfOp candidate) { ifOp = candidate; });
+  ASSERT_TRUE(ifOp);
+  EXPECT_EQ(ifOp.getNumResults(), 0);
+  std::size_t allocations = 0;
+  ifOp.getThenRegion().walk([&](qco::AllocOp) { ++allocations; });
+  EXPECT_EQ(allocations, 1);
+  expectNoQCOperations(*module);
+}
+
+TEST_F(QCToQCORegressionTest,
+       RejectsSameDynamicRegisterIndexWithinOneOperation) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%i: index) attributes {passthrough = ["entry_point"]} {
+    %reg = memref.alloc() : memref<2x!qc.qubit>
+    %q0 = memref.load %reg[%i] : memref<2x!qc.qubit>
+    %q1 = memref.load %reg[%i] : memref<2x!qc.qubit>
+    qc.swap %q0, %q1 : !qc.qubit, !qc.qubit
+    memref.dealloc %reg : memref<2x!qc.qubit>
+    return
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    sawExpectedDiagnostic |=
+        StringRef(diagnostic.str()).contains("use the same dynamic index");
+    return success();
+  });
+  EXPECT_TRUE(failed(runQCToQCOConversion(*module)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
+}
+
+TEST_F(QCToQCORegressionTest,
+       RejectsEqualConstantRegisterIndicesWithinOneOperation) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %reg = memref.alloc() : memref<2x!qc.qubit>
+    %lhs = arith.constant 0 : index
+    %rhs = arith.constant 0 : index
+    %q0 = memref.load %reg[%lhs] : memref<2x!qc.qubit>
+    %q1 = memref.load %reg[%rhs] : memref<2x!qc.qubit>
+    qc.swap %q0, %q1 : !qc.qubit, !qc.qubit
+    memref.dealloc %reg : memref<2x!qc.qubit>
+    return
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    sawExpectedDiagnostic |=
+        StringRef(diagnostic.str()).contains("same constant index");
+    return success();
+  });
+  EXPECT_TRUE(failed(runQCToQCOConversion(*module)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
+}
+
 TEST_P(QCToQCOTest, ProgramConversion) {
-  const auto& [_, programBuilder, referenceBuilder,
-               expectsCompleteTensorState] = GetParam();
+  const auto& [_, programBuilder, referenceBuilder, expectsCompleteTensorState,
+               skipReferenceComparison] = GetParam();
   const auto name = " (" + GetParam().name + ")";
   mqt::test::DeferredPrinter printer;
 
@@ -594,21 +763,20 @@ TEST_P(QCToQCOTest, ProgramConversion) {
   printer.record(program.get(), "Canonicalized Converted QCO IR" + name);
   EXPECT_TRUE(verify(*program).succeeded());
 
-  if (expectsCompleteTensorState) {
-    return;
+  if (!skipReferenceComparison) {
+    auto reference =
+        mqt::test::buildMLIRProgram(context.get(), referenceBuilder);
+    ASSERT_TRUE(reference);
+    printer.record(reference.get(), "Reference QCO IR" + name);
+    EXPECT_TRUE(verify(*reference).succeeded());
+
+    EXPECT_TRUE(runQCOCleanupPipeline(reference.get()).succeeded());
+    printer.record(reference.get(), "Canonicalized Reference QCO IR" + name);
+    EXPECT_TRUE(verify(*reference).succeeded());
+
+    EXPECT_TRUE(
+        areModulesEquivalentWithPermutations(program.get(), reference.get()));
   }
-
-  auto reference = mqt::test::buildMLIRProgram(context.get(), referenceBuilder);
-  ASSERT_TRUE(reference);
-  printer.record(reference.get(), "Reference QCO IR" + name);
-  EXPECT_TRUE(verify(*reference).succeeded());
-
-  EXPECT_TRUE(runQCOCleanupPipeline(reference.get()).succeeded());
-  printer.record(reference.get(), "Canonicalized Reference QCO IR" + name);
-  EXPECT_TRUE(verify(*reference).succeeded());
-
-  EXPECT_TRUE(
-      areModulesEquivalentWithPermutations(program.get(), reference.get()));
 }
 
 /// \name QCToQCO/QubitManagement/StaticOp.cpp
@@ -1190,16 +1358,20 @@ INSTANTIATE_TEST_SUITE_P(
     SCFIfOpTest, QCToQCOTest,
     testing::Values(
         QCToQCOTestCase{"SimpleIfOp", MQT_NAMED_BUILDER(qc::simpleIf),
-                        MQT_NAMED_BUILDER(qco::simpleIf), true},
+                        MQT_NAMED_BUILDER(qco::simpleIfCompleteTensorState),
+                        true},
         QCToQCOTestCase{"IfElse", MQT_NAMED_BUILDER(qc::ifElse),
-                        MQT_NAMED_BUILDER(qco::ifElse), true},
+                        MQT_NAMED_BUILDER(qco::ifElseCompleteTensorState),
+                        true},
         QCToQCOTestCase{"IfTwoQubits", MQT_NAMED_BUILDER(qc::ifTwoQubits),
-                        MQT_NAMED_BUILDER(qco::ifTwoQubits), true},
-        QCToQCOTestCase{"IfWithMeasurement",
-                        MQT_NAMED_BUILDER(qc::ifWithMeasurement),
-                        MQT_NAMED_BUILDER(qco::ifWithMeasurement), true},
+                        MQT_NAMED_BUILDER(qco::ifTwoQubitsCompleteTensorState),
+                        true},
+        QCToQCOTestCase{
+            "IfWithMeasurement", MQT_NAMED_BUILDER(qc::ifWithMeasurement),
+            MQT_NAMED_BUILDER(qco::ifWithMeasurementCompleteTensorState), true},
         QCToQCOTestCase{"IfWithCreg", MQT_NAMED_BUILDER(qc::ifWithCreg),
-                        MQT_NAMED_BUILDER(qco::ifWithCreg), true},
+                        MQT_NAMED_BUILDER(qco::ifWithCregCompleteTensorState),
+                        true},
         QCToQCOTestCase{"NestedIfOpForLoop",
                         MQT_NAMED_BUILDER(qc::nestedIfOpForLoop),
                         MQT_NAMED_BUILDER(qco::nestedIfOpForLoop), true}));
@@ -1210,12 +1382,13 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QCOIndexSwitchOpTest, QCToQCOTest,
     testing::Values(
-        QCToQCOTestCase{"SimpleIndexSwitchOp",
-                        MQT_NAMED_BUILDER(qc::simpleIndexSwitch),
-                        MQT_NAMED_BUILDER(qco::simpleIndexSwitch), true},
-        QCToQCOTestCase{"IndexSwitchMultiCase",
-                        MQT_NAMED_BUILDER(qc::indexSwitchMultiCase),
-                        MQT_NAMED_BUILDER(qco::indexSwitchMultiCase), true}));
+        QCToQCOTestCase{
+            "SimpleIndexSwitchOp", MQT_NAMED_BUILDER(qc::simpleIndexSwitch),
+            MQT_NAMED_BUILDER(qco::simpleIndexSwitchCompleteTensorState), true},
+        QCToQCOTestCase{
+            "IndexSwitchMultiCase", MQT_NAMED_BUILDER(qc::indexSwitchMultiCase),
+            MQT_NAMED_BUILDER(qco::indexSwitchMultiCaseCompleteTensorState),
+            true}));
 /// @}
 
 /// \name QCToQCO/Operations/WhileOp.cpp
@@ -1240,12 +1413,14 @@ INSTANTIATE_TEST_SUITE_P(
         QCToQCOTestCase{"NestedForLoopIfOp",
                         MQT_NAMED_BUILDER(qc::nestedForLoopIfOp),
                         MQT_NAMED_BUILDER(qco::nestedForLoopIfOp), true},
-        QCToQCOTestCase{"NestedForLoopWhileOp",
-                        MQT_NAMED_BUILDER(qc::nestedForLoopWhileOp),
-                        MQT_NAMED_BUILDER(qco::nestedForLoopWhileOp), true},
-        QCToQCOTestCase{"NestedForLoopSwitchOp",
-                        MQT_NAMED_BUILDER(qc::nestedForLoopSwitchOp),
-                        MQT_NAMED_BUILDER(qco::nestedForLoopSwitchOp), true},
+        QCToQCOTestCase{
+            "NestedForLoopWhileOp", MQT_NAMED_BUILDER(qc::nestedForLoopWhileOp),
+            MQT_NAMED_BUILDER(qco::nestedForLoopWhileOp), true, true},
+        QCToQCOTestCase{
+            "NestedForLoopSwitchOp",
+            MQT_NAMED_BUILDER(qc::nestedForLoopSwitchOp),
+            MQT_NAMED_BUILDER(qco::nestedForLoopSwitchOpCompleteTensorState),
+            true},
         QCToQCOTestCase{
             "NestedForLoopCtrlOpWithSeparateQubit",
             MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOpWithSeparateQubit),

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
+#include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
 #include "qc_programs.h"
@@ -49,6 +50,7 @@ struct QCToQCOTestCase {
   std::string name;
   mqt::test::NamedMLIRBuilder<qc::QCProgramBuilder> programBuilder;
   mqt::test::NamedMLIRBuilder<qco::QCOProgramBuilder> referenceBuilder;
+  bool expectsCompleteTensorState = false;
 
   friend std::ostream& operator<<(std::ostream& os,
                                   const QCToQCOTestCase& info);
@@ -108,6 +110,54 @@ protected:
           operation->getDialect() == context.getLoadedDialect<qc::QCDialect>();
     });
     EXPECT_FALSE(retainsQCOperations);
+  }
+
+public:
+  static void expectOperationLocalRegisterAccesses(ModuleOp module) {
+    std::size_t extracts = 0;
+    std::size_t inserts = 0;
+    module.walk([&](qtensor::ExtractOp extract) {
+      ++extracts;
+      ASSERT_TRUE(extract.getResult().hasOneUse());
+      auto* user = *extract.getResult().getUsers().begin();
+      EXPECT_EQ(user->getDialect(),
+                module.getContext()->getOrLoadDialect<qco::QCODialect>());
+    });
+    module.walk([&](qtensor::InsertOp insert) {
+      ++inserts;
+      auto* producer = insert.getScalar().getDefiningOp();
+      ASSERT_NE(producer, nullptr);
+      EXPECT_EQ(producer->getDialect(),
+                module.getContext()->getOrLoadDialect<qco::QCODialect>());
+    });
+    EXPECT_GT(extracts, 0U);
+    EXPECT_EQ(extracts, inserts);
+
+    module.walk([&](memref::LoadOp load) {
+      EXPECT_FALSE(isa<qc::QubitType>(load.getMemRefType().getElementType()));
+    });
+  }
+
+  static void expectStructuredStateUsesCompleteTensors(ModuleOp module) {
+    bool sawStructuredQuantumState = false;
+    module.walk([&](Operation* operation) {
+      if (!isa<qco::IfOp, qco::IndexSwitchOp, scf::ForOp, scf::WhileOp>(
+              operation)) {
+        return;
+      }
+      const auto isQubitTensor = [](Type type) {
+        const auto tensor = dyn_cast<RankedTensorType>(type);
+        return tensor && isa<qco::QubitType>(tensor.getElementType());
+      };
+      const bool hasTensorOperand =
+          llvm::any_of(operation->getOperandTypes(), isQubitTensor);
+      const bool hasTensorResult =
+          llvm::any_of(operation->getResultTypes(), isQubitTensor);
+      EXPECT_TRUE(hasTensorOperand);
+      EXPECT_TRUE(hasTensorResult);
+      sawStructuredQuantumState = true;
+    });
+    EXPECT_TRUE(sawStructuredQuantumState);
   }
 };
 
@@ -437,8 +487,86 @@ module {
   expectNoQCOperations(*module);
 }
 
-TEST_P(QCToQCOTest, ProgramEquivalence) {
-  const auto& [_, programBuilder, referenceBuilder] = GetParam();
+TEST_F(QCToQCORegressionTest,
+       MaterializesSequentialPotentialAliasesAtEachOperation) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%i: index) attributes {passthrough = ["entry_point"]} {
+    %reg = memref.alloc() : memref<2x!qc.qubit>
+    %c0 = arith.constant 0 : index
+    %q0 = memref.load %reg[%c0] : memref<2x!qc.qubit>
+    qc.h %q0 : !qc.qubit
+    %q1 = memref.load %reg[%c0] : memref<2x!qc.qubit>
+    qc.x %q1 : !qc.qubit
+    %q2 = memref.load %reg[%i] : memref<2x!qc.qubit>
+    qc.y %q2 : !qc.qubit
+    %q3 = memref.load %reg[%c0] : memref<2x!qc.qubit>
+    %unused = qc.measure %q3 : !qc.qubit -> i1
+    %q4 = memref.load %reg[%i] : memref<2x!qc.qubit>
+    qc.reset %q4 : !qc.qubit
+    %q5 = memref.load %reg[%c0] : memref<2x!qc.qubit>
+    qc.barrier %q5 : !qc.qubit
+    %q6 = memref.load %reg[%i] : memref<2x!qc.qubit>
+    qc.inv (%arg0 = %q6) {
+      qc.z %arg0 : !qc.qubit
+      qc.yield
+    } : !qc.qubit
+    memref.dealloc %reg : memref<2x!qc.qubit>
+    return
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  expectOperationLocalRegisterAccesses(*module);
+  expectNoQCOperations(*module);
+
+  std::size_t allocations = 0;
+  std::size_t deallocations = 0;
+  module->walk([&](qtensor::AllocOp) { ++allocations; });
+  module->walk([&](qtensor::DeallocOp) { ++deallocations; });
+  EXPECT_EQ(allocations, 1U);
+  EXPECT_EQ(deallocations, 1U);
+}
+
+TEST_F(QCToQCORegressionTest, RejectsRegisterBackedReferenceEscapes) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func private @escape(!qc.qubit)
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %reg = memref.alloc() : memref<1x!qc.qubit>
+    %c0 = arith.constant 0 : index
+    %q = memref.load %reg[%c0] : memref<1x!qc.qubit>
+    func.call @escape(%q) : (!qc.qubit) -> ()
+    memref.dealloc %reg : memref<1x!qc.qubit>
+    return
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    sawExpectedDiagnostic |=
+        StringRef(diagnostic.str())
+            .contains("cannot consume a register-backed qubit reference");
+    return success();
+  });
+  EXPECT_TRUE(failed(runQCToQCOConversion(*module)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
+}
+
+TEST_P(QCToQCOTest, ProgramConversion) {
+  const auto& [_, programBuilder, referenceBuilder,
+               expectsCompleteTensorState] = GetParam();
   const auto name = " (" + GetParam().name + ")";
   mqt::test::DeferredPrinter printer;
 
@@ -454,10 +582,19 @@ TEST_P(QCToQCOTest, ProgramEquivalence) {
   EXPECT_TRUE(succeeded(runQCToQCOConversion(program.get())));
   printer.record(program.get(), "Converted QCO IR" + name);
   EXPECT_TRUE(verify(*program).succeeded());
+  if (expectsCompleteTensorState) {
+    QCToQCORegressionTest::expectOperationLocalRegisterAccesses(program.get());
+    QCToQCORegressionTest::expectStructuredStateUsesCompleteTensors(
+        program.get());
+  }
 
   EXPECT_TRUE(runQCOCleanupPipeline(program.get()).succeeded());
   printer.record(program.get(), "Canonicalized Converted QCO IR" + name);
   EXPECT_TRUE(verify(*program).succeeded());
+
+  if (expectsCompleteTensorState) {
+    return;
+  }
 
   auto reference = mqt::test::buildMLIRProgram(context.get(), referenceBuilder);
   ASSERT_TRUE(reference);
@@ -1021,7 +1158,8 @@ INSTANTIATE_TEST_SUITE_P(
                         MQT_NAMED_BUILDER(qco::partialMeasurementToRegister)},
         QCToQCOTestCase{"DynamicallyIndexedMeasurement",
                         MQT_NAMED_BUILDER(qc::dynamicallyIndexedMeasurement),
-                        MQT_NAMED_BUILDER(qco::dynamicallyIndexedMeasurement)},
+                        MQT_NAMED_BUILDER(qco::dynamicallyIndexedMeasurement),
+                        true},
         QCToQCOTestCase{"MeasurementWithoutRegisters",
                         MQT_NAMED_BUILDER(qc::measurementWithoutRegisters),
                         MQT_NAMED_BUILDER(qco::measurementWithoutRegisters)}));
@@ -1050,32 +1188,32 @@ INSTANTIATE_TEST_SUITE_P(
     SCFIfOpTest, QCToQCOTest,
     testing::Values(
         QCToQCOTestCase{"SimpleIfOp", MQT_NAMED_BUILDER(qc::simpleIf),
-                        MQT_NAMED_BUILDER(qco::simpleIf)},
+                        MQT_NAMED_BUILDER(qco::simpleIf), true},
         QCToQCOTestCase{"IfElse", MQT_NAMED_BUILDER(qc::ifElse),
-                        MQT_NAMED_BUILDER(qco::ifElse)},
+                        MQT_NAMED_BUILDER(qco::ifElse), true},
         QCToQCOTestCase{"IfTwoQubits", MQT_NAMED_BUILDER(qc::ifTwoQubits),
-                        MQT_NAMED_BUILDER(qco::ifTwoQubits)},
+                        MQT_NAMED_BUILDER(qco::ifTwoQubits), true},
         QCToQCOTestCase{"IfWithMeasurement",
                         MQT_NAMED_BUILDER(qc::ifWithMeasurement),
-                        MQT_NAMED_BUILDER(qco::ifWithMeasurement)},
+                        MQT_NAMED_BUILDER(qco::ifWithMeasurement), true},
         QCToQCOTestCase{"IfWithCreg", MQT_NAMED_BUILDER(qc::ifWithCreg),
-                        MQT_NAMED_BUILDER(qco::ifWithCreg)},
+                        MQT_NAMED_BUILDER(qco::ifWithCreg), true},
         QCToQCOTestCase{"NestedIfOpForLoop",
                         MQT_NAMED_BUILDER(qc::nestedIfOpForLoop),
-                        MQT_NAMED_BUILDER(qco::nestedIfOpForLoop)}));
+                        MQT_NAMED_BUILDER(qco::nestedIfOpForLoop), true}));
 /// @}
 
 /// \name QCToQCO/Operations/IndexSwitchOp.cpp
 /// @{
 INSTANTIATE_TEST_SUITE_P(
     QCOIndexSwitchOpTest, QCToQCOTest,
-    testing::Values(QCToQCOTestCase{"SimpleIndexSwitchOp",
-                                    MQT_NAMED_BUILDER(qc::simpleIndexSwitch),
-                                    MQT_NAMED_BUILDER(qco::simpleIndexSwitch)},
-                    QCToQCOTestCase{
-                        "IndexSwitchMultiCase",
+    testing::Values(
+        QCToQCOTestCase{"SimpleIndexSwitchOp",
+                        MQT_NAMED_BUILDER(qc::simpleIndexSwitch),
+                        MQT_NAMED_BUILDER(qco::simpleIndexSwitch), true},
+        QCToQCOTestCase{"IndexSwitchMultiCase",
                         MQT_NAMED_BUILDER(qc::indexSwitchMultiCase),
-                        MQT_NAMED_BUILDER(qco::indexSwitchMultiCase)}));
+                        MQT_NAMED_BUILDER(qco::indexSwitchMultiCase), true}));
 /// @}
 
 /// \name QCToQCO/Operations/WhileOp.cpp
@@ -1096,22 +1234,23 @@ INSTANTIATE_TEST_SUITE_P(
     SCFForOpTest, QCToQCOTest,
     testing::Values(
         QCToQCOTestCase{"SimpleForLoop", MQT_NAMED_BUILDER(qc::simpleForLoop),
-                        MQT_NAMED_BUILDER(qco::simpleForLoop)},
+                        MQT_NAMED_BUILDER(qco::simpleForLoop), true},
         QCToQCOTestCase{"NestedForLoopIfOp",
                         MQT_NAMED_BUILDER(qc::nestedForLoopIfOp),
-                        MQT_NAMED_BUILDER(qco::nestedForLoopIfOp)},
+                        MQT_NAMED_BUILDER(qco::nestedForLoopIfOp), true},
         QCToQCOTestCase{"NestedForLoopWhileOp",
                         MQT_NAMED_BUILDER(qc::nestedForLoopWhileOp),
-                        MQT_NAMED_BUILDER(qco::nestedForLoopWhileOp)},
+                        MQT_NAMED_BUILDER(qco::nestedForLoopWhileOp), true},
         QCToQCOTestCase{"NestedForLoopSwitchOp",
                         MQT_NAMED_BUILDER(qc::nestedForLoopSwitchOp),
-                        MQT_NAMED_BUILDER(qco::nestedForLoopSwitchOp)},
+                        MQT_NAMED_BUILDER(qco::nestedForLoopSwitchOp), true},
         QCToQCOTestCase{
             "NestedForLoopCtrlOpWithSeparateQubit",
             MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOpWithSeparateQubit),
-            MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithSeparateQubit)},
+            MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithSeparateQubit), true},
         QCToQCOTestCase{
             "NestedForLoopCtrlOpWithExtractedQubit",
             MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOpWithExtractedQubit),
-            MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithExtractedQubit)}));
+            MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithExtractedQubit),
+            true}));
 /// @}

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -26,7 +26,10 @@
 #include <gtest/gtest.h>
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -37,6 +40,7 @@
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Matchers.h>
+#include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Region.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Parser/Parser.h>
@@ -44,7 +48,9 @@
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -643,6 +649,270 @@ module {
   EXPECT_FALSE(loop.getBody()->getOps<qco::PowOp>().empty());
   expectNoQCOperations(*module);
 }
+
+namespace {
+
+enum class ModifierKind : std::uint8_t { Inv, Ctrl, Pow };
+enum class StructuredKind : std::uint8_t { For, While, If, IndexSwitch };
+
+struct NestedModifierCase {
+  std::string name;
+  ModifierKind modifier;
+  StructuredKind structured;
+};
+
+} // namespace
+
+static void emitStructuredQubitUse(qc::QCProgramBuilder& builder,
+                                   const StructuredKind kind,
+                                   const Value qubit) {
+  switch (kind) {
+  case StructuredKind::For:
+    builder.scfFor(0, 1, 1, [&](Value) { builder.x(qubit); });
+    return;
+  case StructuredKind::While:
+    builder.scfWhile(
+        [&] {
+          builder.x(qubit);
+          builder.scfCondition(
+              arith::ConstantOp::create(builder, builder.getBoolAttr(false)));
+        },
+        [&] { builder.y(qubit); });
+    return;
+  case StructuredKind::If:
+    builder.scfIf(true, [&] { builder.x(qubit); }, [&] { builder.y(qubit); });
+    return;
+  case StructuredKind::IndexSwitch: {
+    const auto caseBody = [&] { builder.x(qubit); };
+    const auto defaultBody = [&] { builder.y(qubit); };
+    const SmallVector<int64_t> cases{0};
+    const SmallVector<llvm::function_ref<void()>> caseBodies{caseBody};
+    builder.scfIndexSwitch(0, cases, caseBodies, defaultBody);
+    return;
+  }
+  }
+  llvm_unreachable("unknown structured operation");
+}
+
+static OwningOpRef<ModuleOp>
+buildNestedModifierProgram(MLIRContext* context,
+                           const NestedModifierCase& testCase,
+                           const bool registerBacked) {
+  qc::QCProgramBuilder builder(context);
+  builder.initialize();
+  Value target;
+  if (registerBacked) {
+    const auto reg = builder.allocQubitRegisterStorage(1);
+    auto index = arith::ConstantIndexOp::create(builder, 0);
+    target = builder.loadQubit(reg, index.getResult());
+  } else {
+    target = builder.allocQubit();
+  }
+  const auto body = [&](const Value argument) {
+    emitStructuredQubitUse(builder, testCase.structured, argument);
+  };
+
+  switch (testCase.modifier) {
+  case ModifierKind::Inv:
+    builder.inv(target, body);
+    break;
+  case ModifierKind::Ctrl:
+    builder.ctrl(builder.allocQubit(), target, body);
+    break;
+  case ModifierKind::Pow:
+    builder.pow(2.0, target, body);
+    break;
+  }
+  return builder.finalize();
+}
+
+namespace {
+
+class NestedModifierConversionTest
+    : public QCToQCORegressionTest,
+      public testing::WithParamInterface<NestedModifierCase> {};
+
+} // namespace
+
+TEST_P(NestedModifierConversionTest, CarriesQubitThroughStructuredOperation) {
+  for (const bool registerBacked : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "register_backed=" << registerBacked);
+    auto module =
+        buildNestedModifierProgram(&context, GetParam(), registerBacked);
+    ASSERT_TRUE(module);
+    ASSERT_TRUE(succeeded(verify(*module)));
+    ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+    ASSERT_TRUE(succeeded(verify(*module)));
+
+    qco::YieldOp modifierYield;
+    module->walk([&](qco::YieldOp yield) {
+      if (isa<qco::InvOp, qco::CtrlOp, qco::PowOp>(yield->getParentOp())) {
+        modifierYield = yield;
+      }
+    });
+    ASSERT_TRUE(modifierYield);
+    ASSERT_EQ(modifierYield.getNumOperands(), 1);
+
+    Value structuredResult;
+    switch (GetParam().structured) {
+    case StructuredKind::For:
+      module->walk(
+          [&](scf::ForOp op) { structuredResult = op.getResults().back(); });
+      break;
+    case StructuredKind::While:
+      module->walk(
+          [&](scf::WhileOp op) { structuredResult = op.getResults().back(); });
+      break;
+    case StructuredKind::If:
+      module->walk([&](qco::IfOp op) {
+        structuredResult = op.getLinearResults().back();
+      });
+      break;
+    case StructuredKind::IndexSwitch:
+      module->walk([&](qco::IndexSwitchOp op) {
+        structuredResult = op.getLinearResults().back();
+      });
+      break;
+    }
+
+    ASSERT_TRUE(structuredResult);
+    EXPECT_EQ(modifierYield.getOperand(0), structuredResult);
+    if (registerBacked) {
+      expectOperationLocalRegisterAccesses(*module);
+    }
+    expectNoQCOperations(*module);
+  }
+}
+
+static StringRef modifierName(const ModifierKind modifier) {
+  switch (modifier) {
+  case ModifierKind::Inv:
+    return "inv";
+  case ModifierKind::Ctrl:
+    return "ctrl";
+  case ModifierKind::Pow:
+    return "pow";
+  }
+  llvm_unreachable("unknown modifier");
+}
+
+static OwningOpRef<ModuleOp>
+buildInvalidNestedRegisterLoadProgram(MLIRContext* context,
+                                      const ModifierKind modifier) {
+  qc::QCProgramBuilder builder(context);
+  builder.initialize();
+  const auto target = builder.allocQubit();
+  const auto reg = builder.allocQubitRegisterStorage(1);
+  auto index = arith::ConstantIndexOp::create(builder, 0);
+  const auto body = [&](const Value) {
+    builder.scfIf(true, [&] {
+      const auto loaded = builder.loadQubit(reg, index.getResult());
+      builder.x(loaded);
+    });
+  };
+
+  switch (modifier) {
+  case ModifierKind::Inv:
+    builder.inv(target, body);
+    break;
+  case ModifierKind::Ctrl:
+    builder.ctrl(builder.allocQubit(), target, body);
+    break;
+  case ModifierKind::Pow:
+    builder.pow(2.0, target, body);
+    break;
+  }
+  return builder.finalize();
+}
+
+TEST_F(QCToQCORegressionTest,
+       PreflightRejectsNestedRegisterLoadsInEveryModifier) {
+  constexpr std::array modifiers{ModifierKind::Inv, ModifierKind::Ctrl,
+                                 ModifierKind::Pow};
+
+  for (const auto modifier : modifiers) {
+    SCOPED_TRACE(testing::Message()
+                 << "modifier=" << modifierName(modifier).str());
+    auto module = buildInvalidNestedRegisterLoadProgram(&context, modifier);
+    ASSERT_TRUE(module);
+
+    bool sawExpectedDiagnostic = false;
+    ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+      sawExpectedDiagnostic |=
+          StringRef(diagnostic.str())
+              .contains("body must not contain non-unitary quantum operations "
+                        "or modify a quantum register");
+      return success();
+    });
+
+    PassManager pm(&context);
+    pm.enableVerifier(false);
+    pm.addPass(createQCToQCO());
+    EXPECT_TRUE(failed(pm.run(*module)));
+    EXPECT_TRUE(sawExpectedDiagnostic);
+  }
+}
+
+TEST_F(QCToQCORegressionTest,
+       NestedModifiersCarryTheStructuredOperationResultByRegion) {
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  const auto target = builder.allocQubit();
+  builder.inv(target, [&](const Value outerArgument) {
+    builder.pow(2.0, outerArgument, [&](const Value innerArgument) {
+      builder.scfFor(0, 1, 1, [&](Value) { builder.x(innerArgument); });
+    });
+  });
+
+  auto module = builder.finalize();
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  qco::InvOp inv;
+  qco::PowOp pow;
+  scf::ForOp loop;
+  module->walk([&](qco::InvOp op) { inv = op; });
+  module->walk([&](qco::PowOp op) { pow = op; });
+  module->walk([&](scf::ForOp op) { loop = op; });
+  ASSERT_TRUE(inv);
+  ASSERT_TRUE(pow);
+  ASSERT_TRUE(loop);
+
+  auto invYield = cast<qco::YieldOp>(inv.getBody()->getTerminator());
+  auto powYield = cast<qco::YieldOp>(pow.getBody()->getTerminator());
+  ASSERT_EQ(invYield.getNumOperands(), 1);
+  ASSERT_EQ(powYield.getNumOperands(), 1);
+  EXPECT_EQ(invYield.getOperand(0), pow.getQubitsOut().front());
+  EXPECT_EQ(powYield.getOperand(0), loop.getResults().back());
+  expectNoQCOperations(*module);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ModifierStructuredMatrix, NestedModifierConversionTest,
+    testing::Values(
+        NestedModifierCase{"InvFor", ModifierKind::Inv, StructuredKind::For},
+        NestedModifierCase{"InvWhile", ModifierKind::Inv,
+                           StructuredKind::While},
+        NestedModifierCase{"InvIf", ModifierKind::Inv, StructuredKind::If},
+        NestedModifierCase{"InvIndexSwitch", ModifierKind::Inv,
+                           StructuredKind::IndexSwitch},
+        NestedModifierCase{"CtrlFor", ModifierKind::Ctrl, StructuredKind::For},
+        NestedModifierCase{"CtrlWhile", ModifierKind::Ctrl,
+                           StructuredKind::While},
+        NestedModifierCase{"CtrlIf", ModifierKind::Ctrl, StructuredKind::If},
+        NestedModifierCase{"CtrlIndexSwitch", ModifierKind::Ctrl,
+                           StructuredKind::IndexSwitch},
+        NestedModifierCase{"PowFor", ModifierKind::Pow, StructuredKind::For},
+        NestedModifierCase{"PowWhile", ModifierKind::Pow,
+                           StructuredKind::While},
+        NestedModifierCase{"PowIf", ModifierKind::Pow, StructuredKind::If},
+        NestedModifierCase{"PowIndexSwitch", ModifierKind::Pow,
+                           StructuredKind::IndexSwitch}),
+    [](const testing::TestParamInfo<NestedModifierCase>& info) {
+      return info.param.name;
+    });
 
 TEST_F(QCToQCORegressionTest, DoesNotCaptureQubitsAllocatedInsideIf) {
   constexpr llvm::StringLiteral source = R"mlir(

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -28,6 +28,7 @@
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
@@ -38,6 +39,7 @@
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
+#include <cstddef>
 #include <memory>
 #include <ostream>
 #include <string>

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -18,17 +18,23 @@
 #include "qc_programs.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
+#include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Support/LLVM.h>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <iosfwd>
@@ -230,6 +236,140 @@ TEST_F(QCTest, DirectSingleQubitPowBuilder) {
   EXPECT_EQ(pow.getQubits().front(), qubit);
   EXPECT_EQ(pow.getBody()->getArgument(0), bodyQubit);
   EXPECT_TRUE(pow.verify().succeeded());
+}
+
+namespace {
+
+enum class VerifierModifierKind : std::uint8_t { Inv, Ctrl, Pow };
+enum class ForbiddenModifierBodyOp : std::uint8_t {
+  Alloc,
+  Dealloc,
+  Measure,
+  Reset,
+  Load,
+  Store
+};
+
+} // namespace
+
+static StringRef modifierName(const VerifierModifierKind kind) {
+  switch (kind) {
+  case VerifierModifierKind::Inv:
+    return "inv";
+  case VerifierModifierKind::Ctrl:
+    return "ctrl";
+  case VerifierModifierKind::Pow:
+    return "pow";
+  }
+  llvm_unreachable("unknown modifier");
+}
+
+static StringRef forbiddenOperationName(const ForbiddenModifierBodyOp kind) {
+  switch (kind) {
+  case ForbiddenModifierBodyOp::Alloc:
+    return "alloc";
+  case ForbiddenModifierBodyOp::Dealloc:
+    return "dealloc";
+  case ForbiddenModifierBodyOp::Measure:
+    return "measure";
+  case ForbiddenModifierBodyOp::Reset:
+    return "reset";
+  case ForbiddenModifierBodyOp::Load:
+    return "load";
+  case ForbiddenModifierBodyOp::Store:
+    return "store";
+  }
+  llvm_unreachable("unknown forbidden modifier operation");
+}
+
+static void emitForbiddenModifierBodyOperation(
+    QCProgramBuilder& builder, const ForbiddenModifierBodyOp kind,
+    const Value argument, const Value reg, const Value index) {
+  switch (kind) {
+  case ForbiddenModifierBodyOp::Alloc:
+    AllocOp::create(builder);
+    return;
+  case ForbiddenModifierBodyOp::Dealloc:
+    DeallocOp::create(builder, argument);
+    return;
+  case ForbiddenModifierBodyOp::Measure:
+    MeasureOp::create(builder, argument);
+    return;
+  case ForbiddenModifierBodyOp::Reset:
+    ResetOp::create(builder, argument);
+    return;
+  case ForbiddenModifierBodyOp::Load:
+    memref::LoadOp::create(builder, reg, index);
+    return;
+  case ForbiddenModifierBodyOp::Store:
+    memref::StoreOp::create(builder, argument, reg, index);
+    return;
+  }
+  llvm_unreachable("unknown forbidden modifier operation");
+}
+
+static OwningOpRef<ModuleOp> buildInvalidNestedModifierProgram(
+    MLIRContext* context, const VerifierModifierKind modifier,
+    const ForbiddenModifierBodyOp forbiddenOperation) {
+  QCProgramBuilder builder(context);
+  builder.initialize();
+  const auto target = builder.allocQubit();
+  const auto control = builder.allocQubit();
+  const auto reg = builder.allocQubitRegisterStorage(1);
+  auto index = arith::ConstantIndexOp::create(builder, 0);
+  const auto modifierBody = [&](const Value argument) {
+    builder.scfIf(true, [&] {
+      emitForbiddenModifierBodyOperation(builder, forbiddenOperation, argument,
+                                         reg, index.getResult());
+    });
+  };
+
+  switch (modifier) {
+  case VerifierModifierKind::Inv:
+    builder.inv(target, modifierBody);
+    break;
+  case VerifierModifierKind::Ctrl:
+    builder.ctrl(control, target, modifierBody);
+    break;
+  case VerifierModifierKind::Pow:
+    builder.pow(2.0, target, modifierBody);
+    break;
+  }
+  return builder.finalize();
+}
+
+TEST_F(QCTest, ModifiersRecursivelyRejectEveryForbiddenOperation) {
+  constexpr std::array modifiers{VerifierModifierKind::Inv,
+                                 VerifierModifierKind::Ctrl,
+                                 VerifierModifierKind::Pow};
+  constexpr std::array forbiddenOperations{
+      ForbiddenModifierBodyOp::Alloc,   ForbiddenModifierBodyOp::Dealloc,
+      ForbiddenModifierBodyOp::Measure, ForbiddenModifierBodyOp::Reset,
+      ForbiddenModifierBodyOp::Load,    ForbiddenModifierBodyOp::Store};
+
+  for (const auto modifier : modifiers) {
+    for (const auto forbiddenOperation : forbiddenOperations) {
+      SCOPED_TRACE(testing::Message()
+                   << "modifier=" << modifierName(modifier).str()
+                   << ", operation="
+                   << forbiddenOperationName(forbiddenOperation).str());
+      auto module = buildInvalidNestedModifierProgram(context.get(), modifier,
+                                                      forbiddenOperation);
+      ASSERT_TRUE(module);
+
+      bool sawExpectedDiagnostic = false;
+      ScopedDiagnosticHandler handler(
+          context.get(), [&](Diagnostic& diagnostic) {
+            sawExpectedDiagnostic |=
+                StringRef(diagnostic.str())
+                    .contains("body must not contain non-unitary quantum "
+                              "operations or modify a quantum register");
+            return success();
+          });
+      EXPECT_TRUE(failed(verify(*module)));
+      EXPECT_TRUE(sawExpectedDiagnostic);
+    }
+  }
 }
 
 /// \name QC/Modifiers/CtrlOp.cpp

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -30,6 +30,7 @@
 #include <mlir/Support/LLVM.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <iosfwd>
 #include <memory>
 #include <ostream>

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -180,12 +180,12 @@ TEST_F(QCTest, BuilderAllowsRepeatedQubitLoadsAcrossNestedRegions) {
     builder.scfIf(true, [&] { builder.z(builder.loadQubit(reg, index)); });
   });
 
-  auto module = builder.finalize();
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
   std::size_t qubitLoads = 0;
-  module->walk([&](memref::LoadOp load) {
+  moduleOp->walk([&](memref::LoadOp load) {
     if (isa<QubitType>(load.getMemRefType().getElementType())) {
       ++qubitLoads;
       EXPECT_EQ(load.getMemref(), reg);
@@ -200,20 +200,20 @@ TEST_F(QCTest, BuilderCanAllocateQubitRegisterStorageWithoutEagerLoads) {
   builder.initialize();
   const auto reg = builder.allocQubitRegisterStorage(4);
 
-  auto module = builder.finalize();
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
   size_t allocations = 0;
   size_t qubitLoads = 0;
-  module->walk([&](memref::AllocOp allocation) {
+  moduleOp->walk([&](memref::AllocOp allocation) {
     if (isa<QubitType>(allocation.getType().getElementType())) {
       ++allocations;
       EXPECT_EQ(allocation.getResult(), reg);
       EXPECT_EQ(allocation.getType().getShape(), ArrayRef<int64_t>{4});
     }
   });
-  module->walk([&](memref::LoadOp load) {
+  moduleOp->walk([&](memref::LoadOp load) {
     qubitLoads += isa<QubitType>(load.getMemRefType().getElementType());
   });
   EXPECT_EQ(allocations, 1U);
@@ -353,9 +353,9 @@ TEST_F(QCTest, ModifiersRecursivelyRejectEveryForbiddenOperation) {
                    << "modifier=" << modifierName(modifier).str()
                    << ", operation="
                    << forbiddenOperationName(forbiddenOperation).str());
-      auto module = buildInvalidNestedModifierProgram(context.get(), modifier,
-                                                      forbiddenOperation);
-      ASSERT_TRUE(module);
+      auto moduleOp = buildInvalidNestedModifierProgram(context.get(), modifier,
+                                                        forbiddenOperation);
+      ASSERT_TRUE(moduleOp);
 
       bool sawExpectedDiagnostic = false;
       ScopedDiagnosticHandler handler(
@@ -366,7 +366,67 @@ TEST_F(QCTest, ModifiersRecursivelyRejectEveryForbiddenOperation) {
                               "operations or modify a quantum register");
             return success();
           });
-      EXPECT_TRUE(failed(verify(*module)));
+      EXPECT_TRUE(failed(verify(*moduleOp)));
+      EXPECT_TRUE(sawExpectedDiagnostic);
+    }
+  }
+}
+
+static OwningOpRef<ModuleOp>
+buildInvalidModifierCaptureProgram(MLIRContext* context,
+                                   const VerifierModifierKind modifier,
+                                   const bool nested) {
+  QCProgramBuilder builder(context);
+  builder.initialize();
+  const auto target = builder.allocQubit();
+  const auto captured = builder.allocQubit();
+  const auto control = builder.allocQubit();
+  const auto modifierBody = [&](const Value) {
+    if (nested) {
+      builder.scfIf(true, [&] { builder.x(captured); });
+      return;
+    }
+    builder.x(captured);
+  };
+
+  switch (modifier) {
+  case VerifierModifierKind::Inv:
+    builder.inv(target, modifierBody);
+    break;
+  case VerifierModifierKind::Ctrl:
+    builder.ctrl(control, target, modifierBody);
+    break;
+  case VerifierModifierKind::Pow:
+    builder.pow(2.0, target, modifierBody);
+    break;
+  }
+  return builder.finalize();
+}
+
+TEST_F(QCTest, ModifiersRejectDirectAndNestedQubitCaptures) {
+  constexpr std::array modifiers{VerifierModifierKind::Inv,
+                                 VerifierModifierKind::Ctrl,
+                                 VerifierModifierKind::Pow};
+
+  for (const auto modifier : modifiers) {
+    for (const bool nested : {false, true}) {
+      SCOPED_TRACE(testing::Message()
+                   << "modifier=" << modifierName(modifier).str()
+                   << ", nested=" << nested);
+      auto moduleOp =
+          buildInvalidModifierCaptureProgram(context.get(), modifier, nested);
+      ASSERT_TRUE(moduleOp);
+
+      bool sawExpectedDiagnostic = false;
+      ScopedDiagnosticHandler handler(
+          context.get(), [&](Diagnostic& diagnostic) {
+            sawExpectedDiagnostic |=
+                StringRef(diagnostic.str())
+                    .contains("body must not capture qubits from above; use "
+                              "only its aliased block arguments");
+            return success();
+          });
+      EXPECT_TRUE(failed(verify(*moduleOp)));
       EXPECT_TRUE(sawExpectedDiagnostic);
     }
   }

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -189,6 +189,31 @@ TEST_F(QCTest, BuilderAllowsRepeatedQubitLoadsAcrossNestedRegions) {
   EXPECT_EQ(qubitLoads, 5U);
 }
 
+TEST_F(QCTest, BuilderCanAllocateQubitRegisterStorageWithoutEagerLoads) {
+  QCProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto reg = builder.allocQubitRegisterStorage(4);
+
+  auto module = builder.finalize();
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  size_t allocations = 0;
+  size_t qubitLoads = 0;
+  module->walk([&](memref::AllocOp allocation) {
+    if (isa<QubitType>(allocation.getType().getElementType())) {
+      ++allocations;
+      EXPECT_EQ(allocation.getResult(), reg);
+      EXPECT_EQ(allocation.getType().getShape(), ArrayRef<int64_t>{4});
+    }
+  });
+  module->walk([&](memref::LoadOp load) {
+    qubitLoads += isa<QubitType>(load.getMemRefType().getElementType());
+  });
+  EXPECT_EQ(allocations, 1U);
+  EXPECT_EQ(qubitLoads, 0U);
+}
+
 TEST_F(QCTest, DirectSingleQubitPowBuilder) {
   QCProgramBuilder builder(context.get());
   builder.initialize();

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -21,6 +21,8 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Value.h>
@@ -67,7 +69,7 @@ void QCTest::SetUp() {
   // Register all necessary dialects
   DialectRegistry registry;
   registry.insert<QCDialect, arith::ArithDialect, func::FuncDialect,
-                  memref::MemRefDialect>();
+                  memref::MemRefDialect, scf::SCFDialect>();
   context = std::make_unique<MLIRContext>();
   context->appendDialectRegistry(registry);
   context->loadAllAvailableDialects();
@@ -156,6 +158,35 @@ TEST_F(QCTest, BuilderRejectsOutOfBoundsClassicalRegisterIndices) {
         builder.scfCondition(c, 1);
       },
       "Register index is out of bounds");
+}
+
+TEST_F(QCTest, BuilderAllowsRepeatedQubitLoadsAcrossNestedRegions) {
+  QCProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto reg = builder.allocQubitRegister(1);
+  const auto index = arith::ConstantIndexOp::create(builder, 0).getResult();
+
+  builder.h(builder.loadQubit(reg.value, index));
+  builder.x(builder.loadQubit(reg.value, index));
+  builder.scfIf(true, [&] {
+    builder.y(builder.loadQubit(reg.value, index));
+    builder.scfIf(true,
+                  [&] { builder.z(builder.loadQubit(reg.value, index)); });
+  });
+
+  auto module = builder.finalize();
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  std::size_t qubitLoads = 0;
+  module->walk([&](memref::LoadOp load) {
+    if (isa<QubitType>(load.getMemRefType().getElementType())) {
+      ++qubitLoads;
+      EXPECT_EQ(load.getMemref(), reg.value);
+      EXPECT_TRUE(isEqualConstantIntOrValue(load.getIndices().front(), index));
+    }
+  });
+  EXPECT_EQ(qubitLoads, 5U);
 }
 
 TEST_F(QCTest, DirectSingleQubitPowBuilder) {

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -164,15 +164,14 @@ TEST_F(QCTest, BuilderRejectsOutOfBoundsClassicalRegisterIndices) {
 TEST_F(QCTest, BuilderAllowsRepeatedQubitLoadsAcrossNestedRegions) {
   QCProgramBuilder builder(context.get());
   builder.initialize();
-  const auto reg = builder.allocQubitRegister(1);
+  const auto reg = builder.allocQubitRegisterStorage(1);
   const auto index = arith::ConstantIndexOp::create(builder, 0).getResult();
 
-  builder.h(builder.loadQubit(reg.value, index));
-  builder.x(builder.loadQubit(reg.value, index));
+  builder.h(builder.loadQubit(reg, index));
+  builder.x(builder.loadQubit(reg, index));
   builder.scfIf(true, [&] {
-    builder.y(builder.loadQubit(reg.value, index));
-    builder.scfIf(true,
-                  [&] { builder.z(builder.loadQubit(reg.value, index)); });
+    builder.y(builder.loadQubit(reg, index));
+    builder.scfIf(true, [&] { builder.z(builder.loadQubit(reg, index)); });
   });
 
   auto module = builder.finalize();
@@ -183,11 +182,11 @@ TEST_F(QCTest, BuilderAllowsRepeatedQubitLoadsAcrossNestedRegions) {
   module->walk([&](memref::LoadOp load) {
     if (isa<QubitType>(load.getMemRefType().getElementType())) {
       ++qubitLoads;
-      EXPECT_EQ(load.getMemref(), reg.value);
+      EXPECT_EQ(load.getMemref(), reg);
       EXPECT_TRUE(isEqualConstantIntOrValue(load.getIndices().front(), index));
     }
   });
-  EXPECT_EQ(qubitLoads, 5U);
+  EXPECT_EQ(qubitLoads, 4U);
 }
 
 TEST_F(QCTest, BuilderCanAllocateQubitRegisterStorageWithoutEagerLoads) {

--- a/mlir/unittests/Dialect/QC/Translation/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QC/Translation/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(
   PRIVATE GTest::gtest_main
           MLIRParser
           MLIRSupportMQT
+          MLIRQCToQCO
           MLIRQCProgramBuilder
           MLIRQCTranslation
           MLIRQCPrograms

--- a/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
@@ -899,7 +899,7 @@ static void materializeRegisterOperandsAtUse(ModuleOp module) {
         continue;
       }
       if (auto load = operand.get().getDefiningOp<memref::LoadOp>()) {
-        const auto previousUser = lastUser.lookup(load.getResult());
+        auto* const previousUser = lastUser.lookup(load.getResult());
         const auto belongsToSameApplication =
             previousUser == operation ||
             (previousUser != nullptr && previousUser == previousOperation &&

--- a/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
@@ -884,10 +884,10 @@ static SmallVector<Value> conditionIndexedBit(qc::QCProgramBuilder& b) {
   return {c, out};
 }
 
-static LogicalResult convertQCToQCO(ModuleOp module) {
-  PassManager manager(module.getContext());
+static LogicalResult convertQCToQCO(ModuleOp moduleOp) {
+  PassManager manager(moduleOp.getContext());
   manager.addPass(createQCToQCO());
-  return manager.run(module);
+  return manager.run(moduleOp);
 }
 
 TEST_P(QASM3TranslationTest, ProgramEquivalence) {

--- a/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
@@ -21,6 +21,7 @@
 #include "qc_programs.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -879,6 +880,45 @@ static SmallVector<Value> conditionIndexedBit(qc::QCProgramBuilder& b) {
   return {c, out};
 }
 
+/// Rewrite eager register references in legacy fixtures to the per-application
+/// loads emitted by the typed OpenQASM frontend.
+static void materializeRegisterOperandsAtUse(ModuleOp module) {
+  SmallVector<std::pair<Operation*, Operation*>> operations;
+  module.walk([&](Operation* operation) {
+    if (operation != module.getOperation() && !isa<memref::LoadOp>(operation)) {
+      operations.emplace_back(operation, operation->getPrevNode());
+    }
+  });
+
+  llvm::DenseMap<Value, Operation*> lastUser;
+  llvm::DenseMap<Value, Value> lastReload;
+  OpBuilder builder(module.getContext());
+  for (const auto [operation, previousOperation] : operations) {
+    for (auto& operand : operation->getOpOperands()) {
+      if (!isa<qc::QubitType>(operand.get().getType())) {
+        continue;
+      }
+      if (auto load = operand.get().getDefiningOp<memref::LoadOp>()) {
+        const auto previousUser = lastUser.lookup(load.getResult());
+        const auto belongsToSameApplication =
+            previousUser == operation ||
+            (previousUser != nullptr && previousUser == previousOperation &&
+             (isa<qc::CtrlOp>(previousUser) || isa<qc::CtrlOp>(operation)));
+        Value reloaded = lastReload.lookup(load.getResult());
+        if (!belongsToSameApplication) {
+          builder.setInsertionPoint(operation);
+          reloaded = memref::LoadOp::create(builder, operation->getLoc(),
+                                            load.getMemref(), load.getIndices())
+                         .getResult();
+        }
+        operand.set(reloaded);
+        lastUser[load.getResult()] = operation;
+        lastReload[load.getResult()] = reloaded;
+      }
+    }
+  }
+}
+
 TEST_P(QASM3TranslationTest, ProgramEquivalence) {
   const auto name = " (" + GetParam().name + ")";
   const auto& source = GetParam().source;
@@ -896,6 +936,7 @@ TEST_P(QASM3TranslationTest, ProgramEquivalence) {
 
   auto reference = mqt::test::buildMLIRProgram(context.get(), referenceBuilder);
   ASSERT_TRUE(reference);
+  materializeRegisterOperandsAtUse(reference.get());
   printer.record(reference.get(), "Reference QC IR" + name);
   EXPECT_TRUE(verify(*reference).succeeded());
 

--- a/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
@@ -9,11 +9,14 @@
  */
 
 #include "TestCaseUtils.h"
+#include "mlir/Conversion/QCToQCO/QCToQCO.h"
 #include "mlir/Dialect/QC/Builder/QCProgramBuilder.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/Utils/Utils.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
@@ -21,7 +24,6 @@
 #include "qc_programs.h"
 
 #include <gtest/gtest.h>
-#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -33,6 +35,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 
 #include <algorithm>
@@ -76,7 +79,8 @@ protected:
   void SetUp() override {
     DialectRegistry registry;
     registry.insert<arith::ArithDialect, func::FuncDialect, math::MathDialect,
-                    memref::MemRefDialect, qc::QCDialect, scf::SCFDialect>();
+                    memref::MemRefDialect, qc::QCDialect, qco::QCODialect,
+                    qtensor::QTensorDialect, scf::SCFDialect>();
     context = std::make_unique<MLIRContext>();
     context->appendDialectRegistry(registry);
     context->loadAllAvailableDialects();
@@ -880,43 +884,10 @@ static SmallVector<Value> conditionIndexedBit(qc::QCProgramBuilder& b) {
   return {c, out};
 }
 
-/// Rewrite eager register references in legacy fixtures to the per-application
-/// loads emitted by the typed OpenQASM frontend.
-static void materializeRegisterOperandsAtUse(ModuleOp module) {
-  SmallVector<std::pair<Operation*, Operation*>> operations;
-  module.walk([&](Operation* operation) {
-    if (operation != module.getOperation() && !isa<memref::LoadOp>(operation)) {
-      operations.emplace_back(operation, operation->getPrevNode());
-    }
-  });
-
-  llvm::DenseMap<Value, Operation*> lastUser;
-  llvm::DenseMap<Value, Value> lastReload;
-  OpBuilder builder(module.getContext());
-  for (const auto [operation, previousOperation] : operations) {
-    for (auto& operand : operation->getOpOperands()) {
-      if (!isa<qc::QubitType>(operand.get().getType())) {
-        continue;
-      }
-      if (auto load = operand.get().getDefiningOp<memref::LoadOp>()) {
-        auto* const previousUser = lastUser.lookup(load.getResult());
-        const auto belongsToSameApplication =
-            previousUser == operation ||
-            (previousUser != nullptr && previousUser == previousOperation &&
-             (isa<qc::CtrlOp>(previousUser) || isa<qc::CtrlOp>(operation)));
-        Value reloaded = lastReload.lookup(load.getResult());
-        if (!belongsToSameApplication) {
-          builder.setInsertionPoint(operation);
-          reloaded = memref::LoadOp::create(builder, operation->getLoc(),
-                                            load.getMemref(), load.getIndices())
-                         .getResult();
-        }
-        operand.set(reloaded);
-        lastUser[load.getResult()] = operation;
-        lastReload[load.getResult()] = reloaded;
-      }
-    }
-  }
+static LogicalResult convertQCToQCO(ModuleOp module) {
+  PassManager manager(module.getContext());
+  manager.addPass(createQCToQCO());
+  return manager.run(module);
 }
 
 TEST_P(QASM3TranslationTest, ProgramEquivalence) {
@@ -936,13 +907,21 @@ TEST_P(QASM3TranslationTest, ProgramEquivalence) {
 
   auto reference = mqt::test::buildMLIRProgram(context.get(), referenceBuilder);
   ASSERT_TRUE(reference);
-  materializeRegisterOperandsAtUse(reference.get());
   printer.record(reference.get(), "Reference QC IR" + name);
   EXPECT_TRUE(verify(*reference).succeeded());
 
   EXPECT_TRUE(runQCCleanupPipeline(reference.get()).succeeded());
   printer.record(reference.get(), "Canonicalized Reference QC IR" + name);
   EXPECT_TRUE(verify(*reference).succeeded());
+
+  ASSERT_TRUE(succeeded(convertQCToQCO(translated.get())));
+  ASSERT_TRUE(succeeded(convertQCToQCO(reference.get())));
+  ASSERT_TRUE(runQCOCleanupPipeline(translated.get()).succeeded());
+  ASSERT_TRUE(runQCOCleanupPipeline(reference.get()).succeeded());
+  printer.record(translated.get(), "Lowered Translated QCO IR" + name);
+  printer.record(reference.get(), "Lowered Reference QCO IR" + name);
+  ASSERT_TRUE(verify(*translated).succeeded());
+  ASSERT_TRUE(verify(*reference).succeeded());
 
   EXPECT_TRUE(
       areModulesEquivalentWithPermutations(translated.get(), reference.get()));

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -643,15 +643,15 @@ TEST_F(QCOTest, IndexSwitchParser) {
             %out_tensor, %result = qtensor.extract %1[%c0] : tensor<3x!qco.qubit>
             %qubit_out, %result_0 = qco.measure %result : !qco.qubit
             memref.store %result_0, %c[%c0] : memref<3xi1>
-            %out_tensor_1, %result_2 = qtensor.extract %out_tensor[%c1] : tensor<3x!qco.qubit>
+            %2 = qtensor.insert %qubit_out into %out_tensor[%c0] : tensor<3x!qco.qubit>
+            %out_tensor_1, %result_2 = qtensor.extract %2[%c1] : tensor<3x!qco.qubit>
             %qubit_out_3, %result_4 = qco.measure %result_2 : !qco.qubit
             memref.store %result_4, %c[%c1] : memref<3xi1>
-            %out_tensor_5, %result_6 = qtensor.extract %out_tensor_1[%c2] : tensor<3x!qco.qubit>
-            %2 = qtensor.insert %qubit_out into %out_tensor_5[%c0] : tensor<3x!qco.qubit>
-            %3 = qtensor.insert %qubit_out_3 into %2[%c1] : tensor<3x!qco.qubit>
+            %3 = qtensor.insert %qubit_out_3 into %out_tensor_1[%c1] : tensor<3x!qco.qubit>
+            %out_tensor_5, %result_6 = qtensor.extract %3[%c2] : tensor<3x!qco.qubit>
             %qubit_out_7, %result_8 = qco.measure %result_6 : !qco.qubit
             memref.store %result_8, %c[%c2] : memref<3xi1>
-            %4 = qtensor.insert %qubit_out_7 into %3[%c2] : tensor<3x!qco.qubit>
+            %4 = qtensor.insert %qubit_out_7 into %out_tensor_5[%c2] : tensor<3x!qco.qubit>
             qtensor.dealloc %4 : tensor<3x!qco.qubit>
             return %c : memref<3xi1>
         }

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/CMakeLists.txt
@@ -10,8 +10,14 @@ set(target_name mqt-core-mlir-unittest-mapping)
 add_executable(${target_name} test_mapping.cpp)
 
 target_link_libraries(
-  ${target_name} PRIVATE GTest::gtest_main MLIRParser MQTCompilerTarget MLIRQCOProgramBuilder
-                         MLIRQTensorUtils MLIRQCOTransforms)
+  ${target_name}
+  PRIVATE GTest::gtest_main
+          MLIRParser
+          MQTCompilerTarget
+          MLIRQCOProgramBuilder
+          MLIRQTensorUtils
+          MLIRQCOTransforms
+          MLIRSupportMQT)
 
 mqt_mlir_configure_unittest_target(${target_name})
 

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/Utils/Utils.h"
+#include "mlir/Support/Passes.h"
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/STLExtras.h>
@@ -773,8 +774,7 @@ TEST_P(MappingPassTest, MapLoopBasedGHZByUnrolling) {
 
   PassManager pm(context.get());
   pm.addNestedPass<func::FuncOp>(createQuantumLoopUnroll());
-  pm.addPass(createCSEPass());
-  pm.addPass(createCanonicalizerPass());
+  populateQCOCleanupPipeline(pm);
   pm.addPass(createMappingPass(target, MappingPassOptions{}));
 
   QCOProgramBuilder builder(context.get());

--- a/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
+++ b/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
@@ -290,9 +290,9 @@ static OwningOpRef<ModuleOp>
 buildAdjacentInsertExtractProgram(MLIRContext* context,
                                   const AdjacentIndexKind indexKind) {
   const auto loc = UnknownLoc::get(context);
-  auto module = ModuleOp::create(loc);
+  auto moduleOp = ModuleOp::create(loc);
   ImplicitLocOpBuilder b(loc, context);
-  b.setInsertionPointToStart(module.getBody());
+  b.setInsertionPointToStart(moduleOp.getBody());
 
   const auto indexType = b.getIndexType();
   const auto functionType =
@@ -328,13 +328,13 @@ buildAdjacentInsertExtractProgram(MLIRContext* context,
   qtensor::DeallocOp::create(b, finalTensor);
   func::ReturnOp::create(b);
 
-  return module;
+  return moduleOp;
 }
 
-static LogicalResult canonicalize(ModuleOp module) {
-  PassManager manager(module.getContext());
+static LogicalResult canonicalize(ModuleOp moduleOp) {
+  PassManager manager(moduleOp.getContext());
   manager.addPass(createCanonicalizerPass());
-  return manager.run(module);
+  return manager.run(moduleOp);
 }
 
 static OwningOpRef<ModuleOp>
@@ -414,36 +414,36 @@ buildResetWithSameIndexInsertProgram(MLIRContext* context,
 namespace {
 
 TEST_F(QTensorTest, AdjacentInsertExtractFoldsEqualConstants) {
-  auto module = buildAdjacentInsertExtractProgram(
+  auto moduleOp = buildAdjacentInsertExtractProgram(
       context.get(), AdjacentIndexKind::EqualConstants);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(canonicalize(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
-  EXPECT_EQ(countOps<ExtractOp>(*module), 1U);
-  EXPECT_EQ(countOps<InsertOp>(*module), 1U);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(canonicalize(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_EQ(countOps<ExtractOp>(*moduleOp), 1U);
+  EXPECT_EQ(countOps<InsertOp>(*moduleOp), 1U);
 }
 
 TEST_F(QTensorTest, AdjacentInsertExtractFoldsIdenticalDynamicValue) {
-  auto module = buildAdjacentInsertExtractProgram(
+  auto moduleOp = buildAdjacentInsertExtractProgram(
       context.get(), AdjacentIndexKind::IdenticalDynamicValue);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(canonicalize(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
-  EXPECT_EQ(countOps<ExtractOp>(*module), 1U);
-  EXPECT_EQ(countOps<InsertOp>(*module), 1U);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(canonicalize(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_EQ(countOps<ExtractOp>(*moduleOp), 1U);
+  EXPECT_EQ(countOps<InsertOp>(*moduleOp), 1U);
 }
 
 TEST_F(QTensorTest, AdjacentInsertExtractKeepsPotentialDynamicAlias) {
-  auto module = buildAdjacentInsertExtractProgram(
+  auto moduleOp = buildAdjacentInsertExtractProgram(
       context.get(), AdjacentIndexKind::PotentiallyAliasingDynamicValues);
-  ASSERT_TRUE(module);
-  ASSERT_TRUE(succeeded(verify(*module)));
-  ASSERT_TRUE(succeeded(canonicalize(*module)));
-  ASSERT_TRUE(succeeded(verify(*module)));
-  EXPECT_EQ(countOps<ExtractOp>(*module), 2U);
-  EXPECT_EQ(countOps<InsertOp>(*module), 2U);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(canonicalize(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_EQ(countOps<ExtractOp>(*moduleOp), 2U);
+  EXPECT_EQ(countOps<InsertOp>(*moduleOp), 2U);
 }
 
 TEST_F(QTensorTest, InsertChainCanonicalizationRemainsLocal) {

--- a/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
+++ b/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
@@ -16,6 +16,7 @@
 #include "TestCaseUtils.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorUtils.h"
@@ -37,7 +38,9 @@
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Transforms/Passes.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -131,7 +134,7 @@ TEST_F(QTensorTest, AllocOpZeroSizeFailsVerification) {
   auto qubitType = qco::QubitType::get(context.get());
   auto tensorType = RankedTensorType::get({ShapedType::kDynamic}, qubitType);
   auto c0 = arith::ConstantIndexOp::create(b, 0);
-  AllocOp::create(b, tensorType, c0.getResult());
+  qtensor::AllocOp::create(b, tensorType, c0.getResult());
 
   EXPECT_TRUE(verify(module).failed());
 }
@@ -146,7 +149,7 @@ TEST_F(QTensorTest, AllocOpStaticTypeMismatchFailsVerification) {
   auto qubitType = qco::QubitType::get(context.get());
   auto tensorType = RankedTensorType::get({3}, qubitType);
   auto c2 = arith::ConstantIndexOp::create(b, 2);
-  AllocOp::create(b, tensorType, c2.getResult());
+  qtensor::AllocOp::create(b, tensorType, c2.getResult());
 
   EXPECT_TRUE(verify(module).failed());
 }
@@ -161,7 +164,7 @@ TEST_F(QTensorTest, AllocOpDynamicTypeWithConstantSizeVerifies) {
   auto qubitType = qco::QubitType::get(context.get());
   auto tensorType = RankedTensorType::get({ShapedType::kDynamic}, qubitType);
   auto c3 = arith::ConstantIndexOp::create(b, 3);
-  AllocOp::create(b, tensorType, c3.getResult());
+  qtensor::AllocOp::create(b, tensorType, c3.getResult());
 
   EXPECT_TRUE(verify(module).succeeded());
 }
@@ -184,7 +187,7 @@ TEST_F(QTensorTest, AllocOpStaticTypeWithDynamicSizeOperandFailsVerification) {
   auto qubitType = qco::QubitType::get(context.get());
   auto tensorType = RankedTensorType::get({3}, qubitType);
   auto size = block->getArgument(0);
-  AllocOp::create(b, tensorType, size);
+  qtensor::AllocOp::create(b, tensorType, size);
   func::ReturnOp::create(b);
 
   EXPECT_TRUE(verify(module).failed());
@@ -203,8 +206,8 @@ TEST_F(QTensorTest, DeallocOpAllocDeallocPairIsRemoved) {
   ASSERT_TRUE(canonicalized);
   EXPECT_TRUE(verify(*canonicalized).succeeded());
   // Both AllocOp and DeallocOp should have been erased.
-  EXPECT_EQ(countOps<AllocOp>(*canonicalized), 0U);
-  EXPECT_EQ(countOps<DeallocOp>(*canonicalized), 0U);
+  EXPECT_EQ(countOps<qtensor::AllocOp>(*canonicalized), 0U);
+  EXPECT_EQ(countOps<qtensor::DeallocOp>(*canonicalized), 0U);
 }
 
 // ============================================================================
@@ -274,6 +277,63 @@ TEST_F(QTensorTest, InsertOpIndexAtDimFailsVerification) {
 // ============================================================================
 // Canonicalization
 // ============================================================================
+
+enum class AdjacentIndexKind : std::uint8_t {
+  EqualConstants,
+  IdenticalDynamicValue,
+  PotentiallyAliasingDynamicValues,
+};
+
+static OwningOpRef<ModuleOp>
+buildAdjacentInsertExtractProgram(MLIRContext* context,
+                                  const AdjacentIndexKind indexKind) {
+  const auto loc = UnknownLoc::get(context);
+  auto module = ModuleOp::create(loc);
+  ImplicitLocOpBuilder b(loc, context);
+  b.setInsertionPointToStart(module.getBody());
+
+  const auto indexType = b.getIndexType();
+  const auto functionType =
+      b.getFunctionType({indexType, indexType}, TypeRange{});
+  auto function = func::FuncOp::create(b, "test", functionType);
+  auto* block = function.addEntryBlock();
+  b.setInsertionPointToStart(block);
+
+  Value insertIndex;
+  Value extractIndex;
+  if (indexKind == AdjacentIndexKind::EqualConstants) {
+    insertIndex = arith::ConstantIndexOp::create(b, 0);
+    extractIndex = arith::ConstantIndexOp::create(b, 0);
+  } else {
+    insertIndex = block->getArgument(0);
+    extractIndex = indexKind == AdjacentIndexKind::IdenticalDynamicValue
+                       ? insertIndex
+                       : block->getArgument(1);
+  }
+
+  auto size = arith::ConstantIndexOp::create(b, 2);
+  const auto tensorType =
+      RankedTensorType::get({2}, qco::QubitType::get(context));
+  auto tensor = qtensor::AllocOp::create(b, tensorType, size.getResult());
+  auto firstExtract = ExtractOp::create(b, tensor, insertIndex);
+  auto h = qco::HOp::create(b, firstExtract.getResult());
+  auto insert = InsertOp::create(b, h.getResult(), firstExtract.getOutTensor(),
+                                 insertIndex);
+  auto secondExtract = ExtractOp::create(b, insert, extractIndex);
+  auto x = qco::XOp::create(b, secondExtract.getResult());
+  auto finalTensor = InsertOp::create(
+      b, x.getResult(), secondExtract.getOutTensor(), extractIndex);
+  qtensor::DeallocOp::create(b, finalTensor);
+  func::ReturnOp::create(b);
+
+  return module;
+}
+
+static LogicalResult canonicalize(ModuleOp module) {
+  PassManager manager(module.getContext());
+  manager.addPass(createCanonicalizerPass());
+  return manager.run(module);
+}
 
 static OwningOpRef<ModuleOp>
 buildTwoQubitInsertChainProgram(MLIRContext* context,
@@ -351,7 +411,40 @@ buildResetWithSameIndexInsertProgram(MLIRContext* context,
 
 namespace {
 
-TEST_F(QTensorTest, InsertChainPermutationEquivalence) {
+TEST_F(QTensorTest, AdjacentInsertExtractFoldsEqualConstants) {
+  auto module = buildAdjacentInsertExtractProgram(
+      context.get(), AdjacentIndexKind::EqualConstants);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(canonicalize(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+  EXPECT_EQ(countOps<ExtractOp>(*module), 1U);
+  EXPECT_EQ(countOps<InsertOp>(*module), 1U);
+}
+
+TEST_F(QTensorTest, AdjacentInsertExtractFoldsIdenticalDynamicValue) {
+  auto module = buildAdjacentInsertExtractProgram(
+      context.get(), AdjacentIndexKind::IdenticalDynamicValue);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(canonicalize(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+  EXPECT_EQ(countOps<ExtractOp>(*module), 1U);
+  EXPECT_EQ(countOps<InsertOp>(*module), 1U);
+}
+
+TEST_F(QTensorTest, AdjacentInsertExtractKeepsPotentialDynamicAlias) {
+  auto module = buildAdjacentInsertExtractProgram(
+      context.get(), AdjacentIndexKind::PotentiallyAliasingDynamicValues);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(canonicalize(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+  EXPECT_EQ(countOps<ExtractOp>(*module), 2U);
+  EXPECT_EQ(countOps<InsertOp>(*module), 2U);
+}
+
+TEST_F(QTensorTest, InsertChainCanonicalizationRemainsLocal) {
   auto program = buildTwoQubitInsertChainProgram(context.get(), false, false);
   ASSERT_TRUE(program);
   EXPECT_TRUE(verify(*program).succeeded());
@@ -364,8 +457,8 @@ TEST_F(QTensorTest, InsertChainPermutationEquivalence) {
   EXPECT_TRUE(runQCOCleanupPipeline(reference.get()).succeeded());
   EXPECT_TRUE(verify(*reference).succeeded());
 
-  EXPECT_TRUE(
-      areModulesEquivalentWithPermutations(program.get(), reference.get()));
+  EXPECT_EQ(countOps<InsertOp>(*program), 2U);
+  EXPECT_EQ(countOps<InsertOp>(*reference), 0U);
 }
 
 TEST_F(QTensorTest, InsertChainDifferentAssignmentsNotEquivalent) {

--- a/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
+++ b/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
@@ -278,11 +278,13 @@ TEST_F(QTensorTest, InsertOpIndexAtDimFailsVerification) {
 // Canonicalization
 // ============================================================================
 
+namespace {
 enum class AdjacentIndexKind : std::uint8_t {
   EqualConstants,
   IdenticalDynamicValue,
   PotentiallyAliasingDynamicValues,
 };
+} // namespace
 
 static OwningOpRef<ModuleOp>
 buildAdjacentInsertExtractProgram(MLIRContext* context,

--- a/mlir/unittests/Dialect/QTensor/Utils/test_tensoriterator.cpp
+++ b/mlir/unittests/Dialect/QTensor/Utils/test_tensoriterator.cpp
@@ -357,6 +357,12 @@ TEST_F(TensorIteratorTest, TraversesWhileCarriedTensors) {
   qtensor::DeallocOp::create(builder, builder.getLoc(), tensor1Result);
   ASSERT_TRUE(succeeded(verify(loop)));
 
+  TensorIterator beforeRegionIterator(
+      cast<TypedValue<RankedTensorType>>(before->getArgument(1)));
+  ++beforeRegionIterator;
+  ASSERT_TRUE(isa<scf::ConditionOp>(beforeRegionIterator.operation()));
+  ASSERT_EQ(beforeRegionIterator.tensor(), nullptr);
+
   TensorIterator iterator(cast<TypedValue<RankedTensorType>>(tensor0));
   ASSERT_EQ(iterator.operation(), tensor0.getDefiningOp());
   ASSERT_EQ(iterator.tensor(), tensor0);

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -704,7 +704,7 @@ result = internal + 1;
             "result");
 }
 
-TEST(OpenQASMTargetTest, RejectsExcessiveDynamicDispatch) {
+TEST(OpenQASMTargetTest, SupportsLargeDirectDynamicQubitAccess) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
@@ -716,22 +716,20 @@ cx q[i], aux[j];
 )qasm";
 
   MLIRContext context;
-  std::string diagnostic;
-  Location location = UnknownLoc::get(&context);
-  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& value) {
-    diagnostic = value.str();
-    location = value.getLocation();
-    return success();
-  });
   auto moduleOp = qc::translateQASM3ToQC(source, &context);
-  EXPECT_FALSE(moduleOp);
-  const auto fileLocation = dyn_cast<FileLineColLoc>(location);
-  ASSERT_TRUE(fileLocation);
-  EXPECT_EQ(fileLocation.getFilename(), "<input>");
-  EXPECT_EQ(fileLocation.getLine(), 8);
-  EXPECT_EQ(fileLocation.getColumn(), 1);
-  EXPECT_NE(diagnostic.find("projected emitted operation count"),
-            std::string::npos);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  size_t loads = 0;
+  size_t controls = 0;
+  size_t switches = 0;
+  moduleOp->walk([&](memref::LoadOp load) {
+    loads += isa<qc::QubitType>(load.getType());
+  });
+  moduleOp->walk([&](qc::CtrlOp) { ++controls; });
+  moduleOp->walk([&](scf::IndexSwitchOp) { ++switches; });
+  EXPECT_EQ(loads, 2);
+  EXPECT_EQ(controls, 1);
+  EXPECT_EQ(switches, 0);
 }
 
 TEST(OpenQASMTargetTest, RejectsExcessiveCustomGateExpansion) {
@@ -786,7 +784,7 @@ TEST(OpenQASMTargetTest, AccountsForEachLabelInSwitchCaseBudgets) {
       << diagnostic;
 }
 
-TEST(OpenQASMTargetTest, ComposesDispatchAndCustomGateExpansionBudgets) {
+TEST(OpenQASMTargetTest, DoesNotMultiplyCustomGatesByRegisterWidth) {
   std::string source = "OPENQASM 3.1;\n"
                        "include \"stdgates.inc\";\n"
                        "gate expanded a, b {\n";
@@ -801,15 +799,17 @@ TEST(OpenQASMTargetTest, ComposesDispatchAndCustomGateExpansionBudgets) {
             "expanded q[i], aux[j];\n";
 
   MLIRContext context;
-  std::string diagnostic;
-  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& value) {
-    diagnostic = value.str();
-    return success();
-  });
   auto moduleOp = qc::translateQASM3ToQC(source, &context);
-  EXPECT_FALSE(moduleOp);
-  EXPECT_NE(diagnostic.find("projected emitted operation count"),
-            std::string::npos);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  size_t loads = 0;
+  size_t xGates = 0;
+  moduleOp->walk([&](memref::LoadOp load) {
+    loads += isa<qc::QubitType>(load.getType());
+  });
+  moduleOp->walk([&](qc::XOp) { ++xGates; });
+  EXPECT_EQ(loads, 2);
+  EXPECT_EQ(xGates, 25);
 }
 
 TEST(OpenQASMTargetTest, BudgetsRepresentativeOperationConstruction) {
@@ -1422,7 +1422,7 @@ bit[2] result = measure q;
   EXPECT_GE(aliasAssertions, 3);
 }
 
-TEST(OpenQASMTargetTest, DispatchesDynamicQubitGatesWithStructuredControlFlow) {
+TEST(OpenQASMTargetTest, LoadsDynamicQubitGatesDirectly) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
@@ -1436,15 +1436,17 @@ x q[i];
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t switches = 0;
-  size_t conditionals = 0;
-  moduleOp->walk([&](scf::IndexSwitchOp switchOp) {
-    ++switches;
-    EXPECT_EQ(switchOp.getNumCases(), 1);
-    EXPECT_EQ(switchOp.getNumResults(), 0);
+  size_t loads = 0;
+  moduleOp->walk([&](scf::IndexSwitchOp) { ++switches; });
+  moduleOp->walk([&](memref::LoadOp load) {
+    if (!isa<qc::QubitType>(load.getType())) {
+      return;
+    }
+    ++loads;
+    EXPECT_TRUE(load.getIndices().front().getType().isIndex());
   });
-  moduleOp->walk([&](scf::IfOp) { ++conditionals; });
-  EXPECT_EQ(switches, 1);
-  EXPECT_EQ(conditionals, 0);
+  EXPECT_EQ(switches, 0);
+  EXPECT_EQ(loads, 1);
 }
 
 TEST(OpenQASMTargetTest, LowersNativeSwitchWithCasesAndCarriedState) {
@@ -1483,8 +1485,7 @@ switch (selector) {
   EXPECT_EQ(switches, 1);
 }
 
-TEST(OpenQASMTargetTest,
-     DispatchesDynamicQubitMeasurementsWithStructuredControlFlow) {
+TEST(OpenQASMTargetTest, LoadsDynamicQubitMeasurementsDirectly) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 qubit[2] q;
@@ -1498,19 +1499,19 @@ c = measure q[i];
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t switches = 0;
-  size_t conditionals = 0;
-  moduleOp->walk([&](scf::IndexSwitchOp switchOp) {
-    ++switches;
-    EXPECT_EQ(switchOp.getNumCases(), 1);
-    ASSERT_EQ(switchOp.getNumResults(), 1);
-    EXPECT_TRUE(switchOp.getResult(0).getType().isInteger(1));
+  size_t measurements = 0;
+  moduleOp->walk([&](scf::IndexSwitchOp) { ++switches; });
+  moduleOp->walk([&](qc::MeasureOp measurement) {
+    ++measurements;
+    auto load = measurement.getQubit().getDefiningOp<memref::LoadOp>();
+    ASSERT_TRUE(load);
+    EXPECT_TRUE(load.getIndices().front().getType().isIndex());
   });
-  moduleOp->walk([&](scf::IfOp) { ++conditionals; });
-  EXPECT_EQ(switches, 1);
-  EXPECT_EQ(conditionals, 0);
+  EXPECT_EQ(switches, 0);
+  EXPECT_EQ(measurements, 1);
 }
 
-TEST(OpenQASMTargetTest, HandlesWidthOneAndNestedDynamicQubitDispatch) {
+TEST(OpenQASMTargetTest, HandlesWidthOneAndMultipleDynamicQubitLoads) {
   constexpr llvm::StringLiteral widthOneSource = R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
@@ -1522,9 +1523,14 @@ x q[i];
   auto widthOneModule =
       qc::translateQASM3ToQC(widthOneSource, &widthOneContext);
   ASSERT_TRUE(widthOneModule);
-  widthOneModule->walk([&](scf::IndexSwitchOp switchOp) {
-    EXPECT_EQ(switchOp.getNumCases(), 0);
+  size_t widthOneSwitches = 0;
+  size_t widthOneLoads = 0;
+  widthOneModule->walk([&](scf::IndexSwitchOp) { ++widthOneSwitches; });
+  widthOneModule->walk([&](memref::LoadOp load) {
+    widthOneLoads += isa<qc::QubitType>(load.getType());
   });
+  EXPECT_EQ(widthOneSwitches, 0);
+  EXPECT_EQ(widthOneLoads, 1);
 
   constexpr llvm::StringLiteral nestedSource = R"qasm(
 OPENQASM 3.1;
@@ -1543,8 +1549,78 @@ cx left[i], right[j];
   size_t controls = 0;
   nestedModule->walk([&](scf::IndexSwitchOp) { ++switches; });
   nestedModule->walk([&](qc::CtrlOp) { ++controls; });
-  EXPECT_EQ(switches, 3);
-  EXPECT_EQ(controls, 4);
+  size_t loads = 0;
+  nestedModule->walk([&](memref::LoadOp load) {
+    loads += isa<qc::QubitType>(load.getType());
+  });
+  EXPECT_EQ(switches, 0);
+  EXPECT_EQ(controls, 1);
+  EXPECT_EQ(loads, 2);
+}
+
+TEST(OpenQASMTargetTest, LoadsEveryDynamicQuantumStatementDirectly) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+qubit[4] q;
+int i = 0;
+int j = 1;
+negctrl @ x q[i], q[j];
+bit measured = measure q[i];
+reset q[j];
+barrier q[i], q[j];
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  size_t switches = 0;
+  size_t loads = 0;
+  size_t measurements = 0;
+  size_t resets = 0;
+  size_t barriers = 0;
+  size_t distinctnessAssertions = 0;
+  moduleOp->walk([&](scf::IndexSwitchOp) { ++switches; });
+  moduleOp->walk([&](memref::LoadOp load) {
+    if (isa<qc::QubitType>(load.getType())) {
+      ++loads;
+      EXPECT_TRUE(load.getIndices().front().getType().isIndex());
+    }
+  });
+  moduleOp->walk([&](qc::MeasureOp) { ++measurements; });
+  moduleOp->walk([&](qc::ResetOp) { ++resets; });
+  moduleOp->walk([&](qc::BarrierOp) { ++barriers; });
+  moduleOp->walk([&](cf::AssertOp assertion) {
+    distinctnessAssertions += assertion.getMsg().ends_with(
+        "operands must not reference the same qubit");
+  });
+  EXPECT_EQ(switches, 0);
+  EXPECT_EQ(loads, 6);
+  EXPECT_EQ(measurements, 1);
+  EXPECT_EQ(resets, 1);
+  EXPECT_EQ(barriers, 1);
+  EXPECT_EQ(distinctnessAssertions, 2);
+}
+
+TEST(OpenQASMTargetTest, QuantumEmissionDoesNotScaleWithRegisterWidth) {
+  const auto operationCount = [](const int64_t width) {
+    const auto source = "OPENQASM 3.1;\ninclude \"stdgates.inc\";\nqubit[" +
+                        std::to_string(width) + "] q;\nint i = 0;\nh q[i];\n";
+    MLIRContext context;
+    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    EXPECT_TRUE(moduleOp);
+    if (!moduleOp) {
+      return size_t{0};
+    }
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    size_t operations = 0;
+    moduleOp->walk([&](Operation*) { ++operations; });
+    return operations;
+  };
+
+  EXPECT_EQ(operationCount(2), operationCount(100'000));
 }
 
 TEST(OpenQASMTargetTest, SupportsOrdinaryBitInitializationAndAssignment) {
@@ -1918,14 +1994,19 @@ x q[i];
   size_t conditionals = 0;
   size_t indexSwitches = 0;
   size_t xGates = 0;
+  size_t qubitLoads = 0;
   size_t powers = 0;
   moduleOp->walk([&](scf::IfOp) { ++conditionals; });
   moduleOp->walk([&](scf::IndexSwitchOp) { ++indexSwitches; });
   moduleOp->walk([&](qc::XOp) { ++xGates; });
+  moduleOp->walk([&](memref::LoadOp load) {
+    qubitLoads += isa<qc::QubitType>(load.getType());
+  });
   moduleOp->walk([&](qc::PowOp) { ++powers; });
   EXPECT_EQ(conditionals, 0);
-  EXPECT_EQ(indexSwitches, 1);
-  EXPECT_EQ(xGates, 2);
+  EXPECT_EQ(indexSwitches, 0);
+  EXPECT_EQ(xGates, 1);
+  EXPECT_EQ(qubitLoads, 1);
   EXPECT_EQ(powers, 0);
 }
 

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -1623,6 +1623,30 @@ TEST(OpenQASMTargetTest, QuantumEmissionDoesNotScaleWithRegisterWidth) {
   EXPECT_EQ(operationCount(2), operationCount(100'000));
 }
 
+TEST(OpenQASMTargetTest, LargeStaticBarrierAvoidsAliasChecks) {
+  constexpr size_t width = 10'000;
+  const auto source =
+      "OPENQASM 3.1;\nqubit[" + std::to_string(width) + "] q;\nbarrier q;\n";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  size_t loads = 0;
+  size_t barriers = 0;
+  size_t assertions = 0;
+  moduleOp->walk([&](memref::LoadOp load) {
+    if (isa<qc::QubitType>(load.getType())) {
+      ++loads;
+    }
+  });
+  moduleOp->walk([&](qc::BarrierOp) { ++barriers; });
+  moduleOp->walk([&](cf::AssertOp) { ++assertions; });
+  EXPECT_EQ(loads, width);
+  EXPECT_EQ(barriers, 1);
+  EXPECT_EQ(assertions, 0);
+}
+
 TEST(OpenQASMTargetTest, SupportsOrdinaryBitInitializationAndAssignment) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -95,6 +95,7 @@ TEST(OpenQASMFrontendTest, RejectsDuplicateBarrierQubits) {
   constexpr auto sources = std::to_array<llvm::StringLiteral>({
       "OPENQASM 3.1; qubit q; barrier q, q;",
       "OPENQASM 3.1; qubit[2] q; barrier q[0], q[0];",
+      "OPENQASM 3.1; qubit[2] q; int i = 0; barrier q, q[i];",
       "OPENQASM 3.1; barrier $0, $0;",
   });
 

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -91,6 +91,23 @@ cx q, q;
             std::string::npos);
 }
 
+TEST(OpenQASMFrontendTest, RejectsDuplicateBarrierQubits) {
+  constexpr auto sources = std::to_array<llvm::StringLiteral>({
+      "OPENQASM 3.1; qubit q; barrier q, q;",
+      "OPENQASM 3.1; qubit[2] q; barrier q[0], q[0];",
+      "OPENQASM 3.1; barrier $0, $0;",
+  });
+
+  for (const auto source : sources) {
+    SCOPED_TRACE(source.str());
+    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    ASSERT_FALSE(analyzed);
+    ASSERT_FALSE(analyzed.diagnostics.empty());
+    EXPECT_NE(analyzed.diagnostics.front().message.find("same qubit"),
+              std::string::npos);
+  }
+}
+
 TEST(OpenQASMFrontendTest, CompatibilityGatePolicyIsExplicit) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.0;

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -1378,6 +1378,20 @@ x q[index];
 output bit[2] result;
 result = measure q;
 )qasm";
+static const std::string directDynamicQuantumAccess = R"qasm(OPENQASM 3.1;
+include "stdgates.inc";
+qubit[4] q;
+int first = 0;
+int second = 1;
+bit choose = measure q[3];
+if (choose) { first = 1; second = 2; }
+negctrl @ x q[first], q[second];
+bit measured = measure q[first];
+reset q[second];
+barrier q[first], q[second];
+output bit result;
+result = measure q[first];
+)qasm";
 static const std::string inductionVariableIndex = R"qasm(OPENQASM 3.1;
 include "stdgates.inc";
 qubit[3] q;
@@ -1435,6 +1449,8 @@ llvm::ArrayRef<OpenQASMProgram> standardPipelinePrograms() {
       OpenQASMProgram{.name = "mixed-controls", .source = mixedControlledX},
       OpenQASMProgram{.name = "runtime-dynamic-index",
                       .source = runtimeDynamicIndex},
+      OpenQASMProgram{.name = "direct-dynamic-quantum-access",
+                      .source = directDynamicQuantumAccess},
       OpenQASMProgram{.name = "induction-variable-index",
                       .source = inductionVariableIndex},
       OpenQASMProgram{.name = "checked-integer-state",
@@ -1477,6 +1493,8 @@ llvm::ArrayRef<OpenQASMProgram> jeffIncompatiblePrograms() {
   static const std::array programs{
       OpenQASMProgram{.name = "runtime-dynamic-index",
                       .source = runtimeDynamicIndex},
+      OpenQASMProgram{.name = "direct-dynamic-quantum-access",
+                      .source = directDynamicQuantumAccess},
       OpenQASMProgram{.name = "induction-variable-index",
                       .source = inductionVariableIndex},
       OpenQASMProgram{.name = "checked-integer-state",

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -22,6 +22,8 @@
 #include <cstdint>
 #include <numbers>
 #include <tuple>
+#include <utility>
+#include <variant>
 #include <vector>
 
 namespace mlir::qco {
@@ -35,6 +37,32 @@ static Value measureAndReturnQTensor(QCOProgramBuilder& b, Value qTensor,
     qTensor = b.qtensorInsert(q2, qTensorOut, i);
   }
   return c;
+}
+
+static Value
+transformQTensorElement(QCOProgramBuilder& b, Value tensor,
+                        const std::variant<int64_t, Value>& index,
+                        const function_ref<Value(Value)> transform) {
+  auto [outTensor, qubit] = b.qtensorExtract(tensor, index);
+  return b.qtensorInsert(transform(qubit), outTensor, index);
+}
+
+static std::pair<Value, Value>
+measureQTensorElement(QCOProgramBuilder& b, Value tensor,
+                      const std::variant<int64_t, Value>& index) {
+  auto [outTensor, qubit] = b.qtensorExtract(tensor, index);
+  auto [outQubit, bit] = b.measure(qubit);
+  return {b.qtensorInsert(outQubit, outTensor, index), bit};
+}
+
+static Value
+measureQTensorElement(QCOProgramBuilder& b, Value tensor,
+                      const std::variant<int64_t, Value>& tensorIndex,
+                      Value classicalRegister,
+                      const std::variant<int64_t, Value>& classicalIndex) {
+  auto [outTensor, qubit] = b.qtensorExtract(tensor, tensorIndex);
+  auto [outQubit, bit] = b.measure(qubit, classicalRegister, classicalIndex);
+  return b.qtensorInsert(outQubit, outTensor, tensorIndex);
 }
 
 static Value measureToRegister(QCOProgramBuilder& b, ValueRange qubits) {
@@ -4105,6 +4133,77 @@ SmallVector<Value> ifWithCreg(QCOProgramBuilder& b) {
   return {c0, c1};
 }
 
+SmallVector<Value> simpleIfCompleteTensorState(QCOProgramBuilder& b) {
+  auto tensor = b.qtensorAlloc(1);
+  auto c0 = b.allocClassicalBitRegister(1);
+  auto c1 = b.allocClassicalBitRegister(1);
+  tensor = transformQTensorElement(b, tensor, 0,
+                                   [&](Value qubit) { return b.h(qubit); });
+  tensor = measureQTensorElement(b, tensor, 0, c0, 0);
+  tensor = b.qcoIf(c0, 0, tensor, [&](ValueRange branchArgs) {
+    return SmallVector{transformQTensorElement(
+        b, branchArgs[0], 0, [&](Value qubit) { return b.x(qubit); })};
+  })[0];
+  measureQTensorElement(b, tensor, 0, c1, 0);
+  return {c0, c1};
+}
+
+SmallVector<Value> ifElseCompleteTensorState(QCOProgramBuilder& b) {
+  auto tensor = b.qtensorAlloc(1);
+  auto c0 = b.allocClassicalBitRegister(1);
+  auto c1 = b.allocClassicalBitRegister(1);
+  tensor = transformQTensorElement(b, tensor, 0,
+                                   [&](Value qubit) { return b.h(qubit); });
+  tensor = measureQTensorElement(b, tensor, 0, c0, 0);
+  tensor = b.qcoIf(
+      c0, 0, tensor,
+      [&](ValueRange branchArgs) {
+        return SmallVector{transformQTensorElement(
+            b, branchArgs[0], 0, [&](Value qubit) { return b.x(qubit); })};
+      },
+      [&](ValueRange branchArgs) {
+        return SmallVector{transformQTensorElement(
+            b, branchArgs[0], 0, [&](Value qubit) { return b.z(qubit); })};
+      })[0];
+  measureQTensorElement(b, tensor, 0, c1, 0);
+  return {c0, c1};
+}
+
+SmallVector<Value> ifTwoQubitsCompleteTensorState(QCOProgramBuilder& b) {
+  auto tensor = b.qtensorAlloc(2);
+  auto c0 = b.allocClassicalBitRegister(1);
+  auto c1 = b.allocClassicalBitRegister(2);
+  tensor = transformQTensorElement(b, tensor, 0,
+                                   [&](Value qubit) { return b.h(qubit); });
+  tensor = measureQTensorElement(b, tensor, 0, c0, 0);
+  tensor = b.qcoIf(c0, 0, tensor, [&](ValueRange branchArgs) {
+    auto branchTensor = transformQTensorElement(
+        b, branchArgs[0], 0, [&](Value qubit) { return b.x(qubit); });
+    return SmallVector{transformQTensorElement(
+        b, branchTensor, 1, [&](Value qubit) { return b.x(qubit); })};
+  })[0];
+  tensor = measureQTensorElement(b, tensor, 0, c1, 0);
+  measureQTensorElement(b, tensor, 1, c1, 1);
+  return {c0, c1};
+}
+
+SmallVector<Value> ifWithMeasurementCompleteTensorState(QCOProgramBuilder& b) {
+  auto tensor = b.qtensorAlloc(1);
+  auto c0 = b.allocClassicalBitRegister(1);
+  auto c1 = b.allocClassicalBitRegister(1);
+  tensor = transformQTensorElement(b, tensor, 0,
+                                   [&](Value qubit) { return b.h(qubit); });
+  tensor = measureQTensorElement(b, tensor, 0, c0, 0);
+  b.qcoIf(c0, 0, tensor, [&](ValueRange branchArgs) {
+    return SmallVector{measureQTensorElement(b, branchArgs[0], 0, c1, 0)};
+  });
+  return {c0, c1};
+}
+
+SmallVector<Value> ifWithCregCompleteTensorState(QCOProgramBuilder& b) {
+  return simpleIfCompleteTensorState(b);
+}
+
 Value ifOneQubitOneTensor(QCOProgramBuilder& b) {
   auto q0 = b.allocQubit();
   auto t0 = b.allocQubitRegister(1);
@@ -4273,6 +4372,69 @@ Value indexSwitchMultiCase(QCOProgramBuilder& b) {
       [&](ValueRange args) { return args; });
 
   return measureAndReturn(b, reg.qubits);
+}
+
+SmallVector<Value> simpleIndexSwitchCompleteTensorState(QCOProgramBuilder& b) {
+  auto tensor = b.qtensorAlloc(1);
+  tensor = transformQTensorElement(b, tensor, 0,
+                                   [&](Value qubit) { return b.h(qubit); });
+  auto [measuredTensor, bit0] = measureQTensorElement(b, tensor, 0);
+  const auto index =
+      arith::IndexCastUIOp::create(b, b.getIndexType(), bit0).getOut();
+  tensor = b.qcoIndexSwitch(
+      index, measuredTensor, SmallVector<int64_t>{0},
+      SmallVector<function_ref<Value(Value)>>{[&](Value branchTensor) {
+        return transformQTensorElement(b, branchTensor, 0,
+                                       [&](Value qubit) { return b.x(qubit); });
+      }},
+      [&](Value branchTensor) {
+        return transformQTensorElement(b, branchTensor, 0,
+                                       [&](Value qubit) { return b.z(qubit); });
+      });
+  auto [finalTensor, bit1] = measureQTensorElement(b, tensor, 0);
+  b.qtensorDealloc(finalTensor);
+  return {bit0, bit1};
+}
+
+Value indexSwitchMultiCaseCompleteTensorState(QCOProgramBuilder& b) {
+  constexpr int64_t size = 2;
+  auto tensor = b.qtensorAlloc(size);
+  auto c1 = arith::ConstantOp::create(b, b.getIndexType(), b.getIndexAttr(1))
+                .getResult();
+  auto condition =
+      arith::ConstantOp::create(b, b.getIndexType(), b.getIndexAttr(0))
+          .getResult();
+  for (int64_t i = 0; i < size; ++i) {
+    tensor = transformQTensorElement(b, tensor, i,
+                                     [&](Value qubit) { return b.h(qubit); });
+    auto [outTensor, bit] = measureQTensorElement(b, tensor, i);
+    tensor = outTensor;
+    const auto index =
+        arith::IndexCastUIOp::create(b, b.getIndexType(), bit).getOut();
+    condition = arith::OrIOp::create(b, condition, index);
+    condition = arith::ShLIOp::create(b, condition, c1);
+  }
+
+  tensor = b.qcoIndexSwitch(
+      condition, tensor, SmallVector<int64_t>{1, 2, 3},
+      SmallVector<function_ref<Value(Value)>>{
+          [&](Value branchTensor) {
+            return transformQTensorElement(
+                b, branchTensor, 1, [&](Value qubit) { return b.x(qubit); });
+          },
+          [&](Value branchTensor) {
+            return transformQTensorElement(
+                b, branchTensor, 0, [&](Value qubit) { return b.x(qubit); });
+          },
+          [&](Value branchTensor) {
+            branchTensor = transformQTensorElement(
+                b, branchTensor, 0, [&](Value qubit) { return b.x(qubit); });
+            return transformQTensorElement(
+                b, branchTensor, 1, [&](Value qubit) { return b.x(qubit); });
+          }},
+      [&](Value branchTensor) { return branchTensor; });
+
+  return measureAndReturnQTensor(b, tensor, size);
 }
 
 Value qtensorAlloc(QCOProgramBuilder& b) {
@@ -4504,6 +4666,34 @@ Value nestedForLoopSwitchOp(QCOProgramBuilder& b) {
   })[0];
 
   return measureAndReturnQTensor(b, reg, n);
+}
+
+Value nestedForLoopSwitchOpCompleteTensorState(QCOProgramBuilder& b) {
+  constexpr int64_t size = 3;
+  auto tensor = b.qtensorAlloc(size);
+  auto c3 = arith::ConstantOp::create(b, b.getIndexAttr(3));
+  tensor = b.scfFor(0, size, 1, tensor, [&](Value iv, ValueRange iterArgs) {
+    auto remainder = arith::RemUIOp::create(b, iv, c3);
+    auto result = b.qcoIndexSwitch(
+        remainder, iterArgs[0], SmallVector<int64_t>{0, 1, 2},
+        SmallVector<function_ref<Value(Value)>>{
+            [&](Value branchTensor) {
+              return transformQTensorElement(
+                  b, branchTensor, iv, [&](Value qubit) { return b.x(qubit); });
+            },
+            [&](Value branchTensor) {
+              return transformQTensorElement(
+                  b, branchTensor, iv, [&](Value qubit) { return b.y(qubit); });
+            },
+            [&](Value branchTensor) {
+              return transformQTensorElement(
+                  b, branchTensor, iv,
+                  [&](Value qubit) { return b.y(b.x(qubit)); });
+            }},
+        [&](Value branchTensor) { return branchTensor; });
+    return SmallVector{result};
+  })[0];
+  return measureAndReturnQTensor(b, tensor, size);
 }
 
 Value nestedForLoopCtrlOpWithSeparateQubit(QCOProgramBuilder& b) {

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -296,9 +296,9 @@ Value partialMeasurementToRegister(QCOProgramBuilder& b) {
 }
 
 Value dynamicallyIndexedMeasurement(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
+  auto q = b.qtensorAlloc(2);
   auto c = b.allocClassicalBitRegister(2);
-  b.scfFor(0, 2, 1, {q.value}, [&](Value iv, ValueRange iterArgs) {
+  b.scfFor(0, 2, 1, {q}, [&](Value iv, ValueRange iterArgs) {
     auto [t0, qubit] = b.qtensorExtract(iterArgs[0], iv);
     auto q1 = b.measure(qubit, c, iv).first;
     auto insert = b.qtensorInsert(q1, t0, iv);
@@ -3359,9 +3359,10 @@ Value barrierMultipleQubits(QCOProgramBuilder& b) {
 }
 
 Value singleControlledBarrier(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(2);
-  auto res =
-      b.ctrl(q[1], q[0], [&](Value target) { return b.barrier({target})[0]; });
+  auto target = b.allocQubitRegister(1);
+  auto control = b.allocQubit();
+  auto res = b.ctrl(control, target[0],
+                    [&](Value qubit) { return b.barrier({qubit})[0]; });
   return measureToRegister(b, res.second);
 }
 
@@ -4121,8 +4122,8 @@ Value ifOneQubitOneTensor(QCOProgramBuilder& b) {
 }
 
 Value ifOneTensor(QCOProgramBuilder& b) {
-  auto q = b.allocQubitRegister(1);
-  auto result = b.qcoIf(true, q.value, [&](Value tensor) {
+  auto q = b.qtensorAlloc(1);
+  auto result = b.qcoIf(true, q, [&](Value tensor) {
     auto [updatedTensor, qubit] = b.qtensorExtract(tensor, 0);
     qubit = b.x(qubit);
     return b.qtensorInsert(qubit, updatedTensor, 0);
@@ -4413,22 +4414,21 @@ Value simpleDoWhileReset(QCOProgramBuilder& b) {
 }
 
 Value simpleForLoop(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
-  auto scfFor =
-      b.scfFor(0, 2, 1, {reg.value}, [&](Value iv, ValueRange iterArgs) {
-        auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
-        auto q1 = b.h(q0);
-        auto insert = b.qtensorInsert(q1, t0, iv);
-        return SmallVector{insert};
-      });
+  auto reg = b.qtensorAlloc(2);
+  auto scfFor = b.scfFor(0, 2, 1, {reg}, [&](Value iv, ValueRange iterArgs) {
+    auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
+    auto q1 = b.h(q0);
+    auto insert = b.qtensorInsert(q1, t0, iv);
+    return SmallVector{insert};
+  });
   return measureAndReturnQTensor(b, scfFor[0], 2);
 };
 
 Value nestedForLoopIfOp(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
+  auto reg = b.qtensorAlloc(2);
   auto q0 = b.allocQubit();
   auto scfFor =
-      b.scfFor(0, 2, 1, {reg.value, q0}, [&](Value iv, ValueRange iterArgs) {
+      b.scfFor(0, 2, 1, {reg, q0}, [&](Value iv, ValueRange iterArgs) {
         auto q1 = b.h(iterArgs[1]);
         auto [q2, cond] = b.measure(q1);
         auto ifOp = b.qcoIf(cond, iterArgs[0], [&](ValueRange args) {
@@ -4443,9 +4443,9 @@ Value nestedForLoopIfOp(QCOProgramBuilder& b) {
 }
 
 Value nestedForLoopWhileOp(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(2);
+  auto reg = b.qtensorAlloc(2);
   auto loopResult =
-      b.scfFor(0, 2, 1, {reg.value}, [&](Value iv, ValueRange iterArgs) {
+      b.scfFor(0, 2, 1, {reg}, [&](Value iv, ValueRange iterArgs) {
         auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
         auto q1 = b.h(q0);
         auto insert = b.qtensorInsert(q1, t0, iv);
@@ -4473,10 +4473,10 @@ Value nestedForLoopWhileOp(QCOProgramBuilder& b) {
 
 Value nestedForLoopSwitchOp(QCOProgramBuilder& b) {
   constexpr int64_t n = 3;
-  auto reg = b.allocQubitRegister(n);
+  auto reg = b.qtensorAlloc(n);
   auto c3 = arith::ConstantOp::create(b, b.getIndexAttr(3));
 
-  reg.value = b.scfFor(0, n, 1, reg.value, [&](Value iv, ValueRange iterArgs) {
+  reg = b.scfFor(0, n, 1, reg, [&](Value iv, ValueRange iterArgs) {
     auto rem = arith::RemUIOp::create(b, {iv, c3}).getResult();
     auto [t, q] = b.qtensorExtract(iterArgs[0], iv);
     q = b.qcoIndexSwitch(
@@ -4503,15 +4503,15 @@ Value nestedForLoopSwitchOp(QCOProgramBuilder& b) {
     return SmallVector{insert};
   })[0];
 
-  return measureAndReturnQTensor(b, reg.value, n);
+  return measureAndReturnQTensor(b, reg, n);
 }
 
 Value nestedForLoopCtrlOpWithSeparateQubit(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(3);
+  auto reg = b.qtensorAlloc(3);
   auto control0 = b.allocQubit();
   auto control1 = b.h(control0);
-  auto scfFor = b.scfFor(
-      0, 3, 1, {reg.value, control1}, [&](Value iv, ValueRange iterArgs) {
+  auto scfFor =
+      b.scfFor(0, 3, 1, {reg, control1}, [&](Value iv, ValueRange iterArgs) {
         auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
         auto q1 = b.h(q0);
         auto [controlOut, targetOut] =
@@ -4523,27 +4523,37 @@ Value nestedForLoopCtrlOpWithSeparateQubit(QCOProgramBuilder& b) {
 }
 
 Value nestedForLoopCtrlOpWithExtractedQubit(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(4);
-  auto control = b.h(reg[0]);
-  auto scfFor = b.scfFor(
-      1, 4, 1, {reg.value, control}, [&](Value iv, ValueRange iterArgs) {
-        auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
-        auto q1 = b.h(q0);
-        auto [controlOut, targetOut] =
-            b.ctrl(iterArgs[1], q1, [&](Value target) { return b.x(target); });
-        auto insert = b.qtensorInsert(targetOut, t0, iv);
-        return SmallVector{insert, controlOut};
-      });
-  return measureToRegister(b, scfFor[1]);
+  auto reg = b.qtensorAlloc(4);
+  auto [tensorWithoutControl, control] = b.qtensorExtract(reg, 0);
+  control = b.h(control);
+  reg = b.qtensorInsert(control, tensorWithoutControl, 0);
+
+  reg = b.scfFor(1, 4, 1, reg, [&](Value iv, ValueRange iterArgs) {
+    auto [tensorWithoutTarget, target] = b.qtensorExtract(iterArgs[0], iv);
+    target = b.h(target);
+    auto tensor = b.qtensorInsert(target, tensorWithoutTarget, iv);
+
+    auto [withoutControl, loopControl] = b.qtensorExtract(tensor, 0);
+    std::tie(tensorWithoutTarget, target) =
+        b.qtensorExtract(withoutControl, iv);
+    std::tie(loopControl, target) = b.ctrl(
+        loopControl, target, [&](Value ctrlTarget) { return b.x(ctrlTarget); });
+    tensor = b.qtensorInsert(target, tensorWithoutTarget, iv);
+    tensor = b.qtensorInsert(loopControl, tensor, 0);
+    return SmallVector{tensor};
+  })[0];
+
+  auto [finalTensor, finalControl] = b.qtensorExtract(reg, 0);
+  return measureToRegister(b, finalControl);
 }
 
 Value nestedIfOpForLoop(QCOProgramBuilder& b) {
-  auto reg = b.allocQubitRegister(3);
+  auto reg = b.qtensorAlloc(3);
   auto q0 = b.allocQubit();
   auto q1 = b.h(q0);
   auto [q2, cond] = b.measure(q1);
   auto ifRes = b.qcoIf(
-      cond, {reg.value, q2},
+      cond, {reg, q2},
       [&](ValueRange args) {
         auto q3 = b.h(args[1]);
         return SmallVector{args[0], q3};

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -4604,6 +4604,35 @@ Value nestedForLoopIfOp(QCOProgramBuilder& b) {
   return measureToRegister(b, scfFor[1]);
 }
 
+Value nestedForLoopWhileOp(QCOProgramBuilder& b) {
+  auto reg = b.qtensorAlloc(2);
+  auto loopResult =
+      b.scfFor(0, 2, 1, {reg}, [&](Value iv, ValueRange iterArgs) {
+        auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
+        auto q1 = b.h(q0);
+        auto insert = b.qtensorInsert(q1, t0, iv);
+        return SmallVector{insert};
+      });
+  auto scfFor =
+      b.scfFor(0, 2, 1, loopResult, [&](Value iv, ValueRange iterArgs) {
+        auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
+        auto whileResult = b.scfWhile(
+            q0,
+            [&](ValueRange innerIterArgs) {
+              auto [q1, measureResult] = b.measure(innerIterArgs[0]);
+              b.scfCondition(measureResult, q1);
+              return SmallVector{q1};
+            },
+            [&](ValueRange innerIterArgs) {
+              auto q2 = b.h(innerIterArgs[0]);
+              return SmallVector{q2};
+            });
+        auto insert = b.qtensorInsert(whileResult[0], t0, iv);
+        return SmallVector{insert};
+      });
+  return measureAndReturnQTensor(b, scfFor[0], 2);
+}
+
 Value nestedForLoopWhileOpCompleteTensorState(QCOProgramBuilder& b) {
   constexpr int64_t size = 2;
   auto tensor = b.qtensorAlloc(size);

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -4604,33 +4604,31 @@ Value nestedForLoopIfOp(QCOProgramBuilder& b) {
   return measureToRegister(b, scfFor[1]);
 }
 
-Value nestedForLoopWhileOp(QCOProgramBuilder& b) {
-  auto reg = b.qtensorAlloc(2);
-  auto loopResult =
-      b.scfFor(0, 2, 1, {reg}, [&](Value iv, ValueRange iterArgs) {
-        auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
-        auto q1 = b.h(q0);
-        auto insert = b.qtensorInsert(q1, t0, iv);
-        return SmallVector{insert};
-      });
-  auto scfFor =
-      b.scfFor(0, 2, 1, loopResult, [&](Value iv, ValueRange iterArgs) {
-        auto [t0, q0] = b.qtensorExtract(iterArgs[0], iv);
-        auto whileResult = b.scfWhile(
-            q0,
-            [&](ValueRange innerIterArgs) {
-              auto [q1, measureResult] = b.measure(innerIterArgs[0]);
-              b.scfCondition(measureResult, q1);
-              return SmallVector{q1};
-            },
-            [&](ValueRange innerIterArgs) {
-              auto q2 = b.h(innerIterArgs[0]);
-              return SmallVector{q2};
-            });
-        auto insert = b.qtensorInsert(whileResult[0], t0, iv);
-        return SmallVector{insert};
-      });
-  return measureAndReturnQTensor(b, scfFor[0], 2);
+Value nestedForLoopWhileOpCompleteTensorState(QCOProgramBuilder& b) {
+  constexpr int64_t size = 2;
+  auto tensor = b.qtensorAlloc(size);
+  tensor = b.scfFor(0, size, 1, tensor, [&](Value iv, ValueRange iterArgs) {
+    return SmallVector{transformQTensorElement(
+        b, iterArgs[0], iv, [&](Value qubit) { return b.h(qubit); })};
+  })[0];
+  tensor = b.scfFor(0, size, 1, tensor, [&](Value iv, ValueRange iterArgs) {
+    auto whileResult = b.scfWhile(
+        iterArgs[0],
+        [&](ValueRange innerIterArgs) {
+          auto [outTensor, qubit] = b.qtensorExtract(innerIterArgs[0], iv);
+          auto [outQubit, measureResult] = b.measure(qubit);
+          auto measuredTensor = b.qtensorInsert(outQubit, outTensor, iv);
+          b.scfCondition(measureResult, measuredTensor);
+          return SmallVector{measuredTensor};
+        },
+        [&](ValueRange innerIterArgs) {
+          return SmallVector{
+              transformQTensorElement(b, innerIterArgs[0], iv,
+                                      [&](Value qubit) { return b.h(qubit); })};
+        });
+    return SmallVector{whileResult[0]};
+  })[0];
+  return measureAndReturnQTensor(b, tensor, size);
 }
 
 Value nestedForLoopSwitchOp(QCOProgramBuilder& b) {

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -1398,19 +1398,24 @@ Value ctrlPowSx(QCOProgramBuilder& b);
 
 /// Creates a circuit with a simple if operation with one qubit.
 SmallVector<Value> simpleIf(QCOProgramBuilder& b);
+SmallVector<Value> simpleIfCompleteTensorState(QCOProgramBuilder& b);
 
 /// Creates a circuit with an if operation with an else branch.
 SmallVector<Value> ifElse(QCOProgramBuilder& b);
+SmallVector<Value> ifElseCompleteTensorState(QCOProgramBuilder& b);
 
 /// Creates a circuit with an if operation with two qubits.
 SmallVector<Value> ifTwoQubits(QCOProgramBuilder& b);
+SmallVector<Value> ifTwoQubitsCompleteTensorState(QCOProgramBuilder& b);
 
 /// Creates a circuit that measures a qubit inside an if operation.
 SmallVector<Value> ifWithMeasurement(QCOProgramBuilder& b);
+SmallVector<Value> ifWithMeasurementCompleteTensorState(QCOProgramBuilder& b);
 
 /// Creates a circuit with an if operation conditioned on a bit loaded from a
 /// classical bit register.
 SmallVector<Value> ifWithCreg(QCOProgramBuilder& b);
+SmallVector<Value> ifWithCregCompleteTensorState(QCOProgramBuilder& b);
 
 /// Creates a circuit with an if operation with one qubit and one register.
 Value ifOneQubitOneTensor(QCOProgramBuilder& b);
@@ -1442,9 +1447,11 @@ Value nestedIfOpForLoop(QCOProgramBuilder& b);
 
 /// Creates a circuit with an index switch operation with one qubit.
 SmallVector<Value> simpleIndexSwitch(QCOProgramBuilder& b);
+SmallVector<Value> simpleIndexSwitchCompleteTensorState(QCOProgramBuilder& b);
 
 /// Creates a circuit with an index switch operation with multiple cases.
 Value indexSwitchMultiCase(QCOProgramBuilder& b);
+Value indexSwitchMultiCaseCompleteTensorState(QCOProgramBuilder& b);
 
 // --- WhileOp -------------------------------------------------------------- //
 
@@ -1470,6 +1477,7 @@ Value nestedForLoopWhileOp(QCOProgramBuilder& b);
 /// Creates a circuit with a for operation with a register and a nested index
 /// switch operation.
 Value nestedForLoopSwitchOp(QCOProgramBuilder& b);
+Value nestedForLoopSwitchOpCompleteTensorState(QCOProgramBuilder& b);
 
 /// Creates a circuit with a for operation with a register and a qubit and a
 /// nested ctrl operation where the qubit is separately allocated from the

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -1472,6 +1472,10 @@ Value nestedForLoopIfOp(QCOProgramBuilder& b);
 
 /// Creates a circuit with a for operation with a register and a nested while
 /// operation.
+Value nestedForLoopWhileOp(QCOProgramBuilder& b);
+
+/// Creates a circuit with a for operation carrying a complete QTensor and a
+/// nested while operation.
 Value nestedForLoopWhileOpCompleteTensorState(QCOProgramBuilder& b);
 
 /// Creates a circuit with a for operation with a register and a nested index

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -1472,7 +1472,7 @@ Value nestedForLoopIfOp(QCOProgramBuilder& b);
 
 /// Creates a circuit with a for operation with a register and a nested while
 /// operation.
-Value nestedForLoopWhileOp(QCOProgramBuilder& b);
+Value nestedForLoopWhileOpCompleteTensorState(QCOProgramBuilder& b);
 
 /// Creates a circuit with a for operation with a register and a nested index
 /// switch operation.

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -39,8 +39,8 @@ MLIR_STRING = r"""module {
     %c0 = arith.constant 0 : index
     %alloc = memref.alloc() : memref<2x!qc.qubit>
     %0 = memref.load %alloc[%c0] : memref<2x!qc.qubit>
-    %1 = memref.load %alloc[%c1] : memref<2x!qc.qubit>
     qc.h %0 : !qc.qubit
+    %1 = memref.load %alloc[%c1] : memref<2x!qc.qubit>
     qc.ctrl(%0) targets (%arg0 = %1) {
       qc.x %arg0 : !qc.qubit
       qc.yield


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Make repeated and runtime-indexed qubit register loads alias-safe without relying
on CSE for correctness.

The QC-to-QCO conversion now treats qubit `memref.load` operations as access
provenance. It materializes register-backed qubits immediately around each
quantum operation, commits results in reverse extraction order, and carries
complete QTensor values through structured control flow. Local QTensor
canonicalizations only fold accesses whose indices MLIR proves equal.

The typed OpenQASM frontend now allocates non-scalar qubit declarations as
storage and emits checked point-of-use loads. Quantum register access therefore
no longer expands into width-dependent `scf.index_switch` dispatch. Exact
duplicate simultaneous operands are rejected semantically, while potentially
aliasing dynamic gate and barrier operands receive runtime assertions.

Fixes #1893

## Validation

- Clean LLVM/MLIR 22 release build.
- All 4,404 configured CTest cases pass; two existing QDMI tests remain
  configured as skipped.
- Focused QC, QCO, QTensor, QC-to-QCO, QCO-to-QC, OpenQASM, compiler, and
  round-trip suites pass.
- `mqt-cc` successfully emits QC, QCO, and Adaptive QIR for dynamic gate,
  modifier, measurement, reset, and barrier accesses.
- All repository lint hooks pass.
- Fresh independent review of the exact published source found no actionable
  issues.

## AI assistance

GPT-5.6 via Codex materially assisted with implementation, tests, validation,
and preparation of this pull-request description. The commits include
`Assisted-by: GPT-5.6 via Codex` trailers.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to
  this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions,
  changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new
  warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly
  authorized for that scope, as required by our
  [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the
  visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated
  content, and accept full responsibility for it.
