### PR TITLE
✨ Enhance multi-controlled gate decomposition in QCO dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ releases may include breaking changes.
   ([**@simon1hofmann**], [**@burgholzer**])
 - ✨ Add a `decompose-multi-controlled` pass for decomposing controlled X, Z,
   RCCX, and constant-angle phase gates with a configurable `min-controls`
-  threshold ([#1810]) ([**@simon1hofmann**])
+  threshold ([#1810], [#1996]) ([**@simon1hofmann**])
 - ✨ Add an LLVM-native staged OpenQASM frontend with typed semantic analysis
   and direct QC emission, including lexical scope, assignment, inclusive ranges,
   and structured control flow ([#1910]) ([**@burgholzer**], [**@denialhaag**])
@@ -707,6 +707,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#1996]: https://github.com/munich-quantum-toolkit/core/pull/1996
 [#1992]: https://github.com/munich-quantum-toolkit/core/pull/1992
 [#1986]: https://github.com/munich-quantum-toolkit/core/pull/1986
 [#1984]: https://github.com/munich-quantum-toolkit/core/pull/1984

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -380,9 +380,10 @@ def DecomposeMultiControlled
 
     - Two or three controls (X/Z): elementary CCX/CCZ and CCCX/CCCZ; `rccx`
       when `min-controls` is at most 2.
-    - Four or five controls (X/Z): specialized ancilla-free cores (relative-
-      phase `C^4(Z)`; Vale MCP(π) hybrid residual).
-    - Six or more controls (X/Z): Huang-Palsberg (HP24) borrowed-helper
+    - Four controls (X/Z): specialized ancilla-free relative-phase `C^4(Z)`.
+    - Five through 32 controls (X/Z): da Silva-Park SP22 MCP(π) core
+      (`H · MCP(π) · H` for X).
+    - 33 or more controls (X/Z): Huang-Palsberg (HP24) borrowed-helper
       synthesis with a compile-time CX policy table.
     - Phase: optimized `C^2(P)` at two controls; Vale (Barenco-relative
       residual at four) for three and four controls; da Silva-Park SP22

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
@@ -1047,6 +1047,8 @@ synthesizeMultiControlled(OpBuilder& builder, Location loc, ValueRange controls,
 
 // SP22 LDD for general-angle MCP at and above this width.
 static constexpr size_t K_MCP_SP22_MIN_CONTROLS = 5;
+// No-ancilla MCX/MCZ uses SP22 MCP(π) through this control count.
+static constexpr size_t K_MCX_SP22_MAX_CONTROLS = 32;
 
 static CircuitPlan planMcp(double theta, size_t numControls);
 
@@ -1104,18 +1106,6 @@ static CircuitPlan planMcpValeRelativeResidual(double theta,
   CircuitPlan plan;
   appendValeFig7Shell(plan, theta, numControls);
   appendMcpBarencoRelative(plan, theta / 2.0, numControls - 1, numControls - 1);
-  return plan;
-}
-
-/// Recursive Vale shells; Barenco-relative residual at width ≤ 4.
-/// Used for MCX/MCZ k=5 (shell at 5, then relative residual at 4).
-static CircuitPlan planMcpValeHybridResidual(double theta, size_t numControls) {
-  if (numControls <= K_MCP_VALE_RELATIVE_RESIDUAL_CONTROLS) {
-    return planMcpValeRelativeResidual(theta, numControls);
-  }
-  CircuitPlan plan;
-  appendValeFig7Shell(plan, theta, numControls);
-  appendPlanOps(plan, planMcpValeHybridResidual(theta / 2.0, numControls - 1));
   return plan;
 }
 
@@ -1232,13 +1222,14 @@ static CircuitPlan planMcpSp22(double theta, size_t numControls) {
   return plan;
 }
 
-// MCZ core: k=4 relative-phase C^4(Z); k=5 Vale hybrid; else HP24.
+// MCZ core: k=4 relative-phase C^4(Z); SP22 MCP(π) for 5..32; else HP24.
 static CircuitPlan mczCoreForWidth(size_t numControls, size_t numWires) {
   if (numControls == 4) {
     return planMczRelativePhaseK4();
   }
-  if (numControls == 5) {
-    return planMcpValeHybridResidual(K_PI, numControls);
+  if (numControls >= K_MCP_SP22_MIN_CONTROLS &&
+      numControls <= K_MCX_SP22_MAX_CONTROLS) {
+    return planMcpSp22(K_PI, numControls);
   }
   return planHp24Core(numWires, selectHp24Policy(numControls));
 }

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
@@ -65,31 +65,33 @@ static constexpr std::array<size_t, 4> K_SMOKE_CONTROL_COUNTS = {21, 22, 23,
 
 /// Expected elementary Ctrl@X counts after default `min-controls=2` lowering.
 /// Indexed by control count `k`; unused slots are zero.
+/// For `5 ≤ k ≤ 32`, MCX uses SP22 MCP(π); each CRX expands to 2 Ctrl@X while
+/// CP stays as Ctrl@P, so elementary CX is `4k² − 8k + 4`.
 static constexpr std::array<size_t, 25> K_EXPECTED_MCX_CX = {
     0,    0,
     6,    // 2
     14,   // 3
     20,   // 4
-    72,   // 5
-    136,  // 6
-    186,  // 7
-    264,  // 8
-    344,  // 9
-    464,  // 10
-    576,  // 11
-    728,  // 12
-    864,  // 13
-    1048, // 14
-    1200, // 15
-    1416, // 16
-    1624, // 17
-    1872, // 18
-    2048, // 19
-    2328, // 20
-    2466, // 21
-    2670, // 22
-    2672, // 23
-    2942, // 24
+    64,   // 5  SP22
+    100,  // 6
+    144,  // 7
+    196,  // 8
+    256,  // 9
+    324,  // 10
+    400,  // 11
+    484,  // 12
+    576,  // 13
+    676,  // 14
+    784,  // 15
+    900,  // 16
+    1024, // 17
+    1156, // 18
+    1296, // 19
+    1444, // 20
+    1600, // 21
+    1764, // 22
+    1936, // 23
+    2116, // 24
 };
 
 /// Effective CX for MCP: elementary Ctrl@X plus ~2 CX per leftover

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
@@ -48,26 +48,29 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-/// DD for k=2…20: full matrix DD through k=8 (MCX/MCZ) or k=6 (MCP);
-/// basis-state DD for larger MCX/MCZ widths; coherent-state DD at selected
-/// policy boundaries and representative larger MCP widths.
-static constexpr std::array<size_t, 19> K_DD_CONTROL_COUNTS = {
-    2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
+/// DD for k=2…20 plus the first HP24 width (k=33): full matrix DD through k=8
+/// (MCX/MCZ) or k=6 (MCP); basis-state DD for larger MCX/MCZ widths;
+/// coherent-state DD at selected policy boundaries and representative larger
+/// MCP widths.
+static constexpr std::array<size_t, 20> K_DD_CONTROL_COUNTS = {
+    2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 33};
 static constexpr size_t K_MATRIX_DD_MAX_PAULI = 8;
 static constexpr size_t K_MATRIX_DD_MAX_MCP = 6;
 static constexpr std::array<size_t, 5> K_COHERENT_HP24_CONTROL_COUNTS = {
     10, 11, 21, 22, 23};
 static constexpr std::array<size_t, 2> K_COHERENT_MCP_CONTROL_COUNTS = {7, 12};
-/// Additional fully-lowered/CX smoke checks; k=21…23 also receive coherent DD
-/// coverage above, while k=24 remains smoke-only.
-static constexpr std::array<size_t, 4> K_SMOKE_CONTROL_COUNTS = {21, 22, 23,
-                                                                 24};
+/// Additional fully-lowered/CX smoke checks for k > 20 through the SP22 MCX
+/// limit (k=32) and the first HP24 width (k=33). Selected widths also receive
+/// coherent DD coverage above.
+static constexpr std::array<size_t, 13> K_SMOKE_CONTROL_COUNTS = {
+    21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33};
 
 /// Expected elementary Ctrl@X counts after default `min-controls=2` lowering.
 /// Indexed by control count `k`; unused slots are zero.
 /// For `5 ≤ k ≤ 32`, MCX uses SP22 MCP(π); each CRX expands to 2 Ctrl@X while
-/// CP stays as Ctrl@P, so elementary CX is `4k² − 8k + 4`.
-static constexpr std::array<size_t, 25> K_EXPECTED_MCX_CX = {
+/// CP stays as Ctrl@P, so elementary CX is `4k² − 8k + 4`. k=33 is the first
+/// HP24 width (pinned measured CX).
+static constexpr std::array<size_t, 34> K_EXPECTED_MCX_CX = {
     0,    0,
     6,    // 2
     14,   // 3
@@ -92,6 +95,15 @@ static constexpr std::array<size_t, 25> K_EXPECTED_MCX_CX = {
     1764, // 22
     1936, // 23
     2116, // 24
+    2304, // 25
+    2500, // 26
+    2704, // 27
+    2916, // 28
+    3136, // 29
+    3364, // 30
+    3600, // 31
+    3844, // 32  SP22 max
+    3872, // 33  HP24
 };
 
 /// Effective CX for MCP: elementary Ctrl@X plus ~2 CX per leftover


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Switch the no-ancilla MCX/MCZ core chooser to da Silva–Park SP22 (`planMcpSp22(π)`) for `5 ≤ k ≤ 32`.
- Keep the relative-phase `C^4(Z)` core at `k = 4`  and HP24 only for `k ≥ 33`.
- Update pass docs and elementary Ctrl@X pins (`4k² − 8k + 4` for the SP22 band).

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [ ] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
