### PR TITLE
♻️ Return explicit MLIR compiler-target errors

### DIFF
--- a/.agent/plans/issue-1590-no-exceptions.md
+++ b/.agent/plans/issue-1590-no-exceptions.md
@@ -1,0 +1,162 @@
+# Return explicit compiler-target errors
+
+This ExecPlan is a living document maintained according to `.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+Compiler-target construction and FoMaC target discovery must report invalid data
+without throwing through the MLIR compiler libraries. C++ callers receive
+`llvm::Expected`; Python callers continue to receive ordinary `ValueError`
+exceptions at the nanobind boundary. This pull request is independently based on
+`main` and does not change the repository-wide exception build policy.
+
+## Progress
+
+- [x] (2026-08-12 17:00Z) Replace fallible target constructors with named
+  `create` factories and propagate failures through LLVM error types.
+- [x] (2026-08-12 18:00Z) Preserve Python exception behavior and update C++,
+  command-line, mapping, synthesis, and compiler callers and tests.
+- [x] (2026-08-12 19:00Z) Update the C++ target-compilation guide and generic
+  compiler-target changelog entry.
+- [x] (2026-08-12 22:03Z) Use in-place nanobind constructors, remove redundant
+  private constructor tags, and remove unrelated QIR subprocess coverage.
+- [x] (2026-08-12 22:12Z) Validate the simplified implementation with focused
+      C++ and Python suites, generated-signature inspection, repository lint,
+      and whitespace checks.
+
+## Surprises & Discoveries
+
+- `Target.cpp` owned the target model's exception syntax, while the nanobind
+  registration file already provided the correct boundary for translating
+  explicit C++ errors into Python exceptions.
+- Official MLIR bindings use `None` for ordinary absence and exceptions for
+  failed checked construction. nanobind recommends in-place `__init__` bindings
+  over value-returning `nb::new_` when the value can be constructed in
+  caller-provided storage.
+- The isolated stub-generation session could not finish because GitHub returned
+  an empty response while downloading an unchanged build dependency. The
+  worktree package built successfully, and nanobind's runtime signatures for all
+  eight constructors match the checked-in stubs exactly.
+
+## Decision Log
+
+- Use `llvm::Expected<T>` for fallible construction and `llvm::Error` for
+  validation helpers. These types are native to the existing LLVM dependency and
+  retain explanatory diagnostics without an exception-capable ABI.
+- Keep routing accessors as preconditioned fast queries. Construction validates
+  the target graph once, and callers that already hold validated vertices do not
+  need a second fallible API.
+- Keep Python `ValueError` behavior by consuming LLVM errors inside nanobind.
+  LLVM result wrappers are not exposed in the Python API.
+- Keep Python constructor spelling and placement-construct each value only after
+  its `llvm::Expected` succeeds. Returning `None` would discard the validation
+  diagnostic and weaken every constructor's return type.
+- Keep validated value constructors private, but do not add empty passkey tag
+  types. Private access already prevents callers from bypassing the factories.
+- Keep QIR subprocess tests focused on QIR output. Compiler-target and Python
+  tests cover target discovery and validation without adding unrelated `mqt-cc`
+  option cases to that script.
+
+## Outcomes & Retrospective
+
+Target values are constructed only after validation succeeds. The compiler,
+FoMaC adapter, command-line tool, Python bindings, mapping, and synthesis paths
+now propagate explicit errors. Valid target behavior and Python-facing failure
+semantics remain unchanged. Repository-wide exception disabling is deliberately
+left to a later, separately reviewable change. All 232 compiler, 81 mapping, and
+21 target-synthesis tests passed. Six focused Python target tests passed against
+the rebuilt extension. Repository lint and `git diff --check` passed. No tracked
+stub changed, and runtime signature inspection confirmed the four target
+overloads and four nested metadata constructors retain their checked-in Python
+signatures.
+
+## Context and Orientation
+
+`mlir/include/mlir/Compiler/Target.h` and `mlir/lib/Compiler/Target.cpp` define
+the immutable target model. `mlir/lib/Compiler/FoMaCAdapter.cpp` constructs
+targets from device snapshots. `bindings/mlir/register_mlir.cpp` is the Python
+language boundary. Mapping and native synthesis consume validated targets and
+therefore unwrap only fixtures or locally known-valid constructions.
+
+## Plan of Work
+
+Add static factories for `DurationUnit`, `Site`, `SiteTuple`, `Operation`, and
+`CompilerTarget`. Move validation into helpers returning LLVM errors and keep
+constructors private. Make FoMaC target discovery return an expected target,
+propagate failures through compiler and command-line callers, and translate
+errors to `nanobind::value_error` in bindings. Bind the unchanged Python
+constructors with in-place `__init__` functions that construct only after an
+expected result succeeds. Update focused tests for all constructor overloads,
+valid nested metadata, and exact invalid-input diagnostics. Document the C++
+error-handling pattern in the target-compilation guide and the existing generic
+compiler-target changelog entry.
+
+## Milestones
+
+The first milestone replaces exception-throwing target construction with LLVM
+result types. It is complete when invalid metadata produces a descriptive
+`llvm::Error` and valid fixtures retain the same target values.
+
+The second milestone propagates those results through FoMaC, compiler,
+command-line, mapping, synthesis, and Python call sites. It is complete when no
+caller discards an error and Python still reports invalid input as `ValueError`.
+
+The final milestone updates the target-compilation guide and validates the
+standalone change. It is complete when the focused compiler, mapping, synthesis,
+and Python suites, generated-stub checks, repository lint, and whitespace checks
+pass.
+
+## Concrete Steps
+
+Run cache-producing commands through `.agent/run.sh` from the repository root:
+
+    ./.agent/run.sh cmake --preset release
+    ./.agent/run.sh cmake --build build/release --target \
+      mqt-core-mlir-unittests-compiler \
+      mqt-core-mlir-unittest-mapping \
+      mqt-core-mlir-unittest-target-synthesis mqt-core-mlir-bindings
+    ./build/release/mlir/unittests/Compiler/mqt-core-mlir-unittests-compiler
+    ./.agent/run.sh uv run --no-sync pytest test/python/test_mlir.py -k target
+    ./.agent/run.sh uvx nox -s stubs
+    ./.agent/run.sh uvx nox -s lint
+    git diff --check
+
+## Validation and Acceptance
+
+Invalid C++ target metadata must return an `llvm::Error` with a useful message;
+valid targets must preserve their mapping and synthesis behavior; invalid Python
+construction must still raise `ValueError`; and the changed compiler-target core
+must not throw for validation failures. Focused C++ and Python tests, repository
+lint, `git diff --check`, and exact-head CI must pass before merge readiness.
+
+## Idempotence and Recovery
+
+Configuration, builds, tests, and lint are repeatable in this worktree. A failed
+factory result leaves no partially initialized target. The implementation does
+not modify global state, external services, or another task's worktree.
+
+## Artifacts and Notes
+
+The focused test summaries are:
+
+    [  PASSED  ] 232 tests.
+    [  PASSED  ] 81 tests.
+    [  PASSED  ] 21 tests.
+    6 passed in 3.82s
+    nox > Session lint was successful
+
+The runtime nanobind metadata reports four `CompilerTarget.__init__` overloads
+and one unchanged `__init__` signature for each nested metadata class. The
+generated Python stub files have no diff.
+
+## Interfaces and Dependencies
+
+The public factories return `llvm::Expected<DurationUnit>`,
+`llvm::Expected<Site>`, `llvm::Expected<SiteTuple>`,
+`llvm::Expected<Operation>`, and `llvm::Expected<CompilerTarget>`.
+`compilerTargetFromDevice` returns `llvm::Expected<CompilerTarget>`. LLVM/MLIR
+22 and C++20 remain the only relevant language and compiler dependencies.
+
+Revision note (2026-08-12): aligned the Python bindings with MLIR and nanobind
+checked-construction conventions, removed redundant constructor passkeys, and
+removed unrelated QIR command-line coverage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ releases may include breaking changes.
   compiler APIs and `mqt-cc` ([#2003]) ([**@burgholzer**])
 - ✨ Add immutable MLIR compiler targets and a canonical target compilation
   pipeline for decomposition, optimization, mapping, native synthesis, and
-  conformance ([#1993], [#1999]) ([**@simon1hofmann**], [**@burgholzer**])
+  conformance ([#1993], [#1999], [#2049]) ([**@simon1hofmann**],
+  [**@burgholzer**])
 - ✨ Bundle reusable IQM Garnet and Emerald superconducting device models with
   stable QDMI registry IDs ([#1992]) ([**@burgholzer**])
 - ✨ Add compiler-wide scoped global-phase normalization with exact modifier
@@ -739,6 +740,7 @@ for previous changelogs._
 
 [#2060]: https://github.com/munich-quantum-toolkit/core/pull/2060
 [#2058]: https://github.com/munich-quantum-toolkit/core/pull/2058
+[#2049]: https://github.com/munich-quantum-toolkit/core/pull/2049
 [#2042]: https://github.com/munich-quantum-toolkit/core/pull/2042
 [#2039]: https://github.com/munich-quantum-toolkit/core/pull/2039
 [#2038]: https://github.com/munich-quantum-toolkit/core/pull/2038

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Compiler/Programs.h"
 #include "mlir/Compiler/Target.h"
 
+#include <llvm/Support/Error.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/filesystem.h>  // NOLINT(misc-include-cleaner)
 #include <nanobind/stl/optional.h>    // NOLINT(misc-include-cleaner)
@@ -27,6 +28,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -49,6 +51,19 @@ template <class T> [[nodiscard]] T takeResult(std::optional<T>&& result) {
         "MLIR operation failed; see diagnostics for details.");
   }
   return *std::move(result);
+}
+
+template <class T> [[nodiscard]] T takeResult(llvm::Expected<T>&& result) {
+  if (!result) {
+    const auto message = llvm::toString(result.takeError());
+    throw nb::value_error(message.c_str());
+  }
+  return *std::move(result);
+}
+
+template <class T>
+void constructFromExpected(T& self, llvm::Expected<T>&& result) {
+  std::construct_at(&self, takeResult(std::move(result)));
 }
 
 void requireSuccess(const bool succeeded) {
@@ -285,7 +300,16 @@ means every operation is native.)pb");
 
   auto durationUnit = nb::class_<mlir::CompilerTarget::DurationUnit>(
       compilerTarget, "DurationUnit", "Unit for raw target timing metadata.");
-  durationUnit.def(nb::init<std::string, double>(), "unit"_a, "scale_factor"_a)
+  durationUnit
+      .def(
+          "__init__",
+          [](mlir::CompilerTarget::DurationUnit& self, std::string unit,
+             const double scaleFactor) {
+            constructFromExpected(self,
+                                  mlir::CompilerTarget::DurationUnit::create(
+                                      std::move(unit), scaleFactor));
+          },
+          "unit"_a, "scale_factor"_a)
       .def_prop_ro(
           "unit",
           [](const mlir::CompilerTarget::DurationUnit& value) {
@@ -299,10 +323,17 @@ means every operation is native.)pb");
   auto targetSite = nb::class_<mlir::CompilerTarget::Site>(
       compilerTarget, "Site", "A hardware site and its optional metadata.");
   targetSite
-      .def(nb::init<mlir::CompilerTarget::SiteId, std::optional<std::string>,
-                    std::optional<uint64_t>, std::optional<uint64_t>>(),
-           "site_id"_a, "name"_a = nb::none(), "t1"_a = nb::none(),
-           "t2"_a = nb::none())
+      .def(
+          "__init__",
+          [](mlir::CompilerTarget::Site& self,
+             const mlir::CompilerTarget::SiteId siteId,
+             std::optional<std::string> name, const std::optional<uint64_t> t1,
+             const std::optional<uint64_t> t2) {
+            constructFromExpected(self, mlir::CompilerTarget::Site::create(
+                                            siteId, std::move(name), t1, t2));
+          },
+          "site_id"_a, "name"_a = nb::none(), "t1"_a = nb::none(),
+          "t2"_a = nb::none())
       .def_prop_ro("id", &mlir::CompilerTarget::Site::id,
                    "The target-defined nonnegative site identifier.")
       .def_prop_ro(
@@ -322,9 +353,17 @@ means every operation is native.)pb");
       compilerTarget, "SiteTuple",
       "Calibration data for an ordered tuple of target sites.");
   siteTuple
-      .def(nb::init<std::vector<mlir::CompilerTarget::SiteId>,
-                    std::optional<uint64_t>, std::optional<double>>(),
-           "sites"_a, "duration"_a = nb::none(), "fidelity"_a = nb::none())
+      .def(
+          "__init__",
+          [](mlir::CompilerTarget::SiteTuple& self,
+             std::vector<mlir::CompilerTarget::SiteId> sites,
+             const std::optional<uint64_t> duration,
+             const std::optional<double> fidelity) {
+            constructFromExpected(self,
+                                  mlir::CompilerTarget::SiteTuple::create(
+                                      std::move(sites), duration, fidelity));
+          },
+          "sites"_a, "duration"_a = nb::none(), "fidelity"_a = nb::none())
       .def_prop_ro(
           "sites",
           [](const mlir::CompilerTarget::SiteTuple& tuple) {
@@ -341,23 +380,26 @@ means every operation is native.)pb");
       compilerTarget, "Operation",
       "A homogeneous target-wide operation capability and its calibration.");
   targetOperation
-      .def(nb::new_(
-               [](std::string name, const size_t numQubits,
-                  const size_t numParameters,
-                  std::optional<std::vector<mlir::CompilerTarget::SiteTuple>>
-                      siteTuples,
-                  const std::optional<uint64_t> duration,
-                  const std::optional<double> fidelity) {
-                 return mlir::CompilerTarget::Operation(
-                     std::move(name), numQubits, numParameters,
-                     std::move(siteTuples)
-                         .value_or(
-                             std::vector<mlir::CompilerTarget::SiteTuple>{}),
-                     duration, fidelity);
-               }),
-           "name"_a, "num_qubits"_a, "num_parameters"_a,
-           "site_tuples"_a = nb::none(), "duration"_a = nb::none(),
-           "fidelity"_a = nb::none())
+      .def(
+          "__init__",
+          [](mlir::CompilerTarget::Operation& self, std::string name,
+             const size_t numQubits, const size_t numParameters,
+             std::optional<std::vector<mlir::CompilerTarget::SiteTuple>>
+                 siteTuples,
+             const std::optional<uint64_t> duration,
+             const std::optional<double> fidelity) {
+            constructFromExpected(
+                self,
+                mlir::CompilerTarget::Operation::create(
+                    std::move(name), numQubits, numParameters,
+                    std::move(siteTuples)
+                        .value_or(
+                            std::vector<mlir::CompilerTarget::SiteTuple>{}),
+                    duration, fidelity));
+          },
+          "name"_a, "num_qubits"_a, "num_parameters"_a,
+          "site_tuples"_a = nb::none(), "duration"_a = nb::none(),
+          "fidelity"_a = nb::none())
       .def_prop_ro(
           "name",
           [](const mlir::CompilerTarget::Operation& operation) {
@@ -427,32 +469,76 @@ means every operation is native.)pb");
               "The two-qubit entangler.");
 
   compilerTarget
-      .def(nb::init<size_t,
-                    std::optional<std::vector<mlir::CompilerTarget::Coupling>>,
-                    std::optional<std::vector<mlir::CompilerTarget::Operation>>,
-                    std::optional<mlir::CompilerTarget::DurationUnit>>(),
-           "num_qubits"_a, nb::kw_only(), "couplings"_a = nb::none(),
-           "operations"_a = nb::none(), "duration_unit"_a = nb::none())
-      .def(nb::init<std::string, size_t,
-                    std::optional<std::vector<mlir::CompilerTarget::Coupling>>,
-                    std::optional<std::vector<mlir::CompilerTarget::Operation>>,
-                    std::optional<mlir::CompilerTarget::DurationUnit>>(),
-           "name"_a, "num_qubits"_a, nb::kw_only(), "couplings"_a = nb::none(),
-           "operations"_a = nb::none(), "duration_unit"_a = nb::none())
-      .def(nb::init<std::vector<mlir::CompilerTarget::Site>,
-                    std::optional<std::vector<mlir::CompilerTarget::Coupling>>,
-                    std::optional<std::vector<mlir::CompilerTarget::Operation>>,
-                    std::optional<mlir::CompilerTarget::DurationUnit>>(),
-           "sites"_a, nb::kw_only(), "couplings"_a = nb::none(),
-           "operations"_a = nb::none(), "duration_unit"_a = nb::none())
-      .def(nb::init<std::string, std::vector<mlir::CompilerTarget::Site>,
-                    std::optional<std::vector<mlir::CompilerTarget::Coupling>>,
-                    std::optional<std::vector<mlir::CompilerTarget::Operation>>,
-                    std::optional<mlir::CompilerTarget::DurationUnit>>(),
-           "name"_a, "sites"_a, nb::kw_only(), "couplings"_a = nb::none(),
-           "operations"_a = nb::none(), "duration_unit"_a = nb::none())
-      .def_static("from_device", &mlir::compilerTargetFromDevice, "device"_a,
-                  "Snapshot a circuit-model QDMI device.")
+      .def(
+          "__init__",
+          [](mlir::CompilerTarget& self, const size_t numQubits,
+             std::optional<std::vector<mlir::CompilerTarget::Coupling>>
+                 couplings,
+             std::optional<std::vector<mlir::CompilerTarget::Operation>>
+                 operations,
+             std::optional<mlir::CompilerTarget::DurationUnit> durationUnit) {
+            constructFromExpected(self, mlir::CompilerTarget::create(
+                                            numQubits, std::move(couplings),
+                                            std::move(operations),
+                                            std::move(durationUnit)));
+          },
+          "num_qubits"_a, nb::kw_only(), "couplings"_a = nb::none(),
+          "operations"_a = nb::none(), "duration_unit"_a = nb::none())
+      .def(
+          "__init__",
+          [](mlir::CompilerTarget& self, std::string name,
+             const size_t numQubits,
+             std::optional<std::vector<mlir::CompilerTarget::Coupling>>
+                 couplings,
+             std::optional<std::vector<mlir::CompilerTarget::Operation>>
+                 operations,
+             std::optional<mlir::CompilerTarget::DurationUnit> durationUnit) {
+            constructFromExpected(
+                self, mlir::CompilerTarget::create(
+                          std::move(name), numQubits, std::move(couplings),
+                          std::move(operations), std::move(durationUnit)));
+          },
+          "name"_a, "num_qubits"_a, nb::kw_only(), "couplings"_a = nb::none(),
+          "operations"_a = nb::none(), "duration_unit"_a = nb::none())
+      .def(
+          "__init__",
+          [](mlir::CompilerTarget& self,
+             std::vector<mlir::CompilerTarget::Site> sites,
+             std::optional<std::vector<mlir::CompilerTarget::Coupling>>
+                 couplings,
+             std::optional<std::vector<mlir::CompilerTarget::Operation>>
+                 operations,
+             std::optional<mlir::CompilerTarget::DurationUnit> durationUnit) {
+            constructFromExpected(
+                self, mlir::CompilerTarget::create(
+                          std::move(sites), std::move(couplings),
+                          std::move(operations), std::move(durationUnit)));
+          },
+          "sites"_a, nb::kw_only(), "couplings"_a = nb::none(),
+          "operations"_a = nb::none(), "duration_unit"_a = nb::none())
+      .def(
+          "__init__",
+          [](mlir::CompilerTarget& self, std::string name,
+             std::vector<mlir::CompilerTarget::Site> sites,
+             std::optional<std::vector<mlir::CompilerTarget::Coupling>>
+                 couplings,
+             std::optional<std::vector<mlir::CompilerTarget::Operation>>
+                 operations,
+             std::optional<mlir::CompilerTarget::DurationUnit> durationUnit) {
+            constructFromExpected(self, mlir::CompilerTarget::create(
+                                            std::move(name), std::move(sites),
+                                            std::move(couplings),
+                                            std::move(operations),
+                                            std::move(durationUnit)));
+          },
+          "name"_a, "sites"_a, nb::kw_only(), "couplings"_a = nb::none(),
+          "operations"_a = nb::none(), "duration_unit"_a = nb::none())
+      .def_static(
+          "from_device",
+          [](const fomac::Device& device) {
+            return takeResult(mlir::compilerTargetFromDevice(device));
+          },
+          "device"_a, "Snapshot a circuit-model QDMI device.")
       .def_prop_ro(
           "name",
           [](const mlir::CompilerTarget& target) {

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -76,16 +76,23 @@ the compiler-owned target:
 #include "fomac/FoMaC.hpp"
 #include "mlir/Compiler/FoMaCAdapter.h"
 #include "mlir/Compiler/Programs.h"
+#include <llvm/Support/Error.h>
+#include <llvm/Support/raw_ostream.h>
 
 auto device = fomac::Session::openDevice("mqt.sc.iqm.garnet");
 auto target = mlir::compilerTargetFromDevice(device);
+if (!target) {
+  llvm::errs() << "Failed to create compiler target: "
+               << llvm::toString(target.takeError()) << '\n';
+  return 1;
+}
 
 auto qc = mlir::QCProgram::fromQASMFile("input.qasm");
 if (!qc) {
   return 1;
 }
 auto qco = std::move(*qc).intoQCO();
-if (!qco || !qco->compileForTarget(target)) {
+if (!qco || !qco->compileForTarget(*target)) {
   return 1;
 }
 ```

