### PR TITLE
🔀 Backport selected main changes for MQT Core 3.9.0

### DIFF
--- a/.agent/plans/backport-3-9.md
+++ b/.agent/plans/backport-3-9.md
@@ -1,0 +1,204 @@
+# Backport the gate-based QDMI and selected library improvements to v3.x
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+MQT Core 3.9.0 should make gate-based QDMI devices usable through PennyLane
+without adopting the v4 compiler architecture. After this work, a Python 3.11
+or newer installation can install the optional `pennylane` extra, construct the
+built-in DD-based simulator as `qp.device("mqt.ddsim.default", ...)`, and run
+finite-shot PennyLane programs through the same QDMI path used by external
+devices. The release also receives a small set of independent fixes and
+bindings that are valuable on the maintained v3 line and do not require
+LLVM/MLIR 22.
+
+The observable end-to-end result is the executable PennyLane MaxCut notebook
+and the DDSIM tests under `test/python/plugins/qdmi_pennylane/`. Python 3.10
+continues to install and test MQT Core without PennyLane.
+
+## Progress
+
+- [x] (2026-08-09 08:00Z) Refreshed `main` and `v3.x`, inspected the 3.8.0
+  backport precedent, and inventoried changes merged after 3.8.0.
+- [x] (2026-08-09 08:20Z) Selected the v3-compatible functionality groups and
+  recorded explicit exclusions.
+- [ ] Backport typed QDMI device configuration and stable device-ID enumeration.
+- [ ] Backport the independent QIR result-order fix, DD serialization bindings,
+  and ZX multi-controlled-X complexity improvement.
+- [ ] Port the PennyLane QDMI device, tests, packaging, and executable notebook.
+- [ ] Regenerate stubs and `uv.lock`, then run focused and broad validation.
+- [ ] Publish the signed, functionality-scoped commit series as a pull request
+  targeting `v3.x` and monitor its checks.
+
+## Surprises & Discoveries
+
+- Observation: The v3.8.0 branch already contains the configurable QDMI driver,
+  binary-safe FoMaC transport, stable device registration, and composable
+  bundled-device build needed by the PennyLane adapter. Evidence: the merge of
+  the 3.8.0 backport is an ancestor of the current `v3.x` tip.
+- Observation: Changes merged after 3.8.0 split cleanly into v3-compatible
+  library work and compiler work that requires the v4 LLVM/MLIR 22 design.
+  Evidence: the selected changes affect the existing QDMI driver, DD, ZX, QIR,
+  and Python plugin surfaces, while the excluded compiler-target and typed
+  OpenQASM frontend changes depend on new v4 MLIR dialect contracts.
+
+## Decision Log
+
+- Decision: Backport the typed QDMI configuration transport before the
+  PennyLane device. Rationale: the public PennyLane constructor maps device
+  descriptions into this typed transport, and carrying that contract avoids a
+  v3-only adapter API. Date/Author: 2026-08-09 / Codex.
+- Decision: Backport registered device-ID enumeration before the PennyLane
+  device. Rationale: PennyLane entry-point discovery and stable QDMI device IDs
+  should use the same load-free enumeration API as `main`. Date/Author:
+  2026-08-09 / Codex.
+- Decision: Include the QIR result-order fix, DD serialization API, and ZX
+  multi-controlled-X complexity improvement as separate commits. Rationale:
+  each is an independently tested v3-compatible correctness, API, or complexity
+  improvement suitable for a minor release. Date/Author: 2026-08-09 / Codex.
+- Decision: Exclude the LLVM/MLIR 22 compiler-target series, the typed OpenQASM
+  frontend and emitter, QCO mapping fixes, specialized neutral-atom and
+  superconducting runtime configuration, and routine dependency churn.
+  Rationale: those changes either rely on the v4 compiler architecture, are
+  outside this gate-based integration, or do not justify expanding the
+  backport. Date/Author: 2026-08-09 / Codex.
+- Decision: Keep Python 3.10 as a base-package boundary and enable PennyLane on
+  Python 3.11 through 3.14. Rationale: this matches the upstream plugin and
+  prevents the optional dependency from constraining existing v3 deployments.
+  Date/Author: 2026-08-09 / Codex.
+
+## Outcomes & Retrospective
+
+Implementation and publication are in progress. This section will record the
+final commit series, exact validation evidence, and any remaining release work.
+
+## Context and Orientation
+
+`v3.x` is the maintained MQT Core 3 release line. It retains optional
+LLVM/MLIR 21 support, unlike `main`, which contains the v4 compiler collection
+and requires LLVM/MLIR 22. A backport therefore ports user-visible behavior
+against existing v3 interfaces rather than merging the complete `main` tree.
+
+The QDMI driver lives under `include/mqt-core/qdmi/driver/` and
+`src/qdmi/driver/`. FoMaC exposes it to Python through
+`bindings/fomac/fomac.cpp` and `python/mqt/core/fomac.pyi`. The optional
+PennyLane integration belongs under `python/mqt/core/plugins/pennylane/` and
+uses the stable QDMI device registry to open a device, preprocess a PennyLane
+program, serialize it as a device-advertised OpenQASM format, submit finite-shot
+jobs, and reconstruct PennyLane measurement results.
+
+The built-in DD-based simulator is the credential-free integration oracle. Its
+QDMI implementation is under `src/qdmi/devices/dd/`, while PennyLane tests are
+under `test/python/plugins/qdmi_pennylane/`. The executable MyST notebook
+`docs/qdmi/pennylane_device.md` documents the same local path and is generated
+only through the repository's documentation Nox session.
+
+## Plan of Work
+
+Apply each selected upstream pull request as a separate functionality-scoped
+commit. Resolve differences against v3 contracts instead of importing v4-only
+surrounding code. First add typed QDMI configuration transport and stable-ID
+enumeration, regenerate FoMaC stubs, and run the driver and focused Python
+tests. Next port the three independent library changes and run their native or
+Python regression suites. Finally add the PennyLane package, optional
+dependency, tests, and notebook, preserving the `import pennylane as qp`
+convention and the Python 3.10 skip boundary.
+
+Do not copy the `main` lockfile. Regenerate `uv.lock` from the final v3
+`pyproject.toml` so it continues to represent the optional LLVM/MLIR 21 build
+and v3 dependency graph. Preserve the `[Unreleased]` release notes above the
+existing 3.8.0 sections and define links for the upstream pull requests and the
+new backport pull request.
+
+## Concrete Steps
+
+From the repository root, apply and validate the QDMI prerequisites:
+
+    git show --first-parent <upstream-merge> --stat
+    ./.agent/run.sh cmake --preset release
+    ./.agent/run.sh cmake --build --preset release --target mqt-core-qdmi-driver-test
+    ./build/release/test/qdmi/driver/mqt-core-qdmi-driver-test
+    ./.agent/run.sh uv run --no-sync pytest test/python/fomac/test_fomac.py
+
+Run the focused DD and ZX validation after their respective commits:
+
+    ./.agent/run.sh cmake --build --preset release --target mqt-core-dd-test mqt-core-zx-test
+    ./build/release/test/dd/mqt-core-dd-test
+    ./build/release/test/zx/mqt-core-zx-test
+    ./.agent/run.sh uv run --no-sync pytest test/python/dd/test_matrix_dds.py test/python/dd/test_vector_dds.py
+
+After the PennyLane port, regenerate derived artifacts and exercise every
+supported Python boundary:
+
+    ./.agent/run.sh uv lock
+    ./.agent/run.sh uvx nox -s stubs
+    ./.agent/run.sh uvx nox -s tests-3.10
+    ./.agent/run.sh uvx nox -s tests-3.14
+    ./.agent/run.sh uvx nox -s minimums-3.12 -- test/python/plugins/qdmi_pennylane/test_ddsim.py
+    ./.agent/run.sh uvx nox --non-interactive -s docs -- -D nb_execution_mode=force
+    ./.agent/run.sh uvx nox --non-interactive -s docs
+    ./.agent/run.sh uvx nox -s lint
+    git diff --check origin/v3.x...HEAD
+
+Python 3.11 through 3.13 focused sessions should also run when those local
+interpreters are available. The full release build and available C++ tests
+provide the non-Python integration boundary.
+
+## Validation and Acceptance
+
+Acceptance requires QDMI driver tests to prove that typed configuration and
+registered-ID enumeration preserve ordering and do not eagerly load devices.
+The QIR regression must record returned classical registers in function-result
+order. DD serialization must round-trip terminal and non-terminal vector and
+matrix DDs in text and binary forms. The ZX tests must prove unitary equivalence,
+dirty-workspace restoration, and a quadratic resource bound.
+
+On Python 3.11 or newer, `qp.device("mqt.ddsim.default", wires=2)` must execute
+finite-shot Bell-state and QAOA programs, including samples, counts,
+probabilities, expectations, variances, Hamiltonians, shot vectors, sequential
+batches, and parameter-shift gradients. OpenQASM 3 must be preferred whenever
+advertised; OpenQASM 2 is only a format-negotiation fallback. Python 3.10 must
+import and test the base package while skipping PennyLane modules cleanly.
+
+The documentation is accepted only when generated through `nox -s docs`, with
+the first run forcing notebook execution. The complete lint session, lockfile
+check, commit-signature audit, and `git diff --check` must pass before
+publication.
+
+## Idempotence and Recovery
+
+All validation commands are repeatable. Builds, Nox environments, and caches
+remain worktree-local. If an upstream patch conflicts, abort only that
+in-progress application or resolve it against the current v3 file; never reset
+the worktree or discard unrelated changes. A failed lockfile update can be
+rerun after correcting `pyproject.toml` without changing committed source.
+
+## Artifacts and Notes
+
+The authoritative upstream functionality is represented by MQT Core pull
+requests #1967, #1972, #1979, #1983, #1984, and #2005. The 3.8.0 precedent is
+pull request #1966. Their changes are ported independently so reviewers can
+inspect or revert each capability without coupling it to the rest of the
+release series.
+
+## Interfaces and Dependencies
+
+The final Python API must provide `mqt.core.plugins.pennylane.QDMIDevice`, its
+converted-program record and focused exceptions, and the `mqt.ddsim.default`
+PennyLane entry point. `QDMIDevice` must consume stable `device_id`, finite
+`shots`, and optional FoMaC `session_parameters` and `job_parameters` mappings.
+
+The `pennylane` optional extra must require a compatible PennyLane release only
+on Python 3.11 or newer. The base MQT Core installation and Python 3.10 test
+environment must not resolve or import PennyLane. No direct Amazon Braket SDK
+or device-specific dependency belongs in MQT Core.
+
+Revision note: Created the plan after comparing the live `main` and `v3.x`
+heads and the exact upstream pull requests. The initial scope deliberately
+separates v3-compatible library work from the v4-only compiler series.

--- a/.agent/plans/backport-3-9.md
+++ b/.agent/plans/backport-3-9.md
@@ -219,3 +219,13 @@ Revision note: Created the plan after comparing the live `main` and `v3.x` heads
 and the exact upstream pull requests. The initial scope deliberately separates
 v3-compatible library work from the v4-only compiler series. Updated the scope
 after proving that #1979's `QCToQIR` implementation does not exist on v3.x.
+
+Publication note: The selected changes were published as pull request #2024.
+Local validation passed for the QDMI driver, DD and ZX suites, Python 3.10 and
+3.14 boundaries, the Python 3.12 minimums environment, generated stubs, forced
+and cached documentation builds, and the complete lint session. The first CI
+revision passed the complete test matrix and documentation build. Its C++ lint
+job identified four Clang 22 missing-field-initializer diagnostics in newly
+backported QDMI test aggregates; the remediation explicitly initializes each
+device definition and constructs partial session configurations through normal
+assignment before rerunning the driver and lint suites.

--- a/.agent/plans/backport-3-9.md
+++ b/.agent/plans/backport-3-9.md
@@ -29,8 +29,8 @@ continues to install and test MQT Core without PennyLane.
 - [x] (2026-08-09 08:20Z) Selected the v3-compatible functionality groups and
   recorded explicit exclusions.
 - [ ] Backport typed QDMI device configuration and stable device-ID enumeration.
-- [ ] Backport the independent QIR result-order fix, DD serialization bindings,
-  and ZX multi-controlled-X complexity improvement.
+- [ ] Backport the independent DD serialization bindings and ZX
+  multi-controlled-X complexity improvement.
 - [ ] Port the PennyLane QDMI device, tests, packaging, and executable notebook.
 - [ ] Regenerate stubs and `uv.lock`, then run focused and broad validation.
 - [ ] Publish the signed, functionality-scoped commit series as a pull request
@@ -47,6 +47,11 @@ continues to install and test MQT Core without PennyLane.
   Evidence: the selected changes affect the existing QDMI driver, DD, ZX, QIR,
   and Python plugin surfaces, while the excluded compiler-target and typed
   OpenQASM frontend changes depend on new v4 MLIR dialect contracts.
+- Observation: The QIR classical-result ordering fix from #1979 modifies the
+  `QCToQIR` conversion, which does not exist on v3.x. Evidence: applying the
+  upstream change produces modify/delete conflicts for every implementation
+  and test file because those paths were introduced only with the v4 compiler
+  collection.
 
 ## Decision Log
 
@@ -58,16 +63,19 @@ continues to install and test MQT Core without PennyLane.
   device. Rationale: PennyLane entry-point discovery and stable QDMI device IDs
   should use the same load-free enumeration API as `main`. Date/Author:
   2026-08-09 / Codex.
-- Decision: Include the QIR result-order fix, DD serialization API, and ZX
-  multi-controlled-X complexity improvement as separate commits. Rationale:
-  each is an independently tested v3-compatible correctness, API, or complexity
-  improvement suitable for a minor release. Date/Author: 2026-08-09 / Codex.
+- Decision: Include the DD serialization API and ZX multi-controlled-X
+  complexity improvement as separate commits. Rationale: each is an
+  independently tested v3-compatible API or complexity improvement suitable
+  for a minor release. Date/Author: 2026-08-09 / Codex.
 - Decision: Exclude the LLVM/MLIR 22 compiler-target series, the typed OpenQASM
   frontend and emitter, QCO mapping fixes, specialized neutral-atom and
   superconducting runtime configuration, and routine dependency churn.
   Rationale: those changes either rely on the v4 compiler architecture, are
   outside this gate-based integration, or do not justify expanding the
   backport. Date/Author: 2026-08-09 / Codex.
+- Decision: Exclude #1979 after testing patch applicability. Rationale: v3.x
+  has no `QCToQIR` conversion to fix, and importing that subsystem would violate
+  the v3 compiler boundary. Date/Author: 2026-08-09 / Codex.
 - Decision: Keep Python 3.10 as a base-package boundary and enable PennyLane on
   Python 3.11 through 3.14. Rationale: this matches the upstream plugin and
   prevents the optional dependency from constraining existing v3 deployments.
@@ -154,9 +162,8 @@ provide the non-Python integration boundary.
 
 Acceptance requires QDMI driver tests to prove that typed configuration and
 registered-ID enumeration preserve ordering and do not eagerly load devices.
-The QIR regression must record returned classical registers in function-result
-order. DD serialization must round-trip terminal and non-terminal vector and
-matrix DDs in text and binary forms. The ZX tests must prove unitary equivalence,
+DD serialization must round-trip terminal and non-terminal vector and matrix
+DDs in text and binary forms. The ZX tests must prove unitary equivalence,
 dirty-workspace restoration, and a quadratic resource bound.
 
 On Python 3.11 or newer, `qp.device("mqt.ddsim.default", wires=2)` must execute
@@ -182,7 +189,7 @@ rerun after correcting `pyproject.toml` without changing committed source.
 ## Artifacts and Notes
 
 The authoritative upstream functionality is represented by MQT Core pull
-requests #1967, #1972, #1979, #1983, #1984, and #2005. The 3.8.0 precedent is
+requests #1967, #1972, #1983, #1984, and #2005. The 3.8.0 precedent is
 pull request #1966. Their changes are ported independently so reviewers can
 inspect or revert each capability without coupling it to the rest of the
 release series.
@@ -201,4 +208,6 @@ or device-specific dependency belongs in MQT Core.
 
 Revision note: Created the plan after comparing the live `main` and `v3.x`
 heads and the exact upstream pull requests. The initial scope deliberately
-separates v3-compatible library work from the v4-only compiler series.
+separates v3-compatible library work from the v4-only compiler series. Updated
+the scope after proving that #1979's `QCToQIR` implementation does not exist on
+v3.x.

--- a/.agent/plans/backport-3-9.md
+++ b/.agent/plans/backport-3-9.md
@@ -10,16 +10,15 @@ repository root.
 ## Purpose / Big Picture
 
 MQT Core 3.9.0 should make gate-based QDMI devices usable through PennyLane
-without adopting the v4 compiler architecture. After this work, a Python 3.11
-or newer installation can install the optional `pennylane` extra, construct the
+without adopting the v4 compiler architecture. After this work, a Python 3.11 or
+newer installation can install the optional `pennylane` extra, construct the
 built-in DD-based simulator as `qp.device("mqt.ddsim.default", ...)`, and run
 finite-shot PennyLane programs through the same QDMI path used by external
-devices. The release also receives a small set of independent fixes and
-bindings that are valuable on the maintained v3 line and do not require
-LLVM/MLIR 22.
+devices. The release also receives a small set of independent fixes and bindings
+that are valuable on the maintained v3 line and do not require LLVM/MLIR 22.
 
-The observable end-to-end result is the executable PennyLane MaxCut notebook
-and the DDSIM tests under `test/python/plugins/qdmi_pennylane/`. Python 3.10
+The observable end-to-end result is the executable PennyLane MaxCut notebook and
+the DDSIM tests under `test/python/plugins/qdmi_pennylane/`. Python 3.10
 continues to install and test MQT Core without PennyLane.
 
 ## Progress
@@ -28,11 +27,15 @@ continues to install and test MQT Core without PennyLane.
   backport precedent, and inventoried changes merged after 3.8.0.
 - [x] (2026-08-09 08:20Z) Selected the v3-compatible functionality groups and
   recorded explicit exclusions.
-- [ ] Backport typed QDMI device configuration and stable device-ID enumeration.
-- [ ] Backport the independent DD serialization bindings and ZX
-  multi-controlled-X complexity improvement.
-- [ ] Port the PennyLane QDMI device, tests, packaging, and executable notebook.
-- [ ] Regenerate stubs and `uv.lock`, then run focused and broad validation.
+- [x] (2026-08-09 09:10Z) Backported typed QDMI device configuration and stable
+  device-ID enumeration.
+- [x] (2026-08-09 09:35Z) Backported the independent DD serialization bindings
+      and ZX multi-controlled-X complexity improvement.
+- [x] (2026-08-09 10:05Z) Ported the PennyLane QDMI device, tests, packaging,
+  and executable notebook.
+- [x] (2026-08-09 10:50Z) Regenerated stubs and `uv.lock`; completed the native
+      QDMI, DD, and ZX tests, the Python 3.10, minimums 3.12, and 3.14
+      boundaries, and both forced and cached documentation builds.
 - [ ] Publish the signed, functionality-scoped commit series as a pull request
   targeting `v3.x` and monitor its checks.
 
@@ -49,33 +52,33 @@ continues to install and test MQT Core without PennyLane.
   OpenQASM frontend changes depend on new v4 MLIR dialect contracts.
 - Observation: The QIR classical-result ordering fix from #1979 modifies the
   `QCToQIR` conversion, which does not exist on v3.x. Evidence: applying the
-  upstream change produces modify/delete conflicts for every implementation
-  and test file because those paths were introduced only with the v4 compiler
+  upstream change produces modify/delete conflicts for every implementation and
+  test file because those paths were introduced only with the v4 compiler
   collection.
 
 ## Decision Log
 
-- Decision: Backport the typed QDMI configuration transport before the
-  PennyLane device. Rationale: the public PennyLane constructor maps device
-  descriptions into this typed transport, and carrying that contract avoids a
-  v3-only adapter API. Date/Author: 2026-08-09 / Codex.
+- Decision: Backport the typed QDMI configuration transport before the PennyLane
+  device. Rationale: the public PennyLane constructor maps device descriptions
+  into this typed transport, and carrying that contract avoids a v3-only adapter
+  API. Date/Author: 2026-08-09 / Codex.
 - Decision: Backport registered device-ID enumeration before the PennyLane
   device. Rationale: PennyLane entry-point discovery and stable QDMI device IDs
   should use the same load-free enumeration API as `main`. Date/Author:
   2026-08-09 / Codex.
 - Decision: Include the DD serialization API and ZX multi-controlled-X
   complexity improvement as separate commits. Rationale: each is an
-  independently tested v3-compatible API or complexity improvement suitable
-  for a minor release. Date/Author: 2026-08-09 / Codex.
+  independently tested v3-compatible API or complexity improvement suitable for
+  a minor release. Date/Author: 2026-08-09 / Codex.
 - Decision: Exclude the LLVM/MLIR 22 compiler-target series, the typed OpenQASM
   frontend and emitter, QCO mapping fixes, specialized neutral-atom and
   superconducting runtime configuration, and routine dependency churn.
   Rationale: those changes either rely on the v4 compiler architecture, are
-  outside this gate-based integration, or do not justify expanding the
-  backport. Date/Author: 2026-08-09 / Codex.
-- Decision: Exclude #1979 after testing patch applicability. Rationale: v3.x
-  has no `QCToQIR` conversion to fix, and importing that subsystem would violate
-  the v3 compiler boundary. Date/Author: 2026-08-09 / Codex.
+  outside this gate-based integration, or do not justify expanding the backport.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: Exclude #1979 after testing patch applicability. Rationale: v3.x has
+  no `QCToQIR` conversion to fix, and importing that subsystem would violate the
+  v3 compiler boundary. Date/Author: 2026-08-09 / Codex.
 - Decision: Keep Python 3.10 as a base-package boundary and enable PennyLane on
   Python 3.11 through 3.14. Rationale: this matches the upstream plugin and
   prevents the optional dependency from constraining existing v3 deployments.
@@ -83,15 +86,22 @@ continues to install and test MQT Core without PennyLane.
 
 ## Outcomes & Retrospective
 
-Implementation and publication are in progress. This section will record the
-final commit series, exact validation evidence, and any remaining release work.
+The backport is split into independently reviewable commits for the two QDMI
+prerequisites, DD serialization, the ZX construction, and the PennyLane device.
+The QDMI driver suites passed 127 tests in total; the focused DD and ZX suites
+passed 7 tests; the Python DD bindings passed 16 tests; and the PennyLane suite
+passed 33 tests on Python 3.14, 10 tests with minimum dependencies on Python
+3.12, and its optional-dependency boundary on Python 3.10. Stub generation and
+both documentation builds completed successfully. The v3 documentation build
+retains its existing C++ and optional-MLIR warning baseline; the PennyLane
+notebook executes successfully. Publication and remote CI remain in progress.
 
 ## Context and Orientation
 
-`v3.x` is the maintained MQT Core 3 release line. It retains optional
-LLVM/MLIR 21 support, unlike `main`, which contains the v4 compiler collection
-and requires LLVM/MLIR 22. A backport therefore ports user-visible behavior
-against existing v3 interfaces rather than merging the complete `main` tree.
+`v3.x` is the maintained MQT Core 3 release line. It retains optional LLVM/MLIR
+21 support, unlike `main`, which contains the v4 compiler collection and
+requires LLVM/MLIR 22. A backport therefore ports user-visible behavior against
+existing v3 interfaces rather than merging the complete `main` tree.
 
 The QDMI driver lives under `include/mqt-core/qdmi/driver/` and
 `src/qdmi/driver/`. FoMaC exposes it to Python through
@@ -161,9 +171,9 @@ provide the non-Python integration boundary.
 ## Validation and Acceptance
 
 Acceptance requires QDMI driver tests to prove that typed configuration and
-registered-ID enumeration preserve ordering and do not eagerly load devices.
-DD serialization must round-trip terminal and non-terminal vector and matrix
-DDs in text and binary forms. The ZX tests must prove unitary equivalence,
+registered-ID enumeration preserve ordering and do not eagerly load devices. DD
+serialization must round-trip terminal and non-terminal vector and matrix DDs in
+text and binary forms. The ZX tests must prove unitary equivalence,
 dirty-workspace restoration, and a quadratic resource bound.
 
 On Python 3.11 or newer, `qp.device("mqt.ddsim.default", wires=2)` must execute
@@ -183,16 +193,15 @@ publication.
 All validation commands are repeatable. Builds, Nox environments, and caches
 remain worktree-local. If an upstream patch conflicts, abort only that
 in-progress application or resolve it against the current v3 file; never reset
-the worktree or discard unrelated changes. A failed lockfile update can be
-rerun after correcting `pyproject.toml` without changing committed source.
+the worktree or discard unrelated changes. A failed lockfile update can be rerun
+after correcting `pyproject.toml` without changing committed source.
 
 ## Artifacts and Notes
 
 The authoritative upstream functionality is represented by MQT Core pull
-requests #1967, #1972, #1983, #1984, and #2005. The 3.8.0 precedent is
-pull request #1966. Their changes are ported independently so reviewers can
-inspect or revert each capability without coupling it to the rest of the
-release series.
+requests #1967, #1972, #1983, #1984, and #2005. The 3.8.0 precedent is pull
+request #1966. Their changes are ported independently so reviewers can inspect
+or revert each capability without coupling it to the rest of the release series.
 
 ## Interfaces and Dependencies
 
@@ -203,11 +212,10 @@ PennyLane entry point. `QDMIDevice` must consume stable `device_id`, finite
 
 The `pennylane` optional extra must require a compatible PennyLane release only
 on Python 3.11 or newer. The base MQT Core installation and Python 3.10 test
-environment must not resolve or import PennyLane. No direct Amazon Braket SDK
-or device-specific dependency belongs in MQT Core.
+environment must not resolve or import PennyLane. No direct Amazon Braket SDK or
+device-specific dependency belongs in MQT Core.
 
-Revision note: Created the plan after comparing the live `main` and `v3.x`
-heads and the exact upstream pull requests. The initial scope deliberately
-separates v3-compatible library work from the v4-only compiler series. Updated
-the scope after proving that #1979's `QCToQIR` implementation does not exist on
-v3.x.
+Revision note: Created the plan after comparing the live `main` and `v3.x` heads
+and the exact upstream pull requests. The initial scope deliberately separates
+v3-compatible library work from the v4-only compiler series. Updated the scope
+after proving that #1979's `QCToQIR` implementation does not exist on v3.x.

