### PR TITLE
✨ Query custom operation lists through FoMaC

### DIFF
--- a/.agent/plans/custom-operation-lists.md
+++ b/.agent/plans/custom-operation-lists.md
@@ -31,15 +31,15 @@ providers demonstrate that unsupported properties return `std::nullopt` and
       test-provider paths.
 - [x] (2026-08-10 16:25Z) Added the generic handle-array decoder, shared
       operation-wrapper path, and public C++ API.
-- [x] (2026-08-10 16:29Z) Bound the API to Python and regenerated the
-      checked-in stub.
+- [x] (2026-08-10 16:29Z) Bound the API to Python and regenerated the checked-in
+      stub.
 - [x] (2026-08-10 16:34Z) Extended the native test provider and added raw QDMI,
       C++, Python unsupported-result, operation-property, and ownership tests.
 - [ ] Add the changelog entry after the draft pull request provides its number.
-- [x] (2026-08-10 16:52Z) Ran focused and full C++ tests, focused Python
-      tests, generated-file checks, documentation, changed-line clang-tidy 22,
-      and full lint. The final lint check will be repeated after the
-      PR-numbered changelog entry.
+- [x] (2026-08-10 16:52Z) Ran focused and full C++ tests, focused Python tests,
+      generated-file checks, documentation, changed-line clang-tidy 22, and full
+      lint. The final lint check will be repeated after the PR-numbered
+      changelog entry.
 - [ ] Publish the exact reviewed head and inspect replacement
       continuous-integration checks.
 
@@ -74,11 +74,11 @@ providers demonstrate that unsupported properties return `std::nullopt` and
 ## Outcomes & Retrospective
 
 The C++, Python, and raw QDMI paths are implemented and locally validated. The
-successful provider path distinguishes unsupported, empty, malformed, and
-valid arrays; normal operation-property queries and ownership after
-device-wrapper destruction both pass. The documentation build completed
-without a content warning. Publication, the PR-numbered changelog entry, and
-live continuous integration remain.
+successful provider path distinguishes unsupported, empty, malformed, and valid
+arrays; normal operation-property queries and ownership after device-wrapper
+destruction both pass. The documentation build completed without a content
+warning. Publication, the PR-numbered changelog entry, and live continuous
+integration remain.
 
 ## Context and Orientation
 
@@ -248,5 +248,5 @@ provider implementations.
 Revision note (2026-08-10): Recorded the completed API, provider fixture,
 generated binding, and local native, Python, ownership, and clang-tidy evidence.
 
-Revision note (2026-08-10): Recorded the successful full documentation build
-and completed local validation gate before publication.
+Revision note (2026-08-10): Recorded the successful full documentation build and
+completed local validation gate before publication.

--- a/.agent/plans/custom-operation-lists.md
+++ b/.agent/plans/custom-operation-lists.md
@@ -35,13 +35,14 @@ providers demonstrate that unsupported properties return `std::nullopt` and
       stub.
 - [x] (2026-08-10 16:34Z) Extended the native test provider and added raw QDMI,
       C++, Python unsupported-result, operation-property, and ownership tests.
-- [ ] Add the changelog entry after the draft pull request provides its number.
+- [x] (2026-08-10 16:43Z) Opened draft pull request #2042 and added its
+      PR-numbered changelog entry.
 - [x] (2026-08-10 16:52Z) Ran focused and full C++ tests, focused Python tests,
       generated-file checks, documentation, changed-line clang-tidy 22, and full
       lint. The final lint check will be repeated after the PR-numbered
       changelog entry.
-- [ ] Publish the exact reviewed head and inspect replacement
-      continuous-integration checks.
+- [ ] Publish the changelog commit and inspect replacement
+      continuous-integration checks on pull request #2042.
 
 ## Surprises & Discoveries
 