--- a/mlir/include/mlir/Compiler/FoMaCAdapter.h
+++ b/mlir/include/mlir/Compiler/FoMaCAdapter.h
@@ -12,6 +12,8 @@
 
 #include "mlir/Compiler/Target.h"
 
+#include <llvm/Support/Error.h>
+
 namespace fomac {
 class Device;
 } // namespace fomac
@@ -26,7 +28,7 @@ namespace mlir {
  * zone models and site-dependent operation support are not supported by the
  * circuit-model compiler pipeline.
  */
-[[nodiscard]] CompilerTarget
+[[nodiscard]] llvm::Expected<CompilerTarget>
 compilerTargetFromDevice(const fomac::Device& device);
 
 } // namespace mlir

--- a/mlir/include/mlir/Compiler/Target.h
+++ b/mlir/include/mlir/Compiler/Target.h
@@ -13,6 +13,7 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Error.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -50,7 +51,11 @@ public:
    */
   class DurationUnit {
   public:
-    DurationUnit(std::string unit, double scaleFactor);
+    /**
+     * @brief Create a validated duration unit.
+     */
+    [[nodiscard]] static llvm::Expected<DurationUnit>
+    create(std::string unit, double scaleFactor);
 
     /// Return the target's duration unit.
     [[nodiscard]] llvm::StringRef unit() const noexcept;
@@ -59,6 +64,8 @@ public:
     [[nodiscard]] double scaleFactor() const noexcept;
 
   private:
+    DurationUnit(std::string unit, double scaleFactor);
+
     std::string unit_;
     double scaleFactor_;
   };
