### PR TITLE
🐛 Emit textual QIR for .ll outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ releases may include breaking changes.
   ([#1264], [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570],
   [#1572], [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751],
   [#1755], [#1787], [#1815], [#1823], [#1830], [#1886], [#1933], [#1978],
-  [#1979], [#2007], [#2026]) ([**@burgholzer**], [**@denialhaag**],
+  [#1979], [#2007], [#2026], [#2030]) ([**@burgholzer**], [**@denialhaag**],
   [**@simon1hofmann**], [**@li-mingbao**], [**@DRovara**],
   [**@MatthiasReumann**])
 - ✨ Add decision diagram-based construction and simulation of static unitary
@@ -725,6 +725,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2030]: https://github.com/munich-quantum-toolkit/core/pull/2030
 [#2028]: https://github.com/munich-quantum-toolkit/core/pull/2028
 [#2026]: https://github.com/munich-quantum-toolkit/core/pull/2026
 [#2017]: https://github.com/munich-quantum-toolkit/core/pull/2017

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -221,6 +221,18 @@ Use {py:meth}`~mqt.core.mlir.QIRProgram.to_bitcode` to obtain LLVM bitcode as
 {code}`bytes`, or {py:meth}`~mqt.core.mlir.QIRProgram.write_bitcode` to write a
 {code}`.bc` file directly.
 
+The {code}`mqt-cc` compiler driver selects the QIR serialization from the output
+filename. Use {code}`.ll` for textual LLVM IR and {code}`.bc` for LLVM bitcode:
+
+```console
+mqt-cc input.qasm --emit=qir-base -o output.ll
+mqt-cc input.qasm --emit=qir-adaptive -o output.bc
+```
+
+Writing QIR to standard output also produces textual LLVM IR. All other output
+filenames, including filenames without an extension, retain the bitcode output
+used by earlier versions.
+
 The {doc}`QC <QC>`, {doc}`QCO <QCO>`, and {doc}`QTensor <QTensor>` references
 describe the underlying operations. See {doc}`Conversions` for the lowering
 steps between dialects.

--- a/mlir/tools/mqt-cc/CMakeLists.txt
+++ b/mlir/tools/mqt-cc/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 # Build the compiler driver executable
 add_mlir_tool(mqt-cc mqt-cc.cpp DEPENDS MQTCompilerPipeline MQTCompilerFoMaCAdapter SUPPORT_PLUGINS)
+if(BUILD_MQT_CORE_TESTS)
+  # add_mlir_tool excludes tools when LLVM_BUILD_TOOLS is disabled. The driver tests require mqt-cc
+  # in test-enabled default builds.
+  set_property(TARGET mqt-cc PROPERTY EXCLUDE_FROM_ALL FALSE)
+endif()
 llvm_map_components_to_libnames(llvm_native_libs bitwriter)
 target_link_libraries(
   mqt-cc

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -35,6 +35,7 @@
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/InitLLVM.h>
+#include <llvm/Support/Path.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/ToolOutputFile.h>
 #include <llvm/Support/raw_ostream.h>
@@ -81,7 +82,10 @@ static llvm::cl::opt<std::string> inputFormat(
     llvm::cl::value_desc("format"), llvm::cl::init("auto"));
 
 static llvm::cl::opt<std::string>
-    outputFilename("o", llvm::cl::desc("Output filename"),
+    outputFilename("o",
+                   llvm::cl::desc("Output filename (for QIR, - and .ll write "
+                                  "textual LLVM IR; .bc and other names write "
+                                  "LLVM bitcode)"),
                    llvm::cl::value_desc("filename"), llvm::cl::init("-"));
 
 static llvm::cl::opt<std::string> outputFormat(
@@ -360,7 +364,7 @@ static LogicalResult writeOutput(ModuleType mod, StringRef filename) {
       writeBytecodeToFile(mod, output->os());
     }
   } else if constexpr (std::is_same_v<ModuleType, llvm::Module*>) {
-    if (filename == "-") {
+    if (filename == "-" || llvm::sys::path::extension(filename) == ".ll") {
       mod->print(output->os(), nullptr);
     } else {
       llvm::WriteBitcodeToFile(*mod, output->os());

--- a/test/qir/CMakeLists.txt
+++ b/test/qir/CMakeLists.txt
@@ -8,5 +8,6 @@
 
 add_subdirectory(helpers)
 add_subdirectory(jit)
+add_subdirectory(mqt-cc)
 add_subdirectory(runtime)
 add_subdirectory(runner)

--- a/test/qir/mqt-cc/CMakeLists.txt
+++ b/test/qir/mqt-cc/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+add_test(
+  NAME mqt-core-mqt-cc-qir-output-test
+  COMMAND
+    ${CMAKE_COMMAND} "-DMQT_CC=$<TARGET_FILE:mqt-cc>" "-DLLVM_AS=$<TARGET_FILE:llvm-as>"
+    "-DLLVM_DIS=$<TARGET_FILE:llvm-dis>" "-DINPUT_FILE=${CMAKE_CURRENT_SOURCE_DIR}/bell.qasm"
+    "-DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/output-$<CONFIG>" -P
+    "${CMAKE_CURRENT_SOURCE_DIR}/verify_qir_output.cmake")

--- a/test/qir/mqt-cc/bell.qasm
+++ b/test/qir/mqt-cc/bell.qasm
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Munich Quantum Software Company GmbH
+// All rights reserved.
+//
+// SPDX-License-Identifier: MIT
+//
+// Licensed under the MIT License
+
+OPENQASM 3.0;
+include "stdgates.inc";
+
+qubit[2] q;
+bit[2] c;
+
+h q[0];
+cx q[0], q[1];
+c = measure q;

--- a/test/qir/mqt-cc/verify_qir_output.cmake
+++ b/test/qir/mqt-cc/verify_qir_output.cmake
@@ -1,0 +1,67 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+function(run_command description)
+  execute_process(
+    COMMAND ${ARGN}
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error)
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "${description} failed with exit code ${result}:\n${output}${error}")
+  endif()
+endfunction()
+
+function(require_profile filename expected_profile)
+  file(READ "${filename}" llvm_ir)
+  string(FIND "${llvm_ir}" "\"qir_profiles\"=\"${expected_profile}\"" profile_position)
+  if(profile_position EQUAL -1)
+    message(FATAL_ERROR "${filename} does not declare QIR profile ${expected_profile}")
+  endif()
+endfunction()
+
+function(require_textual_llvm_ir filename)
+  file(READ "${filename}" llvm_ir_header LIMIT 10)
+  string(FIND "${llvm_ir_header}" "; ModuleID" module_id_position)
+  if(NOT module_id_position EQUAL 0)
+    message(FATAL_ERROR "${filename} is not textual LLVM IR")
+  endif()
+endfunction()
+
+file(REMOVE_RECURSE "${OUTPUT_DIR}")
+file(MAKE_DIRECTORY "${OUTPUT_DIR}")
+
+foreach(profile IN ITEMS base adaptive)
+  set(expected_profile "${profile}_profile")
+  set(text_file "${OUTPUT_DIR}/${profile}.ll")
+  set(text_bitcode_file "${OUTPUT_DIR}/${profile}-from-text.bc")
+  set(bitcode_file "${OUTPUT_DIR}/${profile}.bc")
+  set(disassembled_file "${OUTPUT_DIR}/${profile}-from-bitcode.ll")
+
+  run_command("mqt-cc ${profile} textual QIR generation" "${MQT_CC}" "${INPUT_FILE}"
+              "--emit=qir-${profile}" -o "${text_file}")
+  require_textual_llvm_ir("${text_file}")
+  run_command("llvm-as ${profile} textual QIR validation" "${LLVM_AS}" "${text_file}" -o
+              "${text_bitcode_file}")
+  require_profile("${text_file}" "${expected_profile}")
+
+  run_command("mqt-cc ${profile} bitcode generation" "${MQT_CC}" "${INPUT_FILE}"
+              "--emit=qir-${profile}" -o "${bitcode_file}")
+  file(
+    READ "${bitcode_file}" bitcode_magic
+    OFFSET 0
+    LIMIT 4
+    HEX)
+  string(TOLOWER "${bitcode_magic}" bitcode_magic)
+  if(NOT bitcode_magic STREQUAL "4243c0de")
+    message(FATAL_ERROR "${bitcode_file} does not start with the LLVM bitcode magic")
+  endif()
+  run_command("llvm-dis ${profile} bitcode validation" "${LLVM_DIS}" "${bitcode_file}" -o
+              "${disassembled_file}")
+  require_profile("${disassembled_file}" "${expected_profile}")
+endforeach()


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Teach `mqt-cc` to honor the conventional LLVM output extensions when emitting QIR. Standard output and `.ll` files now contain textual LLVM IR, while `.bc` and other named outputs retain LLVM bitcode for compatibility.

Add a standalone CTest under `test/qir/` that drives the existing `mqt-cc` executable for the Base and Adaptive profiles. The test verifies the textual `.ll` header, parses it with `llvm-as`, checks the bitcode magic for `.bc`, parses it with `llvm-dis`, and confirms the expected QIR profile metadata. It does not add `mqt-cc` to a unit-test executable or introduce a new build dependency.

The original reverse `.ll` input path described in the issue depended on the removed MQTRef dialect and is no longer applicable. This PR addresses the remaining output-format and regression-testing portion.

Closes #1153

## Validation

- Standalone `mqt-cc` QIR output CTest: 1/1 passed.
- Compiler tests: 230/230 passed.
- QIR IR tests: 111/111 passed.
- QC-to-QIR Base tests: 121/121 passed.
- QC-to-QIR Adaptive tests: 145/145 passed.
- Default debug build passed.
- Full lint session passed.
- Documentation build with warnings as errors passed.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (not needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by the AI Usage Guidelines.
- [x] Every agent-authored or agent-edited public text body begins with the visible AI disclosure.
- [x] AI assistance is disclosed in this PR description. Codex materially assisted with issue investigation, implementation, testing, independent review, and preparation of this description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
