### PR TITLE
🛡️ Make QIR state extraction semantically safe

### DIFF
--- a/.agent/plans/issue-1833-1834-qir-stack.md
+++ b/.agent/plans/issue-1833-1834-qir-stack.md
@@ -78,10 +78,14 @@ own diff before the next layer is created.
       deterministic seeding, complete metadata, and exit codes. Validate all
       fixtures with LLVM 22 plus the 69-test runtime, 21-test JIT, 5-test
       runner, and 9-test DDSIM QIR suites.
-- [ ] Create stack layer 3, then migrate DDSIM sampling/state extraction and add
-      concurrency and end-to-end tests.
-- [ ] Run cumulative release-build tests, lint, diff checks, and a fresh audit
-  of each adjacent branch diff.
+- [x] (2026-08-10 17:08Z) Revise stack layer 3 around Base-only semantic state
+      extraction, eliminate the raw LLVM instruction replacement behind the CI
+      analyzer failure, and validate all 25 JIT and 48 DDSIM tests plus both
+      focused Python QIR execution tests.
+- [x] (2026-08-10) Run the cumulative release build, all 4,622 CTest cases, the
+      focused QIR and DDSIM suites, the full repository lint session, diff
+      checks, and a fresh audit of each adjacent branch diff. The two
+      environment-dependent job-ID tests were skipped by their fixtures.
 - [x] (2026-08-10 02:18Z) Publish all three branches with native GitHub stacked
       PRs, add policy-compliant PR descriptions and labels, and verify the
       remote stack, bases, and heads.
@@ -113,6 +117,12 @@ own diff before the next layer is created.
   Evidence: after replacing all four lists with `mlir/Conversion/GateTable.def`,
   the release build compiled every gate family and all 58 runtime, 9 JIT, 112
   builder, 267 QC-to-QIR, and 304 QC/QCO conversion tests passed.
+- Observation: state extraction cannot be implemented by erasing a fixed list of
+  measurement and result symbols. Evidence: that rewrite left arbitrary gates
+  after the first measurement executable and depended on spellings rather than
+  the Base Profile's required `irreversible` attribute. Truncating the selected
+  entry point at the semantic boundary removes the entire terminal
+  measurement/output region and supports backend-defined measurement names.
 
 ## Decision Log
 
@@ -150,6 +160,11 @@ own diff before the next layer is created.
   `Activation` helper. Rationale: this preserves plain exported C entry points
   while isolating parallel JIT sessions and DDSIM jobs without making dispatch
   mechanics part of the public runtime API. Date/Author: 2026-08-09 / Codex.
+- Decision: Derive state extraction from the selected Base Profile entry point's
+  `irreversible` boundary and reject every other profile. Rationale: this
+  follows the profile's semantic contract, remains compatible with
+  backend-defined measurement names, and fails safely rather than changing
+  adaptive behavior. Date/Author: 2026-08-10 / Codex.
 - Decision: Use GitHub's `gh stack` public-preview feature for publication.
   Rationale: it creates the requested linked stack object and maintains the
   correct adjacent PR bases rather than merely presenting three unrelated PRs.
@@ -157,10 +172,14 @@ own diff before the next layer is created.
 
 ## Outcomes & Retrospective
 
-Implementation is in progress. The expected outcome is a three-layer stack in
-which the bottom PR closes the compiler/runtime parity and controlled-gate ABI
-gaps, the middle PR makes the general runtime and runner complete and safe, and
-the top PR proves that DDSIM consumes the same contract without shared state.
+The implementation is complete as a three-layer stack. The bottom PR owns the
+shared MLIR gate registry and compiler/runtime QIS contract. The middle PR owns
+the current QIR 2.1 resource APIs, strict JIT validation, session-local runtime,
+and runner usability. The top PR owns DDSIM integration, Base-profile semantic
+state extraction, and concurrent-job isolation. The cumulative release build,
+all 4,622 CTest cases, the focused QIR and DDSIM suites, repository lint, and
+diff checks pass. Two job-ID queries remain fixture-skipped because no external
+job service is configured; no implementation was weakened for them.
 
 ## Context and Orientation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@ releases may include breaking changes.
 
 ### Changed
 