--- a/.agent/plans/qdmi-device-configuration-transport.md
+++ b/.agent/plans/qdmi-device-configuration-transport.md
@@ -1,0 +1,191 @@
+# Add typed QDMI device configuration transport
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+MQT Core users can currently configure generic QDMI custom parameters, but
+inline device JSON and a device-description file cannot replace one another
+atomically when registry layers merge. After this change, a device definition or
+an individual `open_device` call can select exactly one typed configuration
+source. The Driver maps that source onto QDMI v1 CUSTOM1 or CUSTOM2 only at the
+native-session boundary. A small integration test demonstrates that a
+higher-precedence file source replaces, rather than coexists with, inherited
+inline JSON.
+
+This is the additive first change in a three-part series. It does not alter the
+neutral-atom or superconducting providers. Those providers consume this
+transport in later changes with their own ExecPlans.
+
+## Progress
+
+- [x] (2026-07-30 00:00Z) Created a clean worktree from current `origin/main`
+  and reviewed repository policy and the completed combined prototype.
+- [x] (2026-07-30 00:00Z) Reconstructed only the typed C++ model, atomic
+  registry merge, Driver adapter, Python arguments, and generic runtime-file
+  propagation.
+- [x] (2026-07-30 00:00Z) Reconstructed focused registry, Driver, Python, and
+  imported-target tests without any provider behavior changes.
+- [x] (2026-07-30 01:15 CEST) Regenerated Python stubs and confirmed that
+  `python/mqt/core/fomac.pyi` is the only generated source change.
+- [x] (2026-07-30 01:15 CEST) Configured and built the release tree, built the
+  documentation, and passed focused C++, Python, CMake, and full lint
+  validation.
+- [x] (2026-07-30 01:15 CEST) Audited the complete diff against the PR A
+  boundary; it contains no neutral-atom or superconducting provider changes.
+- [x] (2026-07-30 15:20 CEST) Published the transport layer as draft PR #1967,
+      added its changelog entry, merged the latest `origin/main`, and corrected
+      the upgrade-guide cross-reference reported by Read the Docs.
+
+## Surprises & Discoveries
+
+- Observation: `DeviceRegistry.cpp` already resolves session file paths relative
+  to the declaring JSON or TOML file, so typed device-description paths can use
+  that same path-resolution boundary. Evidence: `parseSessionPatch` resolves
+  `auth-file` against its `base` argument.
+- Observation: the combined prototype contained provider integration tests and
+  related test build definitions in the same files as transport tests. Evidence:
+  reconstruction retained only the session test device and generic metadata
+  runtime file so this branch remains additive.
+- Observation: exercising `mqt_configure_qdmi_device(RUNTIME_FILES ...)`
+  directly on a main-tree test target would install a test-only data file as
+  part of MQT Core. Evidence: a nested CMake fixture now builds and installs an
+  isolated dummy provider, covering the helper without altering the product
+  install surface.
+- Observation: root-level Markdown files included in the Sphinx documentation
+  must address documents relative to the Sphinx source tree. Evidence: Read the
+  Docs could not resolve `docs/qdmi/configuration.md`; the explicit MyST `{doc}`
+  target is `qdmi/configuration`.
+
+## Decision Log
+
+- Decision: Represent configuration as
+  `optional<variant<InlineDeviceConfiguration, FileDeviceConfiguration>>`.
+  Rationale: one optional variant has replacement semantics across registry
+  layers and cannot preserve an inherited CUSTOM1 while adding CUSTOM2.
+  Date/Author: 2026-07-30 / Codex.
+- Decision: Reject typed configuration combined with raw CUSTOM1 or CUSTOM2
+  after defaults and overrides are merged. Rationale: those QDMI v1 slots are
+  the adapter transport and two simultaneous meanings would be ambiguous.
+  Date/Author: 2026-07-30 / Codex.
+- Decision: Keep provider schemas, loaders, default JSON, calibration, and the
+  multi-technology validation CLI out of this change. Rationale: this branch
+  must compile and test independently while preserving existing provider
+  behavior. Date/Author: 2026-07-30 / Codex.
+
+## Outcomes & Retrospective
+
+PR A is reconstructed as an independently buildable transport layer. The release
+build and documentation build succeeded. Focused validation passed: 15/15
+DeviceRegistry tests, 111/111 Driver tests, the selected Python test, and 6/6
+CMake imported-target/runtime-file fixture tests. Stub generation changed only
+the expected FoMaC `.pyi`, the full repository lint session passed, and
+`git diff --check` reported no whitespace errors.
+
+The final scope audit found changes only in the public configuration type,
+registry and Driver transport, Python bindings/stub, generic CMake runtime-file
+helper, documentation, and their focused tests. No NA or SC provider
+implementation, schema, default configuration, calibration logic, or unified
+validation CLI is present. Draft PR #1967 and its changelog entry now identify
+this transport layer as the independently reviewable prerequisite for the
+provider-specific follow-ups.
+
+## Context and Orientation
+
+`include/mqt-core/qdmi/driver/Driver.hpp` defines `DeviceSessionConfig`, the
+public C++ value stored in each `DeviceDefinition`.
+`src/qdmi/driver/DeviceRegistry.cpp` parses JSON and TOML configuration layers
+into patches and merges each optional session field.
+`src/qdmi/driver/Driver.cpp` applies per-open overrides and sends the merged
+values through the QDMI v1 session-parameter ABI. `bindings/fomac/fomac.cpp`
+exposes definitions and opening to Python. `cmake/AddMQTQDMIDevice.cmake` stages
+relocatable device libraries and their registration manifests. A runtime file is
+a data file that must remain beside a provider library after build, install, or
+copying into a static consumer.
+
+## Plan of Work
+
+Add public source wrapper structs and the variant alias in `Driver.hpp`, then
+add the optional field to `DeviceSessionConfig`. Extend the registry patch type
+and JSON parser to accept `session.device-config` with exactly one of `inline`
+and `file`. Serialize the inline JSON subtree to a compact string and resolve a
+file value against the declaring configuration directory. Merge the optional
+variant atomically.
+
+In `Driver.cpp`, merge this field as one value, reject conflicts with raw
+CUSTOM1 and CUSTOM2, and pass inline content through CUSTOM1 or a file path
+through CUSTOM2. Keep CUSTOM3 through CUSTOM5 unchanged. Extend the nanobind
+helpers and both `DeviceDefinition` and `open_device` APIs with mutually
+exclusive `device_config` and `device_config_file` arguments.
+
+Extend `mqt_configure_qdmi_device` with `RUNTIME_FILES`. Copy each input beside
+the provider after build and install it beside the provider. Export only
+basenames through `QDMI_RUNTIME_FILES`. Extend `mqt_copy_qdmi_runtime` to copy
+those files from built and imported targets.
+
+Add registry parsing and override tests, Driver adapter and conflict tests,
+Python argument tests, and imported-target/runtime-copy coverage. Update
+`docs/qdmi/configuration.md`.
+
+## Concrete Steps
+
+Run commands from the repository root through `.agent/run.sh` when they create
+tool caches or build output:
+
+    ./.agent/run.sh cmake --preset release
+    ./.agent/run.sh cmake --build --preset release
+    ./build/release/test/qdmi/registry/mqt-core-qdmi-registry-test
+    ./build/release/test/qdmi/driver/mqt-core-qdmi-driver-test
+    ./.agent/run.sh uvx nox -s tests-3.14 -- test/python/fomac/test_fomac.py -k device_configuration_arguments
+    ./.agent/run.sh uvx nox -s stubs
+    ./.agent/run.sh uvx nox -s lint
+
+Successful GoogleTest runs report zero failed tests. Stub generation must leave
+only expected generated `.pyi` changes. The imported-device CTest must configure
+and build a consumer that receives the runtime data file beside the copied
+library.
+
+## Validation and Acceptance
+
+Parsing rejects unknown `device-config` keys, missing or simultaneous `inline`
+and `file`, and incorrect types. A relative file becomes an absolute normalized
+path relative to its declaring configuration file. A higher-precedence source
+replaces the full lower-precedence source. Driver tests observe inline bytes in
+CUSTOM1 or a file path in CUSTOM2 and observe no value in the other slot.
+Combining the typed field with raw CUSTOM1 or CUSTOM2 throws before session
+initialization. Python exposes mutually exclusive ergonomic arguments.
+
+## Idempotence and Recovery
+
+Configuration, build, test, stub, and lint commands are repeatable. Generated
+stubs are regenerated from bindings rather than edited. If a registry parse or
+session open fails, no global registry definition or initialized native session
+is committed. No command in this plan publishes remote state.
+
+## Artifacts and Notes
+
+The CTest fixture names are `mqt-core-qdmi-imported-device-configure`,
+`mqt-core-qdmi-imported-device-build`, `mqt-core-qdmi-runtime-file-configure`,
+`mqt-core-qdmi-runtime-file-build`, `mqt-core-qdmi-runtime-file-install`, and
+`mqt-core-qdmi-runtime-file-install-verify`. The exported runtime-file list is
+`metadata-runtime.json`; both the imported consumer and isolated install
+verified byte-identical copies beside their runtime artifacts.
+
+## Interfaces and Dependencies
+
+`qdmi::InlineDeviceConfiguration` owns a `std::string json`.
+`qdmi::FileDeviceConfiguration` owns a `std::filesystem::path path`.
+`qdmi::DeviceConfigurationSource` is their `std::variant`.
+`DeviceSessionConfig::deviceConfiguration` is an optional source. The
+implementation uses existing nlohmann JSON, TOML, nanobind, and CMake facilities
+and adds no dependency. QDMI v1 CUSTOM1 and CUSTOM2 remain confined to
+`Driver.cpp` and provider ABI adapters.
+
+Revision note: reconstructed as an independently reviewable additive change,
+published as draft PR #1967, and refreshed onto `origin/main` on 2026-07-30;
+provider migrations remain in the later NA and SC changes.

--- a/.agent/plans/qdmi-pennylane-device.md
+++ b/.agent/plans/qdmi-pennylane-device.md
@@ -1,0 +1,407 @@
+# Add a PennyLane interface for gate-based QDMI devices
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+PennyLane applications should run unchanged on gate-based quantum devices
+exposed through QDMI. After this change, a user who installs the optional
+`mqt-core[pennylane]` extra can create the built-in simulator with
+`qp.device("mqt.ddsim.default", wires=..., shots=...)`, evaluate ordinary
+sampled measurements and parameter-shift gradients, and reuse the same circuit
+with device integration packages that register stable QDMI device IDs.
+
+Programs use OpenQASM 3 whenever the device advertises that format. A device
+that advertises only OpenQASM 2 uses PennyLane's serializer after the normal
+device preprocessing pipeline. The final documentation demonstrates a
+finite-shot, one-layer MaxCut QAOA application on the local DDSIM QDMI device.
+
+## Progress
+
+- [x] (2026-08-04 09:00Z) Refreshed `origin/main`, created an isolated worktree,
+      read repository policy, and surveyed the QDMI Python API and packaging.
+- [x] (2026-08-04 11:30Z) Implemented the optional PennyLane package,
+      QASM3-first negotiation, QASM2 fallback, modern preprocessing and
+      execution, focused exceptions, and the stable DDSIM entry point.
+- [x] (2026-08-04 12:45Z) Added converter, preprocessing, result, gradient,
+  arbitrary-wire, batch, shot-vector, and DDSIM end-to-end tests.
+- [x] (2026-08-04 13:30Z) Added the marked optional dependency, ordinary test
+      and documentation group coverage, lockfile, changelog entry, QAOA
+      application, and technical documentation.
+- [x] (2026-08-04 15:45Z) Passed the Python 3.10 and 3.14 full test sessions,
+  the focused Python 3.11-3.13 sessions, the warning-clean documentation nox
+  session, and the complete lint nox session; audited the final diff.
+- [x] (2026-08-04 16:30Z) Integrated the latest `origin/main`, broadened the
+  exact Autograd warning filter to work for compile-time warnings in CI,
+  simplified public prose and the changelog, and reduced the shared test
+  support from 300 to 177 lines without reducing its 33-test coverage.
+- [x] (2026-08-04 23:00Z) Replaced the standalone QAOA script and subprocess
+      test with an executable scientific MyST notebook and a compact real-DDSIM
+      smoke test; standardized device-oriented terminology.
+- [x] (2026-08-04 23:10Z) Passed the forced and cached documentation sessions,
+      inspected the rendered SVG figures, passed all 33 focused Python 3.14
+      tests and the complete lint session, and completed the final repository
+      searches.
+- [x] (2026-08-04 23:15Z) Moved the NetworkX import behind the Python 3.10
+      PennyLane guard identified during independent verification; the focused
+      Python 3.10 and 3.14 nox sessions passed.
+- [x] (2026-08-04 23:58Z) Integrated `origin/main` at `ecd32f734` with a signed
+      merge commit; the merged changelog retains the #2005 and #2007 entries and
+      links.
+- [x] (2026-08-05 00:02Z) Addressed all eight review threads by reorganizing the
+      notebook as a quickstart, compact conversion contract, and end-to-end QAOA
+      application; removed explanatory implementation history; replaced repeated
+      QNode return-type suppressions with file-wide Ruff directives.
+- [x] (2026-08-05 00:03Z) Stabilized the Bell-state shot-vector test with
+      partitions of 1000, 1000, and 2000 shots at absolute tolerance 0.1, and
+      added the statistical-robustness rule to `AGENTS.md`.
+- [x] (2026-08-05 00:08Z) Passed the minimums reproduction and focused Python
+      3.10-3.14 sessions, forced and cached documentation builds,
+      rendered-output inspection, complete lint, diff checks, and repository
+      searches.
+- [ ] Complete independent verification, publish the signed revision, monitor
+      replacement CI, and reply to and resolve the eight addressed threads.
+
+## Surprises & Discoveries
+
+- Observation: The QDMI FoMaC Python API already exposes stable device IDs,
+  fresh per-call sessions, program formats, topology, operation names, raw
+  shots, and typed custom job slots. Evidence: `python/mqt/core/fomac.pyi`
+  provides `registered_device_ids`, `open_device`,
+  `Device.supported_program_formats`, `Device.operations`,
+  `Device.coupling_map`, `Device.submit_job`, and `Job.get_shots`.
+- Observation: MQT Core's existing OpenQASM 3 exporter includes `stdgates.inc`,
+  while remote Braket programs need explicit device gate spellings and no
+  include. The PennyLane integration therefore needs a small capability-driven
+  emitter behind its own converted-program boundary.
+- Observation: PennyLane 0.45.1 declares Python 3.14 support, but Autograd 1.8
+  contains a `return` in a `finally` block. MQT Core's warnings-as-errors test
+  policy promotes Python 3.14's compile-time `SyntaxWarning` to an import
+  failure. Evidence: the first Python 3.14 nox run failed while importing
+  `autograd.wrap_util`; an exact message/category warning filter restored normal
+  upstream import behavior and the full session passed.
+- Observation: DDSIM returns QDMI shots in conventional basis-state spelling,
+  with the highest-index site on the left. Evidence: applying X to site zero
+  returned the raw QDMI string `01`; the PennyLane device reverses that
+  representation before selecting columns in declared wire order.
+- Observation: generic exception names such as `TranslationError` conflict with
+  the existing Qiskit plugin in Sphinx's global Python domain. Evidence: the
+  warning-as-error docs build reported ambiguous cross-references. Public
+  `PennyLane...Error` names preserve focused errors and produce clean API docs
+  without changing the Qiskit integration.
+- Observation: optional transitive dependencies must be imported after the
+  Python-version guard in test modules. Evidence: importing NetworkX before the
+  Python 3.10 module skip prevented collection when the PennyLane extra was
+  intentionally absent; moving the import after the guard restored the expected
+  skip behavior.
+- Observation: the Python 3.12 minimums job sampled a Bell-state probability of
+  exactly `0.65`, which lay on the floating-point boundary of the previous
+  `0.5 ± 0.15` assertion. Evidence: CI run `30959612789`, job `92160445071`,
+  passed 564 tests and failed only `test_bell_results_and_shot_vector` at that
+  boundary.
+
+## Decision Log
+
+- Decision: Keep every import of PennyLane in source, tests, and documentation
+  spelled `import pennylane as qp`. Rationale: this is PennyLane's current
+  project convention and avoids adding the retired `qml` alias. Date/Author:
+  2026-08-04 / GPT-5.6 via Codex.
+- Decision: Prefer OpenQASM 3 by advertised format, and never retry the OpenQASM
+  2 path after a QASM3 translation failure. Rationale: advertised QASM3 support
+  is a device contract; hiding a failed capability-driven conversion would make
+  unsupported programs nondeterministic. Date/Author: 2026-08-04 / GPT-5.6 via
+  Codex.
+- Decision: Return raw computational-basis samples from `execute` and let
+  PennyLane's preprocessing transforms reconstruct requested measurements.
+  Rationale: the framework then owns observable diagonalization, non-commuting
+  measurement splitting, Hamiltonian aggregation, shot-vector binning, and
+  result typing. Date/Author: 2026-08-04 / GPT-5.6 via Codex.
+- Decision: Keep QDMI submission sequential. Rationale: the current FoMaC
+  interface has no batch-submission contract, while sequential execution remains
+  correct for batches and parameter-shift expansion. Date/Author: 2026-08-04 /
+  GPT-5.6 via Codex.
+- Decision: Keep PennyLane enabled on Python 3.11 through 3.14 and suppress only
+  Autograd 1.8's exact Python 3.14 compile-time warning in test configuration.
+  Rationale: PennyLane formally supports 3.14, normal imports work, and
+  vendoring or patching Autograd would add unnecessary maintenance. Date/Author:
+  2026-08-04 / GPT-5.6 via Codex.
+- Decision: Build documentation exclusively with the repository's `nox -s docs`
+  session. Rationale: the nox session owns the complete native, AutoAPI,
+  notebook, and strict-warning environment. Date/Author: 2026-08-04 / GPT-5.6
+  via Codex.
+- Decision: Keep the complete QAOA demonstration in the executable MyST notebook
+  and test the same application contract directly through DDSIM. Rationale: one
+  source now defines the narrative, executable analysis, and visual results,
+  while the smoke test remains compact and independent of rendered prose.
+  Date/Author: 2026-08-05 / GPT-5.6 via Codex.
+- Decision: Organize the device guide as a minimal Bell-state quickstart,
+  followed by the conversion contract and a complete finite-shot MaxCut QAOA
+  application. Rationale: device users first see the smallest executable
+  interface and then the scientific application without internal development
+  history. Date/Author: 2026-08-05 / GPT-5.6 via Codex.
+- Decision: Use 1000, 1000, and 2000 shots with an absolute probability
+  tolerance of 0.1 for the Bell shot-vector test. Rationale: this still tests
+  the expected 50/50 distribution while making a stochastic CI failure
+  negligible. Date/Author: 2026-08-05 / GPT-5.6 via Codex.
+
+## Outcomes & Retrospective
+
+The MQT Core implementation is complete. `qp.device("mqt.ddsim.default", ...)`
+executes finite-shot tapes through QDMI, prefers capability-driven OpenQASM 3,
+uses PennyLane's exact QASM2 serializer only for QASM2-only devices,
+reconstructs the documented measurement types through PennyLane preprocessing,
+and runs the one-layer MaxCut QAOA application documented in the executable
+notebook.
+
+Validation evidence:
+
+- `nox -s tests-3.14`: 558 passed, 3 skipped.
+- `nox -s tests-3.10`: 526 passed, 6 skipped; only the three PennyLane-dependent
+  modules are newly skipped.
+- `nox -s tests-3.11 tests-3.12 tests-3.13 -- test/python/plugins/qdmi_pennylane`:
+  33 passed in every session.
+- `nox -s docs`: strict HTML build succeeded with no warnings.
+- `nox -s lint`: every repository hook, including lock validation, Ruff, ty,
+  Markdown, and repository policy, passed.
+- `nox -s docs -- -D nb_execution_mode=force`: the new notebook executed in 4.99
+  seconds; the final cached documentation build also succeeded.
+- Rendered-output inspection: the deterministic input graph and the three-panel
+  analysis figure have readable labels, an explicit theme-neutral background,
+  and distinct cut-edge styling.
+- `nox -s tests-3.14 -- test/python/plugins/qdmi_pennylane`: 33 passed.
+- `nox -s tests-3.10 tests-3.14 -- test/python/plugins/qdmi_pennylane`: Python
+  3.10 reported 1 passed and 3 skipped; Python 3.14 reported 33 passed.
+- `nox -s minimums-3.12 -- test/python/plugins/qdmi_pennylane/test_ddsim.py`: 10
+  passed, reproducing the previously failing CI dependency boundary.
+- `nox -s tests-3.10 tests-3.11 tests-3.12 tests-3.13 tests-3.14 -- test/python/plugins/qdmi_pennylane`:
+  Python 3.10 reported 1 passed and 3 skipped; every supported Python version
+  reported 33 passed.
+- `nox -s docs -- -D nb_execution_mode=force`: strict HTML build succeeded and
+  executed the PennyLane notebook in 2.77 seconds; the normal cached
+  documentation session also succeeded.
+- Rendered-output inspection: both notebook SVGs have readable and unclipped
+  labels, a theme-neutral figure background, an explicitly noisy objective
+  title, and distinct cut-edge styling.
+- `nox -s lint`: all repository hooks passed after applying their canonical
+  Markdown and Ruff formatting.
+- `git diff --check` and the repository searches passed; there are no standalone
+  QAOA-script references, `qml` aliases, QDMI-provider terms, repeated inline
+  QNode suppressions, or review-identified iteration phrases.
+
+The deliberately deferred gaps are routing, parallel submission, analytic
+execution, pulse programming, and non-gate device properties. The separate
+Amazon Braket device integration consumes only the public stable-ID device API
+and remains ordered after the MQT Core release.
+
+## Context and Orientation
+
+`python/mqt/core/fomac.pyi` describes the Python-facing QDMI API. A stable
+device ID is an implementation-independent string registered by MQT Core or an
+installed device integration package. `fomac.open_device` opens a fresh device
+session, and the returned object advertises program formats, named operations,
+operation loci, topology, and a `submit_job` method. A submitted job provides
+raw shot strings.
+
+`python/mqt/core/plugins/qiskit/` is the neighboring optional integration. The
+new sibling package is `python/mqt/core/plugins/pennylane/`. Its public
+`QDMIDevice` derives from PennyLane's modern `Device` base class. A
+`ConvertedProgram` value carries the text payload, selected QDMI
+`ProgramFormat`, deterministic wire mapping, and measurement order so a future
+compiler or JEFF converter can replace the text emitters without changing the
+device API.
+
+PennyLane preprocessing converts a user circuit, called a quantum tape, into one
+or more executable tapes and a postprocessing function. The device uses
+framework transforms to validate wires and shots, defer measurements, split
+non-commuting observables, diagonalize them, decompose unsupported operations,
+expand broadcasts, and replace measurements with raw sampling. Execution submits
+each resulting tape in order and returns the raw sample arrays expected by the
+transform postprocessor.
+
+The built-in DDSIM QDMI registration uses `mqt.ddsim.default`. The package
+exposes that stable ID through a PennyLane device entry point with the same
+name. Device integration packages can register thin subclasses under their own
+stable QDMI IDs and translate device credentials into the generic
+`session_parameters` and `job_parameters` mappings.
+
+## Milestones
+
+### Milestone 1: Prove conversion and preprocessing
+
+Add typed exceptions, `ConvertedProgram`, an operation table, alias resolution,
+format negotiation, and a modern `CompilePipeline`. Exact tests must show that
+QASM3 is chosen over QASM2, uses device-advertised spellings, emits one qubit
+and classical register followed by a whole-register measurement, and includes no
+standard-library include, definitions, pragmas, or modifiers. QASM2-only tests
+must exercise `qp.to_openqasm` with rotations disabled and fail clearly when
+serialization is impossible.
+
+### Milestone 2: Execute through QDMI
+
+Implement `QDMIDevice.execute` with finite-shot validation, deterministic wire
+mapping, topology validation, bound finite parameter checks, sequential
+submission, wait and failure handling, and conversion of QDMI shot strings to
+PennyLane raw sample arrays. Tests must cover arbitrary wire labels, batches,
+shot vectors, samples, counts, probabilities, expectations, variances,
+Hamiltonians, and parameter-shift gradients.
+
+### Milestone 3: Package and demonstrate DDSIM
+
+Register `mqt.ddsim.default`, add a Python-version-marked optional dependency,
+include it in the existing test and documentation groups for Python 3.11 and
+newer, and keep Python 3.10 importable without PennyLane. Add an executable MyST
+notebook containing a four-node, one-layer MaxCut QAOA example and scientific
+visual analysis. Execute the full example locally and ensure the ordinary
+existing Python and wheel CI matrices exercise the optional integration without
+adding a workflow.
+
+### Milestone 4: Validate and hand off the device boundary
+
+Run focused tests, a complete Python test session on a supported version,
+documentation, lint, lockfile consistency, and packaging checks. Audit all new
+PennyLane source and documentation for the `qp` alias and review the final diff.
+The separate Amazon Braket device integration then consumes only this public
+API; it is not part of the MQT Core change.
+
+## Plan of Work
+
+Create `exceptions.py`, `converter.py`, `device.py`, and `__init__.py` below
+`python/mqt/core/plugins/pennylane`. The converter will use a typed table whose
+rows associate PennyLane operation types with semantic alias groups, arity, and
+parameter counts. It will resolve one advertised QDMI spelling for every
+operation, validate the operation's wire tuple against advertised sites or site
+pairs and the device topology, format finite numeric parameters
+deterministically, and emit the minimal OpenQASM 3 program. It will invoke
+`qp.to_openqasm` only when QASM3 is not advertised and QASM2 is.
+
+The device will normalize wires with PennyLane's `Wires`, open its QDMI device
+by stable ID plus session mappings, cache capability metadata, expose a
+framework preprocessing pipeline, and execute transformed tapes one at a time.
+It will preserve QDMI's whole-register bit ordering while remapping to the
+declared PennyLane wire order. Custom session and job parameters will be
+validated against the named FoMaC fields before forwarding.
+
+Add unit tests under `test/python/plugins/qdmi_pennylane` with small mock QDMI
+objects, plus DDSIM end-to-end coverage that runs only when the built native
+device is available. Add the PennyLane entry point and optional dependency in
+`pyproject.toml`, update `uv.lock`, add the documentation intersphinx mapping
+and toctree entry, add the executable QAOA notebook, and record the new feature
+in `CHANGELOG.md`.
+
+## Concrete Steps
+
+Run all commands from the repository root. Install and build the supported
+Python environment with:
+
+    ./.agent/run.sh uv sync --inexact --only-group build --only-group test
+    ./.agent/run.sh uv sync --inexact --no-dev \
+      --no-build-isolation-package mqt-core
+
+Iterate on the new tests with:
+
+    ./.agent/run.sh uv run --no-sync pytest \
+      test/python/plugins/qdmi_pennylane
+
+Validate the executable notebook through the documentation session, then run the
+supported test and lint sessions:
+
+    ./.agent/run.sh uvx nox --non-interactive -s docs -- \
+      -D nb_execution_mode=force
+    ./.agent/run.sh uvx nox -s tests-3.14 -- \
+      test/python/plugins/qdmi_pennylane
+    ./.agent/run.sh uvx nox --non-interactive -s docs
+    ./.agent/run.sh uvx nox -s lint
+
+Finally run `git diff --check`, search every added PennyLane file for forbidden
+`qml` imports, inspect `git status --short`, and update this plan with concise
+evidence.
+
+## Validation and Acceptance
+
+Exact converter tests must show QASM3 preference and device-advertised spellings
+for the documented gate subset. They must show a final `c = measure q;`,
+deterministic wire order, finite bound numbers, and no include, custom
+definition, pragma, or gate modifier. A QASM3 translation failure must remain
+visible even when QASM2 is also advertised. QASM2-only tests must show the
+expected OpenQASM 2 header, `qelib1.inc`, operations, and whole-register
+measurements with each observable rotation applied once.
+
+Preprocessing and mock execution tests must cover raw samples, counts,
+probabilities, expectation values, variances, Hamiltonians, shot vectors,
+arbitrary wire labels, batches, topology errors, unsupported formats,
+unsupported operations, analytic shots, and parameter-shift expansion. DDSIM
+tests must create `qp.device("mqt.ddsim.default", ...)`, produce a Bell
+distribution within finite-shot tolerance, compute a finite parameter-shift
+gradient, and run the QAOA smoke test. The executable notebook must construct
+the same local application and render the input graph, noisy objective
+trajectory, sampled distribution, and best observed partition.
+
+Python 3.10 must resolve and import the base package without PennyLane.
+Supported Python 3.11 through 3.14 environments must install the test group and
+run the new tests through the ordinary matrix. Documentation and lint must pass.
+A repository search over all added source, test, and documentation files must
+find `import pennylane as qp` and no alternative PennyLane import alias.
+
+## Idempotence and Recovery
+
+All source edits, lock generation, builds, and tests are repeatable. Tests use
+mock devices or the local DDSIM device and require no credentials. If a partial
+environment installation fails, rerun the same `.agent/run.sh uv sync` commands;
+do not use shared caches outside this worktree. If generated metadata changes
+unexpectedly, inspect `pyproject.toml` and regenerate `uv.lock` rather than
+editing resolved records by hand. Do not alter another task's worktree.
+
+## Artifacts and Notes
+
+Review-thread mapping for the 2026-08-04 requested-changes review:
+
+- Removed the installation-workflow comparison and related iteration language.
+- Stated unsupported execution modes as out of scope for now.
+- Removed prose about plotting configuration and hid only rendering setup.
+- Presented the Bell-state example as the quickstart.
+- Replaced the serializer call and rotation details with one QASM2 fallback
+  sentence.
+- Presented finite-shot MaxCut QAOA as the end-to-end use case.
+- Retained the graph definition without explaining the fixed node positions.
+- Replaced repeated inline QNode return-type suppressions with file-wide
+  `ANN202` directives in both test modules.
+
+The user authorized a non-force push of the signed remediation revision and
+individual disclosed replies and resolutions for these eight threads. This
+authorization does not include changing the review state, merging the pull
+request, or unrelated metadata mutations.
+
+## Interfaces and Dependencies
+
+`mqt.core.plugins.pennylane.QDMIDevice` accepts `device_id`, `wires`,
+`shots=1024`, `session_parameters`, and `job_parameters`. The mappings use the
+FoMaC session and job keyword names from `python/mqt/core/fomac.pyi`.
+
+`mqt.core.plugins.pennylane.ConvertedProgram` contains `payload: str`,
+`program_format: fomac.ProgramFormat`, `wire_map`, and `measurement_order`.
+`convert_program` accepts a preprocessed PennyLane `QuantumScript`, an opened
+QDMI device, and declared device wires, and returns that value or raises a
+focused translation, validation, configuration, or execution exception.
+
+The optional dependency is `pennylane>=0.45.1,<0.46; python_version >= "3.11"`.
+The implementation uses PennyLane's public device, transform, tape, wire,
+measurement, and serialization APIs, NumPy for sample arrays, and the existing
+`mqt.core.fomac` binding. It does not depend on a device-specific SDK, compiler
+pipeline, JEFF conversion, pulse programming, neutral-atom properties, or
+parallel job submission.
+
+Revision note: created on 2026-08-04 to capture the user-approved MQT Core half
+of the QDMI–PennyLane implementation before production edits.
+
+Revision note: updated on 2026-08-05 to consolidate the QAOA demonstration into
+an executable scientific notebook, standardize QDMI device terminology, and
+record the independent Python 3.10 compatibility verification.
+
+Revision note: updated on 2026-08-05 to integrate `origin/main`, map and address
+the requested-changes review, and record the statistically robust Bell-state
+test parameters and validation plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,9 @@ types such as `llvm::SmallVector` and `llvm::function_ref` where appropriate.
 - Run the supported test sessions with `./.agent/run.sh uvx nox -s tests` and
   `./.agent/run.sh uvx nox -s minimums`. Python 3.14 variants are `tests-3.14`
   and `minimums-3.14`.
