### PR TITLE
✨ Canonicalize positive integral powers of constant `U` gates

### DIFF
--- a/mlir/include/mlir/Dialect/Utils/UGateUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/UGateUtils.h
@@ -47,8 +47,8 @@ powerUParameters(const double theta, const double phi, const double lambda,
   using Matrix = std::array<Complex, 4>;
   const auto multiply = [](const Matrix& lhs, const Matrix& rhs) {
     return Matrix{
-        lhs[0] * rhs[0] + lhs[1] * rhs[2], lhs[0] * rhs[1] + lhs[1] * rhs[3],
-        lhs[2] * rhs[0] + lhs[3] * rhs[2], lhs[2] * rhs[1] + lhs[3] * rhs[3]};
+        (lhs[0] * rhs[0]) + (lhs[1] * rhs[2]), (lhs[0] * rhs[1]) + (lhs[1] * rhs[3]),
+        (lhs[2] * rhs[0]) + (lhs[3] * rhs[2]), (lhs[2] * rhs[1]) + (lhs[3] * rhs[3])};
   };
 
   const double halfTheta = theta / 2.0;
@@ -70,7 +70,7 @@ powerUParameters(const double theta, const double phi, const double lambda,
     }
   }
 
-  const Complex determinant = result[0] * result[3] - result[1] * result[2];
+  const Complex determinant = (result[0] * result[3]) - (result[1] * result[2]);
   const double determinantArgument = std::arg(determinant);
   const double resultTheta =
       2.0 * std::atan2(std::abs(result[2]), std::abs(result[0]));

--- a/mlir/include/mlir/Dialect/Utils/UGateUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/UGateUtils.h
@@ -1,8 +1,11 @@
 /*
- * Copyright (c) 2026 Munich Quantum Software Company GmbH
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
  * All rights reserved.
  *
  * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
  */
 
 #pragma once
