### PR TITLE
🐛 Keep all-to-all compiler target placement compact

### DIFF
--- a/.agent/plans/1133-qir-qdmi-integration.md
+++ b/.agent/plans/1133-qir-qdmi-integration.md
@@ -50,7 +50,8 @@ histogram over 1,024 completed shots.
       fixes.
 - [x] (2026-08-04) Independently verified the amended implementation with no
       remaining code, documentation, or test findings.
-- [ ] Publish the reviewed change only after explicit authorization.
+- [x] (2026-08-04) Published pull request #2007 after explicit authorization and
+      added its required changelog entry.
 
 ## Surprises & Discoveries
 
@@ -101,8 +102,9 @@ one narrow integration defect that the existing component-level tests did not
 expose. Topology-free targets now retain physical placement while avoiding
 randomized layout refinement and routing. The target-aware QIR workflow executes
 successfully through DDSIM, and all focused and complete relevant test suites,
-strict documentation, and repository lint pass. Independent review and
-publication remain.
+strict documentation, and repository lint pass. Independent review found no
+remaining actionable issue, and the change was published as pull request #2007
+with `Closes #1133`.
 
 ## Context and Orientation
 

--- a/.agent/plans/1133-qir-qdmi-integration.md
+++ b/.agent/plans/1133-qir-qdmi-integration.md
@@ -1,0 +1,211 @@
+# Complete the target-aware QIR-to-QDMI path
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+MQT Core already compiles OpenQASM and MLIR programs to textual LLVM IR or LLVM
+bitcode and executes either form through the DDSIM QDMI device. After this
+change, the same end-to-end workflow also works when compilation uses the
+`CompilerTarget` snapshot of that QDMI device. All-to-all targets need neither
+heuristic placement nor routing, so target compilation deterministically uses
+the target's first sites instead of randomly assigning the program to arbitrary
+simulator site IDs.
+
+The behavior is visible from Python by opening `mqt.ddsim.default`, snapshotting
+it as a compiler target, compiling a Bell program to QIR Base Profile bitcode,
+submitting that bitcode to the same device, and observing a correct Bell
+histogram over 1,024 completed shots.
+
+## Progress
+
+- [x] (2026-08-04) Verified that pull request #1687 merged at `a132638c8` and
+      that issue #1082 closed while issues #1079 and #1133 remained open.
+- [x] (2026-08-04) Created a fresh worktree from merged `origin/main` and read
+      the repository, AI-usage, and ExecPlan policies.
+- [x] (2026-08-04) Inventoried the QIR compiler, runtime, runner, DDSIM QDMI
+      formats, FoMaC submission APIs, Python bindings, documentation, and tests.
+- [x] (2026-08-04) Confirmed that untargeted textual and binary QIR submission
+      tests pass.
+- [x] (2026-08-04) Reproduced a target-aware DDSIM execution trap and isolated
+      it to unnecessary all-to-all placement.
+- [x] (2026-08-04) Kept physical placement for final conformance, but made
+      all-to-all layout selection deterministic and compact instead of running
+      random SABRE refinement across every simulator site.
+- [x] (2026-08-04) Added focused C++ coverage, strengthened the existing Python
+      QIR execution integration, and corrected the DDSIM device documentation.
+- [x] (2026-08-04) Passed three focused compiler tests, all 224 compiler unit
+      tests, both focused Python QIR tests, all 294 FoMaC Python tests, strict
+      documentation, and repository lint.
+- [x] (2026-08-04) Completed an independent exact-commit review. Qualified
+      Adaptive QIR state-extraction support and strengthened the Python
+      regression to verify Bell-state semantics in response.
+- [x] (2026-08-04) Re-ran the two focused Python QIR tests, strict
+      documentation, repository lint, and `git diff --check` after the review
+      fixes.
+- [x] (2026-08-04) Independently verified the amended implementation with no
+      remaining code, documentation, or test findings.
+- [ ] Publish the reviewed change only after explicit authorization.
+
+## Surprises & Discoveries
+
+- Observation: Most of issue #1133 is already implemented on `main`. The
+  repository contains the DD-based QIR runtime and runner, QIR Base and Adaptive
+  compiler lowering, textual and bitcode QDMI formats, FoMaC byte submission,
+  and Python tests that compile and execute both payload forms.
+- Observation: the existing Python integration tests compile without a target. A
+  target-aware probe snapshots DDSIM's 65,535 sites, maps two program qubits to
+  arbitrary high IDs, and traps during QIR execution. Evidence: the failing LLVM
+  IR used static qubit IDs 18,449 and 2,472 instead of compact IDs zero and one.
+- Observation: the `CompilerTarget` contract already states that an absent
+  topology means all-to-all connectivity. This case requires no routing, but the
+  mapping pass still has to replace logical allocations with physical
+  `qco.static` sites for final target-conformance verification.
+- Observation: removing the mapping pass for all-to-all targets was therefore
+  not viable. The focused compiler test immediately exposed the missing static
+  placement, allowing the implementation to remain in Mapping rather than adding
+  a pipeline special case.
+- Observation: `docs/qdmi/ddsim_device.md` still claims that DDSIM accepts only
+  OpenQASM 2 and 3 even though its device properties and tests include QIR Base
+  and Adaptive Profile strings and modules.
+
+## Decision Log
+
+- Decision: do not add another compiler, FoMaC, QDMI, or command-line
+  convenience API. Rationale: the existing `CompilerTarget.from_device`,
+  `compile_program`, `QIRProgram`, and `Device.submit_job` values already form a
+  direct typed workflow; another facade would duplicate ownership and format
+  boundaries. Date/Author: 2026-08-04, GPT-5.6 via Codex.
+- Decision: retain physical placement for every target, but use the identity
+  dense layout when `CompilerTarget::hasExplicitTopology()` is false. Rationale:
+  final conformance requires physical `qco.static` sites, while an all-to-all
+  device needs no SABRE refinement or routing. Mapping program indices to the
+  first target sites is deterministic, compact, and preserves explicit site
+  identifiers. Explicit-topology targets retain the existing heuristic behavior.
+  Date/Author: 2026-08-04, GPT-5.6 via Codex.
+- Decision: strengthen the existing Python QIR execution test instead of adding
+  another executable or subprocess harness. Rationale: it already crosses the
+  compiler, binding, registry, FoMaC, QDMI, JIT, runtime, and result boundaries;
+  supplying the device snapshot as its compiler target closes the missing seam
+  without test bloat. Date/Author: 2026-08-04, GPT-5.6 via Codex.
+
+## Outcomes & Retrospective
+
+The initial audit prevented a large reimplementation of issue #1133 and found
+one narrow integration defect that the existing component-level tests did not
+expose. Topology-free targets now retain physical placement while avoiding
+randomized layout refinement and routing. The target-aware QIR workflow executes
+successfully through DDSIM, and all focused and complete relevant test suites,
+strict documentation, and repository lint pass. Independent review and
+publication remain.
+
+## Context and Orientation
+
+`mlir/include/mlir/Compiler/Target.h` defines `mlir::CompilerTarget`. An absent
+coupling topology represents all-to-all connectivity, while an absent operation
+set means every operation is native.
+
+`mlir/lib/Compiler/TargetCompilation.cpp` composes the canonical target
+pipeline. It currently adds multi-qubit decomposition, generic optimization,
+two-qubit fusion, mapping, cleanup, native synthesis, and final conformance in
+that order. The mapping pass remains necessary for physical placement even when
+its routing work is unnecessary for an all-to-all target.
+
+`mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp` performs both initial
+placement and routing. Its random layout spans every target site. This is
+appropriate for explicit hardware topology, but an all-to-all simulator with
+65,535 sites can therefore receive arbitrary high static site IDs even for a
+two-qubit program.
+
+`test/python/fomac/test_fomac.py` already compiles QIR and executes it through
+the DDSIM QDMI device in textual and binary form. The textual test will snapshot
+the same device as a compiler target before compilation, providing the missing
+end-to-end regression.
+
+`docs/qdmi/ddsim_device.md` documents the simulator provider. It must list its
+actual QIR formats and show the target-aware compile-and-submit workflow without
+duplicating the lower-level payload contract in `docs/qir/index.md`.
+
+## Plan of Work
+
+First, update initial layout selection in
+`mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp`. When the target has no
+explicit topology, return the identity dense layout immediately instead of
+running randomized SABRE refinement. Keep the mapping pass so dynamic program
+qubits become physical `qco.static` sites for final conformance. Do not
+introduce a special simulator target.
+
+Add a focused compiler unit test in
+`mlir/unittests/Compiler/test_compiler_pipeline.cpp`. Construct an all-to-all
+target with sparse site IDs, compile a small dynamic QCO program, and verify
+that compilation replaces dynamic allocations with the target's first
+`qco.static` sites without introducing SWAPs. Existing explicit-topology target
+tests continue to prove the heuristic mapping branch.
+
+Then update the existing textual QIR execution test in
+`test/python/fomac/test_fomac.py` to snapshot DDSIM, pass that target to
+`compile_program`, submit the generated LLVM IR, and verify completed shot
+counts. Retain the separate bitcode test so both QDMI payload contracts remain
+covered without duplicating the target-specific assertion.
+
+Finally, correct `docs/qdmi/ddsim_device.md` and add one concise Python example
+covering target snapshot, QIR Base compilation, bitcode submission, waiting, and
+result retrieval. Link to the detailed QIR documentation for format semantics.
+
+## Concrete Steps
+
+Run all commands from the repository root.
+
+Configure and build the release compiler and Python bindings:
+
+    MLIR_DIR=<path-to-MLIR-22>/lib/cmake/mlir \
+      ./.agent/run.sh cmake --preset release
+    ./.agent/run.sh cmake --build --preset release --target \
+      mqt-core-mlir-unittests-compiler mqt-core-mlir-bindings
+
+Run the focused compiler and Python regressions:
+
+    ./build/release/mlir/unittests/Compiler/mqt-core-mlir-unittests-compiler \
+      --gtest_filter='CompilerPipelineTest.QCOProgramUsesCompactAllToAllPlacement'
+    ./.agent/run.sh uv run --no-sync pytest \
+      test/python/fomac/test_fomac.py::test_device_executes_qir_program \
+      test/python/fomac/test_fomac.py::test_device_executes_binary_qir_program \
+      -q
+
+Run the complete compiler binary, the complete FoMaC Python file, strict
+documentation, and repository lint:
+
+    ./build/release/mlir/unittests/Compiler/mqt-core-mlir-unittests-compiler
+    ./.agent/run.sh uv run --no-sync pytest test/python/fomac/test_fomac.py -q
+    ./.agent/run.sh uvx nox --non-interactive -s docs
+    ./.agent/run.sh uvx nox -s lint
+    git diff --check
+
+## Validation and Acceptance
+
+The focused C++ regression must prove that target compilation assigns an
+all-to-all program to the target's first physical sites without SWAPs. Existing
+explicit-topology tests must continue to exercise heuristic mapping.
+
+The focused Python regression must open `mqt.ddsim.default`, snapshot that same
+device as a `CompilerTarget`, compile a Bell program to QIR Base Profile, submit
+the textual LLVM IR through QDMI, wait successfully, and return exactly the
+requested number of shots. The existing binary test must continue to pass.
+
+Strict documentation must describe QASM and all four QIR formats accurately,
+including the Base-only restriction for QIR state extraction. Repository lint
+and `git diff --check` must pass. A fresh independent review must find no new
+target semantic, QIR, packaging, or test-cohesion issue before publication.
+
+## Idempotence and Recovery
+
+The source and test edits are ordinary patches. Reconfiguration, builds, test
+runs, documentation, and lint are safe to repeat. If the target-aware Python
+test still traps, inspect its generated LLVM IR and confirm that static qubit
+IDs remain compact before changing the QIR runtime. Do not increase DDSIM's
+runtime allocation or special-case its stable ID to mask unnecessary mapping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ releases may include breaking changes.
   ([#1264], [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570],
   [#1572], [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751],
   [#1755], [#1787], [#1815], [#1823], [#1830], [#1886], [#1933], [#1978],
-  [#1979]) ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
+  [#1979], [#2007]) ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
   [**@li-mingbao**], [**@DRovara**], [**@MatthiasReumann**])
 - ✨ Add decision diagram-based construction and simulation of static unitary
   QCO functions ([#1915]) ([**@simon1hofmann**])
@@ -112,11 +112,6 @@ releases may include breaking changes.
   ([**@burgholzer**])
 - 🔥 Remove `datastructures` (`ds`) (sub)library from MQT Core ([#1458])
   ([**@burgholzer**])
-
-### Fixed
-
-- 🐛 Keep all-to-all compiler-target placement compact and executable through
-  QIR-backed QDMI devices ([#2007]) ([**@burgholzer**])
 
 ## [3.8.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,11 @@ releases may include breaking changes.
 - 🔥 Remove `datastructures` (`ds`) (sub)library from MQT Core ([#1458])
   ([**@burgholzer**])
 
+### Fixed
+
+- 🐛 Keep all-to-all compiler-target placement compact and executable through
+  QIR-backed QDMI devices ([#2007]) ([**@burgholzer**])
+
 ## [3.8.0] - 2026-07-30
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#380)._
@@ -716,6 +721,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2007]: https://github.com/munich-quantum-toolkit/core/pull/2007
 [#2006]: https://github.com/munich-quantum-toolkit/core/pull/2006
 [#2001]: https://github.com/munich-quantum-toolkit/core/pull/2001
 [#2000]: https://github.com/munich-quantum-toolkit/core/pull/2000

--- a/docs/qdmi/ddsim_device.md
+++ b/docs/qdmi/ddsim_device.md
@@ -11,13 +11,19 @@ simulate quantum programs.
 ## Capabilities
 
 The simulator device supports all operations that our
-[MQT Core IR](../mqt_core_ir.md) supports and takes programs in either OpenQASM
-2 or OpenQASM 3 format. It can either be used for performing weak simulation,
-i.e., sampling from the distribution produced by the circuit, or for performing
-strong simulation, i.e., computing a representation of the full state vector. To
-switch between these two modes, either set the
+[MQT Core IR](../mqt_core_ir.md) supports. It accepts OpenQASM 2, OpenQASM 3,
+and textual or binary QIR programs using the Base or Adaptive Profile. See
+[QIR Support in the MQT](../qir/index.md) for the exact QDMI program formats and
+payload contracts.
+
+The device can perform weak simulation for every supported format, i.e., sample
+from the distribution produced by the program. It can also perform strong
+simulation for OpenQASM and QIR Base Profile programs, i.e., compute a
+representation of the full state vector. Set the
 `QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM` parameter to the desired number of shots
-for weak simulation or to `0` for strong simulation.
+for weak simulation or to `0` for strong simulation. QIR Adaptive Profile
+programs require at least one shot because their measurement-dependent control
+flow cannot be represented by state extraction.
 
 Under the hood, the QDMI device uses the MQT Core OpenQASM parser (see
 {cpp-api:func}`qasm3::Importer::imports`) to parse the program into a
@@ -28,3 +34,29 @@ details and limitations.
 
 The device implements the full QDMI job interface (except for the
 `QDMI_JOB_RESULT_SHOTS` result format not supported by the simulator).
+
+## Compile and execute QIR
+
+The compiler can snapshot the DDSIM device as an all-to-all target, compile a
+program to QIR, and submit the resulting bitcode to the same device:
+
+```python
+from mqt.core.fomac import ProgramFormat, open_device
+from mqt.core.mlir import CompilerTarget, OutputFormat, compile_program
+
+device = open_device("mqt.ddsim.default")
+target = CompilerTarget.from_device(device)
+program = compile_program(
+    "bell.qasm",
+    target=target,
+    output=OutputFormat.QIR_BASE,
+)
+
+job = device.submit_job(
+    program.to_bitcode(),
+    ProgramFormat.QIR_BASE_MODULE,
+    num_shots=1024,
+)
+job.wait()
+print(job.get_counts())
+```

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -847,6 +847,11 @@ private:
   /// finally find the trial with the fewest SWAPs on the final backwards pass
   /// and return the respective layout.
   FailureOr<Layout> generateLayout(const Wires& wires, const WireInfos& infos) {
+    if (!target->hasExplicitTopology()) {
+      return Layout::fromMapping(
+          llvm::to_vector(llvm::seq(target->numQubits())));
+    }
+
     std::mt19937_64 rng{seed};
 
     struct Trial {

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -998,6 +998,46 @@ TEST_F(CompilerPipelineTest, QCOProgramCompilesForTarget) {
 }
 
 /**
+ * @brief Test: all-to-all target compilation uses compact placement.
+ */
+TEST_F(CompilerPipelineTest, QCOProgramUsesCompactAllToAllPlacement) {
+  const std::string qasm = R"(OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q;
+bit[2] c;
+h q[0];
+cx q[0], q[1];
+c = measure q;
+)";
+  auto qc = QCProgram::fromQASMString(qasm);
+  ASSERT_TRUE(qc);
+  auto qco = std::move(*qc).intoQCO();
+  ASSERT_TRUE(qco);
+
+  const CompilerTarget target{std::vector<CompilerTarget::Site>{
+      CompilerTarget::Site{2472}, CompilerTarget::Site{18449}}};
+  ASSERT_TRUE(qco->compileForTarget(target));
+
+  auto compiled = parseRecordedModule(qco->str());
+  ASSERT_TRUE(compiled);
+  EXPECT_TRUE(verify(*compiled).succeeded());
+
+  llvm::SmallVector<int64_t> staticSites;
+  size_t numDynamic = 0;
+  size_t numSwaps = 0;
+  compiled->walk([&](Operation* operation) {
+    if (auto staticOp = dyn_cast<qco::StaticOp>(operation)) {
+      staticSites.emplace_back(staticOp.getIndex());
+    }
+    numDynamic += isa<qco::AllocOp, qtensor::AllocOp>(operation);
+    numSwaps += isa<qco::SWAPOp>(operation);
+  });
+  EXPECT_EQ(staticSites, (llvm::SmallVector<int64_t>{2472, 18449}));
+  EXPECT_EQ(numDynamic, 0);
+  EXPECT_EQ(numSwaps, 0);
+}
+
+/**
  * @brief Test: the default pipeline accepts an optional compiler target.
  */
 TEST_F(CompilerPipelineTest, DefaultPipelineCompilesForTarget) {

--- a/test/python/fomac/test_fomac.py
+++ b/test/python/fomac/test_fomac.py
@@ -504,9 +504,9 @@ def test_device_rejects_formats_without_generic_payload(ddsim_device: Device, pr
 
 
 def test_device_executes_qir_program(ddsim_device: Device) -> None:
-    """Compile and execute a QIR program with the DDSIM device."""
+    """Compile for and execute a QIR program with the DDSIM device."""
     # Keep this lazy to cover loading MLIR after the QIR-enabled device.
-    from mqt.core.mlir import OutputFormat, compile_program  # ruff:ignore[import-outside-top-level]
+    from mqt.core.mlir import CompilerTarget, OutputFormat, compile_program  # ruff:ignore[import-outside-top-level]
 
     qasm3_program = """
 OPENQASM 3.0;
@@ -517,14 +517,17 @@ h q[0];
 cx q[0], q[1];
 c = measure q;
 """
-    program = compile_program(qasm3_program, output=OutputFormat.QIR_BASE)
+    target = CompilerTarget.from_device(ddsim_device)
+    program = compile_program(qasm3_program, output=OutputFormat.QIR_BASE, target=target)
     assert ProgramFormat.QIR_BASE_STRING in ddsim_device.supported_program_formats()
 
-    job = ddsim_device.submit_job(program.llvm_ir, ProgramFormat.QIR_BASE_STRING, num_shots=10)
+    job = ddsim_device.submit_job(program.llvm_ir, ProgramFormat.QIR_BASE_STRING, num_shots=1024)
     job.wait()
 
     assert job.check() == Job.Status.DONE
-    assert sum(job.get_counts().values()) == 10
+    counts = job.get_counts()
+    assert set(counts) == {"00", "11"}
+    assert sum(counts.values()) == 1024
 
 
 def test_device_executes_binary_qir_program(ddsim_device: Device) -> None:

--- a/test/python/fomac/test_fomac.py
+++ b/test/python/fomac/test_fomac.py
@@ -29,6 +29,7 @@ from mqt.core.fomac import (
     register_device_if_absent,
     registered_device_ids,
 )
+from mqt.core.mlir import CompilerTarget, OutputFormat, compile_program
 
 CustomValueType = type[str] | type[bool] | type[int] | type[float] | type[bytes]
 
@@ -505,9 +506,6 @@ def test_device_rejects_formats_without_generic_payload(ddsim_device: Device, pr
 
 def test_device_executes_qir_program(ddsim_device: Device) -> None:
     """Compile for and execute a QIR program with the DDSIM device."""
-    # Keep this lazy to cover loading MLIR after the QIR-enabled device.
-    from mqt.core.mlir import CompilerTarget, OutputFormat, compile_program  # ruff:ignore[import-outside-top-level]
-
     qasm3_program = """
 OPENQASM 3.0;
 include "stdgates.inc";
@@ -532,8 +530,6 @@ c = measure q;
 
 def test_device_executes_binary_qir_program(ddsim_device: Device) -> None:
     """Submit and retrieve an exact QIR module byte payload."""
-    from mqt.core.mlir import OutputFormat, compile_program  # ruff:ignore[import-outside-top-level]
-
     qasm3_program = """
 OPENQASM 3.0;
 include "stdgates.inc";


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Complete the target-aware compiler-to-QDMI execution path:

- keep mandatory physical placement for topology-free compiler targets while selecting the target's first sites deterministically;
- avoid unnecessary randomized SABRE refinement and arbitrary high DDSIM site IDs for all-to-all targets;
- compile a Bell program for the DDSIM device, execute the resulting QIR through QDMI, and verify its output semantics;
- document DDSIM's textual and binary QIR formats and the Base-only restriction for QIR state extraction.

This deliberately uses the existing `CompilerTarget`, QIR, FoMaC, and QDMI interfaces instead of introducing another convenience layer.

Closes #1133

## Validation

- 224 compiler unit tests
- 294 FoMaC Python tests
- focused target-aware textual and binary QIR execution tests
- strict documentation build
- repository lint and `git diff --check`
- independent exact-head review

AI assistance was used for implementation, validation, documentation, and preparation of this pull request.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