+- 🛡️ Isolate DDSIM QIR job execution and restrict statevector extraction to
+  terminal `irreversible` regions of Base-profile programs ([#2036])
+  ([**@burgholzer**])
 - 💥 Update the QIR runner for QIR 2.1 entry points and resource management,
   with entry-point selection and reproducible multi-shot execution ([#2035])
   ([**@burgholzer**])
@@ -732,6 +735,7 @@ for previous changelogs._
 
 [#2030]: https://github.com/munich-quantum-toolkit/core/pull/2030
 [#2042]: https://github.com/munich-quantum-toolkit/core/pull/2042
+[#2036]: https://github.com/munich-quantum-toolkit/core/pull/2036
 [#2035]: https://github.com/munich-quantum-toolkit/core/pull/2035
 [#2028]: https://github.com/munich-quantum-toolkit/core/pull/2028
 [#2026]: https://github.com/munich-quantum-toolkit/core/pull/2026

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,6 +16,17 @@ select among multiple entry points, `--shots` for repeated execution, and
 Dynamic QIR inputs must use the current QIR 2.1 resource-management interface.
 Legacy qir-runner allocator and output overloads are no longer accepted.
 
+### DDSIM QDMI device
+
+DDSIM now isolates the runtime, simulator state, random-number generator, and
+output sink of every QIR job, so concurrently submitted jobs no longer share
+execution state or write QIR records to process stdout.
+
+QIR statevector extraction is supported only for Base-format jobs. The input
+must mark its first measurement boundary as `irreversible`, and no quantum work
+may follow that boundary. Adaptive-format statevector requests continue to
+return `QDMI_ERROR_NOTSUPPORTED`.
+
 ### Runtime-configurable SC QDMI device
 
 The built-in superconducting QDMI provider now parses its device description

--- a/docs/qir/index.md
+++ b/docs/qir/index.md
@@ -104,6 +104,15 @@ for a textual program and `bytes` for an exact binary payload.
 expects a null-terminated UTF-8 text payload and rejects known binary or
 non-text formats.
 
+Every DDSIM QIR job owns its JIT session, runtime, simulator state,
+random-number generator, and output sink. QIR jobs can therefore execute
+concurrently without sharing measurements or interleaving runtime output.
+Sampling supports Base and Adaptive formats. Statevector extraction is limited
+to Base formats: the JIT stops the selected entry point immediately before the
+first call to a function marked `irreversible`, following the semantic boundary
+defined by the Base Profile. It rejects other profiles and Base Profile programs
+whose irreversible region is not terminal.
+
 The generic submission APIs intentionally reject QDMI calibration and batch-job
 formats. Calibration jobs do not carry a program, while batch jobs contain job
 handles rather than serialized program bytes. Their format identifiers remain

--- a/include/mqt-core/qir/jit/IRRewriter.hpp
+++ b/include/mqt-core/qir/jit/IRRewriter.hpp
@@ -14,41 +14,30 @@
 
 #pragma once
 
-#include <llvm/ADT/StringRef.h>
-#include <llvm/IR/Module.h>
-
-#include <array>
-#include <cstddef>
+namespace llvm {
+class Function;
+}
 
 namespace qir {
 
-/// The set of call targets that @c stripMeasurementRelatedCalls erases.
-inline constexpr std::array<llvm::StringRef, 5> STRIP_TARGETS = {
-    "__quantum__qis__mz__body",
-    "__quantum__qis__m__body",
-    "__quantum__qis__measure__body",
-    "__quantum__rt__result_record_output",
-    "__quantum__rt__result_update_reference_count",
-};
-
 /**
- * @brief Strips QIR measurement-related calls from @p m in place.
- * @details Erases calls to the QIR measurement intrinsics, to the
- * result-recording intrinsic, and to the result reference-count update
- * intrinsic (whose Result operands would otherwise reference the null
- * pointers left by the stripped measurements).
- * Intended for QIR Base Profile programs only: in Adaptive Profile programs,
- * measurement results feed classical control flow, so removing them silently
- * changes observable behavior.
+ * @brief Prepares a QIR entry point for state extraction.
+ * @details Truncates @p entryPoint immediately before its first call to a
+ * function carrying the QIR @c irreversible attribute, then removes the
+ * unreachable measurement and output region. This uses the semantic boundary
+ * defined by the QIR Base Profile instead of relying on a fixed list of
+ * measurement and output function names.
  *
- * The typical use is to prepare a Base Profile module for state-vector
- * extraction: after this transform the JIT'd @c main can be run once and
- * the resulting state remains in the @ref qir::Runtime DD instead of being
- * collapsed by measurement.
+ * The transform requires an entry point marked with @c base_profile. Adaptive
+ * Profile measurements may feed classical control flow and cannot be removed
+ * without changing the program's meaning.
  *
- * @param m Module to rewrite in place.
- * @return Number of instructions erased.
+ * @param entryPoint QIR entry point to rewrite in place.
+ * @return Whether an irreversible boundary was found and truncated.
+ * @throws std::invalid_argument if the entry point is not Base Profile, does
+ * not use the QIR 2.x @c i64() signature, or has non-terminal irreversible
+ * operations.
  */
-std::size_t stripMeasurementRelatedCalls(llvm::Module& m);
+bool prepareForStateExtraction(llvm::Function& entryPoint);
 
 } // namespace qir

--- a/include/mqt-core/qir/jit/Session.hpp
+++ b/include/mqt-core/qir/jit/Session.hpp
@@ -33,10 +33,10 @@ class Runtime;
  * @brief Whether the JIT'd program runs to produce measurement samples or
  * to leave the final quantum state in @ref qir::Runtime for external
  * extraction.
- * @details In @c StateExtraction mode the session strips QIR measurement
- * and result-management calls from the IR before JIT-compiling, so the
- * runtime's quantum state remains intact after @c main returns. Intended
- * for QIR Base Profile programs only.
+ * @details In @c StateExtraction mode the session stops a Base Profile entry
+ * point at its first irreversible operation before JIT-compiling, so the
+ * runtime's quantum state remains intact without executing measurements or
+ * output recording. Adaptive Profile entry points are rejected.
  */
 enum class Execution { Sampling, StateExtraction };
 
@@ -123,7 +123,7 @@ private:
 
   /// Prepares the session to run the program:
   /// - Validates the loaded module.
-  /// - Optionally strips measurement and result management calls
+  /// - Optionally truncates the entry point at its first irreversible operation
   ///   (for @c Execution::StateExtraction).
   /// - Builds the @c LLJIT instance
   /// - Registers QIR runtime symbols

--- a/src/qdmi/devices/dd/Device.cpp
+++ b/src/qdmi/devices/dd/Device.cpp
@@ -509,10 +509,9 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgramSampling()
 }
 auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgramStateExtraction()
     -> QDMI_STATUS {
-  // State extraction strips measurement calls from the IR, which only
-  // preserves semantics for QIR Base Profile (measurements are terminal there).
-  // Adaptive Profile has measurement-dependent control flow, so stripping would
-  // silently change the program's meaning.
+  // State extraction stops the entry point at its first irreversible operation.
+  // This preserves Base Profile semantics because measurements are terminal,
+  // whereas Adaptive Profile measurements may feed later quantum control.
   if (format_ != QDMI_PROGRAM_FORMAT_QIRBASEMODULE &&
       format_ != QDMI_PROGRAM_FORMAT_QIRBASESTRING) {
     return QDMI_ERROR_NOTSUPPORTED;

--- a/src/qir/jit/CMakeLists.txt
+++ b/src/qir/jit/CMakeLists.txt
@@ -38,7 +38,8 @@ if(NOT TARGET ${TARGET_NAME})
     orcjit
     orctargetprocess
     support
-    targetparser)
+    targetparser
+    transformutils)
 
   # Add link libraries
   target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreQIRRuntime ${llvm_native_libs})

--- a/src/qir/jit/IRRewriter.cpp
+++ b/src/qir/jit/IRRewriter.cpp
@@ -10,51 +10,128 @@
 
 #include "qir/jit/IRRewriter.hpp"
 
-#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallPtrSet.h>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/CFG.h>
 #include <llvm/IR/Constant.h>
+#include <llvm/IR/Dominators.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
-#include <llvm/IR/Module.h>
 #include <llvm/Support/Casting.h>
+#include <llvm/Transforms/Utils/Local.h>
 
-#include <algorithm>
-#include <cstddef>
+#include <stdexcept>
 
 namespace qir {
 
-static bool isStripTarget(const llvm::CallInst& call) {
-  const auto* callee = call.getCalledFunction();
-  if (callee == nullptr) {
-    return false;
-  }
-  const auto name = callee->getName();
-  return std::ranges::any_of(
-      STRIP_TARGETS, [&](llvm::StringRef target) { return name == target; });
+static constexpr llvm::StringLiteral TERMINAL_REGION_ERROR =
+    "QIR state extraction requires irreversible operations to form a terminal "
+    "region";
+
+static bool isIrreversible(const llvm::CallBase& call) {
+  const auto* callee = llvm::dyn_cast<llvm::Function>(
+      call.getCalledOperand()->stripPointerCasts());
+  return callee != nullptr && callee->hasFnAttribute("irreversible");
 }
 
-std::size_t stripMeasurementRelatedCalls(llvm::Module& m) {
-  std::size_t erased = 0;
-  for (auto& fn : m) {
-    for (auto& bb : fn) {
-      for (auto& inst : llvm::make_early_inc_range(bb)) {
-        auto* call = llvm::dyn_cast<llvm::CallInst>(&inst);
-        if (call == nullptr || !isStripTarget(*call)) {
-          continue;
-        }
-        // `m` and `measure` return a `Result*`.
-        // Replace uses of `m` and `measure` return values with a null before
-        // erasure so they do not dangle.
-        if (!call->getType()->isVoidTy() && !call->use_empty()) {
-          call->replaceAllUsesWith(
-              llvm::Constant::getNullValue(call->getType()));
-        }
-        call->eraseFromParent();
-        ++erased;
+static void requireTerminalIrreversibleRegion(llvm::CallInst& boundary) {
+  llvm::SmallPtrSet<llvm::BasicBlock*, 8> visited;
+  llvm::SmallVector<llvm::BasicBlock*, 8> pending;
+
+  auto inspect = [&](llvm::BasicBlock& block,
+                     llvm::BasicBlock::iterator begin) {
+    for (auto it = begin; it != block.end(); ++it) {
+      const auto* call = llvm::dyn_cast<llvm::CallBase>(&*it);
+      const auto* callee =
+          call == nullptr ? nullptr
+                          : llvm::dyn_cast<llvm::Function>(
+                                call->getCalledOperand()->stripPointerCasts());
+      if (callee != nullptr &&
+          callee->getName().starts_with("__quantum__qis__") &&
+          !isIrreversible(*call)) {
+        throw std::invalid_argument(TERMINAL_REGION_ERROR.str());
+      }
+    }
+
+    auto* terminator = block.getTerminator();
+    if (terminator->getNumSuccessors() > 1) {
+      throw std::invalid_argument(TERMINAL_REGION_ERROR.str());
+    }
+    for (auto* successor : llvm::successors(&block)) {
+      pending.emplace_back(successor);
+    }
+  };
+
+  auto* boundaryBlock = boundary.getParent();
+  visited.insert(boundaryBlock);
+  inspect(*boundaryBlock, boundary.getIterator());
+  while (!pending.empty()) {
+    auto* block = pending.pop_back_val();
+    if (!visited.insert(block).second) {
+      throw std::invalid_argument(TERMINAL_REGION_ERROR.str());
+    }
+    inspect(*block, block->begin());
+  }
+}
+
+bool prepareForStateExtraction(llvm::Function& entryPoint) {
+  if (!entryPoint.getReturnType()->isIntegerTy(64) || !entryPoint.arg_empty()) {
+    throw std::invalid_argument(
+        "QIR state extraction requires an i64() entry point");
+  }
+
+  const auto profile = entryPoint.getFnAttribute("qir_profiles");
+  if (!profile.isStringAttribute() ||
+      profile.getValueAsString() != "base_profile") {
+    throw std::invalid_argument(
+        "QIR state extraction requires a Base Profile entry point");
+  }
+
+  llvm::SmallVector<llvm::CallInst*, 8> irreversibleCalls;
+  for (auto& block : entryPoint) {
+    for (auto& instruction : block) {
+      auto* call = llvm::dyn_cast<llvm::CallInst>(&instruction);
+      if (call != nullptr && isIrreversible(*call)) {
+        irreversibleCalls.emplace_back(call);
       }
     }
   }
-  return erased;
+  if (irreversibleCalls.empty()) {
+    return false;
+  }
+
+  const llvm::DominatorTree dominators(entryPoint);
+  llvm::CallInst* boundary = nullptr;
+  for (auto* candidate : irreversibleCalls) {
+    bool dominatesAll = true;
+    for (auto* call : irreversibleCalls) {
+      if (candidate != call && !dominators.dominates(candidate, call)) {
+        dominatesAll = false;
+        break;
+      }
+    }
+    if (dominatesAll) {
+      boundary = candidate;
+      break;
+    }
+  }
+  if (boundary == nullptr) {
+    throw std::invalid_argument(TERMINAL_REGION_ERROR.str());
+  }
+
+  requireTerminalIrreversibleRegion(*boundary);
+  auto* prefix = boundary->getParent();
+  prefix->splitBasicBlock(boundary, "state-extraction.discarded");
+  auto* oldTerminator = prefix->getTerminator();
+  llvm::IRBuilder<> builder(oldTerminator);
+  builder.CreateRet(llvm::Constant::getNullValue(entryPoint.getReturnType()));
+  oldTerminator->eraseFromParent();
+  llvm::removeUnreachableBlocks(entryPoint);
+  return true;
 }
 
 } // namespace qir

--- a/src/qir/jit/Session.cpp
+++ b/src/qir/jit/Session.cpp
@@ -69,11 +69,11 @@ static auto isEntryPoint(const llvm::Function& function) -> bool {
          function.hasFnAttribute("EntryPoint");
 }
 
-static auto selectEntryPoint(const llvm::Module& module,
+static auto selectEntryPoint(llvm::Module& module,
                              const std::optional<std::string>& requested)
-    -> const llvm::Function& {
-  std::vector<const llvm::Function*> matches;
-  for (const auto& function : module) {
+    -> llvm::Function& {
+  std::vector<llvm::Function*> matches;
+  for (auto& function : module) {
     if (!function.isDeclaration() && isEntryPoint(function) &&
         (!requested || function.getName() == *requested)) {
       matches.emplace_back(&function);
@@ -94,7 +94,7 @@ static auto selectEntryPoint(const llvm::Module& module,
     }
     throw std::runtime_error(message.str());
   }
-  const auto& entryPoint = *matches.front();
+  auto& entryPoint = *matches.front();
   const auto* type = entryPoint.getFunctionType();
   if (type->isVarArg() || type->getNumParams() != 0 ||
       !type->getReturnType()->isIntegerTy(64)) {
@@ -447,8 +447,8 @@ void JitSession::initialize(
   runtime_ = std::make_unique<Runtime>();
 
   std::vector<std::pair<std::string, void*>> runtimeSymbols;
-  module_.withModuleDo([&](const llvm::Module& module) {
-    const auto& entryPoint = selectEntryPoint(module, options.entryPoint);
+  module_.withModuleDo([&](llvm::Module& module) {
+    auto& entryPoint = selectEntryPoint(module, options.entryPoint);
     entryPointName_ = entryPoint.getName().str();
     runtime_->setOutputSchema(readOutputSchema(entryPoint));
     std::vector<std::pair<std::string, std::string>> metadata;
@@ -459,17 +459,13 @@ void JitSession::initialize(
       }
     }
     runtime_->setMetadata(std::move(metadata));
+    if (options.execution == Execution::StateExtraction) {
+      prepareForStateExtraction(entryPoint);
+    }
     runtimeSymbols = selectRuntimeSymbols(module);
   });
   if (options.seed) {
     runtime_->seed(*options.seed);
-  }
-
-  // In StateExtraction mode, strip QIR measurement and result-management calls
-  // so the runtime's quantum state remains intact after main returns.
-  if (options.execution == Execution::StateExtraction) {
-    module_.withModuleDo(
-        [](llvm::Module& m) { stripMeasurementRelatedCalls(m); });
   }
 
   initNativeTargets();

--- a/test/qdmi/devices/dd/concurrency_test.cpp
+++ b/test/qdmi/devices/dd/concurrency_test.cpp
@@ -15,13 +15,19 @@
 #include "helpers/test_utils.hpp"
 #include "mqt_ddsim_qdmi/constants.h"
 #include "mqt_ddsim_qdmi/device.h"
+#include "qir/helpers/test_utils.hpp"
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
+#include <memory>
+#include <numeric>
+#include <ranges>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 TEST(Concurrency, ConcurrentStatevectorReads) {
@@ -118,4 +124,33 @@ TEST(Concurrency, ConcurrentCheckDuringRun) {
   ASSERT_EQ(MQT_DDSIM_QDMI_device_job_wait(j.job, 0), QDMI_SUCCESS);
   done.store(true);
   poller.join();
+}
+
+TEST(Concurrency, ConcurrentQIRJobsOwnTheirRuntimeState) {
+  constexpr size_t numJobs = 4;
+  constexpr size_t shots = 1024;
+  const qdmi_test::SessionGuard session{};
+  const auto program = qir_test::getProgram("BellPairStatic.ll");
+  std::vector<std::unique_ptr<qdmi_test::JobGuard>> jobs;
+  jobs.reserve(numJobs);
+
+  for (size_t i = 0; i < numJobs; ++i) {
+    auto job = std::make_unique<qdmi_test::JobGuard>(session.session);
+    ASSERT_EQ(qdmi_test::setProgram(job->job, QDMI_PROGRAM_FORMAT_QIRBASESTRING,
+                                    program),
+              QDMI_SUCCESS);
+    ASSERT_EQ(qdmi_test::setShots(job->job, shots), QDMI_SUCCESS);
+    ASSERT_EQ(MQT_DDSIM_QDMI_device_job_submit(job->job), QDMI_SUCCESS);
+    jobs.emplace_back(std::move(job));
+  }
+
+  for (const auto& job : jobs) {
+    ASSERT_EQ(MQT_DDSIM_QDMI_device_job_wait(job->job, 0), QDMI_SUCCESS);
+    const auto [keys, values] = qdmi_test::getHistogram(job->job);
+    ASSERT_EQ(keys.size(), values.size());
+    EXPECT_EQ(std::accumulate(values.cbegin(), values.cend(), size_t{0}),
+              shots);
+    EXPECT_TRUE(std::ranges::all_of(
+        keys, [](const auto& key) { return key == "00" || key == "11"; }));
+  }
 }

--- a/test/qdmi/devices/dd/results_sampling_test.cpp
+++ b/test/qdmi/devices/dd/results_sampling_test.cpp
@@ -16,7 +16,6 @@
 #include "mqt_ddsim_qdmi/constants.h"
 #include "mqt_ddsim_qdmi/device.h"
 #include "qir/helpers/test_utils.hpp"
-#include "qir/runtime/Runtime.hpp"
 
 #include <gtest/gtest.h>
 #include <llvm/AsmParser/Parser.h>
@@ -30,7 +29,6 @@
 #include <memory>
 #include <numeric>
 #include <ranges>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -40,10 +38,6 @@ namespace {
 
 class HistogramTest : public ::testing::Test {
 protected:
-  std::ostringstream sink;
-  void SetUp() override { qir::Runtime::getInstance().setOstream(sink); }
-  void TearDown() override { qir::Runtime::getInstance().resetOstream(); }
-
   using Histogram = std::pair<std::vector<std::string>, std::vector<size_t>>;
   static constexpr size_t NUM_SHOTS = 1024;
   static constexpr size_t NUM_QUBITS = 3;

--- a/test/qdmi/devices/dd/results_statevector_test.cpp
+++ b/test/qdmi/devices/dd/results_statevector_test.cpp
@@ -16,7 +16,6 @@
 #include "mqt_ddsim_qdmi/constants.h"
 #include "mqt_ddsim_qdmi/device.h"
 #include "qir/helpers/test_utils.hpp"
-#include "qir/runtime/Runtime.hpp"
 
 #include <gtest/gtest.h>
 
@@ -24,7 +23,6 @@
 #include <complex>
 #include <cstddef>
 #include <numbers>
-#include <sstream>
 #include <vector>
 
 TEST(ResultsStatevector, DenseNormalizedAndBufferTooSmall) {
@@ -109,16 +107,7 @@ TEST(ResultsStatevector, HistogramRequestsInvalidWithShotsZero) {
             QDMI_ERROR_INVALIDARGUMENT);
 }
 
-namespace {
-
-class QIRStateExtractionTest : public testing::Test {
-protected:
-  std::ostringstream sink;
-  void SetUp() override { qir::Runtime::getInstance().setOstream(sink); }
-  void TearDown() override { qir::Runtime::getInstance().resetOstream(); }
-};
-
-TEST_F(QIRStateExtractionTest, BellPairStaticBaseStringYieldsBellState) {
+TEST(ResultsStatevector, QIRBaseStringYieldsBellState) {
   const qdmi_test::SessionGuard s{};
   const qdmi_test::JobGuard j{s.session};
   const auto program = qir_test::getProgram("BellPairStatic.ll");
@@ -138,5 +127,3 @@ TEST_F(QIRStateExtractionTest, BellPairStaticBaseStringYieldsBellState) {
   EXPECT_NEAR(std::abs(vec[2]), 0.0, 1e-6);
   EXPECT_NEAR(std::abs(vec[3]), invSqrt2, 1e-6);
 }
-
-} // namespace

--- a/test/qir/jit/test_ir_rewriter.cpp
+++ b/test/qir/jit/test_ir_rewriter.cpp
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/AsmParser/Parser.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/LLVMContext.h>
@@ -24,7 +25,6 @@
 #include <cstddef>
 #include <filesystem>
 #include <memory>
-#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -50,14 +50,6 @@ std::size_t countCallsTo(const llvm::Module& m, llvm::StringRef name) {
   return count;
 }
 
-std::size_t countCallsToStripTarget(const llvm::Module& m) {
-  return std::accumulate(qir::STRIP_TARGETS.begin(), qir::STRIP_TARGETS.end(),
-                         std::size_t{},
-                         [&m](std::size_t total, const auto& target) {
-                           return total + countCallsTo(m, target);
-                         });
-}
-
 std::unique_ptr<llvm::Module> loadIRFile(const std::filesystem::path& path,
                                          llvm::LLVMContext& ctx) {
   llvm::SMDiagnostic err;
@@ -77,22 +69,95 @@ protected:
   llvm::LLVMContext ctx_;
 };
 
-TEST_P(IRRewriterTest, StripMeasurementRelatedCalls) {
+TEST_P(IRRewriterTest, TruncatesAtIrreversibleBoundary) {
   const std::filesystem::path path =
       std::filesystem::path(QIR_FILES_DIR) / GetParam();
   auto llvmModule = loadIRFile(path, ctx_);
 
-  const auto numStripCalls = countCallsToStripTarget(*llvmModule);
-  ASSERT_GT(numStripCalls, 0U) << "Module has no calls to strip targets";
+  auto* entryPoint = llvmModule->getFunction("main");
+  ASSERT_NE(entryPoint, nullptr);
+  ASSERT_GT(countCallsTo(*llvmModule, "__quantum__rt__result_record_output"),
+            0U);
 
-  const auto numErased = qir::stripMeasurementRelatedCalls(*llvmModule);
-
-  EXPECT_EQ(numErased, numStripCalls);
-  EXPECT_EQ(countCallsToStripTarget(*llvmModule), 0U);
+  EXPECT_TRUE(qir::prepareForStateExtraction(*entryPoint));
+  EXPECT_EQ(countCallsTo(*llvmModule, "__quantum__qis__mz__body"), 0U);
+  EXPECT_EQ(countCallsTo(*llvmModule, "__quantum__rt__qubit_release"), 0U);
+  EXPECT_EQ(countCallsTo(*llvmModule, "__quantum__rt__result_record_output"),
+            0U);
 }
 
 INSTANTIATE_TEST_SUITE_P(BellPair, IRRewriterTest,
-                         testing::Values("BellPairStatic.ll",
-                                         "BellPairDynamic.ll"));
+                         testing::Values("BellPairStatic.ll"));
+
+TEST(IRRewriter, RemovesAllWorkAfterFirstIrreversibleCall) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 {
+  call void @prepare()
+  call void @measure()
+  call void @must_not_run()
+  ret i64 0
+}
+declare void @prepare()
+declare void @measure() #1
+declare void @must_not_run()
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+attributes #1 = { "irreversible" }
+)";
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic error;
+  auto module = llvm::parseAssemblyString(ir, error, context);
+  ASSERT_NE(module, nullptr);
+  auto* entryPoint = module->getFunction("main");
+  ASSERT_NE(entryPoint, nullptr);
+
+  EXPECT_TRUE(qir::prepareForStateExtraction(*entryPoint));
+  EXPECT_EQ(countCallsTo(*module, "prepare"), 1U);
+  EXPECT_EQ(countCallsTo(*module, "measure"), 0U);
+  EXPECT_EQ(countCallsTo(*module, "must_not_run"), 0U);
+}
+
+TEST(IRRewriter, RejectsIndependentIrreversibleRegions) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 {
+entry:
+  br i1 true, label %left, label %right
+left:
+  call void @measure_left()
+  ret i64 0
+right:
+  call void @measure_right()
+  ret i64 0
+}
+declare void @measure_left() #1
+declare void @measure_right() #1
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+attributes #1 = { "irreversible" }
+)";
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic error;
+  auto module = llvm::parseAssemblyString(ir, error, context);
+  ASSERT_NE(module, nullptr);
+  auto* entryPoint = module->getFunction("main");
+  ASSERT_NE(entryPoint, nullptr);
+
+  EXPECT_THROW(qir::prepareForStateExtraction(*entryPoint),
+               std::invalid_argument);
+}
+
+TEST(IRRewriter, RequiresBaseProfile) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 { ret i64 0 }
+attributes #0 = { "entry_point" }
+)";
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic error;
+  auto module = llvm::parseAssemblyString(ir, error, context);
+  ASSERT_NE(module, nullptr);
+  auto* entryPoint = module->getFunction("main");
+  ASSERT_NE(entryPoint, nullptr);
+
+  EXPECT_THROW(qir::prepareForStateExtraction(*entryPoint),
+               std::invalid_argument);
+}
 
 } // namespace

--- a/test/qir/jit/test_jit_session.cpp
+++ b/test/qir/jit/test_jit_session.cpp
@@ -62,6 +62,51 @@ TEST_F(JitSessionTest, StateExtractionLeavesNoRecordedOutputs) {
   EXPECT_TRUE(session.runtime().getMeasurements().empty());
 }
 
+TEST_F(JitSessionTest, StateExtractionRejectsAdaptiveProfile) {
+  constexpr std::string_view ir = R"(
+define i64 @main() #0 { ret i64 0 }
+attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" }
+)";
+  const qir::SessionOptions options{.execution =
+                                        qir::Execution::StateExtraction};
+  EXPECT_THROW(
+      {
+        try {
+          const qir::JitSession session(ir, "Adaptive.ll", options);
+        } catch (const std::invalid_argument& error) {
+          EXPECT_THAT(error.what(), ::testing::HasSubstr("Base Profile"));
+          throw;
+        }
+      },
+      std::invalid_argument);
+}
+
+TEST_F(JitSessionTest, StateExtractionRejectsNonTerminalMeasurement) {
+  constexpr std::string_view ir = R"(
+define i64 @main() #0 {
+  call void @measure()
+  call void @__quantum__qis__x__body(ptr null)
+  ret i64 0
+}
+declare void @measure() #1
+declare void @__quantum__qis__x__body(ptr)
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+attributes #1 = { "irreversible" }
+)";
+  const qir::SessionOptions options{.execution =
+                                        qir::Execution::StateExtraction};
+  EXPECT_THROW(
+      {
+        try {
+          const qir::JitSession session(ir, "NonTerminal.ll", options);
+        } catch (const std::invalid_argument& error) {
+          EXPECT_THAT(error.what(), ::testing::HasSubstr("terminal region"));
+          throw;
+        }
+      },
+      std::invalid_argument);
+}
+
 TEST_F(JitSessionTest, OutputSchemaDefaultsToLabeledWhenAttributeAbsent) {
   constexpr std::string_view ir = R"(
 define i64 @main() #0 { ret i64 0 }


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

This is PR 3 of 4 and is based on #2035.

- Gives every DDSIM QIR job its own JIT session, runtime, simulator state, random-number generator, measurements, and output sink.
- Replaces measurement-name matching with truncation at the first call marked `irreversible`, following the semantic boundary required by the QIR Base Profile.
- Restricts state extraction to Base Profile entry points and rejects non-terminal irreversible regions instead of silently changing program semantics.
- Adds concurrent QIR-job coverage and tightens DDSIM sampling, statevector, JIT rewriting, and documentation tests.
- Updates the upgrade guide only for the already released DDSIM QDMI device behavior.

## Stack

- Previous: #2034 — shared gate registry and compiler/runtime QIS contract.
- Previous: #2035 — current QIR runtime APIs, JIT validation, and runner isolation.
- **This PR:** DDSIM integration, state safety, and cumulative end-to-end coverage.
- Next: #2044 — external Base Profile interoperability tests and Python usage.

## Validation

- Full cumulative release build on current `origin/main`.
- All 4,622 CTest cases; two environment-dependent job-ID queries were fixture-skipped.
- 25 JIT tests, 5 runner tests, and all 48 DDSIM device tests.
- 2 focused Python QIR integration tests.
- Full repository lint and diff checks.

Part of #1833 and #1834.