@@ -46,9 +49,10 @@ powerUParameters(const double theta, const double phi, const double lambda,
   using Complex = std::complex<double>;
   using Matrix = std::array<Complex, 4>;
   const auto multiply = [](const Matrix& lhs, const Matrix& rhs) {
-    return Matrix{
-        (lhs[0] * rhs[0]) + (lhs[1] * rhs[2]), (lhs[0] * rhs[1]) + (lhs[1] * rhs[3]),
-        (lhs[2] * rhs[0]) + (lhs[3] * rhs[2]), (lhs[2] * rhs[1]) + (lhs[3] * rhs[3])};
+    return Matrix{(lhs[0] * rhs[0]) + (lhs[1] * rhs[2]),
+                  (lhs[0] * rhs[1]) + (lhs[1] * rhs[3]),
+                  (lhs[2] * rhs[0]) + (lhs[3] * rhs[2]),
+                  (lhs[2] * rhs[1]) + (lhs[3] * rhs[3])};
   };
 
   const double halfTheta = theta / 2.0;

--- a/mlir/include/mlir/Dialect/Utils/UGateUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/UGateUtils.h
@@ -21,11 +21,17 @@
 
 namespace mlir::utils {
 
+/**
+ * @brief Parameters representing a powered U gate.
+ *
+ * All values are in radians. The phase satisfies
+ * `U(input)^exponent = exp(i * phase) * U(theta, phi, lambda)`.
+ */
 struct UPowerParameters {
-  double theta;
-  double phi;
-  double lambda;
-  double phase;
+  double theta;  ///< Resulting U rotation angle.
+  double phi;    ///< Resulting U phi angle.
+  double lambda; ///< Resulting U lambda angle.
+  double phase;  ///< Remaining global phase.
 };
 
 /**

--- a/mlir/include/mlir/Dialect/Utils/UGateUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/UGateUtils.h
@@ -16,10 +16,17 @@
 #include <cmath>
 #include <complex>
 #include <cstdint>
-#include <limits>
 #include <optional>
 
 namespace mlir::utils {
+
+/**
+ * Maximum exponent for numerically stable binary64 U-gate powering.
+ *
+ * The 2^10 cap keeps the O(n * epsilon) error accumulated by repeated
+ * squaring below the 1e-12 tolerance used by full-matrix equivalence tests.
+ */
+inline constexpr uint64_t MAX_SAFE_U_POWER_EXPONENT = 1024U;
 
 /**
  * @brief Parameters representing a powered U gate.
@@ -39,16 +46,15 @@ struct UPowerParameters {
  *
  * @return Parameters satisfying
  * `U(theta, phi, lambda)^exponent = exp(i*phase) * U(result)`, or
- * `std::nullopt` if @p exponent is not representable as a positive integer.
+ * `std::nullopt` if @p exponent is not a positive integer no greater than
+ * `MAX_SAFE_U_POWER_EXPONENT`.
  */
 [[nodiscard]] inline std::optional<UPowerParameters>
 powerUParameters(const double theta, const double phi, const double lambda,
                  const double exponent) {
-  // Above 2^53, binary64 can no longer represent every integer exactly.
-  if (const double maxExactInteger =
-          std::ldexp(1.0, std::numeric_limits<double>::digits);
-      !mlir::utils::isIntegerExponent(exponent) || exponent <= 0.0 ||
-      exponent > maxExactInteger) {
+  // Repeated squaring magnifies binary64 roundoff with every squared power.
+  if (!mlir::utils::isIntegerExponent(exponent) || exponent <= 0.0 ||
+      exponent > static_cast<double>(MAX_SAFE_U_POWER_EXPONENT)) {
     return std::nullopt;
   }
 

--- a/mlir/include/mlir/Dialect/Utils/UGateUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/UGateUtils.h
@@ -15,18 +15,25 @@
 #include <array>
 #include <cmath>
 #include <complex>
+#include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <numbers>
 #include <optional>
 
 namespace mlir::utils {
 
 /**
- * Maximum exponent for numerically stable binary64 U-gate powering.
+ * Maximum exponent considered for safe binary64 U-gate powering.
  *
- * The 2^10 cap keeps the O(n * epsilon) error accumulated by repeated
- * squaring below the 1e-12 tolerance used by full-matrix equivalence tests.
+ * Even with analytical SU(2) powering, uncertainty in the input angles is
+ * magnified by the exponent. Candidate rewrites are additionally checked
+ * against the source matrix before they are accepted.
  */
 inline constexpr uint64_t MAX_SAFE_U_POWER_EXPONENT = 1024U;
+
+/// Maximum entry-wise matrix error accepted for a powered U-gate rewrite.
+inline constexpr double U_POWER_EQUIVALENCE_TOLERANCE = 5e-13;
 
 /**
  * @brief Parameters representing a powered U gate.
@@ -47,56 +54,150 @@ struct UPowerParameters {
  * @return Parameters satisfying
  * `U(theta, phi, lambda)^exponent = exp(i*phase) * U(result)`, or
  * `std::nullopt` if @p exponent is not a positive integer no greater than
- * `MAX_SAFE_U_POWER_EXPONENT`.
+ * `MAX_SAFE_U_POWER_EXPONENT`, an input is not finite, or the binary64 result
+ * cannot be reconstructed within `U_POWER_EQUIVALENCE_TOLERANCE`.
  */
 [[nodiscard]] inline std::optional<UPowerParameters>
 powerUParameters(const double theta, const double phi, const double lambda,
                  const double exponent) {
-  // Repeated squaring magnifies binary64 roundoff with every squared power.
-  if (!mlir::utils::isIntegerExponent(exponent) || exponent <= 0.0 ||
+  if (!std::isfinite(theta) || !std::isfinite(phi) || !std::isfinite(lambda) ||
+      !mlir::utils::isIntegerExponent(exponent) || exponent <= 0.0 ||
       exponent > static_cast<double>(MAX_SAFE_U_POWER_EXPONENT)) {
     return std::nullopt;
   }
 
+  using Quaternion = std::array<double, 4>;
   using Complex = std::complex<double>;
   using Matrix = std::array<Complex, 4>;
+
+  // U(theta, phi, lambda) = exp(i * (phi + lambda) / 2) *
+  // RZ(phi) * RY(theta) * RZ(lambda). Represent the SU(2) factor by a unit
+  // quaternion and power it analytically by multiplying its axis angle.
+  const double halfTheta = theta / 2.0;
+  const double halfPhi = phi / 2.0;
+  const double halfLambda = lambda / 2.0;
+  const double cosTheta = std::cos(halfTheta);
+  const double sinTheta = std::sin(halfTheta);
+  const double cosPhi = std::cos(halfPhi);
+  const double sinPhi = std::sin(halfPhi);
+  const double cosLambda = std::cos(halfLambda);
+  const double sinLambda = std::sin(halfLambda);
+  Quaternion quaternion{
+      cosTheta * ((cosPhi * cosLambda) - (sinPhi * sinLambda)),
+      sinTheta * ((cosPhi * sinLambda) - (sinPhi * cosLambda)),
+      sinTheta * ((cosPhi * cosLambda) + (sinPhi * sinLambda)),
+      cosTheta * ((cosPhi * sinLambda) + (sinPhi * cosLambda))};
+  const double quaternionNorm =
+      std::hypot(std::hypot(quaternion[0], quaternion[1]),
+                 std::hypot(quaternion[2], quaternion[3]));
+  if (!std::isfinite(quaternionNorm) || quaternionNorm == 0.0) {
+    return std::nullopt;
+  }
+  for (double& component : quaternion) {
+    component /= quaternionNorm;
+  }
+
+  const auto integralExponent = static_cast<uint64_t>(exponent);
+  const double vectorNorm =
+      std::hypot(std::hypot(quaternion[1], quaternion[2]), quaternion[3]);
+  Quaternion poweredQuaternion{};
+  if (vectorNorm == 0.0) {
+    poweredQuaternion[0] =
+        quaternion[0] < 0.0 && (integralExponent & 1U) != 0U ? -1.0 : 1.0;
+  } else {
+    const double axisAngle = std::atan2(vectorNorm, quaternion[0]);
+    const double poweredAxisAngle =
+        std::remainder(exponent * axisAngle, 2.0 * std::numbers::pi);
+    const double vectorScale = std::sin(poweredAxisAngle) / vectorNorm;
+    poweredQuaternion = {
+        std::cos(poweredAxisAngle), quaternion[1] * vectorScale,
+        quaternion[2] * vectorScale, quaternion[3] * vectorScale};
+  }
+  const double poweredNorm =
+      std::hypot(std::hypot(poweredQuaternion[0], poweredQuaternion[1]),
+                 std::hypot(poweredQuaternion[2], poweredQuaternion[3]));
+  if (!std::isfinite(poweredNorm) || poweredNorm == 0.0) {
+    return std::nullopt;
+  }
+  for (double& component : poweredQuaternion) {
+    component /= poweredNorm;
+  }
+
+  const auto [w, x, y, z] = poweredQuaternion;
+  const double transverseNorm = std::hypot(x, y);
+  const double axialNorm = std::hypot(w, z);
+  const double gimbalTolerance = 32.0 * std::numeric_limits<double>::epsilon();
+  double resultTheta = 2.0 * std::atan2(transverseNorm, axialNorm);
+  double resultPhi = 0.0;
+  double resultLambda = 0.0;
+  if (transverseNorm <= gimbalTolerance) {
+    resultTheta = 0.0;
+    resultPhi = 2.0 * std::atan2(z, w);
+  } else if (axialNorm <= gimbalTolerance) {
+    resultTheta = std::numbers::pi;
+    resultPhi = 2.0 * std::atan2(-x, y);
+  } else {
+    const double angleSum = std::atan2(z, w);
+    const double angleDifference = std::atan2(-x, y);
+    resultPhi = angleSum + angleDifference;
+    resultLambda = angleSum - angleDifference;
+  }
+
+  constexpr double fourPi = 4.0 * std::numbers::pi;
+  const double inputPhase =
+      std::remainder((std::remainder(phi, fourPi) / 2.0) +
+                         (std::remainder(lambda, fourPi) / 2.0),
+                     2.0 * std::numbers::pi);
+  const double poweredPhase =
+      std::remainder(exponent * inputPhase, 2.0 * std::numbers::pi);
+  const double resultPhase =
+      std::remainder(poweredPhase - ((resultPhi + resultLambda) / 2.0),
+                     2.0 * std::numbers::pi);
+
+  // Binary64 evaluation of the source U matrix can itself deviate from an
+  // exact unitary for large angles, and powering magnifies that deviation.
+  // Reject a rewrite when the analytical unitary cannot represent the source
+  // operation closely enough for the dialect's full-matrix contract.
+  const Complex imaginary{0.0, 1.0};
+  const auto uMatrix = [&](const double matrixTheta, const double matrixPhi,
+                           const double matrixLambda) {
+    const double matrixCos = std::cos(matrixTheta / 2.0);
+    const double matrixSin = std::sin(matrixTheta / 2.0);
+    return Matrix{matrixCos,
+                  matrixSin *
+                      std::exp(imaginary * (matrixLambda + std::numbers::pi)),
+                  matrixSin * std::exp(imaginary * matrixPhi),
+                  matrixCos * std::exp(imaginary * (matrixPhi + matrixLambda))};
+  };
   const auto multiply = [](const Matrix& lhs, const Matrix& rhs) {
     return Matrix{(lhs[0] * rhs[0]) + (lhs[1] * rhs[2]),
                   (lhs[0] * rhs[1]) + (lhs[1] * rhs[3]),
                   (lhs[2] * rhs[0]) + (lhs[3] * rhs[2]),
                   (lhs[2] * rhs[1]) + (lhs[3] * rhs[3])};
   };
-
-  const double halfTheta = theta / 2.0;
-  const double c = std::cos(halfTheta);
-  const double s = std::sin(halfTheta);
-  const Complex imaginary{0.0, 1.0};
-  Matrix base{c, -s * std::exp(imaginary * lambda),
-              s * std::exp(imaginary * phi),
-              c * std::exp(imaginary * (phi + lambda))};
-  Matrix result{1.0, 0.0, 0.0, 1.0};
-  auto power = static_cast<uint64_t>(exponent);
+  Matrix base = uMatrix(theta, phi, lambda);
+  Matrix sourcePower{1.0, 0.0, 0.0, 1.0};
+  auto power = integralExponent;
   while (power != 0U) {
     if ((power & 1U) != 0U) {
-      result = multiply(result, base);
+      sourcePower = multiply(sourcePower, base);
     }
     power >>= 1U;
     if (power != 0U) {
       base = multiply(base, base);
     }
   }
-
-  const Complex determinant = (result[0] * result[3]) - (result[1] * result[2]);
-  const double determinantArgument = std::arg(determinant);
-  const double resultTheta =
-      2.0 * std::atan2(std::abs(result[2]), std::abs(result[0]));
-  const double angle1 = std::arg(result[3]);
-  const double angle2 =
-      std::abs(result[2]) > TOLERANCE ? std::arg(result[2]) : 0.0;
-  const double resultPhi = angle1 + angle2 - determinantArgument;
-  const double resultLambda = angle1 - angle2;
-  const double resultPhase =
-      0.5 * (determinantArgument - resultPhi - resultLambda);
+  Matrix reconstructed = uMatrix(resultTheta, resultPhi, resultLambda);
+  const Complex phase = std::exp(imaginary * resultPhase);
+  for (size_t i = 0; i < reconstructed.size(); ++i) {
+    reconstructed[i] *= phase;
+    if (!std::isfinite(sourcePower[i].real()) ||
+        !std::isfinite(sourcePower[i].imag()) ||
+        std::abs(sourcePower[i] - reconstructed[i]) >
+            U_POWER_EQUIVALENCE_TOLERANCE) {
+      return std::nullopt;
+    }
+  }
   return UPowerParameters{resultTheta, resultPhi, resultLambda, resultPhase};
 }
 

--- a/mlir/include/mlir/Dialect/Utils/UGateUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/UGateUtils.h
@@ -79,12 +79,8 @@ powerUParameters(const double theta, const double phi, const double lambda,
   const double resultTheta =
       2.0 * std::atan2(std::abs(result[2]), std::abs(result[0]));
   const double angle1 = std::arg(result[3]);
-  double angle2 = 0.0;
-  if (std::abs(result[2]) > TOLERANCE) {
-    angle2 = std::arg(result[2]);
-  } else if (std::abs(result[1]) > TOLERANCE) {
-    angle2 = std::arg(result[1]);
-  }
+  const double angle2 =
+      std::abs(result[2]) > TOLERANCE ? std::arg(result[2]) : 0.0;
   const double resultPhi = angle1 + angle2 - determinantArgument;
   const double resultLambda = angle1 - angle2;
   const double resultPhase =

--- a/mlir/include/mlir/Dialect/Utils/UGateUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/UGateUtils.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "mlir/Dialect/Utils/Utils.h"
+
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+namespace mlir::utils {
+
+struct UPowerParameters {
+  double theta;
+  double phi;
+  double lambda;
+  double phase;
+};
+
+/**
+ * @brief Compute a positive integral power of a constant U gate.
+ *
+ * @return Parameters satisfying
+ * `U(theta, phi, lambda)^exponent = exp(i*phase) * U(result)`, or
+ * `std::nullopt` if @p exponent is not representable as a positive integer.
+ */
+[[nodiscard]] inline std::optional<UPowerParameters>
+powerUParameters(const double theta, const double phi, const double lambda,
+                 const double exponent) {
+  // Above 2^53, binary64 can no longer represent every integer exactly.
+  if (const double maxExactInteger =
+          std::ldexp(1.0, std::numeric_limits<double>::digits);
+      !mlir::utils::isIntegerExponent(exponent) || exponent <= 0.0 ||
+      exponent > maxExactInteger) {
+    return std::nullopt;
+  }
+
+  using Complex = std::complex<double>;
+  using Matrix = std::array<Complex, 4>;
+  const auto multiply = [](const Matrix& lhs, const Matrix& rhs) {
+    return Matrix{
+        lhs[0] * rhs[0] + lhs[1] * rhs[2], lhs[0] * rhs[1] + lhs[1] * rhs[3],
+        lhs[2] * rhs[0] + lhs[3] * rhs[2], lhs[2] * rhs[1] + lhs[3] * rhs[3]};
+  };
+
+  const double halfTheta = theta / 2.0;
+  const double c = std::cos(halfTheta);
+  const double s = std::sin(halfTheta);
+  const Complex imaginary{0.0, 1.0};
+  Matrix base{c, -s * std::exp(imaginary * lambda),
+              s * std::exp(imaginary * phi),
+              c * std::exp(imaginary * (phi + lambda))};
+  Matrix result{1.0, 0.0, 0.0, 1.0};
+  auto power = static_cast<uint64_t>(exponent);
+  while (power != 0U) {
+    if ((power & 1U) != 0U) {
+      result = multiply(result, base);
+    }
+    power >>= 1U;
+    if (power != 0U) {
+      base = multiply(base, base);
+    }
+  }
+
+  const Complex determinant = result[0] * result[3] - result[1] * result[2];
+  const double determinantArgument = std::arg(determinant);
+  const double resultTheta =
+      2.0 * std::atan2(std::abs(result[2]), std::abs(result[0]));
+  const double angle1 = std::arg(result[3]);
+  double angle2 = 0.0;
+  if (std::abs(result[2]) > TOLERANCE) {
+    angle2 = std::arg(result[2]);
+  } else if (std::abs(result[1]) > TOLERANCE) {
+    angle2 = std::arg(result[1]);
+  }
+  const double resultPhi = angle1 + angle2 - determinantArgument;
+  const double resultLambda = angle1 - angle2;
+  const double resultPhase =
+      0.5 * (determinantArgument - resultPhi - resultLambda);
+  return UPowerParameters{resultTheta, resultPhi, resultLambda, resultPhase};
+}
+
+} // namespace mlir::utils

--- a/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/Dialect/Utils/UGateUtils.h"
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <llvm/ADT/SmallVector.h>
@@ -263,6 +264,8 @@ struct MoveCtrlOutsidePow final : OpRewritePattern<PowOp> {
  * - Phase/diagonal gates: named gate if angle matches, else `P` gate,
  *   e.g., `pow(r) { s } => s/sdg/t/tdg/z` or `p(r*π/2)`
  * - Hermitian gates (integer exponent): even => erase, odd => gate
+ * - Constant U gates (positive integer exponent): synthesize as a U gate and
+ *   phase
  * - Identity/barrier: pass through unchanged
  */
 struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
@@ -282,6 +285,20 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     const double r = *exponent;
     auto loc = op.getLoc();
 
+    std::optional<UPowerParameters> uPower;
+    if (auto uOp = dyn_cast<UOp>(innerOp)) {
+      const auto theta = valueToDouble(uOp.getTheta());
+      const auto phi = valueToDouble(uOp.getPhi());
+      const auto lambda = valueToDouble(uOp.getLambda());
+      if (!theta || !phi || !lambda) {
+        return failure();
+      }
+      uPower = powerUParameters(*theta, *phi, *lambda, r);
+      if (!uPower) {
+        return failure();
+      }
+    }
+
     // Scaling a gate parameter represents a principal matrix power only for an
     // integral exponent unless the parameter is known to remain within the
     // principal branch. Keep arbitrary parameters inside fractional powers.
@@ -298,8 +315,8 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     }
     if (!isa<GPhaseOp, XOp, YOp, ZOp, SOp, SdgOp, TOp, TdgOp, SXOp, SXdgOp, HOp,
              ECROp, RCCXOp, SWAPOp, RXOp, RYOp, RZOp, POp, ROp, RXXOp, RYYOp,
-             RZXOp, RZZOp, XXPlusYYOp, XXMinusYYOp, iSWAPOp, IdOp, BarrierOp>(
-            innerOp)) {
+             RZXOp, RZZOp, XXPlusYYOp, XXMinusYYOp, iSWAPOp, UOp, IdOp,
+             BarrierOp>(innerOp)) {
       return failure();
     }
 
@@ -341,6 +358,16 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
           auto mul = scaleByExponent(gate.getTheta(), op, rewriter);
           rewriter.replaceOpWithNewOp<decltype(gate)>(
               op, op.getTarget(0), op.getTarget(1), mul, gate.getBeta());
+          return success();
+        })
+        // pow(n) { u(theta, phi, lambda) } =>
+        // gphase(delta); u(theta', phi', lambda')
+        .Case<UOp>([&](auto) {
+          if (std::abs(normalizeAngle(uPower->phase)) > TOLERANCE) {
+            GPhaseOp::create(rewriter, loc, uPower->phase);
+          }
+          rewriter.replaceOpWithNewOp<UOp>(op, op.getTarget(0), uPower->theta,
+                                           uPower->phi, uPower->lambda);
           return success();
         })
         // --- Pauli gates: decompose to rotation + global phase ---

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -12,6 +12,7 @@
 
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/Utils/Utils.h"
@@ -1445,6 +1446,19 @@ OwningOpRef<ModuleOp> QCOProgramBuilder::finalize(ValueRange returnValues) {
       insertionBlock != &mainFunc.getBody().front()) {
     llvm::reportFatalUsageError(
         "Insertion point is not in entry block of main function");
+  }
+
+  // Returning a linear value is its final consumption. Remove such values from
+  // the live sets before automatically disposing of everything left over.
+  for (const auto returnValue : returnValues) {
+    const auto type = returnValue.getType();
+    if (isa<QubitType>(type)) {
+      validateQubitValue(returnValue);
+      validQubits.erase(returnValue);
+    } else if (isLinearQubitType(type)) {
+      validateTensorValue(returnValue);
+      validTensors.erase(returnValue);
+    }
   }
 
   DenseSet<int64_t> validTensorIds;

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -145,8 +145,12 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
 
     // Special case for single control: replace with a single POp
     if (op.getNumControls() == 1) {
-      rewriter.replaceOpWithNewOp<POp>(op, op.getInputControl(0),
-                                       gPhaseOp.getTheta());
+      auto pOp = POp::create(rewriter, op.getLoc(), op.getInputControl(0),
+                             gPhaseOp.getTheta());
+      // The phase acts only on the control; every target passes through.
+      SmallVector<Value> outputs{pOp.getOutputQubit(0)};
+      llvm::append_range(outputs, op.getTargetsIn());
+      rewriter.replaceOp(op, outputs);
       return success();
     }
 

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QCO/Utils/Matrix.h"
+#include "mlir/Dialect/Utils/UGateUtils.h"
 #include "mlir/Dialect/Utils/Utils.h"
 
 #include <llvm/ADT/STLExtras.h>
@@ -299,6 +300,8 @@ struct MoveCtrlOutsidePow final : OpRewritePattern<PowOp> {
  * - Phase/diagonal gates: named gate if angle matches, else `P` gate,
  *   e.g., `pow(r) { s } => s/sdg/t/tdg/z` or `p(r*π/2)`
  * - Hermitian gates (integer exponent): even => erase, odd => gate
+ * - Constant U gates (positive integer exponent): synthesize as a U gate and
+ *   phase
  * - Identity/barrier: pass through unchanged
  */
 struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
@@ -319,6 +322,20 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     const double r = *exponent;
     auto loc = op.getLoc();
 
+    std::optional<UPowerParameters> uPower;
+    if (auto uOp = dyn_cast<UOp>(innerOp)) {
+      const auto theta = valueToDouble(uOp.getTheta());
+      const auto phi = valueToDouble(uOp.getPhi());
+      const auto lambda = valueToDouble(uOp.getLambda());
+      if (!theta || !phi || !lambda) {
+        return failure();
+      }
+      uPower = powerUParameters(*theta, *phi, *lambda, r);
+      if (!uPower) {
+        return failure();
+      }
+    }
+
     // Scaling a gate parameter represents a principal matrix power only for an
     // integral exponent unless the parameter is known to remain within the
     // principal branch. Keep arbitrary parameters inside fractional powers.
@@ -335,8 +352,8 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     }
     if (!isa<GPhaseOp, XOp, YOp, ZOp, SOp, SdgOp, TOp, TdgOp, SXOp, SXdgOp, HOp,
              ECROp, RCCXOp, SWAPOp, RXOp, RYOp, RZOp, POp, ROp, RXXOp, RYYOp,
-             RZXOp, RZZOp, XXPlusYYOp, XXMinusYYOp, iSWAPOp, IdOp, BarrierOp>(
-            innerOp)) {
+             RZXOp, RZZOp, XXPlusYYOp, XXMinusYYOp, iSWAPOp, UOp, IdOp,
+             BarrierOp>(innerOp)) {
       return failure();
     }
 
@@ -380,6 +397,17 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
               rewriter.replaceOpWithNewOp<decltype(gate)>(
                   op, op.getInputTarget(0), op.getInputTarget(1), mul,
                   gate.getBeta());
+              return success();
+            })
+            // pow(n) { u(theta, phi, lambda) } =>
+            // gphase(delta); u(theta', phi', lambda')
+            .Case<UOp>([&](auto) {
+              if (std::abs(normalizeAngle(uPower->phase)) > TOLERANCE) {
+                GPhaseOp::create(rewriter, loc, uPower->phase);
+              }
+              rewriter.replaceOpWithNewOp<UOp>(op, op.getInputTarget(0),
+                                               uPower->theta, uPower->phi,
+                                               uPower->lambda);
               return success();
             })
             // --- Pauli gates: decompose to rotation + global phase ---

--- a/mlir/lib/Dialect/QCO/IR/QubitManagement/SinkOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QubitManagement/SinkOp.cpp
@@ -31,9 +31,6 @@ struct RemoveAllocSinkPair final : OpRewritePattern<SinkOp> {
 
   LogicalResult matchAndRewrite(SinkOp op,
                                 PatternRewriter& rewriter) const override {
-    if (!op.getQubit().hasOneUse()) {
-      return failure();
-    }
     auto* defOp = op.getQubit().getDefiningOp();
     if (!isa_and_nonnull<AllocOp, StaticOp>(defOp)) {
       return failure();

--- a/mlir/lib/Dialect/QCO/IR/QubitManagement/SinkOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QubitManagement/SinkOp.cpp
@@ -31,6 +31,9 @@ struct RemoveAllocSinkPair final : OpRewritePattern<SinkOp> {
 
   LogicalResult matchAndRewrite(SinkOp op,
                                 PatternRewriter& rewriter) const override {
+    if (!op.getQubit().hasOneUse()) {
+      return failure();
+    }
     auto* defOp = op.getQubit().getDefiningOp();
     if (!isa_and_nonnull<AllocOp, StaticOp>(defOp)) {
       return failure();

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -17,6 +17,7 @@
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/ErrorHandling.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
@@ -28,8 +29,8 @@
 namespace mlir::qco {
 
 bool WireIterator::isSinkLikeOperation(Operation* op) {
-  return isa<SinkOp, YieldOp, qtensor::InsertOp, scf::ConditionOp,
-             scf::YieldOp>(op);
+  return isa<SinkOp, YieldOp, qtensor::InsertOp, scf::ConditionOp, scf::YieldOp,
+             func::ReturnOp>(op);
 }
 
 bool WireIterator::isSourceLikeOperation(Operation* op) {

--- a/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
+++ b/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Conversion/QCOToJeff/QCOToJeff.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
 #include "qco_programs.h"
@@ -31,6 +32,7 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/OwningOpRef.h>
@@ -42,6 +44,7 @@
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/Passes.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <ostream>
@@ -55,6 +58,7 @@ struct JeffRoundTripTestCase {
   std::string name;
   mqt::test::NamedMLIRBuilder<qco::QCOProgramBuilder> programBuilder;
   mqt::test::NamedMLIRBuilder<qco::QCOProgramBuilder> referenceBuilder;
+  bool expectPowAfterCleanup = false;
 
   friend std::ostream& operator<<(std::ostream& os,
                                   const JeffRoundTripTestCase& info);
@@ -93,9 +97,8 @@ static Value measureToRegister(qco::QCOProgramBuilder& b, ValueRange qubits) {
   return c;
 }
 
-// DCX and U are the only gates that `FoldPowIntoGate` leaves alone, so they are
-// the only way to get a power modifier past the QCO cleanup pipeline and into
-// the jeff conversion.
+// DCX and U gates with dynamic parameters survive `FoldPowIntoGate`, so they
+// exercise power modifiers that reach the jeff conversion.
 
 static Value powDcx(qco::QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(2);
@@ -157,6 +160,15 @@ static Value powU(qco::QCOProgramBuilder& b) {
   const auto powOut =
       b.pow(3.0, q[0], [&](Value qubit) { return b.u(0.1, 0.2, 0.3, qubit); });
   return b.measure(powOut).second;
+}
+
+static void makePowUParameterDynamic(ModuleOp program) {
+  auto funcOp = cast<func::FuncOp>(program.getBody()->front());
+  ASSERT_TRUE(succeeded(funcOp.insertArgument(
+      0, Float64Type::get(program.getContext()), {}, funcOp.getLoc())));
+  auto powOp = *funcOp.getBody().getOps<qco::PowOp>().begin();
+  auto uOp = *powOp.getBody()->getOps<qco::UOp>().begin();
+  uOp.getThetaMutable().assign(funcOp.getArgument(0));
 }
 
 static Value ifWithAngle(qco::QCOProgramBuilder& b) {
@@ -435,18 +447,27 @@ module {
 }
 
 TEST_P(JeffRoundTripTest, ProgramEquivalence) {
-  const auto& [nameStr, programBuilder, referenceBuilder] = GetParam();
+  const auto& [nameStr, programBuilder, referenceBuilder,
+               expectPowAfterCleanup] = GetParam();
   const auto name = " (" + nameStr + ")";
   mqt::test::DeferredPrinter printer;
 
   auto program = mqt::test::buildMLIRProgram(context.get(), programBuilder);
   ASSERT_TRUE(program);
+  if (expectPowAfterCleanup) {
+    makePowUParameterDynamic(*program);
+  }
   printer.record(program.get(), "Original QCO IR" + name);
   EXPECT_TRUE(verify(*program).succeeded());
 
   EXPECT_TRUE(runQCOCleanupPipeline(program.get()).succeeded());
   printer.record(program.get(), "Canonicalized QCO IR" + name);
   EXPECT_TRUE(verify(*program).succeeded());
+  if (expectPowAfterCleanup) {
+    size_t powCount = 0;
+    program->walk([&](qco::PowOp) { ++powCount; });
+    EXPECT_EQ(powCount, 1U);
+  }
 
   EXPECT_TRUE(succeeded(convertQCOToJeff(program.get())));
   printer.record(program.get(), "Converted jeff IR" + name);
@@ -475,6 +496,9 @@ TEST_P(JeffRoundTripTest, ProgramEquivalence) {
 
   auto reference = mqt::test::buildMLIRProgram(context.get(), referenceBuilder);
   ASSERT_TRUE(reference);
+  if (expectPowAfterCleanup) {
+    makePowUParameterDynamic(*reference);
+  }
   printer.record(reference.get(), "Reference QCO IR" + name);
   EXPECT_TRUE(verify(*reference).succeeded());
 
@@ -527,7 +551,7 @@ INSTANTIATE_TEST_SUITE_P(
         JeffRoundTripTestCase{"CtrlPowInvDcx", MQT_NAMED_BUILDER(ctrlPowInvDcx),
                               MQT_NAMED_BUILDER(ctrlPowInvDcx)},
         JeffRoundTripTestCase{"PowU", MQT_NAMED_BUILDER(powU),
-                              MQT_NAMED_BUILDER(powU)}));
+                              MQT_NAMED_BUILDER(powU), true}));
 /// @}
 
 /// \name JeffRoundTrip/Operations/StandardGates/BarrierOp.cpp

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -579,8 +579,8 @@ TEST_F(QCTest, PowUWithDynamicParameterDoesNotCanonicalize) {
   ASSERT_TRUE(program);
 
   auto funcOp = cast<func::FuncOp>(program->getBody()->front());
-  funcOp.insertArgument(0, Float64Type::get(context.get()), {},
-                        funcOp.getLoc());
+  ASSERT_TRUE(succeeded(funcOp.insertArgument(
+      0, Float64Type::get(context.get()), {}, funcOp.getLoc())));
   auto powOp = *funcOp.getBody().getOps<PowOp>().begin();
   auto uOp = *powOp.getBody()->getOps<UOp>().begin();
   uOp.getThetaMutable().assign(funcOp.getArgument(0));

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -569,6 +569,41 @@ TEST_F(QCTest, PositiveIntegralPowUCanonicalizes) {
   }
 }
 
+TEST_F(QCTest, PowUWithDynamicParameterDoesNotCanonicalize) {
+  auto program = QCProgramBuilder::build(context.get(), [&](auto& builder) {
+    auto q = builder.allocQubitRegister(1);
+    builder.pow(2.0, q[0], [&](Value arg) { builder.u(0.1, 0.2, 0.3, arg); });
+    return builder.measure(q[0]);
+  });
+  ASSERT_TRUE(program);
+
+  auto funcOp = cast<func::FuncOp>(program->getBody()->front());
+  funcOp.insertArgument(0, Float64Type::get(context.get()), {},
+                        funcOp.getLoc());
+  auto powOp = *funcOp.getBody().getOps<PowOp>().begin();
+  auto uOp = *powOp.getBody()->getOps<UOp>().begin();
+  uOp.getThetaMutable().assign(funcOp.getArgument(0));
+
+  ASSERT_TRUE(runQCCleanupPipeline(program.get()).succeeded());
+  EXPECT_TRUE(program->getBody()
+                  ->walk([](PowOp) { return WalkResult::interrupt(); })
+                  .wasInterrupted());
+}
+
+TEST_F(QCTest, FractionalPowUDoesNotCanonicalize) {
+  auto program = QCProgramBuilder::build(context.get(), [&](auto& builder) {
+    auto q = builder.allocQubitRegister(1);
+    builder.pow(0.5, q[0], [&](Value arg) { builder.u(0.1, 0.2, 0.3, arg); });
+    return builder.measure(q[0]);
+  });
+  ASSERT_TRUE(program);
+
+  ASSERT_TRUE(runQCCleanupPipeline(program.get()).succeeded());
+  EXPECT_TRUE(program->getBody()
+                  ->walk([](PowOp) { return WalkResult::interrupt(); })
+                  .wasInterrupted());
+}
+
 TEST_F(QCTest, NestedPowAcrossBranchCutDoesNotMerge) {
   auto program = mqt::test::buildMLIRProgram(
       context.get(), MQT_NAMED_BUILDER(nestedPowBranchCut));

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -564,7 +564,7 @@ TEST_F(QCTest, PositiveIntegralPowUCanonicalizes) {
     ASSERT_TRUE(program);
 
     ASSERT_TRUE(runQCCleanupPipeline(program.get()).succeeded());
-    std::size_t powCount = 0;
+    size_t powCount = 0;
     program->walk([&](PowOp) { ++powCount; });
     EXPECT_EQ(powCount, 0U);
   }
@@ -586,9 +586,9 @@ TEST_F(QCTest, PowUWithDynamicParameterDoesNotCanonicalize) {
   uOp.getThetaMutable().assign(funcOp.getArgument(0));
 
   ASSERT_TRUE(runQCCleanupPipeline(program.get()).succeeded());
-  EXPECT_TRUE(program->getBody()
-                  ->walk([](PowOp) { return WalkResult::interrupt(); })
-                  .wasInterrupted());
+  size_t powCount = 0;
+  program->walk([&](PowOp) { ++powCount; });
+  EXPECT_EQ(powCount, 1U);
 }
 
 TEST_F(QCTest, FractionalPowUDoesNotCanonicalize) {
@@ -600,9 +600,9 @@ TEST_F(QCTest, FractionalPowUDoesNotCanonicalize) {
   ASSERT_TRUE(program);
 
   ASSERT_TRUE(runQCCleanupPipeline(program.get()).succeeded());
-  EXPECT_TRUE(program->getBody()
-                  ->walk([](PowOp) { return WalkResult::interrupt(); })
-                  .wasInterrupted());
+  size_t powCount = 0;
+  program->walk([&](PowOp) { ++powCount; });
+  EXPECT_EQ(powCount, 1U);
 }
 
 TEST_F(QCTest, NestedPowAcrossBranchCutDoesNotMerge) {

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -26,9 +26,9 @@
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
-#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Matchers.h>
 #include <mlir/IR/OwningOpRef.h>

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -28,6 +28,7 @@
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Matchers.h>
 #include <mlir/IR/OwningOpRef.h>

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -552,6 +552,23 @@ TEST_F(QCTest, PowExponentIsUnitaryParameter) {
   EXPECT_EQ(unitary.getParameters().front(), powOp.getExponent());
 }
 
+TEST_F(QCTest, PositiveIntegralPowUCanonicalizes) {
+  for (const double exponent : {2.0, 3.0, 17.0}) {
+    auto program = QCProgramBuilder::build(context.get(), [&](auto& builder) {
+      auto q = builder.allocQubitRegister(1);
+      builder.pow(exponent, q[0],
+                  [&](Value arg) { builder.u(0.1, 0.2, 0.3, arg); });
+      return builder.measure(q[0]);
+    });
+    ASSERT_TRUE(program);
+
+    ASSERT_TRUE(runQCCleanupPipeline(program.get()).succeeded());
+    std::size_t powCount = 0;
+    program->walk([&](PowOp) { ++powCount; });
+    EXPECT_EQ(powCount, 0U);
+  }
+}
+
 TEST_F(QCTest, NestedPowAcrossBranchCutDoesNotMerge) {
   auto program = mqt::test::buildMLIRProgram(
       context.get(), MQT_NAMED_BUILDER(nestedPowBranchCut));

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -167,13 +167,41 @@ TEST_F(QCOTest, CleanupPreservesReturnedStaticQubit) {
       context.get(), [&](auto& builder) { return builder.staticQubit(0); });
   ASSERT_TRUE(module);
 
+  auto mainFunc = *module->getOps<func::FuncOp>().begin();
+  auto returnOp = cast<func::ReturnOp>(mainFunc.getBody().front().back());
+  ASSERT_EQ(returnOp.getNumOperands(), 1U);
+  const auto returnedQubit = returnOp.getOperand(0);
+  EXPECT_TRUE(returnedQubit.getDefiningOp<StaticOp>());
+  EXPECT_TRUE(returnedQubit.hasOneUse());
+  EXPECT_EQ(*returnedQubit.user_begin(), returnOp.getOperation());
+  EXPECT_TRUE(mainFunc.getBody().getOps<SinkOp>().empty());
+
   ASSERT_TRUE(runQCOCleanupPipeline(*module).succeeded());
   EXPECT_TRUE(verify(*module).succeeded());
+
+  returnOp = cast<func::ReturnOp>(mainFunc.getBody().front().back());
+  EXPECT_TRUE(returnOp.getOperand(0).getDefiningOp<StaticOp>());
+}
+
+TEST_F(QCOTest, CleanupPreservesReturnedQubitTensor) {
+  auto module = QCOProgramBuilder::build(
+      context.get(), [&](auto& builder) { return builder.qtensorAlloc(2); });
+  ASSERT_TRUE(module);
 
   auto mainFunc = *module->getOps<func::FuncOp>().begin();
   auto returnOp = cast<func::ReturnOp>(mainFunc.getBody().front().back());
   ASSERT_EQ(returnOp.getNumOperands(), 1U);
-  EXPECT_TRUE(returnOp.getOperand(0).getDefiningOp<StaticOp>());
+  const auto returnedTensor = returnOp.getOperand(0);
+  EXPECT_TRUE(returnedTensor.getDefiningOp<qtensor::AllocOp>());
+  EXPECT_TRUE(returnedTensor.hasOneUse());
+  EXPECT_EQ(*returnedTensor.user_begin(), returnOp.getOperation());
+  EXPECT_TRUE(mainFunc.getBody().getOps<qtensor::DeallocOp>().empty());
+
+  ASSERT_TRUE(runQCOCleanupPipeline(*module).succeeded());
+  EXPECT_TRUE(verify(*module).succeeded());
+
+  returnOp = cast<func::ReturnOp>(mainFunc.getBody().front().back());
+  EXPECT_TRUE(returnOp.getOperand(0).getDefiningOp<qtensor::AllocOp>());
 }
 
 TEST_F(QCOTest, BuilderRejectsUntrackedTensorInitArg) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -162,6 +162,20 @@ TEST_F(QCOTest, BuilderReturnsTrackedQubit) {
   EXPECT_NO_FATAL_FAILURE(builder.x(output));
 }
 
+TEST_F(QCOTest, CleanupPreservesReturnedStaticQubit) {
+  auto module = QCOProgramBuilder::build(
+      context.get(), [&](auto& builder) { return builder.staticQubit(0); });
+  ASSERT_TRUE(module);
+
+  ASSERT_TRUE(runQCOCleanupPipeline(*module).succeeded());
+  EXPECT_TRUE(verify(*module).succeeded());
+
+  auto mainFunc = *module->getOps<func::FuncOp>().begin();
+  auto returnOp = cast<func::ReturnOp>(mainFunc.getBody().front().back());
+  ASSERT_EQ(returnOp.getNumOperands(), 1U);
+  EXPECT_TRUE(returnOp.getOperand(0).getDefiningOp<StaticOp>());
+}
+
 TEST_F(QCOTest, BuilderRejectsUntrackedTensorInitArg) {
   EXPECT_DEATH(
       {
@@ -1317,6 +1331,30 @@ TEST_F(QCOTest, CtrlPowSxExpands) {
   EXPECT_EQ(gphaseCount, 0) << "controlled GPhase must be extracted";
   EXPECT_EQ(pCount, 1) << "controlled GPhase must become P on the control";
   EXPECT_EQ(rxCount, 1) << "SX fold must emit an RX";
+}
+
+TEST_F(QCOTest, CtrlGPhasePassesTargetsThrough) {
+  auto program = QCOProgramBuilder::build(context.get(), [&](auto& builder) {
+    auto controlIn = builder.staticQubit(0);
+    auto targetIn = builder.staticQubit(1);
+    const auto [control, target] =
+        builder.ctrl(controlIn, targetIn, [&](Value targetArg) {
+          builder.gphase(0.123);
+          return targetArg;
+        });
+    return SmallVector<Value>{control, target};
+  });
+  ASSERT_TRUE(program);
+
+  ASSERT_TRUE(runQCOCleanupPipeline(*program).succeeded());
+  ASSERT_TRUE(verify(*program).succeeded());
+
+  auto mainFunc = *program->getOps<func::FuncOp>().begin();
+  auto returnOp = cast<func::ReturnOp>(mainFunc.getBody().front().back());
+  ASSERT_EQ(returnOp.getNumOperands(), 2U);
+  EXPECT_TRUE(returnOp.getOperand(0).getDefiningOp<POp>());
+  EXPECT_TRUE(returnOp.getOperand(1).getDefiningOp<StaticOp>());
+  EXPECT_TRUE(mainFunc.getBody().getOps<CtrlOp>().empty());
 }
 
 /// \name QCO/Operations/StandardGates/BarrierOp.cpp

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
@@ -567,6 +567,50 @@ TEST_F(QCOMatrixTest, PhaseProducingPowFoldsPreserveFullMatrixUnderControl) {
   }
 }
 
+TEST_F(QCOMatrixTest, IntegralPowUFoldsPreserveFullMatrixUnderControl) {
+  for (const auto& [theta, phi, lambda, exponent] :
+       {std::tuple{0.1, 0.2, 0.3, 2.0}, std::tuple{1.7, -2.1, 0.4, 3.0},
+        std::tuple{std::numbers::pi, 0.7, -1.2, 8.0},
+        std::tuple{0.0, 0.3, 0.8, 17.0}}) {
+    auto moduleOp = QCOProgramBuilder::build(context.get(), [&](auto& b) {
+      auto controlIn = b.staticQubit(0);
+      auto targetIn = b.staticQubit(1);
+      const auto [control, target] =
+          b.ctrl(controlIn, targetIn, [&](Value targetArg) -> Value {
+            return b.pow(exponent, targetArg, [&](Value powArg) {
+              return b.u(theta, phi, lambda, powArg);
+            });
+          });
+      return SmallVector<Value>{control, target};
+    });
+    ASSERT_TRUE(moduleOp);
+    OwningOpRef<ModuleOp> expected(cast<ModuleOp>((*moduleOp)->clone()));
+
+    ASSERT_TRUE(runQCOCleanupPipeline(*moduleOp).succeeded());
+    ASSERT_TRUE(verify(*moduleOp).succeeded());
+    mqt::test::expectFullUnitaryEqual(*expected, *moduleOp, 2);
+
+    std::size_t powCount = 0;
+    moduleOp->walk([&](PowOp) { ++powCount; });
+    EXPECT_EQ(powCount, 0U);
+  }
+}
+
+TEST_F(QCOMatrixTest, FractionalPowURemainsUnchanged) {
+  auto moduleOp = QCOProgramBuilder::build(context.get(), [](auto& b) {
+    auto q = b.staticQubit(0);
+    q = b.pow(0.5, q, [&](Value arg) { return b.u(0.1, 0.2, 0.3, arg); });
+    return SmallVector<Value>{q};
+  });
+  ASSERT_TRUE(moduleOp);
+
+  ASSERT_TRUE(runQCOCleanupPipeline(*moduleOp).succeeded());
+  EXPECT_EQ(llvm::range_size(cast<func::FuncOp>(moduleOp->getBody()->front())
+                                 .getBody()
+                                 .getOps<PowOp>()),
+            1U);
+}
+
 TEST_F(QCOMatrixTest, FractionalParameterizedPowDoesNotFold) {
   for (const double angle : {std::numbers::pi - 1e-12, std::numbers::pi + 1e-12,
                              3.0 * std::numbers::pi}) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
@@ -590,7 +590,7 @@ TEST_F(QCOMatrixTest, IntegralPowUFoldsPreserveFullMatrixUnderControl) {
     ASSERT_TRUE(verify(*moduleOp).succeeded());
     mqt::test::expectFullUnitaryEqual(*expected, *moduleOp, 2);
 
-    std::size_t powCount = 0;
+    size_t powCount = 0;
     moduleOp->walk([&](PowOp) { ++powCount; });
     EXPECT_EQ(powCount, 0U);
   }

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QCO/Utils/Matrix.h"
+#include "mlir/Dialect/Utils/UGateUtils.h"
 #include "mlir/Support/Passes.h"
 #include "qco_programs.h"
 
@@ -571,7 +572,9 @@ TEST_F(QCOMatrixTest, IntegralPowUFoldsPreserveFullMatrixUnderControl) {
   for (const auto& [theta, phi, lambda, exponent] :
        {std::tuple{0.1, 0.2, 0.3, 2.0}, std::tuple{1.7, -2.1, 0.4, 3.0},
         std::tuple{std::numbers::pi, 0.7, -1.2, 8.0},
-        std::tuple{0.0, 0.3, 0.8, 17.0}}) {
+        std::tuple{0.0, 0.3, 0.8, 17.0},
+        std::tuple{0.1, 0.2, 0.3,
+                   static_cast<double>(utils::MAX_SAFE_U_POWER_EXPONENT)}}) {
     auto moduleOp = QCOProgramBuilder::build(context.get(), [&](auto& b) {
       auto controlIn = b.staticQubit(0);
       auto targetIn = b.staticQubit(1);
@@ -594,6 +597,31 @@ TEST_F(QCOMatrixTest, IntegralPowUFoldsPreserveFullMatrixUnderControl) {
     moduleOp->walk([&](PowOp) { ++powCount; });
     EXPECT_EQ(powCount, 0U);
   }
+}
+
+TEST_F(QCOMatrixTest, PowUBeyondSafeExponentRemainsUnchanged) {
+  constexpr double exponent =
+      static_cast<double>(utils::MAX_SAFE_U_POWER_EXPONENT) + 1.0;
+  auto moduleOp = QCOProgramBuilder::build(context.get(), [&](auto& b) {
+    auto controlIn = b.staticQubit(0);
+    auto targetIn = b.staticQubit(1);
+    const auto [control, target] =
+        b.ctrl(controlIn, targetIn, [&](Value targetArg) -> Value {
+          return b.pow(exponent, targetArg, [&](Value powArg) {
+            return b.u(0.1, 0.2, 0.3, powArg);
+          });
+        });
+    return SmallVector<Value>{control, target};
+  });
+  ASSERT_TRUE(moduleOp);
+  OwningOpRef<ModuleOp> expected(cast<ModuleOp>((*moduleOp)->clone()));
+
+  ASSERT_TRUE(runQCOCleanupPipeline(*moduleOp).succeeded());
+  ASSERT_TRUE(verify(*moduleOp).succeeded());
+  mqt::test::expectFullUnitaryEqual(*expected, *moduleOp, 2);
+  size_t powCount = 0;
+  moduleOp->walk([&](PowOp) { ++powCount; });
+  EXPECT_EQ(powCount, 1U);
 }
 
 TEST_F(QCOMatrixTest, FractionalPowURemainsUnchanged) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
@@ -624,6 +624,35 @@ TEST_F(QCOMatrixTest, PowUBeyondSafeExponentRemainsUnchanged) {
   EXPECT_EQ(powCount, 1U);
 }
 
+TEST_F(QCOMatrixTest, NumericallyUnstableIntegralPowURemainsUnchanged) {
+  for (const auto& [theta, phi, lambda, exponent] :
+       {std::tuple{-4.7851911486806245, -18.3028077007916, -18.79029150092365,
+                   1017.0},
+        std::tuple{1123.1619760536523, -8607.999542206799, -9908.553022954226,
+                   2.0}}) {
+    auto moduleOp = QCOProgramBuilder::build(context.get(), [&](auto& b) {
+      auto controlIn = b.staticQubit(0);
+      auto targetIn = b.staticQubit(1);
+      const auto [control, target] =
+          b.ctrl(controlIn, targetIn, [&](Value targetArg) -> Value {
+            return b.pow(exponent, targetArg, [&](Value powArg) {
+              return b.u(theta, phi, lambda, powArg);
+            });
+          });
+      return SmallVector<Value>{control, target};
+    });
+    ASSERT_TRUE(moduleOp);
+    OwningOpRef<ModuleOp> expected(cast<ModuleOp>((*moduleOp)->clone()));
+
+    ASSERT_TRUE(runQCOCleanupPipeline(*moduleOp).succeeded());
+    ASSERT_TRUE(verify(*moduleOp).succeeded());
+    mqt::test::expectFullUnitaryEqual(*expected, *moduleOp, 2);
+    size_t powCount = 0;
+    moduleOp->walk([&](PowOp) { ++powCount; });
+    EXPECT_EQ(powCount, 1U);
+  }
+}
+
 TEST_F(QCOMatrixTest, FractionalPowURemainsUnchanged) {
   auto moduleOp = QCOProgramBuilder::build(context.get(), [](auto& b) {
     auto q = b.staticQubit(0);

--- a/mlir/unittests/Dialect/QCO/Utils/test_wireiterator.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_wireiterator.cpp
@@ -228,6 +228,42 @@ TEST_P(WireIteratorTest, Traversal) {
   ASSERT_EQ(recIt.qubit(), iterQ00);
 }
 
+TEST_P(WireIteratorTest, FunctionReturnTerminatesTraversal) {
+  const bool isDynamic = GetParam();
+  Value source;
+  Value output;
+  auto module =
+      qco::QCOProgramBuilder::build(context.get(), [&](auto& builder) -> Value {
+        source = isDynamic ? builder.allocQubit() : builder.staticQubit(0);
+        output = builder.h(source);
+        return output;
+      });
+  ASSERT_TRUE(module);
+
+  qco::WireIterator it(source);
+  ASSERT_EQ(it.operation(), source.getDefiningOp());
+  ASSERT_EQ(it.qubit(), source);
+
+  ++it;
+  ASSERT_EQ(it.operation(), output.getDefiningOp());
+  ASSERT_EQ(it.qubit(), output);
+
+  ++it;
+  ASSERT_TRUE(isa<func::ReturnOp>(it.operation()));
+  ASSERT_EQ(it.qubit(), nullptr);
+
+  ++it;
+  ASSERT_EQ(it, std::default_sentinel);
+
+  --it;
+  ASSERT_TRUE(isa<func::ReturnOp>(it.operation()));
+  ASSERT_EQ(it.qubit(), nullptr);
+
+  --it;
+  ASSERT_EQ(it.operation(), output.getDefiningOp());
+  ASSERT_EQ(it.qubit(), output);
+}
+
 INSTANTIATE_TEST_SUITE_P(DynamicAndStatic, WireIteratorTest, ::testing::Bool(),
                          [](const ::testing::TestParamInfo<bool>& info) {
                            return info.param ? "Dynamic" : "Static";


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Add canonicalization support for positive integral powers of constant `U` gates in the QC and QCO dialects.

A modifier of the form `pow(n) { u(theta, phi, lambda) }` is replaced with an equivalent `U` gate and, when necessary, a global-phase correction. The existing global-phase normalization pass subsequently combines or converts the correction according to its surrounding scope.

## Implementation

- Factor `U(theta, phi, lambda)` into its global phase and an SU(2) rotation represented by a unit quaternion.
- Compute positive integral powers analytically by multiplying the quaternion's axis angle, then recover stable ZYZ Euler parameters.
- Preserve exact matrix semantics by emitting the remaining global phase.
- Accept the rewrite only when the reconstructed binary64 matrix agrees entry-wise with the source power within the required tolerance; otherwise, leave the `PowOp` unchanged.
- Share the implementation between QC and QCO through `UGateUtils.h`.
- Consider positive integral exponents up to `MAX_SAFE_U_POWER_EXPONENT` (1024). Leave larger, fractional, non-finite, dynamically parameterized, or numerically unstable cases unchanged.
- Preserve pass-through QCO targets when reducing a controlled global phase, and erase alloc/static-sink pairs only when the qubit is genuinely single-use.

## Validation

- QC dialect unit tests: 320 passed.
- QCO dialect unit tests: 468 passed.
- Jeff round-trip unit tests: 138 passed.
- Repository lint passed on Python 3.14.
- Changed-line `clang-tidy` passed with LLVM 22.1.8.

## AI assistance

Codex assisted with the revision-scoped review, the analytical SU(2) remediation, regression tests, and validation. The commits include `Assisted-by` trailers.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
