### PR TITLE
✨ Select QDMI devices from Slurm license environments

### DIFF
--- a/.agent/plans/qdmi-slurm-adapter.md
+++ b/.agent/plans/qdmi-slurm-adapter.md
@@ -1,0 +1,133 @@
+# Add a QDMI adapter for Slurm licenses
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date. Maintain this document in accordance with `.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+A Slurm job can use one local license environment value to open the registered
+QDMI device with the same stable ID. The public names identify the mechanism:
+`fomac::slurm::openDeviceFromLicense()` in C++ and
+`mqt.core.qdmi.slurm.open_device_from_license()` in Python. The QDMI driver
+remains independent of Slurm.
+
+The adapter accepts one local unit license value, opens a fresh device session
+from the persistent definition, and checks the device state. It does not verify
+the allocation, authorize access, inject credentials, or apply per-job QDMI
+configuration.
+
+## Progress
+
+- [x] (2026-08-13 03:38Z) Reconstruct the branch on the QDMI namespace layer.
+- [x] (2026-08-13 03:38Z) Add the C++ Slurm adapter and Python submodule.
+- [x] (2026-08-13 03:38Z) Move grammar and status tests into the FoMaC test
+      component.
+- [x] (2026-08-13 04:23Z) Generate recursive stubs and run the complete FoMaC,
+      DDSIM status, QDMI driver, Python, lint, documentation, wheel, and
+      installed-wheel smoke checks.
+- [x] (2026-08-13 12:31Z) Rebuild the layer on the finalized QDMI namespace head
+      and move the Python test into the QDMI test tree.
+- [x] (2026-08-13 12:45Z) Complete an independent adversarial review and address
+      the changed-surface clang-tidy and coverage findings.
+- [x] (2026-08-13 14:40Z) Define the environment variable as selection metadata,
+      not as allocation evidence or authorization.
+
+## Surprises & Discoveries
+
+- Observation: The adapter needs no Slurm client library. Slurm exports the
+  license expression in `SLURM_JOB_LICENSES` before the job runs. The process
+  can modify this environment variable.
+- Observation: The existing test QDMI provider can report configured device
+  states. This keeps the unavailable-state test provider-independent and out of
+  the QDMI driver tests.
+- Observation: DDSIM reported `OFFLINE` before its first job even though a fresh
+  session could submit work. The adapter correctly rejected that state. DDSIM
+  now reports `IDLE` before its first job, changes to `BUSY` while work runs,
+  and returns to `IDLE` when the work completes.
+
+## Decision Log
+
+- Decision: Put the adapter in `fomac::slurm` and `mqt.core.qdmi.slurm`.
+  Rationale: The names state the mechanism and do not imply support for other
+  resource managers. Date/Author: 2026-08-13, Lukas Burgholzer and Codex.
+- Decision: Accept exactly one license with an implicit count or count one.
+  Rationale: One job needs one device handle. A larger configured pool admits
+  more independent jobs, not more handles in one job. Date/Author: 2026-08-13,
+  Lukas Burgholzer and Codex.
+- Decision: Keep credential handling in each provider. Rationale: IQM, Amazon
+  Braket, and future providers use different standard credential sources. Slurm
+  admission does not own authentication. Date/Author: 2026-08-13, Lukas
+  Burgholzer and Codex.
+- Decision: Treat `SLURM_JOB_LICENSES` as selection metadata only. Rationale:
+  the process can modify the environment and can call the public device-opening
+  API directly. Provider credentials or operating-system isolation must enforce
+  access. Date/Author: 2026-08-13, Lukas Burgholzer and Codex.
+
+## Outcomes & Retrospective
+
+The focused C++ grammar, device-state, and DDSIM transition tests pass. The
+complete FoMaC and QDMI driver suites pass. The QDMI Python suite passes on
+Python 3.10 and 3.14. Recursive stub generation includes the
+`mqt.core.qdmi.slurm` module. Full lint and the documentation build pass. The
+independent review found no remaining local blocker. Platform CI remains.
+
+## Context and Orientation
+
+`include/mqt-core/fomac` and `src/fomac` contain owning C++ wrappers above the
+QDMI client interface. `bindings/qdmi` exposes those wrappers through the native
+`mqt.core.qdmi` extension. `src/qdmi/driver` owns the device registry and must
+not contain scheduler-specific parsing.
+
+Slurm places the license expression in `SLURM_JOB_LICENSES`. A local static
+license has the form `name` or `name:count`. Remote licenses add `@server`.
+Commas and pipes represent compound expressions. This adapter supports only the
+single-device subset. The value is not proof of an allocation.
+
+## Plan of Work
+
+Add `fomac/Slurm.hpp` and `src/fomac/Slurm.cpp`. Parse an owned environment
+string. Use explicitly typed character pointers for `std::from_chars` so the
+code works with the Microsoft standard library. Compare the parsed stable ID to
+the registered IDs, then call the existing fresh-open operation without
+overrides. Query the QDMI device status and accept `IDLE` or `BUSY`.
+
+Expose the function in a sibling Python `slurm` submodule. Keep QDMI entities in
+`mqt.core.qdmi` and ordinary registration and opening functions in
+`mqt.core.qdmi.driver`. Add C++ tests for the complete grammar and status
+contract. Add a Python binding test with the DDSIM device. Document the boundary
+between Slurm admission, environment-based selection, device status, provider
+queues, and provider authorization.
+
+## Validation and Acceptance
+
+The C++ tests cover an absent or empty variable, whitespace, malformed counts,
+signed counts, zero, non-unit counts, trailing characters, integer overflow,
+remote licenses, unknown IDs, AND expressions, OR expressions, implicit and
+explicit unit counts, `IDLE`, `BUSY`, and every other QDMI device state. Each
+device-state rejection diagnostic contains the stable ID and reported status.
+
+Stub generation must add `python/mqt/core/qdmi/slurm.pyi`. Python tests must
+open DDSIM through the binding and reject compound and non-unit expressions. The
+complete lint and documentation sessions must pass. Platform CI provides the
+Windows compiler and free-threaded Python gates.
+
+## Idempotence and Recovery
+
+Tests restore the original process environment after each case. Device
+registrations use stable test IDs and insert only when absent. If the lower
+namespace layer changes, rebuild this branch on its new exact head and rerun all
+affected checks before publication.
+
+## Interfaces and Dependencies
+
+The final public interfaces are:
+
+    #include "fomac/Slurm.hpp"
+    auto device = fomac::slurm::openDeviceFromLicense();
+
+    from mqt.core.qdmi import slurm
+    device = slurm.open_device_from_license()
+
+The adapter depends on MQT Core FoMaC and the QDMI registry. It does not link to
+Slurm or a provider SDK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add C++ and Python adapters that open the QDMI device named by one local
+  Slurm license environment value ([#2025]) ([**@burgholzer**])
 - ✨ Add an `unroll-modifiers` pass for unrolling multi-operation modifiers
   ([#2015]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add generic C++ and Python FoMaC support for custom device properties that
@@ -757,6 +759,7 @@ for previous changelogs._
 [#2030]: https://github.com/munich-quantum-toolkit/core/pull/2030
 [#2028]: https://github.com/munich-quantum-toolkit/core/pull/2028
 [#2026]: https://github.com/munich-quantum-toolkit/core/pull/2026
+[#2025]: https://github.com/munich-quantum-toolkit/core/pull/2025
 [#2018]: https://github.com/munich-quantum-toolkit/core/pull/2018
 [#2017]: https://github.com/munich-quantum-toolkit/core/pull/2017
 [#2016]: https://github.com/munich-quantum-toolkit/core/pull/2016

--- a/bindings/qdmi/qdmi.cpp
+++ b/bindings/qdmi/qdmi.cpp
@@ -36,6 +36,10 @@ namespace mqt {
 namespace nb = nanobind;
 using namespace nb::literals;
 
+namespace bindings {
+void registerSlurm(nb::module_& qdmiModule);
+}
+
 namespace {
 void warnAboutLegacySession() {
   constexpr auto message =
@@ -124,6 +128,7 @@ NB_MODULE(MQT_CORE_MODULE_NAME, qdmiModule) {
   qdmiModule.doc() = "QDMI entities and access to MQT Core's QDMI driver.";
   auto driver = qdmiModule.def_submodule(
       "driver", "Register, discover, and open QDMI devices through MQT Core.");
+  bindings::registerSlurm(qdmiModule);
 
   // Session class
   auto session = nb::class_<fomac::Session>(driver, "Session",

--- a/bindings/qdmi/slurm.cpp
+++ b/bindings/qdmi/slurm.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "fomac/Slurm.hpp"
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+namespace mqt::bindings {
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void registerSlurm(nb::module_& qdmiModule) {
+  auto slurm = qdmiModule.def_submodule(
+      "slurm", "Open a QDMI device named by the Slurm license environment.");
+  slurm.def("open_device_from_license", &fomac::slurm::openDeviceFromLicense,
+            R"pb(Open the QDMI device named by the Slurm license environment.
+
+``SLURM_JOB_LICENSES`` must contain one local license whose name equals a
+registered QDMI device ID. The optional count must be one. The function opens a
+fresh device session from the persistent definition and accepts device status
+``IDLE`` or ``BUSY``. It does not apply job-specific QDMI configuration or
+credentials.
+
+Warning:
+    ``SLURM_JOB_LICENSES`` is process-mutable. This function uses it only for
+    device selection. It does not verify a Slurm allocation, authenticate the
+    caller, or authorize device access. The provider or operating system must
+    enforce access independently.
+
+Returns:
+    mqt.core.qdmi.Device: The fresh device session.
+
+Raises:
+    RuntimeError: If the license value or named device does not satisfy this
+        contract.)pb");
+}
+
+} // namespace mqt::bindings

--- a/docs/qdmi/configuration.md
+++ b/docs/qdmi/configuration.md
@@ -171,6 +171,48 @@ Multiple definitions may refer to the same library and prefix. MQT Core reuses
 the initialized library while creating a fresh QDMI device session, with its own
 session parameters, for every definition.
 
+## Selecting a device from a Slurm license environment
+
+MQT Core provides a mechanism-specific adapter for jobs that use local Slurm
+licenses for cluster-wide admission. The license name must equal one registered
+QDMI device ID. Each job must request one license. For example:
+
+```bash
+sbatch --licenses=mqt.ddsim.default:1 simulation.sh
+```
+
+The job can then open the named device:
+
+```python
+from mqt.core.qdmi import slurm
+
+device = slurm.open_device_from_license()
+```
+
+The equivalent C++ function is `fomac::slurm::openDeviceFromLicense()` from
+`fomac/Slurm.hpp`. Both functions read `SLURM_JOB_LICENSES`. They accept only
+`<registered-device-id>` or `<registered-device-id>:1`. They reject remote,
+compound, and non-unit license values.
+
+The adapter opens a fresh device session from the persistent definition. It does
+not replace configuration or inject credentials. Each provider defines its own
+credential sources. The adapter accepts QDMI device status `IDLE` and `BUSY`. It
+rejects all other device states.
+
+`SLURM_JOB_LICENSES` is process-mutable. The adapter uses this value only for
+device selection. It does not verify that Slurm allocated the license. It does
+not authenticate the caller or authorize access to the device. Provider
+credentials must authorize remote devices. The operating system must isolate a
+local device when access requires enforcement. A caller can also bypass this
+adapter and call {py:func}`~mqt.core.qdmi.driver.open_device` with a stable
+device ID. A different Slurm lookup would therefore not make MQT Core an access
+control boundary.
+
+A cluster can configure more than one license for a device. For example,
+`mqt.ddsim.default:2` permits two independent jobs to request one license each.
+The count is a Slurm admission limit. It is not an access permission, a provider
+availability check, or a provider queue length.
+
 ## Relocatable packages and static consumers
 
 Built-in targets generate manifests beside their runtime libraries in both build

--- a/include/mqt-core/fomac/Slurm.hpp
+++ b/include/mqt-core/fomac/Slurm.hpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/** @file Slurm.hpp
+ * @brief FoMaC adapter for selecting a QDMI device from a Slurm license
+ * environment value.
+ */
+
+#pragma once
+
+#include "fomac/FoMaC.hpp"
+
+namespace fomac::slurm {
+
+/**
+ * @brief Opens the QDMI device named by the Slurm license environment.
+ * @return A fresh device session using the registered device definition.
+ * @details The @c SLURM_JOB_LICENSES value must contain exactly one local
+ * license. Its name must equal a registered QDMI device ID. The optional
+ * license count must be one. The device must report @c QDMI_DEVICE_STATUS_IDLE
+ * or @c QDMI_DEVICE_STATUS_BUSY.
+ * @warning This function uses process-mutable environment data for device
+ * selection. It does not verify a Slurm allocation, authenticate the caller,
+ * or authorize access to the device. The provider or operating system must
+ * enforce access independently.
+ * @throws std::runtime_error If the license value is missing, malformed,
+ * compound, remote, has a non-unit count, names an unknown device, or names a
+ * device in another state.
+ */
+[[nodiscard]] Device openDeviceFromLicense();
+
+} // namespace fomac::slurm

--- a/include/mqt-core/qdmi/devices/dd/Device.hpp
+++ b/include/mqt-core/qdmi/devices/dd/Device.hpp
@@ -45,7 +45,7 @@ class Device final : public Singleton<Device> {
   size_t qubitsNum_ = 0;
 
   /// The status of the device.
-  std::atomic<QDMI_Device_Status> status_{QDMI_DEVICE_STATUS_OFFLINE};
+  std::atomic<QDMI_Device_Status> status_{QDMI_DEVICE_STATUS_IDLE};
 
   /// The list of device sessions.
   std::unordered_map<MQT_DDSIM_QDMI_Device_Session,

--- a/python/mqt/core/qdmi/__init__.pyi
+++ b/python/mqt/core/qdmi/__init__.pyi
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from typing import overload
 
 from . import driver as driver
+from . import slurm as slurm
 
 class Job:
     """A job represents a submitted quantum program execution."""

--- a/python/mqt/core/qdmi/slurm.pyi
+++ b/python/mqt/core/qdmi/slurm.pyi
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Open a QDMI device named by the Slurm license environment."""
+
+import mqt.core.qdmi
+
+def open_device_from_license() -> mqt.core.qdmi.Device:
+    """Open the QDMI device named by the Slurm license environment.
+
+    ``SLURM_JOB_LICENSES`` must contain one local license whose name equals a
+    registered QDMI device ID. The optional count must be one. The function opens a
+    fresh device session from the persistent definition and accepts device status
+    ``IDLE`` or ``BUSY``. It does not apply job-specific QDMI configuration or
+    credentials.
+
+    Warning:
+        ``SLURM_JOB_LICENSES`` is process-mutable. This function uses it only for
+        device selection. It does not verify a Slurm allocation, authenticate the
+        caller, or authorize device access. The provider or operating system must
+        enforce access independently.
+
+    Returns:
+        mqt.core.qdmi.Device: The fresh device session.
+
+    Raises:
+        RuntimeError: If the license value or named device does not satisfy this
+            contract.
+    """

--- a/src/fomac/CMakeLists.txt
+++ b/src/fomac/CMakeLists.txt
@@ -13,11 +13,18 @@ if(NOT TARGET ${TARGET_NAME})
   add_mqt_core_library(${TARGET_NAME} ALIAS_NAME FoMaC)
 
   # Add sources to target
-  target_sources(${TARGET_NAME} PRIVATE FoMaC.cpp)
+  target_sources(${TARGET_NAME} PRIVATE FoMaC.cpp Slurm.cpp)
 
   # Add headers using file sets
-  target_sources(${TARGET_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_CORE_INCLUDE_BUILD_DIR}
-                                       FILES ${MQT_CORE_INCLUDE_BUILD_DIR}/fomac/FoMaC.hpp)
+  target_sources(
+    ${TARGET_NAME}
+    PUBLIC FILE_SET
+           HEADERS
+           BASE_DIRS
+           ${MQT_CORE_INCLUDE_BUILD_DIR}
+           FILES
+           ${MQT_CORE_INCLUDE_BUILD_DIR}/fomac/FoMaC.hpp
+           ${MQT_CORE_INCLUDE_BUILD_DIR}/fomac/Slurm.hpp)
 
   # Add link libraries
   target_link_libraries(

--- a/src/fomac/Slurm.cpp
+++ b/src/fomac/Slurm.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "fomac/Slurm.hpp"
+
+#include "fomac/FoMaC.hpp"
+#include "qdmi/driver/Driver.hpp"
+
+#include <qdmi/constants.h>
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <cstddef>
+#include <cstdlib>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+namespace fomac::slurm {
+namespace {
+
+[[nodiscard]] auto statusName(const QDMI_Device_Status status)
+    -> std::string_view {
+  switch (status) {
+  case QDMI_DEVICE_STATUS_OFFLINE:
+    return "OFFLINE";
+  case QDMI_DEVICE_STATUS_IDLE:
+    return "IDLE";
+  case QDMI_DEVICE_STATUS_BUSY:
+    return "BUSY";
+  case QDMI_DEVICE_STATUS_ERROR:
+    return "ERROR";
+  case QDMI_DEVICE_STATUS_MAINTENANCE:
+    return "MAINTENANCE";
+  case QDMI_DEVICE_STATUS_CALIBRATION:
+    return "CALIBRATION";
+  case QDMI_DEVICE_STATUS_MAX:
+    return "UNKNOWN";
+  }
+  return "UNKNOWN";
+}
+
+[[nodiscard]] auto parseLicense(const std::string& licenseSpec,
+                                const std::vector<std::string>& registeredIds)
+    -> std::string {
+  if (licenseSpec.empty()) {
+    throw std::runtime_error(
+        "SLURM_JOB_LICENSES is not set or empty; no QDMI device license is "
+        "available");
+  }
+  if (std::ranges::any_of(licenseSpec, [](const unsigned char character) {
+        return std::isspace(character) != 0;
+      })) {
+    throw std::runtime_error("SLURM_JOB_LICENSES must not contain whitespace");
+  }
+  if (licenseSpec.find(',') != std::string::npos) {
+    throw std::runtime_error(
+        "SLURM_JOB_LICENSES uses a compound AND expression; exactly one QDMI "
+        "device license is required");
+  }
+  if (licenseSpec.find('|') != std::string::npos) {
+    throw std::runtime_error(
+        "SLURM_JOB_LICENSES uses a compound OR expression; exactly one QDMI "
+        "device license is required");
+  }
+  if (licenseSpec.find('@') != std::string::npos) {
+    throw std::runtime_error(
+        "A remote Slurm license cannot select a QDMI device");
+  }
+
+  const auto countSeparator = licenseSpec.find(':');
+  if (countSeparator != std::string::npos &&
+      licenseSpec.find(':', countSeparator + 1) != std::string::npos) {
+    throw std::runtime_error("SLURM_JOB_LICENSES contains a malformed license");
+  }
+  const auto deviceId = licenseSpec.substr(0, countSeparator);
+  if (deviceId.empty()) {
+    throw std::runtime_error("SLURM_JOB_LICENSES contains a malformed license");
+  }
+
+  if (countSeparator != std::string::npos) {
+    const std::string countText = licenseSpec.substr(countSeparator + 1);
+    if (countText.empty()) {
+      throw std::runtime_error(
+          "SLURM_JOB_LICENSES contains a malformed license count");
+    }
+    size_t count = 0;
+    const char* const countBegin = countText.data();
+    const auto countLength = static_cast<std::ptrdiff_t>(countText.size());
+    const char* const countEnd = std::next(countBegin, countLength);
+    const auto [parsedEnd, error] =
+        std::from_chars(countBegin, countEnd, count);
+    if (error != std::errc{} || parsedEnd != countEnd) {
+      throw std::runtime_error(
+          "SLURM_JOB_LICENSES contains an invalid license count");
+    }
+    if (count != 1) {
+      throw std::runtime_error(
+          "A QDMI device job must request exactly one Slurm license");
+    }
+  }
+
+  if (std::ranges::find(registeredIds, deviceId) == registeredIds.end()) {
+    throw std::runtime_error("Slurm license '" + deviceId +
+                             "' is not a registered QDMI device ID");
+  }
+  return deviceId;
+}
+
+} // namespace
+
+Device openDeviceFromLicense() {
+  // The job can modify its environment. Use this value only to select a
+  // registered device; the provider or operating system must authorize access.
+  const auto* const environmentValue = std::getenv("SLURM_JOB_LICENSES");
+  const std::string licenseSpec =
+      environmentValue == nullptr ? std::string{} : environmentValue;
+  const auto deviceId =
+      parseLicense(licenseSpec, qdmi::Driver::get().registeredDeviceIds());
+
+  auto device = Session::openDevice(deviceId);
+  const auto status = device.getStatus();
+  if (status != QDMI_DEVICE_STATUS_IDLE && status != QDMI_DEVICE_STATUS_BUSY) {
+    throw std::runtime_error("SLURM_JOB_LICENSES names QDMI device '" +
+                             deviceId + "' with status " +
+                             std::string(statusName(status)));
+  }
+  return device;
+}
+
+} // namespace fomac::slurm

--- a/test/fomac/CMakeLists.txt
+++ b/test/fomac/CMakeLists.txt
@@ -9,6 +9,10 @@
 set(TARGET_NAME mqt-core-fomac-test)
 
 if(TARGET MQT::CoreFoMaC)
-  package_add_test(${TARGET_NAME} MQT::CoreFoMaC test_fomac.cpp)
+  package_add_test(${TARGET_NAME} MQT::CoreFoMaC test_fomac.cpp test_slurm.cpp)
+  target_compile_definitions(
+    ${TARGET_NAME}
+    PRIVATE "MQT_CORE_FOMAC_SLURM_TEST_DEVICE=\"$<TARGET_FILE:mqt-core-qdmi-session-device>\"")
+  add_dependencies(${TARGET_NAME} mqt-core-qdmi-session-device)
   mqt_copy_qdmi_runtime(${TARGET_NAME})
 endif()

--- a/test/fomac/test_slurm.cpp
+++ b/test/fomac/test_slurm.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "fomac/Slurm.hpp"
+#include "qdmi/driver/Driver.hpp"
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <qdmi/constants.h>
+
+#include <array>
+#include <cstdlib>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace fomac::slurm {
+namespace {
+
+class ScopedSlurmLicenses {
+public:
+  explicit ScopedSlurmLicenses(const std::optional<std::string>& value)
+      : originalValue(getValue()) {
+    setValue(value);
+  }
+
+  ~ScopedSlurmLicenses() { setValue(originalValue); }
+
+  ScopedSlurmLicenses(const ScopedSlurmLicenses&) = delete;
+  ScopedSlurmLicenses& operator=(const ScopedSlurmLicenses&) = delete;
+  ScopedSlurmLicenses(ScopedSlurmLicenses&&) = delete;
+  ScopedSlurmLicenses& operator=(ScopedSlurmLicenses&&) = delete;
+
+private:
+  [[nodiscard]] static auto getValue() -> std::optional<std::string> {
+    if (const auto* const value = std::getenv("SLURM_JOB_LICENSES")) {
+      return value;
+    }
+    return std::nullopt;
+  }
+
+  static void setValue(const std::optional<std::string>& value) {
+#ifdef _WIN32
+    if (_putenv_s("SLURM_JOB_LICENSES", value.value_or("").c_str()) != 0) {
+      std::abort();
+    }
+#else
+    int result = 0;
+    if (value.has_value()) {
+      // NOLINTNEXTLINE(misc-include-cleaner)
+      result = setenv("SLURM_JOB_LICENSES", value->c_str(), 1);
+    } else {
+      // NOLINTNEXTLINE(misc-include-cleaner)
+      result = unsetenv("SLURM_JOB_LICENSES");
+    }
+    if (result != 0) {
+      std::abort();
+    }
+#endif
+  }
+
+  std::optional<std::string> originalValue;
+};
+
+void registerStatusDevice(const std::string& id,
+                          const std::string& configuredStatus) {
+  static_cast<void>(qdmi::Driver::get().registerDeviceIfAbsent(
+      {.id = id,
+       .library = MQT_CORE_FOMAC_SLURM_TEST_DEVICE,
+       .prefix = "TEST_SESSION",
+       .session = {.custom4 = configuredStatus}}));
+}
+
+} // namespace
+
+TEST(SlurmAdapterTest, AcceptsImplicitAndExplicitUnitCounts) {
+  registerStatusDevice("test.slurm.idle", "idle");
+  for (const auto* const value : {"test.slurm.idle", "test.slurm.idle:1"}) {
+    const ScopedSlurmLicenses licenses(value);
+    EXPECT_EQ(openDeviceFromLicense().getStatus(), QDMI_DEVICE_STATUS_IDLE);
+  }
+}
+
+TEST(SlurmAdapterTest, AcceptsBusyDevice) {
+  registerStatusDevice("test.slurm.busy", "busy");
+  const ScopedSlurmLicenses licenses("test.slurm.busy");
+  EXPECT_EQ(openDeviceFromLicense().getStatus(), QDMI_DEVICE_STATUS_BUSY);
+}
+
+TEST(SlurmAdapterTest, RejectsMissingAndMalformedValues) {
+  registerStatusDevice("test.slurm.grammar", "idle");
+  const std::array<std::optional<std::string>, 13> invalidValues{
+      std::nullopt,
+      "",
+      " test.slurm.grammar",
+      "test.slurm.grammar ",
+      ":1",
+      "test.slurm.grammar:",
+      "test.slurm.grammar:+1",
+      "test.slurm.grammar:-1",
+      "test.slurm.grammar:1x",
+      "test.slurm.grammar:0",
+      "test.slurm.grammar:2",
+      "test.slurm.grammar:184467440737095516160",
+      "test.slurm.grammar:1:1",
+  };
+
+  for (const auto& value : invalidValues) {
+    const ScopedSlurmLicenses licenses(value);
+    EXPECT_THROW(static_cast<void>(openDeviceFromLicense()), std::runtime_error)
+        << "value: " << value.value_or("<unset>");
+  }
+}
+
+TEST(SlurmAdapterTest, RejectsUnknownRemoteAndCompoundLicenses) {
+  registerStatusDevice("test.slurm.single", "idle");
+  constexpr std::array invalidValues{
+      "test.slurm.unknown",          "test.slurm.single@license-server:1",
+      "test.slurm.single,unrelated", "unrelated,test.slurm.single",
+      "test.slurm.single|unrelated", "unrelated|test.slurm.single",
+  };
+
+  for (const auto* const value : invalidValues) {
+    const ScopedSlurmLicenses licenses(value);
+    EXPECT_THROW(static_cast<void>(openDeviceFromLicense()), std::runtime_error)
+        << "value: " << value;
+  }
+}
+
+TEST(SlurmAdapterTest, RejectsUnavailableDeviceWithIdAndStatus) {
+  constexpr std::array rejectedStates{
+      std::pair{"offline", "OFFLINE"},
+      std::pair{"error", "ERROR"},
+      std::pair{"maintenance", "MAINTENANCE"},
+      std::pair{"calibration", "CALIBRATION"},
+      std::pair{"max", "UNKNOWN"},
+  };
+
+  for (const auto& [configuredStatus, reportedStatus] : rejectedStates) {
+    const auto id = std::string{"test.slurm."} + configuredStatus;
+    registerStatusDevice(id, configuredStatus);
+    const ScopedSlurmLicenses licenses(id);
+    EXPECT_THAT(
+        [] { return openDeviceFromLicense(); },
+        testing::ThrowsMessage<std::runtime_error>(testing::AllOf(
+            testing::HasSubstr(id), testing::HasSubstr(reportedStatus))));
+  }
+}
+
+} // namespace fomac::slurm

--- a/test/python/qdmi/test_slurm.py
+++ b/test/python/qdmi/test_slurm.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Test the mechanism-specific Slurm adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from mqt.core.qdmi import slurm
+
+
+def test_open_device_from_license(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Open a fresh registered DDSIM device from a unit license."""
+    monkeypatch.setenv("SLURM_JOB_LICENSES", "mqt.ddsim.default:1")
+    device = slurm.open_device_from_license()
+    assert device.name() == "MQT Core DDSIM QDMI Device"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "mqt.ddsim.default:2",
+        "mqt.ddsim.default,mqt.sc.default",
+        "mqt.ddsim.default|mqt.sc.default",
+    ],
+)
+def test_reject_non_unit_and_compound_licenses(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """Reject license requests that cannot select one QDMI device."""
+    monkeypatch.setenv("SLURM_JOB_LICENSES", value)
+    with pytest.raises(RuntimeError):
+        slurm.open_device_from_license()

--- a/test/qdmi/devices/dd/device_status_test.cpp
+++ b/test/qdmi/devices/dd/device_status_test.cpp
@@ -8,9 +8,7 @@
  * Licensed under the MIT License
  */
 
-/*
- * DDSIM QDMI Device - Device status transitions (OFFLINE/BUSY/IDLE)
- */
+/* DDSIM QDMI device status transitions. */
 #include "helpers/circuits.hpp"
 #include "helpers/test_utils.hpp"
 #include "mqt_ddsim_qdmi/constants.h"
@@ -35,8 +33,9 @@ QDMI_Device_Status queryStatus(MQT_DDSIM_QDMI_Device_Session session) {
 TEST(DeviceStatus, TransitionsBusyThenIdleAfterJob) {
   const qdmi_test::SessionGuard s{};
 
-  // Initial status can be OFFLINE depending on implementation; do not assert
-  // it. Submit a job to force BUSY then completion to IDLE.
+  EXPECT_EQ(queryStatus(s.session), QDMI_DEVICE_STATUS_IDLE);
+
+  // Submit a job to force BUSY, then wait for the return to IDLE.
   const qdmi_test::JobGuard j{s.session};
   ASSERT_EQ(qdmi_test::setProgram(j.job, QDMI_PROGRAM_FORMAT_QASM3,
                                   qdmi_test::QASM3_HEAVY_SAMPLING),

--- a/test/qdmi/driver/session_device.cpp
+++ b/test/qdmi/driver/session_device.cpp
@@ -53,6 +53,29 @@ namespace {
   return "<unset>";
 }
 
+[[nodiscard]] auto deviceStatus(const std::string& configuredStatus)
+    -> QDMI_Device_Status {
+  if (configuredStatus == "busy") {
+    return QDMI_DEVICE_STATUS_BUSY;
+  }
+  if (configuredStatus == "offline") {
+    return QDMI_DEVICE_STATUS_OFFLINE;
+  }
+  if (configuredStatus == "error") {
+    return QDMI_DEVICE_STATUS_ERROR;
+  }
+  if (configuredStatus == "maintenance") {
+    return QDMI_DEVICE_STATUS_MAINTENANCE;
+  }
+  if (configuredStatus == "calibration") {
+    return QDMI_DEVICE_STATUS_CALIBRATION;
+  }
+  if (configuredStatus == "max") {
+    return QDMI_DEVICE_STATUS_MAX;
+  }
+  return QDMI_DEVICE_STATUS_IDLE;
+}
+
 [[nodiscard]] auto childDeviceHandle() -> QDMI_Child_Device {
   static QDMI_Child_Device_impl_d child;
   return &child;
@@ -236,6 +259,11 @@ extern "C" int TEST_SESSION_QDMI_device_session_query_device_property(
       *sizeRet = sizeof(QDMI_Operation) + 1;
     }
     return value == nullptr ? QDMI_SUCCESS : QDMI_ERROR_INVALIDARGUMENT;
+  }
+  if (prop == QDMI_DEVICE_PROPERTY_STATUS) {
+    return queryValue(
+        deviceStatus(parameter(session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM4)),
+        size, value, sizeRet);
   }
   if (prop != QDMI_DEVICE_PROPERTY_NAME) {
     return QDMI_ERROR_NOTSUPPORTED;


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Add a mechanism-specific selector that opens the registered QDMI device named by the current process's Slurm license environment:

- `fomac::slurm::openDeviceFromLicense()` in C++
- `mqt.core.qdmi.slurm.open_device_from_license()` in Python

The selector accepts only `<registered-device-id>` or `<registered-device-id>:1` in `SLURM_JOB_LICENSES`. It rejects missing, malformed, remote, compound, non-unit, and unknown licenses. It opens a fresh device session from the persistent definition without per-job configuration or credential overrides. The device must report `IDLE` or `BUSY`.

## Trust boundary

`SLURM_JOB_LICENSES` is process-mutable metadata. This function uses it only to select and open a registered device. It does not authenticate the caller, attest a Slurm allocation, authorize device access, or enforce the license request. Provider credentials must authorize remote devices, and operating-system isolation must protect local devices. Querying Slurm more directly would not establish authorization because callers can also use `driver.open_device(id)`.

Slurm licenses remain useful cluster-wide admission and accounting controls on a cooperative cluster. A configured count greater than one admits multiple independent jobs; each job requests one license and opens one device handle.

The implementation keeps Slurm parsing outside the generic QDMI driver and remains provider-independent for IQM, Amazon Braket, and future providers. DDSIM now reports `IDLE` before its first job so it satisfies the same status contract.

The QDMI Python namespace from #2074 is now part of `main`. This PR is the lower layer of the remaining #2025 → #2043 native stack. The real Slurm workflow and tutorial follow in #2043.

## Validation

- complete FoMaC C++ suite: 273 passed
- complete QDMI driver suite: 121 passed
- complete DDSIM device suite: 48 passed
- QDMI Python suite on Python 3.10 and 3.14: 315 passed on each version
- focused C++ and Python Slurm selector tests
- recursive stub generation with no source diff
- changed-file hooks and complete repository lint
- Sphinx documentation with warnings as errors
- wheel build and content inspection for the public header, native module, and recursive stubs
- independent exact-head adversarial audit: no source blocker

Platform CI for the signed post-merge revision and the real-Slurm workflow remain replacement-CI responsibilities.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new or changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added an entry to the changelog.
- [x] I have added migration instructions to the upgrade guide (not needed because the superseded API was never released).
- [x] The changes follow the project style guidelines and introduce no known warnings.
- [x] The changes pass the listed local checks.
- [x] An exact-head independent review has been completed for the aggregate stack.

**If PR contains AI-assisted content:**

- [x] Agent access and publication were explicitly authorized.
- [x] Agent-authored public text begins with the required disclosure.
- [x] Commits contain the required assistance footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
