### PR TITLE
✨ Decompose controlled SWAP and gate multi-controlled lowering on min-qubits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ releases may include breaking changes.
   synthesis, and operation-capability and static-site conformance ([#1865],
   [#1961], [#1998]) ([**@simon1hofmann**], [**@burgholzer**])
 - ✨ Add a `decompose-multi-controlled` pass for decomposing controlled X, Z,
-  RCCX, and constant-angle phase gates with a configurable `min-controls`
-  threshold ([#1810], [#1996]) ([**@simon1hofmann**])
+  SWAP, RCCX, and constant-angle phase gates with a configurable `min-qubits`
+  threshold (default 3: wider than two-qubit) ([#1810], [#1996])
+  ([**@simon1hofmann**])
 - ✨ Add an LLVM-native staged OpenQASM frontend with typed semantic analysis
   and direct QC emission, including lexical scope, assignment, inclusive ranges,
   and structured control flow ([#1910], [#1994]) ([**@burgholzer**],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ releases may include breaking changes.
   [#1961], [#1998]) ([**@simon1hofmann**], [**@burgholzer**])
 - ✨ Add a `decompose-multi-controlled` pass for decomposing controlled X, Z,
   SWAP, RCCX, and constant-angle phase gates with a configurable `min-qubits`
-  threshold (default 3: wider than two-qubit) ([#1810], [#1996])
+  threshold (default 3: wider than two-qubit) ([#1810], [#1996], [#2001])
   ([**@simon1hofmann**])
 - ✨ Add an LLVM-native staged OpenQASM frontend with typed semantic analysis
   and direct QC emission, including lexical scope, assignment, inclusive ranges,
@@ -714,6 +714,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2001]: https://github.com/munich-quantum-toolkit/core/pull/2001
 [#1999]: https://github.com/munich-quantum-toolkit/core/pull/1999
 [#1998]: https://github.com/munich-quantum-toolkit/core/pull/1998
 [#1997]: https://github.com/munich-quantum-toolkit/core/pull/1997

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -408,10 +408,10 @@ operations.)pb");
       .def("decompose_multi_controlled",
            &BooleanMemberAdapter<
                &mlir::QCOProgram::decomposeMultiControlled>::call,
-           nb::kw_only(), "min_controls"_a = 2,
-           "Decompose controlled X/Z gates, qco.rccx, and constant-angle phase "
-           "gates with at least min_controls controls (min_controls must be at "
-           "least 2).")
+           nb::kw_only(), "min_qubits"_a = 3,
+           "Decompose controlled X/Z/SWAP gates, qco.rccx, and constant-angle "
+           "phase gates that act on at least min_qubits qubits (min_qubits "
+           "must be at least 3; default 3 means wider than two-qubit).")
       .def(
           "to_qc",
           [](mlir::QCOProgram& value, const bool copy) {

--- a/mlir/include/mlir/Compiler/Programs.h
+++ b/mlir/include/mlir/Compiler/Programs.h
@@ -200,10 +200,10 @@ public:
   /// Prepare the program for qubit reuse and reuse eligible qubits.
   [[nodiscard]] bool runQubitReusePipeline();
 
-  /// Decompose controlled X/Z gates, `qco.rccx`, and constant-angle phase
-  /// gates with at least @p minControls controls (@p minControls must be at
-  /// least 2).
-  [[nodiscard]] bool decomposeMultiControlled(uint64_t minControls = 2);
+  /// Decompose controlled X/Z/SWAP gates, `qco.rccx`, and constant-angle phase
+  /// gates that act on at least @p minQubits qubits (@p minQubits must be at
+  /// least 3; default 3 means wider than two-qubit).
+  [[nodiscard]] bool decomposeMultiControlled(uint64_t minQubits = 3);
 
   /// Compile this program for a target.
   [[nodiscard]] bool compileForTarget(const CompilerTarget& target,

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -324,8 +324,10 @@ def DecomposeMultiControlled
       residual) for four and five qubits; da Silva-Park SP22 linear-depth
       decomposition at six and above. A compile-time angle of `±π` is routed
       through the Z path for every width.
-    - Controlled SWAP: `CX(a,b) · MCX(C∪{b}, a) · CX(a,b)`; the emitted MCX
-      is then lowered by the X path under the same `min-qubits` threshold.
+    - Controlled SWAP: `MCSWAP(C, a, b) = CX(a,b) · MCX(C ∪ {b}, a) · CX(a,b)`,
+      where `C ∪ {b}` is the original control set together with SWAP target
+      `b` and the MCX target is the other SWAP qubit `a`. The emitted MCX is
+      then lowered by the X path under the same `min-qubits` threshold.
 
     Intermediate building blocks may be left as `qco.ctrl` / `qco.rccx` when
     `min-qubits` keeps them; the greedy rewriter lowers further when the

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -304,33 +304,39 @@ def DecomposeMultiControlled
     : Pass<"decompose-multi-controlled", "mlir::ModuleOp"> {
   let dependentDialects = ["mlir::qco::QCODialect",
                            "::mlir::arith::ArithDialect"];
-  let summary = "Decompose controlled X/Z/phase gates and qco.rccx with at "
-                "least min-controls controls";
+  let summary = "Decompose controlled X/Z/phase/SWAP gates and qco.rccx that "
+                "act on at least min-qubits qubits";
   let description = [{
-    Decomposes controlled X, Z, and constant-angle phase gates (`qco.ctrl` with
-    a `qco.x`, `qco.z`, or `qco.p` body, and `qco.rccx`) that have at least
-    `min-controls` controls.
+    Decomposes multi-qubit controlled operations that act on at least
+    `min-qubits` qubits (default 3: everything wider than a two-qubit gate).
+    Supported shapes: `qco.ctrl` with a `qco.x`, `qco.z`, `qco.swap`, or
+    constant-angle `qco.p` body, and `qco.rccx`.
 
-    - Two or three controls (X/Z): elementary CCX/CCZ and CCCX/CCCZ; `rccx`
-      when `min-controls` is at most 2.
-    - Four controls (X/Z): specialized ancilla-free relative-phase `C^4(Z)`.
-    - Five through 32 controls (X/Z): da Silva-Park SP22 MCP(π) core
+    - Three qubits (X/Z): elementary CCX/CCZ; `rccx` when `min-qubits` is at
+      most 3.
+    - Four qubits (X/Z): elementary CCCX/CCCZ.
+    - Five qubits (X/Z): specialized ancilla-free relative-phase `C^4(Z)`.
+    - Six through 33 qubits (X/Z): da Silva-Park SP22 MCP(π) core
       (`H · MCP(π) · H` for X).
-    - 33 or more controls (X/Z): Huang-Palsberg (HP24) borrowed-helper
-      synthesis with a compile-time CX policy table.
-    - Phase: optimized `C^2(P)` at two controls; Vale (Barenco-relative
-      residual at four) for three and four controls; da Silva-Park SP22
-      linear-depth decomposition at five and above. A compile-time angle of
-      `±π` is routed through the Z path for every control count.
+    - 34 or more qubits (X/Z): Huang-Palsberg (HP24) borrowed-helper synthesis
+      with a compile-time CX policy table.
+    - Phase: optimized `C^2(P)` at three qubits; Vale (Barenco-relative
+      residual) for four and five qubits; da Silva-Park SP22 linear-depth
+      decomposition at six and above. A compile-time angle of `±π` is routed
+      through the Z path for every width.
+    - Controlled SWAP: `CX(a,b) · MCX(C∪{b}, a) · CX(a,b)`; the emitted MCX
+      is then lowered by the X path under the same `min-qubits` threshold.
+      With the default `min-qubits=3`, this includes OpenQASM `cswap`.
 
-    Intermediate two- and three-control building blocks may be left as
-    `qco.ctrl` / `qco.rccx` when `min-controls` keeps them; the greedy rewriter
-    lowers further when the threshold allows.
+    Intermediate building blocks may be left as `qco.ctrl` / `qco.rccx` when
+    `min-qubits` keeps them; the greedy rewriter lowers further when the
+    threshold allows.
   }];
   let options = [Option<
-      "minControls", "min-controls", "uint64_t", "2",
-      "Decompose controlled X/Z/phase gates and qco.rccx with at least this "
-      "many controls (must be at least 2).">];
+      "minQubits", "min-qubits", "uint64_t", "3",
+      "Decompose controlled X/Z/phase/SWAP gates and qco.rccx that act on at "
+      "least this many qubits (must be at least 3; default 3 means wider than "
+      "two-qubit).">];
 }
 
 #endif // MLIR_DIALECT_QCO_TRANSFORMS_PASSES_TD

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -312,22 +312,26 @@ def DecomposeMultiControlled
     Supported shapes: `qco.ctrl` with a `qco.x`, `qco.z`, `qco.swap`, or
     constant-angle `qco.p` body, and `qco.rccx`.
 
-    - Three qubits (X/Z): elementary CCX/CCZ; `rccx` when `min-qubits` is at
-      most 3.
-    - Four qubits (X/Z): elementary CCCX/CCCZ.
-    - Five qubits (X/Z): specialized ancilla-free relative-phase `C^4(Z)`.
-    - Six through 33 qubits (X/Z): da Silva-Park SP22 MCP(π) core
-      (`H · MCP(π) · H` for X).
-    - 34 or more qubits (X/Z): Huang-Palsberg (HP24) borrowed-helper synthesis
-      with a compile-time CX policy table.
-    - Phase: optimized `C^2(P)` at three qubits; Vale (Barenco-relative
-      residual) for four and five qubits; da Silva-Park SP22 linear-depth
-      decomposition at six and above. A compile-time angle of `±π` is routed
-      through the Z path for every width.
-    - Controlled SWAP: `MCSWAP(C, a, b) = CX(a,b) · MCX(C ∪ {b}, a) · CX(a,b)`,
-      where `C ∪ {b}` is the original control set together with SWAP target
-      `b` and the MCX target is the other SWAP qubit `a`. The emitted MCX is
-      then lowered by the X path under the same `min-qubits` threshold.
+    | Family | Width (qubits) | Decomposition |
+    | ------ | -------------- | ------------- |
+    | X/Z | 3 | Elementary CCX/CCZ; `rccx` when `min-qubits` is at most 3 |
+    | X/Z | 4 | Elementary CCCX/CCCZ |
+    | X/Z | 5 | Specialized ancilla-free relative-phase `C^4(Z)` |
+    | X/Z | 6–33 | da Silva-Park SP22 MCP(π) core (`H · MCP(π) · H` for X) |
+    | X/Z | ≥34 | Huang-Palsberg (HP24) borrowed-helper synthesis with a compile-time CX policy table |
+    | Phase | 3 | Optimized `C^2(P)` |
+    | Phase | 4–5 | Vale (Barenco-relative residual) |
+    | Phase | ≥6 | da Silva-Park SP22 linear-depth |
+    | Phase | any (`±π`) | Routed through the Z path |
+    | SWAP | ≥ `min-qubits` | `MCSWAP(C, a, b) = CX(a,b) · MCX(C ∪ {b}, a) · CX(a,b)` |
+
+    Width is the total number of qubits the gate acts on (controls plus
+    targets).
+
+    For controlled SWAP, `C ∪ {b}` is the original control set together with
+    SWAP target `b`, and the MCX target is the other SWAP qubit `a`. The
+    emitted MCX is then lowered by the X path under the same `min-qubits`
+    threshold.
 
     Intermediate building blocks may be left as `qco.ctrl` / `qco.rccx` when
     `min-qubits` keeps them; the greedy rewriter lowers further when the

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -326,7 +326,6 @@ def DecomposeMultiControlled
       through the Z path for every width.
     - Controlled SWAP: `CX(a,b) · MCX(C∪{b}, a) · CX(a,b)`; the emitted MCX
       is then lowered by the X path under the same `min-qubits` threshold.
-      With the default `min-qubits=3`, this includes OpenQASM `cswap`.
 
     Intermediate building blocks may be left as `qco.ctrl` / `qco.rccx` when
     `min-qubits` keeps them; the greedy rewriter lowers further when the

--- a/mlir/include/mlir/Support/Passes.h
+++ b/mlir/include/mlir/Support/Passes.h
@@ -37,12 +37,12 @@ void populateDefaultQCOOptimizationPipeline(mlir::OpPassManager& pm);
 /// Populate the qubit reuse pipeline including its preparation passes.
 void populateQubitReusePipeline(mlir::OpPassManager& pm);
 
-/// Return whether @p minControls is valid for multi-controlled decomposition.
-[[nodiscard]] bool isDecomposeMultiControlledConfigValid(uint64_t minControls);
+/// Return whether @p minQubits is valid for multi-controlled decomposition.
+[[nodiscard]] bool isDecomposeMultiControlledConfigValid(uint64_t minQubits);
 
 /// Populate the multi-controlled decomposition pass sequence.
 void populateDecomposeMultiControlledPipeline(mlir::OpPassManager& pm,
-                                              uint64_t minControls);
+                                              uint64_t minQubits);
 
 /// Parse and run a module-level MLIR textual pass pipeline.
 [[nodiscard]] mlir::LogicalResult

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -396,11 +396,11 @@ bool QCOProgram::runQubitReusePipeline() {
       "failed to run the qubit reuse pipeline"));
 }
 
-bool QCOProgram::decomposeMultiControlled(const uint64_t minControls) {
+bool QCOProgram::decomposeMultiControlled(const uint64_t minQubits) {
   return succeeded(runPasses(
       mod(),
-      [minControls](OpPassManager& pm) {
-        populateDecomposeMultiControlledPipeline(pm, minControls);
+      [minQubits](OpPassManager& pm) {
+        populateDecomposeMultiControlledPipeline(pm, minQubits);
       },
       "failed to decompose multi-controlled gates"));
 }

--- a/mlir/lib/Compiler/TargetCompilation.cpp
+++ b/mlir/lib/Compiler/TargetCompilation.cpp
@@ -21,7 +21,7 @@ namespace mlir {
 
 void populateTargetCompilationPipeline(OpPassManager& pm,
                                        const CompilerTarget& target) {
-  populateDecomposeMultiControlledPipeline(pm, 2);
+  populateDecomposeMultiControlledPipeline(pm, 3);
   populateDefaultQCOOptimizationPipeline(pm);
   pm.addPass(qco::createFuseTwoQubitGates());
   pm.addPass(qco::createMappingPass(target, qco::MappingPassOptions{}));

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
@@ -1288,34 +1288,23 @@ matchControlledTarget(UnitaryOpInterface inner) {
 static SmallVector<Value>
 synthesizeControlledSwap(OpBuilder& builder, Location loc, ValueRange controls,
                          Value targetA, Value targetB) {
-  auto cx1 = CtrlOp::create(builder, loc, targetA, targetB, [&](Value t) {
+  const auto makeX = [&](Value t) {
     return XOp::create(builder, loc, t).getOutputQubit(0);
-  });
-  Value a1 = cx1.getControlsOut()[0];
-  Value b1 = cx1.getTargetsOut()[0];
+  };
 
-  SmallVector<Value> mcxControls;
-  mcxControls.reserve(controls.size() + 1);
-  mcxControls.append(controls.begin(), controls.end());
-  mcxControls.push_back(b1);
+  auto cx1 = CtrlOp::create(builder, loc, targetA, targetB, makeX);
+
+  SmallVector<Value, 4> mcxControls(controls);
+  mcxControls.push_back(cx1.getOutputTarget(0));
   auto mcx =
-      CtrlOp::create(builder, loc, ValueRange(mcxControls), a1, [&](Value t) {
-        return XOp::create(builder, loc, t).getOutputQubit(0);
-      });
+      CtrlOp::create(builder, loc, mcxControls, cx1.getOutputControl(0), makeX);
 
-  SmallVector<Value> results;
-  results.reserve(controls.size() + 2);
-  for (size_t i = 0; i < controls.size(); ++i) {
-    results.push_back(mcx.getControlsOut()[i]);
-  }
-  Value b2 = mcx.getControlsOut()[controls.size()];
-  Value a2 = mcx.getTargetsOut()[0];
+  auto cx2 = CtrlOp::create(builder, loc, mcx.getOutputTarget(0),
+                            mcx.getOutputControl(controls.size()), makeX);
 
-  auto cx2 = CtrlOp::create(builder, loc, a2, b2, [&](Value t) {
-    return XOp::create(builder, loc, t).getOutputQubit(0);
-  });
-  results.push_back(cx2.getControlsOut()[0]);
-  results.push_back(cx2.getTargetsOut()[0]);
+  SmallVector<Value> results(mcx.getOutputControls().drop_back());
+  results.push_back(cx2.getOutputControl(0));
+  results.push_back(cx2.getOutputTarget(0));
   return results;
 }
 
@@ -1342,8 +1331,7 @@ struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
       return failure();
     }
 
-    // Controlled-SWAP → CX(a,b)·MCX(C∪{b},a)·CX(a,b). Default min-qubits=3
-    // lowers OpenQASM `cswap` (3 qubits).
+    // MCSWAP(C, a, b) = CX(a,b) · MCX(C ∪ {b}, a) · CX(a,b).
     if (op.getNumTargets() == 2 && isa<SWAPOp>(inner.getOperation())) {
       rewriter.setInsertionPoint(op);
       rewriter.replaceOp(op, synthesizeControlledSwap(

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
@@ -1406,7 +1406,7 @@ struct DecomposeRCCXPattern final : OpRewritePattern<RCCXOp> {
 
   LogicalResult matchAndRewrite(RCCXOp op,
                                 PatternRewriter& rewriter) const override {
-    if (op.getNumQubits() < minQubits_) {
+    if (RCCXOp::getNumQubits() < minQubits_) {
       return failure();
     }
     rewriter.setInsertionPoint(op);

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
@@ -123,7 +123,7 @@ public:
     h(target);
   }
 
-  // Building blocks left as QCO ops (further lowered by min-controls)
+  // Building blocks left as QCO ops (further lowered by min-qubits)
   void emitCcx(size_t c0, size_t c1, size_t target) {
     emitCtrl({c0, c1}, target, [](OpBuilder& builder, Location loc, Value arg) {
       return XOp::create(builder, loc, arg).getOutputQubit(0);
@@ -1281,6 +1281,44 @@ matchControlledTarget(UnitaryOpInterface inner) {
   return std::nullopt;
 }
 
+/// Rewrite controlled-SWAP (Fredkin) as CX–MCX–CX.
+///
+/// Identity: MCSWAP(C, a, b) = CX(a, b) · MCX(C ∪ {b}, a) · CX(a, b).
+/// Callers gate on the controlled-SWAP's total qubit count (`min-qubits`).
+static SmallVector<Value>
+synthesizeControlledSwap(OpBuilder& builder, Location loc, ValueRange controls,
+                         Value targetA, Value targetB) {
+  auto cx1 = CtrlOp::create(builder, loc, targetA, targetB, [&](Value t) {
+    return XOp::create(builder, loc, t).getOutputQubit(0);
+  });
+  Value a1 = cx1.getControlsOut()[0];
+  Value b1 = cx1.getTargetsOut()[0];
+
+  SmallVector<Value> mcxControls;
+  mcxControls.reserve(controls.size() + 1);
+  mcxControls.append(controls.begin(), controls.end());
+  mcxControls.push_back(b1);
+  auto mcx =
+      CtrlOp::create(builder, loc, ValueRange(mcxControls), a1, [&](Value t) {
+        return XOp::create(builder, loc, t).getOutputQubit(0);
+      });
+
+  SmallVector<Value> results;
+  results.reserve(controls.size() + 2);
+  for (size_t i = 0; i < controls.size(); ++i) {
+    results.push_back(mcx.getControlsOut()[i]);
+  }
+  Value b2 = mcx.getControlsOut()[controls.size()];
+  Value a2 = mcx.getTargetsOut()[0];
+
+  auto cx2 = CtrlOp::create(builder, loc, a2, b2, [&](Value t) {
+    return XOp::create(builder, loc, t).getOutputQubit(0);
+  });
+  results.push_back(cx2.getControlsOut()[0]);
+  results.push_back(cx2.getTargetsOut()[0]);
+  return results;
+}
+
 //===----------------------------------------------------------------------===//
 // Patterns and pass
 //===----------------------------------------------------------------------===//
@@ -1289,17 +1327,32 @@ namespace {
 
 struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
   explicit DecomposeControlledGatePattern(MLIRContext* context,
-                                          uint64_t minControls)
-      : OpRewritePattern<CtrlOp>(context), minControls_(minControls) {}
+                                          uint64_t minQubits)
+      : OpRewritePattern<CtrlOp>(context), minQubits_(minQubits) {}
 
   LogicalResult matchAndRewrite(CtrlOp op,
                                 PatternRewriter& rewriter) const override {
-    const auto numControls = op.getNumControls();
-    if (numControls < minControls_ || op.getNumTargets() != 1) {
+    if (op.getNumQubits() < minQubits_) {
       return failure();
     }
+
+    const auto numControls = op.getNumControls();
     auto inner = utils::getSoleBodyUnitary<UnitaryOpInterface>(*op.getBody());
     if (!inner) {
+      return failure();
+    }
+
+    // Controlled-SWAP → CX(a,b)·MCX(C∪{b},a)·CX(a,b). Default min-qubits=3
+    // lowers OpenQASM `cswap` (3 qubits).
+    if (op.getNumTargets() == 2 && isa<SWAPOp>(inner.getOperation())) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOp(op, synthesizeControlledSwap(
+                                 rewriter, op.getLoc(), op.getControlsIn(),
+                                 op.getInputTarget(0), op.getInputTarget(1)));
+      return success();
+    }
+
+    if (op.getNumTargets() != 1) {
       return failure();
     }
     const auto spec = matchControlledTarget(inner);
@@ -1309,8 +1362,8 @@ struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
 
     ControlledTarget gate = spec->gate;
     // A compile-time phase of +/- pi is exactly Z; route it through the
-    // multi-controlled-Z path (elementary at k=2/3, relative-phase / Vale at
-    // k=4/5, else HP24).
+    // multi-controlled-Z path (elementary at 3–4 qubits, relative-phase / Vale
+    // at 5–6 qubits, else HP24).
     if (gate == ControlledTarget::Phase && spec->theta &&
         std::abs(std::abs(*spec->theta) - K_PI) <= utils::TOLERANCE) {
       gate = ControlledTarget::Z;
@@ -1324,7 +1377,7 @@ struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
       return success();
     }
     if (numControls < 3) {
-      // Exactly two controls (k < 2 is rejected by min-controls >= 2).
+      // Exactly two controls (k < 2 is rejected by min-qubits >= 3).
       rewriter.replaceOp(op, synthesizeTwoControlled(
                                  rewriter, op.getLoc(), op.getControlsIn()[0],
                                  op.getControlsIn()[1], op.getInputTarget(0),
@@ -1344,16 +1397,16 @@ struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
   }
 
 private:
-  uint64_t minControls_;
+  uint64_t minQubits_;
 };
 
 struct DecomposeRCCXPattern final : OpRewritePattern<RCCXOp> {
-  explicit DecomposeRCCXPattern(MLIRContext* context, uint64_t minControls)
-      : OpRewritePattern<RCCXOp>(context), minControls_(minControls) {}
+  explicit DecomposeRCCXPattern(MLIRContext* context, uint64_t minQubits)
+      : OpRewritePattern<RCCXOp>(context), minQubits_(minQubits) {}
 
   LogicalResult matchAndRewrite(RCCXOp op,
                                 PatternRewriter& rewriter) const override {
-    if (minControls_ > 2) {
+    if (op.getNumQubits() < minQubits_) {
       return failure();
     }
     rewriter.setInsertionPoint(op);
@@ -1364,7 +1417,7 @@ struct DecomposeRCCXPattern final : OpRewritePattern<RCCXOp> {
   }
 
 private:
-  uint64_t minControls_;
+  uint64_t minQubits_;
 };
 
 struct DecomposeMultiControlled final
@@ -1373,16 +1426,16 @@ struct DecomposeMultiControlled final
 
 protected:
   void runOnOperation() override {
-    if (minControls < 2) {
+    if (minQubits < 3) {
       getOperation().emitError()
-          << "decompose-multi-controlled requires min-controls >= 2";
+          << "decompose-multi-controlled requires min-qubits >= 3";
       signalPassFailure();
       return;
     }
 
     RewritePatternSet patterns(&getContext());
     patterns.add<DecomposeControlledGatePattern, DecomposeRCCXPattern>(
-        &getContext(), minControls);
+        &getContext(), minQubits);
 
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();

--- a/mlir/lib/Support/Passes.cpp
+++ b/mlir/lib/Support/Passes.cpp
@@ -79,14 +79,14 @@ void populateQubitReusePipeline(OpPassManager& pm) {
   pm.addPass(qco::createReuseQubits());
 }
 
-bool isDecomposeMultiControlledConfigValid(const uint64_t minControls) {
-  return minControls >= 2;
+bool isDecomposeMultiControlledConfigValid(const uint64_t minQubits) {
+  return minQubits >= 3;
 }
 
 void populateDecomposeMultiControlledPipeline(OpPassManager& pm,
-                                              const uint64_t minControls) {
+                                              const uint64_t minQubits) {
   qco::DecomposeMultiControlledOptions options;
-  options.minControls = minControls;
+  options.minQubits = minQubits;
   pm.addPass(qco::createDecomposeMultiControlled(options));
 }
 

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -179,18 +179,18 @@ parseOutputFormat(const StringRef format) {
 static llvm::cl::opt<bool> enableDecomposeMultiControlled(
     "decompose-multi-controlled",
     llvm::cl::desc(
-        "Decompose controlled X/Z/phase gates and qco.rccx with at least "
-        "--decompose-multi-controlled-min-controls controls (default 2)."),
+        "Decompose controlled X/Z/phase/SWAP gates and qco.rccx that act on at "
+        "least --decompose-multi-controlled-min-qubits qubits (default 3)."),
     llvm::cl::init(false));
 
-static llvm::cl::opt<unsigned> decomposeMultiControlledMinControls(
-    "decompose-multi-controlled-min-controls",
+static llvm::cl::opt<unsigned> decomposeMultiControlledMinQubits(
+    "decompose-multi-controlled-min-qubits",
     llvm::cl::desc(
-        "Minimum control count for --decompose-multi-controlled: decompose "
-        "controlled X/Z/phase gates and qco.rccx with at least this many "
-        "controls (default 2; must be at least 2). Higher values leave smaller "
-        "controlled gates undecomposed."),
-    llvm::cl::init(2));
+        "Minimum qubit count for --decompose-multi-controlled: decompose "
+        "controlled X/Z/phase/SWAP gates and qco.rccx that act on at least "
+        "this many qubits (default 3; must be at least 3). Higher values leave "
+        "narrower gates undecomposed."),
+    llvm::cl::init(3));
 
 /**
  * @brief Load and parse a `.qasm` file
@@ -391,9 +391,9 @@ static int runCompiler(int argc, char** argv) {
   }
   if (enableDecomposeMultiControlled &&
       !isDecomposeMultiControlledConfigValid(
-          decomposeMultiControlledMinControls.getValue())) {
+          decomposeMultiControlledMinQubits.getValue())) {
     llvm::errs()
-        << "decompose-multi-controlled-min-controls must be at least 2 when "
+        << "decompose-multi-controlled-min-qubits must be at least 3 when "
            "--decompose-multi-controlled is enabled.\n";
     return 1;
   }
@@ -433,7 +433,7 @@ static int runCompiler(int argc, char** argv) {
           } else {
             if (enableDecomposeMultiControlled) {
               populateDecomposeMultiControlledPipeline(
-                  pm, decomposeMultiControlledMinControls.getValue());
+                  pm, decomposeMultiControlledMinQubits.getValue());
             }
             populateDefaultQCOOptimizationPipeline(pm);
           }

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -1198,7 +1198,7 @@ TEST_F(CompilerPipelineTest, DecomposeMultiControlledPass) {
   ASSERT_TRUE(qco);
   ASSERT_TRUE(qco->cleanup());
   const auto before = qco->copy();
-  ASSERT_TRUE(qco->decomposeMultiControlled(2));
+  ASSERT_TRUE(qco->decomposeMultiControlled(3));
   EXPECT_NE(qco->str(), before.str());
 }
 
@@ -1216,15 +1216,14 @@ TEST_F(CompilerPipelineTest, DecomposeMultiControlledPassMcz) {
   ASSERT_TRUE(qco);
   ASSERT_TRUE(qco->cleanup());
   const auto before = qco->copy();
-  ASSERT_TRUE(
-      qco->runPassPipeline("decompose-multi-controlled{min-controls=2}"));
+  ASSERT_TRUE(qco->runPassPipeline("decompose-multi-controlled{min-qubits=3}"));
   EXPECT_NE(qco->str(), before.str());
 }
 
 TEST_F(CompilerPipelineTest,
-       RejectsDecomposeMultiControlledMinControlsBelowTwo) {
-  EXPECT_FALSE(isDecomposeMultiControlledConfigValid(1U));
-  EXPECT_TRUE(isDecomposeMultiControlledConfigValid(2U));
+       RejectsDecomposeMultiControlledMinQubitsBelowThree) {
+  EXPECT_FALSE(isDecomposeMultiControlledConfigValid(2U));
+  EXPECT_TRUE(isDecomposeMultiControlledConfigValid(3U));
 
   auto module = mlir::qc::QCProgramBuilder::build(
       context.get(), mlir::qc::multipleControlledX);
@@ -1236,7 +1235,7 @@ TEST_F(CompilerPipelineTest,
   ASSERT_TRUE(input);
   auto qco = std::move(*input).intoQCO();
   ASSERT_TRUE(qco);
-  EXPECT_FALSE(qco->decomposeMultiControlled(1));
+  EXPECT_FALSE(qco->decomposeMultiControlled(2));
 }
 
 TEST_F(CompilerPipelineTest, PopulateDecomposeMultiControlledPipeline) {
@@ -1254,7 +1253,7 @@ TEST_F(CompilerPipelineTest, PopulateDecomposeMultiControlledPipeline) {
   module->print(beforeStream);
 
   PassManager pm(module->getContext());
-  populateDecomposeMultiControlledPipeline(pm, 2);
+  populateDecomposeMultiControlledPipeline(pm, 3);
   ASSERT_TRUE(pm.run(module.get()).succeeded());
 
   std::string after;

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 #include "mlir/Dialect/QCO/Utils/DDFunctionality.h"
+#include "mlir/Dialect/Utils/Utils.h"
 
 #include <gtest/gtest.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -43,6 +44,7 @@
 #include <numbers>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace mlir;
@@ -65,7 +67,7 @@ static constexpr std::array<size_t, 2> K_COHERENT_MCP_CONTROL_COUNTS = {7, 12};
 static constexpr std::array<size_t, 13> K_SMOKE_CONTROL_COUNTS = {
     21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33};
 
-/// Expected elementary Ctrl@X counts after default `min-controls=2` lowering.
+/// Expected elementary Ctrl@X counts after default `min-qubits=3` lowering.
 /// Indexed by control count `k`; unused slots are zero.
 /// For `5 ≤ k ≤ 32`, MCX uses SP22 MCP(π); each CRX expands to 2 Ctrl@X while
 /// CP stays as Ctrl@P, so elementary CX is `4k² − 8k + 4`. k=33 is the first
@@ -397,11 +399,12 @@ static void expectImplementsMcp(func::FuncOp funcOp, size_t numControls,
   dd->decRef(referenceDD);
 }
 
-[[nodiscard]] static size_t countMultiControlledOps(ModuleOp moduleOp,
-                                                    size_t minControls = 2) {
+/// Count `CtrlOp`s whose control operand count is at least @p minControlCount.
+[[nodiscard]] static size_t
+countMultiControlledOps(ModuleOp moduleOp, size_t minControlCount = 2) {
   size_t count = 0;
-  moduleOp.walk([&count, minControls](CtrlOp op) {
-    if (op.getNumControls() >= minControls) {
+  moduleOp.walk([&count, minControlCount](CtrlOp op) {
+    if (op.getNumControls() >= minControlCount) {
       ++count;
     }
   });
@@ -645,26 +648,130 @@ TEST_F(MultiControlledDecompositionTest, DecomposesRCCX) {
   EXPECT_EQ(countRCCXOps(moduleOp.get()), 0U);
 }
 
-TEST_F(MultiControlledDecompositionTest, LeavesRCCXWhenMinControlsIsThree) {
+TEST_F(MultiControlledDecompositionTest, LeavesRCCXWhenMinQubitsIsFour) {
   auto moduleOp = buildRCCXModule(context());
   ASSERT_TRUE(moduleOp);
   DecomposeMultiControlledOptions options;
-  options.minControls = 3;
+  options.minQubits = 4;
   ASSERT_TRUE(runDecomposeMultiControlled(moduleOp.get(), options).succeeded());
   EXPECT_EQ(countRCCXOps(moduleOp.get()), 1U);
 }
 
-TEST_F(MultiControlledDecompositionTest, MinControlsThreshold) {
+TEST_F(MultiControlledDecompositionTest, MinQubitsThreshold) {
   auto moduleOp = buildMcxModule(context(), 2);
   ASSERT_TRUE(moduleOp);
   DecomposeMultiControlledOptions options;
-  options.minControls = 3;
+  options.minQubits = 4;
   ASSERT_TRUE(runDecomposeMultiControlled(moduleOp.get(), options).succeeded());
   EXPECT_EQ(countMultiControlledOps(moduleOp.get(), 2), 1U);
 
-  options.minControls = 1;
+  options.minQubits = 2;
   EXPECT_FALSE(
       runDecomposeMultiControlled(moduleOp.get(), options).succeeded());
+}
+
+TEST_F(MultiControlledDecompositionTest, DecomposesSingleControlledSwap) {
+  auto moduleOp =
+      QCOProgramBuilder::build(context(), [](QCOProgramBuilder& builder) {
+        std::ignore =
+            builder.cswap(builder.staticQubit(0), builder.staticQubit(1),
+                          builder.staticQubit(2));
+        return SmallVector<Value>{};
+      });
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(runDecomposeMultiControlled(moduleOp.get()).succeeded());
+  expectFullyLowered(moduleOp.get());
+
+  auto funcOp = *moduleOp->getBody()->getOps<func::FuncOp>().begin();
+  expectFullyDecomposed(funcOp);
+
+  const auto numQubits = countStaticQubits(funcOp);
+  ASSERT_EQ(numQubits, 3U);
+  const auto dd = std::make_unique<dd::Package>(numQubits);
+  const auto decomposedDD = buildFunctionality(funcOp, *dd);
+  ASSERT_TRUE(succeeded(decomposedDD));
+
+  qc::QuantumComputation referenceQc(numQubits);
+  referenceQc.cswap(0, 1, 2);
+  const dd::MatrixDD referenceDD = dd::buildFunctionality(referenceQc, *dd);
+  EXPECT_EQ(*decomposedDD, referenceDD);
+  dd->decRef(*decomposedDD);
+  dd->decRef(referenceDD);
+}
+
+TEST_F(MultiControlledDecompositionTest, DecomposesMultipleControlledSwap) {
+  auto moduleOp =
+      QCOProgramBuilder::build(context(), [](QCOProgramBuilder& builder) {
+        std::ignore =
+            builder.mcswap({builder.staticQubit(0), builder.staticQubit(1)},
+                           builder.staticQubit(2), builder.staticQubit(3));
+        return SmallVector<Value>{};
+      });
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(runDecomposeMultiControlled(moduleOp.get()).succeeded());
+  expectFullyLowered(moduleOp.get());
+
+  auto funcOp = *moduleOp->getBody()->getOps<func::FuncOp>().begin();
+  expectFullyDecomposed(funcOp);
+
+  const auto numQubits = countStaticQubits(funcOp);
+  ASSERT_EQ(numQubits, 4U);
+  const auto dd = std::make_unique<dd::Package>(numQubits);
+  const auto decomposedDD = buildFunctionality(funcOp, *dd);
+  ASSERT_TRUE(succeeded(decomposedDD));
+
+  qc::QuantumComputation referenceQc(numQubits);
+  referenceQc.mcswap({0, 1}, 2, 3);
+  const dd::MatrixDD referenceDD = dd::buildFunctionality(referenceQc, *dd);
+  EXPECT_EQ(*decomposedDD, referenceDD);
+  dd->decRef(*decomposedDD);
+  dd->decRef(referenceDD);
+}
+
+TEST_F(MultiControlledDecompositionTest,
+       LeavesSingleControlledSwapWhenMinQubitsIsFour) {
+  auto moduleOp =
+      QCOProgramBuilder::build(context(), [](QCOProgramBuilder& builder) {
+        std::ignore =
+            builder.cswap(builder.staticQubit(0), builder.staticQubit(1),
+                          builder.staticQubit(2));
+        return SmallVector<Value>{};
+      });
+  ASSERT_TRUE(moduleOp);
+  DecomposeMultiControlledOptions options;
+  options.minQubits = 4;
+  ASSERT_TRUE(runDecomposeMultiControlled(moduleOp.get(), options).succeeded());
+
+  size_t controlledSwap = 0;
+  moduleOp->walk([&](CtrlOp op) {
+    if (op.getNumControls() == 1 && op.getNumTargets() == 2) {
+      auto inner = utils::getSoleBodyUnitary<UnitaryOpInterface>(*op.getBody());
+      if (inner && isa<SWAPOp>(inner.getOperation())) {
+        ++controlledSwap;
+      }
+    }
+  });
+  EXPECT_EQ(controlledSwap, 1U);
+}
+
+TEST_F(MultiControlledDecompositionTest,
+       DecomposesTwoControlledSwapWhenMinQubitsIsFour) {
+  // Two-control SWAP acts on 4 qubits, so min-qubits=4 still rewrites it.
+  auto moduleOp =
+      QCOProgramBuilder::build(context(), [](QCOProgramBuilder& builder) {
+        std::ignore =
+            builder.mcswap({builder.staticQubit(0), builder.staticQubit(1)},
+                           builder.staticQubit(2), builder.staticQubit(3));
+        return SmallVector<Value>{};
+      });
+  ASSERT_TRUE(moduleOp);
+  DecomposeMultiControlledOptions options;
+  options.minQubits = 4;
+  ASSERT_TRUE(runDecomposeMultiControlled(moduleOp.get(), options).succeeded());
+  expectFullyLowered(moduleOp.get());
+
+  auto funcOp = *moduleOp->getBody()->getOps<func::FuncOp>().begin();
+  expectFullyDecomposed(funcOp);
 }
 
 TEST_F(MultiControlledDecompositionTest, LeavesUnsupportedCtrlUntouched) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
@@ -783,6 +783,10 @@ TEST_F(MultiControlledDecompositionTest, LeavesUnsupportedCtrlUntouched) {
                      builder.staticQubit(5), [&](Value targetArg) -> Value {
                        return builder.y(builder.x(targetArg));
                      });
+        // Two-target non-SWAP body: passes min-qubits but is not lowered.
+        std::ignore =
+            builder.cdcx(builder.staticQubit(6), builder.staticQubit(7),
+                         builder.staticQubit(8));
         return SmallVector<Value>{};
       });
   ASSERT_TRUE(moduleOp);
@@ -791,7 +795,14 @@ TEST_F(MultiControlledDecompositionTest, LeavesUnsupportedCtrlUntouched) {
 
   size_t multiOpCtrl = 0;
   size_t mchCount = 0;
+  size_t controlledDcx = 0;
   moduleOp->walk([&](CtrlOp op) {
+    if (op.getNumTargets() == 2) {
+      auto inner = utils::getSoleBodyUnitary<UnitaryOpInterface>(*op.getBody());
+      if (inner && isa<DCXOp>(inner.getOperation())) {
+        ++controlledDcx;
+      }
+    }
     if (op.getNumControls() < 2) {
       return;
     }
@@ -805,6 +816,7 @@ TEST_F(MultiControlledDecompositionTest, LeavesUnsupportedCtrlUntouched) {
   });
   EXPECT_EQ(multiOpCtrl, 1U);
   EXPECT_EQ(mchCount, 1U);
+  EXPECT_EQ(controlledDcx, 1U);
 }
 
 TEST_F(MultiControlledDecompositionTest, PhasePiRoutesThroughMcz) {

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -161,8 +161,8 @@ class QCOProgram(Program):
     def run_qubit_reuse_pipeline(self) -> None:
         """Prepare the program for qubit reuse and reuse eligible qubits."""
 
-    def decompose_multi_controlled(self, *, min_controls: int = 2) -> None:
-        """Decompose controlled X/Z gates, qco.rccx, and constant-angle phase gates with at least min_controls controls (min_controls must be at least 2)."""
+    def decompose_multi_controlled(self, *, min_qubits: int = 3) -> None:
+        """Decompose controlled X/Z/SWAP gates, qco.rccx, and constant-angle phase gates that act on at least min_qubits qubits (min_qubits must be at least 3; default 3 means wider than two-qubit)."""
 
     def to_qc(self, *, copy: bool = False) -> QCProgram:
         """Convert this program to QC.

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -375,7 +375,7 @@ def test_qco_program_decomposes_multi_controlled() -> None:
     assert "qco.ctrl" in before
 
     retained = qco.copy()
-    retained.decompose_multi_controlled(min_controls=3)
+    retained.decompose_multi_controlled(min_qubits=4)
     assert "controls_out:2" in retained.ir
 
     qco.decompose_multi_controlled()
@@ -383,7 +383,7 @@ def test_qco_program_decomposes_multi_controlled() -> None:
     assert "controls_out:2" not in qco.ir
 
     with pytest.raises(RuntimeError, match="MLIR operation failed"):
-        qco.decompose_multi_controlled(min_controls=1)
+        qco.decompose_multi_controlled(min_qubits=2)
 
 
 def test_compile_program_fails_for_missing_file() -> None:


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Extend `decompose-multi-controlled` to lower controlled-SWAP (Fredkin) via `CX(a,b) · MCX(C∪{b}, a) · CX(a,b)`, so OpenQASM `cswap` is no longer stuck as a 3-qubit op before mapping.
- Rename the threshold from `min-controls` to `min-qubits` (default `3`: anything wider than a two-qubit gate), unified across CtrlOp X/Z/phase/SWAP and `qco.rccx`.
- Migration: old `min-controls=N` → new `min-qubits=N+1` (CLI/Python/`QCOProgram`/pass option). Update the target compilation pipeline call to pass `3`.


## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [ ] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