--- a/.agent/plans/custom-operation-lists.md
+++ b/.agent/plans/custom-operation-lists.md
@@ -1,0 +1,252 @@
+# Expose custom operation lists through FoMaC
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+After this change, a QDMI provider can return an implementation-defined device
+property whose value is an array of `QDMI_Operation` handles, and FoMaC users
+can consume that list without decoding raw bytes. C++ users call
+`Device::queryCustomOperations(CustomProperty)`. Python users call
+`Device.query_custom_operations(CustomProperty)`. Both interfaces return no
+value when the provider does not support the selected custom property. Returned
+operations use the normal FoMaC `Operation` API and retain the device session
+that owns their QDMI handles.
+
+The visible proof is a test provider that exposes valid, empty, malformed, and
+unsupported custom operation properties. Its tests query operation names from
+valid handles after the original device wrapper is gone, and the normal Core
+providers demonstrate that unsupported properties return `std::nullopt` and
+`None`.
+
+## Progress
+
+- [x] (2026-08-10 16:20Z) Created an isolated worktree from current
+      `origin/main` and reviewed the FoMaC query, ownership, binding, and
+      test-provider paths.
+- [x] (2026-08-10 16:25Z) Added the generic handle-array decoder, shared
+      operation-wrapper path, and public C++ API.
+- [x] (2026-08-10 16:29Z) Bound the API to Python and regenerated the
+      checked-in stub.
+- [x] (2026-08-10 16:34Z) Extended the native test provider and added raw QDMI,
+      C++, Python unsupported-result, operation-property, and ownership tests.
+- [ ] Add the changelog entry after the draft pull request provides its number.
+- [x] (2026-08-10 16:52Z) Ran focused and full C++ tests, focused Python
+      tests, generated-file checks, documentation, changed-line clang-tidy 22,
+      and full lint. The final lint check will be repeated after the
+      PR-numbered changelog entry.
+- [ ] Publish the exact reviewed head and inspect replacement
+      continuous-integration checks.
+
+## Surprises & Discoveries
+
+- Observation: Existing FoMaC operations already store the device as a shared
+  owner, so a custom list does not need a new wrapper type. Evidence:
+  `Operation` in `include/mqt-core/fomac/FoMaC.hpp` stores
+  `std::shared_ptr<QDMI_Device_impl_d> device_`, and `Device::getOperations` in
+  `src/fomac/FoMaC.cpp` constructs each operation with that owner.
+- Observation: The Python test package contains only production providers, all
+  of which correctly report custom operation slots as unsupported. The
+  successful custom-list and post-device-lifetime path must therefore use the
+  native test provider, while Python can verify the public unsupported result
+  and the shared `Operation` lifetime contract that both standard and custom
+  lists use.
+
+## Decision Log
+
+- Decision: Add a handle-array decoder in `fomac::detail` and use it from the
+  new API. Rationale: Size validation and the two-step QDMI query protocol are
+  independent of the Amazon Braket provider and can be reused if QDMI later
+  standardizes another handle-array property. Date/Author: 2026-08-10 / Codex.
+- Decision: Return `std::optional<std::vector<Operation>>` in C++ and
+  `list[Device.Operation] | None` in Python. Rationale: An unsupported property
+  and a supported empty operation list are different provider results and must
+  remain distinguishable. Date/Author: 2026-08-10 / Codex.
+- Decision: Keep raw `queryCustomProperty<std::vector<std::byte>>` unchanged.
+  Rationale: The new typed method is additive and does not remove the lossless
+  raw custom-property path. Date/Author: 2026-08-10 / Codex.
+
+## Outcomes & Retrospective
+
+The C++, Python, and raw QDMI paths are implemented and locally validated. The
+successful provider path distinguishes unsupported, empty, malformed, and
+valid arrays; normal operation-property queries and ownership after
+device-wrapper destruction both pass. The documentation build completed
+without a content warning. Publication, the PR-numbered changelog entry, and
+live continuous integration remain.
+
+## Context and Orientation
+
+QDMI is the C interface that provider libraries implement. A device property is
+queried in two calls: the first call uses a null output pointer and returns the
+required byte count; the second call provides a buffer of that size. An
+operation handle has the C type `QDMI_Operation`. It remains valid only while
+its owning device session remains valid.
+
+FoMaC is MQT Core's C++ and Python wrapper around QDMI. The public C++ classes
+are declared in `include/mqt-core/fomac/FoMaC.hpp`, and their non-template
+methods are implemented in `src/fomac/FoMaC.cpp`. Python bindings are defined
+with nanobind in `bindings/fomac/FoMaC.cpp`. The generated public type stub is
+`python/mqt/core/fomac.pyi`; it must be regenerated with the repository's Nox
+session and must not be edited by hand.
+
+`CustomProperty` selects QDMI custom slots one through five. The existing
+`Device::queryCustomProperty<T>` method decodes scalar, string, or raw-byte
+values. It cannot safely turn arbitrary raw bytes into owned FoMaC operations.
+The new method supplies that missing typed path while retaining the existing raw
+path.
+
+The native test provider in `test/qdmi/driver/session_device.cpp` is loaded by
+`test/qdmi/driver/test_driver.cpp`. It can expose deterministic custom property
+responses and operation-property responses without changing a production
+provider. The driver test already links FoMaC and already receives the provider
+library path through `test/qdmi/driver/CMakeLists.txt`.
+
+This task changes only this worktree. It must preserve unrelated changes and
+must not edit another task's worktree. It must follow `AGENTS.md` and
+`docs/ai_usage.md`. This plan records implementation work but does not by itself
+authorize a GitHub action.
+
+## Plan of Work
+
+First, add a small template in `fomac::detail` in
+`include/mqt-core/fomac/FoMaC.hpp`. The template accepts a QDMI-style query
+callable, returns `std::nullopt` on `QDMI_ERROR_NOTSUPPORTED`, rejects a byte
+count that is not a multiple of the handle size, and otherwise performs the
+second query into a correctly sized vector. It must preserve a supported empty
+list as an engaged optional containing an empty vector.
+
+Next, declare `Device::queryCustomOperations(CustomProperty)` next to the
+existing custom device-property API and implement it in `src/fomac/FoMaC.cpp`.
+Convert the selector with `detail::toDeviceProperty`, use the generic decoder
+for `QDMI_Operation`, and wrap each handle in the same `Operation` class used by
+`Device::getOperations`. Every wrapper receives `device_`, so it retains the
+owning session.
+
+Then, bind the method as `Device.query_custom_operations` in
+`bindings/fomac/FoMaC.cpp`. The docstring must state the difference between an
+unsupported property and a supported empty list. Regenerate
+`python/mqt/core/fomac.pyi` with the Nox stub session.
+
+Extend `test/qdmi/driver/session_device.cpp` with stable test operation objects.
+One custom device-property slot returns their handle array, one reports a
+supported empty list, one reports a malformed byte count, and another remains
+unsupported. Implement the operation name and fixed arity/parameter queries for
+the returned handles. In `test/qdmi/driver/test_driver.cpp`, verify raw QDMI
+size/value queries, FoMaC unsupported and empty results, malformed-size
+rejection, valid operation wrappers, operation-property queries, and ownership
+after the temporary `Device` wrapper is destroyed. Add Python tests in
+`test/python/fomac/test_fomac.py` for the unsupported result and the established
+operation lifetime contract shared by both list-producing methods.
+
+Finally, add a concise changelog entry with the actual pull request number,
+validate the complete diff, commit with a signed commit and the required
+`Assisted-by: GPT-5.6 via Codex` trailer, publish the branch, and inspect all
+checks against the exact published head.
+
+## Concrete Steps
+
+Run all commands from the repository root. Configure and build the focused
+native tests with:
+
+    MLIR_DIR=/path/to/llvm/lib/cmake/mlir ./.agent/run.sh cmake --preset release
+    ./.agent/run.sh cmake --build build/release --target mqt-core-qdmi-driver-test mqt-core-fomac-test
+    ./.agent/run.sh build/release/test/qdmi/driver/mqt-core-qdmi-driver-test --gtest_filter='DeviceRegistrationTest.CustomOperation*'
+    ./.agent/run.sh build/release/test/fomac/mqt-core-fomac-test
+
+Build the bindings, run focused Python tests, and regenerate stubs with:
+
+    MLIR_DIR=/path/to/llvm/lib/cmake/mlir ./.agent/run.sh uvx nox --non-interactive -s tests-3.13 -- test/python/fomac/test_fomac.py -k 'custom_operations or operation_keeps'
+    MLIR_DIR=/path/to/llvm/lib/cmake/mlir ./.agent/run.sh uvx nox --non-interactive -s stubs
+
+Run the repository gate with:
+
+    MLIR_DIR=/path/to/llvm/lib/cmake/mlir ./.agent/run.sh uvx nox --non-interactive -s lint
+    git diff --check
+    git status --short
+
+The focused native test must report every custom-operation test as passed. The
+focused Python test must report no failure. The stub session must leave only the
+expected `fomac.pyi` API addition. The final lint session and diff check must
+exit successfully.
+
+## Validation and Acceptance
+
+The C++ API is accepted when an unsupported custom property produces
+`std::nullopt`, a supported zero-byte property produces an engaged empty vector,
+and a malformed byte count throws `std::invalid_argument`. A valid property must
+return the expected number of `Operation` objects. Their names, arities, and
+parameter counts must come from normal QDMI operation-property queries. At least
+one returned operation must remain usable after the `Device` variable that
+produced it is destroyed.
+
+The raw C path is accepted when the same test provider returns the documented
+byte count and the exact handles through `QDMI_device_query_device_property`.
+This proves that the FoMaC method does not require provider-specific code.
+
+The Python API is accepted when every production device returns `None` for its
+unsupported custom slot, the generated annotation is
+`list[Device.Operation] | None`, and an operation created from a freshly opened
+device remains usable without a separate device variable. Downstream provider
+tests can then exercise a supported custom list without changing this generic
+Core API.
+
+## Idempotence and Recovery
+
+All build, test, stub-generation, and lint commands are repeatable. Generated
+build files stay below `build/`, `.nox/`, and `.cache/` and are ignored by Git.
+If CMake cached an obsolete toolchain, move only the affected generated build
+directory aside and rerun the configure preset. Do not reset or clean source
+files to recover. If publication finds a changed remote branch, stop and fetch
+the new head instead of using an unguarded force push.
+
+## Artifacts and Notes
+
+Expected key result shapes are:
+
+    unsupported.has_value() == false
+    empty.has_value() == true && empty->empty()
+    valid->front().getName() == "custom-rx"
+    malformed query throws std::invalid_argument
+
+Add final exact test counts and the published commit SHA here after validation.
+
+Current focused evidence:
+
+    121/121 mqt-core-qdmi-driver-test cases passed
+    268/268 mqt-core-fomac-test cases passed
+    6/6 focused Python cases passed
+    changed-line clang-tidy 22 produced no diagnostics
+    Nox lint and documentation sessions passed
+
+## Interfaces and Dependencies
+
+The completed public C++ interface must contain:
+
+    [[nodiscard]] std::optional<std::vector<Operation>>
+    Device::queryCustomOperations(CustomProperty property) const;
+
+The completed Python interface must contain:
+
+    def query_custom_operations(
+        self, custom_property: CustomProperty
+    ) -> list[Device.Operation] | None: ...
+
+The implementation depends only on the existing QDMI client API, the existing
+FoMaC `CustomProperty` selector, and the existing `Operation` ownership model.
+It adds no provider SDK and no new external dependency.
+
+Revision note (2026-08-10): Created the initial self-contained execution plan
+after inspecting the current FoMaC, nanobind, generated-stub, and native test
+provider implementations.
+
+Revision note (2026-08-10): Recorded the completed API, provider fixture,
+generated binding, and local native, Python, ownership, and clang-tidy evidence.
+
+Revision note (2026-08-10): Recorded the successful full documentation build
+and completed local validation gate before publication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add generic C++ and Python FoMaC support for custom device properties that
+  contain operation handles ([#2042]) ([**@burgholzer**])
 - ✨ Support retrieving existing jobs by ID through the QDMI client API and C++
   and Python FoMaC APIs, and expose optional device queue length and job queue
   position ([#2008], [#2010]) ([**@burgholzer**])
@@ -726,6 +728,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#2030]: https://github.com/munich-quantum-toolkit/core/pull/2030
+[#2042]: https://github.com/munich-quantum-toolkit/core/pull/2042
 [#2028]: https://github.com/munich-quantum-toolkit/core/pull/2028
 [#2026]: https://github.com/munich-quantum-toolkit/core/pull/2026
 [#2017]: https://github.com/munich-quantum-toolkit/core/pull/2017

--- a/bindings/fomac/fomac.cpp
+++ b/bindings/fomac/fomac.cpp
@@ -420,6 +420,14 @@ when the custom slot is unsupported.)pb");
              "Returns the direct child devices managed by this device.");
 
   device.def(
+      "query_custom_operations", &fomac::Device::queryCustomOperations,
+      "custom_property"_a,
+      R"pb(Query a custom device property that contains operation handles.
+
+Returns normal :class:`Device.Operation` objects, or ``None`` when the custom
+slot is unsupported. A supported empty list is returned as an empty list.)pb");
+
+  device.def(
       "query_custom_property",
       [](const fomac::Device& self, const fomac::CustomProperty customProperty,
          const nb::handle valueType) {

--- a/include/mqt-core/fomac/FoMaC.hpp
+++ b/include/mqt-core/fomac/FoMaC.hpp
@@ -117,6 +117,31 @@ queryCustomValue(Query query, const std::string_view description) {
   }
 }
 
+template <typename Handle, typename Query>
+[[nodiscard]] std::optional<std::vector<Handle>>
+queryHandleArray(Query query, const std::string_view description) {
+  size_t size = 0;
+  const auto sizeResult = query(0, nullptr, &size);
+  if (sizeResult == QDMI_ERROR_NOTSUPPORTED) {
+    return std::nullopt;
+  }
+  qdmi::throwIfError(sizeResult,
+                     "Querying " + std::string(description) + " size");
+  if (size % sizeof(Handle) != 0) {
+    throw std::invalid_argument(
+        "Cannot decode " + std::string(description) + ": the device reported " +
+        std::to_string(size) + " bytes, which is not a multiple of " +
+        std::to_string(sizeof(Handle)));
+  }
+
+  std::vector<Handle> handles(size / sizeof(Handle));
+  if (size != 0) {
+    qdmi::throwIfError(query(size, static_cast<void*>(handles.data()), nullptr),
+                       "Querying " + std::string(description));
+  }
+  return handles;
+}
+
 [[nodiscard]] constexpr QDMI_Device_Property
 toDeviceProperty(const CustomProperty property) {
   switch (property) {
@@ -531,6 +556,17 @@ public:
   }
 
   /**
+   * @brief Queries a custom device property containing operation handles.
+   * @param property Custom property slot to query.
+   * @return Normal FoMaC operation wrappers, or `std::nullopt` if the slot is
+   * unsupported. A supported empty list is returned as an engaged optional.
+   * @throws std::invalid_argument If the returned byte count is not a multiple
+   * of `sizeof(QDMI_Operation)`.
+   */
+  [[nodiscard]] std::optional<std::vector<Operation>>
+  queryCustomOperations(CustomProperty property) const;
+
+  /**
    * @brief Submits a textual program.
    * @details The terminating null byte required by QDMI text formats is
    * included in the submitted payload.
@@ -589,6 +625,10 @@ private:
    */
   explicit Device(std::shared_ptr<QDMI_Device_impl_d> device)
       : device_(std::move(device)) {}
+
+  /// Wrap operation handles while retaining their owning device session.
+  [[nodiscard]] std::vector<Operation>
+  wrapOperations(std::span<const QDMI_Operation> operations) const;
 
   /// Query a device property.
   template <maybe_optional_value_or_string_or_vector T>

--- a/python/mqt/core/fomac.pyi
+++ b/python/mqt/core/fomac.pyi
@@ -325,6 +325,13 @@ class Device:
     def child_devices(self) -> list[Device]:
         """Returns the direct child devices managed by this device."""
 
+    def query_custom_operations(self, custom_property: CustomProperty) -> list[Operation] | None:
+        """Query a custom device property that contains operation handles.
+
+        Returns normal :class:`Device.Operation` objects, or ``None`` when the custom
+        slot is unsupported. A supported empty list is returned as an empty list.
+        """
+
     @overload
     def query_custom_property(self, custom_property: CustomProperty, value_type: type[str]) -> str | None: ...
     @overload

--- a/src/fomac/FoMaC.cpp
+++ b/src/fomac/FoMaC.cpp
@@ -240,12 +240,33 @@ std::vector<Site> Device::getZones() const {
 std::vector<Operation> Device::getOperations() const {
   const auto& qdmiOperations = queryProperty<std::vector<QDMI_Operation>>(
       QDMI_DEVICE_PROPERTY_OPERATIONS);
-  std::vector<Operation> operations;
-  operations.reserve(qdmiOperations.size());
+  return wrapOperations(qdmiOperations);
+}
+
+std::optional<std::vector<Operation>>
+Device::queryCustomOperations(const CustomProperty property) const {
+  const auto qdmiProperty = detail::toDeviceProperty(property);
+  const auto handles = detail::queryHandleArray<QDMI_Operation>(
+      [this, qdmiProperty](const size_t size, void* value, size_t* sizeRet) {
+        return QDMI_device_query_device_property(device_.get(), qdmiProperty,
+                                                 size, value, sizeRet);
+      },
+      "custom operation list " +
+          std::to_string(static_cast<unsigned>(property)));
+  if (!handles.has_value()) {
+    return std::nullopt;
+  }
+  return wrapOperations(*handles);
+}
+
+std::vector<Operation>
+Device::wrapOperations(const std::span<const QDMI_Operation> operations) const {
+  std::vector<Operation> wrappedOperations;
+  wrappedOperations.reserve(operations.size());
   std::ranges::transform(
-      qdmiOperations, std::back_inserter(operations),
+      operations, std::back_inserter(wrappedOperations),
       [this](const QDMI_Operation& op) -> Operation { return {device_, op}; });
-  return operations;
+  return wrappedOperations;
 }
 
 std::optional<std::vector<std::pair<Site, Site>>>

--- a/test/python/fomac/test_fomac.py
+++ b/test/python/fomac/test_fomac.py
@@ -239,6 +239,11 @@ def test_device_custom_property_rejects_invalid_type(device: Device) -> None:
         device.query_custom_property(CustomProperty.CUSTOM1, cast("type[bytes]", list))
 
 
+def test_device_custom_operations_unsupported(device: Device) -> None:
+    """Unsupported custom operation lists return None instead of raw bytes."""
+    assert device.query_custom_operations(CustomProperty.CUSTOM5) is None
+
+
 def test_site_index(device_and_site: tuple[Device, Device.Site]) -> None:
     """Test that the site index is a non-negative integer."""
     _device, site = device_and_site

--- a/test/qdmi/driver/session_device.cpp
+++ b/test/qdmi/driver/session_device.cpp
@@ -10,6 +10,7 @@
 
 #include <qdmi/device.h>
 
+#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstring>
@@ -18,6 +19,12 @@
 #include <unordered_map>
 
 struct QDMI_Child_Device_impl_d {};
+
+struct QDMI_Operation_impl_d {
+  const char* name;
+  size_t qubitsNum;
+  size_t parametersNum;
+};
 
 struct QDMI_Device_Session_impl_d {
   std::unordered_map<int, std::string> parameters;
@@ -51,6 +58,27 @@ namespace {
   return &child;
 }
 
+[[nodiscard]] auto customOperationHandles()
+    -> const std::array<QDMI_Operation, 2>& {
+  static QDMI_Operation_impl_d rotate{
+      .name = "custom-rx", .qubitsNum = 1, .parametersNum = 1};
+  static QDMI_Operation_impl_d controlledNot{
+      .name = "custom-cx", .qubitsNum = 2, .parametersNum = 0};
+  static const std::array<QDMI_Operation, 2> OPERATIONS{&rotate,
+                                                        &controlledNot};
+  return OPERATIONS;
+}
+
+[[nodiscard]] auto findCustomOperation(QDMI_Operation operation)
+    -> const QDMI_Operation_impl_d* {
+  for (auto* const handle : customOperationHandles()) {
+    if (operation == handle) {
+      return handle;
+    }
+  }
+  return nullptr;
+}
+
 auto queryString(const std::string& result, const size_t size, void* value,
                  size_t* sizeRet) -> int {
   const auto required = result.size() + 1;
@@ -64,6 +92,22 @@ auto queryString(const std::string& result, const size_t size, void* value,
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   std::memcpy(value, result.c_str(), required);
+  return QDMI_SUCCESS;
+}
+
+template <typename T>
+auto queryValue(const T& result, const size_t size, void* value,
+                size_t* sizeRet) -> int {
+  if (sizeRet != nullptr) {
+    *sizeRet = sizeof(T);
+  }
+  if (value == nullptr) {
+    return QDMI_SUCCESS;
+  }
+  if (size < sizeof(T)) {
+    return QDMI_ERROR_INVALIDARGUMENT;
+  }
+  std::memcpy(value, &result, sizeof(T));
   return QDMI_SUCCESS;
 }
 } // namespace
@@ -166,6 +210,33 @@ extern "C" int TEST_SESSION_QDMI_device_session_query_device_property(
                 sizeof(QDMI_Child_Device));
     return QDMI_SUCCESS;
   }
+  if (prop == QDMI_DEVICE_PROPERTY_CUSTOM1) {
+    const auto& operations = customOperationHandles();
+    const auto required = operations.size() * sizeof(QDMI_Operation);
+    if (sizeRet != nullptr) {
+      *sizeRet = required;
+    }
+    if (value == nullptr) {
+      return QDMI_SUCCESS;
+    }
+    if (size < required) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    std::memcpy(value, static_cast<const void*>(operations.data()), required);
+    return QDMI_SUCCESS;
+  }
+  if (prop == QDMI_DEVICE_PROPERTY_CUSTOM2) {
+    if (sizeRet != nullptr) {
+      *sizeRet = 0;
+    }
+    return QDMI_SUCCESS;
+  }
+  if (prop == QDMI_DEVICE_PROPERTY_CUSTOM3) {
+    if (sizeRet != nullptr) {
+      *sizeRet = sizeof(QDMI_Operation) + 1;
+    }
+    return value == nullptr ? QDMI_SUCCESS : QDMI_ERROR_INVALIDARGUMENT;
+  }
   if (prop != QDMI_DEVICE_PROPERTY_NAME) {
     return QDMI_ERROR_NOTSUPPORTED;
   }
@@ -191,10 +262,26 @@ extern "C" int TEST_SESSION_QDMI_device_session_query_site_property(
 }
 
 extern "C" int TEST_SESSION_QDMI_device_session_query_operation_property(
-    QDMI_Device_Session /*session*/, QDMI_Operation /*operation*/,
-    size_t /*numSites*/, const QDMI_Site* /*sites*/, size_t /*numParams*/,
-    const double* /*params*/, QDMI_Operation_Property /*property*/,
-    size_t /*size*/, void* /*value*/, size_t* /*sizeRet*/) {
+    QDMI_Device_Session session, QDMI_Operation operation, size_t /*numSites*/,
+    const QDMI_Site* /*sites*/, size_t /*numParams*/, const double* /*params*/,
+    const QDMI_Operation_Property property, const size_t size, void* value,
+    size_t* sizeRet) {
+  if (session == nullptr || !session->initialized) {
+    return QDMI_ERROR_BADSTATE;
+  }
+  const auto* const customOperation = findCustomOperation(operation);
+  if (customOperation == nullptr) {
+    return QDMI_ERROR_INVALIDARGUMENT;
+  }
+  if (property == QDMI_OPERATION_PROPERTY_NAME) {
+    return queryString(customOperation->name, size, value, sizeRet);
+  }
+  if (property == QDMI_OPERATION_PROPERTY_QUBITSNUM) {
+    return queryValue(customOperation->qubitsNum, size, value, sizeRet);
+  }
+  if (property == QDMI_OPERATION_PROPERTY_PARAMETERSNUM) {
+    return queryValue(customOperation->parametersNum, size, value, sizeRet);
+  }
   return QDMI_ERROR_NOTSUPPORTED;
 }
 

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -1129,6 +1129,74 @@ TEST(DeviceRegistrationTest, FreshOpenCreatesDistinctSessions) {
   EXPECT_NE(first, second);
 }
 
+TEST(DeviceRegistrationTest, CustomOperationListSupportsRawAndFoMaCQueries) {
+  registerSessionTestDevice();
+  const auto device = fomac::Session::openDevice("test.session-overrides");
+
+  size_t size = 0;
+  ASSERT_EQ(QDMI_device_query_device_property(
+                device, QDMI_DEVICE_PROPERTY_CUSTOM1, 0, nullptr, &size),
+            QDMI_SUCCESS);
+  ASSERT_EQ(size, 2 * sizeof(QDMI_Operation));
+  std::vector<QDMI_Operation> rawOperations(size / sizeof(QDMI_Operation));
+  EXPECT_EQ(QDMI_device_query_device_property(
+                device, QDMI_DEVICE_PROPERTY_CUSTOM1,
+                size - sizeof(QDMI_Operation),
+                static_cast<void*>(rawOperations.data()), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  ASSERT_EQ(QDMI_device_query_device_property(
+                device, QDMI_DEVICE_PROPERTY_CUSTOM1, size,
+                static_cast<void*>(rawOperations.data()), nullptr),
+            QDMI_SUCCESS);
+
+  const auto operations =
+      device.queryCustomOperations(fomac::CustomProperty::Custom1);
+  ASSERT_TRUE(operations.has_value());
+  ASSERT_EQ(operations->size(), rawOperations.size());
+  EXPECT_EQ(static_cast<QDMI_Operation>(operations->at(0)),
+            rawOperations.at(0));
+  EXPECT_EQ(static_cast<QDMI_Operation>(operations->at(1)),
+            rawOperations.at(1));
+  EXPECT_EQ(operations->at(0).getName(), "custom-rx");
+  EXPECT_EQ(operations->at(0).getQubitsNum(), 1);
+  EXPECT_EQ(operations->at(0).getParametersNum(), 1);
+  EXPECT_EQ(operations->at(1).getName(), "custom-cx");
+  EXPECT_EQ(operations->at(1).getQubitsNum(), 2);
+  EXPECT_EQ(operations->at(1).getParametersNum(), 0);
+}
+
+TEST(DeviceRegistrationTest,
+     CustomOperationListDistinguishesUnsupportedEmptyAndMalformed) {
+  registerSessionTestDevice();
+  const auto device = fomac::Session::openDevice("test.session-overrides");
+
+  EXPECT_EQ(device.queryCustomOperations(fomac::CustomProperty::Custom4),
+            std::nullopt);
+  const auto empty =
+      device.queryCustomOperations(fomac::CustomProperty::Custom2);
+  ASSERT_TRUE(empty.has_value());
+  EXPECT_TRUE(empty->empty());
+  EXPECT_THROW(static_cast<void>(device.queryCustomOperations(
+                   fomac::CustomProperty::Custom3)),
+               std::invalid_argument);
+}
+
+TEST(DeviceRegistrationTest, CustomOperationRetainsOwningDeviceSession) {
+  registerSessionTestDevice();
+  const auto operation = [] {
+    const auto operations =
+        fomac::Session::openDevice("test.session-overrides")
+            .queryCustomOperations(fomac::CustomProperty::Custom1);
+    if (!operations.has_value() || operations->empty()) {
+      throw std::runtime_error("Test provider returned no custom operations");
+    }
+    return operations->front();
+  }();
+
+  EXPECT_EQ(operation.getName(), "custom-rx");
+  EXPECT_EQ(operation.getQubitsNum(), 1);
+}
+
 TEST(DeviceRegistrationTest,
      ScRuntimeConfigurationSeparatesModelsUsingOneProviderLibrary) {
   auto& driver = qdmi::Driver::get();


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Add a provider-independent FoMaC API for custom device properties that contain arrays of `QDMI_Operation` handles.

- Add `Device::queryCustomOperations(CustomProperty)` in C++.
- Add `Device.query_custom_operations(CustomProperty)` in Python.
- Preserve the distinction between an unsupported property and a supported empty list.
- Validate provider-reported byte counts before decoding handles.
- Return normal FoMaC `Operation` objects that retain the owning device session.
- Reuse the generic handle-array query path so a later standard QDMI property can use the same implementation.

The native test provider covers raw QDMI queries, unsupported and empty properties, malformed byte counts, valid handles, operation metadata, and post-device lifetime. Production-provider Python tests cover the unsupported result and the existing shared operation lifetime contract.

## Validation

- 121/121 QDMI driver tests
- 268/268 FoMaC tests
- 6/6 focused Python tests
- generated stub check
- changed-line clang-tidy with LLVM 22
- full lint session
- documentation build
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (not needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

This pull request was implemented with assistance from GPT-5.6 via Codex.
