### PR TITLE
🧪 Test QDMI device admission with Slurm

### DIFF
--- a/.agent/plans/slurm-integration.md
+++ b/.agent/plans/slurm-integration.md
@@ -1,0 +1,176 @@
+# Test and document QDMI device admission with Slurm
+
+This ExecPlan is a living document. Maintain it in accordance with
+`.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+Provide an end-to-end test and a concise tutorial for the mechanism-specific
+QDMI Slurm adapter. A real Slurm controller admits jobs through local static
+licenses whose names are stable QDMI device IDs. The test proves both scheduler
+admission and QDMI execution without coupling the generic driver to Slurm. The
+license environment selects a device. It does not attest the allocation or
+authorize access.
+
+The fixture uses Slurm 25.11 or newer, one controller, two compute nodes,
+systemd, Munge, and cgroup v2. Each node has two CPUs. Slurm configures two
+`mqt.ddsim.default` licenses and one `mqt.sc.default` license.
+
+## Progress
+
+- [x] (2026-08-13 04:04Z) Reconstruct the layer on the exact rewritten #2025
+      head and retain only the workflow, fixture, tutorial, and changelog work.
+- [x] (2026-08-13 04:12Z) Update all workloads and documentation to use
+      `mqt.core.qdmi.slurm.open_device_from_license()`.
+- [x] (2026-08-13 04:12Z) Add live rejection cases for AND, OR, and non-unit
+      QDMI license expressions.
+- [x] (2026-08-13 04:33Z) Run Python syntax, Compose configuration, changed-file
+      hooks, full lint, and the Sphinx warnings-as-errors build.
+- [x] (2026-08-13 12:47Z) Rebuild the layer on the final #2025 head and preserve
+      the workflow, fixture, tutorial, and changelog boundary.
+- [x] (2026-08-13 12:52Z) Complete an independent adversarial review and add the
+      missing real-Slurm OR-expression rejection case.
+- [x] (2026-08-13 14:45Z) Document the process-mutable environment trust
+      boundary and separate Slurm admission, QDMI selection, provider state, and
+      access control.
+- [x] (2026-08-13 14:45Z) Replace staged Python modules with one wheel installed
+      in the container by a pinned uv binary, and remove all `PYTHONPATH`
+      overrides.
+- [x] (2026-08-13 14:45Z) Remove the local `slurmd` unit override and require
+      the packaged unit to report `Delegate=yes` at runtime.
+- [x] (2026-08-13 14:53Z) Pass Python and shell syntax, Compose configuration,
+      changed-file and full lint, the Sphinx warnings-as-errors build, and a
+      local Python 3.14 wheel build.
+
+## Surprises & Discoveries
+
+- Observation: Parser unit tests are not sufficient for Slurm license syntax.
+  The orchestrator submits non-unit, AND, and OR forms and checks the adapter
+  diagnostics and absence of a DDSIM result.
+- Observation: Current Slurm documentation continues to define licenses as
+  cluster-wide shared resources and recommends cgroup v2 with systemd. The
+  fixture uses the packaged systemd units and checks `Delegate=yes` for
+  `slurmd`.
+- Observation: `SLURM_JOB_LICENSES` is ordinary process environment. It is
+  suitable for selection in a cooperative job, but it cannot attest an
+  allocation or authorize device access.
+
+## Decision Log
+
+- Decision: Keep the existing three-container topology. Rationale: Separate
+  compute-node hostnames prove cross-node scheduling and avoid Slurm
+  multi-daemon emulation. Date/Author: 2026-08-13, Lukas Burgholzer and Codex.
+- Decision: Request exactly one device license in every valid job. Rationale: A
+  configured count of two is an admission pool for independent jobs, not two
+  device handles for one job. Date/Author: 2026-08-13, Lukas Burgholzer and
+  Codex.
+- Decision: Exercise invalid expressions through real `sbatch` jobs. Rationale:
+  Unit tests prove parser grammar, while this layer must prove the actual
+  `SLURM_JOB_LICENSES` value and batch-job failure. Date/Author: 2026-08-13,
+  Lukas Burgholzer and Codex.
+- Decision: Keep credentials outside the adapter and fixture. Rationale: IQM,
+  Amazon Braket, and future providers own different credential sources. The
+  tutorial documents this boundary. Date/Author: 2026-08-13, Lukas Burgholzer
+  and Codex.
+- Decision: Keep the adapter as a selector and place authorization at the real
+  resource boundary. Rationale: local devices can use GRES device-file cgroup
+  enforcement, while remote services must authorize provider operations. A
+  different Slurm lookup would not prevent direct QDMI device opening.
+  Date/Author: 2026-08-13, Lukas Burgholzer and Codex.
+- Decision: Install the built wheel in each image. Rationale: the fixture must
+  test the distributable package without source-tree or `PYTHONPATH` effects.
+  Date/Author: 2026-08-13, Lukas Burgholzer and Codex.
+
+## Outcomes & Retrospective
+
+The implementation now states the selector trust boundary and uses the packaged
+systemd units. The workflow builds one wheel, installs it in the container with
+uv, and runs without `PYTHONPATH`. Local syntax, Compose configuration, lint,
+documentation, and a Python 3.14 macOS wheel build pass. The tutorial has 1,177
+words. The local Docker daemon was unavailable, so the Linux wheel installation,
+the packaged `Delegate=yes` assertion, and the complete privileged Slurm fixture
+remain replacement-CI gates. The independent review must run on the amended
+exact head.
+
+## Context and Orientation
+
+`.github/workflows/slurm.yml` builds the current wheel and runs the host harness
+with uv. The Docker build installs that wheel into each image.
+`test/slurm/compose.yml` defines one controller and two compute nodes. The
+systemd preparation unit installs one generated Munge key and creates the
+required spool directories. `slurm.conf` selects `select/cons_tres` and the
+cgroup process, task, and accounting plugins. `cgroup.conf` selects the cgroup
+implementation automatically and constrains cores and memory.
+
+`test/slurm/run_integration.py` is the single orchestrator. It validates cgroup
+v2 and Slurm 25.11+, waits for both nodes, checks the persistent QDMI IDs and
+license counters, runs negative adapter jobs, and then exercises the complete
+admission scenario. The DDSIM workload executes a 256-shot Bell circuit. The SC
+workload proves that a free CPU remains usable while DDSIM admission is full.
+
+`docs/qdmi/slurm.md` is an administrator and user tutorial. It states that a
+Slurm license is cluster-wide admission. It does not represent provider
+availability or a provider queue. Provider credentials remain provider-owned.
+
+## Plan of Work
+
+Build the current branch wheel inside the Docker build context. Copy a pinned
+official uv binary into the image and install the wheel into the system Python.
+Start the controller and compute nodes under systemd. Require the unified cgroup
+v2 hierarchy, the configured Slurm version, and `Delegate=yes` from the packaged
+`slurmd` unit.
+
+First submit a job that requests two DDSIM licenses, one job that requests one
+DDSIM plus one SC license, and one job that requests either license. All three
+allocations can start, but the QDMI adapter must reject their
+`SLURM_JOB_LICENSES` expressions before a device job is created. Check the exact
+diagnostic and verify that Slurm returns the licenses.
+
+Next pin two DDSIM jobs to different nodes. Each job requests one CPU and one
+DDSIM license, executes its Bell circuit, writes its result, and retains its
+allocation. Submit a third DDSIM job. It must remain pending for `Licenses`
+while each node has one free CPU. Submit an SC job and require it to finish on a
+free CPU. Release the first DDSIM job and require the third job to execute.
+Validate all three Bell results, then release the final held job.
+
+Run Python compilation, YAML and Compose validation, full repository lint,
+documentation, spelling, and link checking locally where available. The
+privileged Ubuntu 26.04 workflow is the authoritative real-Slurm gate.
+
+## Validation and Acceptance
+
+The test accepts only Slurm 25.11 or newer and cgroup v2. Both compute nodes
+must report `Delegate=yes`, two CPUs, and an idle state. The controller must
+import the installed wheel from outside the source and runtime mounts. Initial
+license records must report DDSIM total two and SC total one.
+
+Invalid jobs must fail with the adapter diagnostic and produce no device result.
+The two held DDSIM jobs must run on different nodes. The third must be pending
+with reason `Licenses` while both nodes report one allocated CPU. The SC job
+must finish before either held allocation ends. Releasing one DDSIM job must
+allow the third job to run without reconfiguration.
+
+Each DDSIM result must contain exactly 256 samples and only outcomes `00` and
+`11`. Documentation must remain between 800 and 1,200 words and pass the Sphinx
+warnings-as-errors build.
+
+## Idempotence and Recovery
+
+The orchestrator uses one fixed Compose project and always runs
+`compose down --volumes --remove-orphans`. It removes only ignored result files
+below `test/slurm/runtime`, generates a new Munge key for each run, and prints
+daemon, node, queue, license, job, and batch-output diagnostics on failure. The
+wheel is stored separately below the ignored `test/slurm/dist` directory.
+
+## Interfaces and Dependencies
+
+The workload uses:
+
+    from mqt.core.qdmi import ProgramFormat, slurm
+
+    device = slurm.open_device_from_license()
+    job = device.submit_job(program, ProgramFormat.QASM2, 256)
+
+The fixture adds no production dependency. Its system dependencies are Ubuntu
+26.04, Slurm 25.11 or newer, systemd, Munge, Docker Compose, and a cgroup v2
+host.

--- a/.github/workflows/slurm.yml
+++ b/.github/workflows/slurm.yml
@@ -1,0 +1,69 @@
+name: Slurm integration
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/slurm.yml"
+      - "bindings/qdmi/**"
+      - "cmake/**"
+      - "include/mqt-core/fomac/**"
+      - "include/mqt-core/qdmi/**"
+      - "pyproject.toml"
+      - "python/mqt/core/qdmi/**"
+      - "src/fomac/**"
+      - "src/qdmi/**"
+      - "test/slurm/**"
+      - "uv.lock"
+  pull_request:
+    paths:
+      - ".github/workflows/slurm.yml"
+      - "bindings/qdmi/**"
+      - "cmake/**"
+      - "include/mqt-core/fomac/**"
+      - "include/mqt-core/qdmi/**"
+      - "pyproject.toml"
+      - "python/mqt/core/qdmi/**"
+      - "src/fomac/**"
+      - "src/qdmi/**"
+      - "test/slurm/**"
+      - "uv.lock"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  slurm:
+    name: Slurm 25.11 and QDMI devices
+    runs-on: ubuntu-26.04
+    timeout-minutes: 45
+    env:
+      UV_NO_PROGRESS: "1"
+    steps:
+      - name: Check out MQT Core
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+
+      - name: Set up MLIR
+        uses: munich-quantum-software/setup-mlir@fc08baf0a172e98008e6528d465de3b5dd99bc68 # v1.4.1
+        with:
+          llvm-version: 22.1.7
+
+      - name: Build the MQT Core wheel
+        run: uv build --wheel --out-dir test/slurm/dist
+
+      - name: Test Slurm admission and QDMI execution
+        run: uv run --no-project --python 3.14 test/slurm/run_integration.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- 🧪 Test static Slurm license admission and QDMI execution with DDSIM and SC,
+  and document the cluster setup ([#2043]) ([**@burgholzer**])
 - ✨ Add C++ and Python adapters that open the QDMI device named by one local
   Slurm license environment value ([#2025]) ([**@burgholzer**])
 - ✨ Add an `unroll-modifiers` pass for unrolling multi-operation modifiers
@@ -751,6 +753,7 @@ for previous changelogs._
 [#2060]: https://github.com/munich-quantum-toolkit/core/pull/2060
 [#2058]: https://github.com/munich-quantum-toolkit/core/pull/2058
 [#2049]: https://github.com/munich-quantum-toolkit/core/pull/2049
+[#2043]: https://github.com/munich-quantum-toolkit/core/pull/2043
 [#2042]: https://github.com/munich-quantum-toolkit/core/pull/2042
 [#2039]: https://github.com/munich-quantum-toolkit/core/pull/2039
 [#2038]: https://github.com/munich-quantum-toolkit/core/pull/2038

--- a/docs/qdmi/index.md
+++ b/docs/qdmi/index.md
@@ -18,6 +18,7 @@ SC QDMI Device <sc_device>
 DDSIM QDMI Device <ddsim_device>
 QDMI Driver <driver>
 QDMI device configuration <configuration>
+Slurm integration <slurm>
 QDMI-Qiskit Backend <qdmi_backend>
 PennyLane interface for QDMI devices <pennylane_device>
 ```

