### PR TITLE
✨ Complete and isolate the QIR runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@ releases may include breaking changes.
 
 ### Changed
 
+- 💥 Update the QIR runner for QIR 2.1 entry points and resource management,
+  with entry-point selection and reproducible multi-shot execution ([#2035])
+  ([**@burgholzer**])
 - 🚀 Reduce ZX diagram growth for multi-controlled X gates with an exact
   ancilla-free quadratic decomposition ([#1984]) ([**@burgholzer**])
 - 💥 Require LLVM/MLIR and QIR support in every MQT Core build and remove the
@@ -729,6 +732,7 @@ for previous changelogs._
 
 [#2030]: https://github.com/munich-quantum-toolkit/core/pull/2030
 [#2042]: https://github.com/munich-quantum-toolkit/core/pull/2042
+[#2035]: https://github.com/munich-quantum-toolkit/core/pull/2035
 [#2028]: https://github.com/munich-quantum-toolkit/core/pull/2028
 [#2026]: https://github.com/munich-quantum-toolkit/core/pull/2026
 [#2017]: https://github.com/munich-quantum-toolkit/core/pull/2017

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,16 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### QIR runner
+
+The QIR runner now invokes a selected QIR entry point as a parameterless `i64`
+function instead of assuming an `int main(int, char**)`. Use `--entry-point` to
+select among multiple entry points, `--shots` for repeated execution, and
+`--seed` for deterministic sampling.
+
+Dynamic QIR inputs must use the current QIR 2.1 resource-management interface.
+Legacy qir-runner allocator and output overloads are no longer accepted.
+
 ### Runtime-configurable SC QDMI device
 
 The built-in superconducting QDMI provider now parses its device description

--- a/docs/qir/index.md
+++ b/docs/qir/index.md
@@ -41,6 +41,35 @@ The `mqt-core-qir-runner` can be used to execute a QIR file (typically with a
 ./build/bin/mqt-core-qir-runner bell.ll
 ```
 
+The entry-point function may have any valid LLVM name. If a module contains more
+than one function with the `entry_point` attribute, select one explicitly. The
+runner also supports repeated, reproducible execution:
+
+```bash
+./build/bin/mqt-core-qir-runner \
+  --entry-point=bell_entry --shots=1024 --seed=7 bell.ll
+```
+
+QIR entry points take no arguments and return an `i64` exit code. Runtime and
+QIS declarations are checked before JIT compilation; a mismatched or unsupported
+declaration is reported with its actual and accepted LLVM function types.
+
+MQT Core implements the QIR 2.1 Base and Adaptive Profile runtime APIs. The JIT
+accepts one exact LLVM type for each runtime declaration, so unsupported or
+outdated overloads fail before execution.
+
+MQT Core provides dedicated QIS functions for variants with one or two control
+qubits, using the `c<gate>` and `cc<gate>` names. Operations with three or more
+controls use generic `__ctl` and `__ctladj` specializations. The control qubits
+are passed in an Array; parameterized and multi-target gates pass their original
+arguments in a Tuple, following the qir-runner calling convention. MQT accepts
+these functions as implementation-specific extensions to the QIR 2.1 Base and
+Adaptive profiles, so the entry point keeps its `base_profile` or
+`adaptive_profile` attribute.
+
+MQT's two-angle phased-X rotation gate uses the `prx` QIS stem. The incompatible
+qir-runner Pauli-axis operation named `r` is not part of MQT's QIS.
+
 The runner prints the program's outputs to the console in one of the two
 [QIR Output Schemas][output-schemas] (Labeled or Ordered): the two `HEADER`
 records announce the schema, and each shot is wrapped in `START` and `END`

--- a/include/mqt-core/qir/jit/Session.hpp
+++ b/include/mqt-core/qir/jit/Session.hpp
@@ -14,17 +14,20 @@
 
 #pragma once
 
-#include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/Support/Error.h>
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace qir {
+
+class Runtime;
 
 /**
  * @brief Whether the JIT'd program runs to produce measurement samples or
@@ -37,6 +40,12 @@ namespace qir {
  */
 enum class Execution { Sampling, StateExtraction };
 
+struct SessionOptions {
+  Execution execution = Execution::Sampling;
+  std::optional<std::string> entryPoint;
+  std::optional<uint64_t> seed;
+};
+
 /**
  * @brief In-process JIT executor for QIR programs.
  * @details The session does the following, in order:
@@ -44,14 +53,14 @@ enum class Execution { Sampling, StateExtraction };
  *   an in-memory buffer,
  * - JIT-compiles it via LLVM's OrcJIT with lazy compilation.
  * - wires up the QIR runtime symbols, and
- * - runs the module's @c main function.
+ * - runs the module function marked as its QIR entry point.
  * A session owns a single LLJIT instance and is not meant to be reused across
  * modules; create a new @ref JitSession for each program.
  */
 class JitSession {
 public:
-  /// Signature of the @c main function produced by QIR-compiled modules.
-  using MainFn = int(int, char**);
+  /// QIR 2.1 Base and Adaptive Profile entry-point signature.
+  using EntryPointFn = int64_t();
 
   /**
    * @brief Build a session by loading IR from a file on disk.
@@ -61,7 +70,7 @@ public:
    * to initialize.
    */
   explicit JitSession(llvm::StringRef inputFile,
-                      Execution mode = Execution::Sampling);
+                      const SessionOptions& options = {});
 
   /**
    * @brief Build a session by loading IR from a memory buffer.
@@ -74,30 +83,30 @@ public:
    * to initialize.
    */
   JitSession(llvm::StringRef irBytes, llvm::StringRef bufferName,
-             Execution mode = Execution::Sampling);
+             const SessionOptions& options = {});
 
   /// Tears down the LLJIT and any JIT'd resources owned by the session.
   ~JitSession();
 
   /**
-   * @brief Executes the JIT'd @c main function.
-   * @param args Argument strings passed as @c argv (excluding @c argv[0]).
-   * @param progName Value used as @c argv[0].
-   * @return The integer returned by the JIT'd @c main.
+   * @brief Execute the selected QIR entry point.
+   * @return The 64-bit QIR exit code.
    */
-  int run(llvm::ArrayRef<std::string> args = {},
-          llvm::StringRef progName = "") const;
+  int64_t run();
+
+  [[nodiscard]] auto runtime() -> Runtime&;
+  [[nodiscard]] auto runtime() const -> const Runtime&;
+  [[nodiscard]] auto entryPointName() const -> const std::string& {
+    return entryPointName_;
+  }
 
 private:
   llvm::orc::ThreadSafeContext tsCtx_{std::make_unique<llvm::LLVMContext>()};
   llvm::orc::ThreadSafeModule module_;
+  std::unique_ptr<Runtime> runtime_;
   std::unique_ptr<llvm::orc::LLJIT> jit_;
-  MainFn* mainFn_ = nullptr;
-
-  /// Registers the QIR runtime symbols with @c llvm::sys::DynamicLibrary so the
-  /// JIT can resolve them at link time.
-  /// Safe to call multiple times; the work runs only on the first call.
-  static void registerRuntimeSymbols();
+  EntryPointFn* entryPointFn_ = nullptr;
+  std::string entryPointName_;
 
   /// Initializes the native target, asm printer and asm parser.
   /// Safe to call multiple times; the work runs only on the first call.
@@ -118,10 +127,10 @@ private:
   ///   (for @c Execution::StateExtraction).
   /// - Builds the @c LLJIT instance
   /// - Registers QIR runtime symbols
-  /// - Resolves @c main.
+  /// - Resolves the selected QIR entry point.
   /// @throws std::runtime_error if loading failed or the JIT cannot start.
   void initialize(llvm::Expected<llvm::orc::ThreadSafeModule> llvmModule,
-                  Execution mode);
+                  const SessionOptions& options);
 
   /// Tears down the @c LLJIT.
   void deinitialize() const;

--- a/include/mqt-core/qir/runtime/QIR.h
+++ b/include/mqt-core/qir/runtime/QIR.h
@@ -12,10 +12,9 @@
  * @brief C QIR runtime declarations.
  */
 
-// initially taken from
-// https://github.com/qir-alliance/qir-runner/blob/main/stdlib/include/qir_stdlib.h
-// and adopted to match the QIR specification
-// https://github.com/qir-alliance/qir-spec/tree/main/specification/v0.1
+// Implements the QIR 2.1 Base and Adaptive Profile runtime surface used by MQT
+// Core. The Array and Tuple declarations support the generic controlled
+// specializations and are distinct from QIR 2.1 resource arrays.
 
 // Instructions to wrap a C++ class with a C interface are taken from
 // https://stackoverflow.com/a/11971205
@@ -26,6 +25,7 @@
 // NOLINTBEGIN(modernize-deprecated-headers)
 // NOLINTBEGIN(readability-identifier-naming)
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -38,23 +38,9 @@ extern "C" {
 
 typedef struct ResultImpl Result;
 
-/// Returns a constant representing a measurement result zero.
-Result* __quantum__rt__result_get_zero();
-
-/// Returns a constant representing a measurement result one.
-Result* __quantum__rt__result_get_one();
-
-/// Returns true if the two results are the same, and false if they are
-/// different.
-bool __quantum__rt__result_equal(Result*, Result*);
-
-/// Adds the given integer value to the reference count for the result.
-/// Deallocates the result if the reference count becomes 0.
-void __quantum__rt__result_update_reference_count(Result*, int32_t);
-
 // *** QUBITS ***
-// cf.
-// https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/1_Data_Types.md#qubits
+// See
+// https://github.com/qir-alliance/qir-spec/blob/main/specification/Instruction_Set.md
 typedef struct QubitImpl Qubit;
 
 // *** ARRAYS ***
@@ -90,24 +76,25 @@ Tuple* __quantum__rt__tuple_create(int64_t size);
 void __quantum__rt__tuple_update_reference_count(Tuple*, int32_t);
 
 // *** QUANTUM INSTRUCTIONSET AND RUNTIME ***
-// cf.
-// https://github.com/qir-alliance/qir-spec/blob/main/specification/v0.1/4_Quantum_Runtime.md
+// See
+// https://github.com/qir-alliance/qir-spec/blob/main/specification/Memory_Management.md
 
-/// Allocates a single qubit.
-Qubit* __quantum__rt__qubit_allocate();
+/// Allocate a single qubit using the QIR 2.1 error-pointer convention.
+Qubit* __quantum__rt__qubit_allocate(bool* outError);
 
-/// Creates an array of the given size and populates it with newly-allocated
-/// qubits.
-Array* __quantum__rt__qubit_allocate_array(int64_t);
+/// Allocate and release QIR 2.1 caller-owned arrays of qubit pointers.
+void __quantum__rt__qubit_array_allocate(int64_t, Qubit**, bool* outError);
+void __quantum__rt__qubit_array_release(int64_t, Qubit**);
+
+/// Allocate and release dynamically managed QIR 2.1 results.
+Result* __quantum__rt__result_allocate(bool* outError);
+void __quantum__rt__result_release(Result*);
+void __quantum__rt__result_array_allocate(int64_t, Result**, bool* outError);
+void __quantum__rt__result_array_release(int64_t, Result**);
 
 /// Releases a single qubit. Passing a null pointer as argument should cause a
 /// runtime failure.
 void __quantum__rt__qubit_release(Qubit*);
-
-/// Releases an array of qubits; each qubit in the array is released, and the
-/// array itself is unreferenced. Passing a null pointer as argument should
-/// cause a runtime failure.
-void __quantum__rt__qubit_release_array(Array*);
 
 // QUANTUM INSTRUCTION SET
 //
@@ -183,8 +170,6 @@ void __quantum__qis__gphase__body(double);
 /// Common QIS spelling for controlled X.
 void __quantum__qis__cnot__body(Qubit*, Qubit*);
 
-Result* __quantum__qis__m__body(Qubit*);
-Result* __quantum__qis__measure__body(Qubit*);
 void __quantum__qis__mz__body(Qubit*, Result*);
 void __quantum__qis__reset__body(Qubit*);
 
@@ -217,7 +202,7 @@ void __quantum__rt__int_record_output(int64_t, const char*);
 /// Adds a floating-point value to the generated output. The second parameter
 /// defines a string label for the value. Depending on the output schema, the
 /// label is included in the output or omitted.
-void __quantum__rt__float_record_output(double, const char*);
+void __quantum__rt__double_record_output(double, const char*);
 
 /// Inserts a marker in the generated output indicating that the next
 /// \p elementCount recorded values form the contents of a tuple. The second
@@ -228,6 +213,9 @@ void __quantum__rt__tuple_record_output(int64_t elementCount, const char*);
 /// recorded values form the contents of an array. The second parameter defines
 /// a string label for the array.
 void __quantum__rt__array_record_output(int64_t size, const char*);
+
+/// Record the contents of a caller-owned result pointer array.
+void __quantum__rt__result_array_record_output(int64_t, Result**, const char*);
 
 // NOLINTEND(readability-identifier-naming)
 // NOLINTEND(modernize-deprecated-headers)

--- a/include/mqt-core/qir/runtime/Runtime.hpp
+++ b/include/mqt-core/qir/runtime/Runtime.hpp
@@ -45,14 +45,12 @@
 /// @note this struct is purposefully not called ResultImpl to leave the Result
 /// pointer opaque such that it cannot be dereferenced
 struct ResultStruct {
-  int32_t refcount;
-  bool r;
+  bool r{};
 };
 struct ArrayImpl {
-  int32_t refcount;
-  int32_t aliasCount;
-  std::vector<int8_t> data;
-  int64_t elementSize;
+  int32_t refcount{};
+  std::vector<int8_t> data{};
+  int64_t elementSize{};
 };
 
 namespace qir {
@@ -192,16 +190,8 @@ public:
   }
 };
 
-/**
- * @note This class is implemented following the design pattern Singleton in
- * order to access an instance of this class from the C function without having
- * a handle to it.
- */
 class Runtime {
 public:
-  static constexpr uintptr_t RESULT_ZERO_ADDRESS = 0x10000;
-  static constexpr uintptr_t RESULT_ONE_ADDRESS = 0x10001;
-
   /// The quantum state held by the runtime:
   /// - a DD package,
   /// - the root edge into that package, and
@@ -236,14 +226,17 @@ public:
   enum class OutputSchema : uint8_t { Labeled, Ordered };
 
 private:
-  static constexpr uintptr_t MIN_DYN_QUBIT_ADDRESS = 0x10000;
-  enum class AddressMode : uint8_t { UNKNOWN, DYNAMIC, STATIC };
+  friend class JitSession;
 
-  AddressMode addressMode;
+  static constexpr uintptr_t MIN_DYN_QUBIT_ADDRESS = 0x10000;
+  enum class ResourceMode : uint8_t { UNKNOWN, DYNAMIC, STATIC };
+
+  ResourceMode qubitMode;
   std::unordered_map<const Qubit*, qc::Qubit> qRegister;
   // swap gates are not executed, they are tracked here
   std::vector<qc::Qubit> qubitPermutation;
   static constexpr uintptr_t MIN_DYN_RESULT_ADDRESS = 0x10000;
+  ResourceMode resultMode;
   std::unordered_map<Result*, ResultStruct> rRegister;
   std::string measurements;
   uintptr_t currentMaxQubitAddress;
@@ -255,11 +248,10 @@ private:
   // The QIR spec does not define a default output schema.
   // The runtime picks @c Labeled when a program doesn't declare one.
   OutputSchema outputSchema = OutputSchema::Labeled;
-
-  Runtime();
-  explicit Runtime(uint64_t randomSeed);
+  std::vector<std::pair<std::string, std::string>> metadata;
 
   auto enlargeState(std::uint64_t maxQubit) -> void;
+  static auto bind(Runtime* runtime) noexcept -> Runtime*;
   auto translateAddresses(std::span<Qubit* const> qubits)
       -> std::vector<qc::Qubit>;
 
@@ -314,7 +306,12 @@ private:
                   const char* label) const;
 
 public:
+  Runtime();
+  explicit Runtime(uint64_t randomSeed);
+
   [[nodiscard]] static auto generateRandomSeed() -> uint64_t;
+  /// Return the runtime bound to this thread. When no session is executing, a
+  /// thread-local fallback keeps direct calls to the public C ABI convenient.
   static Runtime& getInstance();
 
   Runtime(const Runtime&) = delete;
@@ -323,6 +320,7 @@ public:
   Runtime& operator=(Runtime&&) = delete;
 
   auto reset() -> void;
+  auto seed(uint64_t randomSeed) -> void;
   template <qc::OpType Op, typename... Args>
   auto apply(Args&&... args) -> void {
     if constexpr (Op == qc::SWAP && sizeof...(Args) == 2) {
@@ -336,7 +334,8 @@ public:
   auto applyGlobalPhase(qc::fp phase) -> void {
     qState.edge = dd::applyGlobalPhase(qState.edge, phase, *qState.dd);
   }
-  /// Apply a gate with a runtime-sized control set.
+  /// Apply a gate with a runtime-sized control set, as required by generic
+  /// controlled QIS specializations.
   auto apply(qc::OpType op, std::span<const qc::fp> params,
              std::span<Qubit* const> controls, std::span<Qubit* const> targets)
       -> void;
@@ -385,8 +384,8 @@ public:
       -> std::array<qc::Qubit, SIZE> {
     // extract addresses from opaque qubit pointers
     std::array<qc::Qubit, SIZE> qubitIds{};
-    if (addressMode != AddressMode::STATIC) {
-      // addressMode == AddressMode::DYNAMIC or AddressMode::UNKNOWN
+    if (qubitMode != ResourceMode::STATIC) {
+      // qubitMode == ResourceMode::DYNAMIC or ResourceMode::UNKNOWN
       try {
         Utils::transform(
             [&](const auto q) {
@@ -401,15 +400,15 @@ public:
             },
             qubits, qubitIds);
       } catch (std::out_of_range&) {
-        if (addressMode == AddressMode::DYNAMIC) {
+        if (qubitMode == ResourceMode::DYNAMIC) {
           throw; // rethrow
         }
-        // addressMode == AddressMode::UNKNOWN
-        addressMode = AddressMode::STATIC;
+        // qubitMode == ResourceMode::UNKNOWN
+        qubitMode = ResourceMode::STATIC;
       }
     }
-    // addressMode might have changed to STATIC
-    if (addressMode == AddressMode::STATIC) {
+    // qubitMode might have changed to STATIC
+    if (qubitMode == ResourceMode::STATIC) {
       Utils::transform(
           [](const auto q) {
             return static_cast<qc::Qubit>(reinterpret_cast<uintptr_t>(q));
@@ -424,7 +423,6 @@ public:
   auto rAlloc() -> Result*;
   auto deref(Result* result) -> ResultStruct&;
   auto rFree(Result* result) -> void;
-  auto equal(Result* result1, Result* result2) -> bool;
 
   /// Append a measurement bit to the measurement string.
   auto appendMeasurementBit(bool result) -> void;
@@ -445,6 +443,10 @@ public:
 
   /// Emit `OUTPUT\tRESULT\t<0|1>[\tlabel]\n` to the output stream.
   auto outputResult(bool value, const char* label) const -> void;
+
+  /// Emit `OUTPUT\tRESULT_ARRAY\t<bits>[\tlabel]\n` in memory order.
+  auto outputResultArray(std::string_view values, const char* label) const
+      -> void;
 
   /// Emit `OUTPUT\tBOOL\t<true|false>[\tlabel]\n` to the output stream.
   auto outputBool(bool value, const char* label) const -> void;
@@ -470,12 +472,14 @@ public:
   /// `METADATA\toutput_labeling_schema\t<labeled|ordered>\n` (one per shot).
   auto outputShotStart() const -> void;
 
-  /// Emit `END\t0\n` (one per shot).
-  /// The trailing `0` is a spec literal, not a runtime exit code.
-  auto outputShotEnd() const -> void;
+  /// Emit `END\t<exitCode>\n` (one per shot).
+  auto outputShotEnd(int64_t exitCode = 0) const -> void;
 
   [[nodiscard]] auto getOutputSchema() const -> OutputSchema;
   auto setOutputSchema(OutputSchema schema) -> void;
+  auto setMetadata(
+      std::vector<std::pair<std::string, std::string>> entryPointMetadata)
+      -> void;
 };
 
 /// Write the schema's spec-mandated literal (`labeled` or `ordered`).

--- a/src/qdmi/devices/dd/Device.cpp
+++ b/src/qdmi/devices/dd/Device.cpp
@@ -48,6 +48,7 @@
 #include <numeric>
 #include <ranges>
 #include <span>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -481,7 +482,6 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgram() -> QDMI_STATUS {
 auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgramSampling()
     -> QDMI_STATUS {
   return submitProgramAsync([this]() {
-    auto& runtime = qir::Runtime::getInstance();
     auto irBytes = std::visit(
         [](const auto& p) {
           return llvm::StringRef(reinterpret_cast<const char*>(p.data()),
@@ -489,12 +489,15 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgramSampling()
         },
         program_);
     auto jitSession = qir::JitSession(irBytes, "QDMI job");
+    auto& runtime = jitSession.runtime();
+    std::ostringstream output;
+    runtime.setOstream(output);
     runtime.outputProgramHeader();
     for (size_t i = 0; i < numShots_; ++i) {
       runtime.reset();
       runtime.outputShotStart();
       const auto rc = jitSession.run();
-      runtime.outputShotEnd();
+      runtime.outputShotEnd(rc);
       if (rc != 0) {
         throw std::runtime_error(
             llvm::formatv("QIR program failed with error: {}", rc));
@@ -515,16 +518,18 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgramStateExtraction()
     return QDMI_ERROR_NOTSUPPORTED;
   }
   return submitProgramAsync([this]() {
-    auto& runtime = qir::Runtime::getInstance();
-    runtime.reset();
     auto irBytes = std::visit(
         [](const auto& p) {
           return llvm::StringRef(reinterpret_cast<const char*>(p.data()),
                                  p.size());
         },
         program_);
-    auto jitSession =
-        qir::JitSession(irBytes, "QDMI job", qir::Execution::StateExtraction);
+    const qir::SessionOptions options{.execution =
+                                          qir::Execution::StateExtraction};
+    auto jitSession = qir::JitSession(irBytes, "QDMI job", options);
+    auto& runtime = jitSession.runtime();
+    std::ostringstream output;
+    runtime.setOstream(output);
     if (const auto rc = jitSession.run(); rc != 0) {
       throw std::runtime_error(
           llvm::formatv("QIR program failed with error: {}", rc));

--- a/src/qir/jit/Session.cpp
+++ b/src/qir/jit/Session.cpp
@@ -14,7 +14,7 @@
 #include "qir/runtime/QIR.h"
 #include "qir/runtime/Runtime.hpp"
 
-#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/ScopeExit.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/CodeGen/CommandFlags.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
@@ -29,7 +29,6 @@
 #include <llvm/ExecutionEngine/Orc/LazyReexports.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h>
-#include <llvm/ExecutionEngine/Orc/TargetProcess/TargetExecutionUtils.h>
 #include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/LLVMContext.h>
@@ -37,8 +36,8 @@
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/Debug.h>
-#include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/Error.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/TargetSelect.h>
@@ -46,12 +45,18 @@
 #include <llvm/TargetParser/Triple.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <cstdlib>
+#include <initializer_list>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -59,24 +64,54 @@
 
 namespace qir {
 
-/// Returns the function marked with the `entry_point` attribute,
-/// or @c nullptr if no such function is defined.
-static const llvm::Function* getEntryPointFunction(const llvm::Module& m) {
-  const auto it = std::ranges::find_if(m, [](const llvm::Function& fn) {
-    return fn.hasFnAttribute("entry_point");
-  });
-  return it != m.end() ? &*it : nullptr;
+static auto isEntryPoint(const llvm::Function& function) -> bool {
+  return function.hasFnAttribute("entry_point") ||
+         function.hasFnAttribute("EntryPoint");
 }
 
-/// Read the `output_labeling_schema` attribute from the program's entry point.
-/// Returns @c Labeled when the attribute is absent or its value is not
-/// exactly `ordered` (spec default).
-static Runtime::OutputSchema readOutputSchema(const llvm::Module& m) {
-  if (const auto* fn = getEntryPointFunction(m); fn != nullptr) {
-    if (const auto attr = fn->getFnAttribute("output_labeling_schema");
-        attr.isValid() && attr.getValueAsString() == "ordered") {
-      return Runtime::OutputSchema::Ordered;
+static auto selectEntryPoint(const llvm::Module& module,
+                             const std::optional<std::string>& requested)
+    -> const llvm::Function& {
+  std::vector<const llvm::Function*> matches;
+  for (const auto& function : module) {
+    if (!function.isDeclaration() && isEntryPoint(function) &&
+        (!requested || function.getName() == *requested)) {
+      matches.emplace_back(&function);
     }
+  }
+  if (matches.empty()) {
+    if (requested) {
+      throw std::runtime_error("No QIR entry point named '" + *requested +
+                               "' was found");
+    }
+    throw std::runtime_error("No QIR entry point was found");
+  }
+  if (matches.size() != 1) {
+    std::ostringstream message;
+    message << "Multiple QIR entry points were found; select one explicitly:";
+    for (const auto* function : matches) {
+      message << " " << function->getName().str();
+    }
+    throw std::runtime_error(message.str());
+  }
+  const auto& entryPoint = *matches.front();
+  const auto* type = entryPoint.getFunctionType();
+  if (type->isVarArg() || type->getNumParams() != 0 ||
+      !type->getReturnType()->isIntegerTy(64)) {
+    std::string actual;
+    llvm::raw_string_ostream stream(actual);
+    type->print(stream);
+    throw std::runtime_error("QIR entry point '" + entryPoint.getName().str() +
+                             "' must have type i64 (), but has type " + actual);
+  }
+  return entryPoint;
+}
+
+static auto readOutputSchema(const llvm::Function& entryPoint)
+    -> Runtime::OutputSchema {
+  if (const auto attr = entryPoint.getFnAttribute("output_labeling_schema");
+      attr.isValid() && attr.getValueAsString() == "ordered") {
+    return Runtime::OutputSchema::Ordered;
   }
   return Runtime::OutputSchema::Labeled;
 }
@@ -103,6 +138,229 @@ static llvm::Error tryEnableDebugSupport(llvm::orc::LLJIT& jit) {
     LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE ": " << errMsg << "\n");
   }
   return llvm::Error::success();
+}
+
+namespace {
+
+enum class AbiType : uint8_t { Void, Pointer, I1, I32, I64, F64 };
+
+struct RuntimeSymbol {
+  AbiType result{};
+  std::vector<AbiType> parameters;
+  void* address{};
+};
+
+using RuntimeRegistry = std::unordered_map<std::string, RuntimeSymbol>;
+
+} // namespace
+
+static auto abiTypeName(const AbiType type) -> std::string_view {
+  switch (type) {
+  case AbiType::Void:
+    return "void";
+  case AbiType::Pointer:
+    return "ptr";
+  case AbiType::I1:
+    return "i1";
+  case AbiType::I32:
+    return "i32";
+  case AbiType::I64:
+    return "i64";
+  case AbiType::F64:
+    return "double";
+  }
+  llvm_unreachable("unknown QIR ABI type");
+}
+
+static auto matches(const llvm::Type* actual, const AbiType expected) -> bool {
+  switch (expected) {
+  case AbiType::Void:
+    return actual->isVoidTy();
+  case AbiType::Pointer:
+    return actual->isPointerTy();
+  case AbiType::I1:
+    return actual->isIntegerTy(1);
+  case AbiType::I32:
+    return actual->isIntegerTy(32);
+  case AbiType::I64:
+    return actual->isIntegerTy(64);
+  case AbiType::F64:
+    return actual->isDoubleTy();
+  }
+  llvm_unreachable("unknown QIR ABI type");
+}
+
+static auto matches(const llvm::FunctionType& actual,
+                    const RuntimeSymbol& expected) -> bool {
+  if (actual.isVarArg() || !matches(actual.getReturnType(), expected.result) ||
+      actual.getNumParams() != expected.parameters.size()) {
+    return false;
+  }
+  return std::ranges::equal(actual.params(), expected.parameters,
+                            [](const llvm::Type* type, const AbiType abiType) {
+                              return matches(type, abiType);
+                            });
+}
+
+static auto describe(const RuntimeSymbol& symbol) -> std::string {
+  std::ostringstream description;
+  description << abiTypeName(symbol.result) << " (";
+  for (std::size_t i = 0; i < symbol.parameters.size(); ++i) {
+    if (i != 0) {
+      description << ", ";
+    }
+    description << abiTypeName(symbol.parameters[i]);
+  }
+  description << ")";
+  return description.str();
+}
+
+template <typename Function>
+static auto addSymbol(RuntimeRegistry& registry, const std::string_view name,
+                      const AbiType result,
+                      std::initializer_list<AbiType> parameters,
+                      Function* function) -> void {
+  registry.insert_or_assign(
+      std::string(name),
+      RuntimeSymbol{.result = result,
+                    .parameters = parameters,
+                    .address = reinterpret_cast<void*>(function)});
+}
+
+template <typename Function>
+static auto addGate(RuntimeRegistry& registry, const std::string_view name,
+                    const std::size_t targetCount,
+                    const std::size_t parameterCount,
+                    const std::size_t controlCount, Function* function)
+    -> void {
+  std::vector<AbiType> parameters(parameterCount, AbiType::F64);
+  parameters.insert(parameters.end(), controlCount + targetCount,
+                    AbiType::Pointer);
+  registry.insert_or_assign(
+      std::string(name),
+      RuntimeSymbol{.result = AbiType::Void,
+                    .parameters = std::move(parameters),
+                    .address = reinterpret_cast<void*>(function)});
+}
+
+static auto createRuntimeRegistry() -> RuntimeRegistry {
+  RuntimeRegistry registry;
+
+#define MQT_QIR_ADD_GATE(NAME, SUFFIX, CTL_SUFFIX, TARGETS, PARAMS)            \
+  addGate(registry, "__quantum__qis__" #NAME "__" #SUFFIX, TARGETS, PARAMS, 0, \
+          &__quantum__qis__##NAME##__##SUFFIX);                                \
+  addGate(registry, "__quantum__qis__c" #NAME "__" #SUFFIX, TARGETS, PARAMS,   \
+          1, &__quantum__qis__c##NAME##__##SUFFIX);                            \
+  addGate(registry, "__quantum__qis__cc" #NAME "__" #SUFFIX, TARGETS, PARAMS,  \
+          2, &__quantum__qis__cc##NAME##__##SUFFIX);                           \
+  addSymbol(registry, "__quantum__qis__" #NAME "__" #CTL_SUFFIX,               \
+            AbiType::Void, {AbiType::Pointer, AbiType::Pointer},               \
+            &__quantum__qis__##NAME##__##CTL_SUFFIX);
+#define MQT_GATE(KEY, NAME, OP, GETTER, TARGETS, PARAMS, SUFFIX, CTL_SUFFIX)   \
+  MQT_QIR_ADD_GATE(NAME, SUFFIX, CTL_SUFFIX, TARGETS, PARAMS)
+#include "mlir/Conversion/GateTable.def"
+#undef MQT_QIR_ADD_GATE
+
+  addSymbol(registry, "__quantum__qis__gphase__body", AbiType::Void,
+            {AbiType::F64}, &__quantum__qis__gphase__body);
+  addSymbol(registry, "__quantum__qis__cnot__body", AbiType::Void,
+            {AbiType::Pointer, AbiType::Pointer}, &__quantum__qis__cnot__body);
+  addSymbol(registry, "__quantum__qis__mz__body", AbiType::Void,
+            {AbiType::Pointer, AbiType::Pointer}, &__quantum__qis__mz__body);
+  addSymbol(registry, "__quantum__qis__reset__body", AbiType::Void,
+            {AbiType::Pointer}, &__quantum__qis__reset__body);
+  addSymbol(registry, "__quantum__rt__array_create_1d", AbiType::Pointer,
+            {AbiType::I32, AbiType::I64}, &__quantum__rt__array_create_1d);
+  addSymbol(registry, "__quantum__rt__array_get_size_1d", AbiType::I64,
+            {AbiType::Pointer}, &__quantum__rt__array_get_size_1d);
+  addSymbol(registry, "__quantum__rt__array_get_element_ptr_1d",
+            AbiType::Pointer, {AbiType::Pointer, AbiType::I64},
+            &__quantum__rt__array_get_element_ptr_1d);
+  addSymbol(registry, "__quantum__rt__array_update_reference_count",
+            AbiType::Void, {AbiType::Pointer, AbiType::I32},
+            &__quantum__rt__array_update_reference_count);
+  addSymbol(registry, "__quantum__rt__tuple_create", AbiType::Pointer,
+            {AbiType::I64}, &__quantum__rt__tuple_create);
+  addSymbol(registry, "__quantum__rt__tuple_update_reference_count",
+            AbiType::Void, {AbiType::Pointer, AbiType::I32},
+            &__quantum__rt__tuple_update_reference_count);
+  addSymbol(registry, "__quantum__rt__qubit_allocate", AbiType::Pointer,
+            {AbiType::Pointer}, &__quantum__rt__qubit_allocate);
+  addSymbol(registry, "__quantum__rt__qubit_release", AbiType::Void,
+            {AbiType::Pointer}, &__quantum__rt__qubit_release);
+  addSymbol(registry, "__quantum__rt__qubit_array_allocate", AbiType::Void,
+            {AbiType::I64, AbiType::Pointer, AbiType::Pointer},
+            &__quantum__rt__qubit_array_allocate);
+  addSymbol(registry, "__quantum__rt__qubit_array_release", AbiType::Void,
+            {AbiType::I64, AbiType::Pointer},
+            &__quantum__rt__qubit_array_release);
+  addSymbol(registry, "__quantum__rt__result_allocate", AbiType::Pointer,
+            {AbiType::Pointer}, &__quantum__rt__result_allocate);
+  addSymbol(registry, "__quantum__rt__result_release", AbiType::Void,
+            {AbiType::Pointer}, &__quantum__rt__result_release);
+  addSymbol(registry, "__quantum__rt__result_array_allocate", AbiType::Void,
+            {AbiType::I64, AbiType::Pointer, AbiType::Pointer},
+            &__quantum__rt__result_array_allocate);
+  addSymbol(registry, "__quantum__rt__result_array_release", AbiType::Void,
+            {AbiType::I64, AbiType::Pointer},
+            &__quantum__rt__result_array_release);
+
+  addSymbol(registry, "__quantum__rt__initialize", AbiType::Void,
+            {AbiType::Pointer}, &__quantum__rt__initialize);
+  addSymbol(registry, "__quantum__rt__read_result", AbiType::I1,
+            {AbiType::Pointer}, &__quantum__rt__read_result);
+  addSymbol(registry, "__quantum__rt__result_record_output", AbiType::Void,
+            {AbiType::Pointer, AbiType::Pointer},
+            &__quantum__rt__result_record_output);
+  addSymbol(registry, "__quantum__rt__bool_record_output", AbiType::Void,
+            {AbiType::I1, AbiType::Pointer},
+            &__quantum__rt__bool_record_output);
+  addSymbol(registry, "__quantum__rt__int_record_output", AbiType::Void,
+            {AbiType::I64, AbiType::Pointer},
+            &__quantum__rt__int_record_output);
+  addSymbol(registry, "__quantum__rt__double_record_output", AbiType::Void,
+            {AbiType::F64, AbiType::Pointer},
+            &__quantum__rt__double_record_output);
+  addSymbol(registry, "__quantum__rt__tuple_record_output", AbiType::Void,
+            {AbiType::I64, AbiType::Pointer},
+            &__quantum__rt__tuple_record_output);
+  addSymbol(registry, "__quantum__rt__array_record_output", AbiType::Void,
+            {AbiType::I64, AbiType::Pointer},
+            &__quantum__rt__array_record_output);
+  addSymbol(registry, "__quantum__rt__result_array_record_output",
+            AbiType::Void, {AbiType::I64, AbiType::Pointer, AbiType::Pointer},
+            &__quantum__rt__result_array_record_output);
+  return registry;
+}
+
+static auto selectRuntimeSymbols(const llvm::Module& module)
+    -> std::vector<std::pair<std::string, void*>> {
+  const auto registry = createRuntimeRegistry();
+  std::vector<std::pair<std::string, void*>> selected;
+  for (const auto& function : module) {
+    if (!function.isDeclaration() || function.use_empty() ||
+        !function.getName().starts_with("__quantum__")) {
+      continue;
+    }
+    const auto it = registry.find(function.getName().str());
+    if (it == registry.end()) {
+      throw std::runtime_error("Unsupported QIR runtime declaration '" +
+                               function.getName().str() + "'");
+    }
+    const auto& symbol = it->second;
+    if (!matches(*function.getFunctionType(), symbol)) {
+      std::string actual;
+      llvm::raw_string_ostream stream(actual);
+      function.getFunctionType()->print(stream);
+      std::ostringstream message;
+      message << "QIR declaration '" << function.getName().str()
+              << "' has unsupported type " << actual << "; expected "
+              << describe(symbol);
+      throw std::runtime_error(message.str());
+    }
+    selected.emplace_back(function.getName().str(), symbol.address);
+  }
+  return selected;
 }
 
 static llvm::Expected<llvm::orc::ThreadSafeModule>
@@ -142,77 +400,29 @@ JitSession::loadModuleFromMemory(const llvm::StringRef irBytes,
   return getThreadSafeModuleOrError(std::move(m), err, tsCtx_);
 }
 
-JitSession::JitSession(const llvm::StringRef inputFile, const Execution mode) {
-  initialize(loadModuleFromFile(inputFile), mode);
+JitSession::JitSession(const llvm::StringRef inputFile,
+                       const SessionOptions& options) {
+  initialize(loadModuleFromFile(inputFile), options);
 }
 
 JitSession::JitSession(const llvm::StringRef irBytes,
-                       const llvm::StringRef bufferName, const Execution mode) {
-  initialize(loadModuleFromMemory(irBytes, bufferName), mode);
+                       const llvm::StringRef bufferName,
+                       const SessionOptions& options) {
+  initialize(loadModuleFromMemory(irBytes, bufferName), options);
 }
 
 JitSession::~JitSession() { deinitialize(); }
 
-int JitSession::run(llvm::ArrayRef<std::string> args,
-                    llvm::StringRef progName) const {
-  // Manual in-process execution with RuntimeDyld.
-  return llvm::orc::runAsMain(mainFn_, args, progName);
+int64_t JitSession::run() {
+  auto* previous = Runtime::bind(runtime_.get());
+  const auto restoreRuntime =
+      llvm::make_scope_exit([previous] { Runtime::bind(previous); });
+  return entryPointFn_();
 }
 
-namespace {
-std::vector<std::pair<std::string, void*>> manualSymbols;
-} // namespace
+auto JitSession::runtime() -> Runtime& { return *runtime_; }
 
-#define REGISTER_SYMBOL(name)                                                  \
-  llvm::sys::DynamicLibrary::AddSymbol(#name,                                  \
-                                       reinterpret_cast<void*>(&(name)));      \
-  manualSymbols.emplace_back(#name, reinterpret_cast<void*>(&(name)));
-
-void JitSession::registerRuntimeSymbols() {
-  static std::once_flag flag;
-  std::call_once(flag, []() {
-    REGISTER_SYMBOL(__quantum__rt__result_get_zero);
-    REGISTER_SYMBOL(__quantum__rt__result_get_one);
-    REGISTER_SYMBOL(__quantum__rt__result_equal);
-    REGISTER_SYMBOL(__quantum__rt__result_update_reference_count);
-    REGISTER_SYMBOL(__quantum__rt__array_create_1d);
-    REGISTER_SYMBOL(__quantum__rt__array_get_size_1d);
-    REGISTER_SYMBOL(__quantum__rt__array_get_element_ptr_1d);
-    REGISTER_SYMBOL(__quantum__rt__array_update_reference_count);
-    REGISTER_SYMBOL(__quantum__rt__tuple_create);
-    REGISTER_SYMBOL(__quantum__rt__tuple_update_reference_count);
-    REGISTER_SYMBOL(__quantum__rt__qubit_allocate);
-    REGISTER_SYMBOL(__quantum__rt__qubit_allocate_array);
-    REGISTER_SYMBOL(__quantum__rt__qubit_release);
-    REGISTER_SYMBOL(__quantum__rt__qubit_release_array);
-#define MQT_QIR_REGISTER_GATE(NAME, SUFFIX, CTL_SUFFIX)                        \
-  REGISTER_SYMBOL(__quantum__qis__##NAME##__##SUFFIX);                         \
-  REGISTER_SYMBOL(__quantum__qis__c##NAME##__##SUFFIX);                        \
-  REGISTER_SYMBOL(__quantum__qis__cc##NAME##__##SUFFIX);                       \
-  REGISTER_SYMBOL(__quantum__qis__##NAME##__##CTL_SUFFIX);
-#define MQT_GATE(KEY, NAME, OP, GETTER, TARGETS, PARAMS, SUFFIX, CTL_SUFFIX)   \
-  MQT_QIR_REGISTER_GATE(NAME, SUFFIX, CTL_SUFFIX)
-#include "mlir/Conversion/GateTable.def"
-#undef MQT_QIR_REGISTER_GATE
-
-    REGISTER_SYMBOL(__quantum__qis__gphase__body);
-    REGISTER_SYMBOL(__quantum__qis__cnot__body);
-    REGISTER_SYMBOL(__quantum__qis__m__body);
-    REGISTER_SYMBOL(__quantum__qis__measure__body);
-    REGISTER_SYMBOL(__quantum__qis__mz__body);
-    REGISTER_SYMBOL(__quantum__qis__reset__body);
-    REGISTER_SYMBOL(__quantum__rt__initialize);
-    REGISTER_SYMBOL(__quantum__rt__read_result);
-    REGISTER_SYMBOL(__quantum__rt__result_record_output);
-    REGISTER_SYMBOL(__quantum__rt__bool_record_output);
-    REGISTER_SYMBOL(__quantum__rt__int_record_output);
-    REGISTER_SYMBOL(__quantum__rt__float_record_output);
-    REGISTER_SYMBOL(__quantum__rt__tuple_record_output);
-    REGISTER_SYMBOL(__quantum__rt__array_record_output);
-  });
-}
-
-#undef REGISTER_SYMBOL
+auto JitSession::runtime() const -> const Runtime& { return *runtime_; }
 
 void JitSession::initNativeTargets() {
   static std::once_flag flag;
@@ -229,25 +439,39 @@ void JitSession::initNativeTargets() {
 
 void JitSession::initialize(
     llvm::Expected<llvm::orc::ThreadSafeModule> llvmModule,
-    const Execution mode) {
+    const SessionOptions& options) {
   if (!llvmModule) {
     throw std::runtime_error(llvm::toString(llvmModule.takeError()));
   }
   module_ = std::move(*llvmModule);
+  runtime_ = std::make_unique<Runtime>();
 
-  // Configure the runtime's labeling schema from the program's entry point.
-  module_.withModuleDo([](const llvm::Module& m) {
-    Runtime::getInstance().setOutputSchema(readOutputSchema(m));
+  std::vector<std::pair<std::string, void*>> runtimeSymbols;
+  module_.withModuleDo([&](const llvm::Module& module) {
+    const auto& entryPoint = selectEntryPoint(module, options.entryPoint);
+    entryPointName_ = entryPoint.getName().str();
+    runtime_->setOutputSchema(readOutputSchema(entryPoint));
+    std::vector<std::pair<std::string, std::string>> metadata;
+    for (const auto attribute : entryPoint.getAttributes().getFnAttrs()) {
+      if (attribute.isStringAttribute()) {
+        metadata.emplace_back(attribute.getKindAsString().str(),
+                              attribute.getValueAsString().str());
+      }
+    }
+    runtime_->setMetadata(std::move(metadata));
+    runtimeSymbols = selectRuntimeSymbols(module);
   });
+  if (options.seed) {
+    runtime_->seed(*options.seed);
+  }
 
   // In StateExtraction mode, strip QIR measurement and result-management calls
   // so the runtime's quantum state remains intact after main returns.
-  if (mode == Execution::StateExtraction) {
+  if (options.execution == Execution::StateExtraction) {
     module_.withModuleDo(
         [](llvm::Module& m) { stripMeasurementRelatedCalls(m); });
   }
 
-  registerRuntimeSymbols();
   initNativeTargets();
 
   // Get TargetTriple and DataLayout from the main module if they're explicitly
@@ -324,7 +548,7 @@ void JitSession::initialize(
   // Register QIR runtime symbols.
   auto& jd = jit_->getMainJITDylib();
   llvm::orc::SymbolMap hostSymbols;
-  for (const auto& [name, ptr] : manualSymbols) {
+  for (const auto& [name, ptr] : runtimeSymbols) {
     hostSymbols[jit_->mangleAndIntern(name)] = {
         llvm::orc::ExecutorAddr::fromPtr(ptr), llvm::JITSymbolFlags::Exported};
   }
@@ -381,12 +605,12 @@ void JitSession::initialize(
     throw std::runtime_error(llvm::toString(std::move(err)));
   }
 
-  // Resolve the main function.
-  auto mainAddr = jit_->lookup("main");
-  if (!mainAddr) {
-    throw std::runtime_error(llvm::toString(mainAddr.takeError()));
+  // Resolve the selected QIR entry point.
+  auto entryPointAddress = jit_->lookup(entryPointName_);
+  if (!entryPointAddress) {
+    throw std::runtime_error(llvm::toString(entryPointAddress.takeError()));
   }
-  mainFn_ = mainAddr->toPtr<MainFn*>();
+  entryPointFn_ = entryPointAddress->toPtr<EntryPointFn*>();
 }
 
 void JitSession::deinitialize() const {

--- a/src/qir/runner/Runner.cpp
+++ b/src/qir/runner/Runner.cpp
@@ -16,8 +16,10 @@
 #include <llvm/Support/Error.h>
 #include <llvm/Support/InitLLVM.h>
 
+#include <cstdint>
 #include <exception>
 #include <span>
+#include <stdexcept>
 #include <string>
 
 #define DEBUG_TYPE "mqt-core-qir-runner"
@@ -28,8 +30,14 @@ static llvm::cl::opt<std::string> InputFile(llvm::cl::desc("<input bitcode>"),
                                             llvm::cl::Positional,
                                             llvm::cl::init("-"));
 
-static llvm::cl::list<std::string>
-    InputArgv(llvm::cl::ConsumeAfter, llvm::cl::desc("<program arguments>..."));
+static llvm::cl::opt<std::string>
+    EntryPoint("entry-point", llvm::cl::desc("QIR entry point to execute"));
+
+static llvm::cl::opt<uint64_t>
+    Shots("shots", llvm::cl::desc("Number of executions"), llvm::cl::init(1));
+
+static llvm::cl::opt<uint64_t>
+    Seed("seed", llvm::cl::desc("Seed for deterministic sampling"));
 
 static llvm::ExitOnError ExitOnError;
 
@@ -42,13 +50,29 @@ auto main(int argc, char* argv[]) -> int {
                                     "qir interpreter & dynamic compiler\n");
 
   try {
-    auto jitSession = qir::JitSession(llvm::StringRef(InputFile));
-    auto& runtime = qir::Runtime::getInstance();
+    if (Shots == 0) {
+      throw std::invalid_argument("--shots must be greater than zero");
+    }
+    qir::SessionOptions options;
+    if (!EntryPoint.empty()) {
+      options.entryPoint = EntryPoint;
+    }
+    if (Seed.getNumOccurrences() != 0) {
+      options.seed = Seed;
+    }
+    auto jitSession = qir::JitSession(llvm::StringRef(InputFile), options);
+    auto& runtime = jitSession.runtime();
     runtime.outputProgramHeader();
-    runtime.outputShotStart();
-    const auto rc = jitSession.run(InputArgv, InputFile);
-    runtime.outputShotEnd();
-    return rc;
+    int64_t rc = 0;
+    for (uint64_t shot = 0; shot < Shots; ++shot) {
+      runtime.outputShotStart();
+      rc = jitSession.run();
+      runtime.outputShotEnd(rc);
+      if (rc != 0) {
+        break;
+      }
+    }
+    return static_cast<int>(rc);
   } catch (const std::exception& e) {
     ExitOnError(llvm::createStringError(e.what()));
   }

--- a/src/qir/runtime/QIR.cpp
+++ b/src/qir/runtime/QIR.cpp
@@ -25,6 +25,7 @@
 #include <new>
 #include <span>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -113,46 +114,23 @@ static auto applyControlledTuple(const qc::OpType op, Array* controls,
 
 extern "C" {
 
-// *** MEASUREMENT RESULTS ***
-Result* __quantum__rt__result_get_zero() {
-  // NOLINTNEXTLINE(performance-no-int-to-ptr)
-  return reinterpret_cast<Result*>(qir::Runtime::RESULT_ZERO_ADDRESS);
-}
-
-Result* __quantum__rt__result_get_one() {
-  // NOLINTNEXTLINE(performance-no-int-to-ptr)
-  return reinterpret_cast<Result*>(qir::Runtime::RESULT_ONE_ADDRESS);
-}
-
-bool __quantum__rt__result_equal(Result* result1, Result* result2) {
-  auto& runtime = qir::Runtime::getInstance();
-  return runtime.equal(result1, result2);
-}
-
-void __quantum__rt__result_update_reference_count(Result* result,
-                                                  const int32_t k) {
-  auto& runtime = qir::Runtime::getInstance();
-  // NOLINTBEGIN(performance-no-int-to-ptr)
-  if (result != nullptr &&
-      result != reinterpret_cast<Result*>(qir::Runtime::RESULT_ZERO_ADDRESS) &&
-      result != reinterpret_cast<Result*>(qir::Runtime::RESULT_ONE_ADDRESS)) {
-    // NOLINTEND(performance-no-int-to-ptr)
-    auto& refcount = runtime.deref(result).refcount;
-    refcount += k;
-    if (refcount == 0) {
-      runtime.rFree(result);
-    }
-  }
-}
-
 // *** ARRAYS ***
 Array* __quantum__rt__array_create_1d(const int32_t size, const int64_t n) {
+  if (size <= 0 || n < 0) {
+    throw std::invalid_argument(
+        "QIR array element size must be positive and length nonnegative");
+  }
+  const auto elementSize = static_cast<std::size_t>(size);
+  const auto length = static_cast<std::size_t>(n);
+  constexpr auto maxObjectSize =
+      static_cast<std::size_t>(std::numeric_limits<std::ptrdiff_t>::max());
+  if (length > maxObjectSize / elementSize) {
+    throw std::length_error("QIR array allocation size overflow");
+  }
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   auto* array = new Array;
   array->refcount = 1;
-  array->aliasCount = 0;
-  array->data =
-      std::vector(static_cast<size_t>(size * n), static_cast<int8_t>(0));
+  array->data = std::vector(length * elementSize, static_cast<int8_t>(0));
   array->elementSize = size;
   return array;
 }
@@ -215,36 +193,80 @@ void __quantum__rt__tuple_update_reference_count(Tuple* tuple,
 }
 
 // *** QUANTUM INSTRUCTION SET AND RUNTIME ***
-Qubit* __quantum__rt__qubit_allocate() {
+Qubit* __quantum__rt__qubit_allocate(bool* outError) {
+  if (outError != nullptr) {
+    *outError = false;
+  }
   auto& runtime = qir::Runtime::getInstance();
   return runtime.qAlloc();
 }
 
-Array* __quantum__rt__qubit_allocate_array(const int64_t n) {
-  auto* array = __quantum__rt__array_create_1d(sizeof(Qubit*), n);
-  for (int64_t i = 0; i < n; ++i) {
-    auto* const q = reinterpret_cast<Qubit**>(
-        __quantum__rt__array_get_element_ptr_1d(array, i));
-    *q = __quantum__rt__qubit_allocate();
+void __quantum__rt__qubit_array_allocate(const int64_t size, Qubit** array,
+                                         bool* outError) {
+  if (outError != nullptr) {
+    *outError = false;
   }
-  return array;
+  if (size < 0 || (size > 0 && array == nullptr)) {
+    if (outError != nullptr) {
+      *outError = true;
+      return;
+    }
+    throw std::invalid_argument("Invalid QIR qubit array allocation");
+  }
+  for (auto*& qubit : std::span(array, static_cast<std::size_t>(size))) {
+    qubit = qir::Runtime::getInstance().qAlloc();
+  }
+}
+
+void __quantum__rt__qubit_array_release(const int64_t size, Qubit** array) {
+  if (size < 0 || (size > 0 && array == nullptr)) {
+    throw std::invalid_argument("Invalid QIR qubit array release");
+  }
+  for (Qubit* qubit : std::span(array, static_cast<std::size_t>(size))) {
+    qir::Runtime::getInstance().qFree(qubit);
+  }
+}
+
+Result* __quantum__rt__result_allocate(bool* outError) {
+  if (outError != nullptr) {
+    *outError = false;
+  }
+  return qir::Runtime::getInstance().rAlloc();
+}
+
+void __quantum__rt__result_release(Result* result) {
+  qir::Runtime::getInstance().rFree(result);
+}
+
+void __quantum__rt__result_array_allocate(const int64_t size, Result** array,
+                                          bool* outError) {
+  if (outError != nullptr) {
+    *outError = false;
+  }
+  if (size < 0 || (size > 0 && array == nullptr)) {
+    if (outError != nullptr) {
+      *outError = true;
+      return;
+    }
+    throw std::invalid_argument("Invalid QIR result array allocation");
+  }
+  for (auto*& result : std::span(array, static_cast<std::size_t>(size))) {
+    result = qir::Runtime::getInstance().rAlloc();
+  }
+}
+
+void __quantum__rt__result_array_release(const int64_t size, Result** array) {
+  if (size < 0 || (size > 0 && array == nullptr)) {
+    throw std::invalid_argument("Invalid QIR result array release");
+  }
+  for (Result* result : std::span(array, static_cast<std::size_t>(size))) {
+    qir::Runtime::getInstance().rFree(result);
+  }
 }
 
 void __quantum__rt__qubit_release(Qubit* qubit) {
   auto& runtime = qir::Runtime::getInstance();
   runtime.qFree(qubit);
-}
-
-void __quantum__rt__qubit_release_array(Array* array) {
-  const auto size = __quantum__rt__array_get_size_1d(array);
-  // deallocate every qubit
-  for (int64_t i = 0; i < size; ++i) {
-    auto* const q = reinterpret_cast<Qubit**>(
-        __quantum__rt__array_get_element_ptr_1d(array, i));
-    __quantum__rt__qubit_release(*q);
-  }
-  // deallocate array
-  __quantum__rt__array_update_reference_count(array, -1);
 }
 
 // QUANTUM INSTRUCTION SET
@@ -429,17 +451,6 @@ void __quantum__qis__mz__body(Qubit* qubit, Result* result) {
   runtime.measure(qubit, result);
 }
 
-Result* __quantum__qis__m__body(Qubit* qubit) {
-  auto& runtime = qir::Runtime::getInstance();
-  auto* result = runtime.rAlloc();
-  __quantum__qis__mz__body(qubit, result);
-  return result;
-}
-
-Result* __quantum__qis__measure__body(Qubit* qubit) {
-  return __quantum__qis__m__body(qubit);
-}
-
 void __quantum__qis__reset__body(Qubit* qubit) {
   auto& runtime = qir::Runtime::getInstance();
   runtime.reset<1>({qubit});
@@ -470,7 +481,7 @@ void __quantum__rt__int_record_output(int64_t value, const char* label) {
   qir::Runtime::getInstance().outputInt(value, label);
 }
 
-void __quantum__rt__float_record_output(double value, const char* label) {
+void __quantum__rt__double_record_output(double value, const char* label) {
   qir::Runtime::getInstance().outputFloat(value, label);
 }
 
@@ -481,6 +492,23 @@ void __quantum__rt__tuple_record_output(int64_t elementCount,
 
 void __quantum__rt__array_record_output(int64_t size, const char* label) {
   qir::Runtime::getInstance().outputArray(size, label);
+}
+
+void __quantum__rt__result_array_record_output(const int64_t size,
+                                               Result** results,
+                                               const char* label) {
+  if (size < 0 || (size > 0 && results == nullptr)) {
+    throw std::invalid_argument("Invalid QIR result array output");
+  }
+  auto& runtime = qir::Runtime::getInstance();
+  std::string values;
+  values.reserve(static_cast<std::size_t>(size));
+  for (Result* result : std::span(results, static_cast<std::size_t>(size))) {
+    const auto value = runtime.deref(result).r;
+    values.push_back(value ? '1' : '0');
+    runtime.appendMeasurementBit(value);
+  }
+  runtime.outputResultArray(values, label);
 }
 
 } // extern "C"

--- a/src/qir/runtime/Runtime.cpp
+++ b/src/qir/runtime/Runtime.cpp
@@ -42,6 +42,10 @@
 
 namespace qir {
 
+namespace {
+thread_local Runtime* ActiveRuntime = nullptr;
+} // namespace
+
 auto Runtime::generateRandomSeed() -> uint64_t {
   std::array<std::random_device::result_type, std::mt19937_64::state_size>
       randomData{};
@@ -52,41 +56,40 @@ auto Runtime::generateRandomSeed() -> uint64_t {
   return rng();
 }
 Runtime& Runtime::getInstance() {
-  static Runtime instance;
-  return instance;
+  if (ActiveRuntime != nullptr) {
+    return *ActiveRuntime;
+  }
+  static thread_local Runtime fallback;
+  return fallback;
 }
+
+auto Runtime::bind(Runtime* runtime) noexcept -> Runtime* {
+  return std::exchange(ActiveRuntime, runtime);
+}
+
 auto Runtime::reset() -> void {
-  addressMode = AddressMode::UNKNOWN;
+  qubitMode = ResourceMode::UNKNOWN;
+  resultMode = ResourceMode::UNKNOWN;
   qRegister.clear();
+  qubitPermutation.clear();
   rRegister.clear();
-  // NOLINTBEGIN(performance-no-int-to-ptr)
-  rRegister.emplace(reinterpret_cast<Result*>(RESULT_ZERO_ADDRESS),
-                    ResultStruct{.refcount = 0, .r = false});
-  rRegister.emplace(reinterpret_cast<Result*>(RESULT_ONE_ADDRESS),
-                    ResultStruct{.refcount = 0, .r = true});
-  // NOLINTEND(performance-no-int-to-ptr)
   measurements.clear();
   currentMaxQubitAddress = MIN_DYN_QUBIT_ADDRESS;
   currentMaxQubitId = 0;
   currentMaxResultAddress = MIN_DYN_RESULT_ADDRESS;
   qState.reset();
-  mt.seed(generateRandomSeed());
 }
+
+auto Runtime::seed(const uint64_t randomSeed) -> void { mt.seed(randomSeed); }
 
 Runtime::Runtime() : Runtime(generateRandomSeed()) {}
 
 Runtime::Runtime(const uint64_t randomSeed)
-    : addressMode(AddressMode::UNKNOWN),
+    : qubitMode(ResourceMode::UNKNOWN), resultMode(ResourceMode::UNKNOWN),
       currentMaxQubitAddress(MIN_DYN_QUBIT_ADDRESS), currentMaxQubitId(0),
       currentMaxResultAddress(MIN_DYN_RESULT_ADDRESS), mt(randomSeed) {
   qRegister = std::unordered_map<const Qubit*, qc::Qubit>();
   rRegister = std::unordered_map<Result*, ResultStruct>();
-  // NOLINTBEGIN(performance-no-int-to-ptr)
-  rRegister.emplace(reinterpret_cast<Result*>(RESULT_ZERO_ADDRESS),
-                    ResultStruct{.refcount = 0, .r = false});
-  rRegister.emplace(reinterpret_cast<Result*>(RESULT_ONE_ADDRESS),
-                    ResultStruct{.refcount = 0, .r = true});
-  // NOLINTEND(performance-no-int-to-ptr)
 }
 
 auto Runtime::enlargeState(const std::uint64_t maxQubit) -> void {
@@ -124,7 +127,7 @@ auto Runtime::enlargeState(const std::uint64_t maxQubit) -> void {
 auto Runtime::translateAddresses(const std::span<Qubit* const> qubits)
     -> std::vector<qc::Qubit> {
   std::vector<qc::Qubit> qubitIds(qubits.size());
-  if (addressMode != AddressMode::STATIC) {
+  if (qubitMode != ResourceMode::STATIC) {
     try {
       std::ranges::transform(qubits, qubitIds.begin(), [&](const auto* q) {
         try {
@@ -137,13 +140,13 @@ auto Runtime::translateAddresses(const std::span<Qubit* const> qubits)
         }
       });
     } catch (std::out_of_range&) {
-      if (addressMode == AddressMode::DYNAMIC) {
+      if (qubitMode == ResourceMode::DYNAMIC) {
         throw;
       }
-      addressMode = AddressMode::STATIC;
+      qubitMode = ResourceMode::STATIC;
     }
   }
-  if (addressMode == AddressMode::STATIC) {
+  if (qubitMode == ResourceMode::STATIC) {
     std::ranges::transform(qubits, qubitIds.begin(), [](const auto* q) {
       return static_cast<qc::Qubit>(reinterpret_cast<uintptr_t>(q));
     });
@@ -166,6 +169,11 @@ auto Runtime::apply(const qc::OpType op, const std::span<const qc::fp> params,
     return qubitPermutation[address];
   });
 
+  if (op == qc::SWAP && controls.empty() && targets.size() == 2) {
+    swap(targets[0], targets[1]);
+    return;
+  }
+
   const auto controlEnd =
       addresses.cbegin() + static_cast<std::ptrdiff_t>(controls.size());
   const qc::Controls mappedControls(addresses.cbegin(), controlEnd);
@@ -184,6 +192,11 @@ auto Runtime::swap(Qubit* qubit1, Qubit* qubit2) -> void {
 }
 
 auto Runtime::qAlloc() -> Qubit* {
+  if (qubitMode == ResourceMode::STATIC) {
+    throw std::logic_error(
+        "Cannot dynamically allocate qubits after using static qubit IDs");
+  }
+  qubitMode = ResourceMode::DYNAMIC;
   // NOLINTNEXTLINE(performance-no-int-to-ptr)
   auto* qubit = reinterpret_cast<Qubit*>(currentMaxQubitAddress++);
   qRegister.emplace(qubit, currentMaxQubitId++);
@@ -191,39 +204,44 @@ auto Runtime::qAlloc() -> Qubit* {
 }
 
 auto Runtime::qFree(Qubit* qubit) -> void {
+  if (qubitMode != ResourceMode::DYNAMIC || !qRegister.contains(qubit)) {
+    throw std::out_of_range("QIR qubit was not dynamically allocated");
+  }
   reset<1>({{qubit}});
   qRegister.erase(qubit);
 }
 
 auto Runtime::rAlloc() -> Result* {
+  if (resultMode == ResourceMode::STATIC) {
+    throw std::logic_error(
+        "Cannot dynamically allocate results after using static result IDs");
+  }
+  resultMode = ResourceMode::DYNAMIC;
   // NOLINTNEXTLINE(performance-no-int-to-ptr)
   auto* result = reinterpret_cast<Result*>(currentMaxResultAddress++);
-  rRegister.emplace(result, ResultStruct{.refcount = 1, .r = false});
+  rRegister.emplace(result, ResultStruct{.r = false});
   return result;
 }
 
-auto Runtime::rFree(Result* result) -> void { rRegister.erase(result); }
+auto Runtime::rFree(Result* result) -> void {
+  if (resultMode != ResourceMode::DYNAMIC || rRegister.erase(result) == 0) {
+    throw std::out_of_range("QIR result was not dynamically allocated");
+  }
+}
 
 auto Runtime::deref(Result* result) -> ResultStruct& {
   auto it = rRegister.find(result);
   if (it == rRegister.end()) {
-    if (addressMode != AddressMode::UNKNOWN) {
-      addressMode = AddressMode::STATIC;
-    }
-    if (addressMode == AddressMode::DYNAMIC) {
+    if (resultMode == ResourceMode::DYNAMIC) {
       std::stringstream ss;
       ss << __FILE__ << ":" << __LINE__
          << ": Result not allocated (not found): " << result;
       throw std::out_of_range(ss.str());
     }
-    it = rRegister.emplace(result, ResultStruct{.refcount = 0, .r = false})
-             .first;
+    resultMode = ResourceMode::STATIC;
+    it = rRegister.emplace(result, ResultStruct{.r = false}).first;
   }
   return it->second;
-}
-
-auto Runtime::equal(Result* result1, Result* result2) -> bool {
-  return deref(result1).r == deref(result2).r;
 }
 
 auto Runtime::appendMeasurementBit(bool result) -> void {
@@ -257,6 +275,11 @@ void Runtime::outputType(const char* type, std::string_view value,
 
 auto Runtime::outputResult(bool value, const char* label) const -> void {
   outputType("RESULT", value ? "1" : "0", label);
+}
+
+auto Runtime::outputResultArray(const std::string_view values,
+                                const char* label) const -> void {
+  outputType("RESULT_ARRAY", values, label);
 }
 
 auto Runtime::outputBool(bool value, const char* label) const -> void {
@@ -295,15 +318,33 @@ auto Runtime::outputProgramHeader() const -> void {
 
 auto Runtime::outputShotStart() const -> void {
   *os << "START\n";
-  *os << "METADATA\toutput_labeling_schema\t" << outputSchema << "\n";
+  if (metadata.empty()) {
+    *os << "METADATA\toutput_labeling_schema\t" << outputSchema << "\n";
+    return;
+  }
+  for (const auto& [name, value] : metadata) {
+    *os << "METADATA\t" << name;
+    if (!value.empty()) {
+      *os << "\t" << value;
+    }
+    *os << "\n";
+  }
 }
 
-auto Runtime::outputShotEnd() const -> void { *os << "END\t0\n"; }
+auto Runtime::outputShotEnd(const int64_t exitCode) const -> void {
+  *os << "END\t" << exitCode << "\n";
+}
 
 auto Runtime::getOutputSchema() const -> OutputSchema { return outputSchema; }
 
 auto Runtime::setOutputSchema(OutputSchema schema) -> void {
   outputSchema = schema;
+}
+
+auto Runtime::setMetadata(
+    std::vector<std::pair<std::string, std::string>> entryPointMetadata)
+    -> void {
+  metadata = std::move(entryPointMetadata);
 }
 
 auto operator<<(std::ostream& os, const Runtime::OutputSchema schema)

--- a/test/circuits/AdaptiveRecordOutputs.ll
+++ b/test/circuits/AdaptiveRecordOutputs.ll
@@ -1,9 +1,6 @@
 ; ModuleID = 'Adaptive module implementing a 3-qubit Hamming weight'
 source_filename = "AdaptiveRecordOutputs.ll"
 
-%Qubit = type opaque
-%Result = type opaque
-
 @r0_lbl = internal constant [3 x i8] c"r0\00"
 @r1_lbl = internal constant [3 x i8] c"r1\00"
 @r2_lbl = internal constant [3 x i8] c"r2\00"
@@ -15,21 +12,24 @@ source_filename = "AdaptiveRecordOutputs.ll"
 @weight_lbl = internal constant [17 x i8] c"  hamming_weight\00"
 @mean_lbl = internal constant [7 x i8] c"  mean\00"
 
-define i32 @main() #0 {
+define i64 @main() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  %q0 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %q1 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %q2 = call %Qubit* @__quantum__rt__qubit_allocate()
-  call void @__quantum__qis__h__body(%Qubit* %q0)
-  call void @__quantum__qis__h__body(%Qubit* %q1)
-  call void @__quantum__qis__h__body(%Qubit* %q2)
-  %r0 = call %Result* @__quantum__qis__m__body(%Qubit* %q0)
-  %r1 = call %Result* @__quantum__qis__m__body(%Qubit* %q1)
-  %r2 = call %Result* @__quantum__qis__m__body(%Qubit* %q2)
-  %b0 = call i1 @__quantum__rt__read_result(%Result* %r0)
-  %b1 = call i1 @__quantum__rt__read_result(%Result* %r1)
-  %b2 = call i1 @__quantum__rt__read_result(%Result* %r2)
+  call void @__quantum__rt__initialize(ptr null)
+  %q0 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  %q1 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  %q2 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  call void @__quantum__qis__h__body(ptr %q0)
+  call void @__quantum__qis__h__body(ptr %q1)
+  call void @__quantum__qis__h__body(ptr %q2)
+  %r0 = call ptr @__quantum__rt__result_allocate(ptr null)
+  %r1 = call ptr @__quantum__rt__result_allocate(ptr null)
+  %r2 = call ptr @__quantum__rt__result_allocate(ptr null)
+  call void @__quantum__qis__mz__body(ptr %q0, ptr %r0)
+  call void @__quantum__qis__mz__body(ptr %q1, ptr %r1)
+  call void @__quantum__qis__mz__body(ptr %q2, ptr %r2)
+  %b0 = call i1 @__quantum__rt__read_result(ptr %r0)
+  %b1 = call i1 @__quantum__rt__read_result(ptr %r1)
+  %b2 = call i1 @__quantum__rt__read_result(ptr %r2)
 
   ; Classical compute: Hamming weight and its mean.
   %c0 = zext i1 %b0 to i64
@@ -41,57 +41,59 @@ entry:
   %num_qubits_f = uitofp i64 3 to double
   %mean_f = fdiv double %weight_f, %num_qubits_f
 
-  call void @__quantum__rt__qubit_release(%Qubit* %q0)
-  call void @__quantum__rt__qubit_release(%Qubit* %q1)
-  call void @__quantum__rt__qubit_release(%Qubit* %q2)
+  call void @__quantum__rt__qubit_release(ptr %q0)
+  call void @__quantum__rt__qubit_release(ptr %q1)
+  call void @__quantum__rt__qubit_release(ptr %q2)
 
   ; Record the raw measurement bits (these feed the histogram bucketing key).
-  call void @__quantum__rt__result_record_output(%Result* %r0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @r0_lbl, i32 0, i32 0))
-  call void @__quantum__rt__result_record_output(%Result* %r1, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @r1_lbl, i32 0, i32 0))
-  call void @__quantum__rt__result_record_output(%Result* %r2, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @r2_lbl, i32 0, i32 0))
+  call void @__quantum__rt__result_record_output(ptr %r0, ptr @r0_lbl)
+  call void @__quantum__rt__result_record_output(ptr %r1, ptr @r1_lbl)
+  call void @__quantum__rt__result_record_output(ptr %r2, ptr @r2_lbl)
 
-  ; Output: tuple of 3 elements (array of 3 bools, int count, float mean).
-  call void @__quantum__rt__tuple_record_output(i64 3, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @outputs_lbl, i32 0, i32 0))
-  call void @__quantum__rt__array_record_output(i64 3, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @measurements_lbl, i32 0, i32 0))
-  call void @__quantum__rt__bool_record_output(i1 %b0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @m0_lbl, i32 0, i32 0))
-  call void @__quantum__rt__bool_record_output(i1 %b1, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @m1_lbl, i32 0, i32 0))
-  call void @__quantum__rt__bool_record_output(i1 %b2, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @m2_lbl, i32 0, i32 0))
-  call void @__quantum__rt__int_record_output(i64 %weight, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @weight_lbl, i32 0, i32 0))
-  call void @__quantum__rt__float_record_output(double %mean_f, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @mean_lbl, i32 0, i32 0))
+  ; Output: tuple of 3 elements (array of 3 bools, int count, double mean).
+  call void @__quantum__rt__tuple_record_output(i64 3, ptr @outputs_lbl)
+  call void @__quantum__rt__array_record_output(i64 3, ptr @measurements_lbl)
+  call void @__quantum__rt__bool_record_output(i1 %b0, ptr @m0_lbl)
+  call void @__quantum__rt__bool_record_output(i1 %b1, ptr @m1_lbl)
+  call void @__quantum__rt__bool_record_output(i1 %b2, ptr @m2_lbl)
+  call void @__quantum__rt__int_record_output(i64 %weight, ptr @weight_lbl)
+  call void @__quantum__rt__double_record_output(double %mean_f, ptr @mean_lbl)
 
-  call void @__quantum__rt__result_update_reference_count(%Result* %r0, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %r1, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %r2, i32 -1)
-  ret i32 0
+  call void @__quantum__rt__result_release(ptr %r0)
+  call void @__quantum__rt__result_release(ptr %r1)
+  call void @__quantum__rt__result_release(ptr %r2)
+  ret i64 0
 }
 
-declare void @__quantum__qis__h__body(%Qubit*)
+declare void @__quantum__qis__h__body(ptr)
 
-declare %Result* @__quantum__qis__m__body(%Qubit*) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__rt__read_result(%Result*)
+declare i1 @__quantum__rt__read_result(ptr)
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare %Qubit* @__quantum__rt__qubit_allocate()
+declare ptr @__quantum__rt__qubit_allocate(ptr)
 
-declare void @__quantum__rt__qubit_release(%Qubit*)
+declare ptr @__quantum__rt__result_allocate(ptr)
 
-declare void @__quantum__rt__result_record_output(%Result*, i8*)
+declare void @__quantum__rt__qubit_release(ptr)
 
-declare void @__quantum__rt__tuple_record_output(i64, i8*)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
 
-declare void @__quantum__rt__array_record_output(i64, i8*)
+declare void @__quantum__rt__tuple_record_output(i64, ptr)
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__array_record_output(i64, ptr)
 
-declare void @__quantum__rt__int_record_output(i64, i8*)
+declare void @__quantum__rt__bool_record_output(i1, ptr)
 
-declare void @__quantum__rt__float_record_output(double, i8*)
+declare void @__quantum__rt__int_record_output(i64, ptr)
 
-declare void @__quantum__rt__result_update_reference_count(%Result*, i32)
+declare void @__quantum__rt__double_record_output(double, ptr)
 
-attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="3" "required_num_results"="3" }
+declare void @__quantum__rt__result_release(ptr)
+
+attributes #0 = { "entry_point" "output_labeling_schema"="labeled" "qir_profiles"="adaptive_profile" }
 attributes #1 = { "irreversible" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}

--- a/test/circuits/BellPairAdaptive.ll
+++ b/test/circuits/BellPairAdaptive.ll
@@ -1,56 +1,57 @@
 ; ModuleID = 'Adaptive module implementing Bell-pair correlation via classical correction'
 source_filename = "BellPairAdaptive.ll"
 
-%Qubit = type opaque
-%Result = type opaque
-
 @0 = internal constant [3 x i8] c"r0\00"
 @1 = internal constant [3 x i8] c"r1\00"
 
-define i32 @main() #0 {
+define i64 @main() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  %q0 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %q1 = call %Qubit* @__quantum__rt__qubit_allocate()
-  call void @__quantum__qis__h__body(%Qubit* %q0)
-  %r0 = call %Result* @__quantum__qis__m__body(%Qubit* %q0)
-  %b = call i1 @__quantum__rt__read_result(%Result* %r0)
+  call void @__quantum__rt__initialize(ptr null)
+  %q0 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  %q1 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  call void @__quantum__qis__h__body(ptr %q0)
+  %r0 = call ptr @__quantum__rt__result_allocate(ptr null)
+  %r1 = call ptr @__quantum__rt__result_allocate(ptr null)
+  call void @__quantum__qis__mz__body(ptr %q0, ptr %r0)
+  %b = call i1 @__quantum__rt__read_result(ptr %r0)
   br i1 %b, label %correct, label %record
 
 correct:
-  call void @__quantum__qis__x__body(%Qubit* %q1)
+  call void @__quantum__qis__x__body(ptr %q1)
   br label %record
 
 record:
-  %r1 = call %Result* @__quantum__qis__m__body(%Qubit* %q1)
-  call void @__quantum__rt__qubit_release(%Qubit* %q0)
-  call void @__quantum__rt__qubit_release(%Qubit* %q1)
-  call void @__quantum__rt__result_record_output(%Result* %r0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__rt__result_record_output(%Result* %r1, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @1, i32 0, i32 0))
-  call void @__quantum__rt__result_update_reference_count(%Result* %r0, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %r1, i32 -1)
-  ret i32 0
+  call void @__quantum__qis__mz__body(ptr %q1, ptr %r1)
+  call void @__quantum__rt__qubit_release(ptr %q0)
+  call void @__quantum__rt__qubit_release(ptr %q1)
+  call void @__quantum__rt__result_record_output(ptr %r0, ptr @0)
+  call void @__quantum__rt__result_record_output(ptr %r1, ptr @1)
+  call void @__quantum__rt__result_release(ptr %r0)
+  call void @__quantum__rt__result_release(ptr %r1)
+  ret i64 0
 }
 
-declare void @__quantum__qis__h__body(%Qubit*)
+declare void @__quantum__qis__h__body(ptr)
 
-declare void @__quantum__qis__x__body(%Qubit*)
+declare void @__quantum__qis__x__body(ptr)
 
-declare %Result* @__quantum__qis__m__body(%Qubit*) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__rt__read_result(%Result*)
+declare i1 @__quantum__rt__read_result(ptr)
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare %Qubit* @__quantum__rt__qubit_allocate()
+declare ptr @__quantum__rt__qubit_allocate(ptr)
 
-declare void @__quantum__rt__qubit_release(%Qubit*)
+declare ptr @__quantum__rt__result_allocate(ptr)
 
-declare void @__quantum__rt__result_record_output(%Result*, i8*)
+declare void @__quantum__rt__qubit_release(ptr)
 
-declare void @__quantum__rt__result_update_reference_count(%Result*, i32)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
 
-attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
+declare void @__quantum__rt__result_release(ptr)
+
+attributes #0 = { "entry_point" "output_labeling_schema"="labeled" "qir_profiles"="adaptive_profile" }
 attributes #1 = { "irreversible" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}

--- a/test/circuits/BellPairDynamic.ll
+++ b/test/circuits/BellPairDynamic.ll
@@ -1,47 +1,48 @@
 ; ModuleID = 'Dynamic module implementing Bell pair'
 source_filename = "BellPairDynamic.ll"
 
-%Qubit = type opaque
-%Result = type opaque
-
 @0 = internal constant [3 x i8] c"r0\00"
 @1 = internal constant [3 x i8] c"r1\00"
 
-define i32 @main() #0 {
+define i64 @main() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  %q0 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %q1 = call %Qubit* @__quantum__rt__qubit_allocate()
-  call void @__quantum__qis__h__body(%Qubit* %q0)
-  call void @__quantum__qis__cnot__body(%Qubit* %q0, %Qubit* %q1)
-  %r0 = call %Result* @__quantum__qis__m__body(%Qubit* %q0)
-  %r1 = call %Result* @__quantum__qis__m__body(%Qubit* %q1)
-  call void @__quantum__rt__qubit_release(%Qubit* %q0)
-  call void @__quantum__rt__qubit_release(%Qubit* %q1)
-  call void @__quantum__rt__result_record_output(%Result* %r0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__rt__result_record_output(%Result* %r1, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @1, i32 0, i32 0))
-  call void @__quantum__rt__result_update_reference_count(%Result* %r0, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %r1, i32 -1)
-  ret i32 0
+  call void @__quantum__rt__initialize(ptr null)
+  %q0 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  %q1 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  call void @__quantum__qis__h__body(ptr %q0)
+  call void @__quantum__qis__cnot__body(ptr %q0, ptr %q1)
+  %r0 = call ptr @__quantum__rt__result_allocate(ptr null)
+  %r1 = call ptr @__quantum__rt__result_allocate(ptr null)
+  call void @__quantum__qis__mz__body(ptr %q0, ptr %r0)
+  call void @__quantum__qis__mz__body(ptr %q1, ptr %r1)
+  call void @__quantum__rt__qubit_release(ptr %q0)
+  call void @__quantum__rt__qubit_release(ptr %q1)
+  call void @__quantum__rt__result_record_output(ptr %r0, ptr @0)
+  call void @__quantum__rt__result_record_output(ptr %r1, ptr @1)
+  call void @__quantum__rt__result_release(ptr %r0)
+  call void @__quantum__rt__result_release(ptr %r1)
+  ret i64 0
 }
 
-declare void @__quantum__qis__h__body(%Qubit*)
+declare void @__quantum__qis__h__body(ptr)
 
-declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*)
+declare void @__quantum__qis__cnot__body(ptr, ptr)
 
-declare %Result* @__quantum__qis__m__body(%Qubit*) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare %Qubit* @__quantum__rt__qubit_allocate()
+declare ptr @__quantum__rt__qubit_allocate(ptr)
 
-declare void @__quantum__rt__qubit_release(%Qubit*)
+declare ptr @__quantum__rt__result_allocate(ptr)
 
-declare void @__quantum__rt__result_record_output(%Result*, i8*)
+declare void @__quantum__rt__qubit_release(ptr)
 
-declare void @__quantum__rt__result_update_reference_count(%Result*, i32)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
 
-attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
+declare void @__quantum__rt__result_release(ptr)
+
+attributes #0 = { "entry_point" "output_labeling_schema"="labeled" "qir_profiles"="adaptive_profile" }
 attributes #1 = { "irreversible" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}

--- a/test/circuits/BellPairStatic.ll
+++ b/test/circuits/BellPairStatic.ll
@@ -1,35 +1,32 @@
 ; ModuleID = 'Static module implementing Bell pair'
 source_filename = "BellPairStatic.ll"
 
-%Qubit = type opaque
-%Result = type opaque
-
 @0 = internal constant [3 x i8] c"r0\00"
 @1 = internal constant [3 x i8] c"r1\00"
 
-define i32 @main() #0 {
+define i64 @main() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__h__body(%Qubit* null)
-  call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  call void @__quantum__rt__result_record_output(%Result* null, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @1, i32 0, i32 0))
-  ret i32 0
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__h__body(ptr null)
+  call void @__quantum__qis__cnot__body(ptr null, ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__rt__result_record_output(ptr null, ptr @0)
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr @1)
+  ret i64 0
 }
 
-declare void @__quantum__qis__h__body(%Qubit*)
+declare void @__quantum__qis__h__body(ptr)
 
-declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*)
+declare void @__quantum__qis__cnot__body(ptr, ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__rt__result_record_output(%Result*, i8*)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
 
-attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
+attributes #0 = { "entry_point" "output_labeling_schema"="labeled" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }
 
 !llvm.module.flags = !{!0, !1, !2, !3}

--- a/test/circuits/GHZ4Dynamic.ll
+++ b/test/circuits/GHZ4Dynamic.ll
@@ -1,90 +1,66 @@
-; ModuleID = 'bell'
-source_filename = "bell"
+; ModuleID = 'ghz4-dynamic'
+source_filename = "GHZ4Dynamic.ll"
 
-%Qubit = type opaque
-%Result = type opaque
-%Array = type opaque
+@results_label = internal constant [8 x i8] c"results\00"
 
-@0 = internal constant [3 x i8] c"r0\00"
-@1 = internal constant [3 x i8] c"r1\00"
-@2 = internal constant [3 x i8] c"r2\00"
-@3 = internal constant [3 x i8] c"r3\00"
-
-define i32 @main() #0 {
+define i64 @main() #0 {
 entry:
+  %qubits = alloca [4 x ptr], align 8
+  %results = alloca [4 x ptr], align 8
   call void @__quantum__rt__initialize(ptr null)
-  %q = call ptr @__quantum__rt__qubit_allocate_array(i64 4)
-  %a0 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %q, i64 0)
-  %q0 = load ptr, ptr %a0, align 8
-  %a1 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %q, i64 1)
-  %q1 = load ptr, ptr %a1, align 8
-  %a2 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %q, i64 2)
-  %q2 = load ptr, ptr %a2, align 8
-  %a3 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %q, i64 3)
-  %q3 = load ptr, ptr %a3, align 8
+  call void @__quantum__rt__qubit_array_allocate(i64 4, ptr %qubits, ptr null)
+  call void @__quantum__rt__result_array_allocate(i64 4, ptr %results, ptr null)
+
+  %q0.slot = getelementptr inbounds [4 x ptr], ptr %qubits, i64 0, i64 0
+  %q1.slot = getelementptr inbounds [4 x ptr], ptr %qubits, i64 0, i64 1
+  %q2.slot = getelementptr inbounds [4 x ptr], ptr %qubits, i64 0, i64 2
+  %q3.slot = getelementptr inbounds [4 x ptr], ptr %qubits, i64 0, i64 3
+  %q0 = load ptr, ptr %q0.slot, align 8
+  %q1 = load ptr, ptr %q1.slot, align 8
+  %q2 = load ptr, ptr %q2.slot, align 8
+  %q3 = load ptr, ptr %q3.slot, align 8
+
   call void @__quantum__qis__h__body(ptr %q0)
   call void @__quantum__qis__cnot__body(ptr %q0, ptr %q1)
   call void @__quantum__qis__cnot__body(ptr %q1, ptr %q2)
   call void @__quantum__qis__cnot__body(ptr %q2, ptr %q3)
-  %r0 = call ptr @__quantum__qis__m__body(ptr %q0)
-  %r1 = call ptr @__quantum__qis__m__body(ptr %q1)
-  %r2 = call ptr @__quantum__qis__m__body(ptr %q2)
-  %r3 = call ptr @__quantum__qis__m__body(ptr %q3)
-  call void @__quantum__rt__qubit_release_array(ptr %q)
-  %r = call ptr @__quantum__rt__array_create_1d(i32 8, i64 4)
-  %b0 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %r, i64 0)
-  store ptr %r0, ptr %b0, align 8
-  %b1 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %r, i64 0)
-  store ptr %r1, ptr %b1, align 8
-  %b2 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %r, i64 0)
-  store ptr %r2, ptr %b2, align 8
-  %b3 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %r, i64 0)
-  store ptr %r3, ptr %b3, align 8
-  %o0 = load ptr, ptr %b0, align 8
-  call void @__quantum__rt__result_record_output(ptr %o0, ptr @0)
-  %o1 = load ptr, ptr %b1, align 8
-  call void @__quantum__rt__result_record_output(ptr %o1, ptr @1)
-  %o2 = load ptr, ptr %b2, align 8
-  call void @__quantum__rt__result_record_output(ptr %o2, ptr @2)
-  %o3 = load ptr, ptr %b3, align 8
-  call void @__quantum__rt__result_record_output(ptr %o3, ptr @3)
-  call void @__quantum__rt__array_update_reference_count(ptr %r, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %o0, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %o1, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %o2, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %o3, i32 -1)
-  ret i32 0
+
+  %r0.slot = getelementptr inbounds [4 x ptr], ptr %results, i64 0, i64 0
+  %r1.slot = getelementptr inbounds [4 x ptr], ptr %results, i64 0, i64 1
+  %r2.slot = getelementptr inbounds [4 x ptr], ptr %results, i64 0, i64 2
+  %r3.slot = getelementptr inbounds [4 x ptr], ptr %results, i64 0, i64 3
+  %r0 = load ptr, ptr %r0.slot, align 8
+  %r1 = load ptr, ptr %r1.slot, align 8
+  %r2 = load ptr, ptr %r2.slot, align 8
+  %r3 = load ptr, ptr %r3.slot, align 8
+  call void @__quantum__qis__mz__body(ptr %q0, ptr %r0)
+  call void @__quantum__qis__mz__body(ptr %q1, ptr %r1)
+  call void @__quantum__qis__mz__body(ptr %q2, ptr %r2)
+  call void @__quantum__qis__mz__body(ptr %q3, ptr %r3)
+
+  call void @__quantum__rt__result_array_record_output(i64 4, ptr %results, ptr @results_label)
+  call void @__quantum__rt__result_array_release(i64 4, ptr %results)
+  call void @__quantum__rt__qubit_array_release(i64 4, ptr %qubits)
+  ret i64 0
 }
 
-declare void @__quantum__qis__h__body(ptr)
-
-declare void @__quantum__qis__cnot__body(ptr, ptr)
-
-declare ptr @__quantum__qis__m__body(ptr) #1
-
 declare void @__quantum__rt__initialize(ptr)
+declare void @__quantum__rt__qubit_array_allocate(i64, ptr, ptr)
+declare void @__quantum__rt__qubit_array_release(i64, ptr)
+declare void @__quantum__rt__result_array_allocate(i64, ptr, ptr)
+declare void @__quantum__rt__result_array_release(i64, ptr)
+declare void @__quantum__rt__result_array_record_output(i64, ptr, ptr)
+declare void @__quantum__qis__h__body(ptr)
+declare void @__quantum__qis__cnot__body(ptr, ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare ptr @__quantum__rt__qubit_allocate_array(i64)
-
-declare ptr @__quantum__rt__array_create_1d(i32, i64)
-
-declare ptr @__quantum__rt__array_get_element_ptr_1d(ptr, i64)
-
-declare void @__quantum__rt__qubit_release_array(ptr)
-
-declare void @__quantum__rt__array_update_reference_count(ptr, i32)
-
-declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-declare void @__quantum__rt__result_update_reference_count(%Result*, i32)
-
-
-attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="4" "required_num_results"="4" }
+attributes #0 = { "entry_point" "output_labeling_schema"="labeled" "qir_profiles"="adaptive_profile" }
 attributes #1 = { "irreversible" }
 
-!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
 
 !0 = !{i32 1, !"qir_major_version", i32 2}
 !1 = !{i32 7, !"qir_minor_version", i32 1}
-!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-!3 = !{i32 1, !"dynamic_result_management", i1 false}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 true}
+!3 = !{i32 1, !"dynamic_result_management", i1 true}
+!4 = !{i32 1, !"arrays", i1 true}

--- a/test/qir/jit/test_jit_session.cpp
+++ b/test/qir/jit/test_jit_session.cpp
@@ -12,89 +12,330 @@
 #include "qir/jit/Session.hpp"
 #include "qir/runtime/Runtime.hpp"
 
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <string_view>
+#include <thread>
 
 namespace {
 
 class JitSessionTest : public testing::Test {
 protected:
   std::ostringstream sink;
-
-  void SetUp() override {
-    auto& runtime = qir::Runtime::getInstance();
-    runtime.reset();
-    runtime.setOstream(sink);
-  }
-  void TearDown() override {
-    auto& runtime = qir::Runtime::getInstance();
-    runtime.resetOstream();
-    runtime.setOutputSchema(qir::Runtime::OutputSchema::Labeled);
-  }
 };
 
 TEST_F(JitSessionTest, LoadModuleFromMemory) {
   const auto program = qir_test::getProgram("BellPairStatic.ll");
-  const qir::JitSession session(program, "BellPairStatic.ll");
+  qir::JitSession session(program, "BellPairStatic.ll");
+  session.runtime().setOstream(sink);
   ASSERT_EQ(session.run(), 0);
-  EXPECT_FALSE(qir::Runtime::getInstance().getMeasurements().empty());
+  EXPECT_FALSE(session.runtime().getMeasurements().empty());
 }
 
 TEST_F(JitSessionTest, SamplingRecordsOutputs) {
   const auto path = std::filesystem::path(QIR_FILES_DIR) / "BellPairStatic.ll";
   // qir::Execution::Sampling is the default Execution mode
-  const qir::JitSession session(path.string());
+  qir::JitSession session(path.string());
+  session.runtime().setOstream(sink);
   ASSERT_EQ(session.run(), 0);
-  EXPECT_FALSE(qir::Runtime::getInstance().getMeasurements().empty());
+  EXPECT_FALSE(session.runtime().getMeasurements().empty());
+  session.runtime().outputShotStart();
+  EXPECT_THAT(sink.str(), ::testing::HasSubstr("METADATA\tentry_point\n"));
+  EXPECT_THAT(sink.str(),
+              ::testing::HasSubstr("METADATA\tqir_profiles\tbase_profile\n"));
 }
 
 TEST_F(JitSessionTest, StateExtractionLeavesNoRecordedOutputs) {
   const auto path = std::filesystem::path(QIR_FILES_DIR) / "BellPairStatic.ll";
-  const qir::JitSession session(path.string(), qir::Execution::StateExtraction);
+  const qir::SessionOptions options{.execution =
+                                        qir::Execution::StateExtraction};
+  qir::JitSession session(path.string(), options);
+  session.runtime().setOstream(sink);
   ASSERT_EQ(session.run(), 0);
-  EXPECT_TRUE(qir::Runtime::getInstance().getMeasurements().empty());
+  EXPECT_TRUE(session.runtime().getMeasurements().empty());
 }
 
 TEST_F(JitSessionTest, OutputSchemaDefaultsToLabeledWhenAttributeAbsent) {
   constexpr std::string_view ir = R"(
-define i32 @main() #0 { ret i32 0 }
+define i64 @main() #0 { ret i64 0 }
 attributes #0 = { "entry_point" }
 )";
-  // Preset @c Ordered so we can tell the default kicked in.
-  qir::Runtime::getInstance().setOutputSchema(
-      qir::Runtime::OutputSchema::Ordered);
-  const qir::JitSession session(ir, "NoOutputSchema.ll");
-  EXPECT_EQ(qir::Runtime::getInstance().getOutputSchema(),
+  qir::JitSession session(ir, "NoOutputSchema.ll");
+  EXPECT_EQ(session.runtime().getOutputSchema(),
             qir::Runtime::OutputSchema::Labeled);
 }
 
 TEST_F(JitSessionTest, OutputSchemaFromLabeledAttribute) {
   constexpr std::string_view ir = R"(
-define i32 @main() #0 { ret i32 0 }
+define i64 @main() #0 { ret i64 0 }
 attributes #0 = { "entry_point" "output_labeling_schema"="labeled" }
 )";
-  const qir::JitSession session(ir, "LabeledOutputSchema.ll");
-  EXPECT_EQ(qir::Runtime::getInstance().getOutputSchema(),
+  qir::JitSession session(ir, "LabeledOutputSchema.ll");
+  EXPECT_EQ(session.runtime().getOutputSchema(),
             qir::Runtime::OutputSchema::Labeled);
 }
 
 TEST_F(JitSessionTest, OutputSchemaFromOrderedAttribute) {
   constexpr std::string_view ir = R"(
-define i32 @main() #0 { ret i32 0 }
+define i64 @main() #0 { ret i64 0 }
 attributes #0 = { "entry_point" "output_labeling_schema"="ordered" }
 )";
-  const qir::JitSession session(ir, "OrderedOutputSchema.ll");
-  EXPECT_EQ(qir::Runtime::getInstance().getOutputSchema(),
+  qir::JitSession session(ir, "OrderedOutputSchema.ll");
+  EXPECT_EQ(session.runtime().getOutputSchema(),
             qir::Runtime::OutputSchema::Ordered);
+}
+
+TEST_F(JitSessionTest, ExecutesArbitrarilyNamedEntryPoint) {
+  constexpr std::string_view ir = R"(
+define i64 @bell_entry() #0 { ret i64 7 }
+attributes #0 = { "entry_point" }
+)";
+  qir::JitSession session(ir, "NamedEntry.ll");
+  EXPECT_EQ(session.entryPointName(), "bell_entry");
+  EXPECT_EQ(session.run(), 7);
+}
+
+TEST_F(JitSessionTest, SelectsRequestedEntryPoint) {
+  constexpr std::string_view ir = R"(
+define i64 @first() #0 { ret i64 1 }
+define i64 @second() #0 { ret i64 2 }
+attributes #0 = { "entry_point" }
+)";
+  const qir::SessionOptions options{.entryPoint = "second"};
+  qir::JitSession session(ir, "MultipleEntries.ll", options);
+  EXPECT_EQ(session.run(), 2);
+}
+
+TEST_F(JitSessionTest, SupportsQir21DynamicResources) {
+  constexpr std::string_view ir = R"(
+define i64 @adaptive() #0 {
+  call void @__quantum__rt__initialize(ptr null)
+  %q = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  %r = call ptr @__quantum__rt__result_allocate(ptr null)
+  call void @__quantum__qis__x__body(ptr %q)
+  call void @__quantum__qis__mz__body(ptr %q, ptr %r)
+  call void @__quantum__rt__result_record_output(ptr %r, ptr null)
+  call void @__quantum__rt__result_release(ptr %r)
+  call void @__quantum__rt__qubit_release(ptr %q)
+  ret i64 0
+}
+declare void @__quantum__rt__initialize(ptr)
+declare ptr @__quantum__rt__qubit_allocate(ptr)
+declare ptr @__quantum__rt__result_allocate(ptr)
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+declare void @__quantum__rt__result_release(ptr)
+declare void @__quantum__rt__qubit_release(ptr)
+attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" }
+)";
+  qir::JitSession session(ir, "Qir21Resources.ll");
+  session.runtime().setOstream(sink);
+  EXPECT_EQ(session.run(), 0);
+  EXPECT_EQ(session.runtime().getMeasurements(), "1");
+}
+
+TEST_F(JitSessionTest, SupportsNativeOneAndTwoControlExtensions) {
+  constexpr std::string_view ir = R"(
+define i64 @native_controls() #0 {
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__x__body(ptr null)
+  call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__qis__crx__body(double 0x400921FB54442D18, ptr null, ptr inttoptr (i64 2 to ptr))
+  call void @__quantum__qis__ccrx__body(double 0x400921FB54442D18, ptr null, ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 3 to ptr))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 2 to ptr), ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+  ret i64 0
+}
+declare void @__quantum__rt__initialize(ptr)
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__qis__crx__body(double, ptr, ptr)
+declare void @__quantum__qis__ccrx__body(double, ptr, ptr, ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "required_num_qubits"="4" "required_num_results"="2" }
+)";
+  qir::JitSession session(ir, "NativeControls.ll");
+  session.runtime().setOstream(sink);
+  EXPECT_EQ(session.run(), 0);
+  EXPECT_EQ(session.runtime().getMeasurements(), "11");
+}
+
+TEST_F(JitSessionTest, RejectsObsoleteQubitAllocationSignature) {
+  constexpr std::string_view ir = R"(
+define i64 @legacy() #0 {
+  call void @__quantum__rt__initialize(ptr null)
+  %q = call ptr @__quantum__rt__qubit_allocate()
+  call void @__quantum__rt__qubit_release(ptr %q)
+  ret i64 0
+}
+declare void @__quantum__rt__initialize(ptr)
+declare ptr @__quantum__rt__qubit_allocate()
+declare void @__quantum__rt__qubit_release(ptr)
+attributes #0 = { "entry_point" }
+)";
+  EXPECT_THROW(qir::JitSession(ir, "LegacyAllocation.ll"), std::runtime_error);
+}
+
+TEST_F(JitSessionTest, SupportsGenericControlledSpecialization) {
+  constexpr std::string_view ir = R"(
+define i64 @generic_controlled() #0 {
+  call void @__quantum__rt__initialize(ptr null)
+  %control0 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  %control1 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  %control2 = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  %target = call ptr @__quantum__rt__qubit_allocate(ptr null)
+  %result = call ptr @__quantum__rt__result_allocate(ptr null)
+  %controls = call ptr @__quantum__rt__array_create_1d(i32 8, i64 3)
+  %control_slot0 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %controls, i64 0)
+  %control_slot1 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %controls, i64 1)
+  %control_slot2 = call ptr @__quantum__rt__array_get_element_ptr_1d(ptr %controls, i64 2)
+  store ptr %control0, ptr %control_slot0
+  store ptr %control1, ptr %control_slot1
+  store ptr %control2, ptr %control_slot2
+  %args = call ptr @__quantum__rt__tuple_create(i64 16)
+  %angle_slot = getelementptr { double, ptr }, ptr %args, i32 0, i32 0
+  %target_slot = getelementptr { double, ptr }, ptr %args, i32 0, i32 1
+  store double 0x400921FB54442D18, ptr %angle_slot
+  store ptr %target, ptr %target_slot
+  call void @__quantum__qis__x__body(ptr %control0)
+  call void @__quantum__qis__x__body(ptr %control1)
+  call void @__quantum__qis__x__body(ptr %control2)
+  call void @__quantum__qis__rx__ctl(ptr %controls, ptr %args)
+  call void @__quantum__qis__mz__body(ptr %target, ptr %result)
+  call void @__quantum__rt__result_record_output(ptr %result, ptr null)
+  call void @__quantum__rt__result_release(ptr %result)
+  call void @__quantum__rt__tuple_update_reference_count(ptr %args, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(ptr %controls, i32 -1)
+  call void @__quantum__rt__qubit_release(ptr %control0)
+  call void @__quantum__rt__qubit_release(ptr %control1)
+  call void @__quantum__rt__qubit_release(ptr %control2)
+  call void @__quantum__rt__qubit_release(ptr %target)
+  ret i64 0
+}
+declare void @__quantum__rt__initialize(ptr)
+declare ptr @__quantum__rt__qubit_allocate(ptr)
+declare ptr @__quantum__rt__result_allocate(ptr)
+declare ptr @__quantum__rt__array_create_1d(i32, i64)
+declare ptr @__quantum__rt__array_get_element_ptr_1d(ptr, i64)
+declare ptr @__quantum__rt__tuple_create(i64)
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__qis__rx__ctl(ptr, ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+declare void @__quantum__rt__result_release(ptr)
+declare void @__quantum__rt__tuple_update_reference_count(ptr, i32)
+declare void @__quantum__rt__array_update_reference_count(ptr, i32)
+declare void @__quantum__rt__qubit_release(ptr)
+attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" }
+)";
+  qir::JitSession session(ir, "ControlledRotation.ll");
+  session.runtime().setOstream(sink);
+  EXPECT_EQ(session.run(), 0);
+  EXPECT_EQ(session.runtime().getMeasurements(), "1");
+}
+
+TEST_F(JitSessionTest, RejectsQirRunnerPauliRotationAbi) {
+  constexpr std::string_view ir = R"(
+define i64 @pauli_rotation() #0 {
+  call void @__quantum__qis__r__body(i2 1, double 0x400921FB54442D18, ptr null)
+  ret i64 0
+}
+declare void @__quantum__qis__r__body(i2, double, ptr)
+attributes #0 = { "entry_point" }
+)";
+  EXPECT_THROW(qir::JitSession(ir, "QirRunnerPauli.ll"), std::runtime_error);
+}
+
+TEST_F(JitSessionTest, SessionsExecuteIndependently) {
+  const auto program = qir_test::getProgram("BellPairStatic.ll");
+  qir::JitSession first(program, "first.ll");
+  qir::JitSession second(program, "second.ll");
+  std::ostringstream firstSink;
+  std::ostringstream secondSink;
+  first.runtime().setOstream(firstSink);
+  second.runtime().setOstream(secondSink);
+  int64_t firstExit = -1;
+  int64_t secondExit = -1;
+
+  std::thread firstThread([&] { firstExit = first.run(); });
+  std::thread secondThread([&] { secondExit = second.run(); });
+  firstThread.join();
+  secondThread.join();
+
+  EXPECT_EQ(firstExit, 0);
+  EXPECT_EQ(secondExit, 0);
+  EXPECT_NE(&first.runtime(), &second.runtime());
+  EXPECT_EQ(first.runtime().getMeasurements().size(), 2);
+  EXPECT_EQ(second.runtime().getMeasurements().size(), 2);
+  EXPECT_FALSE(firstSink.str().empty());
+  EXPECT_FALSE(secondSink.str().empty());
+}
+
+TEST_F(JitSessionTest, SeedReproducesShotSequence) {
+  const auto program = qir_test::getProgram("BellPairStatic.ll");
+  const qir::SessionOptions options{.seed = 42};
+  qir::JitSession first(program, "first.ll", options);
+  qir::JitSession second(program, "second.ll", options);
+  first.runtime().setOstream(sink);
+  second.runtime().setOstream(sink);
+  std::string firstSequence;
+  std::string secondSequence;
+
+  for (std::size_t shot = 0; shot < 16; ++shot) {
+    ASSERT_EQ(first.run(), 0);
+    ASSERT_EQ(second.run(), 0);
+    firstSequence += first.runtime().getMeasurements().front();
+    secondSequence += second.runtime().getMeasurements().front();
+  }
+
+  EXPECT_EQ(firstSequence, secondSequence);
+  EXPECT_THAT(firstSequence, ::testing::HasSubstr("0"));
+  EXPECT_THAT(firstSequence, ::testing::HasSubstr("1"));
 }
 
 TEST(JitSessionErrors, MalformedIRThrows) {
   constexpr std::string_view ir = R"(define i32 @main() {})";
   EXPECT_THROW(qir::JitSession(ir, "MalformedIR.ll"), std::runtime_error);
+}
+
+TEST(JitSessionErrors, RejectsNonCompliantEntryPointSignature) {
+  constexpr std::string_view ir = R"(
+define i32 @main() #0 { ret i32 0 }
+attributes #0 = { "entry_point" }
+)";
+  EXPECT_THROW(qir::JitSession(ir, "BadEntrySignature.ll"), std::runtime_error);
+}
+
+TEST(JitSessionErrors, RequiresSelectionForMultipleEntryPoints) {
+  constexpr std::string_view ir = R"(
+define i64 @first() #0 { ret i64 0 }
+define i64 @second() #0 { ret i64 0 }
+attributes #0 = { "entry_point" }
+)";
+  EXPECT_THROW(qir::JitSession(ir, "MultipleEntries.ll"), std::runtime_error);
+}
+
+TEST(JitSessionErrors, RejectsMismatchedRuntimeDeclaration) {
+  constexpr std::string_view ir = R"(
+define i64 @main() #0 {
+  call void @__quantum__qis__x__body(double 0.0)
+  ret i64 0
+}
+declare void @__quantum__qis__x__body(double)
+attributes #0 = { "entry_point" }
+)";
+  EXPECT_THROW(qir::JitSession(ir, "BadRuntimeSignature.ll"),
+               std::runtime_error);
 }
 
 } // namespace

--- a/test/qir/runner/test_qir_runner.cpp
+++ b/test/qir/runner/test_qir_runner.cpp
@@ -34,10 +34,10 @@ INSTANTIATE_TEST_SUITE_P(
       return filename;
     });
 
-TEST_P(QIRRunnerTest, QIRFile) {
+TEST_P(QIRRunnerTest, ExecutesRepeatedlyWithDeterministicSampling) {
   const auto& file = GetParam();
   std::ostringstream command;
-  command << EXECUTABLE_PATH << " " << file;
+  command << EXECUTABLE_PATH << " --shots=2 --seed=7 " << file;
   const auto result = std::system(command.str().c_str());
   EXPECT_EQ(result, 0);
 }

--- a/test/qir/runtime/test_qir_runtime.cpp
+++ b/test/qir/runtime/test_qir_runtime.cpp
@@ -23,7 +23,9 @@
 #include <cstring>
 #include <filesystem>
 #include <ios>
+#include <limits>
 #include <sstream>
+#include <stdexcept>
 
 #ifdef _WIN32
 #define SYSTEM _wsystem
@@ -44,6 +46,50 @@ protected:
     Runtime::getInstance().setOutputSchema(Runtime::OutputSchema::Labeled);
   }
 };
+
+TEST(QIRRuntimeArgumentsTest, RejectsInvalidArrayDimensions) {
+  EXPECT_THROW(__quantum__rt__array_create_1d(0, 1), std::invalid_argument);
+  EXPECT_THROW(__quantum__rt__array_create_1d(sizeof(Qubit*), -1),
+               std::invalid_argument);
+  EXPECT_THROW(
+      __quantum__rt__array_create_1d(2, std::numeric_limits<int64_t>::max()),
+      std::length_error);
+}
+
+TEST(QIRRuntimeArgumentsTest, RejectsInvalidTupleSizes) {
+  EXPECT_THROW(__quantum__rt__tuple_create(-1), std::invalid_argument);
+  EXPECT_THROW(__quantum__rt__tuple_create(std::numeric_limits<int64_t>::max()),
+               std::length_error);
+
+  auto* controls = __quantum__rt__array_create_1d(sizeof(Qubit*), 0);
+  auto* tuple = __quantum__rt__tuple_create(1);
+  EXPECT_THROW(__quantum__qis__rx__ctl(controls, tuple), std::invalid_argument);
+  __quantum__rt__tuple_update_reference_count(tuple, -1);
+  __quantum__rt__array_update_reference_count(controls, -1);
+}
+
+TEST_F(QIRRuntimeTest, RejectsInvalidDynamicResourceUse) {
+  __quantum__rt__initialize(nullptr);
+  auto* qubit = __quantum__rt__qubit_allocate(nullptr);
+  auto* result = __quantum__rt__result_allocate(nullptr);
+  __quantum__rt__qubit_release(qubit);
+  __quantum__rt__result_release(result);
+
+  EXPECT_THROW(__quantum__qis__x__body(qubit), std::out_of_range);
+  EXPECT_THROW(__quantum__rt__read_result(result), std::out_of_range);
+  EXPECT_THROW(__quantum__rt__qubit_release(qubit), std::out_of_range);
+  EXPECT_THROW(__quantum__rt__result_release(result), std::out_of_range);
+}
+
+TEST_F(QIRRuntimeTest, RejectsMixedStaticAndDynamicResourceManagement) {
+  __quantum__rt__initialize(nullptr);
+  __quantum__qis__x__body(nullptr);
+  EXPECT_THROW(__quantum__rt__qubit_allocate(nullptr), std::logic_error);
+
+  __quantum__rt__initialize(nullptr);
+  __quantum__qis__mz__body(nullptr, nullptr);
+  EXPECT_THROW(__quantum__rt__result_allocate(nullptr), std::logic_error);
+}
 
 } // namespace
 
@@ -193,7 +239,7 @@ TEST_F(QIRRuntimeTest, GlobalPhase) {
   EXPECT_NO_THROW(__quantum__qis__gphase__body(qc::PI_2));
 }
 
-TEST_F(QIRRuntimeTest, RGate) {
+TEST_F(QIRRuntimeTest, PRXGate) {
   auto* q0 = reinterpret_cast<Qubit*>(0UL);
   __quantum__rt__initialize(nullptr);
   __quantum__qis__prx__body(qc::PI_2, 0, q0);
@@ -481,18 +527,6 @@ TEST_F(QIRRuntimeTest, RCCXGate) {
   EXPECT_NO_THROW(__quantum__qis__rccx__body(q0, q1, q2));
 }
 
-TEST_F(QIRRuntimeTest, MGate) {
-  auto* q0 = reinterpret_cast<Qubit*>(0UL);
-  __quantum__rt__initialize(nullptr);
-  __quantum__qis__m__body(q0);
-}
-
-TEST_F(QIRRuntimeTest, MeasureGate) {
-  auto* q0 = reinterpret_cast<Qubit*>(0UL);
-  __quantum__rt__initialize(nullptr);
-  __quantum__qis__measure__body(q0);
-}
-
 TEST_F(QIRRuntimeTest, MzGate) {
   auto* q0 = reinterpret_cast<Qubit*>(0UL);
   auto* r0 = reinterpret_cast<Result*>(0UL);
@@ -504,6 +538,30 @@ TEST_F(QIRRuntimeTest, ResetGate) {
   auto* q0 = reinterpret_cast<Qubit*>(0UL);
   __quantum__rt__initialize(nullptr);
   __quantum__qis__reset__body(q0);
+}
+
+TEST_F(QIRRuntimeTest, Qir21BulkResourceManagement) {
+  __quantum__rt__initialize(nullptr);
+  std::array<Qubit*, 2> qubits{};
+  std::array<Result*, 2> results{};
+  bool error = true;
+  __quantum__rt__qubit_array_allocate(qubits.size(), qubits.data(), &error);
+  EXPECT_FALSE(error);
+  __quantum__rt__result_array_allocate(results.size(), results.data(), &error);
+  EXPECT_FALSE(error);
+
+  __quantum__qis__x__body(qubits[0]);
+  __quantum__qis__mz__body(qubits[0], results[0]);
+  __quantum__qis__mz__body(qubits[1], results[1]);
+  EXPECT_TRUE(__quantum__rt__read_result(results[0]));
+  EXPECT_FALSE(__quantum__rt__read_result(results[1]));
+  __quantum__rt__result_array_record_output(results.size(), results.data(),
+                                            "results");
+  EXPECT_THAT(sink.str(),
+              ::testing::HasSubstr("OUTPUT\tRESULT_ARRAY\t10\tresults\n"));
+
+  __quantum__rt__result_array_release(results.size(), results.data());
+  __quantum__rt__qubit_array_release(qubits.size(), qubits.data());
 }
 
 TEST_F(QIRRuntimeTest, BellPairStatic) {
@@ -534,12 +592,14 @@ TEST_F(QIRRuntimeTest, BellPairDynamic) {
   __quantum__rt__initialize(nullptr);
   Runtime::getInstance().outputProgramHeader();
   Runtime::getInstance().outputShotStart();
-  auto* q0 = __quantum__rt__qubit_allocate();
-  auto* q1 = __quantum__rt__qubit_allocate();
+  auto* q0 = __quantum__rt__qubit_allocate(nullptr);
+  auto* q1 = __quantum__rt__qubit_allocate(nullptr);
+  auto* r0 = __quantum__rt__result_allocate(nullptr);
+  auto* r1 = __quantum__rt__result_allocate(nullptr);
   __quantum__qis__h__body(q0);
   __quantum__qis__cx__body(q0, q1);
-  auto* r0 = __quantum__qis__m__body(q0);
-  auto* r1 = __quantum__qis__m__body(q1);
+  __quantum__qis__mz__body(q0, r0);
+  __quantum__qis__mz__body(q1, r1);
   __quantum__rt__qubit_release(q0);
   __quantum__rt__qubit_release(q1);
   const auto m1 = __quantum__rt__read_result(r0);
@@ -552,8 +612,8 @@ TEST_F(QIRRuntimeTest, BellPairDynamic) {
   expected << "OUTPUT\tRESULT\t" << m1 << "\tr0\n"
            << "OUTPUT\tRESULT\t" << m2 << "\tr1\n";
   EXPECT_THAT(sink.str(), ::testing::HasSubstr(expected.str()));
-  __quantum__rt__result_update_reference_count(r0, -1);
-  __quantum__rt__result_update_reference_count(r1, -1);
+  __quantum__rt__result_release(r0);
+  __quantum__rt__result_release(r1);
 }
 
 TEST_F(QIRRuntimeTest, BellPairStaticReverse) {
@@ -584,12 +644,14 @@ TEST_F(QIRRuntimeTest, BellPairDynamicReverse) {
   __quantum__rt__initialize(nullptr);
   Runtime::getInstance().outputProgramHeader();
   Runtime::getInstance().outputShotStart();
-  auto* q0 = __quantum__rt__qubit_allocate();
-  auto* q1 = __quantum__rt__qubit_allocate();
+  auto* q0 = __quantum__rt__qubit_allocate(nullptr);
+  auto* q1 = __quantum__rt__qubit_allocate(nullptr);
+  auto* r0 = __quantum__rt__result_allocate(nullptr);
+  auto* r1 = __quantum__rt__result_allocate(nullptr);
   __quantum__qis__h__body(q1);
   __quantum__qis__cx__body(q1, q0);
-  auto* r0 = __quantum__qis__m__body(q0);
-  auto* r1 = __quantum__qis__m__body(q1);
+  __quantum__qis__mz__body(q0, r0);
+  __quantum__qis__mz__body(q1, r1);
   __quantum__rt__qubit_release(q0);
   __quantum__rt__qubit_release(q1);
   const auto m1 = __quantum__rt__read_result(r0);
@@ -602,8 +664,8 @@ TEST_F(QIRRuntimeTest, BellPairDynamicReverse) {
   expected << "OUTPUT\tRESULT\t" << m1 << "\tr0\n"
            << "OUTPUT\tRESULT\t" << m2 << "\tr1\n";
   EXPECT_THAT(sink.str(), ::testing::HasSubstr(expected.str()));
-  __quantum__rt__result_update_reference_count(r0, -1);
-  __quantum__rt__result_update_reference_count(r1, -1);
+  __quantum__rt__result_release(r0);
+  __quantum__rt__result_release(r1);
 }
 
 TEST_F(QIRRuntimeTest, GHZ4Static) {
@@ -637,36 +699,18 @@ TEST_F(QIRRuntimeTest, GHZ4Static) {
 
 TEST_F(QIRRuntimeTest, GHZ4Dynamic) {
   __quantum__rt__initialize(nullptr);
-  auto* qArr = __quantum__rt__qubit_allocate_array(4);
-  const std::array q = {*reinterpret_cast<Qubit**>(
-                            __quantum__rt__array_get_element_ptr_1d(qArr, 0)),
-                        *reinterpret_cast<Qubit**>(
-                            __quantum__rt__array_get_element_ptr_1d(qArr, 1)),
-                        *reinterpret_cast<Qubit**>(
-                            __quantum__rt__array_get_element_ptr_1d(qArr, 2)),
-                        *reinterpret_cast<Qubit**>(
-                            __quantum__rt__array_get_element_ptr_1d(qArr, 3))};
+  std::array<Qubit*, 4> q{};
+  std::array<Result*, 4> r{};
+  __quantum__rt__qubit_array_allocate(q.size(), q.data(), nullptr);
+  __quantum__rt__result_array_allocate(r.size(), r.data(), nullptr);
   __quantum__qis__h__body(q[0]);
   __quantum__qis__cx__body(q[0], q[1]);
   __quantum__qis__cx__body(q[1], q[2]);
   __quantum__qis__cx__body(q[2], q[3]);
-  auto* rArr = __quantum__rt__array_create_1d(sizeof(Result*), 4);
-  std::array r = {*reinterpret_cast<Result**>(
-                      __quantum__rt__array_get_element_ptr_1d(rArr, 0)),
-                  *reinterpret_cast<Result**>(
-                      __quantum__rt__array_get_element_ptr_1d(rArr, 1)),
-                  *reinterpret_cast<Result**>(
-                      __quantum__rt__array_get_element_ptr_1d(rArr, 2)),
-                  *reinterpret_cast<Result**>(
-                      __quantum__rt__array_get_element_ptr_1d(rArr, 3))};
-  r[0] = __quantum__qis__m__body(q[0]);
-  r[1] = __quantum__qis__m__body(q[1]);
-  r[2] = __quantum__qis__m__body(q[2]);
-  r[3] = __quantum__qis__m__body(q[3]);
-  __quantum__rt__qubit_release_array(qArr);
-  EXPECT_TRUE(__quantum__rt__result_equal(r[0], r[1]));
-  EXPECT_TRUE(__quantum__rt__result_equal(r[1], r[2]));
-  EXPECT_TRUE(__quantum__rt__result_equal(r[2], r[3]));
+  __quantum__qis__mz__body(q[0], r[0]);
+  __quantum__qis__mz__body(q[1], r[1]);
+  __quantum__qis__mz__body(q[2], r[2]);
+  __quantum__qis__mz__body(q[3], r[3]);
   const std::array m = {
       __quantum__rt__read_result(r[0]), __quantum__rt__read_result(r[1]),
       __quantum__rt__read_result(r[2]), __quantum__rt__read_result(r[3])};
@@ -677,11 +721,8 @@ TEST_F(QIRRuntimeTest, GHZ4Dynamic) {
   __quantum__rt__result_record_output(r[1], "r1");
   __quantum__rt__result_record_output(r[2], "r2");
   __quantum__rt__result_record_output(r[3], "r3");
-  __quantum__rt__result_update_reference_count(r[0], -1);
-  __quantum__rt__result_update_reference_count(r[1], -1);
-  __quantum__rt__result_update_reference_count(r[2], -1);
-  __quantum__rt__result_update_reference_count(r[3], -1);
-  __quantum__rt__array_update_reference_count(rArr, -1);
+  __quantum__rt__result_array_release(r.size(), r.data());
+  __quantum__rt__qubit_array_release(q.size(), q.data());
 }
 
 TEST_F(QIRRuntimeTest, PackageResizeWhenEnlargingState) {
@@ -712,15 +753,18 @@ TEST_F(QIRRuntimeTest, AdaptiveRecordOutputs) {
   __quantum__rt__initialize(nullptr);
   Runtime::getInstance().outputProgramHeader();
   Runtime::getInstance().outputShotStart();
-  auto* q0 = __quantum__rt__qubit_allocate();
-  auto* q1 = __quantum__rt__qubit_allocate();
-  auto* q2 = __quantum__rt__qubit_allocate();
+  auto* q0 = __quantum__rt__qubit_allocate(nullptr);
+  auto* q1 = __quantum__rt__qubit_allocate(nullptr);
+  auto* q2 = __quantum__rt__qubit_allocate(nullptr);
+  auto* r0 = __quantum__rt__result_allocate(nullptr);
+  auto* r1 = __quantum__rt__result_allocate(nullptr);
+  auto* r2 = __quantum__rt__result_allocate(nullptr);
   __quantum__qis__h__body(q0);
   __quantum__qis__h__body(q1);
   __quantum__qis__h__body(q2);
-  auto* r0 = __quantum__qis__m__body(q0);
-  auto* r1 = __quantum__qis__m__body(q1);
-  auto* r2 = __quantum__qis__m__body(q2);
+  __quantum__qis__mz__body(q0, r0);
+  __quantum__qis__mz__body(q1, r1);
+  __quantum__qis__mz__body(q2, r2);
   const auto b0 = __quantum__rt__read_result(r0);
   const auto b1 = __quantum__rt__read_result(r1);
   const auto b2 = __quantum__rt__read_result(r2);
@@ -740,7 +784,7 @@ TEST_F(QIRRuntimeTest, AdaptiveRecordOutputs) {
   __quantum__rt__bool_record_output(b1, "m1");
   __quantum__rt__bool_record_output(b2, "m2");
   __quantum__rt__int_record_output(weight, "hamming_weight");
-  __quantum__rt__float_record_output(mean, "mean");
+  __quantum__rt__double_record_output(mean, "mean");
   Runtime::getInstance().outputShotEnd();
 
   std::ostringstream expected;
@@ -754,9 +798,9 @@ TEST_F(QIRRuntimeTest, AdaptiveRecordOutputs) {
            << "OUTPUT\tDOUBLE\t" << mean << "\tmean\n";
   EXPECT_THAT(sink.str(), ::testing::HasSubstr(expected.str()));
 
-  __quantum__rt__result_update_reference_count(r0, -1);
-  __quantum__rt__result_update_reference_count(r1, -1);
-  __quantum__rt__result_update_reference_count(r2, -1);
+  __quantum__rt__result_release(r0);
+  __quantum__rt__result_release(r1);
+  __quantum__rt__result_release(r2);
 }
 
 namespace {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

This is PR 2 of 4 and is based on #2034.

- Implements the current QIR 2.1 qubit, result, array, and output runtime functions and updates the LLVM fixtures to opaque pointers and caller-owned resource arrays.
- Deliberately rejects legacy resource-management overloads and the incompatible Pauli-rotation `r` declaration instead of maintaining an unreleased compatibility seam.
- Validates the exact LLVM type of every referenced runtime and QIS declaration before execution, reports all unsupported declarations together, and registers only the symbols a module uses.
- Gives every `JitSession` its own runtime. Exported C functions use a private scoped thread-local binding during execution; no dispatch helper becomes public API.
- Selects an exact parameterless `i64` QIR entry point and adds explicit entry-point selection, repeated shots, deterministic seeding, complete metadata, and real exit codes to the runner.
- Performs only the small DDSIM source migration required by the breaking session API; the device behavior and concurrency work remain in #2036.
- Updates the upgrade guide only for the already released QIR runner.

## Stack

- Previous: #2034 — shared gate registry and compiler/runtime QIS contract.
- **This PR:** current QIR runtime APIs, JIT validation, and runner isolation.
- Next: #2036 — DDSIM integration and semantic state extraction.
- Final: #2044 — external Base Profile interoperability tests and Python usage.

## Validation

- All QIR fixtures assemble with LLVM 22 and compile through the release build.
- 69 runtime, 21 JIT, and 5 runner tests.
- 9 focused DDSIM QIR tests.
- Repository lint and diff checks.

Part of #1833 and #1834.
