### PR TITLE
🎨 Retain register name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,9 +100,9 @@ releases may include breaking changes.
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
   [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938], [#1975],
-  [#1976], [#2006], [#2014], [#2026], [#2028]) ([**@burgholzer**], [**@denialhaag**],
-  [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
-  [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
+  [#1976], [#2006], [#2014], [#2026], [#2028]) ([**@burgholzer**],
+  [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**],
+  [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,9 +96,9 @@ releases may include breaking changes.
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
   [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938], [#1975],
-  [#1976], [#2006]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
-  [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
-  [**@simon1hofmann**], [**@J4MMlE**])
+  [#1976], [#2006], [#2014]) ([**@burgholzer**], [**@denialhaag**],
+  [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
+  [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 
 ### Changed
 
@@ -721,6 +721,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2014]: https://github.com/munich-quantum-toolkit/core/pull/2014
 [#2011]: https://github.com/munich-quantum-toolkit/core/pull/2011
 [#2007]: https://github.com/munich-quantum-toolkit/core/pull/2007
 [#2006]: https://github.com/munich-quantum-toolkit/core/pull/2006

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -189,6 +189,7 @@ public:
   /**
    * @brief Allocate a qubit register and eagerly load every element
    * @param size Number of qubits (must be positive)
+   * @param name Optional source-level register name
    * @return A `QubitRegister` containing the backing memref and one reference
    * for every eagerly loaded element
    *
@@ -203,18 +204,19 @@ public:
    * %q2 = memref.load %memref[%c2] : memref<3x!qc.qubit>
    * ```
    */
-  QubitRegister allocQubitRegister(int64_t size);
+  QubitRegister allocQubitRegister(int64_t size, StringRef name = {});
 
   /**
    * @brief Allocate storage for a qubit register without loading its elements
    * @param size Number of qubits (must be positive)
+   * @param name Optional source-level register name
    * @return The memref value representing the qubit register
    *
    * @details The register is tracked for automatic deallocation and remains
    * intact until an element is loaded. Use `loadQubit` to obtain references at
    * their points of use.
    */
-  Value allocQubitRegisterStorage(int64_t size);
+  Value allocQubitRegisterStorage(int64_t size, StringRef name = {});
 
   /**
    * @brief Explicitly loads a qubit from a memref

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <llvm/ADT/StringSet.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
@@ -1379,6 +1380,9 @@ private:
 
   /// Track allocated memrefs for automatic deallocation
   DenseSet<Value> allocatedQregs;
+
+  /// Track non-empty source-level quantum register names.
+  llvm::StringSet<> quantumRegisterNames;
 
   /// Check if the builder has been finalized
   void checkFinalized() const;

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -1381,8 +1381,8 @@ private:
   /// Track allocated memrefs for automatic deallocation
   DenseSet<Value> allocatedQregs;
 
-  /// Track non-empty source-level quantum register names.
-  llvm::StringSet<> quantumRegisterNames;
+  /// Track non-empty source-level qubit register names.
+  llvm::StringSet<> qubitRegisterNames;
 
   /// Check if the builder has been finalized
   void checkFinalized() const;

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -1825,8 +1825,8 @@ private:
   MLIRContext* ctx{};
   Operation* module;
 
-  /// Track non-empty source-level quantum register names.
-  llvm::StringSet<> quantumRegisterNames;
+  /// Track non-empty source-level qubit register names.
+  llvm::StringSet<> qubitRegisterNames;
 
   /// Check if the builder has been finalized
   void checkFinalized() const;

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <llvm/ADT/StringSet.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
@@ -212,6 +213,7 @@ public:
   /**
    * @brief Allocate a qubit tensor and eagerly extract every element
    * @param size Number of qubits (must be positive)
+   * @param name Optional source-level register name
    * @return A `QubitRegister` containing the residual tensor and one standalone
    * qubit value for every eagerly extracted element
    *
@@ -226,7 +228,7 @@ public:
    * %t3, %q2 = qtensor.extract %t2[%c2]: tensor<3x!qco.qubit>
    * ```
    */
-  QubitRegister allocQubitRegister(int64_t size);
+  QubitRegister allocQubitRegister(int64_t size, StringRef name = {});
 
   /**
    * @brief Allocate a classical bit register
@@ -1822,6 +1824,9 @@ private:
 
   MLIRContext* ctx{};
   Operation* module;
+
+  /// Track non-empty source-level quantum register names.
+  llvm::StringSet<> quantumRegisterNames;
 
   /// Check if the builder has been finalized
   void checkFinalized() const;

--- a/mlir/include/mlir/Dialect/Utils/Utils.h
+++ b/mlir/include/mlir/Dialect/Utils/Utils.h
@@ -45,6 +45,10 @@ namespace mlir::utils {
 inline constexpr llvm::StringLiteral CLASSICAL_REGISTER_NAME_ATTR =
     "mqt.classical_register_name";
 
+/// Attribute used to retain a source-level quantum-register name.
+inline constexpr llvm::StringLiteral QUANTUM_REGISTER_NAME_ATTR =
+    "mqt.quantum_register_name";
+
 /// Check if a floating-point value is an integer.
 [[nodiscard]] inline bool isIntegerExponent(double r) {
   return r == std::floor(r) && std::isfinite(r);

--- a/mlir/include/mlir/Dialect/Utils/Utils.h
+++ b/mlir/include/mlir/Dialect/Utils/Utils.h
@@ -45,9 +45,9 @@ namespace mlir::utils {
 inline constexpr llvm::StringLiteral CLASSICAL_REGISTER_NAME_ATTR =
     "mqt.classical_register_name";
 
-/// Attribute used to retain a source-level quantum-register name.
-inline constexpr llvm::StringLiteral QUANTUM_REGISTER_NAME_ATTR =
-    "mqt.quantum_register_name";
+/// Attribute used to retain a source-level qubit-register name.
+inline constexpr llvm::StringLiteral QUBIT_REGISTER_NAME_ATTR =
+    "mqt.qubit_register_name";
 
 /// Check if a floating-point value is an integer.
 [[nodiscard]] inline bool isIntegerExponent(double r) {

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
+#include "mlir/Dialect/Utils/Utils.h"
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
@@ -279,14 +280,20 @@ struct ConvertQTensorAllocOp final
     auto tensorType = cast<RankedTensorType>(op.getResult().getType());
     auto memrefType = MemRefType::get(tensorType.getShape(), qubitType);
 
+    const auto registerName = op->getAttr(utils::QUANTUM_REGISTER_NAME_ATTR);
+    memref::AllocOp alloc;
     if (tensorType.hasStaticShape()) {
       // Static size: no dynamic size operand needed
-      rewriter.replaceOpWithNewOp<memref::AllocOp>(op, memrefType);
+      alloc = memref::AllocOp::create(rewriter, op.getLoc(), memrefType);
     } else {
       // Dynamic size: forward the runtime size operand
-      rewriter.replaceOpWithNewOp<memref::AllocOp>(op, memrefType,
-                                                   op.getSize());
+      alloc = memref::AllocOp::create(rewriter, op.getLoc(), memrefType,
+                                      op.getSize());
     }
+    if (registerName) {
+      alloc->setAttr(utils::QUANTUM_REGISTER_NAME_ATTR, registerName);
+    }
+    rewriter.replaceOp(op, alloc.getResult());
     return success();
   }
 };

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -280,7 +280,7 @@ struct ConvertQTensorAllocOp final
     auto tensorType = cast<RankedTensorType>(op.getResult().getType());
     auto memrefType = MemRefType::get(tensorType.getShape(), qubitType);
 
-    const auto registerName = op->getAttr(utils::QUANTUM_REGISTER_NAME_ATTR);
+    const auto registerName = op->getAttr(utils::QUBIT_REGISTER_NAME_ATTR);
     memref::AllocOp alloc;
     if (tensorType.hasStaticShape()) {
       // Static size: no dynamic size operand needed
@@ -291,7 +291,7 @@ struct ConvertQTensorAllocOp final
                                       op.getSize());
     }
     if (registerName) {
-      alloc->setAttr(utils::QUANTUM_REGISTER_NAME_ATTR, registerName);
+      alloc->setAttr(utils::QUBIT_REGISTER_NAME_ATTR, registerName);
     }
     rewriter.replaceOp(op, alloc.getResult());
     return success();

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -839,7 +839,7 @@ struct ConvertMemRefAllocOp final
       return failure();
     }
 
-    const auto registerName = op->getAttr(utils::QUANTUM_REGISTER_NAME_ATTR);
+    const auto registerName = op->getAttr(utils::QUBIT_REGISTER_NAME_ATTR);
     qtensor::AllocOp alloc;
     if (shape[0] == ShapedType::kDynamic) {
       alloc = qtensor::AllocOp::create(rewriter, op.getLoc(),
@@ -850,7 +850,7 @@ struct ConvertMemRefAllocOp final
       alloc = qtensor::AllocOp::create(rewriter, op.getLoc(), size.getResult());
     }
     if (registerName) {
-      alloc->setAttr(utils::QUANTUM_REGISTER_NAME_ATTR, registerName);
+      alloc->setAttr(utils::QUBIT_REGISTER_NAME_ATTR, registerName);
     }
 
     auto& state = getState();

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
+#include "mlir/Dialect/Utils/Utils.h"
 
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
@@ -838,21 +839,25 @@ struct ConvertMemRefAllocOp final
       return failure();
     }
 
-    Value qtensor;
+    const auto registerName = op->getAttr(utils::QUANTUM_REGISTER_NAME_ATTR);
+    qtensor::AllocOp alloc;
     if (shape[0] == ShapedType::kDynamic) {
-      qtensor = rewriter.replaceOpWithNewOp<qtensor::AllocOp>(
-          op, adaptor.getDynamicSizes()[0]);
+      alloc = qtensor::AllocOp::create(rewriter, op.getLoc(),
+                                       adaptor.getDynamicSizes()[0]);
     } else {
       auto size =
           arith::ConstantIndexOp::create(rewriter, op.getLoc(), shape[0]);
-      qtensor =
-          rewriter.replaceOpWithNewOp<qtensor::AllocOp>(op, size.getResult());
+      alloc = qtensor::AllocOp::create(rewriter, op.getLoc(), size.getResult());
+    }
+    if (registerName) {
+      alloc->setAttr(utils::QUANTUM_REGISTER_NAME_ATTR, registerName);
     }
 
     auto& state = getState();
     auto memref = op.getResult();
-    assignMappedTensor(state, qtensor.getDefiningOp(),
-                       lookupRegisterId(state, memref), qtensor);
+    assignMappedTensor(state, alloc, lookupRegisterId(state, memref),
+                       alloc.getResult());
+    rewriter.replaceOp(op, alloc.getResult());
 
     return success();
   }

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -138,6 +138,9 @@ Value QCProgramBuilder::allocQubitRegisterStorage(const int64_t size,
   if (size <= 0) {
     llvm::reportFatalUsageError("Size must be positive");
   }
+  if (!name.empty() && !quantumRegisterNames.insert(name).second) {
+    llvm::reportFatalUsageError("Quantum register names must be unique");
+  }
 
   auto memrefType = MemRefType::get({size}, QubitType::get(ctx));
   auto alloc = memref::AllocOp::create(*this, memrefType);

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -138,14 +138,14 @@ Value QCProgramBuilder::allocQubitRegisterStorage(const int64_t size,
   if (size <= 0) {
     llvm::reportFatalUsageError("Size must be positive");
   }
-  if (!name.empty() && !quantumRegisterNames.insert(name).second) {
-    llvm::reportFatalUsageError("Quantum register names must be unique");
+  if (!name.empty() && !qubitRegisterNames.insert(name).second) {
+    llvm::reportFatalUsageError("Qubit register names must be unique");
   }
 
   auto memrefType = MemRefType::get({size}, QubitType::get(ctx));
   auto alloc = memref::AllocOp::create(*this, memrefType);
   if (!name.empty()) {
-    alloc->setAttr(QUANTUM_REGISTER_NAME_ATTR, getStringAttr(name));
+    alloc->setAttr(QUBIT_REGISTER_NAME_ATTR, getStringAttr(name));
   }
   auto memref = alloc.getResult();
   allocatedQregs.insert(memref);

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -117,8 +117,8 @@ Value QCProgramBuilder::staticQubit(const uint64_t index) {
 }
 
 QCProgramBuilder::QubitRegister
-QCProgramBuilder::allocQubitRegister(const int64_t size) {
-  auto memref = allocQubitRegisterStorage(size);
+QCProgramBuilder::allocQubitRegister(const int64_t size, const StringRef name) {
+  auto memref = allocQubitRegisterStorage(size, name);
 
   SmallVector<Value> qubits;
   qubits.reserve(size);
@@ -130,7 +130,8 @@ QCProgramBuilder::allocQubitRegister(const int64_t size) {
   return {.value = memref, .qubits = std::move(qubits)};
 }
 
-Value QCProgramBuilder::allocQubitRegisterStorage(const int64_t size) {
+Value QCProgramBuilder::allocQubitRegisterStorage(const int64_t size,
+                                                  const StringRef name) {
   checkFinalized();
   ensureAllocationMode(AllocationMode::Dynamic);
 
@@ -139,7 +140,11 @@ Value QCProgramBuilder::allocQubitRegisterStorage(const int64_t size) {
   }
 
   auto memrefType = MemRefType::get({size}, QubitType::get(ctx));
-  auto memref = memref::AllocOp::create(*this, memrefType).getResult();
+  auto alloc = memref::AllocOp::create(*this, memrefType);
+  if (!name.empty()) {
+    alloc->setAttr(QUANTUM_REGISTER_NAME_ATTR, getStringAttr(name));
+  }
+  auto memref = alloc.getResult();
   allocatedQregs.insert(memref);
   return memref;
 }

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -2407,7 +2407,7 @@ private:
         return;
       }
       qubitValues[statement.reg] = builder.allocQubitRegisterStorage(
-          static_cast<int64_t>(declaration.width));
+          static_cast<int64_t>(declaration.width), declaration.name);
       return;
     }
     if (outputBitRegisters[statement.reg]) {

--- a/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
@@ -206,6 +206,13 @@ private:
     return uniqueName("out", nextScalar);
   }
 
+  [[nodiscard]] std::string quantumRegisterName(const StringRef requested) {
+    if (isValidOutputName(requested) && usedNames.insert(requested).second) {
+      return requested.str();
+    }
+    return uniqueName("q", nextQubit);
+  }
+
   [[nodiscard]] LogicalResult preflight() {
     SmallVector<func::FuncOp> functions(moduleOp.getOps<func::FuncOp>());
     if (functions.size() != 1) {
@@ -301,7 +308,12 @@ private:
         return fail(alloc, "only qubit and i1 memrefs are supported");
       }
       if (resource.kind == ResourceKind::Qubit) {
-        resource.name = uniqueName("q", nextQubit);
+        StringRef requested;
+        if (const auto attr = alloc->getAttrOfType<StringAttr>(
+                utils::QUANTUM_REGISTER_NAME_ATTR)) {
+          requested = attr.getValue();
+        }
+        resource.name = quantumRegisterName(requested);
       } else {
         resource.output = returnedMemrefs.contains(alloc.getResult());
         StringRef requested;

--- a/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
@@ -206,7 +206,7 @@ private:
     return uniqueName("out", nextScalar);
   }
 
-  [[nodiscard]] std::string quantumRegisterName(const StringRef requested) {
+  [[nodiscard]] std::string qubitRegisterName(const StringRef requested) {
     if (isValidOutputName(requested) && usedNames.insert(requested).second) {
       return requested.str();
     }
@@ -310,10 +310,10 @@ private:
       if (resource.kind == ResourceKind::Qubit) {
         StringRef requested;
         if (const auto attr = alloc->getAttrOfType<StringAttr>(
-                utils::QUANTUM_REGISTER_NAME_ATTR)) {
+                utils::QUBIT_REGISTER_NAME_ATTR)) {
           requested = attr.getValue();
         }
-        resource.name = quantumRegisterName(requested);
+        resource.name = qubitRegisterName(requested);
       } else {
         resource.output = returnedMemrefs.contains(alloc.getResult());
         StringRef requested;

--- a/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQuantumComputationToQC.cpp
@@ -140,8 +140,8 @@ allocateQregs(QCProgramBuilder& builder,
   // Allocate quantum registers using the builder
   SmallVector<QregInfo> qregs;
   for (const auto* qregPtr : qregPtrs) {
-    auto qubitRegister =
-        builder.allocQubitRegister(static_cast<int64_t>(qregPtr->getSize()));
+    auto qubitRegister = builder.allocQubitRegister(
+        static_cast<int64_t>(qregPtr->getSize()), qregPtr->getName());
     qregs.emplace_back(qregPtr, std::move(qubitRegister.qubits));
   }
 

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -246,7 +246,8 @@ Value QCOProgramBuilder::prepareInitArg(Value initArg,
     return initArg;
   }
 
-  const auto regId = validTensors[initArg].regId;
+  validateTensorValue(initArg);
+  const auto regId = validTensors.find(initArg)->second.regId;
   auto currentTensor = initArg;
   for (auto it = validQubits.begin(); it != validQubits.end();) {
     auto& [qubit, qubitInfo] = *it;

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -134,14 +134,22 @@ Value QCOProgramBuilder::staticQubit(const uint64_t index) {
 }
 
 QCOProgramBuilder::QubitRegister
-QCOProgramBuilder::allocQubitRegister(const int64_t size) {
+QCOProgramBuilder::allocQubitRegister(const int64_t size,
+                                      const StringRef name) {
   checkFinalized();
 
   if (size <= 0) {
     llvm::reportFatalUsageError("Size must be positive");
   }
+  if (!name.empty() && !quantumRegisterNames.insert(name).second) {
+    llvm::reportFatalUsageError("Quantum register names must be unique");
+  }
 
   auto qtensor = qtensorAlloc(size);
+  if (!name.empty()) {
+    qtensor.getDefiningOp()->setAttr(QUANTUM_REGISTER_NAME_ATTR,
+                                     getStringAttr(name));
+  }
 
   SmallVector<Value> qubits;
   qubits.reserve(size);

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -246,8 +246,7 @@ Value QCOProgramBuilder::prepareInitArg(Value initArg,
     return initArg;
   }
 
-  validateTensorValue(initArg);
-  const auto regId = validTensors.find(initArg)->second.regId;
+  const auto regId = validTensors[initArg].regId;
   auto currentTensor = initArg;
   for (auto it = validQubits.begin(); it != validQubits.end();) {
     auto& [qubit, qubitInfo] = *it;

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -141,13 +141,13 @@ QCOProgramBuilder::allocQubitRegister(const int64_t size,
   if (size <= 0) {
     llvm::reportFatalUsageError("Size must be positive");
   }
-  if (!name.empty() && !quantumRegisterNames.insert(name).second) {
-    llvm::reportFatalUsageError("Quantum register names must be unique");
+  if (!name.empty() && !qubitRegisterNames.insert(name).second) {
+    llvm::reportFatalUsageError("Qubit register names must be unique");
   }
 
   auto qtensor = qtensorAlloc(size);
   if (!name.empty()) {
-    qtensor.getDefiningOp()->setAttr(QUANTUM_REGISTER_NAME_ATTR,
+    qtensor.getDefiningOp()->setAttr(QUBIT_REGISTER_NAME_ATTR,
                                      getStringAttr(name));
   }
 

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -113,6 +113,41 @@ TEST(QCOToQCRegressionTest, RetainsQubitRegisterName) {
   EXPECT_EQ(name.getValue(), "named_qubits");
 }
 
+TEST(QCOToQCRegressionTest, RetainsDynamicQubitRegisterName) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
+                  arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
+                  scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%size: index) attributes {passthrough = ["entry_point"]} {
+    %reg = qtensor.alloc(%size) {mqt.qubit_register_name = "named_qubits"} : tensor<?x!qco.qubit>
+    qtensor.dealloc %reg : tensor<?x!qco.qubit>
+    return
+  }
+}
+)mlir";
+
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(runQCOToQCConversion(*moduleOp)));
+
+  memref::AllocOp allocation;
+  moduleOp->walk([&](memref::AllocOp op) { allocation = op; });
+  ASSERT_TRUE(allocation);
+  EXPECT_TRUE(allocation.getType().isDynamicDim(0));
+  ASSERT_EQ(allocation.getDynamicSizes().size(), 1);
+  EXPECT_EQ(allocation.getDynamicSizes().front(),
+            allocation->getBlock()->getArgument(0));
+  const auto name =
+      allocation->getAttrOfType<StringAttr>(utils::QUBIT_REGISTER_NAME_ATTR);
+  ASSERT_TRUE(name);
+  EXPECT_EQ(name.getValue(), "named_qubits");
+}
+
 static Value
 aliasSafeNestedForLoopCtrlOpWithExtractedQubit(qc::QCProgramBuilder& b) {
   auto reg = b.allocQubitRegister(4);

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -86,7 +86,7 @@ static LogicalResult runQCOToQCConversion(ModuleOp module) {
   return pm.run(module);
 }
 
-TEST(QCOToQCRegressionTest, RetainsQuantumRegisterName) {
+TEST(QCOToQCRegressionTest, RetainsQubitRegisterName) {
   DialectRegistry registry;
   registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
                   arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
@@ -108,7 +108,7 @@ TEST(QCOToQCRegressionTest, RetainsQuantumRegisterName) {
   });
   ASSERT_TRUE(allocation);
   const auto name =
-      allocation->getAttrOfType<StringAttr>(utils::QUANTUM_REGISTER_NAME_ATTR);
+      allocation->getAttrOfType<StringAttr>(utils::QUBIT_REGISTER_NAME_ATTR);
   ASSERT_TRUE(name);
   EXPECT_EQ(name.getValue(), "named_qubits");
 }

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -15,6 +15,8 @@
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
+#include "mlir/Dialect/QTensor/IR/QTensorOps.h"
+#include "mlir/Dialect/Utils/Utils.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
 #include "qc_programs.h"
@@ -81,6 +83,33 @@ static LogicalResult runQCOToQCConversion(ModuleOp module) {
   PassManager pm(module.getContext());
   pm.addPass(createQCOToQC());
   return pm.run(module);
+}
+
+TEST(QCOToQCRegressionTest, RetainsQuantumRegisterName) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
+                  arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
+                  scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  qco::QCOProgramBuilder builder(&context);
+  builder.initialize();
+  std::ignore = builder.allocQubitRegister(2, "named_qubits");
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(runQCOToQCConversion(*moduleOp)));
+
+  memref::AllocOp allocation;
+  moduleOp->walk([&](memref::AllocOp op) {
+    if (isa<qc::QubitType>(op.getType().getElementType())) {
+      allocation = op;
+    }
+  });
+  ASSERT_TRUE(allocation);
+  const auto name =
+      allocation->getAttrOfType<StringAttr>(utils::QUANTUM_REGISTER_NAME_ATTR);
+  ASSERT_TRUE(name);
+  EXPECT_EQ(name.getValue(), "named_qubits");
 }
 
 static Value

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -15,7 +15,6 @@
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
-#include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/Utils/Utils.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
@@ -27,6 +26,7 @@
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Value.h>
@@ -39,6 +39,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <tuple>
 
 using namespace mlir;
 

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -588,7 +588,7 @@ module {
   EXPECT_EQ(deallocations, 1U);
 }
 
-TEST_F(QCToQCORegressionTest, RetainsQuantumRegisterName) {
+TEST_F(QCToQCORegressionTest, RetainsQubitRegisterName) {
   qc::QCProgramBuilder builder(&context);
   builder.initialize();
   std::ignore = builder.allocQubitRegisterStorage(2, "named_qubits");
@@ -600,7 +600,7 @@ TEST_F(QCToQCORegressionTest, RetainsQuantumRegisterName) {
   moduleOp->walk([&](qtensor::AllocOp op) { allocation = op; });
   ASSERT_TRUE(allocation);
   const auto name =
-      allocation->getAttrOfType<StringAttr>(utils::QUANTUM_REGISTER_NAME_ATTR);
+      allocation->getAttrOfType<StringAttr>(utils::QUBIT_REGISTER_NAME_ATTR);
   ASSERT_TRUE(name);
   EXPECT_EQ(name.getValue(), "named_qubits");
 }

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -604,6 +604,32 @@ TEST_F(QCToQCORegressionTest, RetainsQubitRegisterName) {
   EXPECT_EQ(name.getValue(), "named_qubits");
 }
 
+TEST_F(QCToQCORegressionTest, RetainsDynamicQubitRegisterName) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%size: index) attributes {passthrough = ["entry_point"]} {
+    %reg = memref.alloc(%size) {mqt.qubit_register_name = "named_qubits"} : memref<?x!qc.qubit>
+    memref.dealloc %reg : memref<?x!qc.qubit>
+    return
+  }
+}
+)mlir";
+
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+
+  qtensor::AllocOp allocation;
+  moduleOp->walk([&](qtensor::AllocOp op) { allocation = op; });
+  ASSERT_TRUE(allocation);
+  EXPECT_TRUE(allocation.getResult().getType().isDynamicDim(0));
+  EXPECT_EQ(allocation.getSize(), allocation->getBlock()->getArgument(0));
+  const auto name =
+      allocation->getAttrOfType<StringAttr>(utils::QUBIT_REGISTER_NAME_ATTR);
+  ASSERT_TRUE(name);
+  EXPECT_EQ(name.getValue(), "named_qubits");
+}
+
 TEST_F(QCToQCORegressionTest, RejectsRegisterBackedReferenceEscapes) {
   constexpr llvm::StringLiteral source = R"mlir(
 module {

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -568,7 +568,6 @@ module {
     return
   }
 }
-
 )mlir";
 
   auto moduleOp = parseSourceString<ModuleOp>(source, &context);

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
+#include "mlir/Dialect/Utils/Utils.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
 #include "qc_programs.h"
@@ -566,6 +567,7 @@ module {
     return
   }
 }
+
 )mlir";
 
   auto moduleOp = parseSourceString<ModuleOp>(source, &context);
@@ -583,6 +585,23 @@ module {
   moduleOp->walk([&](qtensor::DeallocOp) { ++deallocations; });
   EXPECT_EQ(allocations, 1U);
   EXPECT_EQ(deallocations, 1U);
+}
+
+TEST_F(QCToQCORegressionTest, RetainsQuantumRegisterName) {
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  std::ignore = builder.allocQubitRegisterStorage(2, "named_qubits");
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+
+  qtensor::AllocOp allocation;
+  moduleOp->walk([&](qtensor::AllocOp op) { allocation = op; });
+  ASSERT_TRUE(allocation);
+  const auto name =
+      allocation->getAttrOfType<StringAttr>(utils::QUANTUM_REGISTER_NAME_ATTR);
+  ASSERT_TRUE(name);
+  EXPECT_EQ(name.getValue(), "named_qubits");
 }
 
 TEST_F(QCToQCORegressionTest, RejectsRegisterBackedReferenceEscapes) {

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -55,6 +55,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <tuple>
 
 using namespace mlir;
 

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -41,6 +41,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <tuple>
 
 using namespace mlir;
 using namespace mlir::qc;

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -127,6 +127,17 @@ TEST_F(QCTest, BuilderRejectsMixedStaticAndDynamicQubitAllocationModes) {
       "Cannot mix dynamic and static qubit allocation modes");
 }
 
+TEST_F(QCTest, BuilderRejectsDuplicateNonEmptyQuantumRegisterNames) {
+  EXPECT_DEATH(
+      {
+        QCProgramBuilder builder(context.get());
+        builder.initialize();
+        std::ignore = builder.allocQubitRegisterStorage(1, "q");
+        std::ignore = builder.allocQubitRegisterStorage(1, "q");
+      },
+      "Quantum register names must be unique");
+}
+
 TEST_F(QCTest, BuilderRejectsOutOfBoundsClassicalRegisterIndices) {
   EXPECT_DEATH(
       {

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -128,7 +128,7 @@ TEST_F(QCTest, BuilderRejectsMixedStaticAndDynamicQubitAllocationModes) {
       "Cannot mix dynamic and static qubit allocation modes");
 }
 
-TEST_F(QCTest, BuilderRejectsDuplicateNonEmptyQuantumRegisterNames) {
+TEST_F(QCTest, BuilderRejectsDuplicateNonEmptyQubitRegisterNames) {
   EXPECT_DEATH(
       {
         QCProgramBuilder builder(context.get());
@@ -136,7 +136,7 @@ TEST_F(QCTest, BuilderRejectsDuplicateNonEmptyQuantumRegisterNames) {
         std::ignore = builder.allocQubitRegisterStorage(1, "q");
         std::ignore = builder.allocQubitRegisterStorage(1, "q");
       },
-      "Quantum register names must be unique");
+      "Qubit register names must be unique");
 }
 
 TEST_F(QCTest, BuilderRejectsOutOfBoundsClassicalRegisterIndices) {

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -527,7 +527,7 @@ module {
   EXPECT_NE(emitted->find("output bit _mqt_out"), std::string::npos);
 }
 
-TEST(OpenQASM3EmissionTest, ReusesQuantumRegisterNames) {
+TEST(OpenQASM3EmissionTest, ReusesQubitRegisterNames) {
   DialectRegistry registry = emissionDialects();
   MLIRContext context(registry);
   context.loadAllAvailableDialects();

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -513,6 +513,7 @@ module {
     return %single, %bits, %measured : memref<1xi1>, memref<2xi1>, i1
   }
 }
+
 )mlir";
   DialectRegistry registry = emissionDialects();
   MLIRContext context(registry);
@@ -525,6 +526,22 @@ module {
   EXPECT_NE(emitted->find("output bit[1] single;"), std::string::npos);
   EXPECT_NE(emitted->find("output bit[2] bits;"), std::string::npos);
   EXPECT_NE(emitted->find("output bit _mqt_out"), std::string::npos);
+}
+
+TEST(OpenQASM3EmissionTest, ReusesQuantumRegisterNames) {
+  DialectRegistry registry = emissionDialects();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  std::ignore = builder.allocQubitRegister(2, "named_qubits");
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("qubit[2] named_qubits;"), std::string::npos);
 }
 
 TEST(OpenQASM3EmissionTest, DefinesECRWithOneEntanglingGate) {

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -513,7 +513,6 @@ module {
     return %single, %bits, %measured : memref<1xi1>, memref<2xi1>, i1
   }
 }
-
 )mlir";
   DialectRegistry registry = emissionDialects();
   MLIRContext context(registry);

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -534,6 +534,7 @@ TEST(OpenQASM3EmissionTest, ReusesQuantumRegisterNames) {
   qc::QCProgramBuilder builder(&context);
   builder.initialize();
   std::ignore = builder.allocQubitRegister(2, "named_qubits");
+  std::ignore = builder.allocQubitRegister(2, "not-valid");
   auto moduleOp = builder.finalize();
   ASSERT_TRUE(moduleOp);
 
@@ -541,6 +542,10 @@ TEST(OpenQASM3EmissionTest, ReusesQuantumRegisterNames) {
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("qubit[2] named_qubits;"), std::string::npos);
+  EXPECT_EQ(emitted->find("qubit[2] not-valid;"), std::string::npos);
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+      << *emitted;
 }
 
 TEST(OpenQASM3EmissionTest, DefinesECRWithOneEntanglingGate) {

--- a/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
@@ -996,22 +996,22 @@ named_result = measure q;
   EXPECT_EQ(name.getValue(), "named_result");
 }
 
-TEST_F(QASM3TranslationTest, RetainsQuantumRegisterName) {
+TEST_F(QASM3TranslationTest, RetainsQubitRegisterName) {
   constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.0;
 qubit[2] named_qubits;
 )qasm";
   auto translated = qc::translateQASM3ToQC(source, context.get());
   ASSERT_TRUE(translated);
 
-  memref::AllocOp quantumRegister;
+  memref::AllocOp qubitRegister;
   translated->walk([&](memref::AllocOp op) {
     if (isa<qc::QubitType>(op.getType().getElementType())) {
-      quantumRegister = op;
+      qubitRegister = op;
     }
   });
-  ASSERT_TRUE(quantumRegister);
-  const auto name = quantumRegister->getAttrOfType<StringAttr>(
-      utils::QUANTUM_REGISTER_NAME_ATTR);
+  ASSERT_TRUE(qubitRegister);
+  const auto name =
+      qubitRegister->getAttrOfType<StringAttr>(utils::QUBIT_REGISTER_NAME_ATTR);
   ASSERT_TRUE(name);
   EXPECT_EQ(name.getValue(), "named_qubits");
 }

--- a/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_qasm3_translation.cpp
@@ -996,6 +996,26 @@ named_result = measure q;
   EXPECT_EQ(name.getValue(), "named_result");
 }
 
+TEST_F(QASM3TranslationTest, RetainsQuantumRegisterName) {
+  constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.0;
+qubit[2] named_qubits;
+)qasm";
+  auto translated = qc::translateQASM3ToQC(source, context.get());
+  ASSERT_TRUE(translated);
+
+  memref::AllocOp quantumRegister;
+  translated->walk([&](memref::AllocOp op) {
+    if (isa<qc::QubitType>(op.getType().getElementType())) {
+      quantumRegister = op;
+    }
+  });
+  ASSERT_TRUE(quantumRegister);
+  const auto name = quantumRegister->getAttrOfType<StringAttr>(
+      utils::QUANTUM_REGISTER_NAME_ATTR);
+  ASSERT_TRUE(name);
+  EXPECT_EQ(name.getValue(), "named_qubits");
+}
+
 TEST_F(QASM3TranslationTest, DistinguishesScalarAndWidthOneQubitAllocations) {
   constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
 qubit scalar;

--- a/mlir/unittests/Dialect/QC/Translation/test_quantum_computation_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_quantum_computation_translation.cpp
@@ -143,6 +143,26 @@ TEST_F(QuantumComputationTranslationTest, RetainsClassicalRegisterName) {
   EXPECT_EQ(name.getValue(), "named_result");
 }
 
+TEST_F(QuantumComputationTranslationTest, RetainsQuantumRegisterName) {
+  ::qc::QuantumComputation comp;
+  comp.addQubitRegister(2, "named_qubits");
+
+  auto translated = mlir::translateQuantumComputationToQC(context.get(), comp);
+  ASSERT_TRUE(translated);
+
+  mlir::memref::AllocOp quantumRegister;
+  translated->walk([&](mlir::memref::AllocOp op) {
+    if (mlir::isa<mlir::qc::QubitType>(op.getType().getElementType())) {
+      quantumRegister = op;
+    }
+  });
+  ASSERT_TRUE(quantumRegister);
+  const auto name = quantumRegister->getAttrOfType<mlir::StringAttr>(
+      mlir::utils::QUANTUM_REGISTER_NAME_ATTR);
+  ASSERT_TRUE(name);
+  EXPECT_EQ(name.getValue(), "named_qubits");
+}
+
 TEST_F(QuantumComputationTranslationTest, JoinsMeasurementsFromBothBranches) {
   ::qc::QuantumComputation comp;
   const auto& q = comp.addQubitRegister(2, "q");

--- a/mlir/unittests/Dialect/QC/Translation/test_quantum_computation_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_quantum_computation_translation.cpp
@@ -143,22 +143,22 @@ TEST_F(QuantumComputationTranslationTest, RetainsClassicalRegisterName) {
   EXPECT_EQ(name.getValue(), "named_result");
 }
 
-TEST_F(QuantumComputationTranslationTest, RetainsQuantumRegisterName) {
+TEST_F(QuantumComputationTranslationTest, RetainsQubitRegisterName) {
   ::qc::QuantumComputation comp;
   comp.addQubitRegister(2, "named_qubits");
 
   auto translated = mlir::translateQuantumComputationToQC(context.get(), comp);
   ASSERT_TRUE(translated);
 
-  mlir::memref::AllocOp quantumRegister;
+  mlir::memref::AllocOp qubitRegister;
   translated->walk([&](mlir::memref::AllocOp op) {
     if (mlir::isa<mlir::qc::QubitType>(op.getType().getElementType())) {
-      quantumRegister = op;
+      qubitRegister = op;
     }
   });
-  ASSERT_TRUE(quantumRegister);
-  const auto name = quantumRegister->getAttrOfType<mlir::StringAttr>(
-      mlir::utils::QUANTUM_REGISTER_NAME_ATTR);
+  ASSERT_TRUE(qubitRegister);
+  const auto name = qubitRegister->getAttrOfType<mlir::StringAttr>(
+      mlir::utils::QUBIT_REGISTER_NAME_ATTR);
   ASSERT_TRUE(name);
   EXPECT_EQ(name.getValue(), "named_qubits");
 }

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -301,20 +301,6 @@ TEST_F(QCOTest, IndexSwitchBuildersRejectMismatchedCasesAndBodies) {
       "Each case must have a corresponding case body function");
 }
 
-TEST_F(QCOTest, BuilderRejectsUntrackedTensorInitArg) {
-  EXPECT_DEATH(
-      {
-        QCOProgramBuilder builder(context.get());
-        builder.initialize();
-        auto size = arith::ConstantIndexOp::create(builder, 1);
-        const auto tensor =
-            qtensor::AllocOp::create(builder, size.getResult()).getResult();
-        const auto identity = [](Value value) { return value; };
-        builder.qcoIf(true, tensor, identity, identity);
-      },
-      "Invalid tensor value used");
-}
-
 TEST_F(QCOTest, IndexSwitchTiedValuesAndTargetExtension) {
   QCOProgramBuilder builder(context.get());
   builder.initialize();

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -134,7 +134,7 @@ TEST_F(QCOTest, BuilderRejectsMixedStaticAndDynamicQubitAllocationModes) {
       "Cannot mix dynamic and static qubit allocation modes");
 }
 
-TEST_F(QCOTest, BuilderRejectsDuplicateNonEmptyQuantumRegisterNames) {
+TEST_F(QCOTest, BuilderRejectsDuplicateNonEmptyQubitRegisterNames) {
   EXPECT_DEATH(
       {
         QCOProgramBuilder builder(context.get());
@@ -142,7 +142,7 @@ TEST_F(QCOTest, BuilderRejectsDuplicateNonEmptyQuantumRegisterNames) {
         std::ignore = builder.allocQubitRegister(1, "q");
         std::ignore = builder.allocQubitRegister(1, "q");
       },
-      "Quantum register names must be unique");
+      "Qubit register names must be unique");
 }
 
 TEST_F(QCOTest, BuilderRejectsOutOfBoundsClassicalRegisterIndices) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -133,6 +133,17 @@ TEST_F(QCOTest, BuilderRejectsMixedStaticAndDynamicQubitAllocationModes) {
       "Cannot mix dynamic and static qubit allocation modes");
 }
 
+TEST_F(QCOTest, BuilderRejectsDuplicateNonEmptyQuantumRegisterNames) {
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        std::ignore = builder.allocQubitRegister(1, "q");
+        std::ignore = builder.allocQubitRegister(1, "q");
+      },
+      "Quantum register names must be unique");
+}
+
 TEST_F(QCOTest, BuilderRejectsOutOfBoundsClassicalRegisterIndices) {
   EXPECT_DEATH(
       {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -48,6 +48,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <tuple>
 #include <utility>
 
 using namespace mlir;

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -301,6 +301,20 @@ TEST_F(QCOTest, IndexSwitchBuildersRejectMismatchedCasesAndBodies) {
       "Each case must have a corresponding case body function");
 }
 
+TEST_F(QCOTest, BuilderRejectsUntrackedTensorInitArg) {
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        auto size = arith::ConstantIndexOp::create(builder, 1);
+        const auto tensor =
+            qtensor::AllocOp::create(builder, size.getResult()).getResult();
+        const auto identity = [](Value value) { return value; };
+        builder.qcoIf(true, tensor, identity, identity);
+      },
+      "Invalid tensor value used");
+}
+
 TEST_F(QCOTest, IndexSwitchTiedValuesAndTargetExtension) {
   QCOProgramBuilder builder(context.get());
   builder.initialize();


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This PR retains source-level qubit-register names across the QC and QCO MLIR dialects. The builders attach non-empty names to the backing `memref.alloc` or `qtensor.alloc` using the `mqt.qubit_register_name` string attribute and reject duplicate non-empty names.

The attribute is populated by the `QuantumComputation` and typed OpenQASM translations, preserved by the QC-to-QCO and QCO-to-QC conversions, and reused for OpenQASM emission when it is a valid, unique OpenQASM identifier. Invalid or conflicting names fall back to generated identifiers. QIR emission remains unchanged because quantum-register names have no corresponding QIR runtime recording semantics.

Codex materially assisted with implementation, tests, review preparation, conflict resolution, and validation. The human author remains responsible for the contribution.

Fixes #1616.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