+- For finite-shot tests, choose shot counts and tolerances with a sufficiently
+  low false-failure probability; avoid placing expected values on tolerance
+  boundaries.
 - If a file in `bindings/` is added or changed, regenerate type stubs with
   `./.agent/run.sh uvx nox -s stubs`. Never edit generated `.pyi` files in
   `python/mqt/core/` manually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Expose compressed vector and matrix DD serialization through bytes-based
+  Python APIs ([#1983]) ([**@burgholzer**])
 - ✨ Expose registered QDMI device IDs without loading device libraries
   ([#1972]) ([**@burgholzer**])
 - ✨ Add typed runtime configuration transport and relocatable assets for QDMI
@@ -620,6 +622,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1983]: https://github.com/munich-quantum-toolkit/core/pull/1983
 [#1972]: https://github.com/munich-quantum-toolkit/core/pull/1972
 [#1967]: https://github.com/munich-quantum-toolkit/core/pull/1967
 [#1965]: https://github.com/munich-quantum-toolkit/core/pull/1965

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- ✨ Add typed runtime configuration transport and relocatable assets for QDMI
+  device descriptions ([#1967]) ([**@burgholzer**])
+
 ## [3.8.0] - 2026-07-30
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#380)._
@@ -613,6 +618,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1967]: https://github.com/munich-quantum-toolkit/core/pull/1967
 [#1965]: https://github.com/munich-quantum-toolkit/core/pull/1965
 [#1957]: https://github.com/munich-quantum-toolkit/core/pull/1957
 [#1952]: https://github.com/munich-quantum-toolkit/core/pull/1952

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ releases may include breaking changes.
 - ✨ Add typed runtime configuration transport and relocatable assets for QDMI
   device descriptions ([#1967]) ([**@burgholzer**])
 
+### Changed
+
+- 🚀 Reduce ZX diagram growth for multi-controlled X gates with an exact
+  ancilla-free quadratic decomposition ([#1984]) ([**@burgholzer**])
+
 ## [3.8.0] - 2026-07-30
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#380)._
@@ -622,6 +627,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1984]: https://github.com/munich-quantum-toolkit/core/pull/1984
 [#1983]: https://github.com/munich-quantum-toolkit/core/pull/1983
 [#1972]: https://github.com/munich-quantum-toolkit/core/pull/1972
 [#1967]: https://github.com/munich-quantum-toolkit/core/pull/1967

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add PennyLane support for gate-based QDMI devices ([#2005])
+  ([**@burgholzer**])
 - ✨ Expose compressed vector and matrix DD serialization through bytes-based
   Python APIs ([#1983]) ([**@burgholzer**])
 - ✨ Expose registered QDMI device IDs without loading device libraries
@@ -627,6 +629,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#2005]: https://github.com/munich-quantum-toolkit/core/pull/2005
 [#1984]: https://github.com/munich-quantum-toolkit/core/pull/1984
 [#1983]: https://github.com/munich-quantum-toolkit/core/pull/1983
 [#1972]: https://github.com/munich-quantum-toolkit/core/pull/1972

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Expose registered QDMI device IDs without loading device libraries
+  ([#1972]) ([**@burgholzer**])
 - ✨ Add typed runtime configuration transport and relocatable assets for QDMI
   device descriptions ([#1967]) ([**@burgholzer**])
 
@@ -618,6 +620,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#1972]: https://github.com/munich-quantum-toolkit/core/pull/1972
 [#1967]: https://github.com/munich-quantum-toolkit/core/pull/1967
 [#1965]: https://github.com/munich-quantum-toolkit/core/pull/1965
 [#1957]: https://github.com/munich-quantum-toolkit/core/pull/1957

--- a/bindings/dd/register_matrix_dds.cpp
+++ b/bindings/dd/register_matrix_dds.cpp
@@ -12,6 +12,7 @@
 #include "dd/Edge.hpp"
 #include "dd/Export.hpp"
 #include "dd/Node.hpp"
+#include "dd/Package.hpp"
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -22,6 +23,7 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
+#include <ios>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -114,6 +116,49 @@ Returns:
 
 Raises:
     MemoryError: If the memory allocation fails.)pb");
+
+  mat.def(
+      "to_bytes",
+      [](const dd::mEdge& e, const bool binary = true) {
+        std::ostringstream os(std::ios::out | std::ios::binary);
+        serialize(e, os, binary);
+        const auto data = os.view();
+        return nb::bytes(data.data(), data.size());
+      },
+      "binary"_a = true, R"pb(Serialize the DD to bytes.
+
+Args:
+    binary: Whether to use the binary serialization format. Defaults to True.
+        If False, the textual serialization format is used.
+
+Returns:
+    The serialized DD.
+
+Notes:
+    The binary format is not portable across different architectures or platforms.)pb");
+
+  mat.def_static(
+      "from_bytes",
+      [](dd::Package& p, const nb::bytes& data, const bool binary = true) {
+        std::istringstream is(std::string(data.c_str(), data.size()),
+                              std::ios::in | std::ios::binary);
+        return p.deserialize<dd::mNode>(is, binary);
+      },
+      "dd_package"_a, "data"_a, "binary"_a = true,
+      // keep the DD package alive while the returned matrix DD is alive.
+      nb::keep_alive<0, 1>(), R"pb(Deserialize a DD from bytes.
+
+Args:
+    dd_package: The DD package that owns the deserialized DD.
+    data: The serialized DD.
+    binary: Whether the data uses the binary serialization format. Defaults to True.
+        If False, the textual serialization format is expected.
+
+Returns:
+    The deserialized DD.
+
+Notes:
+    The binary format is not portable across different architectures or platforms.)pb");
 
   mat.def(
       "to_dot",

--- a/bindings/dd/register_vector_dds.cpp
+++ b/bindings/dd/register_vector_dds.cpp
@@ -12,6 +12,7 @@
 #include "dd/Edge.hpp"
 #include "dd/Export.hpp"
 #include "dd/Node.hpp"
+#include "dd/Package.hpp"
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -23,6 +24,7 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
+#include <ios>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -102,6 +104,49 @@ Returns:
 
 Raises:
     MemoryError: If the memory allocation fails.)pb");
+
+  vec.def(
+      "to_bytes",
+      [](const dd::vEdge& e, const bool binary = true) {
+        std::ostringstream os(std::ios::out | std::ios::binary);
+        serialize(e, os, binary);
+        const auto data = os.view();
+        return nb::bytes(data.data(), data.size());
+      },
+      "binary"_a = true, R"pb(Serialize the DD to bytes.
+
+Args:
+    binary: Whether to use the binary serialization format. Defaults to True.
+        If False, the textual serialization format is used.
+
+Returns:
+    The serialized DD.
+
+Notes:
+    The binary format is not portable across different architectures or platforms.)pb");
+
+  vec.def_static(
+      "from_bytes",
+      [](dd::Package& p, const nb::bytes& data, const bool binary = true) {
+        std::istringstream is(std::string(data.c_str(), data.size()),
+                              std::ios::in | std::ios::binary);
+        return p.deserialize<dd::vNode>(is, binary);
+      },
+      "dd_package"_a, "data"_a, "binary"_a = true,
+      // keep the DD package alive while the returned vector DD is alive.
+      nb::keep_alive<0, 1>(), R"pb(Deserialize a DD from bytes.
+
+Args:
+    dd_package: The DD package that owns the deserialized DD.
+    data: The serialized DD.
+    binary: Whether the data uses the binary serialization format. Defaults to True.
+        If False, the textual serialization format is expected.
+
+Returns:
+    The deserialized DD.
+
+Notes:
+    The binary format is not portable across different architectures or platforms.)pb");
 
   vec.def(
       "to_dot",

--- a/bindings/fomac/fomac.cpp
+++ b/bindings/fomac/fomac.cpp
@@ -78,16 +78,31 @@ template <typename Query>
     std::optional<std::string> baseUrl, std::optional<std::string> token,
     std::optional<std::filesystem::path> authFile,
     std::optional<std::string> authUrl, std::optional<std::string> username,
-    std::optional<std::string> password, std::optional<std::string> custom1,
-    std::optional<std::string> custom2, std::optional<std::string> custom3,
-    std::optional<std::string> custom4, std::optional<std::string> custom5)
-    -> qdmi::DeviceSessionConfig {
+    std::optional<std::string> password,
+    std::optional<std::string> deviceConfig,
+    std::optional<std::filesystem::path> deviceConfigFile,
+    std::optional<std::string> custom1, std::optional<std::string> custom2,
+    std::optional<std::string> custom3, std::optional<std::string> custom4,
+    std::optional<std::string> custom5) -> qdmi::DeviceSessionConfig {
+  if (deviceConfig && deviceConfigFile) {
+    throw nb::value_error(
+        "device_config and device_config_file are mutually exclusive");
+  }
+  std::optional<qdmi::DeviceConfigurationSource> configuration;
+  if (deviceConfig) {
+    configuration =
+        qdmi::InlineDeviceConfiguration{.json = std::move(*deviceConfig)};
+  } else if (deviceConfigFile) {
+    configuration =
+        qdmi::FileDeviceConfiguration{.path = std::move(*deviceConfigFile)};
+  }
   return {.baseUrl = std::move(baseUrl),
           .token = std::move(token),
           .authFile = std::move(authFile),
           .authUrl = std::move(authUrl),
           .username = std::move(username),
           .password = std::move(password),
+          .deviceConfiguration = std::move(configuration),
           .custom1 = std::move(custom1),
           .custom2 = std::move(custom2),
           .custom3 = std::move(custom3),
@@ -649,6 +664,9 @@ when the custom slot is unsupported.)pb");
              const std::optional<std::string>& authUrl = std::nullopt,
              const std::optional<std::string>& username = std::nullopt,
              const std::optional<std::string>& password = std::nullopt,
+             const std::optional<std::string>& deviceConfig = std::nullopt,
+             const std::optional<std::filesystem::path>& deviceConfigFile =
+                 std::nullopt,
              const std::optional<std::string>& custom1 = std::nullopt,
              const std::optional<std::string>& custom2 = std::nullopt,
              const std::optional<std::string>& custom3 = std::nullopt,
@@ -660,15 +678,17 @@ when the custom slot is unsupported.)pb");
                 .prefix = std::move(prefix),
                 .session = makeDeviceSessionConfig(
                     baseUrl, token, authFile, authUrl, username, password,
-                    custom1, custom2, custom3, custom4, custom5)};
+                    deviceConfig, deviceConfigFile, custom1, custom2, custom3,
+                    custom4, custom5)};
           },
           "device_id"_a, "library_path"_a, "prefix"_a, nb::kw_only(),
           "base_url"_a = std::nullopt, "token"_a = std::nullopt,
           "auth_file"_a = std::nullopt, "auth_url"_a = std::nullopt,
           "username"_a = std::nullopt, "password"_a = std::nullopt,
-          "custom1"_a = std::nullopt, "custom2"_a = std::nullopt,
-          "custom3"_a = std::nullopt, "custom4"_a = std::nullopt,
-          "custom5"_a = std::nullopt,
+          "device_config"_a = std::nullopt,
+          "device_config_file"_a = std::nullopt, "custom1"_a = std::nullopt,
+          "custom2"_a = std::nullopt, "custom3"_a = std::nullopt,
+          "custom4"_a = std::nullopt, "custom5"_a = std::nullopt,
           R"pb(Create a device definition without loading its native library.
 
 Args:
@@ -681,6 +701,8 @@ Args:
     auth_url: Optional authentication server URL.
     username: Optional authentication username.
     password: Optional authentication password.
+    device_config: Optional inline JSON device description.
+    device_config_file: Optional device-description JSON file.
     custom1: Optional custom configuration parameter 1.
     custom2: Optional custom configuration parameter 2.
     custom3: Optional custom configuration parameter 3.
@@ -738,12 +760,15 @@ Raises:
          std::optional<std::string> authUrl,
          std::optional<std::string> username,
          std::optional<std::string> password,
+         std::optional<std::string> deviceConfig,
+         std::optional<std::filesystem::path> deviceConfigFile,
          std::optional<std::string> custom1, std::optional<std::string> custom2,
          std::optional<std::string> custom3, std::optional<std::string> custom4,
          std::optional<std::string> custom5) {
         const auto overrides = makeDeviceSessionConfig(
             std::move(baseUrl), std::move(token), std::move(authFile),
             std::move(authUrl), std::move(username), std::move(password),
+            std::move(deviceConfig), std::move(deviceConfigFile),
             std::move(custom1), std::move(custom2), std::move(custom3),
             std::move(custom4), std::move(custom5));
         return fomac::Session::openDevice(deviceId, overrides);
@@ -751,7 +776,8 @@ Raises:
       "device_id"_a, nb::kw_only(), "base_url"_a = std::nullopt,
       "token"_a = std::nullopt, "auth_file"_a = std::nullopt,
       "auth_url"_a = std::nullopt, "username"_a = std::nullopt,
-      "password"_a = std::nullopt, "custom1"_a = std::nullopt,
+      "password"_a = std::nullopt, "device_config"_a = std::nullopt,
+      "device_config_file"_a = std::nullopt, "custom1"_a = std::nullopt,
       "custom2"_a = std::nullopt, "custom3"_a = std::nullopt,
       "custom4"_a = std::nullopt, "custom5"_a = std::nullopt,
       R"pb(Open a registered QDMI device by stable ID.
@@ -767,6 +793,8 @@ Args:
     auth_url: Optional authentication server URL override.
     username: Optional authentication username override.
     password: Optional authentication password override.
+    device_config: Optional inline JSON device-description override.
+    device_config_file: Optional device-description JSON file override.
     custom1: Optional custom configuration parameter 1 override.
     custom2: Optional custom configuration parameter 2 override.
     custom3: Optional custom configuration parameter 3 override.

--- a/bindings/fomac/fomac.cpp
+++ b/bindings/fomac/fomac.cpp
@@ -753,6 +753,14 @@ Raises:
     ValueError: If the definition is invalid.)pb");
 
   m.def(
+      "registered_device_ids",
+      [] { return qdmi::Driver::get().registeredDeviceIds(); },
+      R"pb(Return registered, enabled QDMI device IDs in registration order.
+
+This includes devices registered at runtime and does not load native device
+libraries or expose their definitions.)pb");
+
+  m.def(
       "open_device",
       [](const std::string& deviceId, std::optional<std::string> baseUrl,
          std::optional<std::string> token,

--- a/cmake/AddMQTQDMIDevice.cmake
+++ b/cmake/AddMQTQDMIDevice.cmake
@@ -22,7 +22,7 @@ endfunction()
 # Configure and register a relocatable built-in QDMI device. The generated fragment is emitted
 # beside the runtime library in both build and install trees.
 function(mqt_configure_qdmi_device target)
-  cmake_parse_arguments(ARG "" "ID;PREFIX" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "ID;PREFIX" "RUNTIME_FILES" ${ARGN})
   if(NOT TARGET ${target})
     message(FATAL_ERROR "Unknown QDMI device target: ${target}")
   endif()
@@ -51,16 +51,28 @@ function(mqt_configure_qdmi_device target)
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${fragment}"
             "$<TARGET_FILE_DIR:${target}>/${target}.qdmi.json")
+  set(runtime_file_names)
+  foreach(runtime_file IN LISTS ARG_RUNTIME_FILES)
+    get_filename_component(runtime_file_name "${runtime_file}" NAME)
+    list(APPEND runtime_file_names "${runtime_file_name}")
+    add_custom_command(
+      TARGET ${target}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${runtime_file}"
+              "$<TARGET_FILE_DIR:${target}>/${runtime_file_name}")
+  endforeach()
   set_target_properties(
     ${target}
     PROPERTIES QDMI_DEVICE_ID "${ARG_ID}"
                QDMI_DEVICE_PREFIX "${ARG_PREFIX}"
-               QDMI_MANIFEST_NAME "${target}.qdmi.json")
+               QDMI_MANIFEST_NAME "${target}.qdmi.json"
+               QDMI_RUNTIME_FILES "${runtime_file_names}")
   set_property(GLOBAL APPEND PROPERTY MQT_QDMI_DEVICE_TARGETS ${target})
   set_property(
     TARGET ${target}
     APPEND
-    PROPERTY EXPORT_PROPERTIES QDMI_DEVICE_ID QDMI_DEVICE_PREFIX QDMI_MANIFEST_NAME)
+    PROPERTY EXPORT_PROPERTIES QDMI_DEVICE_ID QDMI_DEVICE_PREFIX QDMI_MANIFEST_NAME
+             QDMI_RUNTIME_FILES)
   if(WIN32)
     # Shared-library targets are runtime artifacts on Windows and are installed under bin. Keep the
     # fragment beside the DLL so its relative path resolves.
@@ -76,6 +88,12 @@ function(mqt_configure_qdmi_device target)
     FILES "${fragment}"
     DESTINATION ${fragment_install_dir}
     ${install_arguments})
+  if(ARG_RUNTIME_FILES)
+    install(
+      FILES ${ARG_RUNTIME_FILES}
+      DESTINATION ${fragment_install_dir}
+      ${install_arguments})
+  endif()
 endfunction()
 
 # Return every QDMI device registered through mqt_configure_qdmi_device.
@@ -141,5 +159,16 @@ function(mqt_copy_qdmi_runtime target)
               "$<TARGET_FILE_DIR:${target}>"
       COMMAND ${CMAKE_COMMAND} -E copy_if_different "${manifest}"
               "$<TARGET_FILE_DIR:${target}>/${manifest_name}")
+    get_target_property(runtime_files ${device_target} QDMI_RUNTIME_FILES)
+    if(runtime_files)
+      foreach(runtime_file IN LISTS runtime_files)
+        add_custom_command(
+          TARGET ${target}
+          POST_BUILD
+          COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE_DIR:${device}>/${runtime_file}"
+            "$<TARGET_FILE_DIR:${target}>/${runtime_file}")
+      endforeach()
+    endif()
   endforeach()
 endfunction()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,6 +90,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
+    "pennylane": ("https://docs.pennylane.ai/en/stable/", None),
     "mqt": ("https://mqt.readthedocs.io/en/latest", None),
     "ddsim": ("https://mqt.readthedocs.io/projects/ddsim/en/latest", None),
     "qmap": ("https://mqt.readthedocs.io/projects/qmap/en/latest", None),
@@ -161,6 +162,15 @@ python_use_unqualified_type_names = True
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False
 
+# AutoAPI renders these typing expressions as Python cross-references although
+# they are not documented objects.
+nitpick_ignore_regex = [
+    ("py:class", r"Ellipsis"),
+    ("py:class", r"ParametersType"),
+    ("py:class", r"pennylane\.tape\.QuantumScriptOrBatch"),
+    ("py:class", r"pennylane\.transforms\.core\.CompilePipeline"),
+    ("py:class", r"pennylane\.typing\.(Result|ResultBatch)"),
+]
 
 breathe_projects = {"mqt.core": "_build/doxygen/xml"}
 breathe_default_project = "mqt.core"

--- a/docs/qdmi/configuration.md
+++ b/docs/qdmi/configuration.md
@@ -22,7 +22,9 @@ The following `qdmi.json` registers one device:
         "session": {
           "base-url": "https://device.example",
           "auth-file": "credentials.json",
-          "custom1": "device-specific"
+          "device-config": {
+            "file": "device.json"
+          }
         }
       }
     ]
@@ -32,7 +34,28 @@ The following `qdmi.json` registers one device:
 
 Every enabled definition requires a stable, unique `id`, a `library`, and a QDMI
 symbol `prefix`. The `session` object supports `base-url`, `token`, `auth-file`,
-`auth-url`, `username`, `password`, and `custom1` through `custom5`.
+`auth-url`, `username`, `password`, `device-config`, and `custom1` through
+`custom5`.
+
+`device-config` selects exactly one provider configuration source:
+
+```json
+{"device-config": {"inline": {"schema-version": 1}}}
+```
+
+or:
+
+```json
+{"device-config": {"file": "device.json"}}
+```
+
+The inline value must be a JSON object. A relative file path is resolved against
+the registry file that declares it. The complete source is one merge field:
+changing from `inline` to `file` at a higher-precedence layer replaces the
+inherited inline JSON. The Driver adapts inline JSON to QDMI v1 CUSTOM1 and a
+file path to CUSTOM2 when opening the native session. Consequently,
+`device-config` cannot be combined with raw `custom1` or `custom2`; CUSTOM3
+through CUSTOM5 remain available to providers.
 
 Relative library and authentication-file paths are resolved against the file
 that declared them. For `MQT_CORE_QDMI_CONFIG_JSON`, they resolve against the
@@ -95,10 +118,15 @@ register_device(
         "/path/to/libexample-device.so",
         "EXAMPLE",
         base_url="https://device.example",
+        device_config_file="/path/to/device.json",
     )
 )
 device = open_device("example.device")
 ```
+
+`DeviceDefinition` and `open_device` also accept `device_config="<json>"` for
+inline configuration. `device_config` and `device_config_file` are mutually
+exclusive.
 
 Every `open_device` call creates a fresh device session while preserving the
 registered defaults and stable ID. This lets separate backend instances use
@@ -171,4 +199,7 @@ set_property(
 ```
 
 When `mqt_copy_qdmi_runtime` receives that built or imported target, it
-generates the relocatable manifest while copying the device.
+generates the relocatable manifest while copying the device. Device targets may
+also declare `RUNTIME_FILES` through `mqt_configure_qdmi_device`; their exported
+`QDMI_RUNTIME_FILES` basenames are copied beside the provider as part of the
+same operation.

--- a/docs/qdmi/configuration.md
+++ b/docs/qdmi/configuration.md
@@ -140,9 +140,14 @@ Code paths that may be imported more than once can use
 inserted and ignores an existing or explicitly disabled stable ID; malformed
 definitions still raise an error.
 
+Use `registered_device_ids()` to inspect the enabled stable IDs in deterministic
+registration order. This includes runtime registrations without loading native
+device libraries or exposing their paths, prefixes, or session configuration.
+
 The equivalent C++ registration operation is `qdmi::Driver::registerDevice`.
 Duplicate IDs are rejected unless `replace` is true, and an opened definition
-cannot be replaced. `qdmi::Driver::open(id)` returns the cached device.
+cannot be replaced. `qdmi::Driver::registeredDeviceIds()` provides the same
+load-free enumeration, and `qdmi::Driver::open(id)` returns the cached device.
 `fomac::Session::openDevice(id, overrides)` returns a fresh device session and
 does not add it to the QDMI client catalog. Runtime registrations and explicit
 opens are not added to that catalog.

--- a/docs/qdmi/index.md
+++ b/docs/qdmi/index.md
@@ -17,4 +17,5 @@ DDSIM QDMI Device <ddsim_device>
 QDMI Driver <driver>
 QDMI device configuration <configuration>
 QDMI-Qiskit Backend <qdmi_backend>
+PennyLane interface for QDMI devices <pennylane_device>
 ```

--- a/docs/qdmi/pennylane_device.md
+++ b/docs/qdmi/pennylane_device.md
@@ -67,10 +67,10 @@ MQT Core selects the program format in the following order:
 3. A format error before job creation if neither format is available.
 
 The OpenQASM 3 converter selects operation spellings advertised by the QDMI
-device and validates the program against its topology. If conversion fails, MQT
-MQT Core reports the OpenQASM 3 error rather than retrying with OpenQASM 2. A device
-that advertises only OpenQASM 2 uses PennyLane's `qp.to_openqasm` serializer
-after device preprocessing.
+device and validates the program against its topology. MQT Core reports
+conversion failures as OpenQASM 3 errors rather than retrying with OpenQASM 2. A
+device that advertises only OpenQASM 2 uses PennyLane's `qp.to_openqasm`
+serializer after device preprocessing.
 
 ## End-to-end use case: finite-shot MaxCut QAOA
 

--- a/docs/qdmi/pennylane_device.md
+++ b/docs/qdmi/pennylane_device.md
@@ -1,0 +1,326 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+mystnb:
+  number_source_lines: true
+---
+
+# PennyLane interface for gate-based QDMI devices
+
+The {py:mod}`mqt.core.plugins.pennylane` module implements PennyLane's device
+interface for gate-based quantum devices exposed through QDMI. PennyLane
+programs are preprocessed into executable tapes, converted to a program format
+advertised by the selected QDMI device, submitted through FoMaC, and
+reconstructed from finite-shot QDMI results.
+
+Any registered gate-based QDMI device can use this integration if it advertises
+OpenQASM 3 or OpenQASM 2, accepts finite-shot jobs, and returns
+computational-basis samples. Specialized neutral-atom interfaces, pulse-level
+control, and analytic execution are out of scope for now. The examples below use
+the local [DD-based simulator device](ddsim_device.md) included with MQT Core
+and require no credentials or remote resources.
+
+Install MQT Core with the optional PennyLane dependency into the active
+environment:
+
+```bash
+uv pip install "mqt-core[pennylane]"
+```
+
+## Quickstart
+
+A Bell-state circuit illustrates device discovery by stable ID, circuit
+conversion, execution, and finite-shot result reconstruction.
+
+```{code-cell} ipython3
+import pennylane as qp
+
+bell_device = qp.device("mqt.ddsim.default", wires=2, shots=1000)
+
+
+@qp.qnode(bell_device)
+def bell_state():
+    qp.Hadamard(0)
+    qp.CNOT(wires=[0, 1])
+    return qp.counts(wires=[0, 1])
+
+
+bell_counts = bell_state()
+bell_counts
+```
+
+Only the computational-basis states $00$ and $11$ have nonzero probability, up
+to finite-shot fluctuations in their relative frequencies.
+
+## Program conversion
+
+PennyLane first preprocesses every quantum tape. The preprocessing pipeline
+validates the execution request, decomposes higher-level operations, maps
+measurements to computational-basis sampling, and reconstructs the requested
+finite-shot results from the samples returned through QDMI.
+
+MQT Core selects the program format in the following order:
+
+1. OpenQASM 3 if the QDMI device advertises it.
+2. OpenQASM 2 only if OpenQASM 3 is unavailable.
+3. A format error before job creation if neither format is available.
+
+The OpenQASM 3 converter selects operation spellings advertised by the QDMI
+device and validates the program against its topology. If conversion fails, MQT
+MQT Core reports the OpenQASM 3 error rather than retrying with OpenQASM 2. A device
+that advertises only OpenQASM 2 uses PennyLane's `qp.to_openqasm` serializer
+after device preprocessing.
+
+## End-to-end use case: finite-shot MaxCut QAOA
+
+Consider MaxCut on the fixed graph with $E=\{(0,1),(0,2),(1,2),(2,3)\}$.
+
+```{code-cell} ipython3
+from collections import Counter
+import time
+
+import matplotlib.pyplot as plt
+import networkx as nx
+import numpy as np
+```
+
+```{code-cell} ipython3
+:tags: [remove-input]
+
+%config InlineBackend.figure_formats = ['svg']
+
+plt.rcParams.update(
+    {
+        "axes.facecolor": "#f8f9fb",
+        "figure.facecolor": "#f8f9fb",
+        "savefig.facecolor": "#f8f9fb",
+        "text.color": "#202124",
+        "axes.labelcolor": "#202124",
+        "axes.edgecolor": "#5f6368",
+        "xtick.color": "#3c4043",
+        "ytick.color": "#3c4043",
+    }
+)
+```
+
+```{code-cell} ipython3
+graph = nx.Graph([(0, 1), (0, 2), (1, 2), (2, 3)])
+positions = {
+    0: (-1.0, 0.75),
+    1: (-1.0, -0.75),
+    2: (0.25, 0.0),
+    3: (1.35, 0.0),
+}
+
+figure, axis = plt.subplots(figsize=(5.5, 3.3))
+nx.draw_networkx(
+    graph,
+    pos=positions,
+    ax=axis,
+    node_color="#4c78a8",
+    edge_color="#5f6368",
+    font_color="white",
+    node_size=850,
+    width=2,
+)
+axis.set_title("Four-node MaxCut instance")
+axis.set_axis_off()
+figure.tight_layout()
+```
+
+PennyLane constructs the cost and mixer Hamiltonians. The ansatz applies
+Hadamard gates followed by one QAOA cost layer and one mixer layer,
+parameterized by $\gamma$ and $\beta$.
+
+```{code-cell} ipython3
+cost_hamiltonian, mixer_hamiltonian = qp.qaoa.maxcut(graph)
+
+
+def ansatz(parameters):
+    for wire in graph.nodes:
+        qp.Hadamard(wire)
+    qp.qaoa.cost_layer(parameters[0], cost_hamiltonian)
+    qp.qaoa.mixer_layer(parameters[1], mixer_hamiltonian)
+
+
+qaoa_device = qp.device("mqt.ddsim.default", wires=4, shots=1000)
+
+
+@qp.qnode(qaoa_device, diff_method="parameter-shift")
+def cost(parameters):
+    ansatz(parameters)
+    return qp.expval(cost_hamiltonian)
+
+
+@qp.qnode(qaoa_device)
+def sample(parameters):
+    ansatz(parameters)
+    return qp.sample(wires=range(4))
+```
+
+The calculation below evaluates the initial parameter-shift gradient and
+performs four gradient-descent updates. Each objective value is an independent
+finite-shot estimate; the resulting sequence is therefore not expected to be
+monotonic.
+
+```{code-cell} ipython3
+parameters = qp.numpy.array([0.5, 0.5], requires_grad=True)
+optimizer = qp.GradientDescentOptimizer(stepsize=0.15)
+jobs_before = qaoa_device.submitted_jobs
+started = time.monotonic()
+
+objective_values = [float(cost(parameters))]
+initial_gradient = np.asarray(qp.grad(cost)(parameters), dtype=float)
+
+for _ in range(4):
+    parameters = optimizer.step(cost, parameters)
+    objective_values.append(float(cost(parameters)))
+
+samples = np.asarray(sample(parameters), dtype=np.int8)
+submitted_jobs = qaoa_device.submitted_jobs - jobs_before
+elapsed = time.monotonic() - started
+
+print(f"Initial gradient: {initial_gradient}")
+print(f"Final parameters: {np.asarray(parameters)}")
+print(f"QDMI jobs submitted: {submitted_jobs}")
+print(f"Elapsed time: {elapsed:.3f} s")
+```
+
+Parameter-shift expands one gradient evaluation into several shifted tapes. Each
+executable tape is submitted as a distinct QDMI job. Jobs are submitted
+sequentially; parallel QDMI submission is not supported.
+
+The sampled bit strings determine candidate bipartitions. The cut value is the
+number of graph edges whose endpoints have different bit values.
+
+```{code-cell} ipython3
+def bitstring(sample_row):
+    return "".join(str(int(bit)) for bit in sample_row)
+
+
+def cut_value(candidate):
+    return sum(
+        candidate[first] != candidate[second] for first, second in graph.edges
+    )
+
+
+sample_counts = Counter(bitstring(row) for row in samples)
+best_bitstring = max(
+    sample_counts,
+    key=lambda candidate: (cut_value(candidate), sample_counts[candidate], candidate),
+)
+best_cut = cut_value(best_bitstring)
+
+print(f"Best sampled partition: {best_bitstring}")
+print(f"Cut edges: {best_cut} of {graph.number_of_edges()}")
+```
+
+The following panels show the noisy objective estimates, the empirical
+bit-string distribution, and the highest-cut partition observed in the final
+sample. Orange edges cross that partition.
+
+```{code-cell} ipython3
+figure, axes = plt.subplots(1, 3, figsize=(14, 3.8))
+
+axes[0].plot(
+    range(len(objective_values)),
+    objective_values,
+    marker="o",
+    color="#4c78a8",
+)
+axes[0].set(
+    xlabel="Optimizer update",
+    ylabel=r"$\langle H_C \rangle$",
+    title="Noisy finite-shot objective estimates",
+    xticks=range(len(objective_values)),
+)
+axes[0].grid(alpha=0.25)
+
+ordered_bitstrings = sorted(sample_counts)
+axes[1].bar(
+    ordered_bitstrings,
+    [sample_counts[candidate] for candidate in ordered_bitstrings],
+    color="#4c78a8",
+)
+axes[1].set(
+    xlabel="Bit string",
+    ylabel="Observed count",
+    title="Final sampled distribution",
+)
+axes[1].tick_params(axis="x", rotation=60)
+
+node_colors = [
+    "#4c78a8" if best_bitstring[node] == "0" else "#e45756"
+    for node in graph.nodes
+]
+edge_colors = [
+    "#f28e2b"
+    if best_bitstring[first] != best_bitstring[second]
+    else "#9aa0a6"
+    for first, second in graph.edges
+]
+edge_widths = [
+    3.2 if best_bitstring[first] != best_bitstring[second] else 1.5
+    for first, second in graph.edges
+]
+nx.draw_networkx(
+    graph,
+    pos=positions,
+    ax=axes[2],
+    node_color=node_colors,
+    edge_color=edge_colors,
+    width=edge_widths,
+    font_color="white",
+    node_size=850,
+)
+axes[2].set_title(f"Best sampled cut: {best_cut} edges")
+axes[2].set_axis_off()
+
+figure.tight_layout()
+```
+
+## Direct generic construction
+
+Stable entry points such as `mqt.ddsim.default` provide the simplest
+construction. A device integration package can register a
+{py:class}`~mqt.core.plugins.pennylane.device.QDMIDevice` subclass under the
+stable ID of another QDMI device. Applications may also construct the generic
+class directly:
+
+```python
+import pennylane as qp
+
+from mqt.core.plugins.pennylane import QDMIDevice
+
+device_id = "stable ID returned by the QDMI device registration"
+device = QDMIDevice(
+    device_id=device_id,
+    wires=["a", "b", "c", "d"],
+    shots=[(100, 2), 500],
+    session_parameters={
+        "base_url": "device endpoint or selector",
+        "token": "...",
+    },
+    job_parameters={
+        "custom1": "device-specific job value",
+    },
+)
+```
+
+Arbitrary PennyLane wire labels map deterministically to contiguous QASM
+indices. The converter validates the one- and two-qubit loci advertised through
+QDMI but does not route circuits. A topology-incompatible program therefore
+fails before submission. Shot vectors, batches, and parameter-shift tapes are
+executed in order, and every execution requires finite shots.
+
+## Supported gate-level scope
+
+The OpenQASM 3 path covers identity and Pauli gates; H, S, T, SX and supported
+adjoints; RX, RY, RZ, and phase shift; controlled Pauli and phase gates;
+Toffoli, SWAP, and CSWAP; ISWAP, PSWAP, and ECR; and Ising XX, XY, YY, and ZZ
+rotations. PennyLane decomposes higher-level operations when their
+decompositions reach operations advertised by the QDMI device.
+
+The interface does not implement pulse programming, device-specific non-gate
+properties, routing, analytic execution, or parallel job submission.

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -1926,7 +1926,7 @@ public:
   template <class Node, class Edge = Edge<Node>,
             std::size_t N = std::tuple_size_v<decltype(Node::e)>>
   Edge deserialize(std::istream& is, const bool readBinary = false) {
-    auto result = CachedEdge<Node>{};
+    auto result = CachedEdge<Node>::one();
     ComplexValue rootweight{};
 
     std::unordered_map<std::int64_t, Node*> nodes{};

--- a/include/mqt-core/qdmi/driver/Driver.hpp
+++ b/include/mqt-core/qdmi/driver/Driver.hpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 namespace fomac {
@@ -31,6 +32,20 @@ class Session;
 }
 
 namespace qdmi {
+
+/// Inline JSON used to configure one QDMI device session.
+struct InlineDeviceConfiguration {
+  std::string json;
+};
+
+/// JSON file used to configure one QDMI device session.
+struct FileDeviceConfiguration {
+  std::filesystem::path path;
+};
+
+/// One replaceable source for a runtime device description.
+using DeviceConfigurationSource =
+    std::variant<InlineDeviceConfiguration, FileDeviceConfiguration>;
 
 /**
  * @brief Configuration for device session parameters.
@@ -50,6 +65,8 @@ struct DeviceSessionConfig {
   std::optional<std::string> username;
   /// Password for authentication
   std::optional<std::string> password;
+  /// Typed runtime device-description source.
+  std::optional<DeviceConfigurationSource> deviceConfiguration;
   /// Custom configuration parameter 1
   std::optional<std::string> custom1;
   /// Custom configuration parameter 2

--- a/include/mqt-core/qdmi/driver/Driver.hpp
+++ b/include/mqt-core/qdmi/driver/Driver.hpp
@@ -501,6 +501,14 @@ public:
   auto registerDeviceIfAbsent(DeviceDefinition definition) -> bool;
 
   /**
+   * @brief Lists the stable IDs of all registered devices.
+   * @returns The enabled device IDs in deterministic registration order.
+   * @details This query includes runtime registrations and does not load device
+   * libraries or expose their definitions.
+   */
+  [[nodiscard]] auto registeredDeviceIds() const -> std::vector<std::string>;
+
+  /**
    * @brief Opens the registered device with the given stable ID.
    * @returns The existing device handle when the ID is already open.
    * @throws std::out_of_range If the ID is unknown.

--- a/include/mqt-core/zx/FunctionalityConstruction.hpp
+++ b/include/mqt-core/zx/FunctionalityConstruction.hpp
@@ -143,6 +143,11 @@ protected:
   static void addMcrz(ZXDiagram& diag, const PiExpression& phase,
                       std::vector<Qubit> controls, Qubit target,
                       std::vector<Vertex>& qubits);
+  static void addMcxWithDirtyAncillas(ZXDiagram& diag,
+                                      const std::vector<Qubit>& controls,
+                                      Qubit target,
+                                      const std::vector<Qubit>& ancillas,
+                                      std::vector<Vertex>& qubits);
   static void addMcx(ZXDiagram& diag, std::vector<Qubit> controls, Qubit target,
                      std::vector<Vertex>& qubits);
   static void addMcz(ZXDiagram& diag, const std::vector<Qubit>& controls,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,15 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 
 [project.optional-dependencies]
+pennylane = [
+  "pennylane>=0.45.1,<0.46; python_version >= '3.11'",
+]
 qiskit = [
   "qiskit[qasm3-import]>=1.1.0",
 ]
+
+[project.entry-points."pennylane.plugins"]
+"mqt.ddsim.default" = "mqt.core.plugins.pennylane:DDSIMDevice"
 
 [project.scripts]
 mqt-core-cli = "mqt.core.__main__:main"
@@ -165,6 +171,8 @@ filterwarnings = [
   "error",
   'ignore:\s.*Pyarrow.*:DeprecationWarning:',
   'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
+  # Autograd 1.8 uses control flow that Python 3.14 reports while compiling the module.
+  "ignore:'return' in a 'finally' block:SyntaxWarning",
   # Qiskit 1.2 deprecations
   'ignore:.*no need for these schema-conformant objects.*:DeprecationWarning:',
   # Qiskit 1.3 deprecations
@@ -257,6 +265,7 @@ default.extend-ignore-re = [
 [tool.typos.default.extend-words]
 wille = "wille"
 anc = "anc"
+braket = "braket"
 mch = "mch"
 ket = "ket"
 optin = "optin"
@@ -339,6 +348,7 @@ docs = [
   "qiskit[qasm3-import,visualization]>=1.1.0",
   "openqasm-pygments>=0.2.0",
   "breathe>=4.36.0",
+  "pennylane>=0.45.1,<0.46; python_version >= '3.11'",
   "graphviz>=0.21.0",
   "sphinx>=8.1.3",
   "sphinx>=8.2.3; python_version >= '3.11'",
@@ -350,6 +360,7 @@ test = [
   "pytest-cov>=7.1.0",
   "pytest-sugar>=1.1.1",
   "pytest-xdist>=3.8.0",
+  "pennylane>=0.45.1,<0.46; python_version >= '3.11'",
   "qiskit[qasm3-import]>=1.1.0",
   "numpy>=2.1; python_version >= '3.13'",
   "numpy>=2.3.2; python_version >= '3.14'",

--- a/python/mqt/core/dd.pyi
+++ b/python/mqt/core/dd.pyi
@@ -59,6 +59,37 @@ class VectorDD:
             MemoryError: If the memory allocation fails.
         """
 
+    def to_bytes(self, binary: bool = True) -> bytes:
+        """Serialize the DD to bytes.
+
+        Args:
+            binary: Whether to use the binary serialization format. Defaults to True.
+                If False, the textual serialization format is used.
+
+        Returns:
+            The serialized DD.
+
+        Notes:
+            The binary format is not portable across different architectures or platforms.
+        """
+
+    @staticmethod
+    def from_bytes(dd_package: DDPackage, data: bytes, binary: bool = True) -> VectorDD:
+        """Deserialize a DD from bytes.
+
+        Args:
+            dd_package: The DD package that owns the deserialized DD.
+            data: The serialized DD.
+            binary: Whether the data uses the binary serialization format. Defaults to True.
+                If False, the textual serialization format is expected.
+
+        Returns:
+            The deserialized DD.
+
+        Notes:
+            The binary format is not portable across different architectures or platforms.
+        """
+
     def to_dot(
         self,
         colored: bool = True,
@@ -153,6 +184,37 @@ class MatrixDD:
 
         Raises:
             MemoryError: If the memory allocation fails.
+        """
+
+    def to_bytes(self, binary: bool = True) -> bytes:
+        """Serialize the DD to bytes.
+
+        Args:
+            binary: Whether to use the binary serialization format. Defaults to True.
+                If False, the textual serialization format is used.
+
+        Returns:
+            The serialized DD.
+
+        Notes:
+            The binary format is not portable across different architectures or platforms.
+        """
+
+    @staticmethod
+    def from_bytes(dd_package: DDPackage, data: bytes, binary: bool = True) -> MatrixDD:
+        """Deserialize a DD from bytes.
+
+        Args:
+            dd_package: The DD package that owns the deserialized DD.
+            data: The serialized DD.
+            binary: Whether the data uses the binary serialization format. Defaults to True.
+                If False, the textual serialization format is expected.
+
+        Returns:
+            The deserialized DD.
+
+        Notes:
+            The binary format is not portable across different architectures or platforms.
         """
 
     def to_dot(

--- a/python/mqt/core/fomac.pyi
+++ b/python/mqt/core/fomac.pyi
@@ -550,6 +550,8 @@ class DeviceDefinition:
         auth_url: str | None = None,
         username: str | None = None,
         password: str | None = None,
+        device_config: str | None = None,
+        device_config_file: str | os.PathLike | None = None,
         custom1: str | None = None,
         custom2: str | None = None,
         custom3: str | None = None,
@@ -568,6 +570,8 @@ class DeviceDefinition:
             auth_url: Optional authentication server URL.
             username: Optional authentication username.
             password: Optional authentication password.
+            device_config: Optional inline JSON device description.
+            device_config_file: Optional device-description JSON file.
             custom1: Optional custom configuration parameter 1.
             custom2: Optional custom configuration parameter 2.
             custom3: Optional custom configuration parameter 3.
@@ -624,6 +628,8 @@ def open_device(
     auth_url: str | None = None,
     username: str | None = None,
     password: str | None = None,
+    device_config: str | None = None,
+    device_config_file: str | os.PathLike | None = None,
     custom1: str | None = None,
     custom2: str | None = None,
     custom3: str | None = None,
@@ -643,6 +649,8 @@ def open_device(
         auth_url: Optional authentication server URL override.
         username: Optional authentication username override.
         password: Optional authentication password override.
+        device_config: Optional inline JSON device-description override.
+        device_config_file: Optional device-description JSON file override.
         custom1: Optional custom configuration parameter 1 override.
         custom2: Optional custom configuration parameter 2 override.
         custom3: Optional custom configuration parameter 3 override.

--- a/python/mqt/core/fomac.pyi
+++ b/python/mqt/core/fomac.pyi
@@ -619,6 +619,13 @@ def register_device_if_absent(definition: DeviceDefinition) -> bool:
         ValueError: If the definition is invalid.
     """
 
+def registered_device_ids() -> list[str]:
+    """Return registered, enabled QDMI device IDs in registration order.
+
+    This includes devices registered at runtime and does not load native device
+    libraries or expose their definitions.
+    """
+
 def open_device(
     device_id: str,
     *,

--- a/python/mqt/core/plugins/pennylane/__init__.py
+++ b/python/mqt/core/plugins/pennylane/__init__.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""PennyLane interface for gate-based QDMI devices."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from ..._compat.optional import OptionalDependencyTester
+
+HAS_PENNYLANE = OptionalDependencyTester(  # ruff:ignore[non-empty-init-module] Optional plugin
+    "pennylane",
+    install_msg="Install with 'uv pip install mqt-core[pennylane]'",
+)
+
+__all__ = ["HAS_PENNYLANE"]
+
+if TYPE_CHECKING or (  # ruff:ignore[non-empty-init-module] Optional plugin
+    sys.version_info >= (3, 11) and HAS_PENNYLANE
+):
+    from .converter import ConvertedProgram, convert_program
+    from .device import DDSIMDevice, QDMIDevice
+    from .exceptions import (
+        PennyLaneConfigurationError,
+        PennyLaneExecutionError,
+        PennyLaneTranslationError,
+        PennyLaneUnsupportedFormatError,
+        PennyLaneUnsupportedOperationError,
+        PennyLaneValidationError,
+        QDMIPluginError,
+    )
+
+    __all__ += [
+        "ConvertedProgram",
+        "DDSIMDevice",
+        "PennyLaneConfigurationError",
+        "PennyLaneExecutionError",
+        "PennyLaneTranslationError",
+        "PennyLaneUnsupportedFormatError",
+        "PennyLaneUnsupportedOperationError",
+        "PennyLaneValidationError",
+        "QDMIDevice",
+        "QDMIPluginError",
+        "convert_program",
+    ]

--- a/python/mqt/core/plugins/pennylane/converter.py
+++ b/python/mqt/core/plugins/pennylane/converter.py
@@ -1,0 +1,415 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Convert preprocessed PennyLane programs to QDMI program formats."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+import pennylane as qp
+
+from mqt.core import fomac
+
+from .exceptions import (
+    PennyLaneTranslationError as TranslationError,
+)
+from .exceptions import (
+    PennyLaneUnsupportedFormatError as UnsupportedFormatError,
+)
+from .exceptions import (
+    PennyLaneUnsupportedOperationError as UnsupportedOperationError,
+)
+from .exceptions import (
+    PennyLaneValidationError as ValidationError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable, Mapping
+
+    from pennylane.operation import Operator
+    from pennylane.tape import QuantumScript
+    from pennylane.wires import Wires
+
+__all__ = ["ConvertedProgram", "convert_program", "supports_operation"]
+
+
+@dataclass(frozen=True)
+class ConvertedProgram:
+    """A QDMI payload plus the information required to decode its measurements."""
+
+    payload: str
+    program_format: fomac.ProgramFormat
+    wire_map: Mapping[Hashable, int]
+    measurement_order: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _OperationSpec:
+    aliases: tuple[str, ...]
+    wires: int
+    parameters: int
+
+
+_QASM3_OPERATIONS: Mapping[str, _OperationSpec] = MappingProxyType({
+    "Identity": _OperationSpec(("i", "id"), 1, 0),
+    "PauliX": _OperationSpec(("x",), 1, 0),
+    "PauliY": _OperationSpec(("y",), 1, 0),
+    "PauliZ": _OperationSpec(("z",), 1, 0),
+    "Hadamard": _OperationSpec(("h",), 1, 0),
+    "S": _OperationSpec(("s",), 1, 0),
+    "Adjoint(S)": _OperationSpec(("sdg", "si"), 1, 0),
+    "T": _OperationSpec(("t",), 1, 0),
+    "Adjoint(T)": _OperationSpec(("tdg", "ti"), 1, 0),
+    "SX": _OperationSpec(("sx", "v"), 1, 0),
+    "Adjoint(SX)": _OperationSpec(("sxdg", "vi"), 1, 0),
+    "RX": _OperationSpec(("rx",), 1, 1),
+    "RY": _OperationSpec(("ry",), 1, 1),
+    "RZ": _OperationSpec(("rz",), 1, 1),
+    "PhaseShift": _OperationSpec(("p", "phaseshift"), 1, 1),
+    "CNOT": _OperationSpec(("cx", "cnot"), 2, 0),
+    "CY": _OperationSpec(("cy",), 2, 0),
+    "CZ": _OperationSpec(("cz",), 2, 0),
+    "ControlledPhaseShift": _OperationSpec(("cp", "cphaseshift"), 2, 1),
+    "CPhaseShift00": _OperationSpec(("cphaseshift00",), 2, 1),
+    "CPhaseShift01": _OperationSpec(("cphaseshift01",), 2, 1),
+    "CPhaseShift10": _OperationSpec(("cphaseshift10",), 2, 1),
+    "Toffoli": _OperationSpec(("ccx", "ccnot"), 3, 0),
+    "SWAP": _OperationSpec(("swap",), 2, 0),
+    "CSWAP": _OperationSpec(("cswap",), 3, 0),
+    "ISWAP": _OperationSpec(("iswap",), 2, 0),
+    "PSWAP": _OperationSpec(("pswap",), 2, 1),
+    "ECR": _OperationSpec(("ecr",), 2, 0),
+    "IsingXX": _OperationSpec(("rxx", "xx"), 2, 1),
+    "IsingXY": _OperationSpec(("rxy", "xy"), 2, 1),
+    "IsingYY": _OperationSpec(("ryy", "yy"), 2, 1),
+    "IsingZZ": _OperationSpec(("rzz", "zz"), 2, 1),
+})
+
+# PennyLane's OpenQASM 2 serializer emits these exact qelib1 gate names.
+_QASM2_OPERATIONS: Mapping[str, str] = MappingProxyType({
+    "CNOT": "cx",
+    "CZ": "cz",
+    "U3": "u3",
+    "U2": "u2",
+    "U1": "u1",
+    "Identity": "id",
+    "PauliX": "x",
+    "PauliY": "y",
+    "PauliZ": "z",
+    "Hadamard": "h",
+    "S": "s",
+    "Adjoint(S)": "sdg",
+    "T": "t",
+    "Adjoint(T)": "tdg",
+    "RX": "rx",
+    "RY": "ry",
+    "RZ": "rz",
+    "CRX": "crx",
+    "CRY": "cry",
+    "CRZ": "crz",
+    "SWAP": "swap",
+    "Toffoli": "ccx",
+    "CSWAP": "cswap",
+    "PhaseShift": "u1",
+})
+
+
+def _device_operations(device: fomac.Device) -> dict[str, fomac.Device.Operation]:
+    """Return advertised operations keyed by their lower-case spelling."""
+    return {operation.name().lower(): operation for operation in device.operations()}
+
+
+def _preferred_format(device: fomac.Device) -> fomac.ProgramFormat:
+    """Choose the required QASM3-first exchange format.
+
+    Returns:
+        The selected QDMI program format.
+
+    Raises:
+        PennyLaneUnsupportedFormatError: If neither OpenQASM version is advertised.
+    """
+    formats = set(device.supported_program_formats())
+    if fomac.ProgramFormat.QASM3 in formats:
+        return fomac.ProgramFormat.QASM3
+    if fomac.ProgramFormat.QASM2 in formats:
+        return fomac.ProgramFormat.QASM2
+    msg = f"QDMI device '{device.name()}' supports none of the required program formats: OpenQASM 3 or OpenQASM 2."
+    raise UnsupportedFormatError(msg)
+
+
+def _resolve_qasm3_operation(
+    operation: Operator, advertised: Mapping[str, fomac.Device.Operation]
+) -> tuple[str, _OperationSpec, fomac.Device.Operation] | None:
+    """Resolve a PennyLane operation to one advertised QDMI spelling.
+
+    Returns:
+        The spelling, operation specification, and QDMI operation, or ``None``.
+    """
+    spec = _QASM3_OPERATIONS.get(operation.name)
+    if spec is None:
+        return None
+    for alias in spec.aliases:
+        if alias in advertised:
+            return alias, spec, advertised[alias]
+    return None
+
+
+def supports_operation(operation: Operator, device: fomac.Device, program_format: fomac.ProgramFormat) -> bool:
+    """Return whether an operation can stop PennyLane decomposition.
+
+    For OpenQASM 3, support requires an operation-table entry and one matching
+    semantic spelling advertised by QDMI. For OpenQASM 2, support additionally
+    requires the exact gate spelling produced by PennyLane's serializer.
+    """
+    advertised = _device_operations(device)
+    if program_format == fomac.ProgramFormat.QASM3:
+        return _resolve_qasm3_operation(operation, advertised) is not None
+    if program_format == fomac.ProgramFormat.QASM2:
+        spelling = _QASM2_OPERATIONS.get(operation.name)
+        return spelling is not None and spelling in advertised
+    return False
+
+
+def _wire_mapping(device_wires: Wires) -> Mapping[Hashable, int]:
+    """Build an immutable, deterministic wire-label mapping.
+
+    Returns:
+        The mapping from wire labels to contiguous QASM indices.
+    """
+    return MappingProxyType({wire: index for index, wire in enumerate(device_wires)})
+
+
+def _measurement_order(tape: QuantumScript, wire_map: Mapping[Hashable, int]) -> tuple[int, ...]:
+    """Return sample columns in the order requested by the transformed tape."""
+    if not tape.measurements:
+        return tuple(wire_map.values())
+    measured_wires = tape.measurements[0].wires
+    if len(measured_wires) == 0:
+        return tuple(wire_map.values())
+    return tuple(wire_map[wire] for wire in measured_wires)
+
+
+def _finite_parameter(parameter: object, operation_name: str) -> float:
+    """Convert one bound scalar parameter to a finite Python float.
+
+    Returns:
+        The finite scalar parameter.
+
+    Raises:
+        PennyLaneValidationError: If the value is unbound, non-scalar, or non-finite.
+    """
+    try:
+        value = float(qp.math.toarray(parameter))
+    except (TypeError, ValueError) as exc:
+        msg = f"Operation '{operation_name}' has an unbound or non-scalar parameter: {parameter!r}."
+        raise ValidationError(msg) from exc
+    if not math.isfinite(value):
+        msg = f"Operation '{operation_name}' has a non-finite parameter: {value!r}."
+        raise ValidationError(msg)
+    return value
+
+
+def _format_parameter(parameter: object, operation_name: str) -> str:
+    """Format one QASM parameter without losing double precision.
+
+    Returns:
+        The OpenQASM numeric literal.
+    """
+    return format(_finite_parameter(parameter, operation_name), ".17g")
+
+
+def _validate_operation_shape(operation: Operator, spec: _OperationSpec) -> None:
+    """Validate the operation-table arity and parameter contract.
+
+    Raises:
+        PennyLaneValidationError: If the operation does not match its typed table row.
+    """
+    if len(operation.wires) != spec.wires:
+        msg = f"Operation '{operation.name}' requires {spec.wires} wires, but received {len(operation.wires)}."
+        raise ValidationError(msg)
+    if len(set(operation.wires)) != len(operation.wires):
+        msg = f"Operation '{operation.name}' uses the same wire more than once."
+        raise ValidationError(msg)
+    if len(operation.parameters) != spec.parameters:
+        msg = (
+            f"Operation '{operation.name}' requires {spec.parameters} parameters, "
+            f"but received {len(operation.parameters)}."
+        )
+        raise ValidationError(msg)
+
+
+def _validate_qdmi_contract(
+    operation: Operator,
+    spec: _OperationSpec,
+    qdmi_operation: fomac.Device.Operation,
+    indices: tuple[int, ...],
+    device: fomac.Device,
+) -> None:
+    """Validate operation metadata and any loci advertised by QDMI.
+
+    Raises:
+        PennyLaneValidationError: If arity, parameters, or topology do not match.
+    """
+    qdmi_wires = qdmi_operation.qubits_num()
+    if qdmi_wires is not None and qdmi_wires != spec.wires:
+        msg = (
+            f"QDMI operation '{qdmi_operation.name()}' advertises {qdmi_wires} wires, "
+            f"but '{operation.name}' requires {spec.wires}."
+        )
+        raise ValidationError(msg)
+    if qdmi_operation.parameters_num() != spec.parameters:
+        msg = (
+            f"QDMI operation '{qdmi_operation.name()}' advertises "
+            f"{qdmi_operation.parameters_num()} parameters, but '{operation.name}' "
+            f"requires {spec.parameters}."
+        )
+        raise ValidationError(msg)
+
+    if spec.wires == 1:
+        sites = qdmi_operation.sites()
+        if sites is not None and indices[0] not in {site.index() for site in sites}:
+            msg = f"Operation '{operation.name}' is not advertised on device wire {indices[0]}."
+            raise ValidationError(msg)
+        return
+
+    if spec.wires != 2:
+        return
+
+    site_pairs = qdmi_operation.site_pairs()
+    if site_pairs is not None:
+        advertised_pairs = {(first.index(), second.index()) for first, second in site_pairs}
+        if indices not in advertised_pairs:
+            msg = f"Operation '{operation.name}' is not advertised on device wires {indices}."
+            raise ValidationError(msg)
+        return
+
+    coupling_map = device.coupling_map()
+    if coupling_map is None:
+        return
+    edges = {(first.index(), second.index()) for first, second in coupling_map}
+    if indices not in edges and tuple(reversed(indices)) not in edges:
+        msg = f"Device topology does not connect wires {indices} for operation '{operation.name}'."
+        raise ValidationError(msg)
+
+
+def _convert_qasm3(
+    tape: QuantumScript,
+    device: fomac.Device,
+    device_wires: Wires,
+) -> ConvertedProgram:
+    """Emit a minimal capability-driven OpenQASM 3 program.
+
+    Returns:
+        The converted QDMI program.
+
+    Raises:
+        PennyLaneUnsupportedOperationError: If no advertised spelling exists.
+        PennyLaneValidationError: If parameters, wires, or topology are invalid.
+    """
+    wire_map = _wire_mapping(device_wires)
+    advertised = _device_operations(device)
+    lines = [
+        "OPENQASM 3.0;",
+        f"qubit[{len(device_wires)}] q;",
+        f"bit[{len(device_wires)}] c;",
+    ]
+
+    for operation in tape.operations:
+        resolved = _resolve_qasm3_operation(operation, advertised)
+        if resolved is None:
+            msg = f"Operation '{operation.name}' has no supported OpenQASM 3 spelling on QDMI device '{device.name()}'."
+            raise UnsupportedOperationError(msg)
+        spelling, spec, qdmi_operation = resolved
+        _validate_operation_shape(operation, spec)
+        try:
+            indices = tuple(wire_map[wire] for wire in operation.wires)
+        except KeyError as exc:
+            msg = f"Operation '{operation.name}' uses wire {exc.args[0]!r}, which is not a device wire."
+            raise ValidationError(msg) from exc
+        _validate_qdmi_contract(operation, spec, qdmi_operation, indices, device)
+
+        parameters = ",".join(_format_parameter(parameter, operation.name) for parameter in operation.parameters)
+        parameter_list = f"({parameters})" if parameters else ""
+        operands = ",".join(f"q[{index}]" for index in indices)
+        lines.append(f"{spelling}{parameter_list} {operands};")
+
+    lines.append("c = measure q;")
+    payload = "\n".join(lines) + "\n"
+    return ConvertedProgram(
+        payload=payload,
+        program_format=fomac.ProgramFormat.QASM3,
+        wire_map=wire_map,
+        measurement_order=_measurement_order(tape, wire_map),
+    )
+
+
+def _convert_qasm2(
+    tape: QuantumScript,
+    device: fomac.Device,
+    device_wires: Wires,
+) -> ConvertedProgram:
+    """Serialize a QASM2-only program with PennyLane's built-in converter.
+
+    Returns:
+        The converted QDMI program.
+
+    Raises:
+        PennyLaneUnsupportedOperationError: If the serializer/device intersection is empty.
+        PennyLaneTranslationError: If PennyLane cannot serialize the program.
+    """
+    advertised = _device_operations(device)
+    for operation in tape.operations:
+        spelling = _QASM2_OPERATIONS.get(operation.name)
+        if spelling is None or spelling not in advertised:
+            msg = (
+                f"Operation '{operation.name}' cannot be serialized to an "
+                f"OpenQASM 2 gate advertised by QDMI device '{device.name()}'."
+            )
+            raise UnsupportedOperationError(msg)
+
+    try:
+        payload = qp.to_openqasm(
+            tape,
+            wires=device_wires,
+            rotations=False,
+            measure_all=True,
+        )
+    except Exception as exc:
+        msg = f"Failed to translate the PennyLane program to OpenQASM 2: {exc}"
+        raise TranslationError(msg) from exc
+
+    wire_map = _wire_mapping(device_wires)
+    return ConvertedProgram(
+        payload=payload,
+        program_format=fomac.ProgramFormat.QASM2,
+        wire_map=wire_map,
+        measurement_order=_measurement_order(tape, wire_map),
+    )
+
+
+def convert_program(
+    tape: QuantumScript,
+    device: fomac.Device,
+    device_wires: Wires,
+) -> ConvertedProgram:
+    """Convert one preprocessed tape using QASM3-first negotiation.
+
+    A QASM3 translation error is never retried as QASM2. QASM2 is selected
+    only if QASM3 is not advertised at all.
+
+    Returns:
+        The converted program and its deterministic measurement metadata.
+    """
+    program_format = _preferred_format(device)
+    if program_format == fomac.ProgramFormat.QASM3:
+        return _convert_qasm3(tape, device, device_wires)
+    return _convert_qasm2(tape, device, device_wires)

--- a/python/mqt/core/plugins/pennylane/device.py
+++ b/python/mqt/core/plugins/pennylane/device.py
@@ -1,0 +1,388 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""A modern PennyLane device backed by a gate-based QDMI device."""
+
+from __future__ import annotations
+
+import operator
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+import pennylane as qp
+from pennylane.devices import Device, ExecutionConfig
+from pennylane.devices.preprocess import (
+    decompose,
+    measurements_from_samples,
+    validate_device_wires,
+    validate_measurements,
+)
+from pennylane.measurements import CountsMP, ExpectationMP, ProbabilityMP, SampleMP, Shots, VarianceMP
+from pennylane.transforms import broadcast_expand, defer_measurements, split_non_commuting
+from pennylane.transforms.core import CompilePipeline
+
+from mqt.core import fomac
+
+from .converter import ConvertedProgram, convert_program, supports_operation
+from .exceptions import (
+    PennyLaneConfigurationError as ConfigurationError,
+)
+from .exceptions import (
+    PennyLaneExecutionError as ExecutionError,
+)
+from .exceptions import (
+    PennyLaneUnsupportedFormatError as UnsupportedFormatError,
+)
+from .exceptions import (
+    PennyLaneUnsupportedOperationError as UnsupportedOperationError,
+)
+from .exceptions import (
+    PennyLaneValidationError as ValidationError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable, Mapping, Sequence
+
+    from pennylane.tape import QuantumScript, QuantumScriptOrBatch
+    from pennylane.typing import Result, ResultBatch
+
+__all__ = ["DDSIMDevice", "QDMIDevice"]
+
+_SESSION_PARAMETERS = frozenset({
+    "base_url",
+    "token",
+    "auth_file",
+    "auth_url",
+    "username",
+    "password",
+    "device_config",
+    "device_config_file",
+    "custom1",
+    "custom2",
+    "custom3",
+    "custom4",
+    "custom5",
+})
+_JOB_PARAMETERS = frozenset({"custom1", "custom2", "custom3", "custom4", "custom5"})
+_SAMPLED_MEASUREMENTS = (SampleMP, CountsMP, ProbabilityMP, ExpectationMP, VarianceMP)
+
+
+def _validate_parameter_names(parameters: Mapping[str, object], allowed: frozenset[str], kind: str) -> None:
+    """Reject unknown FoMaC configuration fields before opening or submission.
+
+    Raises:
+        PennyLaneConfigurationError: If an unknown parameter name is present.
+    """
+    unknown = sorted(set(parameters) - allowed)
+    if unknown:
+        msg = f"Unknown QDMI {kind} parameter(s): {', '.join(unknown)}."
+        raise ConfigurationError(msg)
+
+
+@qp.transform
+def _validate_finite_shots(tape: QuantumScript) -> tuple[tuple[QuantumScript], Any]:
+    """Reject analytic execution before program conversion or submission.
+
+    Returns:
+        The unchanged finite-shot tape and its scalar postprocessor.
+
+    Raises:
+        PennyLaneValidationError: If the tape requests analytic execution.
+    """
+    if not tape.shots:
+        msg = "QDMI devices require a finite number of shots."
+        raise ValidationError(msg)
+    return (tape,), operator.itemgetter(0)
+
+
+class QDMIDevice(Device):
+    """Execute PennyLane programs on a gate-based QDMI device.
+
+    Args:
+        device_id: Stable ID from the QDMI device registry.
+        wires: PennyLane wire labels or number of wires. By default all QDMI
+            qubits are exposed as consecutive integer wires.
+        shots: Finite default shot configuration.
+        session_parameters: FoMaC device-session keyword arguments.
+        job_parameters: FoMaC custom job keyword arguments.
+    """
+
+    def __init__(
+        self,
+        device_id: str,
+        wires: int | Sequence[Hashable] | None = None,
+        shots: int | Sequence[int | tuple[int, int]] | Shots | None = 1024,
+        *,
+        session_parameters: Mapping[str, Any] | None = None,
+        job_parameters: Mapping[str, str | bool | float | None] | None = None,
+    ) -> None:
+        """Initialize and open a fresh QDMI device session.
+
+        Raises:
+            PennyLaneConfigurationError: If configuration or requested wires are invalid.
+        """
+        self._device_id = device_id
+        self._session_parameters = dict(session_parameters or {})
+        self._job_parameters = dict(job_parameters or {})
+        _validate_parameter_names(self._session_parameters, _SESSION_PARAMETERS, "session")
+        _validate_parameter_names(self._job_parameters, _JOB_PARAMETERS, "job")
+
+        try:
+            self._qdmi_device = fomac.open_device(device_id, **self._session_parameters)
+        except (IndexError, RuntimeError, ValueError) as exc:
+            msg = f"Failed to open QDMI device '{device_id}': {exc}"
+            raise ConfigurationError(msg) from exc
+
+        num_qubits = self._qdmi_device.qubits_num()
+        resolved_wires: int | Sequence[Hashable] = num_qubits if wires is None else wires
+        requested_wires = resolved_wires if isinstance(resolved_wires, int) else len(resolved_wires)
+        if requested_wires <= 0:
+            msg = "A QDMI PennyLane device requires at least one wire."
+            raise ConfigurationError(msg)
+        if requested_wires > num_qubits:
+            msg = f"QDMI device '{device_id}' exposes {num_qubits} qubits, but {requested_wires} wires were requested."
+            raise ConfigurationError(msg)
+
+        # PennyLane deprecates passing device-level shots to Device.__init__,
+        # but still reads Device.shots as the default. Set the validated value
+        # after initializing the base class to preserve the finite default
+        # without emitting a deprecation warning for every plugin instance.
+        super().__init__(wires=resolved_wires, shots=None)
+        self._shots = Shots(shots)
+        self._program_format = self._select_program_format()
+        self._submitted_jobs = 0
+        self._execution_time = 0.0
+
+    @property
+    def device_id(self) -> str:
+        """Stable QDMI device ID."""
+        return self._device_id
+
+    @property
+    def qdmi_device(self) -> fomac.Device:
+        """Opened FoMaC device used for execution."""
+        return self._qdmi_device
+
+    @property
+    def submitted_jobs(self) -> int:
+        """Number of QDMI jobs submitted by this instance."""
+        return self._submitted_jobs
+
+    @property
+    def execution_time(self) -> float:
+        """Cumulative wall-clock time spent submitting and waiting for QDMI jobs."""
+        return self._execution_time
+
+    def _select_program_format(self) -> fomac.ProgramFormat:
+        """Select QASM3 before QASM2 and reject all other format sets.
+
+        Returns:
+            The selected QDMI program format.
+
+        Raises:
+            PennyLaneUnsupportedFormatError: If neither OpenQASM version is advertised.
+        """
+        formats = set(self._qdmi_device.supported_program_formats())
+        if fomac.ProgramFormat.QASM3 in formats:
+            return fomac.ProgramFormat.QASM3
+        if fomac.ProgramFormat.QASM2 in formats:
+            return fomac.ProgramFormat.QASM2
+        msg = f"QDMI device '{self._device_id}' advertises neither OpenQASM 3 nor OpenQASM 2."
+        raise UnsupportedFormatError(msg)
+
+    def preprocess_transforms(self, execution_config: ExecutionConfig | None = None) -> CompilePipeline:
+        """Build the PennyLane preprocessing pipeline for sampled QDMI execution.
+
+        Returns:
+            The transforms applied before device execution.
+        """
+        del execution_config
+        pipeline = CompilePipeline()
+        pipeline.add_transform(_validate_finite_shots)
+        pipeline.add_transform(defer_measurements, allow_postselect=False, num_wires=len(self.wires))
+        pipeline.add_transform(validate_device_wires, self.wires, name=self.name)
+        pipeline.add_transform(
+            validate_measurements,
+            analytic_measurements=lambda _measurement: False,
+            sample_measurements=lambda measurement: isinstance(measurement, _SAMPLED_MEASUREMENTS),
+            name=self.name,
+        )
+        pipeline.add_transform(split_non_commuting, grouping_strategy="qwc")
+        pipeline.add_transform(measurements_from_samples)
+        pipeline.add_transform(
+            decompose,
+            stopping_condition=lambda operation: supports_operation(operation, self._qdmi_device, self._program_format),
+            stopping_condition_shots=lambda operation: supports_operation(
+                operation, self._qdmi_device, self._program_format
+            ),
+            skip_initial_state_prep=False,
+            device_wires=self.wires,
+            name=self.name,
+            error=UnsupportedOperationError,
+        )
+        pipeline.add_transform(broadcast_expand)
+        return pipeline
+
+    @staticmethod
+    def _shot_copies(shots: Shots) -> tuple[int, ...]:
+        """Expand a PennyLane shot vector into sequential QDMI job sizes.
+
+        Returns:
+            One positive shot count per required QDMI job.
+
+        Raises:
+            PennyLaneValidationError: If execution is analytic.
+        """
+        if not shots:
+            msg = "QDMI devices require a finite number of shots."
+            raise ValidationError(msg)
+        return tuple(shot_copy.shots for shot_copy in shots.shot_vector for _ in range(shot_copy.copies))
+
+    @staticmethod
+    def _shots_or_counts(job: fomac.Job) -> list[str]:
+        """Read ordered shots, falling back to an equivalent expansion of counts.
+
+        Returns:
+            One QDMI bit string per shot.
+
+        Raises:
+            PennyLaneExecutionError: If the job exposes neither result representation.
+        """
+        try:
+            shots = job.get_shots()
+        except RuntimeError:
+            shots = []
+        if shots:
+            return shots
+
+        try:
+            counts = job.get_counts()
+        except RuntimeError as exc:
+            msg = "The QDMI job exposes neither raw shots nor measurement counts."
+            raise ExecutionError(msg) from exc
+        return [bitstring for bitstring, count in sorted(counts.items()) for _ in range(count)]
+
+    def _samples(self, job: fomac.Job, converted: ConvertedProgram, shots: int) -> np.ndarray:
+        """Convert QDMI bit strings to PennyLane sample rows.
+
+        Returns:
+            A shot-by-wire array in PennyLane measurement order.
+
+        Raises:
+            PennyLaneExecutionError: If QDMI returns malformed or incomplete results.
+        """
+        bitstrings = self._shots_or_counts(job)
+        if len(bitstrings) != shots:
+            msg = f"QDMI returned {len(bitstrings)} samples for a {shots}-shot job."
+            raise ExecutionError(msg)
+
+        rows: list[list[int]] = []
+        width = len(converted.wire_map)
+        for bitstring in bitstrings:
+            clean = bitstring.replace(" ", "")
+            if len(clean) != width or any(bit not in "01" for bit in clean):
+                msg = f"QDMI returned an invalid {width}-wire shot: {bitstring!r}."
+                raise ExecutionError(msg)
+            # QDMI bit strings use the conventional basis-state spelling with
+            # the highest-index site on the left. PennyLane sample columns use
+            # the declared wire order, starting with wire zero.
+            wire_order = clean[::-1]
+            rows.append([int(wire_order[index]) for index in converted.measurement_order])
+        return np.asarray(rows, dtype=np.int8)
+
+    @staticmethod
+    def _require_done(job: fomac.Job) -> None:
+        """Require successful QDMI completion.
+
+        Raises:
+            PennyLaneExecutionError: If the terminal QDMI status is not ``DONE``.
+        """
+        status = job.check()
+        if status != fomac.Job.Status.DONE:
+            msg = f"QDMI job '{job.id}' finished with status {status.name}."
+            raise ExecutionError(msg)
+
+    def _submit(self, converted: ConvertedProgram, shots: int) -> fomac.Job:
+        """Submit and wait for one QDMI job.
+
+        Returns:
+            The successfully completed job.
+
+        Raises:
+            PennyLaneExecutionError: If submission, waiting, or execution fails.
+        """
+        try:
+            job = self._qdmi_device.submit_job(
+                converted.payload,
+                converted.program_format,
+                shots,
+                **self._job_parameters,
+            )
+            self._submitted_jobs += 1
+            job.wait()
+        except (RuntimeError, ValueError) as exc:
+            msg = f"QDMI execution on '{self._device_id}' failed: {exc}"
+            raise ExecutionError(msg) from exc
+        self._require_done(job)
+        return job
+
+    def _execute_tape(self, tape: QuantumScript) -> np.ndarray | tuple[np.ndarray, ...]:
+        """Execute one preprocessed tape, including every shot-vector partition.
+
+        Returns:
+            Raw samples, partitioned when a shot vector was requested.
+        """
+        converted = convert_program(tape, self._qdmi_device, self.wires)
+        results: list[np.ndarray] = []
+        for shots in self._shot_copies(tape.shots):
+            started = time.monotonic()
+            try:
+                results.append(self._samples(self._submit(converted, shots), converted, shots))
+            finally:
+                self._execution_time += time.monotonic() - started
+
+        if tape.shots.has_partitioned_shots:
+            return tuple(results)
+        return results[0]
+
+    def execute(
+        self,
+        circuits: QuantumScriptOrBatch,
+        execution_config: ExecutionConfig | None = None,
+    ) -> Result | ResultBatch:
+        """Execute a batch sequentially through QDMI.
+
+        Returns:
+            One result for every preprocessed input tape.
+        """
+        del execution_config
+        if isinstance(circuits, qp.tape.QuantumScript):
+            return cast("Result", self._execute_tape(circuits))
+        return cast("ResultBatch", tuple(self._execute_tape(tape) for tape in circuits))
+
+
+class DDSIMDevice(QDMIDevice):
+    """PennyLane entry point for MQT Core's local DDSIM QDMI device."""
+
+    def __init__(
+        self,
+        wires: int | Sequence[Hashable] | None = None,
+        shots: int | Sequence[int | tuple[int, int]] | Shots | None = 1024,
+        *,
+        session_parameters: Mapping[str, object] | None = None,
+        job_parameters: Mapping[str, str | bool | float | None] | None = None,
+    ) -> None:
+        """Open the built-in DDSIM device by its stable QDMI ID."""
+        super().__init__(
+            "mqt.ddsim.default",
+            wires=wires,
+            shots=shots,
+            session_parameters=session_parameters,
+            job_parameters=job_parameters,
+        )

--- a/python/mqt/core/plugins/pennylane/exceptions.py
+++ b/python/mqt/core/plugins/pennylane/exceptions.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Exception types for the QDMI PennyLane integration."""
+
+__all__ = [
+    "PennyLaneConfigurationError",
+    "PennyLaneExecutionError",
+    "PennyLaneTranslationError",
+    "PennyLaneUnsupportedFormatError",
+    "PennyLaneUnsupportedOperationError",
+    "PennyLaneValidationError",
+    "QDMIPluginError",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+class QDMIPluginError(RuntimeError):
+    """Base class for QDMI PennyLane plugin errors."""
+
+
+class PennyLaneConfigurationError(QDMIPluginError):
+    """Raised when device or job configuration is invalid."""
+
+
+class PennyLaneValidationError(QDMIPluginError):
+    """Raised when a quantum program is invalid for the selected device."""
+
+
+class PennyLaneTranslationError(QDMIPluginError):
+    """Raised when a PennyLane program cannot be translated."""
+
+
+class PennyLaneUnsupportedFormatError(PennyLaneTranslationError):
+    """Raised when a device advertises no supported exchange format."""
+
+
+class PennyLaneUnsupportedOperationError(PennyLaneTranslationError):
+    """Raised when an operation cannot be represented for the selected device."""
+
+
+class PennyLaneExecutionError(QDMIPluginError):
+    """Raised when submission or execution of a QDMI job fails."""

--- a/src/qdmi/driver/DeviceRegistry.cpp
+++ b/src/qdmi/driver/DeviceRegistry.cpp
@@ -48,6 +48,7 @@ struct SessionPatch {
   std::optional<std::string> authUrl;
   std::optional<std::string> username;
   std::optional<std::string> password;
+  std::optional<DeviceConfigurationSource> deviceConfiguration;
   std::optional<std::string> custom1;
   std::optional<std::string> custom2;
   std::optional<std::string> custom3;
@@ -131,7 +132,7 @@ parseSessionPatch(const Json& value, const std::filesystem::path& source,
   rejectUnknownKeys(value,
                     {"base-url", "token", "auth-file", "auth-url", "username",
                      "password", "custom1", "custom2", "custom3", "custom4",
-                     "custom5"},
+                     "custom5", "device-config"},
                     source, path);
   SessionPatch patch;
   patch.baseUrl = optionalString(value, "base-url", source, path);
@@ -144,6 +145,34 @@ parseSessionPatch(const Json& value, const std::filesystem::path& source,
   patch.custom3 = optionalString(value, "custom3", source, path);
   patch.custom4 = optionalString(value, "custom4", source, path);
   patch.custom5 = optionalString(value, "custom5", source, path);
+  if (const auto config = value.find("device-config"); config != value.end()) {
+    const auto configPath = path + ".device-config";
+    requireObject(*config, source, configPath);
+    rejectUnknownKeys(*config, {"inline", "file"}, source, configPath);
+    const auto inlineConfig = config->find("inline");
+    const auto fileConfig = config->find("file");
+    if ((inlineConfig == config->end()) == (fileConfig == config->end())) {
+      throw std::invalid_argument(sourceLabel(source, configPath) +
+                                  " must contain exactly one of 'inline' and "
+                                  "'file'");
+    }
+    if (inlineConfig != config->end()) {
+      if (!inlineConfig->is_object()) {
+        throw std::invalid_argument(
+            sourceLabel(source, configPath + ".inline") + " must be an object");
+      }
+      patch.deviceConfiguration =
+          InlineDeviceConfiguration{.json = inlineConfig->dump()};
+    } else {
+      if (!fileConfig->is_string() ||
+          fileConfig->get_ref<const std::string&>().empty()) {
+        throw std::invalid_argument(sourceLabel(source, configPath + ".file") +
+                                    " must be a non-empty string");
+      }
+      patch.deviceConfiguration = FileDeviceConfiguration{
+          .path = resolvePath(fileConfig->get<std::string>(), base)};
+    }
+  }
   if (auto authFile = optionalString(value, "auth-file", source, path)) {
     patch.authFile = resolvePath(*authFile, base);
   }
@@ -269,6 +298,7 @@ void mergeSession(SessionPatch& target, const SessionPatch& source) {
   mergeOptional(target.authUrl, source.authUrl);
   mergeOptional(target.username, source.username);
   mergeOptional(target.password, source.password);
+  mergeOptional(target.deviceConfiguration, source.deviceConfiguration);
   mergeOptional(target.custom1, source.custom1);
   mergeOptional(target.custom2, source.custom2);
   mergeOptional(target.custom3, source.custom3);
@@ -467,6 +497,7 @@ void appendFragments(std::vector<std::filesystem::path>& files,
   definition.session.authUrl = patch.session.authUrl;
   definition.session.username = patch.session.username;
   definition.session.password = patch.session.password;
+  definition.session.deviceConfiguration = patch.session.deviceConfiguration;
   definition.session.custom1 = patch.session.custom1;
   definition.session.custom2 = patch.session.custom2;
   definition.session.custom3 = patch.session.custom3;

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -673,6 +673,14 @@ auto Driver::registerDeviceIfAbsent(DeviceDefinition definition) -> bool {
   return true;
 }
 
+auto Driver::registeredDeviceIds() const -> std::vector<std::string> {
+  std::vector<std::string> ids;
+  ids.reserve(definitions_.size());
+  std::ranges::transform(definitions_, std::back_inserter(ids),
+                         &DeviceDefinition::id);
+  return ids;
+}
+
 auto Driver::open(const std::string_view id) -> QDMI_Device {
   if (disabledDeviceIds_.contains(std::string(id))) {
     throw std::runtime_error("QDMI device ID '" + std::string(id) +

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -33,8 +33,10 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #ifdef _WIN32
@@ -219,6 +221,7 @@ void applyOverride(std::optional<T>& value,
   applyOverride(merged.authUrl, overrides.authUrl);
   applyOverride(merged.username, overrides.username);
   applyOverride(merged.password, overrides.password);
+  applyOverride(merged.deviceConfiguration, overrides.deviceConfiguration);
   applyOverride(merged.custom1, overrides.custom1);
   applyOverride(merged.custom2, overrides.custom2);
   applyOverride(merged.custom3, overrides.custom3);
@@ -276,6 +279,29 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(
   setParameter(config.authUrl, QDMI_DEVICE_SESSION_PARAMETER_AUTHURL);
   setParameter(config.username, QDMI_DEVICE_SESSION_PARAMETER_USERNAME);
   setParameter(config.password, QDMI_DEVICE_SESSION_PARAMETER_PASSWORD);
+  if (config.deviceConfiguration &&
+      (config.custom1.has_value() || config.custom2.has_value())) {
+    library_->device_session_free(deviceSession_);
+    deviceSession_ = nullptr;
+    throw std::invalid_argument(
+        "Typed device configuration cannot be combined with raw custom1 or "
+        "custom2 session parameters");
+  }
+  if (config.deviceConfiguration) {
+    std::visit(
+        [&](const auto& source) {
+          using Source = std::decay_t<decltype(source)>;
+          if constexpr (std::is_same_v<Source,
+                                       qdmi::InlineDeviceConfiguration>) {
+            setParameter(std::optional{source.json},
+                         QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1);
+          } else {
+            setParameter(std::optional{source.path.string()},
+                         QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2);
+          }
+        },
+        *config.deviceConfiguration);
+  }
   setParameter(config.custom1, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1);
   setParameter(config.custom2, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2);
   setParameter(config.custom3, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3);
@@ -584,6 +610,12 @@ void validateDefinition(const DeviceDefinition& definition) {
   }
   if (definition.prefix.empty()) {
     throw std::invalid_argument("Device definition prefix must not be empty");
+  }
+  if (definition.session.deviceConfiguration &&
+      (definition.session.custom1 || definition.session.custom2)) {
+    throw std::invalid_argument(
+        "Typed device configuration cannot be combined with raw custom1 or "
+        "custom2 session parameters");
   }
 }
 } // namespace

--- a/src/zx/FunctionalityConstruction.cpp
+++ b/src/zx/FunctionalityConstruction.cpp
@@ -145,25 +145,49 @@ void FunctionalityConstruction::addMcphase(ZXDiagram& diag,
                                            const std::vector<Qubit>& controls,
                                            const Qubit target,
                                            std::vector<Vertex>& qubits) {
-  auto newConst = phase.getConst() / 2;
-  auto newPhase = phase / 2.0;
-  newPhase.setConst(newConst);
-  addZSpider(diag, target, qubits, newPhase);
-  addMcx(diag, controls, target, qubits);
-  addZSpider(diag, target, qubits, -newPhase);
-  addMcx(diag, controls, target, qubits);
-  switch (controls.size()) {
-  case 1:
-    addZSpider(diag, controls[0], qubits, newPhase);
+  if (controls.empty()) {
+    addZSpider(diag, target, qubits, phase);
     return;
-  case 2:
-    addCphase(diag, newPhase, controls[0], controls[1], qubits);
-    return;
-  default:
-    addMcphase(diag, newPhase,
-               std::vector<Qubit>(controls.begin(), controls.end() - 1),
-               controls.back(), qubits);
   }
+  if (controls.size() == 1) {
+    addCphase(diag, phase, controls.front(), target, qubits);
+    return;
+  }
+  if (controls.size() == 2) {
+    auto halfPhase = phase / 2.0;
+    halfPhase.setConst(phase.getConst() / 2);
+    addZSpider(diag, target, qubits, halfPhase);
+    addCcx(diag, controls.front(), controls.back(), target, qubits);
+    addZSpider(diag, target, qubits, -halfPhase);
+    addCcx(diag, controls.front(), controls.back(), target, qubits);
+    addCphase(diag, halfPhase, controls.front(), controls.back(), qubits);
+    return;
+  }
+
+  // Vale et al., Fig. 7 (arXiv:2302.06377): split the controls and use each
+  // half as dirty workspace for the other half. Recursing on the residual
+  // controlled phase yields an exact ancilla-free O(N^2) construction.
+  const auto firstSize = (controls.size() + 1) / 2;
+  const auto split = controls.begin() + static_cast<std::ptrdiff_t>(firstSize);
+  const std::vector<Qubit> first(controls.begin(), split);
+  const std::vector<Qubit> second(split, controls.end());
+  auto quarterPhase = phase / 4.0;
+  quarterPhase.setConst(phase.getConst() / 4);
+
+  addMcxWithDirtyAncillas(diag, first, target, second, qubits);
+  addZSpider(diag, target, qubits, -quarterPhase);
+  addMcxWithDirtyAncillas(diag, second, target, first, qubits);
+  addZSpider(diag, target, qubits, quarterPhase);
+  addMcxWithDirtyAncillas(diag, first, target, second, qubits);
+  addZSpider(diag, target, qubits, -quarterPhase);
+  addMcxWithDirtyAncillas(diag, second, target, first, qubits);
+  addZSpider(diag, target, qubits, quarterPhase);
+
+  auto halfPhase = phase / 2.0;
+  halfPhase.setConst(phase.getConst() / 2);
+  addMcphase(diag, halfPhase,
+             std::vector<Qubit>(controls.begin(), controls.end() - 1),
+             controls.back(), qubits);
 }
 
 void FunctionalityConstruction::addRzz(
@@ -496,6 +520,58 @@ void FunctionalityConstruction::addMcrz(ZXDiagram& diag,
   addMcx(diag, controls, target, qubits);
 }
 
+void FunctionalityConstruction::addMcxWithDirtyAncillas(
+    ZXDiagram& diag, const std::vector<Qubit>& controls, const Qubit target,
+    const std::vector<Qubit>& ancillas, std::vector<Vertex>& qubits) {
+  switch (controls.size()) {
+  case 0:
+    addXSpider(diag, target, qubits, PiExpression(PiRational(1, 1)));
+    return;
+  case 1:
+    addCnot(diag, controls.front(), target, qubits);
+    return;
+  case 2:
+    addCcx(diag, controls.front(), controls.back(), target, qubits);
+    return;
+  default:
+    break;
+  }
+
+  const auto requiredAncillas = controls.size() - 2;
+  if (ancillas.size() < requiredAncillas) {
+    throw ZXException("Insufficient dirty ancillas for MCX decomposition");
+  }
+
+  const auto addAction = [&](const Qubit control0, const Qubit control1,
+                             const Qubit actionTarget) {
+    addZSpider(diag, actionTarget, qubits, PiExpression(), EdgeType::Hadamard);
+    addZSpider(diag, actionTarget, qubits, PiExpression(PiRational(1, 4)));
+    addCnot(diag, control0, actionTarget, qubits);
+    addZSpider(diag, actionTarget, qubits, PiExpression(PiRational(-1, 4)));
+    addCnot(diag, control1, actionTarget, qubits);
+  };
+  const auto addReset = [&](const Qubit control0, const Qubit control1,
+                            const Qubit actionTarget) {
+    addCnot(diag, control1, actionTarget, qubits);
+    addZSpider(diag, actionTarget, qubits, PiExpression(PiRational(1, 4)));
+    addCnot(diag, control0, actionTarget, qubits);
+    addZSpider(diag, actionTarget, qubits, PiExpression(PiRational(-1, 4)));
+    addZSpider(diag, actionTarget, qubits, PiExpression(), EdgeType::Hadamard);
+  };
+
+  for (std::size_t pass = 0; pass < 2; ++pass) {
+    addCcx(diag, controls.back(), ancillas[requiredAncillas - 1], target,
+           qubits);
+    for (auto i = requiredAncillas - 1; i-- > 0;) {
+      addAction(controls[i + 2], ancillas[i], ancillas[i + 1]);
+    }
+    addRccx(diag, controls[0], controls[1], ancillas[0], qubits);
+    for (std::size_t i = 0; i + 1 < requiredAncillas; ++i) {
+      addReset(controls[i + 2], ancillas[i], ancillas[i + 1]);
+    }
+  }
+}
+
 void FunctionalityConstruction::addMcx(ZXDiagram& diag,
                                        std::vector<Qubit> controls,
                                        const Qubit target,
@@ -508,30 +584,11 @@ void FunctionalityConstruction::addMcx(ZXDiagram& diag,
     addCcx(diag, controls.front(), controls.back(), target, qubits);
     return;
   default:
-    const auto half = static_cast<std::ptrdiff_t>((controls.size() + 1) / 2);
-    const std::vector<Qubit> first(controls.begin(), controls.begin() + half);
-    const std::vector<Qubit> second(controls.begin() + half, controls.end());
-
-    addRx(diag, PiExpression(PiRational(1, 4)), target, qubits);
+    // MCX = H · MCP(pi) · H. The Vale-style MCP construction uses O(N^2)
+    // spiders and no qubits beyond the controls and target.
     addZSpider(diag, target, qubits, PiExpression(), EdgeType::Hadamard);
-    addMcx(diag, first, target, qubits);
+    addMcphase(diag, PiExpression(PiRational(1, 1)), controls, target, qubits);
     addZSpider(diag, target, qubits, PiExpression(), EdgeType::Hadamard);
-    addRx(diag, PiExpression(-PiRational(1, 4)), target, qubits);
-    addZSpider(diag, target, qubits, PiExpression(), EdgeType::Hadamard);
-    addMcx(diag, second, target, qubits);
-    addZSpider(diag, target, qubits, PiExpression(), EdgeType::Hadamard);
-    addRx(diag, PiExpression(PiRational(1, 4)), target, qubits);
-    addZSpider(diag, target, qubits, PiExpression(), EdgeType::Hadamard);
-    addMcx(diag, first, target, qubits);
-    addZSpider(diag, target, qubits, PiExpression(), EdgeType::Hadamard);
-    addRx(diag, PiExpression(-PiRational(1, 4)), target, qubits);
-    addZSpider(diag, target, qubits, PiExpression(), EdgeType::Hadamard);
-    addMcx(diag, second, target, qubits);
-    addZSpider(diag, target, qubits, PiExpression(), EdgeType::Hadamard);
-    const Qubit lastControl = controls.back();
-    controls.pop_back();
-    addMcphase(diag, PiExpression(PiRational(1, 2)), controls, lastControl,
-               qubits);
   }
 }
 

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -482,6 +482,12 @@ TEST(DDPackageTest, StateGenerationManipulation) {
 TEST(DDPackageTest, VectorSerializationTest) {
   auto dd = std::make_unique<Package>(2);
 
+  for (const bool binary : {false, true}) {
+    std::stringstream serialized{};
+    serialize(vEdge::one(), serialized, binary);
+    EXPECT_EQ(dd->deserialize<vNode>(serialized, binary), vEdge::one());
+  }
+
   auto hGate = getDD(qc::StandardOperation(1, qc::H), *dd);
   auto cxGate = getDD(qc::StandardOperation(1_pc, 0, qc::X), *dd);
   auto zeroState = makeZeroState(2, *dd);
@@ -583,6 +589,12 @@ TEST(DDPackageTest, BellMatrix) {
 
 TEST(DDPackageTest, MatrixSerializationTest) {
   auto dd = std::make_unique<Package>(2);
+
+  for (const bool binary : {false, true}) {
+    std::stringstream serialized{};
+    serialize(mEdge::one(), serialized, binary);
+    EXPECT_EQ(dd->deserialize<mNode>(serialized, binary), mEdge::one());
+  }
 
   auto hGate = getDD(qc::StandardOperation(1, qc::H), *dd);
   auto cxGate = getDD(qc::StandardOperation(1_pc, 0, qc::X), *dd);

--- a/test/python/dd/test_matrix_dds.py
+++ b/test/python/dd/test_matrix_dds.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
-from mqt.core.dd import DDPackage
+from mqt.core.dd import DDPackage, MatrixDD
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -129,3 +129,17 @@ def test_from_matrix() -> None:
             dd = p.from_matrix(mat)
             mat2 = dd.get_matrix(i)
             assert np.allclose(mat, mat2)
+
+
+@pytest.mark.parametrize("binary", [False, True])
+def test_serialization(*, binary: bool) -> None:
+    """Test serializing and deserializing matrix DDs."""
+    p = DDPackage(3)
+    hadamard = np.array([[1, 1], [1, -1]], dtype=np.complex128) / np.sqrt(2)
+    matrix_dds = ((p.identity(), 0), (p.single_qubit_gate(hadamard, 2), 3))
+    for dd, num_qubits in matrix_dds:
+        data = dd.to_bytes(binary=binary)
+        assert isinstance(data, bytes)
+
+        restored = MatrixDD.from_bytes(DDPackage(3), data, binary=binary)
+        assert np.allclose(restored.get_matrix(num_qubits), dd.get_matrix(num_qubits))

--- a/test/python/dd/test_vector_dds.py
+++ b/test/python/dd/test_vector_dds.py
@@ -11,8 +11,9 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
-from mqt.core.dd import BasisStates, DDPackage
+from mqt.core.dd import BasisStates, DDPackage, VectorDD
 
 
 def test_zero_state() -> None:
@@ -98,3 +99,16 @@ def test_from_vector() -> None:
             vec2 = dd.get_vector()
             assert np.allclose(vec, vec2)
             p.dec_ref_vec(dd)
+
+
+@pytest.mark.parametrize("binary", [False, True])
+def test_serialization(*, binary: bool) -> None:
+    """Test serializing and deserializing vector DDs."""
+    p = DDPackage(3)
+    for dd in (p.zero_state(0), p.ghz_state(3)):
+        data = dd.to_bytes(binary=binary)
+        assert isinstance(data, bytes)
+
+        restored = VectorDD.from_bytes(DDPackage(3), data, binary=binary)
+        assert np.allclose(restored.get_vector(), dd.get_vector())
+        p.dec_ref_vec(dd)

--- a/test/python/fomac/test_fomac.py
+++ b/test/python/fomac/test_fomac.py
@@ -26,6 +26,7 @@ from mqt.core.fomac import (
     open_device,
     register_device,
     register_device_if_absent,
+    registered_device_ids,
 )
 
 CustomValueType = type[str] | type[bool] | type[int] | type[float] | type[bytes]
@@ -977,6 +978,19 @@ def test_register_device_if_absent_only_ignores_existing_id() -> None:
     assert not register_device_if_absent(definition)
     with pytest.raises(ValueError, match="library must not be empty"):
         register_device_if_absent(DeviceDefinition("python.if-absent", "", "PREFIX"))
+
+
+def test_registered_device_ids_include_runtime_registrations_in_order() -> None:
+    """Stable-ID enumeration is ordered and does not load native libraries."""
+    ids_before = registered_device_ids()
+    register_device(DeviceDefinition("python.enumeration.first", "/nonexistent/first.so", "FIRST"))
+    register_device(DeviceDefinition("python.enumeration.second", "/nonexistent/second.so", "SECOND"))
+
+    assert registered_device_ids() == [
+        *ids_before,
+        "python.enumeration.first",
+        "python.enumeration.second",
+    ]
 
 
 def test_open_device_rejects_unknown_id() -> None:

--- a/test/python/fomac/test_fomac.py
+++ b/test/python/fomac/test_fomac.py
@@ -992,6 +992,36 @@ def test_open_device_creates_a_fresh_session() -> None:
     assert first != second
 
 
+def test_device_configuration_arguments_are_mutually_exclusive() -> None:
+    """Typed device configuration must select exactly one source."""
+    DeviceDefinition(
+        "python.inline-config",
+        "/nonexistent/device.so",
+        "PREFIX",
+        device_config="{}",
+    )
+    DeviceDefinition(
+        "python.file-config",
+        "/nonexistent/device.so",
+        "PREFIX",
+        device_config_file="device.json",
+    )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        DeviceDefinition(
+            "python.config-conflict",
+            "/nonexistent/device.so",
+            "PREFIX",
+            device_config="{}",
+            device_config_file="device.json",
+        )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        open_device(
+            "mqt.na.default",
+            device_config="{}",
+            device_config_file="device.json",
+        )
+
+
 def test_site_keeps_fresh_session_alive() -> None:
     """A site should remain usable after its device wrapper is destroyed."""
     site = open_device("mqt.na.default").sites()[0]

--- a/test/python/plugins/qdmi_pennylane/__init__.py
+++ b/test/python/plugins/qdmi_pennylane/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Tests for the QDMI PennyLane plugin."""

--- a/test/python/plugins/qdmi_pennylane/helpers.py
+++ b/test/python/plugins/qdmi_pennylane/helpers.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Compact test support for the QDMI PennyLane plugin."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import TYPE_CHECKING, cast
+from unittest.mock import Mock
+
+from mqt.core import fomac
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+
+def _site(index: int) -> fomac.Device.Site:
+    """Return a site mock with one stable index."""
+    site = Mock()
+    site.index.return_value = index
+    return cast("fomac.Device.Site", site)
+
+
+def operation(
+    name: str,
+    wires: int,
+    parameters: int = 0,
+    *,
+    sites: Sequence[int] | None = None,
+    site_pairs: Sequence[tuple[int, int]] | None = None,
+) -> fomac.Device.Operation:
+    """Return the operation metadata consumed by the converter."""
+    metadata = Mock()
+    metadata.name.return_value = name
+    metadata.qubits_num.return_value = wires
+    metadata.parameters_num.return_value = parameters
+    metadata.sites.return_value = None if sites is None else [_site(index) for index in sites]
+    metadata.site_pairs.return_value = (
+        None if site_pairs is None else [(_site(first), _site(second)) for first, second in site_pairs]
+    )
+    return cast("fomac.Device.Operation", metadata)
+
+
+def _standard_operations(program_format: fomac.ProgramFormat) -> list[fomac.Device.Operation]:
+    """Return the gate set used by execution tests."""
+    qasm2 = program_format == fomac.ProgramFormat.QASM2
+    return [
+        operation("id" if qasm2 else "i", 1),
+        operation("x", 1),
+        operation("y", 1),
+        operation("z", 1),
+        operation("h", 1),
+        operation("s", 1),
+        operation("sdg", 1),
+        operation("t", 1),
+        operation("tdg", 1),
+        operation("rx", 1, 1),
+        operation("ry", 1, 1),
+        operation("rz", 1, 1),
+        operation("u1" if qasm2 else "p", 1, 1),
+        operation("cx", 2),
+        operation("cz", 2),
+        operation("swap", 2),
+        operation("ccx", 3),
+        operation("cswap", 3),
+    ]
+
+
+def bell_results(_program: str, shots: int) -> list[str]:
+    """Return an even Bell-state histogram."""
+    zeros = shots // 2
+    return ["00"] * zeros + ["11"] * (shots - zeros)
+
+
+def rotation_results(program: str, shots: int) -> list[str]:
+    """Return deterministic counts for the final RY instruction."""
+    matches = re.findall(r"ry\(([-+0-9.eE]+)\)", program)
+    angle = float(matches[-1]) if matches else 0.0
+    ones = round(shots * math.sin(angle / 2) ** 2)
+    return ["0"] * (shots - ones) + ["1"] * ones
+
+
+class StubDevice:
+    """Small QDMI boundary stub with configurable capabilities and results."""
+
+    def __init__(
+        self,
+        operations: Sequence[fomac.Device.Operation],
+        formats: Sequence[fomac.ProgramFormat],
+        *,
+        qubits: int = 2,
+        coupling_map: Sequence[tuple[int, int]] | None = None,
+        result_factory: Callable[[str, int], Sequence[str]] = bell_results,
+        expose_shots: bool = True,
+    ) -> None:
+        """Store the advertised capabilities and result behavior."""
+        self._operations = list(operations)
+        self._formats = list(formats)
+        self._qubits = qubits
+        self._coupling_map = coupling_map
+        self._result_factory = result_factory
+        self._expose_shots = expose_shots
+        self.submissions: list[tuple[str, fomac.ProgramFormat, int, Mapping[str, object]]] = []
+
+    @staticmethod
+    def name() -> str:
+        """Return the stable stub name."""
+        return "stub.qdmi"
+
+    def operations(self) -> list[fomac.Device.Operation]:
+        """Return the advertised operations."""
+        return self._operations
+
+    def supported_program_formats(self) -> list[fomac.ProgramFormat]:
+        """Return the advertised program formats."""
+        return self._formats
+
+    def qubits_num(self) -> int:
+        """Return the device width."""
+        return self._qubits
+
+    def coupling_map(self) -> list[tuple[fomac.Device.Site, fomac.Device.Site]] | None:
+        """Return the optional topology."""
+        if self._coupling_map is None:
+            return None
+        return [(_site(first), _site(second)) for first, second in self._coupling_map]
+
+    def submit_job(
+        self,
+        program: str,
+        program_format: fomac.ProgramFormat,
+        num_shots: int,
+        **parameters: object,
+    ) -> fomac.Job:
+        """Record one submission and return an immediately completed job.
+
+        Returns:
+            The completed job mock.
+        """
+        self.submissions.append((program, program_format, num_shots, parameters))
+        shots = list(self._result_factory(program, num_shots))
+        job = Mock()
+        job.id = str(len(self.submissions))
+        job.wait.return_value = True
+        job.check.return_value = fomac.Job.Status.DONE
+        if self._expose_shots:
+            job.get_shots.return_value = shots
+        else:
+            job.get_shots.side_effect = RuntimeError("Not supported")
+        job.get_counts.return_value = dict(Counter(shots))
+        return cast("fomac.Job", job)
+
+
+def stub_device(
+    *,
+    program_format: fomac.ProgramFormat = fomac.ProgramFormat.QASM3,
+    operations: Sequence[fomac.Device.Operation] | None = None,
+    qubits: int = 2,
+    result_factory: Callable[[str, int], Sequence[str]] = bell_results,
+    expose_shots: bool = True,
+) -> StubDevice:
+    """Return a stub with the ordinary execution-test gate set."""
+    return StubDevice(
+        _standard_operations(program_format) if operations is None else operations,
+        [program_format],
+        qubits=qubits,
+        result_factory=result_factory,
+        expose_shots=expose_shots,
+    )

--- a/test/python/plugins/qdmi_pennylane/test_converter.py
+++ b/test/python/plugins/qdmi_pennylane/test_converter.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Tests for capability-driven PennyLane program conversion."""
+
+from __future__ import annotations
+
+import sys
+from typing import cast
+
+import numpy as np
+import pytest
+
+if sys.version_info < (3, 11):
+    pytest.skip("PennyLane requires Python 3.11 or newer.", allow_module_level=True)
+
+try:
+    import pennylane as qp
+except ImportError:
+    pytest.skip("Install the PennyLane extra to run these tests.", allow_module_level=True)
+
+from mqt.core import fomac
+from mqt.core.plugins.pennylane import (
+    PennyLaneTranslationError,
+    PennyLaneUnsupportedFormatError,
+    PennyLaneUnsupportedOperationError,
+    PennyLaneValidationError,
+    convert_program,
+)
+
+from .helpers import StubDevice, operation
+
+
+def _device(value: StubDevice) -> fomac.Device:
+    """Present a test double at the public converter boundary.
+
+    Returns:
+        The fake device with the public QDMI type.
+    """
+    return cast("fomac.Device", value)
+
+
+def test_qasm3_prefers_and_resolves_braket_spellings() -> None:
+    """Prefer QASM3 and emit only spellings advertised by a Braket-style device."""
+    device = StubDevice(
+        [
+            operation("h", 1),
+            operation("cnot", 2),
+            operation("phaseshift", 1, 1),
+            operation("xx", 2, 1),
+        ],
+        [fomac.ProgramFormat.QASM2, fomac.ProgramFormat.QASM3],
+    )
+    tape = qp.tape.QuantumScript(
+        [
+            qp.Hadamard("left"),
+            qp.CNOT(wires=["left", "right"]),
+            qp.PhaseShift(0.25, wires="right"),
+            qp.IsingXX(0.5, wires=["right", "left"]),
+        ],
+        [qp.sample(wires=["right", "left"])],
+        shots=10,
+    )
+
+    converted = convert_program(tape, _device(device), qp.wires.Wires(["left", "right"]))
+
+    assert converted.program_format == fomac.ProgramFormat.QASM3
+    assert converted.measurement_order == (1, 0)
+    assert converted.payload == (
+        "OPENQASM 3.0;\n"
+        "qubit[2] q;\n"
+        "bit[2] c;\n"
+        "h q[0];\n"
+        "cnot q[0],q[1];\n"
+        "phaseshift(0.25) q[1];\n"
+        "xx(0.5) q[1],q[0];\n"
+        "c = measure q;\n"
+    )
+    assert "include" not in converted.payload
+    assert "gate " not in converted.payload
+    assert "pragma" not in converted.payload
+    assert "inv @" not in converted.payload
+
+
+def test_qasm3_resolves_ddsim_aliases_and_inverse_gates() -> None:
+    """Resolve MQT Core-style aliases for controls, phases, rotations, and inverses."""
+    device = StubDevice(
+        [
+            operation("cx", 2),
+            operation("p", 1, 1),
+            operation("sdg", 1),
+            operation("tdg", 1),
+            operation("sx", 1),
+            operation("sxdg", 1),
+            operation("rxx", 2, 1),
+            operation("ryy", 2, 1),
+            operation("rzz", 2, 1),
+        ],
+        [fomac.ProgramFormat.QASM3],
+    )
+    tape = qp.tape.QuantumScript(
+        [
+            qp.CNOT(wires=[0, 1]),
+            qp.PhaseShift(-0.125, wires=1),
+            qp.adjoint(qp.S)(0),
+            qp.adjoint(qp.T)(1),
+            qp.SX(0),
+            qp.adjoint(qp.SX)(1),
+            qp.IsingXX(0.1, wires=[0, 1]),
+            qp.IsingYY(0.2, wires=[0, 1]),
+            qp.IsingZZ(0.3, wires=[0, 1]),
+        ],
+        [qp.sample(wires=[0, 1])],
+        shots=5,
+    )
+
+    payload = convert_program(tape, _device(device), qp.wires.Wires([0, 1])).payload
+
+    assert "cx q[0],q[1];" in payload
+    assert "p(-0.125) q[1];" in payload
+    assert "sdg q[0];" in payload
+    assert "tdg q[1];" in payload
+    assert "sx q[0];" in payload
+    assert "sxdg q[1];" in payload
+    assert "rxx(0.10000000000000001) q[0],q[1];" in payload
+    assert "ryy(0.20000000000000001) q[0],q[1];" in payload
+    assert "rzz(0.29999999999999999) q[0],q[1];" in payload
+
+
+def test_qasm3_failure_does_not_fall_back_to_qasm2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep a QASM3 capability error visible when both formats are advertised."""
+    device = StubDevice(
+        [operation("h", 1)],
+        [fomac.ProgramFormat.QASM3, fomac.ProgramFormat.QASM2],
+    )
+    tape = qp.tape.QuantumScript([qp.RX(0.2, 0)], [qp.sample(wires=0)], shots=4)
+    qasm2_called = False
+
+    def fail_if_called(*_args: object, **_kwargs: object) -> str:
+        nonlocal qasm2_called
+        qasm2_called = True
+        return ""
+
+    monkeypatch.setattr(qp, "to_openqasm", fail_if_called)
+    with pytest.raises(PennyLaneUnsupportedOperationError, match="RX"):
+        convert_program(tape, _device(device), qp.wires.Wires([0]))
+    assert not qasm2_called
+
+
+def test_qasm2_fallback_uses_pennylane_serializer_without_rotations() -> None:
+    """Use PennyLane's QASM2 serializer only when QASM3 is unavailable."""
+    device = StubDevice(
+        [operation("h", 1), operation("cx", 2), operation("rx", 1, 1)],
+        [fomac.ProgramFormat.QASM2],
+    )
+    tape = qp.tape.QuantumScript(
+        [qp.Hadamard(0), qp.CNOT(wires=[0, 1]), qp.RX(0.25, 1)],
+        [qp.sample(wires=[0, 1])],
+        shots=10,
+    )
+
+    converted = convert_program(tape, _device(device), qp.wires.Wires([0, 1]))
+
+    assert converted.program_format == fomac.ProgramFormat.QASM2
+    assert converted.payload == (
+        "OPENQASM 2.0;\n"
+        'include "qelib1.inc";\n'
+        "qreg q[2];\n"
+        "creg c[2];\n"
+        "h q[0];\n"
+        "cx q[0],q[1];\n"
+        "rx(0.25) q[1];\n"
+        "measure q[0] -> c[0];\n"
+        "measure q[1] -> c[1];\n"
+    )
+
+
+def test_qasm2_rejects_non_intersection_operation() -> None:
+    """Reject an operation the serializer knows when the QDMI device does not."""
+    device = StubDevice([operation("h", 1)], [fomac.ProgramFormat.QASM2])
+    tape = qp.tape.QuantumScript([qp.CNOT(wires=[0, 1])], [qp.sample(wires=[0, 1])], shots=2)
+
+    with pytest.raises(PennyLaneUnsupportedOperationError, match="CNOT"):
+        convert_program(tape, _device(device), qp.wires.Wires([0, 1]))
+
+
+def test_qasm2_wraps_serializer_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expose serializer failures as focused translation errors."""
+    device = StubDevice([operation("h", 1)], [fomac.ProgramFormat.QASM2])
+    tape = qp.tape.QuantumScript([qp.Hadamard(0)], [qp.sample(wires=0)], shots=2)
+
+    def fail(*_args: object, **_kwargs: object) -> str:
+        msg = "serializer failed"
+        raise ValueError(msg)
+
+    monkeypatch.setattr(qp, "to_openqasm", fail)
+    with pytest.raises(PennyLaneTranslationError, match="serializer failed"):
+        convert_program(tape, _device(device), qp.wires.Wires([0]))
+
+
+def test_rejects_device_without_qasm() -> None:
+    """Fail before submission when neither supported format is advertised."""
+    device = StubDevice([], [fomac.ProgramFormat.QIR_BASE_STRING])
+    tape = qp.tape.QuantumScript([], [qp.sample(wires=0)], shots=2)
+
+    with pytest.raises(PennyLaneUnsupportedFormatError, match="OpenQASM 3 or OpenQASM 2"):
+        convert_program(tape, _device(device), qp.wires.Wires([0]))
+
+
+@pytest.mark.parametrize("parameter", [np.nan, np.inf, -np.inf])
+def test_rejects_non_finite_parameters(parameter: float) -> None:
+    """Reject non-finite bound parameters before submission."""
+    device = StubDevice([operation("rx", 1, 1)], [fomac.ProgramFormat.QASM3])
+    tape = qp.tape.QuantumScript([qp.RX(parameter, 0)], [qp.sample(wires=0)], shots=2)
+
+    with pytest.raises(PennyLaneValidationError, match="non-finite"):
+        convert_program(tape, _device(device), qp.wires.Wires([0]))
+
+
+def test_validates_operation_topology() -> None:
+    """Honor operation-specific QDMI site pairs."""
+    device = StubDevice(
+        [operation("cx", 2, site_pairs=[(0, 1)])],
+        [fomac.ProgramFormat.QASM3],
+        qubits=3,
+    )
+    tape = qp.tape.QuantumScript([qp.CNOT(wires=[1, 0])], [qp.sample(wires=[0, 1])], shots=2)
+
+    with pytest.raises(PennyLaneValidationError, match=r"not advertised on device wires \(1, 0\)"):
+        convert_program(tape, _device(device), qp.wires.Wires([0, 1, 2]))

--- a/test/python/plugins/qdmi_pennylane/test_ddsim.py
+++ b/test/python/plugins/qdmi_pennylane/test_ddsim.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""End-to-end PennyLane tests with the DDSIM QDMI device."""
+
+# ruff: file-ignore[missing-return-type-private-function]
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+
+if sys.version_info < (3, 11):
+    pytest.skip("PennyLane requires Python 3.11 or newer.", allow_module_level=True)
+
+try:
+    import pennylane as qp
+except ImportError:
+    pytest.skip("Install the PennyLane extra to run these tests.", allow_module_level=True)
+
+import networkx as nx
+
+from mqt.core.plugins.pennylane import DDSIMDevice
+
+GRAPH_EDGES = ((0, 1), (0, 2), (1, 2), (2, 3))
+
+
+def test_stable_entry_point_and_wire_order() -> None:
+    """Discover the stable device ID and map QDMI bit strings to PennyLane wires."""
+    device = qp.device("mqt.ddsim.default", wires=["first", "second"], shots=20)
+
+    @qp.qnode(device)
+    def circuit():
+        qp.PauliX("first")
+        return qp.counts(wires=["first", "second"])
+
+    assert isinstance(device, DDSIMDevice)
+    assert device.device_id == "mqt.ddsim.default"
+    assert circuit() == {"10": 20}
+
+
+def test_bell_results_and_shot_vector() -> None:
+    """Execute probabilities, samples, and shot-vector partitions end to end."""
+    device = qp.device("mqt.ddsim.default", wires=2, shots=[(1000, 2), 2000])
+
+    @qp.qnode(device)
+    def circuit():
+        qp.Hadamard(0)
+        qp.CNOT(wires=[0, 1])
+        return qp.probs(wires=[0, 1])
+
+    results = circuit()
+
+    assert len(results) == 3
+    for probabilities in results:
+        assert probabilities[0] == pytest.approx(0.5, abs=0.1)
+        assert probabilities[3] == pytest.approx(0.5, abs=0.1)
+        assert probabilities[1] + probabilities[2] == pytest.approx(0.0)
+
+
+def test_parameter_shift_gradient() -> None:
+    """Compute a finite sampled parameter-shift gradient through QDMI."""
+    device = qp.device("mqt.ddsim.default", wires=1, shots=10_000)
+
+    @qp.qnode(device, diff_method="parameter-shift")
+    def circuit(angle: float):
+        qp.RY(angle, 0)
+        return qp.expval(qp.PauliZ(0))
+
+    angle = qp.numpy.array(0.4, requires_grad=True)
+    gradient = qp.grad(circuit)(angle)
+
+    assert np.isfinite(gradient)
+    assert gradient == pytest.approx(-np.sin(0.4), abs=0.04)
+    assert device.submitted_jobs >= 2
+
+
+@pytest.mark.parametrize(
+    "operations",
+    [
+        [qp.Hadamard(0), qp.PhaseShift(0.43, 0), qp.Hadamard(0)],
+        [qp.Hadamard(0), qp.adjoint(qp.S)(0), qp.adjoint(qp.T)(0), qp.Hadamard(0)],
+        [qp.SX(0), qp.adjoint(qp.SX)(1), qp.CNOT(wires=[1, 0])],
+        [qp.IsingXX(0.37, wires=[0, 1])],
+        [qp.IsingYY(0.37, wires=[0, 1])],
+        [
+            qp.Hadamard(0),
+            qp.Hadamard(1),
+            qp.IsingZZ(0.37, wires=[0, 1]),
+            qp.Hadamard(0),
+            qp.Hadamard(1),
+        ],
+    ],
+)
+def test_gate_semantics_against_pennylane_reference(operations: list[qp.operation.Operator]) -> None:
+    """Match phase, inverse, parameter, and wire-order semantics."""
+    qdmi_device = qp.device("mqt.ddsim.default", wires=2, shots=20_000)
+    reference_device = qp.device("default.qubit", wires=2)
+    sampled_tape = qp.tape.QuantumScript(operations, [qp.probs(wires=[0, 1])], shots=20_000)
+    analytic_tape = qp.tape.QuantumScript(operations, [qp.probs(wires=[0, 1])])
+
+    (actual,) = qp.execute((sampled_tape,), qdmi_device, diff_method=None)
+    (expected,) = qp.execute((analytic_tape,), reference_device, diff_method=None)
+
+    np.testing.assert_allclose(actual, expected, atol=0.025)
+
+
+def test_qaoa_application() -> None:
+    """Optimize one finite-shot MaxCut QAOA step through the real QDMI device."""
+    graph = nx.Graph(GRAPH_EDGES)
+    cost_hamiltonian, mixer_hamiltonian = qp.qaoa.maxcut(graph)
+    device = qp.device("mqt.ddsim.default", wires=4, shots=200)
+
+    def ansatz(parameters: np.ndarray) -> None:
+        for wire in graph.nodes:
+            qp.Hadamard(wire)
+        qp.qaoa.cost_layer(parameters[0], cost_hamiltonian)
+        qp.qaoa.mixer_layer(parameters[1], mixer_hamiltonian)
+
+    @qp.qnode(device, diff_method="parameter-shift")
+    def cost(parameters: np.ndarray):
+        ansatz(parameters)
+        return qp.expval(cost_hamiltonian)
+
+    @qp.qnode(device)
+    def sample(parameters: np.ndarray):
+        ansatz(parameters)
+        return qp.sample(wires=range(4))
+
+    parameters = qp.numpy.array([0.5, 0.5], requires_grad=True)
+    initial_cost = float(cost(parameters))
+    gradient = np.asarray(qp.grad(cost)(parameters), dtype=float)
+    optimized = qp.GradientDescentOptimizer(stepsize=0.15).step(cost, parameters)
+    samples = np.asarray(sample(optimized), dtype=np.int8)
+    bitstrings = {"".join(str(int(bit)) for bit in row) for row in samples}
+    cuts = [sum(bitstring[first] != bitstring[second] for first, second in GRAPH_EDGES) for bitstring in bitstrings]
+
+    assert np.isfinite(initial_cost)
+    assert np.all(np.isfinite(gradient))
+    assert not np.allclose(optimized, parameters)
+    assert samples.shape == (200, 4)
+    assert bitstrings
+    assert all(len(bitstring) == 4 and set(bitstring) <= {"0", "1"} for bitstring in bitstrings)
+    assert all(0 <= cut <= len(GRAPH_EDGES) for cut in cuts)
+    assert device.submitted_jobs > 1

--- a/test/python/plugins/qdmi_pennylane/test_device.py
+++ b/test/python/plugins/qdmi_pennylane/test_device.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Tests for modern PennyLane execution through QDMI."""
+
+# ruff: file-ignore[missing-return-type-private-function]
+
+from __future__ import annotations
+
+import sys
+from typing import cast
+
+import numpy as np
+import pytest
+
+if sys.version_info < (3, 11):
+    pytest.skip("PennyLane requires Python 3.11 or newer.", allow_module_level=True)
+
+try:
+    import pennylane as qp
+except ImportError:
+    pytest.skip("Install the PennyLane extra to run these tests.", allow_module_level=True)
+
+from mqt.core import fomac
+from mqt.core.plugins.pennylane import (
+    PennyLaneConfigurationError,
+    PennyLaneUnsupportedFormatError,
+    PennyLaneValidationError,
+    QDMIDevice,
+)
+
+from .helpers import StubDevice, rotation_results, stub_device
+
+
+def _patch_device(monkeypatch: pytest.MonkeyPatch, device: StubDevice) -> None:
+    """Route fresh stable-ID opens to a test double."""
+    monkeypatch.setattr(fomac, "open_device", lambda *_args, **_kwargs: cast("fomac.Device", device))
+
+
+def test_samples_counts_probabilities_expectations_and_variances(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reconstruct common PennyLane result types from raw QDMI samples."""
+    qdmi = stub_device()
+    _patch_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=["left", "right"], shots=100)
+
+    @qp.qnode(device)
+    def circuit() -> tuple[object, ...]:
+        return (
+            qp.sample(wires=["left", "right"]),
+            qp.counts(wires=["left", "right"]),
+            qp.probs(wires=["left", "right"]),
+            qp.expval(qp.PauliZ("left")),
+            qp.var(qp.PauliZ("right")),
+        )
+
+    samples, counts, probabilities, expectation, variance = circuit()
+
+    assert samples.shape == (100, 2)
+    assert counts == {"00": 50, "11": 50}
+    np.testing.assert_allclose(probabilities, [0.5, 0.0, 0.0, 0.5])
+    assert expectation == pytest.approx(0.0)
+    assert variance == pytest.approx(1.0)
+    assert device.submitted_jobs == 1
+    assert device.execution_time >= 0.0
+
+
+def test_histogram_only_device_reconstructs_samples(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reconstruct raw samples when a QDMI implementation exposes only counts."""
+    qdmi = stub_device(expose_shots=False)
+    _patch_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=8)
+
+    @qp.qnode(device)
+    def circuit():
+        return qp.sample(wires=[0, 1])
+
+    samples = circuit()
+
+    assert samples.shape == (8, 2)
+    np.testing.assert_array_equal(samples[:4], np.zeros((4, 2), dtype=np.int8))
+    np.testing.assert_array_equal(samples[4:], np.ones((4, 2), dtype=np.int8))
+
+
+def test_shot_vectors_submit_sequential_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Execute every shot-vector copy as a sequential QDMI job."""
+    qdmi = stub_device()
+    _patch_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=[(5, 2), 7])
+
+    @qp.qnode(device)
+    def circuit():
+        return qp.probs(wires=[0, 1])
+
+    results = circuit()
+
+    assert len(results) == 3
+    assert [submission[2] for submission in qdmi.submissions] == [5, 5, 7]
+    for probabilities in results:
+        assert np.sum(probabilities) == pytest.approx(1.0)
+
+
+def test_batches_execute_in_input_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Preserve batch ordering with one QDMI submission per tape."""
+    qdmi = stub_device()
+    _patch_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=6)
+    tapes = (
+        qp.tape.QuantumScript([qp.PauliX(0)], [qp.probs(wires=[0, 1])], shots=6),
+        qp.tape.QuantumScript([qp.PauliX(1)], [qp.probs(wires=[0, 1])], shots=6),
+    )
+
+    results = qp.execute(tapes, device, diff_method=None)
+
+    assert len(results) == 2
+    assert len(qdmi.submissions) == 2
+    assert "x q[0];" in qdmi.submissions[0][0]
+    assert "x q[1];" in qdmi.submissions[1][0]
+
+
+def test_parameter_shift_gradient_uses_multiple_qdmi_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Differentiate sampled execution through PennyLane's parameter-shift rule."""
+    qdmi = stub_device(qubits=1, result_factory=rotation_results)
+    _patch_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=["theta"], shots=4000)
+
+    @qp.qnode(device, diff_method="parameter-shift")
+    def circuit(angle: float):
+        qp.RY(angle, wires="theta")
+        return qp.expval(qp.PauliZ("theta"))
+
+    angle = qp.numpy.array(0.4, requires_grad=True)
+    value = circuit(angle)
+    gradient = qp.grad(circuit)(angle)
+
+    assert value == pytest.approx(np.cos(0.4), abs=0.01)
+    assert gradient == pytest.approx(-np.sin(0.4), abs=0.02)
+    # One explicit value call, then one forward and two shifted tapes for grad.
+    assert device.submitted_jobs == 4
+
+
+def test_hamiltonian_and_non_commuting_measurements_split(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let PennyLane split and aggregate Hamiltonian and non-commuting terms."""
+    qdmi = stub_device()
+    _patch_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=100)
+    hamiltonian = 0.5 * qp.PauliZ(0) + 0.5 * qp.PauliZ(1)
+
+    @qp.qnode(device)
+    def circuit():
+        return qp.expval(hamiltonian), qp.expval(qp.PauliX(0))
+
+    energy, x_expectation = circuit()
+
+    assert energy == pytest.approx(0.0)
+    assert np.isfinite(x_expectation)
+    assert device.submitted_jobs >= 2
+
+
+def test_qasm2_diagonalizes_observable_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Do not duplicate the X-basis rotation in PennyLane's QASM2 serializer."""
+    qdmi = stub_device(program_format=fomac.ProgramFormat.QASM2)
+    _patch_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=10)
+
+    @qp.qnode(device)
+    def circuit():
+        return qp.expval(qp.PauliX(0))
+
+    assert np.isfinite(circuit())
+    assert qdmi.submissions[0][1] == fomac.ProgramFormat.QASM2
+    assert qdmi.submissions[0][0].count("ry(-1.5707963267948966) q[0];") == 1
+
+
+def test_rejects_analytic_execution_before_submission(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject analytic tapes before a QDMI job is created."""
+    qdmi = stub_device()
+    _patch_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=None)
+
+    @qp.qnode(device)
+    def circuit():
+        return qp.expval(qp.PauliZ(0))
+
+    with pytest.raises(PennyLaneValidationError, match="finite number of shots"):
+        circuit()
+    assert not qdmi.submissions
+
+
+def test_validates_configuration_and_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject unknown FoMaC parameters and excessive wire counts."""
+    qdmi = stub_device()
+    _patch_device(monkeypatch, qdmi)
+
+    with pytest.raises(PennyLaneConfigurationError, match="unknown"):
+        QDMIDevice("fake.qdmi", wires=2, session_parameters={"unknown": "value"})
+    with pytest.raises(PennyLaneConfigurationError, match="3 wires"):
+        QDMIDevice("fake.qdmi", wires=3)
+
+
+def test_rejects_device_without_openqasm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject unsupported program formats during construction."""
+    qdmi = StubDevice([], [fomac.ProgramFormat.QIR_BASE_STRING])
+    _patch_device(monkeypatch, qdmi)
+
+    with pytest.raises(PennyLaneUnsupportedFormatError, match="neither OpenQASM 3 nor OpenQASM 2"):
+        QDMIDevice("fake.qdmi", wires=2)
+
+
+def test_forwards_job_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Forward generic FoMaC custom job parameters unchanged."""
+    qdmi = stub_device()
+    _patch_device(monkeypatch, qdmi)
+    device = QDMIDevice(
+        "fake.qdmi",
+        wires=2,
+        shots=4,
+        job_parameters={"custom1": "bucket", "custom2": "prefix"},
+    )
+
+    @qp.qnode(device)
+    def circuit():
+        return qp.sample(wires=[0, 1])
+
+    circuit()
+    assert qdmi.submissions[0][3] == {"custom1": "bucket", "custom2": "prefix"}

--- a/test/python/plugins/qdmi_pennylane/test_optional.py
+++ b/test/python/plugins/qdmi_pennylane/test_optional.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Test optional PennyLane dependency handling."""
+
+from __future__ import annotations
+
+import sys
+
+from mqt.core.plugins import pennylane as plugin
+
+
+def test_optional_dependency_matches_supported_python() -> None:
+    """Keep the base Python 3.10 installation free of PennyLane."""
+    assert ("QDMIDevice" in plugin.__all__) == (sys.version_info >= (3, 11))

--- a/test/qdmi/driver/CMakeLists.txt
+++ b/test/qdmi/driver/CMakeLists.txt
@@ -15,11 +15,18 @@ if(TARGET MQT::CoreQDMIDriver)
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/device"
                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/device"
                QDMI_DEVICE_ID "test.metadata-only"
-               QDMI_DEVICE_PREFIX "TEST_METADATA")
+               QDMI_DEVICE_PREFIX "TEST_METADATA"
+               QDMI_RUNTIME_FILES "metadata-runtime.json")
+  add_custom_command(
+    TARGET mqt-core-qdmi-metadata-device
+    POST_BUILD
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/metadata-runtime.json"
+      "$<TARGET_FILE_DIR:mqt-core-qdmi-metadata-device>/metadata-runtime.json")
   set_property(
     TARGET mqt-core-qdmi-metadata-device
     APPEND
-    PROPERTY EXPORT_PROPERTIES QDMI_DEVICE_ID QDMI_DEVICE_PREFIX)
+    PROPERTY EXPORT_PROPERTIES QDMI_DEVICE_ID QDMI_DEVICE_PREFIX QDMI_RUNTIME_FILES)
   set(metadata_device_export
       "${CMAKE_CURRENT_BINARY_DIR}/mqt-core-qdmi-metadata-device-targets.cmake")
   export(TARGETS mqt-core-qdmi-metadata-device FILE "${metadata_device_export}")
@@ -76,4 +83,48 @@ if(TARGET MQT::CoreQDMIDriver)
                        PROPERTIES FIXTURES_SETUP mqt-core-qdmi-imported-device)
   set_tests_properties(mqt-core-qdmi-imported-device-build PROPERTIES FIXTURES_REQUIRED
                                                                       mqt-core-qdmi-imported-device)
+
+  set(runtime_file_device_build_dir "${CMAKE_CURRENT_BINARY_DIR}/runtime-file-device")
+  set(runtime_file_device_install_dir "${runtime_file_device_build_dir}/install")
+  if(WIN32)
+    set(runtime_file_device_artifact_dir "${CMAKE_INSTALL_BINDIR}")
+  else()
+    set(runtime_file_device_artifact_dir "${CMAKE_INSTALL_LIBDIR}")
+  endif()
+  set(runtime_file_device_configure_command
+      ${CMAKE_COMMAND} -S "${CMAKE_CURRENT_SOURCE_DIR}/runtime_file_device" -B
+      "${runtime_file_device_build_dir}" -G "${CMAKE_GENERATOR}"
+      "-DMQT_CORE_QDMI_HELPER=${PROJECT_SOURCE_DIR}/cmake/AddMQTQDMIDevice.cmake"
+      "-DMQT_CORE_QDMI_TEST_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}" "-DCMAKE_BUILD_TYPE=$<CONFIG>")
+  if(CMAKE_GENERATOR_PLATFORM)
+    list(APPEND runtime_file_device_configure_command -A "${CMAKE_GENERATOR_PLATFORM}")
+  endif()
+  if(CMAKE_GENERATOR_TOOLSET)
+    list(APPEND runtime_file_device_configure_command -T "${CMAKE_GENERATOR_TOOLSET}")
+  endif()
+  add_test(NAME mqt-core-qdmi-runtime-file-configure
+           COMMAND ${runtime_file_device_configure_command})
+  add_test(NAME mqt-core-qdmi-runtime-file-build
+           COMMAND ${CMAKE_COMMAND} --build "${runtime_file_device_build_dir}" --config $<CONFIG>)
+  add_test(NAME mqt-core-qdmi-runtime-file-install
+           COMMAND ${CMAKE_COMMAND} --install "${runtime_file_device_build_dir}" --config $<CONFIG>
+                   --prefix "${runtime_file_device_install_dir}")
+  add_test(
+    NAME mqt-core-qdmi-runtime-file-install-verify
+    COMMAND
+      ${CMAKE_COMMAND} -E compare_files
+      "${runtime_file_device_install_dir}/${runtime_file_device_artifact_dir}/metadata-runtime.json"
+      "${CMAKE_CURRENT_SOURCE_DIR}/metadata-runtime.json")
+  set_tests_properties(mqt-core-qdmi-runtime-file-configure
+                       PROPERTIES FIXTURES_SETUP mqt-core-qdmi-runtime-file-configure)
+  set_tests_properties(
+    mqt-core-qdmi-runtime-file-build
+    PROPERTIES FIXTURES_REQUIRED mqt-core-qdmi-runtime-file-configure FIXTURES_SETUP
+               mqt-core-qdmi-runtime-file-build)
+  set_tests_properties(
+    mqt-core-qdmi-runtime-file-install
+    PROPERTIES FIXTURES_REQUIRED mqt-core-qdmi-runtime-file-build FIXTURES_SETUP
+               mqt-core-qdmi-runtime-file-install)
+  set_tests_properties(mqt-core-qdmi-runtime-file-install-verify
+                       PROPERTIES FIXTURES_REQUIRED mqt-core-qdmi-runtime-file-install)
 endif()

--- a/test/qdmi/driver/imported_device/CMakeLists.txt
+++ b/test/qdmi/driver/imported_device/CMakeLists.txt
@@ -19,10 +19,20 @@ include("${MQT_CORE_QDMI_HELPER}")
 set(device mqt-core-qdmi-metadata-device)
 get_target_property(device_id ${device} QDMI_DEVICE_ID)
 get_target_property(device_prefix ${device} QDMI_DEVICE_PREFIX)
-if(NOT device_id STREQUAL "test.metadata-only" OR NOT device_prefix STREQUAL "TEST_METADATA")
+get_target_property(runtime_files ${device} QDMI_RUNTIME_FILES)
+if(NOT device_id STREQUAL "test.metadata-only"
+   OR NOT device_prefix STREQUAL "TEST_METADATA"
+   OR NOT runtime_files STREQUAL "metadata-runtime.json")
   message(FATAL_ERROR "Exported QDMI device metadata was not preserved")
 endif()
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/main.cpp" "int main() { return 0; }\n")
 add_executable(imported-device-consumer "${CMAKE_CURRENT_BINARY_DIR}/main.cpp")
 mqt_copy_qdmi_runtime(imported-device-consumer ${device})
+add_custom_command(
+  TARGET imported-device-consumer
+  POST_BUILD
+  COMMAND
+    ${CMAKE_COMMAND} -E compare_files
+    "$<TARGET_FILE_DIR:imported-device-consumer>/metadata-runtime.json"
+    "$<TARGET_FILE_DIR:${device}>/metadata-runtime.json")

--- a/test/qdmi/driver/metadata-runtime.json
+++ b/test/qdmi/driver/metadata-runtime.json
@@ -1,0 +1,1 @@
+{ "runtime-file": true }

--- a/test/qdmi/driver/runtime_file_device/CMakeLists.txt
+++ b/test/qdmi/driver/runtime_file_device/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+cmake_minimum_required(VERSION 3.24)
+project(mqt-core-qdmi-runtime-file-device-test LANGUAGES CXX)
+
+if(NOT MQT_CORE_QDMI_HELPER OR NOT MQT_CORE_QDMI_TEST_SOURCE_DIR)
+  message(FATAL_ERROR "The QDMI helper and test source directory are required")
+endif()
+
+set(QDMI_VERSION "test")
+include("${MQT_CORE_QDMI_HELPER}")
+
+add_library(mqt-core-qdmi-runtime-file-device SHARED
+            "${MQT_CORE_QDMI_TEST_SOURCE_DIR}/metadata_device.cpp")
+mqt_configure_qdmi_device(
+  mqt-core-qdmi-runtime-file-device
+  ID
+  test.runtime-file
+  PREFIX
+  TEST_RUNTIME
+  RUNTIME_FILES
+  "${MQT_CORE_QDMI_TEST_SOURCE_DIR}/metadata-runtime.json")

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -952,6 +952,28 @@ TEST(DeviceRegistrationTest, RegistrationDoesNotLoadLibraries) {
                std::runtime_error);
 }
 
+TEST(DeviceRegistrationTest,
+     EnumeratesEnabledIdsInOrderWithoutLoadingLibraries) {
+  auto& driver = qdmi::Driver::get();
+  const auto idsBefore = driver.registeredDeviceIds();
+  driver.registerDevice({.id = "test.enumeration.first",
+                         .library = "/nonexistent/first-device-library",
+                         .prefix = "MISSING_FIRST"});
+  driver.registerDevice({.id = "test.enumeration.second",
+                         .library = "/nonexistent/second-device-library",
+                         .prefix = "MISSING_SECOND"});
+
+  const auto idsAfter = driver.registeredDeviceIds();
+  ASSERT_EQ(idsAfter.size(), idsBefore.size() + 2);
+  EXPECT_TRUE(std::equal(idsBefore.begin(), idsBefore.end(), idsAfter.begin()));
+  EXPECT_EQ(idsAfter[idsBefore.size()], "test.enumeration.first");
+  EXPECT_EQ(idsAfter[idsBefore.size() + 1], "test.enumeration.second");
+  EXPECT_THAT(idsAfter, testing::Not(testing::Contains("test.disabled")));
+
+  EXPECT_THROW(static_cast<void>(driver.open("test.enumeration.first")),
+               std::runtime_error);
+}
+
 TEST(DeviceRegistrationTest, SynthesizesManifestForMetadataOnlyTarget) {
   std::ifstream manifest(MQT_CORE_QDMI_METADATA_MANIFEST);
   ASSERT_TRUE(manifest);

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -958,10 +958,12 @@ TEST(DeviceRegistrationTest,
   const auto idsBefore = driver.registeredDeviceIds();
   driver.registerDevice({.id = "test.enumeration.first",
                          .library = "/nonexistent/first-device-library",
-                         .prefix = "MISSING_FIRST"});
+                         .prefix = "MISSING_FIRST",
+                         .session = {}});
   driver.registerDevice({.id = "test.enumeration.second",
                          .library = "/nonexistent/second-device-library",
-                         .prefix = "MISSING_SECOND"});
+                         .prefix = "MISSING_SECOND",
+                         .session = {}});
 
   const auto idsAfter = driver.registeredDeviceIds();
   ASSERT_EQ(idsAfter.size(), idsBefore.size() + 2);
@@ -1026,12 +1028,14 @@ TEST(DeviceRegistrationTest,
 }
 
 TEST(DeviceRegistrationTest, TypedConfigurationUsesExactlyOneAdapterSlot) {
+  qdmi::DeviceSessionConfig sessionConfig;
+  sessionConfig.deviceConfiguration =
+      qdmi::InlineDeviceConfiguration{.json = R"({"name":"inline"})"};
   static_cast<void>(qdmi::Driver::get().registerDeviceIfAbsent(
       {.id = "test.typed-configuration",
        .library = MQT_CORE_QDMI_SESSION_DEVICE,
        .prefix = "TEST_SESSION",
-       .session = {.deviceConfiguration = qdmi::InlineDeviceConfiguration{
-                       .json = R"({"name":"inline"})"}}}));
+       .session = std::move(sessionConfig)}));
 
   const auto inlineDevice =
       fomac::Session::openDevice("test.typed-configuration");
@@ -1050,13 +1054,15 @@ TEST(DeviceRegistrationTest, TypedConfigurationUsesExactlyOneAdapterSlot) {
 
 TEST(DeviceRegistrationTest, TypedConfigurationRejectsRawAdapterSlotConflict) {
   auto& driver = qdmi::Driver::get();
+  qdmi::DeviceSessionConfig conflictingConfig;
+  conflictingConfig.deviceConfiguration =
+      qdmi::InlineDeviceConfiguration{.json = "{}"};
+  conflictingConfig.custom1 = "raw";
   const qdmi::DeviceDefinition definition{
       .id = "test.typed-conflict",
       .library = MQT_CORE_QDMI_SESSION_DEVICE,
       .prefix = "TEST_SESSION",
-      .session = {.deviceConfiguration =
-                      qdmi::InlineDeviceConfiguration{.json = "{}"},
-                  .custom1 = "raw"}};
+      .session = std::move(conflictingConfig)};
   EXPECT_THROW(driver.registerDevice(definition), std::invalid_argument);
 
   registerSessionTestDevice();

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -1003,6 +1003,50 @@ TEST(DeviceRegistrationTest,
   EXPECT_EQ(clientCatalogSize(), catalogSizeBefore);
 }
 
+TEST(DeviceRegistrationTest, TypedConfigurationUsesExactlyOneAdapterSlot) {
+  static_cast<void>(qdmi::Driver::get().registerDeviceIfAbsent(
+      {.id = "test.typed-configuration",
+       .library = MQT_CORE_QDMI_SESSION_DEVICE,
+       .prefix = "TEST_SESSION",
+       .session = {.deviceConfiguration = qdmi::InlineDeviceConfiguration{
+                       .json = R"({"name":"inline"})"}}}));
+
+  const auto inlineDevice =
+      fomac::Session::openDevice("test.typed-configuration");
+  EXPECT_THAT(
+      inlineDevice.getName(),
+      testing::HasSubstr(R"(custom1={"name":"inline"};custom2=<unset>)"));
+
+  qdmi::DeviceSessionConfig fileOverrides;
+  fileOverrides.deviceConfiguration =
+      qdmi::FileDeviceConfiguration{.path = "device.json"};
+  const auto fileDevice =
+      fomac::Session::openDevice("test.typed-configuration", fileOverrides);
+  EXPECT_THAT(fileDevice.getName(),
+              testing::HasSubstr("custom1=<unset>;custom2=device.json"));
+}
+
+TEST(DeviceRegistrationTest, TypedConfigurationRejectsRawAdapterSlotConflict) {
+  auto& driver = qdmi::Driver::get();
+  const qdmi::DeviceDefinition definition{
+      .id = "test.typed-conflict",
+      .library = MQT_CORE_QDMI_SESSION_DEVICE,
+      .prefix = "TEST_SESSION",
+      .session = {.deviceConfiguration =
+                      qdmi::InlineDeviceConfiguration{.json = "{}"},
+                  .custom1 = "raw"}};
+  EXPECT_THROW(driver.registerDevice(definition), std::invalid_argument);
+
+  registerSessionTestDevice();
+  qdmi::DeviceSessionConfig overrides;
+  overrides.deviceConfiguration =
+      qdmi::FileDeviceConfiguration{.path = "device.json"};
+  overrides.custom2 = "raw";
+  EXPECT_THROW(static_cast<void>(fomac::Session::openDevice(
+                   "test.session-overrides", overrides)),
+               std::invalid_argument);
+}
+
 TEST(DeviceRegistrationTest, FreshOpenCreatesDistinctSessions) {
   registerSessionTestDevice();
   const auto first = fomac::Session::openDevice("test.session-overrides");

--- a/test/qdmi/registry/test_device_registry.cpp
+++ b/test/qdmi/registry/test_device_registry.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace {
@@ -212,6 +213,87 @@ TEST(DeviceRegistry, MergesEnvironmentJsonOverExplicitFile) {
   EXPECT_EQ(definition->prefix, "FILE");
   EXPECT_EQ(definition->session.custom1, "from-json");
   EXPECT_EQ(definition->session.custom2, "preserved");
+}
+
+TEST(DeviceRegistry, DeviceConfigurationSourceReplacesAtomically) {
+  const TemporaryDirectory directory;
+  const ScopedCurrentPath currentPath(directory.path());
+  const auto path = directory.write("environment.json", R"({
+    "schema-version": 1,
+    "qdmi": {"devices": [{
+      "id": "environment", "library": "file.so", "prefix": "FILE",
+      "session": {"device-config": {"inline": {
+        "schema-version": 1, "name": "inline"
+      }}}
+    }]}
+  })");
+  const ScopedEnvironmentVariable configFile("MQT_CORE_QDMI_CONFIG_FILE",
+                                             path.string());
+  const ScopedEnvironmentVariable configJson("MQT_CORE_QDMI_CONFIG_JSON", R"({
+    "schema-version": 1,
+    "qdmi": {"devices": [{
+      "id": "environment",
+      "session": {"device-config": {"file": "overrides/device.json"}}
+    }]}
+  })");
+
+  const qdmi::detail::DeviceRegistry registry;
+  const auto* definition = findDefinition(registry, "environment");
+  ASSERT_NE(definition, nullptr);
+  ASSERT_TRUE(definition->session.deviceConfiguration);
+  const auto* file = std::get_if<qdmi::FileDeviceConfiguration>(
+      &*definition->session.deviceConfiguration);
+  ASSERT_NE(file, nullptr);
+  EXPECT_EQ(std::filesystem::weakly_canonical(file->path),
+            std::filesystem::weakly_canonical(directory.path()) /
+                "overrides/device.json");
+}
+
+TEST(DeviceRegistry, SerializesInlineDeviceConfigurationCompactly) {
+  const TemporaryDirectory directory;
+  const auto configFile = emptyConfig(directory);
+  const ScopedEnvironmentVariable configJson("MQT_CORE_QDMI_CONFIG_JSON", R"({
+    "schema-version": 1,
+    "qdmi": {"devices": [{
+      "id": "inline", "library": "file.so", "prefix": "FILE",
+      "session": {"device-config": {"inline": {
+        "schema-version": 1, "name": "inline"
+      }}}
+    }]}
+  })");
+
+  const qdmi::detail::DeviceRegistry registry;
+  const auto* definition = findDefinition(registry, "inline");
+  ASSERT_NE(definition, nullptr);
+  ASSERT_TRUE(definition->session.deviceConfiguration);
+  const auto* inlineConfig = std::get_if<qdmi::InlineDeviceConfiguration>(
+      &*definition->session.deviceConfiguration);
+  ASSERT_NE(inlineConfig, nullptr);
+  EXPECT_EQ(inlineConfig->json, R"({"name":"inline","schema-version":1})");
+}
+
+TEST(DeviceRegistry, RejectsInvalidDeviceConfigurationSources) {
+  const TemporaryDirectory directory;
+  const auto configFile = emptyConfig(directory);
+  const std::vector<std::string_view> invalidSources{
+      R"({})",
+      R"({"unknown": true})",
+      R"({"inline": []})",
+      R"({"file": ""})",
+      R"({"file": 1})",
+      R"({"inline": {"schema-version": 1}, "file": "device.json"})",
+  };
+  for (const auto source : invalidSources) {
+    SCOPED_TRACE(source);
+    const auto json =
+        R"({"schema-version":1,"qdmi":{"devices":[{"id":"invalid",)"
+        R"("library":"file.so","prefix":"FILE","session":{"device-config":)" +
+        std::string(source) + "}}]}}";
+    const ScopedEnvironmentVariable configJson("MQT_CORE_QDMI_CONFIG_JSON",
+                                               json);
+    EXPECT_THROW(static_cast<void>(qdmi::detail::DeviceRegistry()),
+                 std::invalid_argument);
+  }
 }
 
 TEST(DeviceRegistry, DisabledEnvironmentEntryMasksExplicitDefinition) {

--- a/test/zx/CMakeLists.txt
+++ b/test/zx/CMakeLists.txt
@@ -9,5 +9,5 @@
 if(TARGET MQT::CoreZX)
   file(GLOB_RECURSE ZX_TEST_SOURCES *.cpp)
   package_add_test(mqt-core-zx-test MQT::CoreZX ${ZX_TEST_SOURCES})
-  target_link_libraries(mqt-core-zx-test PRIVATE MQT::CoreQASM)
+  target_link_libraries(mqt-core-zx-test PRIVATE MQT::CoreDD MQT::CoreQASM)
 endif()

--- a/test/zx/test_zx_functionality.cpp
+++ b/test/zx/test_zx_functionality.cpp
@@ -8,6 +8,8 @@
  * Licensed under the MIT License
  */
 
+#include "dd/FunctionalityConstruction.hpp"
+#include "dd/Package.hpp"
 #include "ir/Definitions.hpp"
 #include "ir/Permutation.hpp"
 #include "ir/QuantumComputation.hpp"
@@ -26,6 +28,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -57,6 +60,88 @@ void checkEquivalence(const qc::QuantumComputation& qc1,
     ASSERT_LT(q, qc1.getNqubits());
     EXPECT_TRUE(d1.connected(d1.getInput(q), d1.getOutput(q)));
   }
+}
+
+void addDirtyAncillaMcx(qc::QuantumComputation& circuit,
+                        const std::vector<qc::Qubit>& controls,
+                        const qc::Qubit target,
+                        const std::vector<qc::Qubit>& ancillas) {
+  if (controls.size() == 1) {
+    circuit.cx(controls.front(), target);
+    return;
+  }
+  if (controls.size() == 2) {
+    circuit.mcx({controls.front(), controls.back()}, target);
+    return;
+  }
+
+  const auto requiredAncillas = controls.size() - 2;
+  for (std::size_t pass = 0; pass < 2; ++pass) {
+    circuit.mcx({controls.back(), ancillas[requiredAncillas - 1]}, target);
+    for (auto i = requiredAncillas - 1; i-- > 0;) {
+      circuit.h(ancillas[i + 1]);
+      circuit.t(ancillas[i + 1]);
+      circuit.cx(controls[i + 2], ancillas[i + 1]);
+      circuit.tdg(ancillas[i + 1]);
+      circuit.cx(ancillas[i], ancillas[i + 1]);
+    }
+    circuit.rccx(controls[0], controls[1], ancillas[0]);
+    for (std::size_t i = 0; i + 1 < requiredAncillas; ++i) {
+      circuit.cx(ancillas[i], ancillas[i + 1]);
+      circuit.t(ancillas[i + 1]);
+      circuit.cx(controls[i + 2], ancillas[i + 1]);
+      circuit.tdg(ancillas[i + 1]);
+      circuit.h(ancillas[i + 1]);
+    }
+  }
+}
+
+void addReferenceMcphase(qc::QuantumComputation& circuit, const double phase,
+                         const std::vector<qc::Qubit>& controls,
+                         const qc::Qubit target) {
+  if (controls.size() == 1) {
+    circuit.cp(phase, controls.front(), target);
+    return;
+  }
+  if (controls.size() == 2) {
+    const auto halfPhase = phase / 2.0;
+    circuit.p(halfPhase, target);
+    circuit.mcx({controls.front(), controls.back()}, target);
+    circuit.p(-halfPhase, target);
+    circuit.mcx({controls.front(), controls.back()}, target);
+    circuit.cp(halfPhase, controls.front(), controls.back());
+    return;
+  }
+
+  const auto split =
+      controls.begin() + static_cast<std::ptrdiff_t>((controls.size() + 1) / 2);
+  const std::vector<qc::Qubit> first(controls.begin(), split);
+  const std::vector<qc::Qubit> second(split, controls.end());
+  const auto quarterPhase = phase / 4.0;
+  addDirtyAncillaMcx(circuit, first, target, second);
+  circuit.p(-quarterPhase, target);
+  addDirtyAncillaMcx(circuit, second, target, first);
+  circuit.p(quarterPhase, target);
+  addDirtyAncillaMcx(circuit, first, target, second);
+  circuit.p(-quarterPhase, target);
+  addDirtyAncillaMcx(circuit, second, target, first);
+  circuit.p(quarterPhase, target);
+
+  addReferenceMcphase(
+      circuit, phase / 2.0,
+      std::vector<qc::Qubit>(controls.begin(), controls.end() - 1),
+      controls.back());
+}
+
+qc::QuantumComputation makeReferenceMcx(const std::size_t numControls) {
+  const auto numQubits = numControls + 1;
+  qc::QuantumComputation reference(numQubits);
+  std::vector<qc::Qubit> controls(numControls);
+  std::iota(controls.begin(), controls.end(), 1U);
+  reference.h(0);
+  addReferenceMcphase(reference, PI, controls, 0);
+  reference.h(0);
+  return reference;
 }
 
 } // namespace
@@ -263,6 +348,35 @@ TEST_F(ZXFunctionalityTest, MCX1) {
   qcPrime.cx(1, 0);
 
   checkEquivalence(qc, qcPrime, {0, 1});
+}
+
+TEST_F(ZXFunctionalityTest, LargeMCX) {
+  for (const std::size_t numControls : {5U, 8U}) {
+    const auto numQubits = numControls + 1;
+    qc::Controls controls;
+    for (qc::Qubit q = 1; q < numQubits; ++q) {
+      controls.emplace(q);
+    }
+
+    qc = qc::QuantumComputation(numQubits);
+    qc.mcx(controls, 0);
+
+    const auto reference = makeReferenceMcx(numControls);
+    std::vector<qc::Qubit> qubits(numQubits);
+    std::iota(qubits.begin(), qubits.end(), 0U);
+
+    checkEquivalence(qc, reference, qubits);
+
+    const auto diag = FunctionalityConstruction::buildFunctionality(&qc);
+    EXPECT_LT(diag.getNVertices(), 22U * numControls * numControls);
+
+    dd::Package package(numQubits);
+    const auto actual = dd::buildFunctionality(qc, package);
+    const auto expected = dd::buildFunctionality(reference, package);
+    EXPECT_EQ(actual.p, expected.p);
+    package.decRef(actual);
+    package.decRef(expected);
+  }
 }
 
 TEST_F(ZXFunctionalityTest, MCZ) {

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,15 @@ wheels = [
 ]
 
 [[package]]
+name = "appdirs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -96,6 +105,28 @@ wheels = [
 ]
 
 [[package]]
+name = "autograd"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/1c/3c24ec03c8ba4decc742b1df5a10c52f98c84ca8797757f313e7bdcdf276/autograd-1.8.0.tar.gz", hash = "sha256:107374ded5b09fc8643ac925348c0369e7b0e73bbed9565ffd61b8fd04425683", size = 2562146, upload-time = "2025-05-05T12:49:02.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/ea/e16f0c423f7d83cf8b79cae9452040fb7b2e020c7439a167ee7c317de448/autograd-1.8.0-py3-none-any.whl", hash = "sha256:4ab9084294f814cf56c280adbe19612546a35574d67c574b04933c7d2ecb7d78", size = 51478, upload-time = "2025-05-05T12:49:00.585Z" },
+]
+
+[[package]]
+name = "autoray"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/8f/c951dc8acf51db7554b075f184488400401472ad9aa25edffa9ed9982621/autoray-0.8.4.tar.gz", hash = "sha256:b4ce7066334279b216431a260bb5b5b84d87815e3295020a76d8701e43dc3432", size = 1321434, upload-time = "2025-12-05T01:42:25.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/49/bc1c2e3ca121f6468e0cd8d78a96ab2dcb65d0f003917f5d4edcaea103a2/autoray-0.8.4-py3-none-any.whl", hash = "sha256:287c366f2ba9d9c045ffa2b2421deea07439ed5a7f18b5d25b3a406d53b5c63c", size = 937489, upload-time = "2025-12-05T01:42:23.658Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -129,6 +160,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/01/56/99bf7d0799d95ad485d95596dc01c2a5b3dda58ebf50a94f6f73b33bacdf/breathe-4.36.0.tar.gz", hash = "sha256:14860b73118ac140b7a3f55446890c777d1b67149cb024279fe3710dad7f535c", size = 154842, upload-time = "2025-02-22T18:36:03.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/bc/d67ef1e11ed6e6343c135bf605aa9d5734ff0cc77eb42a2a41f182abc9d9/breathe-4.36.0-py3-none-any.whl", hash = "sha256:af85436f1f09e842bd1fd95617281211c635f8768d245ff830c59b979888d1d5", size = 97231, upload-time = "2025-02-22T18:36:01.087Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/d2/47e8bc06fe2a06d3f5bdf20f1126ab66c4e99dc48d940e7ba873f7ac7131/cachetools-7.1.7.tar.gz", hash = "sha256:a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50", size = 40680, upload-time = "2026-08-01T21:20:40.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl", hash = "sha256:ef98ef375ad188819ef2f9b3645e3987f4b8c5b7550e436ad998c2de78296df0", size = 16830, upload-time = "2026-08-01T21:20:38.977Z" },
 ]
 
 [[package]]
@@ -710,6 +750,18 @@ wheels = [
 ]
 
 [[package]]
+name = "diastatic-malt"
+version = "2.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/2a/2b9d9c4636288b4b2f3b31df4ed628ee97ed9d39ade4edac46cd45459b94/diastatic_malt-2.15.3.tar.gz", hash = "sha256:bc99f842a35e4f2594488ac231b8594011e4e11eea0fc661a98a554dff60d1c3", size = 115050, upload-time = "2026-03-09T21:22:30.557Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/f1/a2d24084039855e912ff893d2d51088e3769d998f509592494c819ff442d/diastatic_malt-2.15.3-py3-none-any.whl", hash = "sha256:f41aeff992bd07553b85a5947700452f551d419d439ab34464bca4f30dc2a6a1", size = 167238, upload-time = "2026-03-09T21:22:29.311Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -883,6 +935,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
+]
+
+[[package]]
+name = "gast"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/f6/e73969782a2ecec280f8a176f2476149dd9dba69d5f8779ec6108a7721e6/gast-0.7.0.tar.gz", hash = "sha256:0bb14cd1b806722e91ddbab6fb86bba148c22b40e7ff11e248974e04c8adfdae", size = 33630, upload-time = "2025-11-29T15:30:05.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl", hash = "sha256:99cbf1365633a74099f69c59bd650476b96baa5ef196fec88032b00b31ba36f7", size = 22966, upload-time = "2025-11-29T15:30:03.983Z" },
 ]
 
 [[package]]
@@ -1695,6 +1756,9 @@ name = "mqt-core"
 source = { editable = "." }
 
 [package.optional-dependencies]
+pennylane = [
+    { name = "pennylane", marker = "python_full_version >= '3.11'" },
+]
 qiskit = [
     { name = "qiskit", extra = ["qasm3-import"] },
 ]
@@ -1710,6 +1774,7 @@ dev = [
     { name = "nanobind" },
     { name = "nox" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pennylane", marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
     { name = "pytest-console-scripts" },
     { name = "pytest-cov" },
@@ -1726,6 +1791,7 @@ docs = [
     { name = "mlir-pygments" },
     { name = "myst-nb" },
     { name = "openqasm-pygments" },
+    { name = "pennylane", marker = "python_full_version >= '3.11'" },
     { name = "qiskit", extra = ["qasm3-import", "visualization"] },
     { name = "setuptools-scm" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1741,6 +1807,7 @@ docs = [
 ]
 test = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pennylane", marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
     { name = "pytest-console-scripts" },
     { name = "pytest-cov" },
@@ -1750,8 +1817,11 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "qiskit", extras = ["qasm3-import"], marker = "extra == 'qiskit'", specifier = ">=1.1.0" }]
-provides-extras = ["qiskit"]
+requires-dist = [
+    { name = "pennylane", marker = "python_full_version >= '3.11' and extra == 'pennylane'", specifier = ">=0.45.1,<0.46" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "extra == 'qiskit'", specifier = ">=1.1.0" },
+]
+provides-extras = ["pennylane", "qiskit"]
 
 [package.metadata.requires-dev]
 build = [
@@ -1765,6 +1835,7 @@ dev = [
     { name = "nox", specifier = ">=2025.11.12" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
+    { name = "pennylane", marker = "python_full_version >= '3.11'", specifier = ">=0.45.1,<0.46" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -1781,6 +1852,7 @@ docs = [
     { name = "mlir-pygments", specifier = ">=1.0.0" },
     { name = "myst-nb", specifier = ">=1.3.0" },
     { name = "openqasm-pygments", specifier = ">=0.2.0" },
+    { name = "pennylane", marker = "python_full_version >= '3.11'", specifier = ">=0.45.1,<0.46" },
     { name = "qiskit", extras = ["qasm3-import", "visualization"], specifier = ">=1.1.0" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
     { name = "sphinx", specifier = ">=8.1.3" },
@@ -1795,6 +1867,7 @@ docs = [
 test = [
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
+    { name = "pennylane", marker = "python_full_version >= '3.11'", specifier = ">=0.45.1,<0.46" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -1926,6 +1999,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -2342,6 +2424,62 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pennylane"
+version = "0.45.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appdirs" },
+    { name = "autograd" },
+    { name = "autoray" },
+    { name = "cachetools" },
+    { name = "diastatic-malt" },
+    { name = "gast" },
+    { name = "networkx" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "pennylane-lightning" },
+    { name = "requests" },
+    { name = "rustworkx" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "tomlkit" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/b1/87dcc5c26dd73cf44897b98f8276bc39c38a7300ee0c40a7e507ded03d56/pennylane-0.45.1-py3-none-any.whl", hash = "sha256:b8cc7f590c43281b6e35b3a35707e9583c6b7babeb31dcf6f1cbde32a754ab93", size = 5414360, upload-time = "2026-06-26T21:40:32.556Z" },
+]
+
+[[package]]
+name = "pennylane-lightning"
+version = "0.45.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pennylane" },
+    { name = "scipy-openblas32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/3b/54b667f2eca85bc66e5b290cb873d274a0bd234e1b5027b21edcd4a87dd5/pennylane_lightning-0.45.0.tar.gz", hash = "sha256:fb146f1b8be30ae0d445c6a9cd646a29234e9ed81e7d92467a48e62c20691ede", size = 792720, upload-time = "2026-05-12T19:12:42.557Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/c3/3675f0dec694cb83aaa4b86637b5adb9807f92a01bcc5ac83444e0a89bf3/pennylane_lightning-0.45.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:f6457de996eb733bdee8be28e6521efdb64cb5ae9c64a8e40e40a0e21f85550c", size = 1749825, upload-time = "2026-05-12T19:10:36.922Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fe/7be347726a2814e812de21bae0d711c5978049efe4f0117da3fb5f09be36/pennylane_lightning-0.45.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c067f3fda4c337775f21fed041189f561ccbb7ed7a0185d04b5de6e274809a4", size = 16929405, upload-time = "2026-05-12T19:10:40.632Z" },
+    { url = "https://files.pythonhosted.org/packages/02/48/932aaa64bd3e90d352713090f8dd8ea39fc77ef59d49abaf402cb5b24aa5/pennylane_lightning-0.45.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd23c8aa6543f3c9f701b97d4c19fd4c88549b830b646b747079ff7cb6b1e767", size = 25529585, upload-time = "2026-05-12T19:10:45.645Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4e/539f48ec9730a37e0afc3cb8e6637cec2ae94911e7a364e5778afed70f7e/pennylane_lightning-0.45.0-cp311-cp311-win_amd64.whl", hash = "sha256:445368b1681efef949a11c973e7e519b39f2ec012068bc4a89fcb23d98945750", size = 5415713, upload-time = "2026-05-12T19:10:48.753Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6d/cf601da59f3c6718123c2f6df393a588a3eeb398a3e382f915dd83be9add/pennylane_lightning-0.45.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:f43dd51f1e3d62681fd8d8e440c0ff458876fefd695bf38d57e2247b5c6a814f", size = 1749238, upload-time = "2026-05-12T19:10:50.908Z" },
+    { url = "https://files.pythonhosted.org/packages/63/23/cb39e4f2e56c04d27e562b3b730e3735be85f6678c9ef114d067d97c9faf/pennylane_lightning-0.45.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9221aa1019bf38baf32a1ef0cf81b4daf423022d35de1dfe320166e1fa72507", size = 16927701, upload-time = "2026-05-12T19:10:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/55/a3/54c7c47c5c4b02bd13345c370459c80492b304975cdedb8148e971a1987d/pennylane_lightning-0.45.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90f894f958af07081eda1ba4d112c23f3eae9514fe6d1128d53c8c601a95f15", size = 25531143, upload-time = "2026-05-12T19:10:59.217Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5e/f2a5be54003f26d3e628f766e50f1b06f344dce673e695174fe850b09ae4/pennylane_lightning-0.45.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4ba86c22d53f92dcfdf668d605c9f74f12613080a4c6ca261092104997607ce", size = 5413913, upload-time = "2026-05-12T19:11:01.908Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3e/c92ad96ce11978874028e8aac9cd335930fb415700572bf8299f1ddf87ac/pennylane_lightning-0.45.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:413f82918f0252e1a63031f3a9608f0b35e4e6a97c2046d8976fbef6d011e8a3", size = 1749197, upload-time = "2026-05-12T19:11:03.904Z" },
+    { url = "https://files.pythonhosted.org/packages/76/05/4299d122385e47512304e33e1ff16450c9d11305f75741054a6b22d4b534/pennylane_lightning-0.45.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b1bcd8102aa11bf4030726de9134f61a2ef86b32a36a76068c9632e8b510aa", size = 16927607, upload-time = "2026-05-12T19:11:07.571Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/87/62e7e7638017eb7ddd72f07777783c7a4ab5196806800ace10fac5bae16c/pennylane_lightning-0.45.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:588eb157976a970f1a0c21c51edf4302aae00f1a98cf558314726b966cd5be6c", size = 25531276, upload-time = "2026-05-12T19:11:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/67/85/a0d763d77b21312b36c55b2ab9ce307dc4570892efe7b241290ed564b55e/pennylane_lightning-0.45.0-cp313-cp313-win_amd64.whl", hash = "sha256:1b0c4084eb2e9de90aa7528bc6e9213f436d3ef4a7c79d4c9d15fd812aa136ac", size = 5413522, upload-time = "2026-05-12T19:11:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/df/94/f979e63fb7ddbd89ff42b57e9c0f21bd49a7c6a0ccb022a80d9f36bfa317/pennylane_lightning-0.45.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:a18f3b4e98c6def4e9826909d2eec95e55656de2d566a7d3e944cd3cc522fa98", size = 1749473, upload-time = "2026-05-12T19:11:18.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/88/f4eb42a49f3036acf0d936184e025dc945dbeafc21878eee71b683e9f959/pennylane_lightning-0.45.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd82239669e5abef0b7c324a0a086cac76f5c5d9361c4b6496d9370da5c016d9", size = 16926925, upload-time = "2026-05-12T19:11:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/74/cecb20d032bc5f98ec2a6b373fc464a6979de6a306f7bb1db0fd61ecd922/pennylane_lightning-0.45.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7992ba71246751cabebfc371b8cbe6b953bfdb746c2044c8161a9373d1eda33c", size = 25528043, upload-time = "2026-05-12T19:11:27.129Z" },
+    { url = "https://files.pythonhosted.org/packages/21/2a/e17e7a8746be2539c255ca6c53dfb7e7e3bb1d54c71e2219065021a8fd0d/pennylane_lightning-0.45.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0869f6fe2091bf9cb88f501257ccb18d2dd4a21e7a0d5d66239c10897a36e6", size = 5435459, upload-time = "2026-05-12T19:11:29.87Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/c1f12a8d137c135551c9fb71890021d8958dc0d6152505907cf35854df68/pennylane_lightning-0.45.0-py3-none-any.whl", hash = "sha256:24f6c1f7db13dec80fdbe167579c5c42f1098c8f798ba9513e1b8d0906f64cc1", size = 1046727, upload-time = "2026-05-12T19:11:31.98Z" },
 ]
 
 [[package]]
@@ -3441,6 +3579,26 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy-openblas32"
+version = "0.3.34.0.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/ad/b0330d85dd2ab60968bff39b1b9454db3306b965c71b98db201093ba1898/scipy_openblas32-0.3.34.0.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b6589278b79442ea79567c8e530643be751a1354196d27396f3c7b2369f10c1e", size = 10425671, upload-time = "2026-07-19T20:13:39.452Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/ad1ae888597867ded86175d294658eb84b2881577651b370336ccc7df72a/scipy_openblas32-0.3.34.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:64619387b7a90a5b062856fdbf8c8788bb0cd2d7da1c866cf568e90c6e93756b", size = 6845528, upload-time = "2026-07-19T20:13:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b5/6e296b54ac83a0a59d678d295b1695224b2cf1cd67533e0a286d7e216655/scipy_openblas32-0.3.34.0.0-py3-none-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b534496a7c5fd69abf7938cbcc3f4fbb8108d9ed99ac9f93db229abd99281b06", size = 9329914, upload-time = "2026-07-19T20:13:43.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/30/8774fa1342b254a64df07f6140cbf17ebf07233a09f8d3c7da0d11b461e2/scipy_openblas32-0.3.34.0.0-py3-none-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:614542d69fcd29628972918c3f45d0634bac7386a648849b5969e394deb4304c", size = 9115958, upload-time = "2026-07-19T20:13:45.697Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e7/83c3bb3404bf800006495b807e148e4f1b280f3a3609d0e869b3468f7ded/scipy_openblas32-0.3.34.0.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ed3007fe0c8775637069b53bc82cdfe11c2e4d004df8d2decd3639d1043d1f2f", size = 6953948, upload-time = "2026-07-19T20:13:47.861Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d1/e201ef4ff4cb22a30bbba58a6917a1ee097c685b8d8ac0165f66149731bf/scipy_openblas32-0.3.34.0.0-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5b5df658f32271b3115d845ea91b19bed190591b55d27d9b5399b83071c68ea1", size = 8836393, upload-time = "2026-07-19T20:13:49.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b5/a4e12f7f0978738387652016c0addf5db9b4f1eee3cc6f8a2934de79e6fd/scipy_openblas32-0.3.34.0.0-py3-none-manylinux_2_28_i686.whl", hash = "sha256:b20d34a5c2d8df746f747c60cd2a657034475be58d1f5cdefdec1c47c3894b85", size = 7057363, upload-time = "2026-07-19T20:13:51.728Z" },
+    { url = "https://files.pythonhosted.org/packages/00/c9/4918544dc57a33872642f2ea30e5d7c75abcdde106b4836ecbb198d89b89/scipy_openblas32-0.3.34.0.0-py3-none-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3a43c4677f133682271d983b30101e6ed44c8dbed6125646ee9aafae1194c3aa", size = 6028922, upload-time = "2026-07-19T20:13:53.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f5/02eb78221e61c8d2e470f1a3610525e4569e5263a6a674ee16b01cdc2006/scipy_openblas32-0.3.34.0.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f8cb72bac195384ac04372d55e98bcfe156e0c494b07802b5a2ad7ccf61e3715", size = 9608131, upload-time = "2026-07-19T20:13:55.418Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/28/3a5b098a737e47761f5ed297449b12f0c493f021c6aa6aea15fc0b051f36/scipy_openblas32-0.3.34.0.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:367ffdbc0e7b51c6851a629a04dd751af20ceffc2123223412bbccbc48a23356", size = 9461494, upload-time = "2026-07-19T20:13:57.643Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d2/36384cf949e0e0064025fa4dea478d76cd0e31fc176f818cb004232f125e/scipy_openblas32-0.3.34.0.0-py3-none-win32.whl", hash = "sha256:798a20dcdb62001adb2df066eb4524a697b486f45598dfc803fcbe4a23a29289", size = 5614749, upload-time = "2026-07-19T20:13:59.677Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/b9fcec55d931cb928295043872f7e65b7052e65722f55e9a613e6b307cbc/scipy_openblas32-0.3.34.0.0-py3-none-win_amd64.whl", hash = "sha256:e80cd667c9604f85aee2f0aa2ca547c5fc0f63d97b7b81b4b45401b1f912ff03", size = 7127068, upload-time = "2026-07-19T20:14:01.786Z" },
+    { url = "https://files.pythonhosted.org/packages/39/7b/5f946bfb49e1dadcdbaf30d317fa84b20e53ec0991dd2a349058966dd2fd/scipy_openblas32-0.3.34.0.0-py3-none-win_arm64.whl", hash = "sha256:3003d1d72b95cd919bf6fccacd29f05f3bb007aba74e411c94388049fc9d153e", size = 5129104, upload-time = "2026-07-19T20:14:03.575Z" },
+]
+
+[[package]]
 name = "seaborn"
 version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3986,6 +4144,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Backport selected changes from `main` to the maintained `v3.x` branch in preparation for MQT Core 3.9.0.

The commits remain separate by upstream functionality. The series includes:

- typed QDMI device-configuration transport from #1967
- deterministic, load-free registered QDMI device-ID enumeration from #1972
- DD serialization bindings and terminal-root deserialization fix from #1983
- the quadratic, ancilla-free ZX multi-controlled-X construction from #1984
- the gate-based QDMI–PennyLane device, OpenQASM 3-first conversion, OpenQASM 2 fallback, DDSIM integration, tests, packaging, and executable MaxCut notebook from #2005

## v3 compatibility

This backport preserves the MQT Core 3 architecture:

- LLVM/MLIR remains optional and continues to use LLVM/MLIR 21.
- Python 3.10 continues to install and test MQT Core without PennyLane; the optional PennyLane integration is enabled on Python 3.11 and newer.
- The LLVM/MLIR 22 compiler-target series, typed OpenQASM frontend and emitter, QCO mapping changes, specialized neutral-atom and superconducting runtime configuration, and routine dependency churn are not included.
- The QIR classical-result ordering fix from #1979 is not backportable because its `QCToQIR` conversion does not exist on `v3.x`.

## Validation

- QDMI driver and registry suites: 127 tests passed
- focused DD serialization and ZX construction suites: 7 tests passed
- Python DD serialization tests: 16 tests passed
- complete PennyLane/DDSIM suite on Python 3.14: 33 tests passed
- minimum-dependency PennyLane/DDSIM suite on Python 3.12: 10 tests passed
- Python 3.10 optional-dependency boundary: passed without installing PennyLane
- regenerated Python stubs without a tracked diff
- forced and cached documentation builds completed through `nox -s docs`; the executable PennyLane notebook completed successfully
- complete lint, lockfile validation, commit-signature audit, and `git diff --check` passed

The pre-existing v3 test configuration still requires an explicit `llc` path even when MLIR is disabled. The focused native build used LLVM 21.1.8's `llc`. The documentation build retains the existing v3 C++ and optional-MLIR warning baseline.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide where needed.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the applicable local checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our AI Usage Guidelines.
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
