### PR TITLE
🚨 Fix linter errors instead of ignoring them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ releases may include breaking changes.
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
   [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938], [#1975],
-  [#1976], [#2006], [#2026]) ([**@burgholzer**], [**@denialhaag**],
+  [#1976], [#2006], [#2026], [#2028]) ([**@burgholzer**], [**@denialhaag**],
   [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
   [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 
@@ -725,6 +725,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2028]: https://github.com/munich-quantum-toolkit/core/pull/2028
 [#2026]: https://github.com/munich-quantum-toolkit/core/pull/2026
 [#2011]: https://github.com/munich-quantum-toolkit/core/pull/2011
 [#2010]: https://github.com/munich-quantum-toolkit/core/pull/2010

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -370,8 +370,9 @@ struct EntryInfo {
   std::vector<std::string> outputRecordings;
 };
 
-[[nodiscard]] std::string
-// NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
+} // namespace
+
+[[nodiscard]] static std::string
 openQASMProgramName(const testing::TestParamInfo<qasm::OpenQASMProgram>& info) {
   std::string name = info.param.name.str();
   for (auto& character : name) {
@@ -382,16 +383,15 @@ openQASMProgramName(const testing::TestParamInfo<qasm::OpenQASMProgram>& info) {
   return name;
 }
 
-// NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
-[[nodiscard]] std::string printType(const Type type) {
+[[nodiscard]] static std::string printType(const Type type) {
   std::string text;
   llvm::raw_string_ostream stream(text);
   type.print(stream);
   return text;
 }
 
-// NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
-[[nodiscard]] std::optional<EntryInfo> inspectEntry(const llvm::StringRef ir) {
+[[nodiscard]] static std::optional<EntryInfo>
+inspectEntry(const llvm::StringRef ir) {
   DialectRegistry registry;
   registry.insert<QCDialect, QCODialect, qtensor::QTensorDialect,
                   arith::ArithDialect, cf::ControlFlowDialect,
@@ -432,8 +432,7 @@ openQASMProgramName(const testing::TestParamInfo<qasm::OpenQASMProgram>& info) {
   return info;
 }
 
-[[nodiscard]] testing::AssertionResult
-// NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
+[[nodiscard]] static testing::AssertionResult
 throughOptimizedQCO(const qasm::OpenQASMProgram& source,
                     std::optional<QCProgram>& restored,
                     std::vector<std::string>& resultTypes) {
@@ -467,8 +466,7 @@ throughOptimizedQCO(const qasm::OpenQASMProgram& source,
   return testing::AssertionSuccess();
 }
 
-[[nodiscard]] testing::AssertionResult
-// NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
+[[nodiscard]] static testing::AssertionResult
 roundTripThroughOptimizedJeff(const qasm::OpenQASMProgram& source,
                               std::optional<QCProgram>& restored,
                               std::vector<std::string>& resultTypes) {
@@ -561,6 +559,8 @@ roundTripThroughOptimizedJeff(const qasm::OpenQASMProgram& source,
   return matchesEntry(*restored, "restored QC");
 }
 
+namespace {
+
 TEST(OpenQASMCompilerOutputTest,
      CanonicalizesMixedScalarAndRegisterResultsThroughQCO) {
   constexpr llvm::StringLiteral source = R"qasm(
@@ -634,10 +634,12 @@ if (flag) {
 
 enum class OutputRecordingShape : std::uint8_t { AdaptiveArrays, BaseArrays };
 
-// NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
-void expectQIRArtifacts(const QIRProgram& program, const llvm::StringRef name,
-                        const ArrayRef<std::string> sourceResultTypes,
-                        const OutputRecordingShape outputShape) {
+} // namespace
+
+static void expectQIRArtifacts(const QIRProgram& program,
+                               const llvm::StringRef name,
+                               const ArrayRef<std::string> sourceResultTypes,
+                               const OutputRecordingShape outputShape) {
   const auto entry = inspectEntry(program.str());
   ASSERT_TRUE(entry) << name.str() << ": QIR entry inspection";
   ASSERT_EQ(entry->resultTypes.size(), 1) << name.str() << ": QIR main result";
@@ -670,6 +672,8 @@ void expectQIRArtifacts(const QIRProgram& program, const llvm::StringRef name,
   EXPECT_EQ(std::to_integer<std::uint8_t>((*bitcode)[2]), 0xC0U);
   EXPECT_EQ(std::to_integer<std::uint8_t>((*bitcode)[3]), 0xDEU);
 }
+
+namespace {
 
 TEST_P(OpenQASMCompilerPipelineTest, TraversesTheExplicitStandardPipeline) {
   const auto& source = GetParam();

--- a/mlir/unittests/Dialect/QC/Translation/test_quantum_computation_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_quantum_computation_translation.cpp
@@ -80,8 +80,9 @@ protected:
   }
 };
 
-mlir::SmallVector<mlir::Value>
-// NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
+} // namespace
+
+static mlir::SmallVector<mlir::Value>
 partiallyMeasuredRegisterControlReference(mlir::qc::QCProgramBuilder& builder) {
   auto q = builder.allocQubitRegister(1);
   auto prefix = builder.allocClassicalBitRegister(2, "prefix");
@@ -108,8 +109,6 @@ partiallyMeasuredRegisterControlReference(mlir::qc::QCProgramBuilder& builder) {
   builder.scfIf(comparison.getResult(), [&] { builder.x(q[0]); });
   return {prefix, condition};
 }
-
-} // namespace
 
 TEST_P(QuantumComputationTranslationTest, ProgramEquivalence) {
   const auto& [_, programBuilder, referenceBuilder] = GetParam();

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -61,13 +61,10 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::utils;
 
-namespace {
-// NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
-SmallVector<Value> getQubitValues(ValueRange values) {
+static SmallVector<Value> getQubitValues(ValueRange values) {
   return to_vector(llvm::make_filter_range(
       values, [](Value value) { return isa<QubitType>(value.getType()); }));
 }
-} // namespace
 
 /// Return true, if the operations within a region fulfill the given coupling
 /// constraints.


### PR DESCRIPTION
## Description

This PR fixes a handful of `llvm-prefer-static-over-anonymous-namespace` instead of ignoring them.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
