### PR TITLE
✨ Enhance single-qubit gate merging by expanding supported gate types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ releases may include breaking changes.
   containing quantum operations ([#1718]) ([**@MatthiasReumann**])
 - ✨ Add a `hadamard-lifting` pass for lifting Hadamard gates above Pauli gates
   ([#1605]) ([**@lirem101**], [**@burgholzer**])
-- ✨ Extend the `merge-single-qubit-rotation-gates` pass to merge consecutive
+- ✨ Add a `merge-single-qubit-rotation-gates` pass for merging consecutive
   fixed and parameterized single-qubit gates using quaternions with global-phase
   correction ([#1407], [#1674], [#2002], [#2038]) ([**@J4MMlE**],
   [**@denialhaag**], [**@MatthiasReumann**], [**@simon1hofmann**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,9 @@ releases may include breaking changes.
   containing quantum operations ([#1718]) ([**@MatthiasReumann**])
 - ✨ Add a `hadamard-lifting` pass for lifting Hadamard gates above Pauli gates
   ([#1605]) ([**@lirem101**], [**@burgholzer**])
-- ✨ Add a `merge-single-qubit-rotation-gates` pass for merging consecutive
-  rotation gates using quaternions ([#1407], [#1674], [#2002], [#2038])
+- ✨ Extend the `merge-single-qubit-rotation-gates` pass to merge consecutive
+  fixed and parameterized single-qubit gates using quaternions with
+  global-phase correction ([#1407], [#1674], [#2002], [#2038])
   ([**@J4MMlE**], [**@denialhaag**], [**@MatthiasReumann**],
   [**@simon1hofmann**])
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,9 @@ releases may include breaking changes.
 - ✨ Add a `hadamard-lifting` pass for lifting Hadamard gates above Pauli gates
   ([#1605]) ([**@lirem101**], [**@burgholzer**])
 - ✨ Add a `merge-single-qubit-rotation-gates` pass for merging consecutive
-  rotation gates using quaternions ([#1407], [#1674], [#2002], [#2038]) ([**@J4MMlE**],
-  [**@denialhaag**], [**@MatthiasReumann**], [**@simon1hofmann**])
+  rotation gates using quaternions ([#1407], [#1674], [#2002], [#2038])
+  ([**@J4MMlE**], [**@denialhaag**], [**@MatthiasReumann**],
+  [**@simon1hofmann**])
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637],
   [#1676], [#1706], [#1776], [#1836], [#1934], [#2000]) ([**@denialhaag**],
   [**@burgholzer**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ releases may include breaking changes.
 - ✨ Add a `hadamard-lifting` pass for lifting Hadamard gates above Pauli gates
   ([#1605]) ([**@lirem101**], [**@burgholzer**])
 - ✨ Add a `merge-single-qubit-rotation-gates` pass for merging consecutive
-  rotation gates using quaternions ([#1407], [#1674], [#2002]) ([**@J4MMlE**],
+  rotation gates using quaternions ([#1407], [#1674], [#2002], [#2038]) ([**@J4MMlE**],
   [**@denialhaag**], [**@MatthiasReumann**], [**@simon1hofmann**])
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637],
   [#1676], [#1706], [#1776], [#1836], [#1934], [#2000]) ([**@denialhaag**],
@@ -737,6 +737,7 @@ for previous changelogs._
 [#2042]: https://github.com/munich-quantum-toolkit/core/pull/2042
 [#2036]: https://github.com/munich-quantum-toolkit/core/pull/2036
 [#2035]: https://github.com/munich-quantum-toolkit/core/pull/2035
+[#2038]: https://github.com/munich-quantum-toolkit/core/pull/2038
 [#2028]: https://github.com/munich-quantum-toolkit/core/pull/2028
 [#2026]: https://github.com/munich-quantum-toolkit/core/pull/2026
 [#2017]: https://github.com/munich-quantum-toolkit/core/pull/2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,9 @@ releases may include breaking changes.
 - ✨ Add a `hadamard-lifting` pass for lifting Hadamard gates above Pauli gates
   ([#1605]) ([**@lirem101**], [**@burgholzer**])
 - ✨ Extend the `merge-single-qubit-rotation-gates` pass to merge consecutive
-  fixed and parameterized single-qubit gates using quaternions with
-  global-phase correction ([#1407], [#1674], [#2002], [#2038])
-  ([**@J4MMlE**], [**@denialhaag**], [**@MatthiasReumann**],
-  [**@simon1hofmann**])
+  fixed and parameterized single-qubit gates using quaternions with global-phase
+  correction ([#1407], [#1674], [#2002], [#2038]) ([**@J4MMlE**],
+  [**@denialhaag**], [**@MatthiasReumann**], [**@simon1hofmann**])
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637],
   [#1676], [#1706], [#1776], [#1836], [#1934], [#2000]) ([**@denialhaag**],
   [**@burgholzer**])

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -49,7 +49,7 @@ def MergeSingleQubitRotationGates
     parameters at run time.
 
     The emitted `UOp` is defined by $U = \exp [i (\phi + \lambda) / 2] R_z (\phi) R_y (\theta) R_z (\lambda)$.
-    Normalizing either extracted Z angle into $(-\pi, \pi]$ by $\pm 2\pi$ flips
+    Normalizing either extracted Z angle into $[-\pi, \pi)$ by $\pm 2\pi$ flips
     the $\mathrm{SU}(2)$ representative; half of each removed angle is returned
     as an Euler-wrap phase correction. Each merge therefore computes
     $\mathrm{inputPhase} - (\phi + \lambda) / 2 + \mathrm{eulerPhase}$, which

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -56,8 +56,10 @@ def MergeSingleQubitRotationGates
     restores exact matrix equality (including global phase). This applies even
     to chains of purely $\mathrm{SU}(2)$ gates (`rx`, `ry`, `rz`, `r`).
     On the host (static) path, a near-zero correction may be omitted; on the
-    SSA (dynamic) path a `GPhaseOp` is always emitted and may later be removed
-    by global-phase normalization when it folds to near zero.
+    SSA (dynamic) path a `GPhaseOp` is always emitted. After greedy merging,
+    the implementation directly invokes the shared global-phase normalization
+    utility to combine, normalize, and remove trivial corrections in their
+    respective scopes.
   }];
 }
 

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -16,22 +16,32 @@ def MergeSingleQubitRotationGates
   let dependentDialects = ["mlir::qco::QCODialect",
                            "::mlir::arith::ArithDialect",
                            "::mlir::math::MathDialect"];
-  let summary = "Merge rotation gates using quaternion-based fusion";
+  let summary = "Merge single-qubit gates using quaternion-based fusion";
   let description = [{
-    Merges consecutive single-qubit rotation gates acting on the same qubit into a single equivalent U gate, reducing circuit depth and gate count.
+    Merges consecutive mergeable single-qubit gates acting on the same qubit
+    into a single equivalent U gate, reducing circuit depth and gate count.
 
-    Supported gate types: `rx`, `ry`, `rz`, `p`, `r`, `u2`, `u`.
+    Supported gate types: `rx`, `ry`, `rz`, `p`, `r`, `u2`, `u`, `x`, `y`,
+    `z`, `h`, `s`, `sdg`, `t`, `tdg`, `sx`, `sxdg`, and `id`.
 
     The pass greedily collects the longest possible chain of consecutive mergeable gates.
     Each gate is converted to a unit quaternion:
 
     - `rx`, `ry`, `rz`, `p`: single-axis rotations via half-angle formulas.
+    - `x`, `y`, `z`: fixed-axis `pi` rotations (`rx`/`ry`/`rz`).
+    - `s` / `sdg`: `rz(+/- pi / 2)`; `t` / `tdg`: `rz(+/- pi / 4)`.
+    - `sx` / `sxdg`: `rx(+/- pi / 2)`.
+    - `h`: a `pi` rotation around the `(x + z) / sqrt(2)` axis.
+    - `id`: the identity quaternion.
     - `r(theta, phi)`: rotation by `theta` around axis `(cos(phi), sin(phi), 0)`.
     - `u2(phi, lambda) = u(pi / 2, phi, lambda)`.
     - `u(theta, phi, lambda)`: ZYZ decomposition `rz(phi) * ry(theta) * rz(lambda)`, each factor converted to a quaternion and merged via the Hamilton product.
 
-    The gates are then folded one by one via the Hamilton product into a single quaternion, which is decomposed back into ZYZ Euler angles and emitted as a single `UOp`, representing the same rotation as the chain of single gates.
-    The global phase of each gate is tracked alongside and combined together.
+    The gates are then folded one by one via the Hamilton product into a single quaternion, which is decomposed back into ZYZ Euler angles and emitted as a single `UOp`, representing the same unitary as the input chain.
+    The global phase of each gate is tracked alongside and combined together
+    (`x`/`y`/`z`/`h`: `pi / 2`; `s`/`sx`: `pi / 4`; `sdg`/`sxdg`: `-pi / 4`;
+    `t`/`tdg`: `+/- pi / 8`; `id` and pure `SU(2)` rotations: `0`;
+    `p(theta)`: `theta / 2`; `u`/`u2`: `(phi + lambda) / 2`).
 
     When every angle in the chain is a compile-time constant, the same algorithm
     runs on host scalars and emits constant `U` / `gphase` results directly.
@@ -39,10 +49,12 @@ def MergeSingleQubitRotationGates
     parameters at run time.
 
     The emitted `UOp` is defined by $U = \exp [i (\phi + \lambda) / 2] R_z (\phi) R_y (\theta) R_z (\lambda)$.
-    Each merge computes a global-phase correction of
-    $\mathrm{inputPhase} - (\phi + \lambda) / 2$, which compensates for the
-    intrinsic phase of the synthesized `UOp`. This applies even to chains of
-    purely $\mathrm{SU} (2)$ gates (`rx`, `ry`, `rz`, `r`).
+    Normalizing either extracted Z angle into $(-\pi, \pi]$ by $\pm 2\pi$ flips
+    the $\mathrm{SU}(2)$ representative; half of each removed angle is returned
+    as an Euler-wrap phase correction. Each merge therefore computes
+    $\mathrm{inputPhase} - (\phi + \lambda) / 2 + \mathrm{eulerPhase}$, which
+    restores exact matrix equality (including global phase). This applies even
+    to chains of purely $\mathrm{SU}(2)$ gates (`rx`, `ry`, `rz`, `r`).
     On the host (static) path, a near-zero correction may be omitted; on the
     SSA (dynamic) path a `GPhaseOp` is always emitted and may later be removed
     by global-phase normalization when it folds to near zero.

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
@@ -381,9 +381,12 @@ static std::optional<Val<T>> gateParam(UnitaryOpInterface op, unsigned i,
 }
 
 /**
- * @brief Converts a rotation gate to quaternion representation.
+ * @brief Converts a supported single-qubit gate to quaternion representation.
  *
  * - RX, RY, RZ, P: single-axis half-angle formulas.
+ * - X, Y, Z, S, Sdg, T, Tdg, SX, SXdg: fixed-axis rotations.
+ * - H: a pi rotation around the (X + Z) / sqrt(2) axis.
+ * - Id: the identity quaternion.
  * - R(theta, phi): Q(cos(θ/2), sin(θ/2)cos(φ), sin(θ/2)sin(φ), 0).
  * - U2(phi, lambda) = U(π/2, phi, lambda).
  * - U(theta, phi, lambda): ZYZ via quaternionFromZYZ.
@@ -393,9 +396,9 @@ static std::optional<Val<T>> gateParam(UnitaryOpInterface op, unsigned i,
  *         (static path: unfoldable SSA value).
  */
 template <typename T>
-static std::optional<Quat<T>>
-quaternionFromRotation(UnitaryOpInterface op, const ScalarConsts<T>& c,
-                       PatternRewriter& rewriter) {
+static std::optional<Quat<T>> quaternionFromGate(UnitaryOpInterface op,
+                                                 const ScalarConsts<T>& c,
+                                                 PatternRewriter& rewriter) {
   const Location loc = op->getLoc();
   auto param = [&](unsigned i) { return gateParam<T>(op, i, rewriter, loc); };
 
@@ -406,6 +409,46 @@ quaternionFromRotation(UnitaryOpInterface op, const ScalarConsts<T>& c,
       return std::nullopt;
     }
     return axisQuaternion(*angle, *axis, c);
+  }
+
+  const auto fixedAxisRotation = [&](RotationAxis axis, double angle) {
+    return axisQuaternion(Val<T>::constant(rewriter, loc, angle), axis, c);
+  };
+
+  if (isa<XOp>(op.getOperation())) {
+    return fixedAxisRotation(RotationAxis::X, std::numbers::pi);
+  }
+  if (isa<YOp>(op.getOperation())) {
+    return fixedAxisRotation(RotationAxis::Y, std::numbers::pi);
+  }
+  if (isa<ZOp>(op.getOperation())) {
+    return fixedAxisRotation(RotationAxis::Z, std::numbers::pi);
+  }
+  if (isa<SOp>(op.getOperation())) {
+    return fixedAxisRotation(RotationAxis::Z, std::numbers::pi / 2.0);
+  }
+  if (isa<SdgOp>(op.getOperation())) {
+    return fixedAxisRotation(RotationAxis::Z, -std::numbers::pi / 2.0);
+  }
+  if (isa<TOp>(op.getOperation())) {
+    return fixedAxisRotation(RotationAxis::Z, std::numbers::pi / 4.0);
+  }
+  if (isa<TdgOp>(op.getOperation())) {
+    return fixedAxisRotation(RotationAxis::Z, -std::numbers::pi / 4.0);
+  }
+  if (isa<SXOp>(op.getOperation())) {
+    return fixedAxisRotation(RotationAxis::X, std::numbers::pi / 2.0);
+  }
+  if (isa<SXdgOp>(op.getOperation())) {
+    return fixedAxisRotation(RotationAxis::X, -std::numbers::pi / 2.0);
+  }
+  if (isa<HOp>(op.getOperation())) {
+    const auto invSqrtTwo =
+        Val<T>::constant(rewriter, loc, 1.0 / std::numbers::sqrt2);
+    return Quat<T>{.w = c.zero, .x = invSqrtTwo, .y = c.zero, .z = invSqrtTwo};
+  }
+  if (isa<IdOp>(op.getOperation())) {
+    return Quat<T>{.w = c.one, .x = c.zero, .y = c.zero, .z = c.zero};
   }
 
   // Multi-parameter gates each need their own conversion
@@ -444,7 +487,7 @@ quaternionFromRotation(UnitaryOpInterface op, const ScalarConsts<T>& c,
 }
 
 /**
- * @brief Returns the global phase contribution of a rotation gate.
+ * @brief Returns the global phase contribution of a supported gate.
  *
  * Rotation gates can be factored as U = e^{i * phase} * SU(2), where SU(2)
  * is the quaternion-representable part and phase is the global phase:
@@ -453,6 +496,11 @@ quaternionFromRotation(UnitaryOpInterface op, const ScalarConsts<T>& c,
  * - P(theta)              -> theta / 2 (P = e^{i * theta / 2} * RZ(theta))
  * - U(theta, phi, lambda) -> (phi + lambda) / 2
  * - U2(phi, lambda)       -> (phi + lambda) / 2
+ * - X, Y, Z, H            -> pi / 2
+ * - S, SX                 -> pi / 4
+ * - Sdg, SXdg             -> -pi / 4
+ * - T / Tdg               -> +/- pi / 8
+ * - Id                    -> 0
  *
  * @return Success with the phase contribution, including an explicit zero for
  *         SU(2) gates. Failure if a required parameter does not fold on the
@@ -468,6 +516,19 @@ static FailureOr<Val<T>> globalPhaseOf(UnitaryOpInterface op,
   return TypeSwitch<Operation*, FailureOr<Val<T>>>(op.getOperation())
       .template Case<RXOp, RYOp, RZOp, ROp>(
           [&](auto) -> FailureOr<Val<T>> { return c.zero; })
+      .template Case<XOp, YOp, ZOp, HOp>(
+          [&](auto) -> FailureOr<Val<T>> { return c.pi / c.two; })
+      .template Case<SOp, SXOp>(
+          [&](auto) -> FailureOr<Val<T>> { return c.pi / (c.two * c.two); })
+      .template Case<SdgOp, SXdgOp>(
+          [&](auto) -> FailureOr<Val<T>> { return -c.pi / (c.two * c.two); })
+      .template Case<TOp>([&](auto) -> FailureOr<Val<T>> {
+        return c.pi / (c.two * c.two * c.two);
+      })
+      .template Case<TdgOp>([&](auto) -> FailureOr<Val<T>> {
+        return -c.pi / (c.two * c.two * c.two);
+      })
+      .template Case<IdOp>([&](auto) -> FailureOr<Val<T>> { return c.zero; })
       .template Case<POp>([&](auto) -> FailureOr<Val<T>> {
         const auto theta = param(0);
         if (!theta) {
@@ -513,10 +574,13 @@ static FailureOr<Val<T>> globalPhaseOf(UnitaryOpInterface op,
  * MLIR's constant folder never sees atan2(0,0) → NaN on a dead select input.
  *
  * @note Floating-point errors may accumulate when merging many gates.
- * @return {theta, phi, lambda} = {beta, alpha, gamma} suitable for UOp
+ * Normalizing either Z angle by 2*pi flips the corresponding SU(2)
+ * quaternion sign. The returned phase correction accounts for those flips.
+ *
+ * @return {theta, phi, lambda, phaseCorrection} suitable for UOp
  */
 template <typename T>
-static std::array<Val<T>, 3> anglesFromQuaternion(const Quat<T>& q,
+static std::array<Val<T>, 4> anglesFromQuaternion(const Quat<T>& q,
                                                   const ScalarConsts<T>& c) {
   PatternRewriter& rewriter = *q.w.rewriter;
   const Location loc = q.w.loc;
@@ -527,7 +591,11 @@ static std::array<Val<T>, 3> anglesFromQuaternion(const Quat<T>& q,
   // Host path can take the pure-Z shortcut without building the full tree.
   if constexpr (std::is_same_v<T, double>) {
     if (xyNearZero) {
-      return {c.zero, wrapToPi(q.z.atan2(q.w) * c.two, c), c.zero};
+      const auto alpha = q.z.atan2(q.w) * c.two;
+      const auto phi = wrapToPi(alpha, c);
+      // Wrapping alpha by 2*pi flips the SU(2) representative, which is
+      // compensated by half the removed angle as a global phase.
+      return {c.zero, phi, c.zero, (alpha - phi) / c.two};
     }
   }
 
@@ -565,11 +633,16 @@ static std::array<Val<T>, 3> anglesFromQuaternion(const Quat<T>& q,
   const auto alpha = Val<T>::select(safe, alphaSafe, alphaUnsafe);
   const auto gamma = Val<T>::select(safe, gammaSafe, c.zero);
 
-  return {beta, wrapToPi(alpha, c), wrapToPi(gamma, c)};
+  const auto phi = wrapToPi(alpha, c);
+  const auto lambda = wrapToPi(gamma, c);
+  // Each removed 2*pi Z rotation flips the SU(2) representative. Half of the
+  // total removed angle restores the original matrix as a global phase.
+  return {beta, phi, lambda, ((alpha - phi) + (gamma - lambda)) / c.two};
 }
 
 static bool isMergeable(Operation* op) {
-  return isa<RXOp, RYOp, RZOp, POp, ROp, U2Op, UOp>(op);
+  return isa<RXOp, RYOp, RZOp, POp, ROp, U2Op, UOp, XOp, YOp, ZOp, HOp, SOp,
+             SdgOp, TOp, TdgOp, SXOp, SXdgOp, IdOp>(op);
 }
 
 static bool areQuaternionMergeable(Operation* a, Operation* b) {
@@ -641,7 +714,7 @@ struct MergeSingleQubitRotationGatesPattern final
     std::optional<Quat<double>> qAccum;
     Val<double> phaseAccum = consts.zero;
     for (UnitaryOpInterface chainOp : chain) {
-      auto qi = quaternionFromRotation<double>(chainOp, consts, rewriter);
+      auto qi = quaternionFromGate<double>(chainOp, consts, rewriter);
       if (!qi) {
         return failure();
       }
@@ -653,8 +726,10 @@ struct MergeSingleQubitRotationGatesPattern final
       qAccum = qAccum ? hamiltonProduct(*qi, *qAccum) : *qi;
     }
 
-    const auto [theta, phi, lambda] = anglesFromQuaternion(*qAccum, consts);
-    const auto correction = phaseAccum - ((phi + lambda) / consts.two);
+    const auto [theta, phi, lambda, eulerPhase] =
+        anglesFromQuaternion(*qAccum, consts);
+    const auto correction =
+        phaseAccum - ((phi + lambda) / consts.two) + eulerPhase;
     const double correctionHost = utils::normalizeAngle(correction.v);
 
     for (auto chainOp : llvm::drop_begin(chain)) {
@@ -695,7 +770,7 @@ struct MergeSingleQubitRotationGatesPattern final
     quats.reserve(chain.size());
     Val<Value> phaseAccum = consts.zero;
     for (UnitaryOpInterface chainOp : chain) {
-      auto qi = quaternionFromRotation<Value>(chainOp, consts, rewriter);
+      auto qi = quaternionFromGate<Value>(chainOp, consts, rewriter);
       if (!qi) {
         return failure();
       }
@@ -712,9 +787,10 @@ struct MergeSingleQubitRotationGatesPattern final
       qAccum = hamiltonProduct(qi, qAccum);
     }
 
-    const auto [theta, phi, lambda] = anglesFromQuaternion(qAccum, consts);
+    const auto [theta, phi, lambda, eulerPhase] =
+        anglesFromQuaternion(qAccum, consts);
     const auto outPhase = (phi + lambda) / consts.two;
-    Val<Value> phaseCorrection = phaseAccum - outPhase;
+    Val<Value> phaseCorrection = phaseAccum - outPhase + eulerPhase;
     if (const auto constant = utils::valueToConstantDouble(phaseCorrection.v)) {
       phaseCorrection =
           Val<Value>::constant(rewriter, loc, utils::normalizeAngle(*constant));

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
@@ -730,15 +730,13 @@ struct MergeSingleQubitRotationGatesPattern final
         anglesFromQuaternion(*qAccum, consts);
     const auto correction =
         phaseAccum - ((phi + lambda) / consts.two) + eulerPhase;
-    const double correctionHost = utils::normalizeAngle(correction.v);
 
     for (auto chainOp : llvm::drop_begin(chain)) {
       rewriter.replaceOp(chainOp, chainOp.getInputQubit(0));
     }
-    if (std::abs(correctionHost) > utils::TOLERANCE) {
-      GPhaseOp::create(
-          rewriter, loc,
-          utils::constantFromScalar(rewriter, loc, correctionHost));
+    if (std::abs(correction.v) > utils::TOLERANCE) {
+      GPhaseOp::create(rewriter, loc,
+                       utils::constantFromScalar(rewriter, loc, correction.v));
     }
     rewriter.replaceOpWithNewOp<UOp>(
         chain.front(), chain.front().getInputQubit(0),
@@ -755,7 +753,8 @@ struct MergeSingleQubitRotationGatesPattern final
    * correction:
    *   outPhase = (phi + lambda) / 2
    *   correction = totalInputPhase - outPhase
-   * Foldable corrections are normalized into the practical gphase range.
+   * The pass-level global-phase normalization subsequently combines and
+   * normalizes the emitted correction.
    *
    * Converts every gate before rewriting so a missing conversion Case cannot
    * leave partially rewired ops.
@@ -790,11 +789,7 @@ struct MergeSingleQubitRotationGatesPattern final
     const auto [theta, phi, lambda, eulerPhase] =
         anglesFromQuaternion(qAccum, consts);
     const auto outPhase = (phi + lambda) / consts.two;
-    Val<Value> phaseCorrection = phaseAccum - outPhase + eulerPhase;
-    if (const auto constant = utils::valueToConstantDouble(phaseCorrection.v)) {
-      phaseCorrection =
-          Val<Value>::constant(rewriter, loc, utils::normalizeAngle(*constant));
-    }
+    const Val<Value> phaseCorrection = phaseAccum - outPhase + eulerPhase;
 
     for (auto chainOp : llvm::drop_begin(chain)) {
       rewriter.replaceOp(chainOp, chainOp.getInputQubit(0));

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
@@ -415,44 +415,44 @@ static std::optional<Quat<T>> quaternionFromGate(UnitaryOpInterface op,
     return axisQuaternion(Val<T>::constant(rewriter, loc, angle), axis, c);
   };
 
-  if (isa<XOp>(op.getOperation())) {
-    return fixedAxisRotation(RotationAxis::X, std::numbers::pi);
-  }
-  if (isa<YOp>(op.getOperation())) {
-    return fixedAxisRotation(RotationAxis::Y, std::numbers::pi);
-  }
-  if (isa<ZOp>(op.getOperation())) {
-    return fixedAxisRotation(RotationAxis::Z, std::numbers::pi);
-  }
-  if (isa<SOp>(op.getOperation())) {
-    return fixedAxisRotation(RotationAxis::Z, std::numbers::pi / 2.0);
-  }
-  if (isa<SdgOp>(op.getOperation())) {
-    return fixedAxisRotation(RotationAxis::Z, -std::numbers::pi / 2.0);
-  }
-  if (isa<TOp>(op.getOperation())) {
-    return fixedAxisRotation(RotationAxis::Z, std::numbers::pi / 4.0);
-  }
-  if (isa<TdgOp>(op.getOperation())) {
-    return fixedAxisRotation(RotationAxis::Z, -std::numbers::pi / 4.0);
-  }
-  if (isa<SXOp>(op.getOperation())) {
-    return fixedAxisRotation(RotationAxis::X, std::numbers::pi / 2.0);
-  }
-  if (isa<SXdgOp>(op.getOperation())) {
-    return fixedAxisRotation(RotationAxis::X, -std::numbers::pi / 2.0);
-  }
-  if (isa<HOp>(op.getOperation())) {
-    const auto invSqrtTwo =
-        Val<T>::constant(rewriter, loc, 1.0 / std::numbers::sqrt2);
-    return Quat<T>{.w = c.zero, .x = invSqrtTwo, .y = c.zero, .z = invSqrtTwo};
-  }
-  if (isa<IdOp>(op.getOperation())) {
-    return Quat<T>{.w = c.one, .x = c.zero, .y = c.zero, .z = c.zero};
-  }
-
-  // Multi-parameter gates each need their own conversion
+  // Fixed and multi-parameter gates each need their own conversion.
   return TypeSwitch<Operation*, std::optional<Quat<T>>>(op.getOperation())
+      .template Case<XOp>([&](XOp) {
+        return fixedAxisRotation(RotationAxis::X, std::numbers::pi);
+      })
+      .template Case<YOp>([&](YOp) {
+        return fixedAxisRotation(RotationAxis::Y, std::numbers::pi);
+      })
+      .template Case<ZOp>([&](ZOp) {
+        return fixedAxisRotation(RotationAxis::Z, std::numbers::pi);
+      })
+      .template Case<SOp>([&](SOp) {
+        return fixedAxisRotation(RotationAxis::Z, std::numbers::pi / 2.0);
+      })
+      .template Case<SdgOp>([&](SdgOp) {
+        return fixedAxisRotation(RotationAxis::Z, -std::numbers::pi / 2.0);
+      })
+      .template Case<TOp>([&](TOp) {
+        return fixedAxisRotation(RotationAxis::Z, std::numbers::pi / 4.0);
+      })
+      .template Case<TdgOp>([&](TdgOp) {
+        return fixedAxisRotation(RotationAxis::Z, -std::numbers::pi / 4.0);
+      })
+      .template Case<SXOp>([&](SXOp) {
+        return fixedAxisRotation(RotationAxis::X, std::numbers::pi / 2.0);
+      })
+      .template Case<SXdgOp>([&](SXdgOp) {
+        return fixedAxisRotation(RotationAxis::X, -std::numbers::pi / 2.0);
+      })
+      .template Case<HOp>([&](HOp) -> std::optional<Quat<T>> {
+        const auto invSqrtTwo =
+            Val<T>::constant(rewriter, loc, 1.0 / std::numbers::sqrt2);
+        return Quat<T>{
+            .w = c.zero, .x = invSqrtTwo, .y = c.zero, .z = invSqrtTwo};
+      })
+      .template Case<IdOp>([&](IdOp) -> std::optional<Quat<T>> {
+        return Quat<T>{.w = c.one, .x = c.zero, .y = c.zero, .z = c.zero};
+      })
       .template Case<ROp>([&](ROp) -> std::optional<Quat<T>> {
         const auto theta = param(0);
         const auto phi = param(1);
@@ -518,15 +518,17 @@ static FailureOr<Val<T>> globalPhaseOf(UnitaryOpInterface op,
           [&](auto) -> FailureOr<Val<T>> { return c.zero; })
       .template Case<XOp, YOp, ZOp, HOp>(
           [&](auto) -> FailureOr<Val<T>> { return c.pi / c.two; })
-      .template Case<SOp, SXOp>(
-          [&](auto) -> FailureOr<Val<T>> { return c.pi / (c.two * c.two); })
-      .template Case<SdgOp, SXdgOp>(
-          [&](auto) -> FailureOr<Val<T>> { return -c.pi / (c.two * c.two); })
+      .template Case<SOp, SXOp>([&](auto) -> FailureOr<Val<T>> {
+        return Val<T>::constant(rewriter, loc, std::numbers::pi / 4.0);
+      })
+      .template Case<SdgOp, SXdgOp>([&](auto) -> FailureOr<Val<T>> {
+        return Val<T>::constant(rewriter, loc, -std::numbers::pi / 4.0);
+      })
       .template Case<TOp>([&](auto) -> FailureOr<Val<T>> {
-        return c.pi / (c.two * c.two * c.two);
+        return Val<T>::constant(rewriter, loc, std::numbers::pi / 8.0);
       })
       .template Case<TdgOp>([&](auto) -> FailureOr<Val<T>> {
-        return -c.pi / (c.two * c.two * c.two);
+        return Val<T>::constant(rewriter, loc, -std::numbers::pi / 8.0);
       })
       .template Case<IdOp>([&](auto) -> FailureOr<Val<T>> { return c.zero; })
       .template Case<POp>([&](auto) -> FailureOr<Val<T>> {

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(
   ${target_name}
   PRIVATE GTest::gtest_main
           MLIRControlFlowDialect
+          MLIRQCODDFunctionality
           MLIRQCOProgramBuilder
           MLIRQCOTransforms
           MLIRQCOUtils

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/compute_expected_merge_single_qubit_rotation.py
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/compute_expected_merge_single_qubit_rotation.py
@@ -28,13 +28,28 @@ def u2_gate(phi: float, lam: float) -> Quaternion:
 
 
 def normalize_angle(a: float) -> float:
-    """Normalize angle to [-pi, pi], matching the pass's normalizeAngle.
+    """Wrap an Euler angle to [-pi, pi), matching wrapToPi in the pass.
 
     Returns:
-        Angle in the range [-pi, pi].
+        Angle in the range [-pi, pi).
     """
     two_pi = 2 * math.pi
     return a - math.floor((a + math.pi) / two_pi) * two_pi
+
+
+def normalize_global_phase(a: float) -> float:
+    """Normalize to (-pi, pi], matching utils::normalizeAngle.
+
+    Returns:
+        Angle in the range (-pi, pi].
+    """
+    two_pi = 2 * math.pi
+    a = math.fmod(a, two_pi)
+    if a > math.pi:
+        a -= two_pi
+    if a <= -math.pi:
+        a += two_pi
+    return a
 
 
 def angles_from_quaternion(w: float, x: float, y: float, z: float) -> tuple[float, float, float, float]:
@@ -152,7 +167,7 @@ def compute_merge(chain: list[tuple]) -> tuple[float, float, float, float]:
     theta, phi, lam, euler_phase = angles_from_quaternion(w, x, y, z)
     corr = gphase_correction(total_input_phase, phi, lam, euler_phase)
 
-    return theta, phi, lam, float(N(corr))
+    return theta, phi, lam, normalize_global_phase(float(N(corr)))
 
 
 # ---- Build gates ----

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/compute_expected_merge_single_qubit_rotation.py
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/compute_expected_merge_single_qubit_rotation.py
@@ -37,11 +37,11 @@ def normalize_angle(a: float) -> float:
     return a - math.floor((a + math.pi) / two_pi) * two_pi
 
 
-def angles_from_quaternion(w: float, x: float, y: float, z: float) -> tuple[float, float, float]:
+def angles_from_quaternion(w: float, x: float, y: float, z: float) -> tuple[float, float, float, float]:
     """ZYZ Euler angles from quaternion, matching anglesFromQuaternion in the pass.
 
     Returns:
-        Tuple (theta, phi, lambda) in ZYZ convention.
+        Tuple (theta, phi, lambda, phase correction) in ZYZ convention.
     """
     eps = 1e-12
 
@@ -72,11 +72,12 @@ def angles_from_quaternion(w: float, x: float, y: float, z: float) -> tuple[floa
         alpha = 2 * theta_minus
         gamma = 0.0
 
-    alpha = normalize_angle(alpha)
-    gamma = normalize_angle(gamma)
+    normalized_alpha = normalize_angle(alpha)
+    normalized_gamma = normalize_angle(gamma)
+    phase_correction = ((alpha - normalized_alpha) + (gamma - normalized_gamma)) / 2
 
     # U gate convention: theta=beta, phi=alpha, lambda=gamma
-    return beta, alpha, gamma
+    return beta, normalized_alpha, normalized_gamma, phase_correction
 
 
 def global_phase(gate_type: str, *angles: float) -> float:
@@ -115,13 +116,13 @@ def output_phase(phi: float, lam: float) -> float:
     return (phi + lam) / 2
 
 
-def gphase_correction(input_phase: float, phi: float, lam: float) -> float:
-    """Return the GPhaseOp correction = total_input_phase - output_UOp_phase.
+def gphase_correction(input_phase: float, phi: float, lam: float, euler_phase: float) -> float:
+    """Return the GPhaseOp correction, including Euler normalization phase.
 
     Returns:
         Phase correction in radians.
     """
-    return input_phase - output_phase(phi, lam)
+    return input_phase - output_phase(phi, lam) + euler_phase
 
 
 # ---- Helper to compute merge + gphase for a chain ----
@@ -130,9 +131,9 @@ def compute_merge(chain: list[tuple]) -> tuple[float, float, float, float]:
 
     chain: list of (gate_type, quaternion, *angles).
 
-    Uses our own Euler extraction that matches the C++ pass exactly:
-    no quaternion sign normalization, same atan2/acos/clamp logic,
-    same gimbal-lock handling, same angle normalization.
+    Uses our own Euler extraction that matches the C++ pass exactly: same
+    atan2/acos/clamp logic, gimbal-lock handling, angle normalization, and
+    global-phase correction induced by normalizing the Euler angles.
 
     Returns:
         Tuple (theta, phi, lambda, gphase) all as floats.
@@ -146,11 +147,10 @@ def compute_merge(chain: list[tuple]) -> tuple[float, float, float, float]:
         q = qi.mul(q)  # Hamilton product in circuit order
         total_input_phase += global_phase(gt, *ai)
 
-    # Extract Euler angles matching the pass (no sign normalization)
+    # Extract Euler angles matching the pass.
     w, x, y, z = float(N(q.a)), float(N(q.b)), float(N(q.c)), float(N(q.d))
-    theta, phi, lam = angles_from_quaternion(w, x, y, z)
-
-    corr = gphase_correction(total_input_phase, phi, lam)
+    theta, phi, lam, euler_phase = angles_from_quaternion(w, x, y, z)
+    corr = gphase_correction(total_input_phase, phi, lam, euler_phase)
 
     return theta, phi, lam, float(N(corr))
 

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "ExactUnitaryTest.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
@@ -32,6 +33,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <complex>
 #include <cstdint>
 #include <numbers>
 #include <optional>
@@ -246,12 +248,18 @@ protected:
    * all rotations in the list.
    */
   LogicalResult testGateMerge(ArrayRef<RotationGate> rotations) {
-    auto q = builder.allocQubitRegister(1);
+    auto q = builder.staticQubit(0);
 
-    buildRotations(rotations, q[0]);
+    q = buildRotations(rotations, q);
+    builder.sink(q);
 
     module = builder.finalize();
-    return runMergePass(module.get());
+    OwningOpRef<ModuleOp> original = cast<ModuleOp>(module->clone());
+    const auto result = runMergePass(*module);
+    if (succeeded(result)) {
+      mqt::test::expectFullUnitaryEqual(*original, *module, 1);
+    }
+    return result;
   }
 
   /**
@@ -263,6 +271,24 @@ protected:
     return pm.run(module);
   }
 };
+
+enum class FixedGateType : std::uint8_t {
+  X,
+  Y,
+  Z,
+  H,
+  S,
+  Sdg,
+  T,
+  Tdg,
+  SX,
+  SXdg,
+  Id
+};
+
+class MergeFixedSingleQubitGateTest
+    : public MergeSingleQubitRotationGatesTest,
+      public testing::WithParamInterface<FixedGateType> {};
 
 } // namespace
 
@@ -411,7 +437,7 @@ TEST_F(MergeSingleQubitRotationGatesTest, mergeUUGates) {
   EXPECT_EQ(countOps<UOp>(), 1);
   EXPECT_EQ(countOps<GPhaseOp>(), 1);
   expectUGateParams(2.03289042623884, 0.663830775701153, 0.849231441867857);
-  expectGPhaseParam(7.243468891215494);
+  expectGPhaseParam(-2.1813090695538833);
 }
 
 /**
@@ -522,7 +548,8 @@ TEST_F(MergeSingleQubitRotationGatesTest, mergePUGates) {
                   .succeeded());
   EXPECT_EQ(countOps<UOp>(), 1);
   EXPECT_EQ(countOps<POp>(), 0);
-  EXPECT_EQ(countOps<GPhaseOp>(), 1);
+  EXPECT_EQ(countOps<GPhaseOp>(), 0);
+  expectGPhaseParam(0.0);
 }
 
 /**
@@ -561,7 +588,7 @@ TEST_F(MergeSingleQubitRotationGatesTest, mergeRRGates) {
   EXPECT_EQ(countOps<UOp>(), 1);
   EXPECT_EQ(countOps<ROp>(), 0);
   expectUGateParams(2.07770669385131, 1.36334275733332, 2.85969871348886);
-  expectGPhaseParam(-2.1115207354110845);
+  expectGPhaseParam(1.0300719181787086);
 }
 
 /**
@@ -588,7 +615,7 @@ TEST_F(MergeSingleQubitRotationGatesTest, mergeU2U2Gates) {
   EXPECT_EQ(countOps<U2Op>(), 0);
   EXPECT_EQ(countOps<GPhaseOp>(), 1);
   expectUGateParams(1.85840734641021, 1.42920367320511, 0.429203673205103);
-  expectGPhaseParam(4.070796326794897);
+  expectGPhaseParam(0.92920367320510344);
 }
 
 // ##################################################
@@ -644,21 +671,78 @@ TEST_F(MergeSingleQubitRotationGatesTest, dontMergeGatesFromDifferentQubits) {
   EXPECT_EQ(countOps<GPhaseOp>(), 0);
 }
 
+TEST_P(MergeFixedSingleQubitGateTest, PreservesMatrix) {
+  auto q = builder.staticQubit(0);
+  switch (GetParam()) {
+  case FixedGateType::X:
+    q = builder.x(q);
+    break;
+  case FixedGateType::Y:
+    q = builder.y(q);
+    break;
+  case FixedGateType::Z:
+    q = builder.z(q);
+    break;
+  case FixedGateType::H:
+    q = builder.h(q);
+    break;
+  case FixedGateType::S:
+    q = builder.s(q);
+    break;
+  case FixedGateType::Sdg:
+    q = builder.sdg(q);
+    break;
+  case FixedGateType::T:
+    q = builder.t(q);
+    break;
+  case FixedGateType::Tdg:
+    q = builder.tdg(q);
+    break;
+  case FixedGateType::SX:
+    q = builder.sx(q);
+    break;
+  case FixedGateType::SXdg:
+    q = builder.sxdg(q);
+    break;
+  case FixedGateType::Id:
+    q = builder.id(q);
+    break;
+  }
+  q = builder.rx(0.37, q);
+  builder.sink(q);
+  module = builder.finalize();
+
+  OwningOpRef<ModuleOp> original = cast<ModuleOp>(module->clone());
+  ASSERT_TRUE(runMergePass(*module).succeeded());
+
+  mqt::test::expectFullUnitaryEqual(*original, *module, 1);
+  EXPECT_EQ(countOps<UOp>(), 1);
+  EXPECT_EQ(countOps<RXOp>(), 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(AllFixedGates, MergeFixedSingleQubitGateTest,
+                         testing::Values(FixedGateType::X, FixedGateType::Y,
+                                         FixedGateType::Z, FixedGateType::H,
+                                         FixedGateType::S, FixedGateType::Sdg,
+                                         FixedGateType::T, FixedGateType::Tdg,
+                                         FixedGateType::SX, FixedGateType::SXdg,
+                                         FixedGateType::Id));
+
 /**
- * @brief Test: Non-consecutive gates should not merge
+ * @brief Test: Gates separated by a barrier should not merge.
  */
-TEST_F(MergeSingleQubitRotationGatesTest, dontMergeNonConsecutiveGates) {
+TEST_F(MergeSingleQubitRotationGatesTest, dontMergeAcrossBarrier) {
   auto q = builder.allocQubitRegister(1);
 
   auto q1 = builder.rx(1.0, q[0]);
-  auto q2 = builder.h(q1);
+  auto q2 = builder.barrier({q1})[0];
   builder.ry(1.0, q2);
 
   module = builder.finalize();
 
   ASSERT_TRUE(runMergePass(module.get()).succeeded());
   EXPECT_EQ(countOps<RXOp>(), 1);
-  EXPECT_EQ(countOps<HOp>(), 1);
+  EXPECT_EQ(countOps<BarrierOp>(), 1);
   EXPECT_EQ(countOps<RYOp>(), 1);
   EXPECT_EQ(countOps<GPhaseOp>(), 0);
 }
@@ -696,7 +780,7 @@ TEST_F(MergeSingleQubitRotationGatesTest, mergeManyWithUnmergeable) {
                       {.type = GateType::RY, .angles = {2.}},
                       {.type = GateType::RZ, .angles = {3.}}},
                      q);
-  q = builder.h(q);
+  q = builder.barrier({q})[0];
   q = buildRotations({{.type = GateType::RZ, .angles = {4.}},
                       {.type = GateType::RY, .angles = {5.}},
                       {.type = GateType::RX, .angles = {6.}},
@@ -707,7 +791,7 @@ TEST_F(MergeSingleQubitRotationGatesTest, mergeManyWithUnmergeable) {
 
   ASSERT_TRUE(runMergePass(module.get()).succeeded());
   EXPECT_EQ(countOps<UOp>(), 2);
-  EXPECT_EQ(countOps<HOp>(), 1);
+  EXPECT_EQ(countOps<BarrierOp>(), 1);
   EXPECT_EQ(countOps<RXOp>(), 0);
   EXPECT_EQ(countOps<RYOp>(), 0);
   EXPECT_EQ(countOps<RZOp>(), 0);
@@ -744,6 +828,7 @@ TEST_F(MergeSingleQubitRotationGatesTest, mergeConsecutiveWithGateInBetween) {
 
 /**
  * @brief Test: RZ(PI)->RY(PI)->RX(PI) should merge into U(0, 0, 0)
+ * with a pi global phase.
  */
 TEST_F(MergeSingleQubitRotationGatesTest, numericalRotationIdentity) {
   ASSERT_TRUE(testGateMerge({{.type = GateType::RZ, .angles = {PI}},
@@ -753,9 +838,10 @@ TEST_F(MergeSingleQubitRotationGatesTest, numericalRotationIdentity) {
   EXPECT_EQ(countOps<UOp>(), 1);
   EXPECT_EQ(countOps<RYOp>(), 0);
   EXPECT_EQ(countOps<RZOp>(), 0);
-  EXPECT_EQ(countOps<GPhaseOp>(), 0);
+  EXPECT_EQ(countOps<GPhaseOp>(), 1);
   expectUGateParams(0., 0., 0.);
-  expectGPhaseParam(0.);
+  // In circuit order, RZ(pi);RY(pi);RX(pi) is -I rather than I.
+  expectGPhaseParam(PI);
 }
 
 /**
@@ -950,6 +1036,60 @@ TEST_F(MergeSingleQubitRotationGatesTest,
   EXPECT_FALSE(std::isnan(*phi));
   EXPECT_FALSE(std::isnan(*lambda));
   EXPECT_FALSE(std::isnan(*phase));
+}
+
+TEST_F(MergeSingleQubitRotationGatesTest,
+       mergeFixedGateWithDynamicRotationPreservesMatrix) {
+  constexpr double angle = 0.37;
+  auto q = builder.staticQubit(0);
+  q = builder.h(q);
+  q = builder.rz(angle, q);
+  builder.sink(q);
+  module = builder.finalize();
+
+  auto funcOp = cast<func::FuncOp>(module->getBody()->front());
+  const auto f64 = Float64Type::get(&context);
+  funcOp.insertArgument(0, f64, {}, funcOp.getLoc());
+
+  RZOp rzOp = nullptr;
+  module->walk([&](RZOp op) { rzOp = op; });
+  ASSERT_TRUE(rzOp);
+  rzOp.getThetaMutable().assign(funcOp.getArgument(0));
+
+  ASSERT_TRUE(runMergePass(*module).succeeded());
+  EXPECT_EQ(countOps<HOp>(), 0);
+  EXPECT_EQ(countOps<RZOp>(), 0);
+  EXPECT_EQ(countOps<UOp>(), 1);
+
+  UOp uOp = nullptr;
+  module->walk([&](UOp op) { uOp = op; });
+  ASSERT_TRUE(uOp);
+  EXPECT_TRUE(valueDependsOn(uOp.getTheta(), funcOp.getArgument(0)) ||
+              valueDependsOn(uOp.getPhi(), funcOp.getArgument(0)) ||
+              valueDependsOn(uOp.getLambda(), funcOp.getArgument(0)));
+
+  bindLeadingArgs(funcOp, {angle});
+  const auto theta = utils::valueToConstantDouble(uOp.getTheta());
+  const auto phi = utils::valueToConstantDouble(uOp.getPhi());
+  const auto lambda = utils::valueToConstantDouble(uOp.getLambda());
+  ASSERT_TRUE(theta.has_value());
+  ASSERT_TRUE(phi.has_value());
+  ASSERT_TRUE(lambda.has_value());
+  double globalPhase = 0.0;
+  module->walk([&](GPhaseOp op) {
+    const auto phase = utils::valueToConstantDouble(op.getParameter(0));
+    ASSERT_TRUE(phase.has_value());
+    globalPhase += *phase;
+  });
+  const auto actual =
+      UOp::unitaryMatrix(*theta, *phi, *lambda) * std::polar(1.0, globalPhase);
+  const auto halfAngle = angle / 2.0;
+  const std::complex<double> upperPhase = std::polar(1.0, -halfAngle);
+  const std::complex<double> lowerPhase = std::polar(1.0, halfAngle);
+  const double invSqrtTwo = 1.0 / std::numbers::sqrt2;
+  const Matrix2x2 expected{upperPhase * invSqrtTwo, upperPhase * invSqrtTwo,
+                           lowerPhase * invSqrtTwo, -lowerPhase * invSqrtTwo};
+  EXPECT_TRUE(actual.isApprox(expected, 1e-8));
 }
 
 /**

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
@@ -202,7 +202,7 @@ protected:
     EXPECT_NEAR(*param, expected, tolerance);
   }
 
-  Value buildRotations(ArrayRef<RotationGate> rotations, Value& q) {
+  Value buildRotations(ArrayRef<RotationGate> rotations, Value q) {
     auto qubit = q;
 
     for (const auto& gate : rotations) {

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -1461,6 +1461,7 @@ llvm::ArrayRef<OpenQASMProgram> standardPipelinePrograms() {
       OpenQASMProgram{.name = "controlled-inverse-pow-s",
                       .source = controlledInversePowS},
       OpenQASMProgram{.name = "nested-pow-x", .source = nestedPowX},
+      OpenQASMProgram{.name = "custom-pow-hs", .source = customPowHS},
       OpenQASMProgram{.name = "broadcast-pow-x", .source = broadcastPowX},
       OpenQASMProgram{.name = "floating-pow-x", .source = floatingPowX},
   };
@@ -1481,6 +1482,7 @@ llvm::ArrayRef<OpenQASMProgram> jeffCompatiblePrograms() {
       OpenQASMProgram{.name = "controlled-inverse-pow-s",
                       .source = controlledInversePowS},
       OpenQASMProgram{.name = "nested-pow-x", .source = nestedPowX},
+      OpenQASMProgram{.name = "custom-pow-hs", .source = customPowHS},
       OpenQASMProgram{.name = "broadcast-pow-x", .source = broadcastPowX},
       OpenQASMProgram{.name = "floating-pow-x", .source = floatingPowX},
       OpenQASMProgram{.name = "runtime-scalar-rounding",

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -1461,7 +1461,6 @@ llvm::ArrayRef<OpenQASMProgram> standardPipelinePrograms() {
       OpenQASMProgram{.name = "controlled-inverse-pow-s",
                       .source = controlledInversePowS},
       OpenQASMProgram{.name = "nested-pow-x", .source = nestedPowX},
-      OpenQASMProgram{.name = "custom-pow-hs", .source = customPowHS},
       OpenQASMProgram{.name = "broadcast-pow-x", .source = broadcastPowX},
       OpenQASMProgram{.name = "floating-pow-x", .source = floatingPowX},
   };
@@ -1501,6 +1500,7 @@ llvm::ArrayRef<OpenQASMProgram> jeffIncompatiblePrograms() {
       OpenQASMProgram{.name = "checked-integer-state",
                       .source = checkedIntegerState},
       OpenQASMProgram{.name = "dynamic-range", .source = dynamicRange},
+      OpenQASMProgram{.name = "custom-pow-hs", .source = customPowHS},
       OpenQASMProgram{.name = "bit-vector-builtins",
                       .source = bitVectorBuiltins},
   };

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -1461,6 +1461,7 @@ llvm::ArrayRef<OpenQASMProgram> standardPipelinePrograms() {
       OpenQASMProgram{.name = "controlled-inverse-pow-s",
                       .source = controlledInversePowS},
       OpenQASMProgram{.name = "nested-pow-x", .source = nestedPowX},
+      OpenQASMProgram{.name = "custom-pow-hs", .source = customPowHS},
       OpenQASMProgram{.name = "broadcast-pow-x", .source = broadcastPowX},
       OpenQASMProgram{.name = "floating-pow-x", .source = floatingPowX},
   };
@@ -1500,7 +1501,6 @@ llvm::ArrayRef<OpenQASMProgram> jeffIncompatiblePrograms() {
       OpenQASMProgram{.name = "checked-integer-state",
                       .source = checkedIntegerState},
       OpenQASMProgram{.name = "dynamic-range", .source = dynamicRange},
-      OpenQASMProgram{.name = "custom-pow-hs", .source = customPowHS},
       OpenQASMProgram{.name = "bit-vector-builtins",
                       .source = bitVectorBuiltins},
   };

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -1500,7 +1500,6 @@ llvm::ArrayRef<OpenQASMProgram> jeffIncompatiblePrograms() {
       OpenQASMProgram{.name = "checked-integer-state",
                       .source = checkedIntegerState},
       OpenQASMProgram{.name = "dynamic-range", .source = dynamicRange},
-      OpenQASMProgram{.name = "custom-pow-hs", .source = customPowHS},
       OpenQASMProgram{.name = "bit-vector-builtins",
                       .source = bitVectorBuiltins},
   };


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Extends the `MergeSingleQubitRotationGates` pass to merge fixed single-qubit gates in addition to parameterized rotation gates.

## Changes

- Adds quaternion representations and global-phase contributions for:
  - `X`, `Y`, `Z`, `H`
  - `S`, `Sdg`
  - `T`, `Tdg`
  - `SX`, `SXdg`
  - `Id`
- Supports chains containing both fixed gates and parameterized gates.
- Preserves symbolic SSA angles through the existing dynamic merge path.
- Accounts for global-phase changes introduced when canonicalizing ZYZ Euler angles.
- Updates the pass documentation.
- Updates the reference calculation script.

## Testing

- Added parameterized coverage for every newly supported fixed gate.
- Added a mixed fixed-gate/symbolic-angle test.
- Added exact pre-/post-pass DD functionality comparisons, including global phase.
- Corrected existing expected phases where the previous values did not preserve the complete unitary matrix.
- Replaced H with a barrier in tests where H previously served as an unmergeable boundary.

Fixes #1639
Fixes #1642 

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [ ] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
