### PR TITLE
🧪 Strengthen ZX multi-control equivalence tests

### DIFF
--- a/test/zx/test_zx_functionality.cpp
+++ b/test/zx/test_zx_functionality.cpp
@@ -62,6 +62,18 @@ void checkEquivalence(const qc::QuantumComputation& qc1,
   }
 }
 
+void checkExactUnitaryEquivalence(const qc::QuantumComputation& qc1,
+                                  const qc::QuantumComputation& qc2) {
+  ASSERT_EQ(qc1.getNqubits(), qc2.getNqubits());
+
+  dd::Package package(qc1.getNqubits());
+  const auto actual = dd::buildFunctionality(qc1, package);
+  const auto expected = dd::buildFunctionality(qc2, package);
+  EXPECT_EQ(actual, expected);
+  package.decRef(actual);
+  package.decRef(expected);
+}
+
 void addDirtyAncillaMcx(qc::QuantumComputation& circuit,
                         const std::vector<qc::Qubit>& controls,
                         const qc::Qubit target,
@@ -321,9 +333,9 @@ TEST_F(ZXFunctionalityTest, MCX) {
   qc = qc::QuantumComputation(4);
   qc.mcx({1, 2, 3}, 0);
 
-  auto qcPrime = qc::QuantumComputation(4);
-  qcPrime.mcx({3, 2, 1}, 0);
+  const auto qcPrime = makeReferenceMcx(3);
 
+  checkExactUnitaryEquivalence(qc, qcPrime);
   checkEquivalence(qc, qcPrime, {0, 1, 2, 3});
 }
 
@@ -365,17 +377,11 @@ TEST_F(ZXFunctionalityTest, LargeMCX) {
     std::vector<qc::Qubit> qubits(numQubits);
     std::iota(qubits.begin(), qubits.end(), 0U);
 
+    checkExactUnitaryEquivalence(qc, reference);
     checkEquivalence(qc, reference, qubits);
 
     const auto diag = FunctionalityConstruction::buildFunctionality(&qc);
     EXPECT_LT(diag.getNVertices(), 22U * numControls * numControls);
-
-    dd::Package package(numQubits);
-    const auto actual = dd::buildFunctionality(qc, package);
-    const auto expected = dd::buildFunctionality(reference, package);
-    EXPECT_EQ(actual.p, expected.p);
-    package.decRef(actual);
-    package.decRef(expected);
   }
 }
 
@@ -385,8 +391,9 @@ TEST_F(ZXFunctionalityTest, MCZ) {
   qc.mcz({1, 2, 3}, 0);
 
   auto qcPrime = qc::QuantumComputation(4);
-  qcPrime.mcz({1, 2, 3}, 0);
+  addReferenceMcphase(qcPrime, PI, {1, 2, 3}, 0);
 
+  checkExactUnitaryEquivalence(qc, qcPrime);
   checkEquivalence(qc, qcPrime, {0, 1, 2, 3});
 }
 
@@ -427,13 +434,17 @@ TEST_F(ZXFunctionalityTest, MCZ2) {
 
 TEST_F(ZXFunctionalityTest, MCRZ) {
 
+  const auto phase = PI / 4;
   qc = qc::QuantumComputation(4);
-  qc.mcrz(PI / 4, {1, 2, 3}, 0);
+  qc.mcrz(phase, {1, 2, 3}, 0);
 
   auto qcPrime = qc::QuantumComputation(4);
-  qcPrime.h(0);
-  qcPrime.mcrx(PI / 4, {1, 2, 3}, 0);
-  qcPrime.h(0);
+  qcPrime.crz(phase / 2, 3, 0);
+  qcPrime.mcx({1, 2}, 0);
+  qcPrime.crz(-phase / 2, 3, 0);
+  qcPrime.mcx({1, 2}, 0);
+
+  checkExactUnitaryEquivalence(qc, qcPrime);
   checkEquivalence(qc, qcPrime, {0, 1, 2, 3});
 }
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Replace the remaining placeholder-style ZX functionality checks for three-control MCX, MCZ, and MCRZ gates with comparisons against known decompositions.

The tests now combine two independent checks:

- exact decision-diagram equality, including the root weight and global phase;
- ZX construction equivalence via concatenation with the inverse, `fullReduce`, identity, zero-global-phase, and wire-connectivity assertions.

The existing decision-diagram logic from `LargeMCX` is centralized in a small helper and retained for its five- and eight-control cases. No ZX simplification rules or public interfaces need to change because the current simplifier already reduces these decomposition-based checks.

Fixes #1429

## Validation

- Focused MCX, MCZ, MCRZ, and LargeMCX tests: 4/4 passed.
- Complete ZX test binary: 111/111 passed.
- `uvx nox -s lint`: passed all hooks.
- Independent final verification: passed with no findings.

AI assistance was used to investigate the issue against current `main`, implement and refine the tests, run validation, independently review the final diff, and draft this description.

## Checklist

- [x] The pull request only contains focused and relevant changes.
- [x] Appropriate tests cover the changed behavior.
- [x] Documentation, changelog, and upgrading-guide changes are not required for this test-only update.
- [x] The changes follow the project's style guidelines and introduce no new local warnings.
- [x] The GitHub CI checks have completed successfully.
- [x] I have reviewed my own code changes.

**AI-assisted content:**

- [x] The agent was explicitly authorized to implement and publish this scoped change.
- [x] This agent-authored description begins with the required visible disclosure.
- [x] AI assistance is disclosed above.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