--- a/docs/qdmi/slurm.md
+++ b/docs/qdmi/slurm.md
@@ -1,0 +1,218 @@
+# Use QDMI devices with Slurm
+
+This example uses Slurm 25.11 or newer on Ubuntu 26.04. It has one controller,
+two compute nodes, and two CPUs on each compute node.
+
+A Slurm license controls admission to a cluster-wide resource. In this setup,
+the license name is a stable QDMI device ID. A license does not show provider
+availability. It does not show the device queue. The QDMI provider supplies that
+information when its interface supports it.
+
+## Understand the control boundaries
+
+This example is suitable for admission and accounting tests on a cooperative
+cluster. It does not make a Slurm license an access-control credential. The
+controls are independent:
+
+- Slurm admits jobs and accounts for the configured license count.
+- The MQT Core adapter uses the license environment to select a registered QDMI
+  device.
+- The QDMI provider reports device availability and queue data.
+- The provider or the operating system authorizes access to the device.
+
+`SLURM_JOB_LICENSES` is process-mutable. A job can change it before it calls
+`slurm.open_device_from_license()`. Thus, the function does not prove that Slurm
+allocated the named license. It does not authenticate the user. It does not
+authorize access. A lookup through another Slurm interface would not make MQT
+Core an access-control boundary because a program can also call
+`driver.open_device(device_id)` directly.
+
+## Install the software
+
+Install the same MQT Core package on each compute node. The package contains the
+MQT Core QDMI interface and the bundled QDMI devices. You can use a shared
+software environment or install the same wheel on each node.
+
+Install Slurm, Munge, and systemd. Start Munge before Slurm. Use the same Munge
+key on all nodes. Keep this key outside the QDMI device configuration.
+
+Use the unified cgroup v2 hierarchy. Add these settings to `slurm.conf`:
+
+```ini
+ProctrackType=proctrack/cgroup
+TaskPlugin=task/cgroup,task/affinity
+JobAcctGatherType=jobacct_gather/cgroup
+SelectType=select/cons_tres
+SelectTypeParameters=CR_CPU
+```
+
+Use the cgroup plugin to constrain processors and memory. For example, use this
+`cgroup.conf`:
+
+```ini
+CgroupPlugin=autodetect
+ConstrainCores=yes
+ConstrainRAMSpace=yes
+ConstrainSwapSpace=yes
+```
+
+This fixture has no local device file. For strict isolation of a local device,
+configure it as a Slurm GRES with a `File=` entry. Also set
+`ConstrainDevices=yes` for the cgroup task plugin. Slurm can then restrict the
+device files that a job can open. See the [Slurm GRES configuration]
+documentation. A remote QPU has no local device file, so the provider must
+enforce its authorization.
+
+Run `slurmd -C` on each compute node and use its output for the `NodeName`
+record. The MQT Core test uses two CPUs on `node1` and `node2`.
+
+## Register the devices
+
+MQT Core installs persistent definitions for `mqt.ddsim.default` and
+`mqt.sc.default`. You do not have to add another registry file for these two
+devices. You can verify the stable IDs before you configure Slurm:
+
+```console
+python -c "from mqt.core.qdmi import driver; print(*driver.registered_device_ids(), sep='\n')"
+```
+
+For an external provider, install its shared library and QDMI manifest. You can
+also add one trusted system registry file at `/etc/mqt-core/qdmi.json`. The `id`
+field in that file is the stable device ID. Use the same ID as the local Slurm
+license name. Do not put short-lived access tokens in this file. Use the
+authentication method that the provider documents for batch jobs.
+
+The Slurm adapter does not supply credentials. IQM can use its configured token
+source. Amazon Braket uses the AWS credential provider chain, such as an
+instance role, workload identity, or AWS profile. A job can also export provider
+configuration. Use provider-scoped credentials with minimum permissions. Do not
+store access tokens or AWS access keys in a persistent device definition.
+
+Add the licenses to `slurm.conf` on the controller:
+
+```ini
+Licenses=mqt.ddsim.default:2,mqt.sc.default:1
+```
+
+The DDSIM count is two. Therefore, Slurm can admit two jobs that each request
+one DDSIM license. These jobs can run on different nodes. The count is a local
+cluster policy. It is not a DDSIM property and it is not a per-node count.
+
+Restart `slurmctld` after you first add the licenses. Reconfigure the compute
+nodes as required by your Slurm installation. Then inspect the configured
+resources:
+
+```console
+scontrol show lic
+```
+
+The initial report must contain these values:
+
+```text
+LicenseName=mqt.ddsim.default Total=2 Used=0 Free=2 Remote=no
+LicenseName=mqt.sc.default Total=1 Used=0 Free=1 Remote=no
+```
+
+## Submit a DDSIM job
+
+Save this program as `bell.py` in a location that all compute nodes can read:
+
+```python
+from mqt.core.qdmi import ProgramFormat, slurm
+
+program = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+measure q -> c;
+"""
+
+device = slurm.open_device_from_license()
+job = device.submit_job(program, ProgramFormat.QASM2, num_shots=256)
+if not job.wait(60):
+    raise RuntimeError("DDSIM did not finish within 60 seconds")
+
+counts = job.get_counts()
+if sum(counts.values()) != 256 or not set(counts) <= {"00", "11"}:
+    raise RuntimeError(f"Invalid Bell results: {counts}")
+print(counts)
+```
+
+Save this batch script as `bell.sbatch`:
+
+```bash
+#!/bin/bash
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --licenses=mqt.ddsim.default:1
+#SBATCH --output=bell-%j.out
+
+set -euo pipefail
+python bell.py
+```
+
+The adapter reads `SLURM_JOB_LICENSES` and selects the persistent device
+definition with the same ID. It requires one unambiguous QDMI device license. It
+opens a fresh device session and checks the device status. The function accepts
+`IDLE` and `BUSY`. This check is not authorization. The provider can still
+reject a later submission or put the quantum task in its device queue.
+
+Submit the job with this command:
+
+```console
+sbatch bell.sbatch
+```
+
+## Check concurrent jobs
+
+For a scheduling test, add a sufficiently long classical post-processing step
+after the Python command. For example, add `sleep 120` to `bell.sbatch`. Then
+submit two jobs:
+
+```console
+sbatch --nodelist=node1 bell.sbatch
+sbatch --nodelist=node2 bell.sbatch
+```
+
+Both jobs can run because two DDSIM licenses exist. Each job uses one CPU. One
+CPU remains free on each node. Submit a third DDSIM job. Slurm keeps it pending
+until one DDSIM license becomes free.
+
+Use these commands to inspect the state:
+
+```console
+squeue --format="%.18i %.9T %.20R %.12N %.20L"
+scontrol show lic mqt.ddsim.default
+scontrol show node node1
+scontrol show node node2
+```
+
+The third job must have state `PENDING` and reason `Licenses`. The license
+report must show `Total=2 Used=2 Free=0`. The node records must still show one
+free CPU on each node. A job that requests `mqt.sc.default:1` can use one of
+these CPUs because it uses a different license.
+
+When one DDSIM job ends, Slurm returns its license. The pending job can then
+start without a change to the device registry or `slurm.conf`.
+
+## Diagnose a failure
+
+First, run `scontrol show job <job-id>`. Check `JobState`, `Reason`, `Licenses`,
+and `NodeList`. Use `scontrol show lic` to compare the total, used, and free
+counts. Use `scontrol show node` to check CPU allocation.
+
+If a node is down, check `systemctl status munge slurmd` and the Slurm journal
+on that node. Check that `/sys/fs/cgroup/cgroup.controllers` exists. Check that
+all nodes use the same Munge key and the same `slurm.conf`.
+
+If MQT Core cannot select a device, print `SLURM_JOB_LICENSES` inside the batch
+job and list the registered QDMI IDs. Use this value only to diagnose selection.
+It is not proof of the Slurm allocation. The license name and stable ID must
+match exactly. Do not add a generic device license. Do not use a Slurm OR
+license expression for device selection because the environment does not
+identify a single selected device in that case.
+
+[Slurm GRES configuration]: https://slurm.schedmd.com/gres.conf.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ known-first-party = ["mqt.core"]
 
 [tool.ruff.lint.per-file-ignores]
 "test/python/**" = ["T20", "INP001"]
