### PR TITLE
✨ Pull `GPhaseOp`s out of multi-operation `ctrl` modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,9 +96,9 @@ releases may include breaking changes.
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
   [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938], [#1975],
-  [#1976], [#2006]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
-  [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
-  [**@simon1hofmann**], [**@J4MMlE**])
+  [#1976], [#2006], [#2013]) ([**@burgholzer**], [**@denialhaag**],
+  [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
+  [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 
 ### Changed
 
@@ -721,6 +721,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2013]: https://github.com/munich-quantum-toolkit/core/pull/2013
 [#2011]: https://github.com/munich-quantum-toolkit/core/pull/2011
 [#2007]: https://github.com/munich-quantum-toolkit/core/pull/2007
 [#2006]: https://github.com/munich-quantum-toolkit/core/pull/2006

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -32,15 +32,14 @@
 using namespace mlir;
 using namespace mlir::qc;
 
-namespace {
-
 /**
  * @brief Materialize a global phase controlled by @p controls.
  */
-void createControlledPhase(PatternRewriter& rewriter,
-                           const Location controlledLoc,
-                           const Location phaseLoc, const ValueRange controls,
-                           const Value theta) {
+static void createControlledPhase(PatternRewriter& rewriter,
+                                  const Location controlledLoc,
+                                  const Location phaseLoc,
+                                  const ValueRange controls,
+                                  const Value theta) {
   assert(!controls.empty());
   if (controls.size() == 1) {
     POp::create(rewriter, controlledLoc, controls.front(), theta);
@@ -51,6 +50,8 @@ void createControlledPhase(PatternRewriter& rewriter,
       rewriter, controlledLoc, controls.drop_back(), controls.back(),
       [&](Value target) { POp::create(rewriter, phaseLoc, target, theta); });
 }
+
+namespace {
 
 /**
  * @brief Merge nested control modifiers into a single one.

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -36,10 +36,8 @@ using namespace mlir::qc;
  * @brief Materialize a global phase controlled by @p controls.
  */
 static void createControlledPhase(PatternRewriter& rewriter,
-                                  const Location controlledLoc,
-                                  const Location phaseLoc,
-                                  const ValueRange controls,
-                                  const Value theta) {
+                                  Location controlledLoc, Location phaseLoc,
+                                  ValueRange controls, Value theta) {
   assert(!controls.empty());
   if (controls.size() == 1) {
     POp::create(rewriter, controlledLoc, controls.front(), theta);

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -35,6 +35,24 @@ using namespace mlir::qc;
 namespace {
 
 /**
+ * @brief Materialize a global phase controlled by @p controls.
+ */
+void createControlledPhase(PatternRewriter& rewriter,
+                           const Location controlledLoc,
+                           const Location phaseLoc, const ValueRange controls,
+                           const Value theta) {
+  assert(!controls.empty());
+  if (controls.size() == 1) {
+    POp::create(rewriter, controlledLoc, controls.front(), theta);
+    return;
+  }
+
+  CtrlOp::create(
+      rewriter, controlledLoc, controls.drop_back(), controls.back(),
+      [&](Value target) { POp::create(rewriter, phaseLoc, target, theta); });
+}
+
+/**
  * @brief Merge nested control modifiers into a single one.
  */
 struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
@@ -89,6 +107,41 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
 };
 
 /**
+ * @brief Pull global phases out of multi-operation control modifiers.
+ */
+struct PullGPhaseOutOfCtrl final : OpRewritePattern<CtrlOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(CtrlOp op,
+                                PatternRewriter& rewriter) const override {
+    if (op.getNumControls() == 0 || op.getNumBodyUnitaries() < 2) {
+      return failure();
+    }
+
+    SmallVector<GPhaseOp> globalPhases;
+    for (auto gphase : op.getBody()->getOps<GPhaseOp>()) {
+      // Moving the phase out must not leave its angle defined in the body.
+      if (gphase.getTheta().getParentBlock() == op.getBody()) {
+        return failure();
+      }
+      globalPhases.push_back(gphase);
+    }
+    if (globalPhases.empty()) {
+      return failure();
+    }
+
+    const OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    for (auto gphase : globalPhases) {
+      createControlledPhase(rewriter, gphase.getLoc(), gphase.getLoc(),
+                            op.getControls(), gphase.getTheta());
+      rewriter.eraseOp(gphase);
+    }
+    return success();
+  }
+};
+
+/**
  * @brief Reduce controls for well-known gates.
  * @details Removes empty control ops and handles controlled IdOp, GPhaseOp and
  * BarrierOp.
@@ -120,32 +173,11 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
       return failure();
     }
 
-    // Special case for single control: replace with a single POp
-    if (op.getNumControls() == 1) {
-      rewriter.replaceOpWithNewOp<POp>(op, op.getControl(0),
-                                       gPhaseOp.getTheta());
-      return success();
-    }
-
-    // Reinterpret the last control as a target qubit and apply a phase gate to
-    // it inside the (smaller) controlled region
-    const auto opSegmentsAttrName = CtrlOp::getOperandSegmentSizeAttr();
-    auto segmentsAttr =
-        op->getAttrOfType<DenseI32ArrayAttr>(opSegmentsAttrName);
-    auto newSegments = DenseI32ArrayAttr::get(
-        rewriter.getContext(), {segmentsAttr[0] - 1, segmentsAttr[1] + 1});
-    op->setAttr(opSegmentsAttrName, newSegments);
-
-    // Add a block argument for the target qubit
-    auto arg = op.getBody()->addArgument(QubitType::get(rewriter.getContext()),
-                                         op.getLoc());
-
-    // Replace the current GPhaseOp with a PhaseOp
     const OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(gPhaseOp);
-    POp::create(rewriter, gPhaseOp.getLoc(), arg, gPhaseOp.getTheta());
-    rewriter.eraseOp(gPhaseOp);
-
+    rewriter.setInsertionPoint(op);
+    createControlledPhase(rewriter, op.getLoc(), gPhaseOp.getLoc(),
+                          op.getControls(), gPhaseOp.getTheta());
+    rewriter.eraseOp(op);
     return success();
   }
 };
@@ -242,5 +274,6 @@ LogicalResult CtrlOp::verify() {
 
 void CtrlOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                          MLIRContext* context) {
-  results.add<MergeNestedCtrl, ReduceCtrl, EraseEmptyCtrl>(context);
+  results.add<MergeNestedCtrl, PullGPhaseOutOfCtrl, ReduceCtrl, EraseEmptyCtrl>(
+      context);
 }

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -16,6 +16,7 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVectorExtras.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -33,17 +34,13 @@ using namespace mlir;
 using namespace mlir::qc;
 
 /**
- * @brief Materialize a global phase controlled by @p controls.
+ * @brief Materialize a global phase controlled by multiple @p controls.
  */
-static void createControlledPhase(PatternRewriter& rewriter,
-                                  Location controlledLoc, Location phaseLoc,
-                                  ValueRange controls, Value theta) {
-  assert(!controls.empty());
-  if (controls.size() == 1) {
-    POp::create(rewriter, controlledLoc, controls.front(), theta);
-    return;
-  }
-
+static void createMultiControlledPhase(PatternRewriter& rewriter,
+                                       Location controlledLoc,
+                                       Location phaseLoc, ValueRange controls,
+                                       Value theta) {
+  assert(controls.size() > 1);
   CtrlOp::create(
       rewriter, controlledLoc, controls.drop_back(), controls.back(),
       [&](Value target) { POp::create(rewriter, phaseLoc, target, theta); });
@@ -131,9 +128,19 @@ struct PullGPhaseOutOfCtrl final : OpRewritePattern<CtrlOp> {
 
     const OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
+    Value theta = globalPhases.front().getTheta();
+    for (auto gphase : llvm::drop_begin(globalPhases)) {
+      theta = rewriter.createOrFold<arith::AddFOp>(gphase.getLoc(), theta,
+                                                   gphase.getTheta());
+    }
+    const auto phaseLoc = globalPhases.front().getLoc();
+    if (op.getNumControls() == 1) {
+      POp::create(rewriter, phaseLoc, op.getControl(0), theta);
+    } else {
+      createMultiControlledPhase(rewriter, phaseLoc, phaseLoc, op.getControls(),
+                                 theta);
+    }
     for (auto gphase : globalPhases) {
-      createControlledPhase(rewriter, gphase.getLoc(), gphase.getLoc(),
-                            op.getControls(), gphase.getTheta());
       rewriter.eraseOp(gphase);
     }
     return success();
@@ -174,8 +181,12 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
 
     const OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
-    createControlledPhase(rewriter, op.getLoc(), gPhaseOp.getLoc(),
-                          op.getControls(), gPhaseOp.getTheta());
+    if (op.getNumControls() == 1) {
+      POp::create(rewriter, op.getLoc(), op.getControl(0), gPhaseOp.getTheta());
+    } else {
+      createMultiControlledPhase(rewriter, op.getLoc(), gPhaseOp.getLoc(),
+                                 op.getControls(), gPhaseOp.getTheta());
+    }
     rewriter.eraseOp(op);
     return success();
   }

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -38,17 +38,15 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
 /**
  * @brief Materialize a global phase controlled by @p controls.
  * @return The updated control qubits in their original order.
  */
-SmallVector<Value> createControlledPhase(PatternRewriter& rewriter,
-                                         const Location controlledLoc,
-                                         const Location phaseLoc,
-                                         const ValueRange controls,
-                                         const Value theta) {
+static SmallVector<Value> createControlledPhase(PatternRewriter& rewriter,
+                                                const Location controlledLoc,
+                                                const Location phaseLoc,
+                                                const ValueRange controls,
+                                                const Value theta) {
   assert(!controls.empty());
   if (controls.size() == 1) {
     return {POp::create(rewriter, controlledLoc, controls.front(), theta)
@@ -62,6 +60,8 @@ SmallVector<Value> createControlledPhase(PatternRewriter& rewriter,
       });
   return SmallVector<Value>(controlledPhase.getOutputQubits());
 }
+
+namespace {
 
 /**
  * @brief Merge nested control modifiers into a single one.

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -41,6 +41,29 @@ using namespace mlir::qco;
 namespace {
 
 /**
+ * @brief Materialize a global phase controlled by @p controls.
+ * @return The updated control qubits in their original order.
+ */
+SmallVector<Value> createControlledPhase(PatternRewriter& rewriter,
+                                         const Location controlledLoc,
+                                         const Location phaseLoc,
+                                         const ValueRange controls,
+                                         const Value theta) {
+  assert(!controls.empty());
+  if (controls.size() == 1) {
+    return {POp::create(rewriter, controlledLoc, controls.front(), theta)
+                .getOutputQubit(0)};
+  }
+
+  auto controlledPhase = CtrlOp::create(
+      rewriter, controlledLoc, controls.drop_back(), controls.back(),
+      [&](Value target) -> Value {
+        return POp::create(rewriter, phaseLoc, target, theta).getOutputQubit(0);
+      });
+  return SmallVector<Value>(controlledPhase.getOutputQubits());
+}
+
+/**
  * @brief Merge nested control modifiers into a single one.
  */
 struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
@@ -104,6 +127,49 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
 };
 
 /**
+ * @brief Pull global phases out of multi-operation control modifiers.
+ */
+struct PullGPhaseOutOfCtrl final : OpRewritePattern<CtrlOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(CtrlOp op,
+                                PatternRewriter& rewriter) const override {
+    if (op.getNumControls() == 0 || op.getNumBodyUnitaries() < 2) {
+      return failure();
+    }
+
+    SmallVector<GPhaseOp> globalPhases;
+    for (auto gphase : op.getBody()->getOps<GPhaseOp>()) {
+      // Moving the phase out must not leave its angle defined in the body.
+      if (gphase.getTheta().getParentBlock() == op.getBody()) {
+        return failure();
+      }
+      globalPhases.push_back(gphase);
+    }
+    if (globalPhases.empty()) {
+      return failure();
+    }
+
+    SmallVector<Value> controls(op.getControlsIn());
+    const OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    for (auto gphase : globalPhases) {
+      controls =
+          createControlledPhase(rewriter, gphase.getLoc(), gphase.getLoc(),
+                                controls, gphase.getTheta());
+      rewriter.eraseOp(gphase);
+    }
+
+    rewriter.modifyOpInPlace(op, [&]() {
+      for (auto [index, control] : llvm::enumerate(controls)) {
+        op->setOperand(index, control);
+      }
+    });
+    return success();
+  }
+};
+
+/**
  * @brief Reduce controls for well-known gates.
  * @details Removes empty control ops and handles controlled IdOp, GPhaseOp and
  * BarrierOp.
@@ -143,41 +209,12 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
       return failure();
     }
 
-    // Special case for single control: replace with a single POp
-    if (op.getNumControls() == 1) {
-      rewriter.replaceOpWithNewOp<POp>(op, op.getInputControl(0),
-                                       gPhaseOp.getTheta());
-      return success();
-    }
-
-    // Reinterpret the last control as a target qubit and apply a phase gate to
-    // it inside the (smaller) controlled region
-    const auto opSegmentsAttrName = CtrlOp::getOperandSegmentSizeAttr();
-    auto segmentsAttr =
-        op->getAttrOfType<DenseI32ArrayAttr>(opSegmentsAttrName);
-    auto newSegments = DenseI32ArrayAttr::get(
-        rewriter.getContext(), {segmentsAttr[0] - 1, segmentsAttr[1] + 1});
-    op->setAttr(opSegmentsAttrName, newSegments);
-    const auto opResultSegmentsAttrName = CtrlOp::getResultSegmentSizeAttr();
-    op->setAttr(opResultSegmentsAttrName, newSegments);
-
-    // Add a block argument for the target qubit
-    auto arg = op.getBody()->addArgument(QubitType::get(rewriter.getContext()),
-                                         op.getLoc());
-
-    // Replace the current GPhaseOp with a PhaseOp
     const OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(gPhaseOp);
-    auto pOp =
-        POp::create(rewriter, gPhaseOp.getLoc(), arg, gPhaseOp.getTheta());
-
-    // Add the results of the POp to the yield operation
-    auto yieldOp = cast<YieldOp>(op.getBody()->back());
-    yieldOp->setOperands(pOp->getResults());
-
-    // Erase the GPhaseOp
-    rewriter.eraseOp(gPhaseOp);
-
+    rewriter.setInsertionPoint(op);
+    auto outputs =
+        createControlledPhase(rewriter, op.getLoc(), gPhaseOp.getLoc(),
+                              op.getControlsIn(), gPhaseOp.getTheta());
+    rewriter.replaceOp(op, outputs);
     return success();
   }
 };
@@ -323,7 +360,8 @@ LogicalResult CtrlOp::verify() {
 
 void CtrlOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                          MLIRContext* context) {
-  results.add<MergeNestedCtrl, ReduceCtrl, EraseEmptyCtrl>(context);
+  results.add<MergeNestedCtrl, PullGPhaseOutOfCtrl, ReduceCtrl, EraseEmptyCtrl>(
+      context);
 }
 
 bool CtrlOp::hasCompileTimeKnownUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -42,11 +42,9 @@ using namespace mlir::qco;
  * @brief Materialize a global phase controlled by @p controls.
  * @return The updated control qubits in their original order.
  */
-static SmallVector<Value> createControlledPhase(PatternRewriter& rewriter,
-                                                const Location controlledLoc,
-                                                const Location phaseLoc,
-                                                const ValueRange controls,
-                                                const Value theta) {
+static SmallVector<Value>
+createControlledPhase(PatternRewriter& rewriter, Location controlledLoc,
+                      Location phaseLoc, ValueRange controls, Value theta) {
   assert(!controls.empty());
   if (controls.size() == 1) {
     return {POp::create(rewriter, controlledLoc, controls.front(), theta)

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -20,6 +20,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <llvm/Support/ErrorHandling.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/QTensor/IR/QTensorOps.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>
@@ -39,18 +40,15 @@ using namespace mlir;
 using namespace mlir::qco;
 
 /**
- * @brief Materialize a global phase controlled by @p controls.
+ * @brief Materialize a global phase controlled by multiple @p controls.
  * @return The updated control qubits in their original order.
  */
-static SmallVector<Value>
-createControlledPhase(PatternRewriter& rewriter, Location controlledLoc,
-                      Location phaseLoc, ValueRange controls, Value theta) {
-  assert(!controls.empty());
-  if (controls.size() == 1) {
-    return {POp::create(rewriter, controlledLoc, controls.front(), theta)
-                .getOutputQubit(0)};
-  }
-
+static SmallVector<Value> createMultiControlledPhase(PatternRewriter& rewriter,
+                                                     Location controlledLoc,
+                                                     Location phaseLoc,
+                                                     ValueRange controls,
+                                                     Value theta) {
+  assert(controls.size() > 1);
   auto controlledPhase = CtrlOp::create(
       rewriter, controlledLoc, controls.drop_back(), controls.back(),
       [&](Value target) -> Value {
@@ -151,10 +149,21 @@ struct PullGPhaseOutOfCtrl final : OpRewritePattern<CtrlOp> {
     SmallVector<Value> controls(op.getControlsIn());
     const OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
+    Value theta = globalPhases.front().getTheta();
+    for (auto gphase : llvm::drop_begin(globalPhases)) {
+      theta = rewriter.createOrFold<arith::AddFOp>(gphase.getLoc(), theta,
+                                                   gphase.getTheta());
+    }
+    const auto phaseLoc = globalPhases.front().getLoc();
+    if (controls.size() == 1) {
+      controls.front() =
+          POp::create(rewriter, phaseLoc, controls.front(), theta)
+              .getOutputQubit(0);
+    } else {
+      controls = createMultiControlledPhase(rewriter, phaseLoc, phaseLoc,
+                                            controls, theta);
+    }
     for (auto gphase : globalPhases) {
-      controls =
-          createControlledPhase(rewriter, gphase.getLoc(), gphase.getLoc(),
-                                controls, gphase.getTheta());
       rewriter.eraseOp(gphase);
     }
 
@@ -209,10 +218,17 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
 
     const OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
-    auto outputs =
-        createControlledPhase(rewriter, op.getLoc(), gPhaseOp.getLoc(),
-                              op.getControlsIn(), gPhaseOp.getTheta());
-    rewriter.replaceOp(op, outputs);
+    if (op.getNumControls() == 1) {
+      auto output = POp::create(rewriter, op.getLoc(),
+                                op.getControlsIn().front(), gPhaseOp.getTheta())
+                        .getOutputQubit(0);
+      rewriter.replaceOp(op, output);
+    } else {
+      auto outputs =
+          createMultiControlledPhase(rewriter, op.getLoc(), gPhaseOp.getLoc(),
+                                     op.getControlsIn(), gPhaseOp.getTheta());
+      rewriter.replaceOp(op, outputs);
+    }
     return success();
   }
 };

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -452,6 +452,11 @@ INSTANTIATE_TEST_SUITE_P(
                    MQT_NAMED_BUILDER(fourControlledRxx)},
         QCTestCase{"NestedCtrlTwo", MQT_NAMED_BUILDER(nestedCtrlTwo),
                    MQT_NAMED_BUILDER(ctrlTwo)},
+        QCTestCase{"CtrlGPhaseAndX", MQT_NAMED_BUILDER(ctrlGPhaseAndX),
+                   MQT_NAMED_BUILDER(ctrlGPhaseAndXRef)},
+        QCTestCase{"CtrlMultipleGPhases",
+                   MQT_NAMED_BUILDER(ctrlMultipleGPhases),
+                   MQT_NAMED_BUILDER(ctrlMultipleGPhasesRef)},
         QCTestCase{"ModifierBodyReuseReordered",
                    MQT_NAMED_BUILDER(modifierBodyReuseReordered),
                    MQT_NAMED_BUILDER(modifierBodyReuseReorderedRef)}));

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -1096,6 +1096,11 @@ INSTANTIATE_TEST_SUITE_P(
                     MQT_NAMED_BUILDER(fourControlledRxx)},
         QCOTestCase{"NestedCtrlTwo", MQT_NAMED_BUILDER(nestedCtrlTwo),
                     MQT_NAMED_BUILDER(ctrlTwo)},
+        QCOTestCase{"CtrlGPhaseAndX", MQT_NAMED_BUILDER(ctrlGPhaseAndX),
+                    MQT_NAMED_BUILDER(ctrlGPhaseAndXRef)},
+        QCOTestCase{"CtrlMultipleGPhases",
+                    MQT_NAMED_BUILDER(ctrlMultipleGPhases),
+                    MQT_NAMED_BUILDER(ctrlMultipleGPhasesRef)},
         QCOTestCase{"ModifierBodyReuseReordered",
                     MQT_NAMED_BUILDER(modifierBodyReuseReordered),
                     MQT_NAMED_BUILDER(modifierBodyReuseReorderedRef)}));

--- a/mlir/unittests/programs/qc_programs.cpp
+++ b/mlir/unittests/programs/qc_programs.cpp
@@ -2225,7 +2225,7 @@ Value ctrlMultipleGPhases(QCProgramBuilder& b) {
 
 Value ctrlMultipleGPhasesRef(QCProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.cp(0.589, q[0], q[1]);
+  b.cp(0.579, q[0], q[1]);
   b.ctrl({q[0], q[1]}, {q[2], q[3]}, [&](ValueRange targets) {
     b.x(targets[0]);
     b.rxx(0.789, targets[0], targets[1]);

--- a/mlir/unittests/programs/qc_programs.cpp
+++ b/mlir/unittests/programs/qc_programs.cpp
@@ -2196,6 +2196,44 @@ Value nestedCtrlTwo(QCProgramBuilder& b) {
   return measureAndReturn(b, q.qubits);
 }
 
+Value ctrlGPhaseAndX(QCProgramBuilder& b) {
+  auto q = b.allocQubitRegister(2);
+  b.ctrl(q[0], q[1], [&](Value target) {
+    b.gphase(0.123);
+    b.x(target);
+  });
+  return measureAndReturn(b, q.qubits);
+}
+
+Value ctrlGPhaseAndXRef(QCProgramBuilder& b) {
+  auto q = b.allocQubitRegister(2);
+  b.p(0.123, q[0]);
+  b.cx(q[0], q[1]);
+  return measureAndReturn(b, q.qubits);
+}
+
+Value ctrlMultipleGPhases(QCProgramBuilder& b) {
+  auto q = b.allocQubitRegister(4);
+  b.ctrl({q[0], q[1]}, {q[2], q[3]}, [&](ValueRange targets) {
+    b.gphase(0.123);
+    b.x(targets[0]);
+    b.gphase(0.456);
+    b.rxx(0.789, targets[0], targets[1]);
+  });
+  return measureAndReturn(b, q.qubits);
+}
+
+Value ctrlMultipleGPhasesRef(QCProgramBuilder& b) {
+  auto q = b.allocQubitRegister(4);
+  b.cp(0.123, q[0], q[1]);
+  b.cp(0.456, q[0], q[1]);
+  b.ctrl({q[0], q[1]}, {q[2], q[3]}, [&](ValueRange targets) {
+    b.x(targets[0]);
+    b.rxx(0.789, targets[0], targets[1]);
+  });
+  return measureAndReturn(b, q.qubits);
+}
+
 Value ctrlInvTwo(QCProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
   b.ctrl(q[0], {q[1], q[2]}, [&](ValueRange targets) {

--- a/mlir/unittests/programs/qc_programs.cpp
+++ b/mlir/unittests/programs/qc_programs.cpp
@@ -2225,8 +2225,7 @@ Value ctrlMultipleGPhases(QCProgramBuilder& b) {
 
 Value ctrlMultipleGPhasesRef(QCProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  b.cp(0.123, q[0], q[1]);
-  b.cp(0.456, q[0], q[1]);
+  b.cp(0.589, q[0], q[1]);
   b.ctrl({q[0], q[1]}, {q[2], q[3]}, [&](ValueRange targets) {
     b.x(targets[0]);
     b.rxx(0.789, targets[0], targets[1]);

--- a/mlir/unittests/programs/qc_programs.h
+++ b/mlir/unittests/programs/qc_programs.h
@@ -1080,6 +1080,18 @@ Value ctrlTwoMixed(QCProgramBuilder& b);
 /// Creates a circuit with nested control modifiers applied to two gates.
 Value nestedCtrlTwo(QCProgramBuilder& b);
 
+/// Creates a single-control modifier containing a global phase and an X gate.
+Value ctrlGPhaseAndX(QCProgramBuilder& b);
+
+/// Reference for ctrlGPhaseAndX with the phase lifted onto the control.
+Value ctrlGPhaseAndXRef(QCProgramBuilder& b);
+
+/// Creates a multi-control modifier containing two global phases and two gates.
+Value ctrlMultipleGPhases(QCProgramBuilder& b);
+
+/// Reference for ctrlMultipleGPhases with both phases lifted in order.
+Value ctrlMultipleGPhasesRef(QCProgramBuilder& b);
+
 /// Creates a circuit with a control modifier applied to a inverse modifier
 /// applied to two gates.
 Value ctrlInvTwo(QCProgramBuilder& b);

--- a/mlir/unittests/programs/qc_programs.h
+++ b/mlir/unittests/programs/qc_programs.h
@@ -1089,7 +1089,7 @@ Value ctrlGPhaseAndXRef(QCProgramBuilder& b);
 /// Creates a multi-control modifier containing two global phases and two gates.
 Value ctrlMultipleGPhases(QCProgramBuilder& b);
 
-/// Reference for ctrlMultipleGPhases with both phases lifted in order.
+/// Reference for ctrlMultipleGPhases with the combined phase lifted.
 Value ctrlMultipleGPhasesRef(QCProgramBuilder& b);
 
 /// Creates a circuit with a control modifier applied to a inverse modifier

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -3602,7 +3602,7 @@ Value ctrlMultipleGPhases(QCOProgramBuilder& b) {
 
 Value ctrlMultipleGPhasesRef(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  std::tie(q[0], q[1]) = b.cp(0.589, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.cp(0.579, q[0], q[1]);
   const auto [controls, targets] =
       b.ctrl({q[0], q[1]}, {q[2], q[3]}, [&](ValueRange args) {
         auto target0 = b.x(args[0]);

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -3569,6 +3569,51 @@ Value nestedCtrlTwo(QCOProgramBuilder& b) {
       b, {res.first[0], res.second[0], res.second[1], res.second[2]});
 }
 
+Value ctrlGPhaseAndX(QCOProgramBuilder& b) {
+  auto q = b.allocQubitRegister(2);
+  const auto [controls, targets] =
+      b.ctrl(q[0], q[1], [&](Value target) -> Value {
+        b.gphase(0.123);
+        return b.x(target);
+      });
+  return measureAndReturn(b, {controls, targets});
+}
+
+Value ctrlGPhaseAndXRef(QCOProgramBuilder& b) {
+  auto q = b.allocQubitRegister(2);
+  q[0] = b.p(0.123, q[0]);
+  std::tie(q[0], q[1]) = b.cx(q[0], q[1]);
+  return measureAndReturn(b, q.qubits);
+}
+
+Value ctrlMultipleGPhases(QCOProgramBuilder& b) {
+  auto q = b.allocQubitRegister(4);
+  const auto [controls, targets] =
+      b.ctrl({q[0], q[1]}, {q[2], q[3]}, [&](ValueRange args) {
+        b.gphase(0.123);
+        auto target0 = b.x(args[0]);
+        b.gphase(0.456);
+        auto [output0, output1] = b.rxx(0.789, target0, args[1]);
+        return SmallVector{output0, output1};
+      });
+  return measureAndReturn(b,
+                          {controls[0], controls[1], targets[0], targets[1]});
+}
+
+Value ctrlMultipleGPhasesRef(QCOProgramBuilder& b) {
+  auto q = b.allocQubitRegister(4);
+  std::tie(q[0], q[1]) = b.cp(0.123, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.cp(0.456, q[0], q[1]);
+  const auto [controls, targets] =
+      b.ctrl({q[0], q[1]}, {q[2], q[3]}, [&](ValueRange args) {
+        auto target0 = b.x(args[0]);
+        auto [output0, output1] = b.rxx(0.789, target0, args[1]);
+        return SmallVector{output0, output1};
+      });
+  return measureAndReturn(b,
+                          {controls[0], controls[1], targets[0], targets[1]});
+}
+
 Value ctrlInvTwo(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
   auto res = b.ctrl(q[0], {q[1], q[2]}, [&](ValueRange targets) {

--- a/mlir/unittests/programs/qco_programs.cpp
+++ b/mlir/unittests/programs/qco_programs.cpp
@@ -3602,8 +3602,7 @@ Value ctrlMultipleGPhases(QCOProgramBuilder& b) {
 
 Value ctrlMultipleGPhasesRef(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(4);
-  std::tie(q[0], q[1]) = b.cp(0.123, q[0], q[1]);
-  std::tie(q[0], q[1]) = b.cp(0.456, q[0], q[1]);
+  std::tie(q[0], q[1]) = b.cp(0.589, q[0], q[1]);
   const auto [controls, targets] =
       b.ctrl({q[0], q[1]}, {q[2], q[3]}, [&](ValueRange args) {
         auto target0 = b.x(args[0]);

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -1258,6 +1258,18 @@ Value ctrlTwoMixed(QCOProgramBuilder& b);
 /// Creates a circuit with nested control modifiers applied to two gates.
 Value nestedCtrlTwo(QCOProgramBuilder& b);
 
+/// Creates a single-control modifier containing a global phase and an X gate.
+Value ctrlGPhaseAndX(QCOProgramBuilder& b);
+
+/// Reference for ctrlGPhaseAndX with the phase lifted onto the control.
+Value ctrlGPhaseAndXRef(QCOProgramBuilder& b);
+
+/// Creates a multi-control modifier containing two global phases and two gates.
+Value ctrlMultipleGPhases(QCOProgramBuilder& b);
+
+/// Reference for ctrlMultipleGPhases with both phases lifted in order.
+Value ctrlMultipleGPhasesRef(QCOProgramBuilder& b);
+
 /// Creates a circuit with a control modifier applied to an inverse modifier
 /// applied to two gates.
 Value ctrlInvTwo(QCOProgramBuilder& b);

--- a/mlir/unittests/programs/qco_programs.h
+++ b/mlir/unittests/programs/qco_programs.h
@@ -1267,7 +1267,7 @@ Value ctrlGPhaseAndXRef(QCOProgramBuilder& b);
 /// Creates a multi-control modifier containing two global phases and two gates.
 Value ctrlMultipleGPhases(QCOProgramBuilder& b);
 
-/// Reference for ctrlMultipleGPhases with both phases lifted in order.
+/// Reference for ctrlMultipleGPhases with the combined phase lifted.
 Value ctrlMultipleGPhasesRef(QCOProgramBuilder& b);
 
 /// Creates a circuit with a control modifier applied to an inverse modifier


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Add canonicalization patterns that pull `GPhaseOp`s out of multi-operation `ctrl` modifiers in the QC and QCO dialects.

A controlled global phase is materialized as:

- a `POp` on the control for a single-control modifier;
- a reduced `CtrlOp` applying `POp` to the final control for a multi-control modifier.

The existing single-operation and new multi-operation canonicalizations share the same controlled-phase construction helper. The QCO implementation also threads the updated control-qubit SSA values through the remaining modifier.

Global phases whose angle is defined inside the modifier body are conservatively left unchanged to avoid violating SSA dominance.

Fixes #1759

AI assistance was used to inspect the existing canonicalizations, implement and refactor the QC and QCO patterns, add regression tests, and run validation.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [ ] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