@@ -68,9 +75,13 @@ public:
    */
   class Site {
   public:
-    explicit Site(SiteId id, std::optional<std::string> name = std::nullopt,
-                  std::optional<uint64_t> t1 = std::nullopt,
-                  std::optional<uint64_t> t2 = std::nullopt);
+    /**
+     * @brief Create validated hardware-site metadata.
+     */
+    [[nodiscard]] static llvm::Expected<Site>
+    create(SiteId id, std::optional<std::string> name = std::nullopt,
+           std::optional<uint64_t> t1 = std::nullopt,
+           std::optional<uint64_t> t2 = std::nullopt);
 
     /// Return the target-defined nonnegative site identifier.
     [[nodiscard]] SiteId id() const noexcept;
@@ -85,6 +96,9 @@ public:
     [[nodiscard]] std::optional<uint64_t> t2() const noexcept;
 
   private:
+    Site(SiteId id, std::optional<std::string> name, std::optional<uint64_t> t1,
+         std::optional<uint64_t> t2);
+
     SiteId id_;
     std::optional<std::string> name_;
     std::optional<uint64_t> t1_;
@@ -96,9 +110,13 @@ public:
    */
   class SiteTuple {
   public:
-    explicit SiteTuple(std::vector<SiteId> sites,
-                       std::optional<uint64_t> duration = std::nullopt,
-                       std::optional<double> fidelity = std::nullopt);
+    /**
+     * @brief Create validated calibration data for a site tuple.
+     */
+    [[nodiscard]] static llvm::Expected<SiteTuple>
+    create(std::vector<SiteId> sites,
+           std::optional<uint64_t> duration = std::nullopt,
+           std::optional<double> fidelity = std::nullopt);
 
     /// Return the ordered target site identifiers.
     [[nodiscard]] llvm::ArrayRef<SiteId> sites() const noexcept;
@@ -110,6 +128,9 @@ public:
     [[nodiscard]] std::optional<double> fidelity() const noexcept;
 
   private:
+    SiteTuple(std::vector<SiteId> sites, std::optional<uint64_t> duration,
+              std::optional<double> fidelity);
+
     std::vector<SiteId> sites_;
     std::optional<uint64_t> duration_;
     std::optional<double> fidelity_;
@@ -125,10 +146,14 @@ public:
    */
   class Operation {
   public:
-    Operation(std::string name, size_t numQubits, size_t numParameters,
-              std::vector<SiteTuple> siteTuples = {},
-              std::optional<uint64_t> duration = std::nullopt,
-              std::optional<double> fidelity = std::nullopt);
+    /**
+     * @brief Create a validated operation capability.
+     */
+    [[nodiscard]] static llvm::Expected<Operation>
+    create(std::string name, size_t numQubits, size_t numParameters,
+           std::vector<SiteTuple> siteTuples = {},
+           std::optional<uint64_t> duration = std::nullopt,
+           std::optional<double> fidelity = std::nullopt);
 
     /// Return the exact reported operation name.
     [[nodiscard]] llvm::StringRef name() const noexcept;
@@ -152,6 +177,10 @@ public:
     [[nodiscard]] std::optional<double> fidelity() const noexcept;
 
   private:
+    Operation(std::string name, std::string canonicalName, size_t numQubits,
+              size_t numParameters, std::vector<SiteTuple> siteTuples,
+              std::optional<uint64_t> duration, std::optional<double> fidelity);
+
     std::string name_;
     std::string canonicalName_;
     size_t numQubits_;
@@ -207,40 +236,40 @@ public:
   };
 
   /**
-   * @brief Construct an unnamed target with dense site IDs `0..numQubits-1`.
+   * @brief Create an unnamed target with dense site IDs `0..numQubits-1`.
    */
-  explicit CompilerTarget(
-      size_t numQubits,
-      std::optional<std::vector<Coupling>> couplings = std::nullopt,
-      std::optional<std::vector<Operation>> operations = std::nullopt,
-      std::optional<DurationUnit> durationUnit = std::nullopt);
+  [[nodiscard]] static llvm::Expected<CompilerTarget>
+  create(size_t numQubits,
+         std::optional<std::vector<Coupling>> couplings = std::nullopt,
+         std::optional<std::vector<Operation>> operations = std::nullopt,
+         std::optional<DurationUnit> durationUnit = std::nullopt);
 
   /**
-   * @brief Construct a named target with dense site IDs `0..numQubits-1`.
+   * @brief Create a named target with dense site IDs `0..numQubits-1`.
    */
-  CompilerTarget(
-      std::string name, size_t numQubits,
-      std::optional<std::vector<Coupling>> couplings = std::nullopt,
-      std::optional<std::vector<Operation>> operations = std::nullopt,
-      std::optional<DurationUnit> durationUnit = std::nullopt);
+  [[nodiscard]] static llvm::Expected<CompilerTarget>
+  create(std::string name, size_t numQubits,
+         std::optional<std::vector<Coupling>> couplings = std::nullopt,
+         std::optional<std::vector<Operation>> operations = std::nullopt,
+         std::optional<DurationUnit> durationUnit = std::nullopt);
 
   /**
-   * @brief Construct an unnamed target from detailed sites.
+   * @brief Create an unnamed target from detailed sites.
    */
-  explicit CompilerTarget(
-      std::vector<Site> sites,
-      std::optional<std::vector<Coupling>> couplings = std::nullopt,
-      std::optional<std::vector<Operation>> operations = std::nullopt,
-      std::optional<DurationUnit> durationUnit = std::nullopt);
+  [[nodiscard]] static llvm::Expected<CompilerTarget>
+  create(std::vector<Site> sites,
+         std::optional<std::vector<Coupling>> couplings = std::nullopt,
+         std::optional<std::vector<Operation>> operations = std::nullopt,
+         std::optional<DurationUnit> durationUnit = std::nullopt);
 
   /**
-   * @brief Construct a named target from detailed sites.
+   * @brief Create a named target from detailed sites.
    */
-  CompilerTarget(
-      std::string name, std::vector<Site> sites,
-      std::optional<std::vector<Coupling>> couplings = std::nullopt,
-      std::optional<std::vector<Operation>> operations = std::nullopt,
-      std::optional<DurationUnit> durationUnit = std::nullopt);
+  [[nodiscard]] static llvm::Expected<CompilerTarget>
+  create(std::string name, std::vector<Site> sites,
+         std::optional<std::vector<Coupling>> couplings = std::nullopt,
+         std::optional<std::vector<Operation>> operations = std::nullopt,
+         std::optional<DurationUnit> durationUnit = std::nullopt);
 
   /// Copying shares immutable storage; rvalues copy and keep the source valid.
   CompilerTarget(const CompilerTarget&) noexcept = default;
@@ -266,7 +295,7 @@ public:
   /// Return the dense compiler vertex for a target site identifier.
   [[nodiscard]] std::optional<size_t> vertexForSite(SiteId site) const noexcept;
 
-  /// Return the target site identifier for a dense compiler vertex.
+  /// Return the target site identifier for a valid dense compiler vertex.
   [[nodiscard]] SiteId siteForVertex(size_t vertex) const;
 
   /// Return whether the target contains an explicit coupling topology.
@@ -277,16 +306,16 @@ public:
    */
   [[nodiscard]] llvm::ArrayRef<Coupling> couplings() const noexcept;
 
-  /// Return whether two dense compiler vertices are adjacent.
+  /// Return whether two valid dense compiler vertices are adjacent.
   [[nodiscard]] bool areAdjacent(size_t source, size_t target) const;
 
   /**
-   * @brief Return the cached shortest-path distance between dense vertices.
+   * @brief Return the cached shortest-path distance between valid vertices.
    */
   [[nodiscard]] size_t distanceBetween(size_t source, size_t target) const;
 
   /**
-   * @brief Invoke @p callback for every neighbour of a dense compiler vertex.
+   * @brief Invoke @p callback for every neighbour of a valid dense vertex.
    */
   void forEachNeighbour(size_t vertex,
                         llvm::function_ref<void(size_t)> callback) const;
@@ -321,15 +350,15 @@ public:
 
 private:
   struct Storage;
-  struct StorageConstructorTag {};
 
-  CompilerTarget(std::optional<std::string> name, std::vector<Site> sites,
-                 std::optional<std::vector<Coupling>> couplings,
-                 std::optional<std::vector<Operation>> operations,
-                 std::optional<DurationUnit> durationUnit,
-                 StorageConstructorTag storageConstructorTag);
+  explicit CompilerTarget(std::shared_ptr<const Storage> storage);
 
-  [[noreturn]] static void throwVertexOutOfRange();
+  [[nodiscard]] static llvm::Expected<CompilerTarget>
+  createImpl(std::optional<std::string> name, std::vector<Site> sites,
+             std::optional<std::vector<Coupling>> couplings,
+             std::optional<std::vector<Operation>> operations,
+             std::optional<DurationUnit> durationUnit);
+
   [[nodiscard]] llvm::ArrayRef<size_t> explicitNeighbours(size_t vertex) const;
 
   std::shared_ptr<const Storage> storage_;

--- a/mlir/lib/Compiler/FoMaCAdapter.cpp
+++ b/mlir/lib/Compiler/FoMaCAdapter.cpp
@@ -18,30 +18,33 @@
 #include <llvm/ADT/StringSwitch.h>
 #include <llvm/ADT/Twine.h>
 #include <llvm/Support/CheckedArithmetic.h>
+#include <llvm/Support/Error.h>
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <optional>
-#include <stdexcept>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
 namespace mlir {
 
-static void requireAdapterInput(const bool condition,
-                                const llvm::Twine& message) {
+[[nodiscard]] static llvm::Error
+requireAdapterInput(const bool condition, const llvm::Twine& message) {
   if (!condition) {
-    throw std::invalid_argument(message.str());
+    return llvm::createStringError(
+        std::make_error_code(std::errc::invalid_argument), message);
   }
+  return llvm::Error::success();
 }
 
-static void requireCircuitDevice(const bool condition,
-                                 const llvm::StringRef deviceName,
-                                 const llvm::StringRef detail) {
-  requireAdapterInput(
+[[nodiscard]] static llvm::Error
+requireCircuitDevice(const bool condition, const llvm::StringRef deviceName,
+                     const llvm::StringRef detail) {
+  return requireAdapterInput(
       condition, llvm::Twine("QDMI device '") + deviceName +
                      "' cannot be used as an MLIR compiler target: only "
                      "circuit-model devices with one qubit per non-zone site "
@@ -49,11 +52,10 @@ static void requireCircuitDevice(const bool condition,
                      detail + ")");
 }
 
-static void requireHomogeneousOperation(const bool condition,
-                                        const llvm::StringRef deviceName,
-                                        const llvm::StringRef operationName,
-                                        const llvm::StringRef detail) {
-  requireAdapterInput(
+[[nodiscard]] static llvm::Error requireHomogeneousOperation(
+    const bool condition, const llvm::StringRef deviceName,
+    const llvm::StringRef operationName, const llvm::StringRef detail) {
+  return requireAdapterInput(
       condition, llvm::Twine("QDMI device '") + deviceName + "' operation '" +
                      operationName +
                      "' cannot be represented by the MLIR compiler target: "
@@ -62,11 +64,15 @@ static void requireHomogeneousOperation(const bool condition,
                      detail + ")");
 }
 
-[[nodiscard]] static CompilerTarget::SiteId checkedSiteId(const size_t index) {
-  requireAdapterInput(
-      index <= static_cast<uintmax_t>(
-                   std::numeric_limits<CompilerTarget::SiteId>::max()),
-      "QDMI site index exceeds the nonnegative i64 compiler-target domain");
+[[nodiscard]] static llvm::Expected<CompilerTarget::SiteId>
+checkedSiteId(const size_t index) {
+  if (auto error = requireAdapterInput(
+          index <= static_cast<uintmax_t>(
+                       std::numeric_limits<CompilerTarget::SiteId>::max()),
+          "QDMI site index exceeds the nonnegative i64 compiler-target "
+          "domain")) {
+    return std::move(error);
+  }
   return static_cast<CompilerTarget::SiteId>(index);
 }
 
@@ -96,27 +102,30 @@ isSwapInvariantOperation(const llvm::StringRef operationName) {
       .Default(false);
 }
 
-static void validateHomogeneousSupport(
+[[nodiscard]] static llvm::Error validateHomogeneousSupport(
     const fomac::Operation& operation, const size_t arity,
     const std::optional<std::vector<fomac::Site>>& flattenedSites,
     const std::vector<CompilerTarget::Site>& deviceSites,
     const std::optional<std::vector<CompilerTarget::Coupling>>& couplings,
     const llvm::StringRef deviceName) {
   if (!flattenedSites) {
-    requireHomogeneousOperation(
+    return requireHomogeneousOperation(
         arity != 2 || !couplings, deviceName, operation.getName(),
         "the device reports an explicit topology but no ordered two-qubit "
         "site support");
-    return;
   }
   const auto operationName = operation.getName();
-  requireHomogeneousOperation(
-      flattenedSites->size() % arity == 0, deviceName, operationName,
-      "the reported site list is not divisible by the fixed arity");
-  requireHomogeneousOperation(
-      arity <= 2, deviceName, operationName,
-      "explicit site lists are supported only for one- and two-qubit "
-      "operations");
+  if (auto error = requireHomogeneousOperation(
+          flattenedSites->size() % arity == 0, deviceName, operationName,
+          "the reported site list is not divisible by the fixed arity")) {
+    return error;
+  }
+  if (auto error = requireHomogeneousOperation(
+          arity <= 2, deviceName, operationName,
+          "explicit site lists are supported only for one- and two-qubit "
+          "operations")) {
+    return error;
+  }
 
   llvm::DenseSet<CompilerTarget::SiteId> knownSites;
   knownSites.reserve(deviceSites.size());
@@ -128,16 +137,21 @@ static void validateHomogeneousSupport(
     llvm::DenseSet<CompilerTarget::SiteId> supportedSites;
     supportedSites.reserve(flattenedSites->size());
     for (const auto& site : *flattenedSites) {
-      const auto siteId = checkedSiteId(site.getIndex());
-      const auto inserted = supportedSites.insert(siteId).second;
-      requireHomogeneousOperation(
-          knownSites.contains(siteId) && inserted, deviceName, operationName,
-          "the reported one-qubit sites must be unique device sites");
+      auto siteId = checkedSiteId(site.getIndex());
+      if (!siteId) {
+        return siteId.takeError();
+      }
+      const auto inserted = supportedSites.insert(*siteId).second;
+      if (auto error = requireHomogeneousOperation(
+              knownSites.contains(*siteId) && inserted, deviceName,
+              operationName,
+              "the reported one-qubit sites must be unique device sites")) {
+        return error;
+      }
     }
-    requireHomogeneousOperation(
+    return requireHomogeneousOperation(
         supportedSites.size() == knownSites.size(), deviceName, operationName,
         "the operation is not available on every device site");
-    return;
   }
 
   llvm::DenseSet<CompilerTarget::Coupling> reportedTuples;
@@ -145,15 +159,24 @@ static void validateHomogeneousSupport(
   reportedTuples.reserve(flattenedSites->size() / arity);
   supportedCouplings.reserve(flattenedSites->size() / arity);
   for (size_t offset = 0; offset < flattenedSites->size(); offset += arity) {
-    const auto first = checkedSiteId((*flattenedSites)[offset].getIndex());
-    const auto second = checkedSiteId((*flattenedSites)[offset + 1].getIndex());
-    const auto inserted = reportedTuples.insert({first, second}).second;
-    const auto validTuple = first != second && knownSites.contains(first) &&
-                            knownSites.contains(second) && inserted;
-    requireHomogeneousOperation(
-        validTuple, deviceName, operationName,
-        "the reported two-qubit sites must be unique pairs of device sites");
-    supportedCouplings.insert(canonicalCoupling(first, second));
+    auto first = checkedSiteId((*flattenedSites)[offset].getIndex());
+    if (!first) {
+      return first.takeError();
+    }
+    auto second = checkedSiteId((*flattenedSites)[offset + 1].getIndex());
+    if (!second) {
+      return second.takeError();
+    }
+    const auto inserted = reportedTuples.insert({*first, *second}).second;
+    const auto validTuple = *first != *second && knownSites.contains(*first) &&
+                            knownSites.contains(*second) && inserted;
+    if (auto error =
+            requireHomogeneousOperation(validTuple, deviceName, operationName,
+                                        "the reported two-qubit sites must be "
+                                        "unique pairs of device sites")) {
+      return error;
+    }
+    supportedCouplings.insert(canonicalCoupling(*first, *second));
   }
 
   auto coversTarget = false;
@@ -172,13 +195,15 @@ static void validateHomogeneousSupport(
           return supportedCouplings.contains(coupling);
         });
   }
-  requireHomogeneousOperation(
-      coversTarget, deviceName, operationName,
-      couplings ? "the operation is not available on every topology edge"
-                : "the operation is not available on every all-to-all site "
-                  "pair");
+  if (auto error = requireHomogeneousOperation(
+          coversTarget, deviceName, operationName,
+          couplings ? "the operation is not available on every topology edge"
+                    : "the operation is not available on every all-to-all site "
+                      "pair")) {
+    return error;
+  }
 
-  requireHomogeneousOperation(
+  return requireHomogeneousOperation(
       isSwapInvariantOperation(operationName) ||
           std::ranges::all_of(
               supportedCouplings,
@@ -191,27 +216,34 @@ static void validateHomogeneousSupport(
       "both orientations must be available on every supported site pair");
 }
 
-[[nodiscard]] static std::optional<CompilerTarget::DurationUnit>
+[[nodiscard]] static llvm::Expected<std::optional<CompilerTarget::DurationUnit>>
 snapshotDurationUnit(const fomac::Device& device) {
   auto unit = device.getDurationUnit();
   const auto scaleFactor = device.getDurationScaleFactor();
-  requireAdapterInput(
-      unit || !scaleFactor,
-      "QDMI device reports a duration scale factor without a duration unit");
+  if (auto error = requireAdapterInput(unit || !scaleFactor,
+                                       "QDMI device reports a duration scale "
+                                       "factor without a duration unit")) {
+    return std::move(error);
+  }
   if (!unit) {
     return std::nullopt;
   }
-  return CompilerTarget::DurationUnit(std::move(*unit),
-                                      scaleFactor.value_or(1.));
+  auto durationUnit = CompilerTarget::DurationUnit::create(
+      std::move(*unit), scaleFactor.value_or(1.));
+  if (!durationUnit) {
+    return durationUnit.takeError();
+  }
+  return std::optional<CompilerTarget::DurationUnit>(std::move(*durationUnit));
 }
 
-[[nodiscard]] static std::vector<CompilerTarget::SiteTuple> snapshotSiteTuples(
+[[nodiscard]] static llvm::Expected<std::vector<CompilerTarget::SiteTuple>>
+snapshotSiteTuples(
     const fomac::Operation& operation, const size_t arity,
     const std::optional<std::vector<fomac::Site>>& flattenedSites,
     const std::optional<uint64_t> defaultDuration,
     const std::optional<double> defaultFidelity) {
   if (!flattenedSites) {
-    return {};
+    return std::vector<CompilerTarget::SiteTuple>{};
   }
 
   std::vector<CompilerTarget::SiteTuple> siteTuples;
@@ -224,19 +256,29 @@ snapshotDurationUnit(const fomac::Device& device) {
     for (size_t index = 0; index < arity; ++index) {
       const auto& site = (*flattenedSites)[offset + index];
       sites.emplace_back(site);
-      siteIds.emplace_back(checkedSiteId(site.getIndex()));
+      auto siteId = checkedSiteId(site.getIndex());
+      if (!siteId) {
+        return siteId.takeError();
+      }
+      siteIds.emplace_back(*siteId);
     }
 
     const auto duration = operation.getDuration(sites);
     const auto fidelity = operation.getFidelity(sites);
     if (duration != defaultDuration || fidelity != defaultFidelity) {
-      siteTuples.emplace_back(std::move(siteIds), duration, fidelity);
+      auto siteTuple = CompilerTarget::SiteTuple::create(std::move(siteIds),
+                                                         duration, fidelity);
+      if (!siteTuple) {
+        return siteTuple.takeError();
+      }
+      siteTuples.emplace_back(std::move(*siteTuple));
     }
   }
   return siteTuples;
 }
 
-[[nodiscard]] static std::vector<CompilerTarget::Operation> snapshotOperations(
+[[nodiscard]] static llvm::Expected<std::vector<CompilerTarget::Operation>>
+snapshotOperations(
     const std::vector<fomac::Operation>& operations,
     const std::vector<CompilerTarget::Site>& deviceSites,
     const std::optional<std::vector<CompilerTarget::Coupling>>& couplings,
@@ -244,41 +286,68 @@ snapshotDurationUnit(const fomac::Device& device) {
   std::vector<CompilerTarget::Operation> targetOperations;
   targetOperations.reserve(operations.size());
   for (const auto& operation : operations) {
-    requireCircuitDevice(!operation.isZoned(), deviceName,
-                         "the device exposes a zoned operation");
+    if (auto error =
+            requireCircuitDevice(!operation.isZoned(), deviceName,
+                                 "the device exposes a zoned operation")) {
+      return error;
+    }
     const auto arity = operation.getQubitsNum();
     if (!arity || *arity == 0) {
       continue;
     }
     const auto flattenedSites = operation.getSites();
-    validateHomogeneousSupport(operation, *arity, flattenedSites, deviceSites,
-                               couplings, deviceName);
+    if (auto error =
+            validateHomogeneousSupport(operation, *arity, flattenedSites,
+                                       deviceSites, couplings, deviceName)) {
+      return error;
+    }
     const auto duration = operation.getDuration();
     const auto fidelity = operation.getFidelity();
-    targetOperations.emplace_back(
+    auto siteTuples = snapshotSiteTuples(operation, *arity, flattenedSites,
+                                         duration, fidelity);
+    if (!siteTuples) {
+      return siteTuples.takeError();
+    }
+    auto targetOperation = CompilerTarget::Operation::create(
         operation.getName(), *arity, operation.getParametersNum(),
-        snapshotSiteTuples(operation, *arity, flattenedSites, duration,
-                           fidelity),
-        duration, fidelity);
+        std::move(*siteTuples), duration, fidelity);
+    if (!targetOperation) {
+      return targetOperation.takeError();
+    }
+    targetOperations.emplace_back(std::move(*targetOperation));
   }
   return targetOperations;
 }
 
-CompilerTarget compilerTargetFromDevice(const fomac::Device& device) {
+llvm::Expected<CompilerTarget>
+compilerTargetFromDevice(const fomac::Device& device) {
   auto deviceName = device.getName();
   const auto deviceSites = device.getSites();
-  requireCircuitDevice(
-      std::ranges::none_of(deviceSites,
-                           [](const auto& site) { return site.isZone(); }),
-      deviceName, "the device exposes zone sites");
-  requireCircuitDevice(device.getQubitsNum() == deviceSites.size(), deviceName,
-                       "the qubit count does not match the regular-site count");
+  if (auto error = requireCircuitDevice(
+          std::ranges::none_of(deviceSites,
+                               [](const auto& site) { return site.isZone(); }),
+          deviceName, "the device exposes zone sites")) {
+    return error;
+  }
+  if (auto error = requireCircuitDevice(
+          device.getQubitsNum() == deviceSites.size(), deviceName,
+          "the qubit count does not match the regular-site count")) {
+    return error;
+  }
 
   std::vector<CompilerTarget::Site> sites;
   sites.reserve(deviceSites.size());
   for (const auto& site : deviceSites) {
-    sites.emplace_back(checkedSiteId(site.getIndex()), site.getName(),
-                       site.getT1(), site.getT2());
+    auto siteId = checkedSiteId(site.getIndex());
+    if (!siteId) {
+      return siteId.takeError();
+    }
+    auto targetSite = CompilerTarget::Site::create(*siteId, site.getName(),
+                                                   site.getT1(), site.getT2());
+    if (!targetSite) {
+      return targetSite.takeError();
+    }
+    sites.emplace_back(std::move(*targetSite));
   }
 
   std::optional<std::vector<CompilerTarget::Coupling>> couplings;
@@ -286,16 +355,30 @@ CompilerTarget compilerTargetFromDevice(const fomac::Device& device) {
     couplings.emplace();
     couplings->reserve(deviceCouplings->size());
     for (const auto& [source, target] : *deviceCouplings) {
-      couplings->emplace_back(checkedSiteId(source.getIndex()),
-                              checkedSiteId(target.getIndex()));
+      auto sourceId = checkedSiteId(source.getIndex());
+      if (!sourceId) {
+        return sourceId.takeError();
+      }
+      auto targetId = checkedSiteId(target.getIndex());
+      if (!targetId) {
+        return targetId.takeError();
+      }
+      couplings->emplace_back(*sourceId, *targetId);
     }
   }
 
   auto operations =
       snapshotOperations(device.getOperations(), sites, couplings, deviceName);
+  if (!operations) {
+    return operations.takeError();
+  }
   auto durationUnit = snapshotDurationUnit(device);
-  return {std::move(deviceName), std::move(sites), std::move(couplings),
-          std::move(operations), std::move(durationUnit)};
+  if (!durationUnit) {
+    return durationUnit.takeError();
+  }
+  return CompilerTarget::create(std::move(deviceName), std::move(sites),
+                                std::move(couplings), std::move(*operations),
+                                std::move(*durationUnit));
 }
 
 } // namespace mlir

--- a/mlir/lib/Compiler/Target.cpp
+++ b/mlir/lib/Compiler/Target.cpp
@@ -338,6 +338,11 @@ std::optional<double> CompilerTarget::Operation::fidelity() const noexcept {
 }
 
 struct CompilerTarget::Storage {
+  Storage(std::optional<std::string> targetName, std::vector<Site> targetSites,
+          std::optional<std::vector<Coupling>> targetCouplings,
+          std::optional<std::vector<Operation>> targetOperations,
+          std::optional<DurationUnit> targetDurationUnit);
+
   [[nodiscard]] static llvm::Expected<std::shared_ptr<const Storage>>
   create(std::optional<std::string> targetName, std::vector<Site> targetSites,
          std::optional<std::vector<Coupling>> targetCouplings,
@@ -364,12 +369,6 @@ struct CompilerTarget::Storage {
   llvm::StringMap<SmallVector<size_t, 1>> capabilities;
   SmallVector<GateKind> supportedGates;
   std::optional<SynthesisBasis> basis;
-
-private:
-  Storage(std::optional<std::string> targetName, std::vector<Site> targetSites,
-          std::optional<std::vector<Coupling>> targetCouplings,
-          std::optional<std::vector<Operation>> targetOperations,
-          std::optional<DurationUnit> targetDurationUnit);
 };
 
 CompilerTarget::Storage::Storage(
@@ -387,12 +386,9 @@ CompilerTarget::Storage::create(
     std::optional<std::vector<Coupling>> targetCouplings,
     std::optional<std::vector<Operation>> targetOperations,
     std::optional<DurationUnit> targetDurationUnit) {
-  // The constructor is deliberately private, so std::make_shared cannot invoke
-  // it through its implementation context.
-  // NOLINTNEXTLINE(modernize-make-shared)
-  auto storage = std::shared_ptr<Storage>(new Storage(
+  auto storage = std::make_shared<Storage>(
       std::move(targetName), std::move(targetSites), std::move(targetCouplings),
-      std::move(targetOperations), std::move(targetDurationUnit)));
+      std::move(targetOperations), std::move(targetDurationUnit));
   if (auto error = storage->initialize()) {
     return std::move(error);
   }

--- a/mlir/lib/Compiler/Target.cpp
+++ b/mlir/lib/Compiler/Target.cpp
@@ -19,11 +19,13 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Error.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/Support/LLVM.h>
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -31,8 +33,8 @@
 #include <memory>
 #include <optional>
 #include <set>
-#include <stdexcept>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -108,55 +110,70 @@ constexpr std::array GATE_SPECIFICATIONS{
   return canonical;
 }
 
-static void validatePositiveCoherenceTime(const std::optional<uint64_t> time,
-                                          const StringRef description) {
-  if (time && *time == 0) {
-    throw std::invalid_argument((description + " must be positive").str());
-  }
+[[nodiscard]] static llvm::Error invalidTarget(const Twine& message) {
+  return llvm::createStringError(
+      std::make_error_code(std::errc::invalid_argument), message);
 }
 
-static void validateFidelity(const std::optional<double> fidelity,
-                             const StringRef description) {
+[[nodiscard]] static llvm::Error
+validatePositiveCoherenceTime(const std::optional<uint64_t> time,
+                              const StringRef description) {
+  if (time && *time == 0) {
+    return invalidTarget(description + " must be positive");
+  }
+  return llvm::Error::success();
+}
+
+[[nodiscard]] static llvm::Error
+validateFidelity(const std::optional<double> fidelity,
+                 const StringRef description) {
   if (fidelity &&
       (!std::isfinite(*fidelity) || *fidelity < 0. || *fidelity > 1.)) {
-    throw std::invalid_argument(
-        (description + " must be finite and in [0, 1]").str());
+    return invalidTarget(description + " must be finite and in [0, 1]");
   }
+  return llvm::Error::success();
 }
 
-[[nodiscard]] static std::vector<CompilerTarget::Site>
+[[nodiscard]] static llvm::Expected<std::vector<CompilerTarget::Site>>
 makeDenseSites(const size_t numQubits) {
   if (numQubits == 0) {
-    throw std::invalid_argument(
-        "Compiler target must contain at least one site");
+    return invalidTarget("Compiler target must contain at least one site");
   }
   constexpr auto maxNumSites =
       static_cast<uintmax_t>(std::numeric_limits<int64_t>::max()) + 1;
   if (static_cast<uintmax_t>(numQubits) > maxNumSites) {
-    throw std::invalid_argument(
+    return invalidTarget(
         "Compiler target qubit count exceeds the nonnegative i64 site domain");
   }
 
   std::vector<CompilerTarget::Site> sites;
   sites.reserve(numQubits);
   for (size_t id = 0; id < numQubits; ++id) {
-    sites.emplace_back(static_cast<SiteId>(id));
+    auto site = CompilerTarget::Site::create(static_cast<SiteId>(id));
+    if (!site) {
+      return site.takeError();
+    }
+    sites.emplace_back(std::move(*site));
   }
   return sites;
 }
 
-CompilerTarget::DurationUnit::DurationUnit(std::string unit,
-                                           const double scaleFactor)
-    : unit_(std::move(unit)), scaleFactor_(scaleFactor) {
-  if (StringRef(unit_).trim().empty()) {
-    throw std::invalid_argument(
-        "Compiler target duration unit must not be empty");
+llvm::Expected<CompilerTarget::DurationUnit>
+CompilerTarget::DurationUnit::create(std::string unit,
+                                     const double scaleFactor) {
+  if (StringRef(unit).trim().empty()) {
+    return invalidTarget("Compiler target duration unit must not be empty");
   }
-  if (!std::isfinite(scaleFactor_) || scaleFactor_ <= 0.) {
-    throw std::invalid_argument(
+  if (!std::isfinite(scaleFactor) || scaleFactor <= 0.) {
+    return invalidTarget(
         "Compiler target duration scale factor must be positive and finite");
   }
+  return DurationUnit(std::move(unit), scaleFactor);
 }
+
+CompilerTarget::DurationUnit::DurationUnit(std::string unit,
+                                           const double scaleFactor)
+    : unit_(std::move(unit)), scaleFactor_(scaleFactor) {}
 
 StringRef CompilerTarget::DurationUnit::unit() const noexcept { return unit_; }
 
@@ -164,20 +181,32 @@ double CompilerTarget::DurationUnit::scaleFactor() const noexcept {
   return scaleFactor_;
 }
 
+llvm::Expected<CompilerTarget::Site>
+CompilerTarget::Site::create(const SiteId id, std::optional<std::string> name,
+                             const std::optional<uint64_t> t1,
+                             const std::optional<uint64_t> t2) {
+  if (id < 0) {
+    return invalidTarget("Compiler target site ID must be nonnegative");
+  }
+  if (name && name->empty()) {
+    return invalidTarget(
+        "Compiler target site name must not be empty when present");
+  }
+  if (auto error =
+          validatePositiveCoherenceTime(t1, "Compiler target site T1")) {
+    return std::move(error);
+  }
+  if (auto error =
+          validatePositiveCoherenceTime(t2, "Compiler target site T2")) {
+    return std::move(error);
+  }
+  return Site(id, std::move(name), t1, t2);
+}
+
 CompilerTarget::Site::Site(const SiteId id, std::optional<std::string> name,
                            const std::optional<uint64_t> t1,
                            const std::optional<uint64_t> t2)
-    : id_(id), name_(std::move(name)), t1_(t1), t2_(t2) {
-  if (id_ < 0) {
-    throw std::invalid_argument("Compiler target site ID must be nonnegative");
-  }
-  if (name_ && name_->empty()) {
-    throw std::invalid_argument(
-        "Compiler target site name must not be empty when present");
-  }
-  validatePositiveCoherenceTime(t1_, "Compiler target site T1");
-  validatePositiveCoherenceTime(t2_, "Compiler target site T2");
-}
+    : id_(id), name_(std::move(name)), t1_(t1), t2_(t2) {}
 
 CompilerTarget::SiteId CompilerTarget::Site::id() const noexcept { return id_; }
 
@@ -196,23 +225,32 @@ std::optional<uint64_t> CompilerTarget::Site::t2() const noexcept {
   return t2_;
 }
 
-CompilerTarget::SiteTuple::SiteTuple(std::vector<SiteId> sites,
-                                     const std::optional<uint64_t> duration,
-                                     const std::optional<double> fidelity)
-    : sites_(std::move(sites)), duration_(duration), fidelity_(fidelity) {
+llvm::Expected<CompilerTarget::SiteTuple>
+CompilerTarget::SiteTuple::create(std::vector<SiteId> sites,
+                                  const std::optional<uint64_t> duration,
+                                  const std::optional<double> fidelity) {
   std::set<SiteId> uniqueSites;
-  for (const auto site : sites_) {
+  for (const auto site : sites) {
     if (site < 0) {
-      throw std::invalid_argument(
+      return invalidTarget(
           "Compiler target site tuple contains a negative site ID");
     }
     if (!uniqueSites.insert(site).second) {
-      throw std::invalid_argument(
+      return invalidTarget(
           "Compiler target site tuple contains a duplicate site");
     }
   }
-  validateFidelity(fidelity_, "Compiler target site-tuple fidelity");
+  if (auto error =
+          validateFidelity(fidelity, "Compiler target site-tuple fidelity")) {
+    return std::move(error);
+  }
+  return SiteTuple(std::move(sites), duration, fidelity);
 }
+
+CompilerTarget::SiteTuple::SiteTuple(std::vector<SiteId> sites,
+                                     const std::optional<uint64_t> duration,
+                                     const std::optional<double> fidelity)
+    : sites_(std::move(sites)), duration_(duration), fidelity_(fidelity) {}
 
 ArrayRef<SiteId> CompilerTarget::SiteTuple::sites() const noexcept {
   return sites_;
@@ -226,39 +264,51 @@ std::optional<double> CompilerTarget::SiteTuple::fidelity() const noexcept {
   return fidelity_;
 }
 
-CompilerTarget::Operation::Operation(std::string name, const size_t numQubits,
-                                     const size_t numParameters,
-                                     std::vector<SiteTuple> siteTuples,
-                                     const std::optional<uint64_t> duration,
-                                     const std::optional<double> fidelity)
-    : name_(std::move(name)), canonicalName_(canonicalOperationName(name_)),
-      numQubits_(numQubits), numParameters_(numParameters),
-      siteTuples_(std::move(siteTuples)), duration_(duration),
-      fidelity_(fidelity) {
-  if (canonicalName_.empty()) {
-    throw std::invalid_argument(
-        "Compiler target operation name must not be empty");
+llvm::Expected<CompilerTarget::Operation> CompilerTarget::Operation::create(
+    std::string name, const size_t numQubits, const size_t numParameters,
+    std::vector<SiteTuple> siteTuples, const std::optional<uint64_t> duration,
+    const std::optional<double> fidelity) {
+  auto canonicalName = canonicalOperationName(name);
+  if (canonicalName.empty()) {
+    return invalidTarget("Compiler target operation name must not be empty");
   }
-  if (numQubits_ == 0) {
-    throw std::invalid_argument(
+  if (numQubits == 0) {
+    return invalidTarget(
         "Compiler target operation qubit count must be positive");
   }
-  validateFidelity(fidelity_, "Compiler target operation fidelity");
+  if (auto error =
+          validateFidelity(fidelity, "Compiler target operation fidelity")) {
+    return std::move(error);
+  }
 
   std::set<std::vector<SiteId>> uniqueSiteCombinations;
-  for (const auto& siteTuple : siteTuples_) {
-    if (siteTuple.sites().size() != numQubits_) {
-      throw std::invalid_argument(
+  for (const auto& siteTuple : siteTuples) {
+    if (siteTuple.sites().size() != numQubits) {
+      return invalidTarget(
           "Compiler target operation site tuple does not match its arity");
     }
     if (!uniqueSiteCombinations
              .emplace(siteTuple.sites().begin(), siteTuple.sites().end())
              .second) {
-      throw std::invalid_argument(
+      return invalidTarget(
           "Compiler target operation contains a duplicate site tuple");
     }
   }
+  return Operation(std::move(name), std::move(canonicalName), numQubits,
+                   numParameters, std::move(siteTuples), duration, fidelity);
 }
+
+CompilerTarget::Operation::Operation(std::string name,
+                                     std::string canonicalName,
+                                     const size_t numQubits,
+                                     const size_t numParameters,
+                                     std::vector<SiteTuple> siteTuples,
+                                     const std::optional<uint64_t> duration,
+                                     const std::optional<double> fidelity)
+    : name_(std::move(name)), canonicalName_(std::move(canonicalName)),
+      numQubits_(numQubits), numParameters_(numParameters),
+      siteTuples_(std::move(siteTuples)), duration_(duration),
+      fidelity_(fidelity) {}
 
 StringRef CompilerTarget::Operation::name() const noexcept { return name_; }
 
@@ -288,10 +338,13 @@ std::optional<double> CompilerTarget::Operation::fidelity() const noexcept {
 }
 
 struct CompilerTarget::Storage {
-  Storage(std::optional<std::string> targetName, std::vector<Site> targetSites,
-          std::optional<std::vector<Coupling>> targetCouplings,
-          std::optional<std::vector<Operation>> targetOperations,
-          std::optional<DurationUnit> targetDurationUnit);
+  [[nodiscard]] static llvm::Expected<std::shared_ptr<const Storage>>
+  create(std::optional<std::string> targetName, std::vector<Site> targetSites,
+         std::optional<std::vector<Coupling>> targetCouplings,
+         std::optional<std::vector<Operation>> targetOperations,
+         std::optional<DurationUnit> targetDurationUnit);
+
+  [[nodiscard]] llvm::Error initialize();
 
   [[nodiscard]] bool
   supportsOperation(StringRef name, size_t numQubits,
@@ -311,6 +364,12 @@ struct CompilerTarget::Storage {
   llvm::StringMap<SmallVector<size_t, 1>> capabilities;
   SmallVector<GateKind> supportedGates;
   std::optional<SynthesisBasis> basis;
+
+private:
+  Storage(std::optional<std::string> targetName, std::vector<Site> targetSites,
+          std::optional<std::vector<Coupling>> targetCouplings,
+          std::optional<std::vector<Operation>> targetOperations,
+          std::optional<DurationUnit> targetDurationUnit);
 };
 
 CompilerTarget::Storage::Storage(
@@ -320,22 +379,39 @@ CompilerTarget::Storage::Storage(
     std::optional<DurationUnit> targetDurationUnit)
     : name(std::move(targetName)), durationUnit(std::move(targetDurationUnit)),
       sites(std::move(targetSites)), couplings(std::move(targetCouplings)),
-      operations(std::move(targetOperations)) {
+      operations(std::move(targetOperations)) {}
+
+llvm::Expected<std::shared_ptr<const CompilerTarget::Storage>>
+CompilerTarget::Storage::create(
+    std::optional<std::string> targetName, std::vector<Site> targetSites,
+    std::optional<std::vector<Coupling>> targetCouplings,
+    std::optional<std::vector<Operation>> targetOperations,
+    std::optional<DurationUnit> targetDurationUnit) {
+  // The constructor is deliberately private, so std::make_shared cannot invoke
+  // it through its implementation context.
+  // NOLINTNEXTLINE(modernize-make-shared)
+  auto storage = std::shared_ptr<Storage>(new Storage(
+      std::move(targetName), std::move(targetSites), std::move(targetCouplings),
+      std::move(targetOperations), std::move(targetDurationUnit)));
+  if (auto error = storage->initialize()) {
+    return std::move(error);
+  }
+  return std::shared_ptr<const Storage>(std::move(storage));
+}
+
+llvm::Error CompilerTarget::Storage::initialize() {
   if (name && name->empty()) {
-    throw std::invalid_argument(
-        "Compiler target name must not be empty when present");
+    return invalidTarget("Compiler target name must not be empty when present");
   }
   if (sites.empty()) {
-    throw std::invalid_argument(
-        "Compiler target must contain at least one site");
+    return invalidTarget("Compiler target must contain at least one site");
   }
 
   siteIds.reserve(sites.size());
   siteToVertex.reserve(sites.size());
   for (const auto [vertex, site] : llvm::enumerate(sites)) {
     if (!siteToVertex.try_emplace(site.id(), vertex).second) {
-      throw std::invalid_argument(
-          "Compiler target contains duplicate site IDs");
+      return invalidTarget("Compiler target contains duplicate site IDs");
     }
     siteIds.emplace_back(site.id());
   }
@@ -344,11 +420,11 @@ CompilerTarget::Storage::Storage(
     std::set<Coupling> canonicalCouplings;
     for (auto [source, target] : *couplings) {
       if (!siteToVertex.contains(source) || !siteToVertex.contains(target)) {
-        throw std::invalid_argument(
+        return invalidTarget(
             "Compiler target topology references an unknown site");
       }
       if (source == target) {
-        throw std::invalid_argument(
+        return invalidTarget(
             "Compiler target topology contains a self-coupling");
       }
       if (target < source) {
@@ -371,7 +447,7 @@ CompilerTarget::Storage::Storage(
     }
 
     if (sites.size() > std::numeric_limits<size_t>::max() / sites.size()) {
-      throw std::invalid_argument(
+      return invalidTarget(
           "Compiler target topology distance matrix is too large");
     }
     constexpr auto unreachable = std::numeric_limits<size_t>::max();
@@ -394,8 +470,7 @@ CompilerTarget::Storage::Storage(
       if (llvm::is_contained(
               ArrayRef<size_t>(distances).slice(rowOffset, sites.size()),
               unreachable)) {
-        throw std::invalid_argument(
-            "Compiler target topology must be connected");
+        return invalidTarget("Compiler target topology must be connected");
       }
     }
   } else {
@@ -405,15 +480,15 @@ CompilerTarget::Storage::Storage(
   if (operations) {
     for (const auto [index, operation] : llvm::enumerate(*operations)) {
       if (operation.numQubits() > sites.size()) {
-        throw std::invalid_argument(
+        return invalidTarget(
             "Compiler target operation arity exceeds its site count");
       }
       for (const auto& siteTuple : operation.siteTuples()) {
         if (llvm::any_of(siteTuple.sites(), [&](const auto site) {
               return !siteToVertex.contains(site);
             })) {
-          throw std::invalid_argument("Compiler target operation site tuple "
-                                      "references an unknown site");
+          return invalidTarget("Compiler target operation site tuple "
+                               "references an unknown site");
         }
       }
       capabilities[operation.canonicalName()].emplace_back(index);
@@ -431,7 +506,7 @@ CompilerTarget::Storage::Storage(
                });
       });
   if ((hasSiteTiming || hasOperationTiming) && !durationUnit) {
-    throw std::invalid_argument(
+    return invalidTarget(
         "Compiler target timing metadata requires a duration unit");
   }
 
@@ -442,6 +517,7 @@ CompilerTarget::Storage::Storage(
     }
   }
   basis = resolveSynthesisBasis();
+  return llvm::Error::success();
 }
 
 bool CompilerTarget::Storage::supportsOperation(
@@ -501,49 +577,69 @@ CompilerTarget::Storage::resolveSynthesisBasis() const {
   return SynthesisBasis{.singleQubit = *singleQubit, .entangler = *entangler};
 }
 
-CompilerTarget::CompilerTarget(const size_t numQubits,
-                               std::optional<std::vector<Coupling>> couplings,
-                               std::optional<std::vector<Operation>> operations,
-                               std::optional<DurationUnit> durationUnit)
-    : CompilerTarget(std::nullopt, makeDenseSites(numQubits),
-                     std::move(couplings), std::move(operations),
-                     std::move(durationUnit), StorageConstructorTag{}) {}
+llvm::Expected<CompilerTarget>
+CompilerTarget::create(const size_t numQubits,
+                       std::optional<std::vector<Coupling>> couplings,
+                       std::optional<std::vector<Operation>> operations,
+                       std::optional<DurationUnit> durationUnit) {
+  auto sites = makeDenseSites(numQubits);
+  if (!sites) {
+    return sites.takeError();
+  }
+  return createImpl(std::nullopt, std::move(*sites), std::move(couplings),
+                    std::move(operations), std::move(durationUnit));
+}
 
-CompilerTarget::CompilerTarget(std::string name, const size_t numQubits,
-                               std::optional<std::vector<Coupling>> couplings,
-                               std::optional<std::vector<Operation>> operations,
-                               std::optional<DurationUnit> durationUnit)
-    : CompilerTarget(std::optional<std::string>(std::move(name)),
-                     makeDenseSites(numQubits), std::move(couplings),
-                     std::move(operations), std::move(durationUnit),
-                     StorageConstructorTag{}) {}
+llvm::Expected<CompilerTarget>
+CompilerTarget::create(std::string name, const size_t numQubits,
+                       std::optional<std::vector<Coupling>> couplings,
+                       std::optional<std::vector<Operation>> operations,
+                       std::optional<DurationUnit> durationUnit) {
+  auto sites = makeDenseSites(numQubits);
+  if (!sites) {
+    return sites.takeError();
+  }
+  return createImpl(std::optional<std::string>(std::move(name)),
+                    std::move(*sites), std::move(couplings),
+                    std::move(operations), std::move(durationUnit));
+}
 
-CompilerTarget::CompilerTarget(std::vector<Site> sites,
-                               std::optional<std::vector<Coupling>> couplings,
-                               std::optional<std::vector<Operation>> operations,
-                               std::optional<DurationUnit> durationUnit)
-    : CompilerTarget(std::nullopt, std::move(sites), std::move(couplings),
-                     std::move(operations), std::move(durationUnit),
-                     StorageConstructorTag{}) {}
+llvm::Expected<CompilerTarget>
+CompilerTarget::create(std::vector<Site> sites,
+                       std::optional<std::vector<Coupling>> couplings,
+                       std::optional<std::vector<Operation>> operations,
+                       std::optional<DurationUnit> durationUnit) {
+  return createImpl(std::nullopt, std::move(sites), std::move(couplings),
+                    std::move(operations), std::move(durationUnit));
+}
 
-CompilerTarget::CompilerTarget(std::string name, std::vector<Site> sites,
-                               std::optional<std::vector<Coupling>> couplings,
-                               std::optional<std::vector<Operation>> operations,
-                               std::optional<DurationUnit> durationUnit)
-    : CompilerTarget(std::optional<std::string>(std::move(name)),
-                     std::move(sites), std::move(couplings),
-                     std::move(operations), std::move(durationUnit),
-                     StorageConstructorTag{}) {}
+llvm::Expected<CompilerTarget>
+CompilerTarget::create(std::string name, std::vector<Site> sites,
+                       std::optional<std::vector<Coupling>> couplings,
+                       std::optional<std::vector<Operation>> operations,
+                       std::optional<DurationUnit> durationUnit) {
+  return createImpl(std::optional<std::string>(std::move(name)),
+                    std::move(sites), std::move(couplings),
+                    std::move(operations), std::move(durationUnit));
+}
 
-CompilerTarget::CompilerTarget(
-    std::optional<std::string> name, std::vector<Site> sites,
-    std::optional<std::vector<Coupling>> couplings,
-    std::optional<std::vector<Operation>> operations,
-    std::optional<DurationUnit> durationUnit,
-    [[maybe_unused]] StorageConstructorTag storageConstructorTag)
-    : storage_(std::make_shared<const Storage>(
-          std::move(name), std::move(sites), std::move(couplings),
-          std::move(operations), std::move(durationUnit))) {}
+llvm::Expected<CompilerTarget>
+CompilerTarget::createImpl(std::optional<std::string> name,
+                           std::vector<Site> sites,
+                           std::optional<std::vector<Coupling>> couplings,
+                           std::optional<std::vector<Operation>> operations,
+                           std::optional<DurationUnit> durationUnit) {
+  auto storage =
+      Storage::create(std::move(name), std::move(sites), std::move(couplings),
+                      std::move(operations), std::move(durationUnit));
+  if (!storage) {
+    return storage.takeError();
+  }
+  return CompilerTarget(std::move(*storage));
+}
+
+CompilerTarget::CompilerTarget(std::shared_ptr<const Storage> storage)
+    : storage_(std::move(storage)) {}
 
 std::optional<StringRef> CompilerTarget::name() const noexcept {
   if (!storage_->name) {
@@ -579,9 +675,7 @@ CompilerTarget::vertexForSite(const SiteId site) const noexcept {
 }
 
 SiteId CompilerTarget::siteForVertex(const size_t vertex) const {
-  if (vertex >= numQubits()) {
-    throwVertexOutOfRange();
-  }
+  assert(vertex < numQubits() && "Compiler target vertex is out of range");
   return storage_->siteIds[vertex];
 }
 
@@ -598,9 +692,8 @@ ArrayRef<CompilerTarget::Coupling> CompilerTarget::couplings() const noexcept {
 
 bool CompilerTarget::areAdjacent(const size_t source,
                                  const size_t target) const {
-  if (source >= numQubits() || target >= numQubits()) {
-    throwVertexOutOfRange();
-  }
+  assert(source < numQubits() && target < numQubits() &&
+         "Compiler target vertex is out of range");
   if (!hasExplicitTopology()) {
     return source != target;
   }
@@ -611,9 +704,7 @@ void CompilerTarget::forEachNeighbour(
     const size_t vertex,
     const llvm::function_ref<void(size_t)> callback) const {
   if (!hasExplicitTopology()) {
-    if (vertex >= numQubits()) {
-      throwVertexOutOfRange();
-    }
+    assert(vertex < numQubits() && "Compiler target vertex is out of range");
     for (size_t neighbour = 0; neighbour < numQubits(); ++neighbour) {
       if (neighbour != vertex) {
         callback(neighbour);
@@ -628,9 +719,8 @@ void CompilerTarget::forEachNeighbour(
 
 size_t CompilerTarget::distanceBetween(const size_t source,
                                        const size_t target) const {
-  if (source >= numQubits() || target >= numQubits()) {
-    throwVertexOutOfRange();
-  }
+  assert(source < numQubits() && target < numQubits() &&
+         "Compiler target vertex is out of range");
   if (!hasExplicitTopology()) {
     return source == target ? 0 : 1;
   }
@@ -638,14 +728,8 @@ size_t CompilerTarget::distanceBetween(const size_t source,
 }
 
 ArrayRef<size_t> CompilerTarget::explicitNeighbours(const size_t vertex) const {
-  if (vertex >= numQubits()) {
-    throwVertexOutOfRange();
-  }
+  assert(vertex < numQubits() && "Compiler target vertex is out of range");
   return storage_->adjacency[vertex];
-}
-
-void CompilerTarget::throwVertexOutOfRange() {
-  throw std::out_of_range("Compiler target vertex is out of range");
 }
 
 size_t CompilerTarget::maxDegree() const noexcept {

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -34,6 +34,7 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/CommandLine.h>
+#include <llvm/Support/Error.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/InitLLVM.h>
 #include <llvm/Support/Path.h>
@@ -447,7 +448,14 @@ static int runCompiler(int argc, char** argv) {
       return 1;
     }
     const auto device = fomac::Session::openDevice(qdmiDevice);
-    compilerTarget.emplace(compilerTargetFromDevice(device));
+    auto target = compilerTargetFromDevice(device);
+    if (!target) {
+      llvm::errs() << "Failed to create compiler target from QDMI device '"
+                   << qdmiDevice << "': " << llvm::toString(target.takeError())
+                   << '\n';
+      return 1;
+    }
+    compilerTarget.emplace(std::move(*target));
   }
 
   // Set up MLIR context with all required dialects

--- a/mlir/unittests/Compiler/test_compiler_fomac_adapter.cpp
+++ b/mlir/unittests/Compiler/test_compiler_fomac_adapter.cpp
@@ -17,8 +17,9 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Error.h>
 
-#include <stdexcept>
+#include <cassert>
 #include <string>
 
 using mlir::CompilerTarget;
@@ -28,17 +29,15 @@ findOperation(const CompilerTarget& target, const llvm::StringRef name) {
   const auto* const found =
       llvm::find_if(target.operations(),
                     [&](const auto& op) { return op.canonicalName() == name; });
-  if (found == target.operations().end()) {
-    throw std::out_of_range("Target operation not found");
-  }
+  assert(found != target.operations().end() && "Target operation not found");
   return *found;
 }
 
 TEST(CompilerFoMaCAdapterTest, SnapshotsIQMCalibrationAndLifetime) {
-  const auto target = [] {
+  const auto target = llvm::cantFail([] {
     const auto device = fomac::Session::openDevice("mqt.sc.iqm.garnet");
     return mlir::compilerTargetFromDevice(device);
-  }();
+  }());
 
   ASSERT_TRUE(target.name());
   EXPECT_EQ(*target.name(), "IQM Garnet");
@@ -83,7 +82,7 @@ TEST(CompilerFoMaCAdapterTest, SnapshotsIQMCalibrationAndLifetime) {
 
 TEST(CompilerFoMaCAdapterTest, PreservesMissingTopologyAsAllToAll) {
   const auto device = fomac::Session::openDevice("mqt.ddsim.default");
-  const auto target = mlir::compilerTargetFromDevice(device);
+  const auto target = llvm::cantFail(mlir::compilerTargetFromDevice(device));
 
   EXPECT_EQ(target.numQubits(), 65535);
   EXPECT_FALSE(target.hasExplicitTopology());
@@ -98,15 +97,11 @@ TEST(CompilerFoMaCAdapterTest, RejectsNonhomogeneousOperationSupport) {
   overrides.deviceConfiguration =
       qdmi::FileDeviceConfiguration{MQT_CORE_MLIR_HETEROGENEOUS_SC_CONFIG};
   const auto device = fomac::Session::openDevice("mqt.sc.default", overrides);
-  try {
-    const auto target = mlir::compilerTargetFromDevice(device);
-    FAIL() << "Expected a homogeneous-operation diagnostic, got "
-           << target.operations().size() << " target operations";
-  } catch (const std::invalid_argument& error) {
-    EXPECT_NE(std::string(error.what()).find("homogeneous"), std::string::npos);
-    EXPECT_NE(std::string(error.what()).find("every topology edge"),
-              std::string::npos);
-  }
+  auto target = mlir::compilerTargetFromDevice(device);
+  ASSERT_FALSE(target);
+  const auto message = llvm::toString(target.takeError());
+  EXPECT_NE(message.find("homogeneous"), std::string::npos);
+  EXPECT_NE(message.find("every topology edge"), std::string::npos);
 }
 
 TEST(CompilerFoMaCAdapterTest, RejectsDirectionalOperationWithoutReverseSites) {
@@ -114,14 +109,10 @@ TEST(CompilerFoMaCAdapterTest, RejectsDirectionalOperationWithoutReverseSites) {
   overrides.deviceConfiguration = qdmi::FileDeviceConfiguration{
       MQT_CORE_MLIR_DIRECTIONAL_ONE_WAY_SC_CONFIG};
   const auto device = fomac::Session::openDevice("mqt.sc.default", overrides);
-  try {
-    const auto target = mlir::compilerTargetFromDevice(device);
-    FAIL() << "Expected a bidirectional-operation diagnostic, got "
-           << target.operations().size() << " target operations";
-  } catch (const std::invalid_argument& error) {
-    EXPECT_NE(std::string(error.what()).find("both orientations"),
-              std::string::npos);
-  }
+  auto target = mlir::compilerTargetFromDevice(device);
+  ASSERT_FALSE(target);
+  const auto message = llvm::toString(target.takeError());
+  EXPECT_NE(message.find("both orientations"), std::string::npos);
 }
 
 TEST(CompilerFoMaCAdapterTest,
@@ -130,7 +121,7 @@ TEST(CompilerFoMaCAdapterTest,
   overrides.deviceConfiguration = qdmi::FileDeviceConfiguration{
       MQT_CORE_MLIR_DIRECTIONAL_TWO_WAY_SC_CONFIG};
   const auto device = fomac::Session::openDevice("mqt.sc.default", overrides);
-  const auto target = mlir::compilerTargetFromDevice(device);
+  const auto target = llvm::cantFail(mlir::compilerTargetFromDevice(device));
 
   ASSERT_EQ(target.couplings().size(), 1);
   const auto& cx = findOperation(target, "cx");
@@ -145,13 +136,9 @@ TEST(CompilerFoMaCAdapterTest,
 
 TEST(CompilerFoMaCAdapterTest, RejectsNeutralAtomZoneModels) {
   const auto device = fomac::Session::openDevice("mqt.na.default");
-  try {
-    const auto target = mlir::compilerTargetFromDevice(device);
-    FAIL() << "Expected a neutral-atom diagnostic, got " << target.numQubits()
-           << " target sites";
-  } catch (const std::invalid_argument& error) {
-    EXPECT_NE(std::string(error.what()).find("only circuit-model devices"),
-              std::string::npos);
-    EXPECT_NE(std::string(error.what()).find("zone"), std::string::npos);
-  }
+  auto target = mlir::compilerTargetFromDevice(device);
+  ASSERT_FALSE(target);
+  const auto message = llvm::toString(target.takeError());
+  EXPECT_NE(message.find("only circuit-model devices"), std::string::npos);
+  EXPECT_NE(message.find("zone"), std::string::npos);
 }

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -35,6 +35,7 @@
 #include <gtest/gtest.h>
 #include <jeff/IR/JeffDialect.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/Error.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
@@ -205,13 +206,18 @@ makeSparseUCZTarget(const bool includeMeasure) {
   using Operation = CompilerTarget::Operation;
   using Site = CompilerTarget::Site;
 
-  std::vector operations{Operation{"u", 1, 3}, Operation{"cz", 2, 0}};
+  std::vector operations{llvm::cantFail(Operation::create("u", 1, 3)),
+                         llvm::cantFail(Operation::create("cz", 2, 0))};
   if (includeMeasure) {
-    operations.emplace_back("measure", 1, 0);
+    operations.emplace_back(llvm::cantFail(Operation::create("measure", 1, 0)));
   }
-  return CompilerTarget{"sparse-line", std::vector{Site{5}, Site{9}, Site{17}},
-                        std::vector<CompilerTarget::Coupling>{{5, 9}, {9, 17}},
-                        std::move(operations)};
+  std::vector sites{llvm::cantFail(Site::create(5)),
+                    llvm::cantFail(Site::create(9)),
+                    llvm::cantFail(Site::create(17))};
+  return llvm::cantFail(CompilerTarget::create(
+      "sparse-line", std::move(sites),
+      std::vector<CompilerTarget::Coupling>{{5, 9}, {9, 17}},
+      std::move(operations)));
 }
 
 TEST_P(CompilerPipelineTest, EndToEndPipeline) {
@@ -1131,8 +1137,9 @@ c = measure q;
   auto qco = std::move(*qc).intoQCO();
   ASSERT_TRUE(qco);
 
-  const CompilerTarget target{std::vector<CompilerTarget::Site>{
-      CompilerTarget::Site{2472}, CompilerTarget::Site{18449}}};
+  std::vector sites{llvm::cantFail(CompilerTarget::Site::create(2472)),
+                    llvm::cantFail(CompilerTarget::Site::create(18449))};
+  const auto target = llvm::cantFail(CompilerTarget::create(std::move(sites)));
   ASSERT_TRUE(qco->compileForTarget(target));
 
   auto compiled = parseRecordedModule(qco->str());
@@ -1273,7 +1280,7 @@ h q;
       CompilerInput{std::move(*customPipelineInput)}, ProgramFormat::QCO,
       nullptr, "builtin.module(merge-single-qubit-rotation-gates)"));
 
-  const CompilerTarget target{1};
+  const auto target = llvm::cantFail(CompilerTarget::create(1));
   auto targetedImport = QCProgram::fromQASMString(qasm);
   auto targetedRawQCO = QCProgram::fromQASMString(qasm);
   auto targetedJeff = QCProgram::fromQASMString(qasm);

--- a/mlir/unittests/Compiler/test_compiler_target.cpp
+++ b/mlir/unittests/Compiler/test_compiler_target.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/Error.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/DialectRegistry.h>
@@ -28,7 +29,6 @@
 #include <cstdint>
 #include <limits>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -36,6 +36,17 @@
 #include <vector>
 
 namespace mqt::test::compiler {
+template <class T> [[nodiscard]] static T valid(llvm::Expected<T> value) {
+  return llvm::cantFail(std::move(value));
+}
+
+template <class T>
+static void expectInvalid(llvm::Expected<T> value,
+                          const std::string_view expectedMessage) {
+  ASSERT_FALSE(value);
+  EXPECT_EQ(llvm::toString(value.takeError()), expectedMessage);
+}
+
 namespace {
 
 using Target = mlir::CompilerTarget;
@@ -49,18 +60,20 @@ using SiteTuple = Target::SiteTuple;
 
 TEST(CompilerTargetTest, ConstructsDetailedNamedTargetAndSharesStorage) {
   std::vector<Site> sites;
-  sites.emplace_back(7, "left", 100, 80);
-  sites.emplace_back(2, std::nullopt, 120, std::nullopt);
-  sites.emplace_back(11, "right");
+  sites.emplace_back(valid(Site::create(7, "left", 100, 80)));
+  sites.emplace_back(valid(Site::create(2, std::nullopt, 120, std::nullopt)));
+  sites.emplace_back(valid(Site::create(11, "right")));
 
   std::vector<Operation> operations;
+  std::vector siteTuples{valid(SiteTuple::create({7}, 0, 0.99)),
+                         valid(SiteTuple::create({2}, 5, 0.98))};
   operations.emplace_back(
-      " PRX ", 1, 2,
-      std::vector{SiteTuple{{7}, 0, 0.99}, SiteTuple{{2}, 5, 0.98}}, 0, 0.97);
+      valid(Operation::create(" PRX ", 1, 2, std::move(siteTuples), 0, 0.97)));
 
-  const Target target{"device", std::move(sites),
-                      std::vector<Coupling>{{11, 2}, {2, 11}, {7, 2}},
-                      std::move(operations), DurationUnit{"ns", 0.5}};
+  const auto target = valid(Target::create(
+      "device", std::move(sites),
+      std::vector<Coupling>{{11, 2}, {2, 11}, {7, 2}}, std::move(operations),
+      valid(DurationUnit::create("ns", 0.5))));
   // The copy itself is the behavior under test: both objects must share the
   // immutable backing storage.
   // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
@@ -93,8 +106,8 @@ TEST(CompilerTargetTest, ConstructsDetailedNamedTargetAndSharesStorage) {
 }
 
 TEST(CompilerTargetTest, ConstructsDenseUnnamedAllToAllTarget) {
-  const Target target{3};
-  const Target named{"simulator", 2};
+  const auto target = valid(Target::create(3));
+  const auto named = valid(Target::create("simulator", 2));
 
   EXPECT_FALSE(target.name());
   ASSERT_TRUE(named.name());
@@ -118,15 +131,14 @@ TEST(CompilerTargetTest, ConstructsDenseUnnamedAllToAllTarget) {
   target.forEachNeighbour(
       1, [&](const auto neighbour) { neighbours.emplace_back(neighbour); });
   EXPECT_EQ(neighbours, (std::vector<size_t>{0, 2}));
-  EXPECT_THROW(target.siteForVertex(3), std::out_of_range);
-  EXPECT_THROW(target.areAdjacent(0, 3), std::out_of_range);
-  EXPECT_THROW(target.distanceBetween(3, 0), std::out_of_range);
-  EXPECT_THROW(target.forEachNeighbour(3, [](size_t) {}), std::out_of_range);
 }
 
 TEST(CompilerTargetTest, CanonicalizesConnectedTopologyAndCachesDistances) {
-  const Target target{std::vector<Site>{Site{7}, Site{2}, Site{11}},
-                      std::vector<Coupling>{{11, 2}, {2, 11}, {7, 2}, {2, 7}}};
+  std::vector sites{valid(Site::create(7)), valid(Site::create(2)),
+                    valid(Site::create(11))};
+  const auto target = valid(
+      Target::create(std::move(sites),
+                     std::vector<Coupling>{{11, 2}, {2, 11}, {7, 2}, {2, 7}}));
 
   EXPECT_TRUE(target.hasExplicitTopology());
   EXPECT_EQ(target.couplings(), (llvm::ArrayRef<Coupling>{{2, 7}, {2, 11}}));
@@ -147,75 +159,97 @@ TEST(CompilerTargetTest, CanonicalizesConnectedTopologyAndCachesDistances) {
 }
 
 TEST(CompilerTargetTest, RejectsInvalidMetadata) {
-  const auto expectInvalid = [](const auto& construct) {
-    EXPECT_THROW(construct(), std::invalid_argument);
-  };
-
-  expectInvalid([] { static_cast<void>(Target{0}); });
+  expectInvalid(Target::create(0),
+                "Compiler target must contain at least one site");
   if constexpr (sizeof(size_t) >= sizeof(uint64_t)) {
     expectInvalid(
-        [] { static_cast<void>(Target{std::numeric_limits<size_t>::max()}); });
+        Target::create(std::numeric_limits<size_t>::max()),
+        "Compiler target qubit count exceeds the nonnegative i64 site domain");
   }
-  expectInvalid([] { static_cast<void>(Site{-1}); });
-  expectInvalid([] { static_cast<void>(Site{0, ""}); });
-  expectInvalid([] { static_cast<void>(Site{0, std::nullopt, 0}); });
-  expectInvalid([] { static_cast<void>(DurationUnit{"", 1.}); });
-  expectInvalid([] { static_cast<void>(DurationUnit{"ns", 0.}); });
-  expectInvalid([] {
-    static_cast<void>(
-        DurationUnit{"ns", std::numeric_limits<double>::infinity()});
-  });
-  expectInvalid([] { static_cast<void>(SiteTuple{{0, 0}}); });
-  expectInvalid([] { static_cast<void>(SiteTuple{{0}, std::nullopt, -0.1}); });
-  expectInvalid([] { static_cast<void>(Operation{"", 1, 0}); });
-  expectInvalid([] { static_cast<void>(Operation{"x", 0, 0}); });
-  expectInvalid([] {
-    static_cast<void>(Operation{"x", 1, 0, std::vector{SiteTuple{{0, 1}}}});
-  });
-  expectInvalid([] {
-    static_cast<void>(
-        Operation{"x", 1, 0, std::vector{SiteTuple{{0}}, SiteTuple{{0}}}});
-  });
-  expectInvalid([] {
-    static_cast<void>(Operation{
-        "x", 1, 0, {}, std::nullopt, std::numeric_limits<double>::quiet_NaN()});
-  });
+  expectInvalid(Site::create(-1),
+                "Compiler target site ID must be nonnegative");
+  expectInvalid(Site::create(0, ""),
+                "Compiler target site name must not be empty when present");
+  expectInvalid(Site::create(0, std::nullopt, 0),
+                "Compiler target site T1 must be positive");
+  expectInvalid(Site::create(0, std::nullopt, std::nullopt, 0),
+                "Compiler target site T2 must be positive");
+  expectInvalid(DurationUnit::create("", 1.),
+                "Compiler target duration unit must not be empty");
+  expectInvalid(
+      DurationUnit::create("ns", 0.),
+      "Compiler target duration scale factor must be positive and finite");
+  expectInvalid(
+      DurationUnit::create("ns", std::numeric_limits<double>::infinity()),
+      "Compiler target duration scale factor must be positive and finite");
+  expectInvalid(SiteTuple::create({0, 0}),
+                "Compiler target site tuple contains a duplicate site");
+  expectInvalid(SiteTuple::create({-1}),
+                "Compiler target site tuple contains a negative site ID");
+  expectInvalid(
+      SiteTuple::create({0}, std::nullopt, -0.1),
+      "Compiler target site-tuple fidelity must be finite and in [0, 1]");
+  expectInvalid(Operation::create("", 1, 0),
+                "Compiler target operation name must not be empty");
+  expectInvalid(Operation::create("x", 0, 0),
+                "Compiler target operation qubit count must be positive");
+  expectInvalid(
+      Operation::create("x", 1, 0,
+                        std::vector{valid(SiteTuple::create({0, 1}))}),
+      "Compiler target operation site tuple does not match its arity");
+  expectInvalid(Operation::create("x", 1, 0,
+                                  std::vector{valid(SiteTuple::create({0})),
+                                              valid(SiteTuple::create({0}))}),
+                "Compiler target operation contains a duplicate site tuple");
+  expectInvalid(
+      Operation::create("x", 1, 0, {}, std::nullopt,
+                        std::numeric_limits<double>::quiet_NaN()),
+      "Compiler target operation fidelity must be finite and in [0, 1]");
 
-  expectInvalid([] { static_cast<void>(Target{std::vector<Site>{}}); });
+  expectInvalid(Target::create(std::vector<Site>{}),
+                "Compiler target must contain at least one site");
+  expectInvalid(Target::create("", 1),
+                "Compiler target name must not be empty when present");
+  expectInvalid(Target::create("invalid", 0),
+                "Compiler target must contain at least one site");
+  expectInvalid(Target::create(std::vector{valid(Site::create(1)),
+                                           valid(Site::create(1))}),
+                "Compiler target contains duplicate site IDs");
   expectInvalid(
-      [] { static_cast<void>(Target{std::vector<Site>{Site{1}, Site{1}}}); });
-  expectInvalid([] {
-    static_cast<void>(Target{std::vector<Site>{Site{0, std::nullopt, 1}}});
-  });
-  expectInvalid([] {
-    static_cast<void>(
-        Target{1, std::nullopt, std::vector{Operation{"x", 1, 0, {}, 1}}});
-  });
-  expectInvalid([] {
-    std::vector<Operation> operations;
-    operations.emplace_back("x", 1, 0, std::vector{SiteTuple{{0}, 1}});
-    static_cast<void>(Target{1, std::nullopt, std::move(operations)});
-  });
+      Target::create(std::vector{valid(Site::create(0, std::nullopt, 1))}),
+      "Compiler target timing metadata requires a duration unit");
   expectInvalid(
-      [] { static_cast<void>(Target{2, std::vector<Coupling>{{0, 0}}}); });
+      Target::create(1, std::nullopt,
+                     std::vector{valid(Operation::create("x", 1, 0, {}, 1))}),
+      "Compiler target timing metadata requires a duration unit");
   expectInvalid(
-      [] { static_cast<void>(Target{2, std::vector<Coupling>{{0, 2}}}); });
+      Target::create(
+          1, std::nullopt,
+          std::vector{valid(Operation::create(
+              "x", 1, 0, std::vector{valid(SiteTuple::create({0}, 1))}))}),
+      "Compiler target timing metadata requires a duration unit");
+  expectInvalid(Target::create(2, std::vector<Coupling>{{0, 0}}),
+                "Compiler target topology contains a self-coupling");
+  expectInvalid(Target::create(2, std::vector<Coupling>{{0, 2}}),
+                "Compiler target topology references an unknown site");
+  expectInvalid(Target::create(3, std::vector<Coupling>{{0, 1}}),
+                "Compiler target topology must be connected");
   expectInvalid(
-      [] { static_cast<void>(Target{3, std::vector<Coupling>{{0, 1}}}); });
-  expectInvalid([] {
-    std::vector<Operation> operations;
-    operations.emplace_back("x", 1, 0, std::vector{SiteTuple{{2}}});
-    static_cast<void>(Target{2, std::nullopt, std::move(operations)});
-  });
-  expectInvalid([] {
-    static_cast<void>(
-        Target{1, std::nullopt, std::vector{Operation{"cx", 2, 0}}});
-  });
+      Target::create(
+          2, std::nullopt,
+          std::vector{valid(Operation::create(
+              "x", 1, 0, std::vector{valid(SiteTuple::create({2}))}))}),
+      "Compiler target operation site tuple references an unknown site");
+  expectInvalid(
+      Target::create(1, std::nullopt,
+                     std::vector{valid(Operation::create("cx", 2, 0))}),
+      "Compiler target operation arity exceeds its site count");
 }
 
 TEST(CompilerTargetTest, DistinguishesAbsentAndEmptyOperationSets) {
-  const Target permissive{2};
-  const Target closed{2, std::nullopt, std::vector<Operation>{}};
+  const auto permissive = valid(Target::create(2));
+  const auto closed =
+      valid(Target::create(2, std::nullopt, std::vector<Operation>{}));
 
   EXPECT_FALSE(permissive.hasExplicitOperations());
   EXPECT_TRUE(permissive.operations().empty());
@@ -236,10 +270,12 @@ TEST(CompilerTargetTest, DistinguishesAbsentAndEmptyOperationSets) {
 
 TEST(CompilerTargetTest, PreservesCalibrationAndResolvesHomogeneousBasis) {
   const std::vector<Coupling> chain{{0, 1}, {1, 2}};
-  const Operation globalU{"U3", 1, 3};
-  const Operation cz{"cz", 2, 0, std::vector{SiteTuple{{1, 0}, 5, 0.99}}};
-  const Target target{3, chain, std::vector{globalU, cz},
-                      DurationUnit{"ns", 1.}};
+  const auto globalU = valid(Operation::create("U3", 1, 3));
+  const auto cz = valid(Operation::create(
+      "cz", 2, 0, std::vector{valid(SiteTuple::create({1, 0}, 5, 0.99))}));
+  const auto target =
+      valid(Target::create(3, chain, std::vector{globalU, cz},
+                           valid(DurationUnit::create("ns", 1.))));
 
   EXPECT_TRUE(target.supportsOperation("u", 1, 3));
   EXPECT_TRUE(target.supportsOperation(" U3 ", 1, 3));
@@ -267,12 +303,14 @@ TEST(CompilerTargetTest, ClassifiesEveryEntangler) {
                               Entangler{GateKind::ECR, "ecr", 0},
                               Entangler{GateKind::RZX, "rzx", 1}};
   const std::vector<Coupling> chain{{0, 1}, {1, 2}};
-  const Operation globalU{"u", 1, 3};
+  const auto globalU = valid(Operation::create("u", 1, 3));
 
   for (const auto& [gate, name, numParameters] : entanglers) {
     SCOPED_TRACE(name);
-    const Operation operation{std::string{name}, 2, numParameters};
-    const Target target{3, chain, std::vector{globalU, operation}};
+    const auto operation =
+        valid(Operation::create(std::string{name}, 2, numParameters));
+    const auto target =
+        valid(Target::create(3, chain, std::vector{globalU, operation}));
     EXPECT_TRUE(llvm::is_contained(target.supportedGates(), gate));
     EXPECT_TRUE(target.supports(gate));
     ASSERT_TRUE(target.synthesisBasis());
@@ -335,13 +373,16 @@ TEST(CompilerTargetTest, SupportsRealQCOOperationsAndStructuralOps) {
   ASSERT_NE(barrier, nullptr);
   ASSERT_NE(gphase, nullptr);
 
-  const Target target{
-      std::vector<Site>{Site{10}, Site{20}}, std::nullopt,
-      std::vector{
-          Operation{"x", 1, 0}, Operation{"measure", 1, 0},
-          Operation{"reset", 1, 0},
-          Operation{"cnot", 2, 0,
-                    std::vector{SiteTuple{{10, 20}}, SiteTuple{{20, 10}}}}}};
+  std::vector sites{valid(Site::create(10)), valid(Site::create(20))};
+  std::vector directionalTuples{valid(SiteTuple::create({10, 20})),
+                                valid(SiteTuple::create({20, 10}))};
+  std::vector operations{
+      valid(Operation::create("x", 1, 0)),
+      valid(Operation::create("measure", 1, 0)),
+      valid(Operation::create("reset", 1, 0)),
+      valid(Operation::create("cnot", 2, 0, std::move(directionalTuples)))};
+  const auto target = valid(
+      Target::create(std::move(sites), std::nullopt, std::move(operations)));
   EXPECT_TRUE(target.supports(x));
   EXPECT_TRUE(target.supports(cx));
   EXPECT_TRUE(target.supports(measure));
@@ -350,7 +391,8 @@ TEST(CompilerTargetTest, SupportsRealQCOOperationsAndStructuralOps) {
   EXPECT_TRUE(target.supports(gphase));
   EXPECT_FALSE(target.supports(nullptr));
 
-  const Target closed{2, std::nullopt, std::vector<Operation>{}};
+  const auto closed =
+      valid(Target::create(2, std::nullopt, std::vector<Operation>{}));
   EXPECT_TRUE(closed.supports(barrier));
   EXPECT_TRUE(closed.supports(gphase));
   EXPECT_FALSE(closed.supports(x));

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -26,6 +26,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Debug.h>
+#include <llvm/Support/Error.h>
 #include <llvm/Support/LogicalResult.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -234,7 +235,8 @@ static CompilerTarget getSquareGridTarget(const size_t n) {
     }
   }
 
-  return CompilerTarget(numTarget, std::move(couplings));
+  return llvm::cantFail(
+      CompilerTarget::create(numTarget, std::move(couplings)));
 }
 
 /// Creates an N-qubit GHZ state, where N = `qubits.size()` using
@@ -325,9 +327,9 @@ class MappingPassTest : public MappingPassFixture,
 TEST_F(MappingPassFixture, MapTopologyOnlyWithEmptyOperationSet) {
   constexpr int64_t size = 3;
 
-  const CompilerTarget target(
+  const auto target = llvm::cantFail(CompilerTarget::create(
       3, std::vector<CompilerTarget::Coupling>{{0, 1}, {1, 2}},
-      std::vector<CompilerTarget::Operation>{});
+      std::vector<CompilerTarget::Operation>{}));
 
   QCOProgramBuilder builder(context.get());
   builder.initialize(SmallVector<Type>(size, builder.getI1Type()));
@@ -364,14 +366,14 @@ TEST_F(MappingPassFixture, PreserveNoncontiguousTargetSiteIds) {
   constexpr int64_t size = 3;
 
   std::vector<CompilerTarget::Site> sites;
-  sites.emplace_back(7);
-  sites.emplace_back(19);
-  sites.emplace_back(42);
+  sites.emplace_back(llvm::cantFail(CompilerTarget::Site::create(7)));
+  sites.emplace_back(llvm::cantFail(CompilerTarget::Site::create(19)));
+  sites.emplace_back(llvm::cantFail(CompilerTarget::Site::create(42)));
 
-  const CompilerTarget target(
+  const auto target = llvm::cantFail(CompilerTarget::create(
       std::move(sites),
       std::vector<CompilerTarget::Coupling>{{7, 19}, {19, 42}},
-      std::vector<CompilerTarget::Operation>{});
+      std::vector<CompilerTarget::Operation>{}));
 
   QCOProgramBuilder builder(context.get());
   builder.initialize(SmallVector<Type>(size, builder.getI1Type()));
@@ -414,7 +416,8 @@ TEST_F(MappingPassFixture, KeepWorkspaceSparseOnLargeTarget) {
     couplings.emplace_back(0, static_cast<int64_t>(site));
   }
 
-  const CompilerTarget target(numTargetQubits, std::move(couplings));
+  const auto target = llvm::cantFail(
+      CompilerTarget::create(numTargetQubits, std::move(couplings)));
 
   QCOProgramBuilder builder(context.get());
   builder.initialize(SmallVector<Type>(2, builder.getI1Type()));
@@ -1625,8 +1628,8 @@ TEST_P(MappingPassTest, MapNestedForSwitch) {
 }
 
 TEST_P(MappingPassTest, MapIndexSwitchUsesVotedLayout) {
-  const CompilerTarget target(
-      3, std::vector<CompilerTarget::Coupling>{{0, 1}, {1, 2}});
+  const auto target = llvm::cantFail(CompilerTarget::create(
+      3, std::vector<CompilerTarget::Coupling>{{0, 1}, {1, 2}}));
 
   QCOProgramBuilder builder(context.get());
   builder.initialize();

--- a/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 
 #include <gtest/gtest.h>
+#include <llvm/Support/Error.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -60,6 +61,10 @@ using mlir::qco::RXXOp;
 using mlir::qco::SWAPOp;
 using mlir::qco::XOp;
 using mlir::qco::ZOp;
+
+template <class T> [[nodiscard]] static T valid(llvm::Expected<T> value) {
+  return llvm::cantFail(std::move(value));
+}
 
 [[nodiscard]] static mlir::func::FuncOp mainFunction(ModuleOp module) {
   return *module.getBody()->getOps<mlir::func::FuncOp>().begin();
@@ -131,10 +136,15 @@ runPass(ModuleOp module, std::unique_ptr<mlir::Pass> pass) {
   return manager.run(module);
 }
 
-[[nodiscard]] static Target makeUCxTarget(std::vector<Site> sites = std::vector{
-                                              Site{0}, Site{1}}) {
-  return Target{std::move(sites), std::nullopt,
-                std::vector{Operation{"u", 1, 3}, Operation{"cx", 2, 0}}};
+[[nodiscard]] static Target
+makeUCxTarget(std::optional<std::vector<Site>> sites = std::nullopt) {
+  if (!sites) {
+    sites = std::vector{valid(Site::create(0)), valid(Site::create(1))};
+  }
+  std::vector operations{valid(Operation::create("u", 1, 3)),
+                         valid(Operation::create("cx", 2, 0))};
+  return valid(
+      Target::create(std::move(*sites), std::nullopt, std::move(operations)));
 }
 
 namespace {
@@ -174,7 +184,7 @@ protected:
 } // namespace
 
 TEST(TargetSynthesisPassContract, FactoriesAreIndependentlyConstructible) {
-  const Target target{2};
+  const auto target = valid(Target::create(2));
   auto fusion = mlir::qco::createFuseTwoQubitGates();
   auto synthesis = mlir::qco::createTargetNativeSynthesis(target);
   auto conformance = mlir::qco::createVerifyTargetConformance(target);
@@ -346,8 +356,8 @@ TEST_F(TargetSynthesisTest, TargetNativeSynthesisPreservesNativeSwap) {
     std::tie(q0, q1) = builder.swap(q0, q1);
     return builder.intConstant(0);
   });
-  const Target swapTarget{2, std::nullopt,
-                          std::vector{Operation{"swap", 2, 0}}};
+  const auto swapTarget = valid(Target::create(
+      2, std::nullopt, std::vector{valid(Operation::create("swap", 2, 0))}));
   ASSERT_FALSE(swapTarget.synthesisBasis());
   const auto before = printModule(*module);
 
@@ -368,8 +378,10 @@ TEST_F(TargetSynthesisTest, TargetNativeSynthesisUsesHomogeneousCapability) {
   };
   auto expected = build(swap);
   auto synthesized = build(swap);
-  const Target target{2, std::nullopt,
-                      std::vector{Operation{"u", 1, 3}, Operation{"cz", 2, 0}}};
+  const auto target =
+      valid(Target::create(2, std::nullopt,
+                           std::vector{valid(Operation::create("u", 1, 3)),
+                                       valid(Operation::create("cz", 2, 0))}));
   ASSERT_TRUE(target.synthesisBasis());
   ASSERT_EQ(target.synthesisBasis()->entangler, Target::GateKind::CZ);
 
@@ -389,7 +401,7 @@ TEST_F(TargetSynthesisTest, AbsentOperationSetTreatsEveryOperationAsNative) {
     qubit = builder.h(qubit);
     return builder.intConstant(0);
   });
-  const Target permissive{1};
+  const auto permissive = valid(Target::create(1));
   const auto before = printModule(*module);
 
   ASSERT_TRUE(mlir::succeeded(
@@ -406,7 +418,8 @@ TEST_F(TargetSynthesisTest, NativePowShellHidesItsImplementationBody) {
                         [&](Value argument) { return builder.h(argument); });
     return builder.intConstant(0);
   });
-  const Target powOnly{1, std::nullopt, std::vector{Operation{"pow", 1, 1}}};
+  const auto powOnly = valid(Target::create(
+      1, std::nullopt, std::vector{valid(Operation::create("pow", 1, 1))}));
   ASSERT_FALSE(powOnly.synthesisBasis());
   const auto before = printModule(*module);
 
@@ -418,7 +431,8 @@ TEST_F(TargetSynthesisTest, NativePowShellHidesItsImplementationBody) {
 }
 
 TEST_F(TargetSynthesisTest, MissingBasisIsDiagnosedOnlyWhenLoweringIsNeeded) {
-  const Target hOnly{1, std::nullopt, std::vector{Operation{"h", 1, 0}}};
+  const auto hOnly = valid(Target::create(
+      1, std::nullopt, std::vector{valid(Operation::create("h", 1, 0))}));
   ASSERT_FALSE(hOnly.synthesisBasis());
 
   auto supported = build([](QCOProgramBuilder& builder) {
@@ -461,9 +475,10 @@ TEST_F(TargetSynthesisTest, SupportedRuntimeParameterizedGateStaysUntouched) {
   )mlir",
                                                   context.get());
   ASSERT_TRUE(module);
-  const Target target{
-      2, std::nullopt,
-      std::vector{Operation{"u", 1, 3}, Operation{"rxx", 2, 1}}};
+  const auto target =
+      valid(Target::create(2, std::nullopt,
+                           std::vector{valid(Operation::create("u", 1, 3)),
+                                       valid(Operation::create("rxx", 2, 1))}));
   const auto before = printModule(*module);
 
   ASSERT_TRUE(mlir::succeeded(
@@ -522,8 +537,9 @@ TEST_F(TargetSynthesisTest,
 
 TEST_F(TargetSynthesisTest,
        ConformanceUsesHomogeneousCapabilitiesAndValidatesSites) {
-  const Target target{std::vector{Site{10}, Site{20}}, std::nullopt,
-                      std::vector{Operation{"cx", 2, 0}}};
+  const auto target = valid(Target::create(
+      std::vector{valid(Site::create(10)), valid(Site::create(20))},
+      std::nullopt, std::vector{valid(Operation::create("cx", 2, 0))}));
   ASSERT_FALSE(target.synthesisBasis());
 
   auto reversed = build([](QCOProgramBuilder& builder) {
@@ -551,7 +567,8 @@ TEST_F(TargetSynthesisTest,
 }
 
 TEST_F(TargetSynthesisTest, ConformanceRejectsDynamicAllocations) {
-  const Target target{1, std::nullopt, std::vector{Operation{"x", 1, 0}}};
+  const auto target = valid(Target::create(
+      1, std::nullopt, std::vector{valid(Operation::create("x", 1, 0))}));
   const auto expectDynamicAllocationFailure =
       [&](OwningOpRef<ModuleOp> module) {
         const auto diagnostics = expectFailure(
@@ -585,7 +602,8 @@ TEST_F(TargetSynthesisTest, ConformanceRejectsQuantumFunctionInputs) {
   )mlir",
                                                   context.get());
   ASSERT_TRUE(module);
-  const Target target{1, std::nullopt, std::vector{Operation{"x", 1, 0}}};
+  const auto target = valid(Target::create(
+      1, std::nullopt, std::vector{valid(Operation::create("x", 1, 0))}));
 
   const auto diagnostics =
       expectFailure(*module, mlir::qco::createVerifyTargetConformance(target));
@@ -606,32 +624,36 @@ TEST_F(TargetSynthesisTest, ConformanceChecksTypeArityAndParameters) {
     EXPECT_NE(diagnostics.find(details), std::string::npos) << diagnostics;
   };
 
-  expectUnsupported(Target{std::vector{Site{10}}, std::nullopt,
-                           std::vector{Operation{"x", 1, 0}}},
-                    build([](QCOProgramBuilder& builder) {
-                      auto qubit = builder.staticQubit(10);
-                      qubit = builder.h(qubit);
-                      return builder.intConstant(0);
-                    }),
-                    "'qco.h'", "arity 1 and 0 parameter(s)");
+  expectUnsupported(
+      valid(Target::create(std::vector{valid(Site::create(10))}, std::nullopt,
+                           std::vector{valid(Operation::create("x", 1, 0))})),
+      build([](QCOProgramBuilder& builder) {
+        auto qubit = builder.staticQubit(10);
+        qubit = builder.h(qubit);
+        return builder.intConstant(0);
+      }),
+      "'qco.h'", "arity 1 and 0 parameter(s)");
 
-  expectUnsupported(Target{std::vector{Site{10}, Site{20}}, std::nullopt,
-                           std::vector{Operation{"x", 2, 0}}},
-                    build([](QCOProgramBuilder& builder) {
-                      auto qubit = builder.staticQubit(10);
-                      qubit = builder.x(qubit);
-                      return builder.intConstant(0);
-                    }),
-                    "'qco.x'", "arity 1 and 0 parameter(s)");
+  expectUnsupported(
+      valid(Target::create(
+          std::vector{valid(Site::create(10)), valid(Site::create(20))},
+          std::nullopt, std::vector{valid(Operation::create("x", 2, 0))})),
+      build([](QCOProgramBuilder& builder) {
+        auto qubit = builder.staticQubit(10);
+        qubit = builder.x(qubit);
+        return builder.intConstant(0);
+      }),
+      "'qco.x'", "arity 1 and 0 parameter(s)");
 
-  expectUnsupported(Target{std::vector{Site{10}}, std::nullopt,
-                           std::vector{Operation{"rz", 1, 0}}},
-                    build([](QCOProgramBuilder& builder) {
-                      auto qubit = builder.staticQubit(10);
-                      qubit = builder.rz(0.25, qubit);
-                      return builder.intConstant(0);
-                    }),
-                    "'qco.rz'", "arity 1 and 1 parameter(s)");
+  expectUnsupported(
+      valid(Target::create(std::vector{valid(Site::create(10))}, std::nullopt,
+                           std::vector{valid(Operation::create("rz", 1, 0))})),
+      build([](QCOProgramBuilder& builder) {
+        auto qubit = builder.staticQubit(10);
+        qubit = builder.rz(0.25, qubit);
+        return builder.intConstant(0);
+      }),
+      "'qco.rz'", "arity 1 and 1 parameter(s)");
 }
 
 TEST_F(TargetSynthesisTest, ConformanceChecksNonUnitaryCapabilities) {
@@ -642,7 +664,8 @@ TEST_F(TargetSynthesisTest, ConformanceChecksNonUnitaryCapabilities) {
     measured = builder.reset(measured);
     return builder.intConstant(0);
   });
-  const Target xOnly{1, std::nullopt, std::vector{Operation{"x", 1, 0}}};
+  const auto xOnly = valid(Target::create(
+      1, std::nullopt, std::vector{valid(Operation::create("x", 1, 0))}));
   const auto diagnostics =
       expectFailure(*module, mlir::qco::createVerifyTargetConformance(xOnly));
   EXPECT_NE(diagnostics.find("'qco.measure' with arity 1 and 0 parameter(s)"),

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -413,6 +413,50 @@ def test_qco_program_compiles_for_direct_sparse_target() -> None:
     assert qco.ir.count("qco.measure") == 2
 
 
+def test_compiler_target_constructors_preserve_python_api() -> None:
+    """Construct every target metadata type and target overload."""
+    duration_unit = CompilerTarget.DurationUnit("ns", 1.0)
+    sites = [
+        CompilerTarget.Site(10, "q0", 100, 200),
+        CompilerTarget.Site(20, "q1"),
+    ]
+    site_tuple = CompilerTarget.SiteTuple([10, 20], duration=10, fidelity=0.99)
+    operation = CompilerTarget.Operation("cx", 2, 0, site_tuples=[site_tuple], duration=20, fidelity=0.98)
+
+    targets = [
+        CompilerTarget(2, duration_unit=duration_unit),
+        CompilerTarget("dense", 2, duration_unit=duration_unit),
+        CompilerTarget(sites, operations=[operation], duration_unit=duration_unit),
+        CompilerTarget("sparse", sites, operations=[operation], duration_unit=duration_unit),
+    ]
+
+    assert [target.num_qubits for target in targets] == [2, 2, 2, 2]
+    assert targets[1].name == "dense"
+    assert targets[3].name == "sparse"
+    assert sites[0].name == "q0"
+    assert sites[0].t1 == 100
+    assert sites[0].t2 == 200
+    assert site_tuple.sites == [10, 20]
+    assert len(operation.site_tuples) == 1
+    assert operation.site_tuples[0].sites == [10, 20]
+    assert duration_unit.unit == "ns"
+
+
+def test_compiler_target_construction_preserves_validation_errors() -> None:
+    """Translate explicit C++ construction errors to Python ``ValueError``."""
+    for _ in range(2):
+        with pytest.raises(ValueError, match="must contain at least one site"):
+            CompilerTarget(0)
+    with pytest.raises(ValueError, match="site ID must be nonnegative"):
+        CompilerTarget.Site(-1)
+    with pytest.raises(ValueError, match="contains a duplicate site"):
+        CompilerTarget.SiteTuple([0, 0])
+    with pytest.raises(ValueError, match="duration unit must not be empty"):
+        CompilerTarget.DurationUnit("", 1.0)
+    with pytest.raises(ValueError, match="operation qubit count must be positive"):
+        CompilerTarget.Operation("x", 0, 0)
+
+
 def test_compiler_target_snapshots_qdmi_device(garnet_target: CompilerTarget) -> None:
     """Retain IQM topology and calibration independently of the live device."""
     target = garnet_target


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Return compiler-target construction failures explicitly instead of throwing from C++ constructors.

- Add `llvm::Expected<T>` factories for `mlir::CompilerTarget` and its metadata values.
- Propagate device-snapshot and target-construction failures through the FoMaC adapter and `mqt-cc`.
- Translate failures to the existing Python `ValueError` behavior only at the nanobind boundary.
- Treat invalid routing vertices as caller precondition violations and cover the changed contracts in compiler, mapping, synthesis, CLI, FoMaC, and Python tests.
- Document the C++ migration while preserving Python's existing `ValueError` contract.

This PR is based directly on `main`; it has no OpenQASM-angle or stacked-PR dependency.

## Validation

- Release builds of the compiler, mapping, target-synthesis, `mqt-cc`, and MLIR binding targets pass locally.
- Compiler (232), mapping (81), and target-synthesis (21) tests pass.
- The MLIR Python binding target builds successfully; binding tests cover valid construction and `ValueError` diagnostics.
- Repository lint and `git diff --check` pass.

GPT-5.6 via Codex materially assisted with implementation, CI diagnosis, review remediation, testing, rebasing, and publication under maintainer direction.