+"test/slurm/**" = ["DOC201", "DOC501", "INP001"]
 "docs/**" = ["T20", "INP001"]
 "noxfile.py" = ["T20", "TID251", "PLC0415"]
 "mlir/unittests/**/*.py" = ["INP001", "T201"]

--- a/test/slurm/.dockerignore
+++ b/test/slurm/.dockerignore
@@ -1,0 +1,1 @@
+runtime/

--- a/test/slurm/.gitignore
+++ b/test/slurm/.gitignore
@@ -1,0 +1,2 @@
+dist/
+runtime/

--- a/test/slurm/Dockerfile
+++ b/test/slurm/Dockerfile
@@ -1,0 +1,46 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+FROM ghcr.io/astral-sh/uv:0.12.1 AS uv
+
+FROM ubuntu:26.04 AS common
+
+ENV container=docker
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        ca-certificates \
+        dbus \
+        munge \
+        python3 \
+        slurm-wlm \
+        systemd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=uv /uv /uvx /bin/
+COPY dist/*.whl /tmp/dist/
+COPY mqt-slurm-prepare /usr/local/sbin/mqt-slurm-prepare
+COPY mqt-slurm-prepare.service /etc/systemd/system/mqt-slurm-prepare.service
+
+RUN uv pip install --system --no-deps --break-system-packages /tmp/dist/*.whl \
+    && rm -rf /root/.cache/uv /tmp/dist \
+    && chmod 0755 /usr/local/sbin/mqt-slurm-prepare \
+    && systemctl enable mqt-slurm-prepare.service munge.service
+
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["/usr/lib/systemd/systemd"]
+
+FROM common AS controller
+
+RUN systemctl enable slurmctld.service
+
+FROM common AS compute
+
+RUN systemctl enable slurmd.service

--- a/test/slurm/bell_job.py
+++ b/test/slurm/bell_job.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Execute a Bell circuit on the DDSIM device named by the license environment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+from mqt.core.qdmi import ProgramFormat, slurm
+
+BELL_PROGRAM = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+measure q -> c;
+"""
+SHOTS = 256
+
+
+def main() -> None:
+    """Run the circuit, write its result, and optionally retain the allocation."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hold", action="store_true")
+    args = parser.parse_args()
+
+    job_id = os.environ["SLURM_JOB_ID"]
+    device = slurm.open_device_from_license()
+    job = device.submit_job(BELL_PROGRAM, ProgramFormat.QASM2, SHOTS)
+    if not job.wait(60):
+        msg = "DDSIM did not complete the Bell circuit within 60 seconds"
+        raise RuntimeError(msg)
+
+    counts = job.get_counts()
+    if sum(counts.values()) != SHOTS:
+        msg = f"Expected {SHOTS} Bell samples, got {sum(counts.values())}"
+        raise RuntimeError(msg)
+    if set(counts) != {"00", "11"}:
+        msg = f"Expected only Bell outcomes 00 and 11, got {sorted(counts)}"
+        raise RuntimeError(msg)
+
+    result = {
+        "counts": counts,
+        "device": device.name(),
+        "job_id": job_id,
+        "licenses": os.environ["SLURM_JOB_LICENSES"],
+        "node": os.environ["SLURM_JOB_NODELIST"],
+        "shots": SHOTS,
+    }
+    runtime = Path("/runtime")
+    (runtime / f"ddsim-{job_id}.json").write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+
+    if args.hold:
+        release = runtime / f"release-{job_id}"
+        deadline = time.monotonic() + 180
+        while not release.exists():
+            if time.monotonic() >= deadline:
+                msg = f"Release marker for Slurm job {job_id} did not appear"
+                raise TimeoutError(msg)
+            time.sleep(0.2)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/slurm/cgroup.conf
+++ b/test/slurm/cgroup.conf
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+CgroupPlugin=autodetect
+ConstrainCores=yes
+ConstrainRAMSpace=yes
+ConstrainSwapSpace=yes

--- a/test/slurm/compose.yml
+++ b/test/slurm/compose.yml
@@ -1,0 +1,107 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+services:
+  controller:
+    build:
+      context: .
+      target: controller
+    hostname: controller
+    privileged: true
+    cgroup: host
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ../..:/workspace:ro
+      - ./runtime:/runtime
+      - ./slurm.conf:/etc/slurm/slurm.conf:ro
+      - ./cgroup.conf:/etc/slurm/cgroup.conf:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "systemctl",
+          "is-active",
+          "--quiet",
+          "munge.service",
+          "slurmctld.service",
+        ]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 5s
+
+  node1:
+    build:
+      context: .
+      target: compute
+    hostname: node1
+    privileged: true
+    cgroup: host
+    depends_on:
+      controller:
+        condition: service_healthy
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ../..:/workspace:ro
+      - ./runtime:/runtime
+      - ./slurm.conf:/etc/slurm/slurm.conf:ro
+      - ./cgroup.conf:/etc/slurm/cgroup.conf:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "systemctl",
+          "is-active",
+          "--quiet",
+          "munge.service",
+          "slurmd.service",
+        ]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 5s
+
+  node2:
+    build:
+      context: .
+      target: compute
+    hostname: node2
+    privileged: true
+    cgroup: host
+    depends_on:
+      controller:
+        condition: service_healthy
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ../..:/workspace:ro
+      - ./runtime:/runtime
+      - ./slurm.conf:/etc/slurm/slurm.conf:ro
+      - ./cgroup.conf:/etc/slurm/cgroup.conf:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "systemctl",
+          "is-active",
+          "--quiet",
+          "munge.service",
+          "slurmd.service",
+        ]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 5s

--- a/test/slurm/ddsim-job.sh
+++ b/test/slurm/ddsim-job.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+set -eu
+
+exec python3 /workspace/test/slurm/bell_job.py "$@"

--- a/test/slurm/mqt-slurm-prepare
+++ b/test/slurm/mqt-slurm-prepare
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+set -eu
+
+test -s /runtime/munge.key
+
+install -d -o munge -g munge -m 0755 /etc/munge /run/munge
+install -o munge -g munge -m 0400 /runtime/munge.key /etc/munge/munge.key
+install -d -o slurm -g slurm -m 0755 /var/spool/slurmctld /var/log/slurm
+install -d -o root -g root -m 0755 /var/spool/slurmd

--- a/test/slurm/mqt-slurm-prepare.service
+++ b/test/slurm/mqt-slurm-prepare.service
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+[Unit]
+Description=Prepare the MQT Core Slurm test node
+RequiresMountsFor=/runtime
+Before=munge.service slurmctld.service slurmd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/mqt-slurm-prepare
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/test/slurm/run_integration.py
+++ b/test/slurm/run_integration.py
@@ -1,0 +1,385 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Run the real Slurm admission and QDMI execution integration test."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import secrets
+import shlex
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "test" / "slurm"
+DIST = FIXTURE / "dist"
+RUNTIME = FIXTURE / "runtime"
+COMPOSE = (
+    "docker",
+    "compose",
+    "--project-name",
+    "mqt-core-slurm-test",
+    "--file",
+    str(FIXTURE / "compose.yml"),
+)
+TIMEOUT = 120.0
+RESULT_VISIBILITY_GRACE_PERIOD = 5.0
+LOGGER = logging.getLogger(__name__)
+
+
+def run(command: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a command and retain output for assertions and diagnostics."""
+    LOGGER.info("+ %s", shlex.join(command))
+    result = subprocess.run(command, check=False, capture_output=True, text=True)  # ruff: ignore[subprocess-without-shell-equals-true]
+    if result.stdout:
+        LOGGER.info("%s", result.stdout.rstrip())
+    if result.stderr:
+        LOGGER.info("%s", result.stderr.rstrip())
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, command, output=result.stdout, stderr=result.stderr)
+    return result
+
+
+def compose(*arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run Docker Compose for the fixed, isolated test project."""
+    return run((*COMPOSE, *arguments), check=check)
+
+
+def controller(*command: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a Slurm client command in the controller container."""
+    return compose("exec", "-T", "controller", *command, check=check)
+
+
+def compute(node: str, *command: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a diagnostic command in one compute container."""
+    return compose("exec", "-T", node, *command, check=check)
+
+
+def wait_for(description: str, predicate: Callable[[], bool], timeout: float = TIMEOUT) -> None:
+    """Poll a condition and report a precise timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.5)
+    msg = f"Timed out while waiting for {description}"
+    raise TimeoutError(msg)
+
+
+def node_record(node: str) -> str:
+    """Return one machine-readable Slurm node record."""
+    return controller("scontrol", "show", "node", node, "--oneliner").stdout.strip()
+
+
+def node_is_idle(node: str) -> bool:
+    """Return whether a compute node has registered and is idle."""
+    record = node_record(node)
+    return "State=IDLE" in record and "CPUTot=2" in record
+
+
+def job_record(job_id: str) -> tuple[str, str, str] | None:
+    """Return state, reason, and node for an active job."""
+    output = controller("squeue", "--noheader", "--jobs", job_id, "--format=%T|%R|%N").stdout.strip()
+    if not output:
+        return None
+    state, reason, node = output.split("|", maxsplit=2)
+    # squeue renders a pending reason in parentheses even with a custom format.
+    if reason.startswith("(") and reason.endswith(")"):
+        reason = reason[1:-1]
+    return state, reason, node
+
+
+def job_matches(job_id: str, state: str, *, node: str | None = None, reason: str | None = None) -> bool:
+    """Return whether an active job has the requested observable state."""
+    record = job_record(job_id)
+    if record is None:
+        return False
+    actual_state, actual_reason, actual_node = record
+    return (
+        actual_state == state and (node is None or actual_node == node) and (reason is None or actual_reason == reason)
+    )
+
+
+def submit(script: str, license_expression: str, *, node: str | None = None, hold: bool = False) -> str:
+    """Submit one single-processor batch job and return its numeric ID."""
+    command = [
+        "sbatch",
+        "--parsable",
+        "--nodes=1",
+        "--ntasks=1",
+        "--cpus-per-task=1",
+        f"--licenses={license_expression}",
+        "--chdir=/workspace",
+        "--output=/runtime/slurm-%j.out",
+    ]
+    if node is not None:
+        command.append(f"--nodelist={node}")
+    command.append(f"/workspace/test/slurm/{script}")
+    if hold:
+        command.append("--hold")
+    job_id = controller(*command).stdout.strip().split(";", maxsplit=1)[0]
+    if not job_id.isdecimal():
+        msg = f"sbatch returned an invalid job ID: {job_id!r}"
+        raise RuntimeError(msg)
+    return job_id
+
+
+def license_record(name: str) -> dict[str, str]:
+    """Parse one `scontrol show lic` record."""
+    output = controller("scontrol", "show", "lic", name, "--oneliner").stdout
+    return dict(field.split("=", maxsplit=1) for field in output.split() if "=" in field)
+
+
+def assert_license(name: str, *, total: int, used: int, free: int) -> None:
+    """Require the exact static Slurm license counters."""
+    record = license_record(name)
+    expected = {"LicenseName": name, "Total": str(total), "Used": str(used), "Free": str(free)}
+    if not expected.items() <= record.items():
+        msg = f"Unexpected license record for {name}: {record}; expected {expected}"
+        raise AssertionError(msg)
+
+
+def load_result(kind: str, job_id: str) -> dict[str, Any]:
+    """Load one batch-job result from the shared runtime directory."""
+    return json.loads((RUNTIME / f"{kind}-{job_id}.json").read_text(encoding="utf-8"))
+
+
+def wait_for_result(kind: str, job_id: str, description: str) -> None:
+    """Wait for a result and allow bounded shared-file visibility delay."""
+    result_path = RUNTIME / f"{kind}-{job_id}.json"
+    left_queue_at: float | None = None
+
+    def result_exists_or_raise() -> bool:
+        nonlocal left_queue_at
+        if result_path.exists():
+            return True
+        if job_record(job_id) is not None:
+            left_queue_at = None
+            return False
+
+        now = time.monotonic()
+        if left_queue_at is None:
+            left_queue_at = now
+            return False
+        if now - left_queue_at < RESULT_VISIBILITY_GRACE_PERIOD:
+            return False
+
+        output_path = RUNTIME / f"slurm-{job_id}.out"
+        output = output_path.read_text(encoding="utf-8") if output_path.exists() else "<no batch output>"
+        msg = f"Slurm job {job_id} exited before producing {result_path.name}:\n{output.rstrip()}"
+        raise RuntimeError(msg)
+
+    wait_for(description, result_exists_or_raise)
+
+
+def wait_for_failed_adapter(job_id: str, diagnostic: str) -> None:
+    """Require an adapter diagnostic and a failed batch job without a result."""
+    output_path = RUNTIME / f"slurm-{job_id}.out"
+
+    def failed_with_diagnostic() -> bool:
+        if not output_path.exists() or job_record(job_id) is not None:
+            return False
+        return diagnostic in output_path.read_text(encoding="utf-8")
+
+    wait_for(f"Slurm job {job_id} to fail with {diagnostic!r}", failed_with_diagnostic)
+    if (RUNTIME / f"ddsim-{job_id}.json").exists():
+        msg = f"Rejected Slurm job {job_id} unexpectedly produced a DDSIM result"
+        raise AssertionError(msg)
+
+
+def assert_bell_result(job_id: str, expected_node: str | None = None) -> None:
+    """Recheck the Bell result outside the batch job."""
+    result = load_result("ddsim", job_id)
+    if result["shots"] != 256 or sum(result["counts"].values()) != 256:
+        msg = f"Slurm job {job_id} did not return 256 Bell samples: {result}"
+        raise AssertionError(msg)
+    if set(result["counts"]) != {"00", "11"}:
+        msg = f"Slurm job {job_id} returned non-Bell outcomes: {result}"
+        raise AssertionError(msg)
+    if expected_node is not None and result["node"] != expected_node:
+        msg = f"Slurm job {job_id} ran on {result['node']}, expected {expected_node}"
+        raise AssertionError(msg)
+    if result["licenses"] not in {"mqt.ddsim.default", "mqt.ddsim.default:1"}:
+        msg = f"Slurm exposed an unexpected license string: {result['licenses']}"
+        raise AssertionError(msg)
+
+
+def clean_runtime() -> None:
+    """Remove only result artifacts created by an earlier fixture run."""
+    RUNTIME.mkdir(parents=True, exist_ok=True)
+    for pattern in ("ddsim-*.json", "sc-*.json", "release-*", "slurm-*.out"):
+        for path in RUNTIME.glob(pattern):
+            path.unlink()
+    key = RUNTIME / "munge.key"
+    key.write_bytes(secrets.token_bytes(1024))
+    key.chmod(0o600)
+
+
+def print_diagnostics() -> None:
+    """Print cluster state without hiding the original test failure."""
+    controller("squeue", "--all", check=False)
+    controller(
+        "sacct",
+        "--allusers",
+        "--starttime=now-1hour",
+        "--format=JobID,State,ExitCode,Reason,NodeList",
+        check=False,
+    )
+    controller("scontrol", "show", "node", check=False)
+    controller("scontrol", "show", "lic", check=False)
+    for output in sorted(RUNTIME.glob("slurm-*.out")):
+        LOGGER.info("=== %s ===", output.name)
+        try:
+            LOGGER.info("%s", output.read_text(encoding="utf-8").rstrip())
+        except OSError as error:
+            LOGGER.info("Could not read %s: %s", output, error)
+    for service, units in (
+        ("controller", ("munge.service", "slurmctld.service")),
+        ("node1", ("munge.service", "slurmd.service")),
+        ("node2", ("munge.service", "slurmd.service")),
+    ):
+        compose("exec", "-T", service, "systemctl", "status", "--no-pager", *units, check=False)
+        compose(
+            "exec",
+            "-T",
+            service,
+            "journalctl",
+            "--no-pager",
+            "--lines=100",
+            *(argument for unit in units for argument in ("--unit", unit)),
+            check=False,
+        )
+    compose("logs", "--no-color", check=False)
+
+
+def main() -> None:
+    """Build the cluster and verify Slurm admission and DDSIM execution."""
+    clean_runtime()
+    wheels = tuple(DIST.glob("*.whl"))
+    if len(wheels) != 1:
+        msg = f"Build exactly one MQT Core wheel in {DIST}, found {len(wheels)}"
+        raise RuntimeError(msg)
+
+    success = False
+    started = False
+    try:
+        cgroup_version = run(("docker", "info", "--format", "{{.CgroupVersion}}")).stdout.strip()
+        if cgroup_version != "2":
+            msg = f"The Slurm integration requires Docker on cgroup v2, got {cgroup_version!r}"
+            raise RuntimeError(msg)
+
+        started = True
+        compose("up", "--build", "--detach", "--wait")
+
+        version_output = controller("scontrol", "--version").stdout.strip()
+        version_match = re.search(r"^slurm(?:-wlm)?\s+(\d+)\.(\d+)\b", version_output, flags=re.IGNORECASE)
+        if version_match is None or tuple(map(int, version_match.groups())) < (25, 11):
+            msg = f"The fixture requires Slurm 25.11 or newer, got {version_output!r}"
+            raise RuntimeError(msg)
+
+        for node in ("node1", "node2"):
+            compute(node, "test", "-r", "/sys/fs/cgroup/cgroup.controllers")
+            delegate = compute(
+                node,
+                "systemctl",
+                "show",
+                "slurmd.service",
+                "--property=Delegate",
+                "--value",
+            ).stdout.strip()
+            if delegate != "yes":
+                msg = f"The packaged slurmd.service on {node} must set Delegate=yes, got {delegate!r}"
+                raise RuntimeError(msg)
+            wait_for(f"{node} to become IDLE with two processors", lambda node=node: node_is_idle(node))
+
+        registry_check = (
+            "from pathlib import Path; "
+            "import mqt.core; "
+            "from mqt.core.qdmi import driver; "
+            "module_path = Path(mqt.core.__file__).resolve(); "
+            "assert not any(module_path.is_relative_to(root) for root in ('/workspace', '/runtime')), module_path; "
+            "ids = driver.registered_device_ids(); "
+            "assert 'mqt.ddsim.default' in ids and 'mqt.sc.default' in ids, ids"
+        )
+        controller("python3", "-c", registry_check)
+        assert_license("mqt.ddsim.default", total=2, used=0, free=2)
+        assert_license("mqt.sc.default", total=1, used=0, free=1)
+
+        non_unit = submit("ddsim-job.sh", "mqt.ddsim.default:2")
+        wait_for_failed_adapter(non_unit, "must request exactly one Slurm license")
+        compound = submit("ddsim-job.sh", "mqt.ddsim.default:1,mqt.sc.default:1")
+        wait_for_failed_adapter(compound, "uses a compound AND expression")
+        alternative = submit("ddsim-job.sh", "mqt.ddsim.default:1|mqt.sc.default:1")
+        wait_for_failed_adapter(alternative, "uses a compound OR expression")
+        assert_license("mqt.ddsim.default", total=2, used=0, free=2)
+        assert_license("mqt.sc.default", total=1, used=0, free=1)
+
+        first = submit("ddsim-job.sh", "mqt.ddsim.default:1", node="node1", hold=True)
+        second = submit("ddsim-job.sh", "mqt.ddsim.default:1", node="node2", hold=True)
+        wait_for_result("ddsim", first, "the first DDSIM Bell result")
+        wait_for_result("ddsim", second, "the second DDSIM Bell result")
+        wait_for("the first DDSIM job to hold on node1", lambda: job_matches(first, "RUNNING", node="node1"))
+        wait_for("the second DDSIM job to hold on node2", lambda: job_matches(second, "RUNNING", node="node2"))
+        if "CPUAlloc=1" not in node_record("node1") or "CPUAlloc=1" not in node_record("node2"):
+            msg = "Each held DDSIM job must leave one processor free on its compute node"
+            raise AssertionError(msg)
+
+        third = submit("ddsim-job.sh", "mqt.ddsim.default:1")
+        wait_for(
+            "the third DDSIM job to wait for its license",
+            lambda: job_matches(third, "PENDING", reason="Licenses"),
+        )
+        assert_license("mqt.ddsim.default", total=2, used=2, free=0)
+
+        sc_job = submit("sc-job.sh", "mqt.sc.default:1")
+        wait_for_result("sc", sc_job, "the SC job to execute on a free CPU")
+        wait_for("the SC job to leave the queue", lambda: job_record(sc_job) is None)
+        sc_result = load_result("sc", sc_job)
+        if sc_result["node"] not in {"node1", "node2"} or sc_result["qubits"] <= 0:
+            msg = f"Unexpected SC job result: {sc_result}"
+            raise AssertionError(msg)
+        if not job_matches(first, "RUNNING", node="node1") or not job_matches(second, "RUNNING", node="node2"):
+            msg = "The SC job did not complete while both DDSIM licenses remained held"
+            raise AssertionError(msg)
+
+        (RUNTIME / f"release-{first}").touch()
+        wait_for("the released first DDSIM job to finish", lambda: job_record(first) is None)
+        wait_for_result("ddsim", third, "the pending third DDSIM job to execute")
+        wait_for("the third DDSIM job to finish", lambda: job_record(third) is None)
+
+        assert_bell_result(first, "node1")
+        assert_bell_result(second, "node2")
+        assert_bell_result(third)
+        assert_license("mqt.ddsim.default", total=2, used=1, free=1)
+
+        (RUNTIME / f"release-{second}").touch()
+        wait_for("the released second DDSIM job to finish", lambda: job_record(second) is None)
+        assert_license("mqt.ddsim.default", total=2, used=0, free=2)
+
+        LOGGER.info(
+            "Slurm 25.11+ admitted two held DDSIM jobs, blocked the third for Licenses, "
+            "ran the SC job on a free CPU, and executed the third Bell job after release."
+        )
+        success = True
+    finally:
+        if started and not success:
+            print_diagnostics()
+        compose("down", "--volumes", "--remove-orphans", check=False)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    main()

--- a/test/slurm/sc-job.sh
+++ b/test/slurm/sc-job.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+set -eu
+
+exec python3 /workspace/test/slurm/sc_job.py

--- a/test/slurm/sc_job.py
+++ b/test/slurm/sc_job.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Open the SC device named by the license environment on a free processor."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from mqt.core.qdmi import slurm
+
+
+def main() -> None:
+    """Query the license-selected SC device and record the compute node."""
+    job_id = os.environ["SLURM_JOB_ID"]
+    device = slurm.open_device_from_license()
+    result = {
+        "device": device.name(),
+        "job_id": job_id,
+        "licenses": os.environ["SLURM_JOB_LICENSES"],
+        "node": os.environ["SLURM_JOB_NODELIST"],
+        "qubits": device.qubits_num(),
+    }
+    Path(f"/runtime/sc-{job_id}.json").write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/slurm/slurm.conf
+++ b/test/slurm/slurm.conf
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+ClusterName=mqt-core-test
+SlurmctldHost=controller
+SlurmUser=slurm
+AuthType=auth/munge
+StateSaveLocation=/var/spool/slurmctld
+SlurmdSpoolDir=/var/spool/slurmd
+SlurmctldPidFile=/run/slurmctld.pid
+SlurmdPidFile=/run/slurmd.pid
+
+ProctrackType=proctrack/cgroup
+TaskPlugin=task/cgroup,task/affinity
+JobAcctGatherType=jobacct_gather/cgroup
+SelectType=select/cons_tres
+SelectTypeParameters=CR_CPU
+PrologFlags=Contain
+
+SchedulerType=sched/backfill
+ReturnToService=2
+SlurmdParameters=config_overrides
+SlurmctldParameters=reconfig_on_restart
+
+Licenses=mqt.ddsim.default:2,mqt.sc.default:1
+
+NodeName=node1 NodeAddr=node1 CPUs=2 Boards=1 SocketsPerBoard=1 CoresPerSocket=2 ThreadsPerCore=1 RealMemory=512 State=UNKNOWN
+NodeName=node2 NodeAddr=node2 CPUs=2 Boards=1 SocketsPerBoard=1 CoresPerSocket=2 ThreadsPerCore=1 RealMemory=512 State=UNKNOWN
+PartitionName=compute Nodes=node1,node2 Default=YES MaxTime=INFINITE State=UP


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- add a real Slurm 25.11+ cluster fixture with one controller and two compute nodes on Ubuntu 26.04
- use systemd, Munge, cgroup v2, `select/cons_tres`, two CPUs per node, two DDSIM licenses, and one SC license
- build one Python 3.14 wheel on the runner, install it in the disposable image with pinned uv, and run without `PYTHONPATH`
- rely on the packaged Slurm unit's `Delegate=yes` and assert that property at runtime
- reject live non-unit, AND, and OR QDMI license requests through the mechanism-specific selector
- run two DDSIM Bell jobs concurrently on separate nodes and hold both allocations after execution
- require a third DDSIM job to remain pending for `Licenses` while CPUs remain free
- run an SC job on a free CPU, then release one DDSIM job and require the pending job to execute

Each valid job requests one license and uses `mqt.core.qdmi.slurm.open_device_from_license()`. Each DDSIM result contains 256 samples and only Bell outcomes `00` and `11`.

## Resource-management boundary

The tutorial separates four controls:

1. Slurm licenses provide cluster-wide admission and accounting.
2. The mutable license environment selects a registered QDMI device.
3. The provider reports device availability and queue state.
4. Provider credentials or operating-system isolation authorize access.

The example is suitable for admission testing on a cooperative cluster. Strict isolation of a local device requires a GRES `File=` entry with `ConstrainDevices=yes`. Remote IQM and Amazon Braket devices require provider-scoped credentials.

The QDMI Python namespace from #2074 is now part of `main`. This PR remains the direct child of #2025 and the top layer of the #2025 → #2043 native stack.

## Validation

- Python and shell syntax
- Docker Compose configuration
- changed-file hooks and complete repository lint
- complete FoMaC C++, QDMI driver, and DDSIM suites
- QDMI Python suite on Python 3.10 and 3.14
- recursive nanobind stub regeneration with no source diff
- Sphinx documentation with warnings as errors
- Python 3.14 wheel build and wheel-content inspection
- tutorial length: 1,177 words
- independent exact-head adversarial audit: no source blocker
- exact-head privileged Slurm workflow: passed, including the installed wheel without `PYTHONPATH`, packaged `Delegate=yes`, non-unit/AND/OR rejection, concurrent admission, SC independence, DDSIM readmission, and Bell results

Replacement standard CI for the signed post-merge revision is in progress.
