### PR TITLE
♻️ Propagate OpenQASM semantic errors explicitly

### DIFF
--- a/.agent/plans/issue-1590-openqasm-errors.md
+++ b/.agent/plans/issue-1590-openqasm-errors.md
@@ -1,0 +1,191 @@
+# Propagate OpenQASM semantic errors without exceptions
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+The OpenQASM frontend should diagnose invalid programs even when its translation
+unit is compiled with C++ exceptions disabled. After this change, semantic
+analysis reports the same first diagnostic and produces the same typed program
+for valid input, but uses MLIR result values rather than throwing and catching a
+private exception. This is observable through the existing frontend tests, a
+late recursive-gate failure test, and a direct `-fno-exceptions` compilation of
+the semantic analyzer.
+
+### Progress
+
+- [x] (2026-08-13 21:48Z) Reconstructed the semantic analyzer change directly on
+      current `main` without replaying the obsolete stacked commits.
+- [x] (2026-08-13 21:48Z) Replaced exception unwinding with
+      `mlir::LogicalResult` and `mlir::FailureOr<T>` while retaining one stored
+      diagnostic.
+- [x] (2026-08-13 21:48Z) Added the late recursive-gate regression with exact
+      message and source-position assertions.
+- [x] (2026-08-13 21:52Z) Built and passed all 88 frontend tests and all 164
+      tests in the complete OpenQASM target binary.
+- [x] (2026-08-13 21:52Z) Compiled the complete `obj.MLIROpenQASMFrontend`
+      target with `-fno-exceptions` as the final compiler option.
+- [x] (2026-08-13 21:52Z) Verified the semantic source has no exception syntax
+      and completed repository lint, `git diff --check`, and final diff
+      inspection.
+
+### Surprises & Discoveries
+
+- Observation: The obsolete branch depended on unrelated fixed-width angle work,
+  so replaying its commits would reintroduce changes outside this analyzer.
+  Evidence: applying only the semantic commit as a behavioral reference required
+  adapting helper signatures to the current, simpler scalar representation.
+- Observation: Current `main` has 87 `OpenQASMFrontendTest.*` cases, and all
+  passed after the result propagation compiled. Evidence: the focused test run
+  reported `87 tests from 1 test suite` and `PASSED` before adding the new
+  regression.
+
+### Decision Log
+
+- Decision: Keep one translation-unit-local assignment-and-propagation macro and
+  undefine it after `SemanticAnalyzer`. Rationale: MLIR's result types remain
+  explicit at function boundaries while repetitive `FailureOr<T>` extraction
+  stays compact; no shared repository abstraction is introduced. Date/Author:
+  2026-08-13 / Codex.
+- Decision: Store only the first `Diagnostic` in `SemanticAnalyzer` and stop
+  every phase on failure. Rationale: this exactly preserves the frontend's
+  existing single-semantic-diagnostic contract and avoids partial typed
+  programs. Date/Author: 2026-08-13 / Codex.
+- Decision: Leave public types and `analyzeOpenQASM` unchanged. Rationale:
+  callers should not participate in this internal control-flow refactor.
+  Date/Author: 2026-08-13 / Codex.
+
+### Outcomes & Retrospective
+
+The analyzer now propagates semantic failures explicitly while preserving the
+public frontend result and first-diagnostic behavior. The focused and complete
+OpenQASM test suites pass, and a separate build proved that every source in the
+frontend object library compiles with exceptions disabled. The product change is
+limited to the analyzer and one focused regression; no public interface, shared
+helper, or compiler policy changed.
+
+### Context and Orientation
+
+`mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp` converts the parser's syntax
+program into a `TypedProgram`. Before this work it used a private exception to
+leave deeply nested semantic helpers after recording a `Diagnostic`. A
+`Diagnostic` contains the message, source location, and include stack returned
+through the unchanged `AnalysisResult` API.
+
+MLIR provides two small result types in `mlir/Support/LogicalResult.h`.
+`mlir::LogicalResult` represents success or failure for procedures, and
+`mlir::FailureOr<T>` additionally carries a value on success. The analyzer uses
+the former for mutating helpers and the latter for helpers that compute IDs,
+constants, types, resolved operands, or statements. `std::optional` remains
+appropriate only where absence is a successful outcome, such as a nonconstant
+index.
+
+The focused regression belongs in
+`mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp`. It defines a gate
+that calls itself. The analyzer discovers this only after analyzing the body,
+making it a useful proof that late failures propagate without constructing a
+typed program.
+
+This task changes only this plan, the semantic analyzer, and that focused test.
+It does not change compiler flags, public headers, repository-wide exception
+policy, or later OpenQASM semantic work. Follow `AGENTS.md` and
+`docs/ai_usage.md`; this plan does not authorize pushing a branch or editing a
+pull request.
+
+### Plan of Work
+
+In `OpenQASMSemantics.cpp`, remove the private semantic exception and exception
+headers. Give `SemanticAnalyzer` one optional diagnostic. Make `fail` record
+that diagnostic and return `mlir::failure()`. Convert procedural helpers to
+`LogicalResult` and value-producing helpers to `FailureOr<T>`, then immediately
+propagate every failure so the first diagnostic cannot be overwritten.
+
+Use one local macro to evaluate a `FailureOr<T>`, return failure if necessary,
+and move its value into a named local. Keep the macro next to the analyzer and
+undefine it immediately after the class. In `run`, execute each phase in order
+and construct `TypedProgram` only if version validation, depth validation, body
+analysis, gate-cycle validation, and output finalization all succeed.
+
+Add the recursive-gate test after the existing uninitialized-scalar-output test.
+Assert failure, exactly one diagnostic, the exact recursive-gate message, and
+line 4, column 3.
+
+### Concrete Steps
+
+From the repository root, configure and build the focused test target with the
+repository wrapper:
+
+    MLIR_DIR=/path/to/llvm/lib/cmake/mlir ./.agent/run.sh cmake --preset release
+    ./.agent/run.sh cmake --build --preset release --target mqt-core-mlir-unittest-openqasm-target -j2
+
+Run the focused suite and then the whole binary:
+
+    build/release/mlir/unittests/Target/OpenQASM/mqt-core-mlir-unittest-openqasm-target --gtest_filter='OpenQASMFrontendTest.*'
+    build/release/mlir/unittests/Target/OpenQASM/mqt-core-mlir-unittest-openqasm-target
+
+Compile the semantic source in a separate build context with `-fno-exceptions`.
+The compile command must place `-fno-exceptions` after any configured
+`-fexceptions` flag so the final option is authoritative. Then verify the source
+contains no exception syntax and run repository checks:
+
+    rg -n '\bthrow\b|\bcatch\b|<exception>|<stdexcept>' mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+    ./.agent/run.sh uvx nox -s lint
+    git diff --check
+
+The `rg` command succeeds by printing nothing. Both test commands report no
+failures, and lint plus `git diff --check` exit with status zero.
+
+### Validation and Acceptance
+
+Acceptance requires all frontend semantic tests and the complete OpenQASM target
+test binary to pass. The recursive-gate test must observe exactly
+`recursive custom gate definition involving 'recursive'` at line 4, column 3,
+with no second diagnostic.
+
+The analyzer object must compile while exceptions are disabled, and the source
+must contain no `throw`, `catch`, `<exception>`, or `<stdexcept>`. A valid input
+must still yield a populated `AnalysisResult::program`; an invalid semantic
+input must yield one diagnostic with its existing message, source location, and
+include stack. No public header or caller may change.
+
+### Idempotence and Recovery
+
+Configuration, builds, tests, searches, lint, and diff checks are repeatable.
+Use a separate build directory or a copied compiler invocation for the
+`-fno-exceptions` proof so normal release configuration is not altered. If a
+build stops after a source edit, rerun the same target; Ninja rebuilds only
+out-of-date objects. Never discard unrelated changes or operate in another
+task's worktree.
+
+### Artifacts and Notes
+
+The final focused and complete test evidence was:
+
+    [==========] Running 88 tests from 1 test suite.
+    [  PASSED  ] 88 tests.
+    [==========] Running 164 tests from 2 test suites.
+    [  PASSED  ] 164 tests.
+
+The separate build's semantic compile command ended with:
+
+    ... -fexceptions ... -fno-exceptions -o OpenQASMSemantics.cpp.o -c OpenQASMSemantics.cpp
+
+Repository lint ended with `nox > Session lint was successful`, and the source
+exception search plus `git diff --check` produced no output.
+
+### Interfaces and Dependencies
+
+The public `analyzeOpenQASM`, `AnalysisResult`, `Diagnostic`, and `TypedProgram`
+interfaces remain unchanged. The implementation depends only on MLIR's
+`LogicalResult` and `FailureOr<T>` from `mlir/Support/LogicalResult.h`. There is
+no new shared result type, utility header, external library, or repository-wide
+compiler option.
+
+Revision note: Created this standalone plan after reconstructing the analyzer on
+current `main`, then completed it with the focused, full-suite,
+exception-disabled, lint, and diff-validation evidence.

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -28,19 +28,18 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
 
 #include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <exception>
 #include <limits>
 #include <memory>
 #include <numbers>
 #include <optional>
 #include <set>
-#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -55,14 +54,6 @@ constexpr uint64_t TOTAL_REGISTER_ELEMENT_LIMIT = 100'000;
 constexpr size_t EXPRESSION_DEPTH_LIMIT = 256;
 constexpr size_t GATE_DEPENDENCY_DEPTH_LIMIT = 64;
 constexpr size_t TYPED_STATEMENT_LIMIT = 1'000'000;
-
-class SemanticError final : public std::runtime_error {
-public:
-  Diagnostic diagnostic;
-
-  explicit SemanticError(Diagnostic value)
-      : std::runtime_error(value.message), diagnostic(std::move(value)) {}
-};
 
 struct Constant {
   ScalarType type = ScalarType::Int;
@@ -143,11 +134,11 @@ belongsToStdGates(const GateAvailability availability) {
                     constant.value);
 }
 
-[[nodiscard]] static int64_t asSigned(const Constant& constant) {
+[[nodiscard]] static std::optional<int64_t> asSigned(const Constant& constant) {
   if (constant.type == ScalarType::Uint) {
     const auto value = std::get<uint64_t>(constant.value);
     if (value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-      throw std::overflow_error("unsigned value does not fit in signed i64");
+      return std::nullopt;
     }
     return static_cast<int64_t>(value);
   }
@@ -217,6 +208,14 @@ belongsToStdGates(const GateAvailability availability) {
 
 namespace {
 
+#define MQT_OQ3_TRY_ASSIGN(NAME, EXPRESSION)                                   \
+  auto NAME##Result = (EXPRESSION);                                            \
+  if (::mlir::failed(NAME##Result)) {                                          \
+    return ::mlir::failure();                                                  \
+  }                                                                            \
+  /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                             \
+  auto NAME = std::move(*NAME##Result)
+
 class SemanticAnalyzer {
 public:
   SemanticAnalyzer(const SyntaxProgram& syntaxProgram,
@@ -230,18 +229,13 @@ public:
   }
 
   [[nodiscard]] AnalysisResult run() {
-    try {
-      analyzeVersion();
-      validateExpressionDepth();
-      analyzeTopLevelBody();
-      validateGateCallGraph();
-      finalizeOutputs();
-      return {.program = std::make_unique<TypedProgram>(std::move(program))};
-    } catch (const SemanticError& error) {
-      return {.diagnostics = {error.diagnostic}};
-    } catch (const std::exception& error) {
-      return {.diagnostics = {{.message = error.what()}}};
+    if (failed(analyzeVersion()) || failed(validateExpressionDepth()) ||
+        failed(analyzeTopLevelBody()) || failed(validateGateCallGraph()) ||
+        failed(finalizeOutputs())) {
+      assert(failureDiagnostic.has_value());
+      return {.diagnostics = {std::move(*failureDiagnostic)}};
     }
+    return {.program = std::make_unique<TypedProgram>(std::move(program))};
   }
 
 private:
@@ -275,6 +269,7 @@ private:
   std::set<uint64_t> hardwareQubits;
   uint64_t totalRegisterElements = 0;
   std::optional<SyntaxIncludeContextId> currentIncludeContext;
+  mutable std::optional<Diagnostic> failureDiagnostic;
 
   [[nodiscard]] SourceLocation getSourceLocation(const SMLoc location) const {
     auto result = sourceLocation(sources, location);
@@ -294,12 +289,20 @@ private:
     return result;
   }
 
-  [[noreturn]] void fail(SMLoc location, const Twine& message) const {
-    throw SemanticError(
-        {.location = getSourceLocation(location), .message = message.str()});
+  [[nodiscard]] LogicalResult fail(SourceLocation location,
+                                   const Twine& message) const {
+    assert(!failureDiagnostic.has_value());
+    failureDiagnostic =
+        Diagnostic{.location = std::move(location), .message = message.str()};
+    return failure();
   }
 
-  void validateExpressionDepth() const {
+  [[nodiscard]] LogicalResult fail(const SMLoc location,
+                                   const Twine& message) const {
+    return fail(getSourceLocation(location), message);
+  }
+
+  [[nodiscard]] LogicalResult validateExpressionDepth() const {
     std::vector<size_t> depths(syntax.expressions.size(), 1);
     for (const auto [id, expression] : llvm::enumerate(syntax.expressions)) {
       auto depth = size_t{1};
@@ -310,12 +313,13 @@ private:
         depth = std::max(depth, depths[*expression.rhs] + 1);
       }
       if (depth > EXPRESSION_DEPTH_LIMIT) {
-        fail(expression.location,
-             Twine("expression depth exceeds the limit of ") +
-                 Twine(static_cast<unsigned>(EXPRESSION_DEPTH_LIMIT)));
+        return fail(expression.location,
+                    Twine("expression depth exceeds the limit of ") +
+                        Twine(static_cast<unsigned>(EXPRESSION_DEPTH_LIMIT)));
       }
       depths[id] = depth;
     }
+    return success();
   }
 
   void restoreStatePrefix(
@@ -461,16 +465,16 @@ private:
     }
   }
 
-  [[nodiscard]] std::optional<bool>
+  [[nodiscard]] FailureOr<std::optional<bool>>
   constantCondition(const SyntaxExpressionId expression) const {
     if (!isConstantExpression(expression)) {
-      return std::nullopt;
+      return std::optional<bool>{};
     }
-    const auto value = evaluateConstant(expression);
+    MQT_OQ3_TRY_ASSIGN(value, evaluateConstant(expression));
     if (value.type != ScalarType::Bool) {
-      return std::nullopt;
+      return std::optional<bool>{};
     }
-    return std::get<bool>(value.value);
+    return std::optional<bool>(std::get<bool>(value.value));
   }
 
   [[nodiscard]] const Symbol* lookup(StringRef name) const {
@@ -482,7 +486,8 @@ private:
     return nullptr;
   }
 
-  void declare(SMLoc location, StringRef name, Symbol symbol) {
+  [[nodiscard]] LogicalResult declare(SMLoc location, StringRef name,
+                                      Symbol symbol) {
     const auto* catalog = lookupGate(name);
     const bool catalogNameReserved =
         catalog != nullptr &&
@@ -494,11 +499,12 @@ private:
     if (builtinConstant(name) ||
         (scopes.size() == 1 &&
          (customGates.contains(name) || catalogNameReserved))) {
-      fail(location, "identifier '" + name + "' is already declared");
+      return fail(location, "identifier '" + name + "' is already declared");
     }
     if (!scopes.back().insert({name, symbol}).second) {
-      fail(location, "identifier '" + name + "' is already declared");
+      return fail(location, "identifier '" + name + "' is already declared");
     }
+    return success();
   }
 
   [[nodiscard]] bool isGateAvailable(const GateCatalogEntry& gate) const {
@@ -513,24 +519,25 @@ private:
            (program.openQASM2 && gate.name == "CX");
   }
 
-  void analyzeVersion() {
+  [[nodiscard]] LogicalResult analyzeVersion() {
     if (!syntax.version) {
-      return;
+      return success();
     }
     const auto version = *syntax.version;
     if (version.major == 2 && version.minor == 0) {
       program.openQASM2 = true;
-      return;
+      return success();
     }
     if (version.major == 3 && (version.minor == 0 || version.minor == 1)) {
-      return;
+      return success();
     }
-    fail(syntax.versionLocation, "Unsupported OpenQASM version " +
-                                     std::to_string(version.major) + "." +
-                                     std::to_string(version.minor));
+    return fail(syntax.versionLocation, "Unsupported OpenQASM version " +
+                                            std::to_string(version.major) +
+                                            "." +
+                                            std::to_string(version.minor));
   }
 
-  void validateGateCallGraph() const {
+  [[nodiscard]] LogicalResult validateGateCallGraph() const {
     llvm::StringMap<size_t> gateIndices;
     for (const auto [index, gate] : llvm::enumerate(program.gates)) {
       gateIndices[gate.name] = index;
@@ -540,76 +547,94 @@ private:
     std::vector<size_t> dependencyDepths(program.gates.size());
     const auto visitApplications = [&](auto&& self,
                                        ArrayRef<StatementId> statements,
-                                       const auto& callback) -> void {
+                                       const auto& callback) -> LogicalResult {
       for (const auto statementId : statements) {
         const auto& statement = program.statements[statementId];
-        std::visit(
-            [&](const auto& data) {
-              using T = std::decay_t<decltype(data)>;
-              if constexpr (std::is_same_v<T, GateApplication>) {
-                callback(data, statement.location);
-              } else if constexpr (std::is_same_v<T, IfStatement>) {
-                self(self, data.thenStatements, callback);
-                self(self, data.elseStatements, callback);
-              } else if constexpr (std::is_same_v<T, ForStatement> ||
-                                   std::is_same_v<T, WhileStatement>) {
-                self(self, data.body, callback);
-              } else if constexpr (std::is_same_v<T, SwitchStatement>) {
-                for (const auto& switchCase : data.cases) {
-                  self(self, switchCase.body, callback);
-                }
-                self(self, data.defaultStatements, callback);
-              }
-            },
-            statement.data);
+        if (failed(std::visit(
+                [&](const auto& data) -> LogicalResult {
+                  using T = std::decay_t<decltype(data)>;
+                  if constexpr (std::is_same_v<T, GateApplication>) {
+                    return callback(data, statement.location);
+                  } else if constexpr (std::is_same_v<T, IfStatement>) {
+                    if (failed(self(self, data.thenStatements, callback))) {
+                      return failure();
+                    }
+                    return self(self, data.elseStatements, callback);
+                  } else if constexpr (std::is_same_v<T, ForStatement> ||
+                                       std::is_same_v<T, WhileStatement>) {
+                    return self(self, data.body, callback);
+                  } else if constexpr (std::is_same_v<T, SwitchStatement>) {
+                    for (const auto& switchCase : data.cases) {
+                      if (failed(self(self, switchCase.body, callback))) {
+                        return failure();
+                      }
+                    }
+                    return self(self, data.defaultStatements, callback);
+                  }
+                  return success();
+                },
+                statement.data))) {
+          return failure();
+        }
       }
+      return success();
     };
-    const auto visit = [&](auto&& self, const size_t index) -> size_t {
+    const auto visit = [&](auto&& self,
+                           const size_t index) -> FailureOr<size_t> {
       if (states[index] == VisitState::Complete) {
         return dependencyDepths[index];
       }
       states[index] = VisitState::Active;
       size_t dependencyDepth = 1;
-      visitApplications(
-          visitApplications, program.gates[index].body,
-          [&](const GateApplication& application,
-              const SourceLocation& location) {
-            const auto callee = gateIndices.find(application.callee);
-            if (callee == gateIndices.end()) {
-              return;
-            }
-            if (states[callee->second] == VisitState::Active) {
-              throw SemanticError(
-                  {.location = location,
-                   .message = "recursive custom gate definition involving '" +
-                              application.callee + "'"});
-            }
-            const auto calleeDepth = self(self, callee->second);
-            if (calleeDepth >= GATE_DEPENDENCY_DEPTH_LIMIT) {
-              throw SemanticError(
-                  {.location = location,
-                   .message =
-                       "custom gate dependency depth exceeds the limit of " +
-                       std::to_string(GATE_DEPENDENCY_DEPTH_LIMIT)});
-            }
-            dependencyDepth = std::max(dependencyDepth, calleeDepth + 1);
-          });
+      if (failed(visitApplications(
+              visitApplications, program.gates[index].body,
+              [&](const GateApplication& application,
+                  const SourceLocation& location) -> LogicalResult {
+                const auto callee = gateIndices.find(application.callee);
+                if (callee == gateIndices.end()) {
+                  return success();
+                }
+                if (states[callee->second] == VisitState::Active) {
+                  return fail(location,
+                              "recursive custom gate definition involving '" +
+                                  application.callee + "'");
+                }
+                const auto calleeDepth = self(self, callee->second);
+                if (failed(calleeDepth)) {
+                  return failure();
+                }
+                if (*calleeDepth >= GATE_DEPENDENCY_DEPTH_LIMIT) {
+                  return fail(
+                      location,
+                      "custom gate dependency depth exceeds the limit of " +
+                          std::to_string(GATE_DEPENDENCY_DEPTH_LIMIT));
+                }
+                dependencyDepth = std::max(dependencyDepth, *calleeDepth + 1);
+                return success();
+              }))) {
+        return failure();
+      }
       states[index] = VisitState::Complete;
       dependencyDepths[index] = dependencyDepth;
       return dependencyDepth;
     };
     for (size_t index = 0; index < program.gates.size(); ++index) {
       if (states[index] == VisitState::Unvisited) {
-        std::ignore = visit(visit, index);
+        if (failed(visit(visit, index))) {
+          return failure();
+        }
       }
     }
+    return success();
   }
 
-  [[nodiscard]] StatementId addStatement(SMLoc location, StatementData data) {
+  [[nodiscard]] FailureOr<StatementId> addStatement(SMLoc location,
+                                                    StatementData data) {
     if (program.statements.size() >= TYPED_STATEMENT_LIMIT) {
-      fail(location, Twine("typed OpenQASM program exceeds the statement "
-                           "limit of ") +
-                         Twine(static_cast<unsigned>(TYPED_STATEMENT_LIMIT)));
+      return fail(location,
+                  Twine("typed OpenQASM program exceeds the "
+                        "statement limit of ") +
+                      Twine(static_cast<unsigned>(TYPED_STATEMENT_LIMIT)));
     }
     const auto id = static_cast<StatementId>(program.statements.size());
     program.statements.push_back(
@@ -665,30 +690,31 @@ private:
     llvm_unreachable("unknown scalar type");
   }
 
-  [[nodiscard]] ExpressionId castExpression(const ExpressionId expression,
-                                            const ScalarType target,
-                                            const SMLoc location) {
+  [[nodiscard]] FailureOr<ExpressionId>
+  castExpression(const ExpressionId expression, const ScalarType target,
+                 const SMLoc location) {
     const auto source = program.expressions[expression].type;
     if (source == target) {
       return expression;
     }
     if (!canImplicitlyConvert(source, target)) {
-      fail(location, "expression of type '" + scalarTypeName(source) +
-                         "' cannot be implicitly converted to '" +
-                         scalarTypeName(target) + "'");
+      return fail(location, "expression of type '" + scalarTypeName(source) +
+                                "' cannot be implicitly converted to '" +
+                                scalarTypeName(target) + "'");
     }
     return addExpression(
         {.kind = ExpressionKind::Cast, .type = target, .lhs = expression});
   }
 
-  [[nodiscard]] Constant promoteConstInitializer(const Constant& initializer,
-                                                 const ScalarType destination,
-                                                 const SMLoc location) const {
+  [[nodiscard]] FailureOr<Constant>
+  promoteConstInitializer(const Constant& initializer,
+                          const ScalarType destination,
+                          const SMLoc location) const {
     if (!canImplicitlyPromote(initializer, destination)) {
-      fail(location, "constant initializer of type '" +
-                         scalarTypeName(initializer.type) +
-                         "' cannot be implicitly promoted to '" +
-                         scalarTypeName(destination) + "'");
+      return fail(location, "constant initializer of type '" +
+                                scalarTypeName(initializer.type) +
+                                "' cannot be implicitly promoted to '" +
+                                scalarTypeName(destination) + "'");
     }
     if (initializer.type == destination) {
       return initializer;
@@ -698,26 +724,28 @@ private:
       llvm_unreachable("only bool constants can initialize bool constants");
     case ScalarType::Int:
       if (initializer.type == ScalarType::Bool) {
-        return {.type = ScalarType::Int,
-                .value =
-                    static_cast<int64_t>(std::get<bool>(initializer.value))};
+        return Constant{
+            .type = ScalarType::Int,
+            .value = static_cast<int64_t>(std::get<bool>(initializer.value))};
       }
-      return {.type = ScalarType::Int,
-              .value =
-                  static_cast<int64_t>(std::get<uint64_t>(initializer.value))};
+      return Constant{
+          .type = ScalarType::Int,
+          .value = static_cast<int64_t>(std::get<uint64_t>(initializer.value))};
     case ScalarType::Uint:
       if (initializer.type == ScalarType::Bool) {
-        return {.type = ScalarType::Uint,
-                .value =
-                    static_cast<uint64_t>(std::get<bool>(initializer.value))};
+        return Constant{
+            .type = ScalarType::Uint,
+            .value = static_cast<uint64_t>(std::get<bool>(initializer.value))};
       }
-      return {.type = ScalarType::Uint,
-              .value =
-                  static_cast<uint64_t>(std::get<int64_t>(initializer.value))};
+      return Constant{
+          .type = ScalarType::Uint,
+          .value = static_cast<uint64_t>(std::get<int64_t>(initializer.value))};
     case ScalarType::Float:
-      return {.type = ScalarType::Float, .value = asDouble(initializer)};
+      return Constant{.type = ScalarType::Float,
+                      .value = asDouble(initializer)};
     case ScalarType::Angle:
-      return {.type = ScalarType::Angle, .value = asDouble(initializer)};
+      return Constant{.type = ScalarType::Angle,
+                      .value = asDouble(initializer)};
     }
     llvm_unreachable("unknown scalar type");
   }
@@ -753,19 +781,19 @@ private:
     }
   }
 
-  [[nodiscard]] ConditionId
+  [[nodiscard]] FailureOr<ConditionId>
   analyzeBoolValue(const SyntaxExpressionId syntaxId) {
     if (expressionProducesBool(syntaxId)) {
       return analyzeCondition(syntaxId);
     }
     if (isConstantExpression(syntaxId)) {
-      const auto constant = evaluateConstant(syntaxId);
+      MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(syntaxId));
       return addCondition({.kind = ConditionKind::Literal,
                            .location = sourceLocation(
                                sources, syntax.expressions[syntaxId].location),
                            .literal = asDouble(constant) != 0.0});
     }
-    const auto value = analyzeExpression(syntaxId);
+    MQT_OQ3_TRY_ASSIGN(value, analyzeExpression(syntaxId));
     const auto type = program.expressions[value].type;
     auto zeroValue = Constant{.type = ScalarType::Int, .value = int64_t{0}};
     if (type == ScalarType::Float || type == ScalarType::Angle) {
@@ -797,28 +825,30 @@ private:
     return std::nullopt;
   }
 
-  [[nodiscard]] Constant evaluateConstant(const SyntaxExpressionId id) const {
+  [[nodiscard]] FailureOr<Constant>
+  evaluateConstant(const SyntaxExpressionId id) const {
     if (constantValues[id]) {
       return *constantValues[id];
     }
-    const auto result = [&]() -> Constant {
+    const auto result = [&]() -> FailureOr<Constant> {
       const auto& expression = syntax.expressions[id];
       switch (expression.kind) {
       case Expr::Kind::Int:
         if (!expression.wideInteger.empty()) {
-          fail(expression.location,
-               "integer literal exceeds 64-bit constant evaluation");
+          return fail(expression.location,
+                      "integer literal exceeds 64-bit constant evaluation");
         }
         if (expression.integer <=
             static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-          return {.type = ScalarType::Int,
-                  .value = static_cast<int64_t>(expression.integer)};
+          return Constant{.type = ScalarType::Int,
+                          .value = static_cast<int64_t>(expression.integer)};
         }
-        return {.type = ScalarType::Uint, .value = expression.integer};
+        return Constant{.type = ScalarType::Uint, .value = expression.integer};
       case Expr::Kind::Float:
-        return {.type = ScalarType::Float, .value = expression.floatingPoint};
+        return Constant{.type = ScalarType::Float,
+                        .value = expression.floatingPoint};
       case Expr::Kind::Bool:
-        return {.type = ScalarType::Bool, .value = expression.boolean};
+        return Constant{.type = ScalarType::Bool, .value = expression.boolean};
       case Expr::Kind::Identifier: {
         if (const auto builtin = builtinConstant(expression.identifier)) {
           return *builtin;
@@ -826,75 +856,82 @@ private:
         const auto* symbol = lookup(expression.identifier);
         if (symbol == nullptr || symbol->kind != SymbolKind::Constant ||
             !symbol->constant) {
-          fail(expression.location,
-               "expression is not a compile-time constant");
+          return fail(expression.location,
+                      "expression is not a compile-time constant");
         }
         return *symbol->constant;
       }
       case Expr::Kind::Neg: {
-        auto operand = evaluateConstant(*expression.lhs);
+        MQT_OQ3_TRY_ASSIGN(operand, evaluateConstant(*expression.lhs));
         if (operand.type == ScalarType::Bool) {
-          fail(expression.location,
-               "numeric negation requires a numeric operand");
+          return fail(expression.location,
+                      "numeric negation requires a numeric operand");
         }
         if (operand.type == ScalarType::Float ||
             operand.type == ScalarType::Angle) {
-          return {.type = operand.type, .value = -asDouble(operand)};
+          return Constant{.type = operand.type, .value = -asDouble(operand)};
         }
         if (operand.type == ScalarType::Uint) {
           const auto value = std::get<uint64_t>(operand.value);
           if (syntax.expressions[*expression.lhs].kind == Expr::Kind::Int) {
             if (value > (1ULL << 63)) {
-              fail(expression.location, "integer negation overflows i64");
+              return fail(expression.location,
+                          "integer negation overflows i64");
             }
-            return {.type = ScalarType::Int,
-                    .value = std::numeric_limits<int64_t>::min()};
+            return Constant{.type = ScalarType::Int,
+                            .value = std::numeric_limits<int64_t>::min()};
           }
-          return {.type = ScalarType::Uint, .value = 0ULL - value};
+          return Constant{.type = ScalarType::Uint, .value = 0ULL - value};
         }
         const auto value = std::get<int64_t>(operand.value);
         if (value == std::numeric_limits<int64_t>::min()) {
-          fail(expression.location, "integer negation overflows i64");
+          return fail(expression.location, "integer negation overflows i64");
         }
-        return {.type = ScalarType::Int, .value = -value};
+        return Constant{.type = ScalarType::Int, .value = -value};
       }
       case Expr::Kind::Not: {
-        const auto operand = evaluateConstant(*expression.lhs);
+        MQT_OQ3_TRY_ASSIGN(operand, evaluateConstant(*expression.lhs));
         if (operand.type != ScalarType::Bool) {
-          fail(expression.location, "logical negation requires a bool operand");
+          return fail(expression.location,
+                      "logical negation requires a bool operand");
         }
-        return {.type = ScalarType::Bool,
-                .value = !std::get<bool>(operand.value)};
+        return Constant{.type = ScalarType::Bool,
+                        .value = !std::get<bool>(operand.value)};
       }
       case Expr::Kind::BitNot: {
-        fail(expression.location,
-             "bitwise operators require explicitly sized uint, bit, or angle "
-             "operands, which are not supported yet");
+        return fail(
+            expression.location,
+            "bitwise operators require explicitly sized uint, bit, or angle "
+            "operands, which are not supported yet");
       }
       case Expr::Kind::And:
       case Expr::Kind::Or: {
-        const auto lhs = evaluateConstant(*expression.lhs);
+        MQT_OQ3_TRY_ASSIGN(lhs, evaluateConstant(*expression.lhs));
         if (lhs.type != ScalarType::Bool) {
-          fail(expression.location, "logical operators require bool operands");
+          return fail(expression.location,
+                      "logical operators require bool operands");
         }
         const auto left = std::get<bool>(lhs.value);
         const auto shortCircuits =
             expression.kind == Expr::Kind::And ? !left : left;
         if (shortCircuits) {
-          if (constantExpressionType(*expression.rhs) != ScalarType::Bool) {
-            fail(expression.location,
-                 "logical operators require bool operands");
+          MQT_OQ3_TRY_ASSIGN(rhsType, constantExpressionType(*expression.rhs));
+          if (rhsType != ScalarType::Bool) {
+            return fail(expression.location,
+                        "logical operators require bool operands");
           }
-          return {.type = ScalarType::Bool, .value = left};
+          return Constant{.type = ScalarType::Bool, .value = left};
         }
-        const auto rhs = evaluateConstant(*expression.rhs);
+        MQT_OQ3_TRY_ASSIGN(rhs, evaluateConstant(*expression.rhs));
         if (rhs.type != ScalarType::Bool) {
-          fail(expression.location, "logical operators require bool operands");
+          return fail(expression.location,
+                      "logical operators require bool operands");
         }
         const auto right = std::get<bool>(rhs.value);
-        return {.type = ScalarType::Bool,
-                .value = expression.kind == Expr::Kind::And ? left && right
-                                                            : left || right};
+        return Constant{.type = ScalarType::Bool,
+                        .value = expression.kind == Expr::Kind::And
+                                     ? left && right
+                                     : left || right};
       }
       case Expr::Kind::Equal:
       case Expr::Kind::NotEqual:
@@ -902,16 +939,17 @@ private:
       case Expr::Kind::LessEqual:
       case Expr::Kind::Greater:
       case Expr::Kind::GreaterEqual: {
-        const auto lhs = evaluateConstant(*expression.lhs);
-        const auto rhs = evaluateConstant(*expression.rhs);
+        MQT_OQ3_TRY_ASSIGN(lhs, evaluateConstant(*expression.lhs));
+        MQT_OQ3_TRY_ASSIGN(rhs, evaluateConstant(*expression.rhs));
         bool result = false;
         if (lhs.type == ScalarType::Bool || rhs.type == ScalarType::Bool) {
           if (lhs.type != ScalarType::Bool || rhs.type != ScalarType::Bool ||
               (expression.kind != Expr::Kind::Equal &&
                expression.kind != Expr::Kind::NotEqual)) {
-            fail(expression.location,
-                 "bool values only support equality comparisons with bool "
-                 "values");
+            return fail(
+                expression.location,
+                "bool values only support equality comparisons with bool "
+                "values");
           }
           const auto equal =
               std::get<bool>(lhs.value) == std::get<bool>(rhs.value);
@@ -941,7 +979,7 @@ private:
             llvm_unreachable("not a comparison expression");
           }
         }
-        return {.type = ScalarType::Bool, .value = result};
+        return Constant{.type = ScalarType::Bool, .value = result};
       }
       case Expr::Kind::ArcCos:
       case Expr::Kind::ArcSin:
@@ -954,9 +992,10 @@ private:
       case Expr::Kind::Sin:
       case Expr::Kind::Sqrt:
       case Expr::Kind::Tan: {
-        const auto operand = evaluateConstant(*expression.lhs);
+        MQT_OQ3_TRY_ASSIGN(operand, evaluateConstant(*expression.lhs));
         if (operand.type == ScalarType::Bool) {
-          fail(expression.location, "math functions require numeric operands");
+          return fail(expression.location,
+                      "math functions require numeric operands");
         }
         const bool inverseTrig = expression.kind == Expr::Kind::ArcCos ||
                                  expression.kind == Expr::Kind::ArcSin ||
@@ -965,10 +1004,11 @@ private:
                           expression.kind == Expr::Kind::Sin ||
                           expression.kind == Expr::Kind::Tan;
         if (operand.type == ScalarType::Angle && !trig) {
-          fail(expression.location,
-               inverseTrig
-                   ? "inverse trigonometric functions require a float operand"
-                   : "this math function does not accept an angle operand");
+          return fail(
+              expression.location,
+              inverseTrig
+                  ? "inverse trigonometric functions require a float operand"
+                  : "this math function does not accept an angle operand");
         }
         const auto value = asDouble(operand);
         double result = 0.0;
@@ -1010,11 +1050,12 @@ private:
           llvm_unreachable("not a unary math expression");
         }
         if (!std::isfinite(result)) {
-          fail(expression.location,
-               "constant math expression has a non-finite result");
+          return fail(expression.location,
+                      "constant math expression has a non-finite result");
         }
-        return {.type = inverseTrig ? ScalarType::Angle : ScalarType::Float,
-                .value = result};
+        return Constant{.type =
+                            inverseTrig ? ScalarType::Angle : ScalarType::Float,
+                        .value = result};
       }
       case Expr::Kind::Add:
       case Expr::Kind::Sub:
@@ -1030,35 +1071,40 @@ private:
       case Expr::Kind::BitXor:
       case Expr::Kind::ShiftLeft:
       case Expr::Kind::ShiftRight:
-        fail(expression.location,
-             "bitwise operators require explicitly sized uint, bit, or angle "
-             "operands, which are not supported yet");
+        return fail(
+            expression.location,
+            "bitwise operators require explicitly sized uint, bit, or angle "
+            "operands, which are not supported yet");
       case Expr::Kind::Index:
-        fail(expression.location, "expression is not a compile-time constant");
+        return fail(expression.location,
+                    "expression is not a compile-time constant");
       case Expr::Kind::PopCount:
       case Expr::Kind::RotateLeft:
       case Expr::Kind::RotateRight:
-        fail(expression.location,
-             "bit-register expressions are not compile-time constants");
+        return fail(expression.location,
+                    "bit-register expressions are not compile-time constants");
       }
       llvm_unreachable("unknown syntax expression kind");
     }();
-    constantValues[id] = result;
-    return result;
+    if (failed(result)) {
+      return failure();
+    }
+    constantValues[id] = *result;
+    return *result;
   }
 
-  [[nodiscard]] ScalarType
+  [[nodiscard]] FailureOr<ScalarType>
   constantExpressionType(const SyntaxExpressionId id) const {
     if (constantTypes[id]) {
       return *constantTypes[id];
     }
-    const auto result = [&]() -> ScalarType {
+    const auto result = [&]() -> FailureOr<ScalarType> {
       const auto& expression = syntax.expressions[id];
       switch (expression.kind) {
       case Expr::Kind::Int:
         if (!expression.wideInteger.empty()) {
-          fail(expression.location,
-               "integer literal exceeds 64-bit constant evaluation");
+          return fail(expression.location,
+                      "integer literal exceeds 64-bit constant evaluation");
         }
         return expression.integer <= static_cast<uint64_t>(
                                          std::numeric_limits<int64_t>::max())
@@ -1075,81 +1121,98 @@ private:
         const auto* symbol = lookup(expression.identifier);
         if (symbol == nullptr || symbol->kind != SymbolKind::Constant ||
             !symbol->constant) {
-          fail(expression.location,
-               "expression is not a compile-time constant");
+          return fail(expression.location,
+                      "expression is not a compile-time constant");
         }
         return symbol->constant->type;
       }
       case Expr::Kind::Neg: {
-        const auto type = constantExpressionType(*expression.lhs);
+        MQT_OQ3_TRY_ASSIGN(type, constantExpressionType(*expression.lhs));
         if (type == ScalarType::Bool) {
-          fail(expression.location,
-               "numeric negation requires a numeric operand");
+          return fail(expression.location,
+                      "numeric negation requires a numeric operand");
         }
         return type;
       }
-      case Expr::Kind::Not:
-        if (constantExpressionType(*expression.lhs) != ScalarType::Bool) {
-          fail(expression.location, "logical negation requires a bool operand");
+      case Expr::Kind::Not: {
+        MQT_OQ3_TRY_ASSIGN(type, constantExpressionType(*expression.lhs));
+        if (type != ScalarType::Bool) {
+          return fail(expression.location,
+                      "logical negation requires a bool operand");
         }
         return ScalarType::Bool;
+      }
       case Expr::Kind::And:
-      case Expr::Kind::Or:
-        if (constantExpressionType(*expression.lhs) != ScalarType::Bool ||
-            constantExpressionType(*expression.rhs) != ScalarType::Bool) {
-          fail(expression.location, "logical operators require bool operands");
+      case Expr::Kind::Or: {
+        MQT_OQ3_TRY_ASSIGN(lhs, constantExpressionType(*expression.lhs));
+        MQT_OQ3_TRY_ASSIGN(rhs, constantExpressionType(*expression.rhs));
+        if (lhs != ScalarType::Bool || rhs != ScalarType::Bool) {
+          return fail(expression.location,
+                      "logical operators require bool operands");
         }
         return ScalarType::Bool;
+      }
       case Expr::Kind::Equal:
       case Expr::Kind::NotEqual:
       case Expr::Kind::Less:
       case Expr::Kind::LessEqual:
       case Expr::Kind::Greater:
       case Expr::Kind::GreaterEqual: {
-        const auto lhs = constantExpressionType(*expression.lhs);
-        const auto rhs = constantExpressionType(*expression.rhs);
+        MQT_OQ3_TRY_ASSIGN(lhs, constantExpressionType(*expression.lhs));
+        MQT_OQ3_TRY_ASSIGN(rhs, constantExpressionType(*expression.rhs));
         if (lhs == ScalarType::Bool || rhs == ScalarType::Bool) {
           if (lhs != ScalarType::Bool || rhs != ScalarType::Bool ||
               (expression.kind != Expr::Kind::Equal &&
                expression.kind != Expr::Kind::NotEqual)) {
-            fail(expression.location,
-                 "bool values only support equality comparisons with bool "
-                 "values");
+            return fail(
+                expression.location,
+                "bool values only support equality comparisons with bool "
+                "values");
           }
         }
         return ScalarType::Bool;
       }
       case Expr::Kind::ArcCos:
       case Expr::Kind::ArcSin:
-      case Expr::Kind::ArcTan:
-        if (constantExpressionType(*expression.lhs) == ScalarType::Angle) {
-          fail(expression.location,
-               "inverse trigonometric functions require a float operand");
+      case Expr::Kind::ArcTan: {
+        MQT_OQ3_TRY_ASSIGN(type, constantExpressionType(*expression.lhs));
+        if (type == ScalarType::Angle) {
+          return fail(
+              expression.location,
+              "inverse trigonometric functions require a float operand");
         }
-        if (constantExpressionType(*expression.lhs) == ScalarType::Bool) {
-          fail(expression.location, "math functions require numeric operands");
+        if (type == ScalarType::Bool) {
+          return fail(expression.location,
+                      "math functions require numeric operands");
         }
         return ScalarType::Angle;
+      }
       case Expr::Kind::Ceiling:
       case Expr::Kind::Exp:
       case Expr::Kind::Floor:
       case Expr::Kind::Log:
-      case Expr::Kind::Sqrt:
-        if (constantExpressionType(*expression.lhs) == ScalarType::Bool) {
-          fail(expression.location, "math functions require numeric operands");
+      case Expr::Kind::Sqrt: {
+        MQT_OQ3_TRY_ASSIGN(type, constantExpressionType(*expression.lhs));
+        if (type == ScalarType::Bool) {
+          return fail(expression.location,
+                      "math functions require numeric operands");
         }
-        if (constantExpressionType(*expression.lhs) == ScalarType::Angle) {
-          fail(expression.location,
-               "this math function does not accept an angle operand");
+        if (type == ScalarType::Angle) {
+          return fail(expression.location,
+                      "this math function does not accept an angle operand");
         }
         return ScalarType::Float;
+      }
       case Expr::Kind::Cos:
       case Expr::Kind::Sin:
-      case Expr::Kind::Tan:
-        if (constantExpressionType(*expression.lhs) == ScalarType::Bool) {
-          fail(expression.location, "math functions require numeric operands");
+      case Expr::Kind::Tan: {
+        MQT_OQ3_TRY_ASSIGN(type, constantExpressionType(*expression.lhs));
+        if (type == ScalarType::Bool) {
+          return fail(expression.location,
+                      "math functions require numeric operands");
         }
         return ScalarType::Float;
+      }
       case Expr::Kind::Add:
       case Expr::Kind::Sub:
       case Expr::Kind::Mul:
@@ -1158,17 +1221,17 @@ private:
       case Expr::Kind::BuiltinMod:
       case Expr::Kind::BuiltinPow:
       case Expr::Kind::Pow: {
-        const auto lhs = constantExpressionType(*expression.lhs);
-        const auto rhs = constantExpressionType(*expression.rhs);
+        MQT_OQ3_TRY_ASSIGN(lhs, constantExpressionType(*expression.lhs));
+        MQT_OQ3_TRY_ASSIGN(rhs, constantExpressionType(*expression.rhs));
         if (lhs == ScalarType::Bool || rhs == ScalarType::Bool) {
-          fail(expression.location,
-               "arithmetic operators require numeric operands");
+          return fail(expression.location,
+                      "arithmetic operators require numeric operands");
         }
         if (expression.kind == Expr::Kind::Mod &&
             (lhs == ScalarType::Float || rhs == ScalarType::Float)) {
-          fail(expression.location,
-               "the '%' operator requires integer operands; use mod() for "
-               "floating-point remainder");
+          return fail(expression.location,
+                      "the '%' operator requires integer operands; use mod() "
+                      "for floating-point remainder");
         }
         if (lhs == ScalarType::Angle || rhs == ScalarType::Angle) {
           if (expression.kind == Expr::Kind::Add ||
@@ -1185,16 +1248,17 @@ private:
               rhs == ScalarType::Angle) {
             return ScalarType::Float;
           }
-          fail(expression.location,
-               "unsupported arithmetic operation on angle operands");
+          return fail(expression.location,
+                      "unsupported arithmetic operation on angle operands");
         }
         if (lhs == ScalarType::Float || rhs == ScalarType::Float) {
           return ScalarType::Float;
         }
         if (expression.kind == Expr::Kind::BuiltinPow &&
             lhs == ScalarType::Int) {
+          MQT_OQ3_TRY_ASSIGN(rhsConstant, evaluateConstant(*expression.rhs));
           if (rhs == ScalarType::Int &&
-              std::get<int64_t>(evaluateConstant(*expression.rhs).value) < 0) {
+              std::get<int64_t>(rhsConstant.value) < 0) {
             return ScalarType::Float;
           }
           return ScalarType::Int;
@@ -1209,31 +1273,36 @@ private:
       case Expr::Kind::BitXor:
       case Expr::Kind::ShiftLeft:
       case Expr::Kind::ShiftRight:
-        fail(expression.location,
-             "bitwise operators require explicitly sized uint, bit, or angle "
-             "operands, which are not supported yet");
+        return fail(
+            expression.location,
+            "bitwise operators require explicitly sized uint, bit, or angle "
+            "operands, which are not supported yet");
       case Expr::Kind::Index:
-        fail(expression.location, "expression is not a compile-time constant");
+        return fail(expression.location,
+                    "expression is not a compile-time constant");
       case Expr::Kind::PopCount:
         return ScalarType::Uint;
       case Expr::Kind::RotateLeft:
       case Expr::Kind::RotateRight:
-        fail(expression.location,
-             "bit-register rotations are not scalar expressions");
+        return fail(expression.location,
+                    "bit-register rotations are not scalar expressions");
       }
       llvm_unreachable("unknown syntax expression kind");
     }();
-    constantTypes[id] = result;
-    return result;
+    if (failed(result)) {
+      return failure();
+    }
+    constantTypes[id].emplace(*result);
+    return *result;
   }
 
-  [[nodiscard]] Constant
+  [[nodiscard]] FailureOr<Constant>
   evaluateConstantBinary(const SyntaxExpression& expression) const {
-    const auto lhs = evaluateConstant(*expression.lhs);
-    const auto rhs = evaluateConstant(*expression.rhs);
+    MQT_OQ3_TRY_ASSIGN(lhs, evaluateConstant(*expression.lhs));
+    MQT_OQ3_TRY_ASSIGN(rhs, evaluateConstant(*expression.rhs));
     if (lhs.type == ScalarType::Bool || rhs.type == ScalarType::Bool) {
-      fail(expression.location,
-           "arithmetic operators require numeric operands");
+      return fail(expression.location,
+                  "arithmetic operators require numeric operands");
     }
     const bool builtinFloatPower = expression.kind == Expr::Kind::BuiltinPow &&
                                    rhs.type == ScalarType::Int &&
@@ -1243,31 +1312,33 @@ private:
       const auto right = asDouble(rhs);
       if (expression.kind == Expr::Kind::Add ||
           expression.kind == Expr::Kind::Sub) {
-        return {.type = ScalarType::Angle,
-                .value = expression.kind == Expr::Kind::Add ? left + right
-                                                            : left - right};
+        return Constant{.type = ScalarType::Angle,
+                        .value = expression.kind == Expr::Kind::Add
+                                     ? left + right
+                                     : left - right};
       }
       if (expression.kind == Expr::Kind::Mul &&
           (lhs.type == ScalarType::Angle) != (rhs.type == ScalarType::Angle)) {
-        return {.type = ScalarType::Angle, .value = left * right};
+        return Constant{.type = ScalarType::Angle, .value = left * right};
       }
       if (expression.kind == Expr::Kind::Div && lhs.type == ScalarType::Angle) {
         if (right == 0.0) {
-          fail(expression.location, "division by zero");
+          return fail(expression.location, "division by zero");
         }
-        return {.type = rhs.type == ScalarType::Angle ? ScalarType::Float
-                                                      : ScalarType::Angle,
-                .value = left / right};
+        return Constant{.type = rhs.type == ScalarType::Angle
+                                    ? ScalarType::Float
+                                    : ScalarType::Angle,
+                        .value = left / right};
       }
-      fail(expression.location,
-           "unsupported arithmetic operation on angle operands");
+      return fail(expression.location,
+                  "unsupported arithmetic operation on angle operands");
     }
     if (lhs.type == ScalarType::Float || rhs.type == ScalarType::Float ||
         builtinFloatPower) {
       if (expression.kind == Expr::Kind::Mod) {
-        fail(expression.location,
-             "the '%' operator requires integer operands; use mod() for "
-             "floating-point remainder");
+        return fail(expression.location,
+                    "the '%' operator requires integer operands; use mod() "
+                    "for floating-point remainder");
       }
       const auto left = asDouble(lhs);
       const auto right = asDouble(rhs);
@@ -1284,13 +1355,13 @@ private:
         break;
       case Expr::Kind::Div:
         if (right == 0.0) {
-          fail(expression.location, "division by zero");
+          return fail(expression.location, "division by zero");
         }
         result = left / right;
         break;
       case Expr::Kind::BuiltinMod:
         if (right == 0.0) {
-          fail(expression.location, "modulo by zero");
+          return fail(expression.location, "modulo by zero");
         }
         result = std::fmod(left, right);
         break;
@@ -1302,10 +1373,10 @@ private:
         llvm_unreachable("not a binary expression");
       }
       if (!std::isfinite(result)) {
-        fail(expression.location,
-             "constant arithmetic has a non-finite result");
+        return fail(expression.location,
+                    "constant arithmetic has a non-finite result");
       }
-      return {.type = ScalarType::Float, .value = result};
+      return Constant{.type = ScalarType::Float, .value = result};
     }
 
     if (expression.kind == Expr::Kind::BuiltinPow &&
@@ -1324,9 +1395,10 @@ private:
         }
       }
       if (overflow) {
-        fail(expression.location, "constant integer arithmetic overflows i64");
+        return fail(expression.location,
+                    "constant integer arithmetic overflows i64");
       }
-      return {.type = ScalarType::Int, .value = result};
+      return Constant{.type = ScalarType::Int, .value = result};
     }
 
     if (lhs.type == ScalarType::Uint || rhs.type == ScalarType::Uint) {
@@ -1350,14 +1422,14 @@ private:
         break;
       case Expr::Kind::Div:
         if (right == 0) {
-          fail(expression.location, "division by zero");
+          return fail(expression.location, "division by zero");
         }
         result = left / right;
         break;
       case Expr::Kind::Mod:
       case Expr::Kind::BuiltinMod:
         if (right == 0) {
-          fail(expression.location, "modulo by zero");
+          return fail(expression.location, "modulo by zero");
         }
         result = left % right;
         break;
@@ -1374,7 +1446,7 @@ private:
       default:
         llvm_unreachable("not a binary expression");
       }
-      return {.type = ScalarType::Uint, .value = result};
+      return Constant{.type = ScalarType::Uint, .value = result};
     }
 
     const auto left = std::get<int64_t>(lhs.value);
@@ -1393,7 +1465,7 @@ private:
       break;
     case Expr::Kind::Div:
       if (right == 0) {
-        fail(expression.location, "division by zero");
+        return fail(expression.location, "division by zero");
       }
       if (left == std::numeric_limits<int64_t>::min() && right == -1) {
         overflow = true;
@@ -1404,7 +1476,7 @@ private:
     case Expr::Kind::Mod:
     case Expr::Kind::BuiltinMod:
       if (right == 0) {
-        fail(expression.location, "modulo by zero");
+        return fail(expression.location, "modulo by zero");
       }
       if (left == std::numeric_limits<int64_t>::min() && right == -1) {
         overflow = true;
@@ -1417,8 +1489,8 @@ private:
       if (right < 0) {
         assert(expression.kind == Expr::Kind::Pow &&
                "negative built-in powers use the floating overload");
-        fail(expression.location,
-             "integer power requires a nonnegative exponent");
+        return fail(expression.location,
+                    "integer power requires a nonnegative exponent");
       }
       result = 1;
       auto base = left;
@@ -1438,9 +1510,10 @@ private:
       llvm_unreachable("not a binary expression");
     }
     if (overflow) {
-      fail(expression.location, "constant integer arithmetic overflows i64");
+      return fail(expression.location,
+                  "constant integer arithmetic overflows i64");
     }
-    return {.type = ScalarType::Int, .value = result};
+    return Constant{.type = ScalarType::Int, .value = result};
   }
 
   [[nodiscard]] bool isConstantExpression(const SyntaxExpressionId id) const {
@@ -1475,7 +1548,8 @@ private:
     return result;
   }
 
-  void validateGateExpression(const SyntaxExpressionId id) const {
+  [[nodiscard]] LogicalResult
+  validateGateExpression(const SyntaxExpressionId id) const {
     const auto& expression = syntax.expressions[id];
     if (expression.kind == Expr::Kind::Identifier &&
         !builtinConstant(expression.identifier)) {
@@ -1483,31 +1557,36 @@ private:
       if (symbol == nullptr || (symbol->kind != SymbolKind::GateParameter &&
                                 symbol->kind != SymbolKind::GateLocalScalar &&
                                 symbol->kind != SymbolKind::Constant)) {
-        fail(expression.location,
-             "gate definitions cannot capture outer scalar '" +
-                 expression.identifier + "'");
+        return fail(expression.location,
+                    "gate definitions cannot capture outer scalar '" +
+                        expression.identifier + "'");
       }
     }
+    return success();
   }
 
-  [[nodiscard]] BitVectorExpressionId
+  [[nodiscard]] FailureOr<BitVectorExpressionId>
   analyzeBitVectorExpression(const SyntaxExpressionId syntaxId) {
     const auto& expression = syntax.expressions[syntaxId];
     if (expression.kind == Expr::Kind::Identifier) {
       const auto* symbol = lookup(expression.identifier);
       if (symbol == nullptr || symbol->kind != SymbolKind::Register ||
           program.registers[symbol->id].kind != RegisterKind::Bit) {
-        fail(expression.location,
-             "bit-vector expression requires a bit register");
+        return fail(expression.location,
+                    "bit-vector expression requires a bit register");
       }
       const auto reg = static_cast<RegisterId>(symbol->id);
       if (program.registers[reg].isScalar) {
-        fail(expression.location,
-             "bit-vector expression requires a bit register, not scalar bit");
+        return fail(
+            expression.location,
+            "bit-vector expression requires a bit register, not scalar bit");
       }
       const auto width = program.registers[reg].width;
       for (uint64_t bit = 0; bit < width; ++bit) {
-        ensureBitInitialized({.reg = reg, .index = bit}, expression.location);
+        if (failed(ensureBitInitialized({.reg = reg, .index = bit},
+                                        expression.location))) {
+          return failure();
+        }
       }
       return addBitVectorExpression({.kind = BitVectorExpressionKind::Register,
                                      .width = width,
@@ -1515,14 +1594,14 @@ private:
     }
     if (expression.kind != Expr::Kind::RotateLeft &&
         expression.kind != Expr::Kind::RotateRight) {
-      fail(expression.location,
-           "bit-vector expression requires a bit register or rotation");
+      return fail(expression.location,
+                  "bit-vector expression requires a bit register or rotation");
     }
-    const auto operand = analyzeBitVectorExpression(*expression.lhs);
-    const auto distance = analyzeExpression(*expression.rhs);
+    MQT_OQ3_TRY_ASSIGN(operand, analyzeBitVectorExpression(*expression.lhs));
+    MQT_OQ3_TRY_ASSIGN(distance, analyzeExpression(*expression.rhs));
     if (program.expressions[distance].type != ScalarType::Int) {
-      fail(syntax.expressions[*expression.rhs].location,
-           "bit-register rotation distance must have signed int type");
+      return fail(syntax.expressions[*expression.rhs].location,
+                  "bit-register rotation distance must have signed int type");
     }
     return addBitVectorExpression(
         {.kind = expression.kind == Expr::Kind::RotateLeft
@@ -1533,26 +1612,28 @@ private:
          .distance = distance});
   }
 
-  [[nodiscard]] ExpressionId
+  [[nodiscard]] FailureOr<ExpressionId>
   analyzeExpression(const SyntaxExpressionId syntaxId) {
     const auto& expression = syntax.expressions[syntaxId];
-    if (insideGate) {
-      validateGateExpression(syntaxId);
+    if (insideGate && failed(validateGateExpression(syntaxId))) {
+      return failure();
     }
     if (isConstantExpression(syntaxId)) {
-      return addConstant(evaluateConstant(syntaxId));
+      MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(syntaxId));
+      return addConstant(constant);
     }
     if (expression.kind == Expr::Kind::PopCount) {
-      return addExpression(
-          {.kind = ExpressionKind::PopCount,
-           .type = ScalarType::Uint,
-           .bitVector = analyzeBitVectorExpression(*expression.lhs)});
+      MQT_OQ3_TRY_ASSIGN(bitVector,
+                         analyzeBitVectorExpression(*expression.lhs));
+      return addExpression({.kind = ExpressionKind::PopCount,
+                            .type = ScalarType::Uint,
+                            .bitVector = bitVector});
     }
     if (expression.kind == Expr::Kind::Identifier) {
       const auto* symbol = lookup(expression.identifier);
       if (symbol == nullptr) {
-        fail(expression.location,
-             "unknown scalar identifier '" + expression.identifier + "'");
+        return fail(expression.location, "unknown scalar identifier '" +
+                                             expression.identifier + "'");
       }
       if (symbol->kind == SymbolKind::GateParameter) {
         return addExpression({.kind = ExpressionKind::GateParameter,
@@ -1561,12 +1642,13 @@ private:
       }
       if (symbol->kind != SymbolKind::Scalar &&
           symbol->kind != SymbolKind::GateLocalScalar) {
-        fail(expression.location, "identifier '" + expression.identifier +
-                                      "' is not a scalar value");
+        return fail(expression.location, "identifier '" +
+                                             expression.identifier +
+                                             "' is not a scalar value");
       }
       if (!initializedScalars.at(symbol->id)) {
-        fail(expression.location,
-             "scalar '" + expression.identifier + "' is uninitialized");
+        return fail(expression.location,
+                    "scalar '" + expression.identifier + "' is uninitialized");
       }
       return addExpression({.kind = ExpressionKind::Variable,
                             .type = symbol->type,
@@ -1579,9 +1661,10 @@ private:
       kind = ExpressionKind::Negate;
       break;
     case Expr::Kind::BitNot:
-      fail(expression.location,
-           "bitwise operators require explicitly sized uint, bit, or angle "
-           "operands, which are not supported yet");
+      return fail(
+          expression.location,
+          "bitwise operators require explicitly sized uint, bit, or angle "
+          "operands, which are not supported yet");
     case Expr::Kind::Add:
       kind = ExpressionKind::Add;
       break;
@@ -1607,13 +1690,14 @@ private:
     case Expr::Kind::BitXor:
     case Expr::Kind::ShiftLeft:
     case Expr::Kind::ShiftRight:
-      fail(expression.location,
-           "bitwise operators require explicitly sized uint, bit, or angle "
-           "operands, which are not supported yet");
+      return fail(
+          expression.location,
+          "bitwise operators require explicitly sized uint, bit, or angle "
+          "operands, which are not supported yet");
     case Expr::Kind::RotateLeft:
     case Expr::Kind::RotateRight:
-      fail(expression.location,
-           "bit-register rotations require a whole-register assignment");
+      return fail(expression.location,
+                  "bit-register rotations require a whole-register assignment");
     case Expr::Kind::PopCount:
       llvm_unreachable("handled bit-register population count");
     case Expr::Kind::ArcCos:
@@ -1659,26 +1743,28 @@ private:
     case Expr::Kind::And:
     case Expr::Kind::Or:
     case Expr::Kind::Index:
-      fail(expression.location, "expected a scalar arithmetic expression");
+      return fail(expression.location,
+                  "expected a scalar arithmetic expression");
     case Expr::Kind::Int:
     case Expr::Kind::Float:
     case Expr::Kind::Bool:
     case Expr::Kind::Identifier:
       llvm_unreachable("handled expression kind");
     }
-    auto lhs = analyzeExpression(*expression.lhs);
-    auto rhs =
-        expression.rhs
-            ? std::optional<ExpressionId>(analyzeExpression(*expression.rhs))
-            : std::nullopt;
+    MQT_OQ3_TRY_ASSIGN(lhs, analyzeExpression(*expression.lhs));
+    std::optional<ExpressionId> rhs;
+    if (expression.rhs) {
+      MQT_OQ3_TRY_ASSIGN(evaluatedRhs, analyzeExpression(*expression.rhs));
+      rhs = evaluatedRhs;
+    }
     auto lhsType = program.expressions[lhs].type;
     auto rhsType =
         rhs ? std::optional<ScalarType>(program.expressions[*rhs].type)
             : std::nullopt;
     if (lhsType == ScalarType::Bool ||
         (rhsType && *rhsType == ScalarType::Bool)) {
-      fail(expression.location,
-           "arithmetic operators require numeric operands");
+      return fail(expression.location,
+                  "arithmetic operators require numeric operands");
     }
 
     const bool inverseTrig = kind == ExpressionKind::ArcCos ||
@@ -1693,13 +1779,17 @@ private:
         kind == ExpressionKind::Sqrt;
     if (inverseTrig || trig || otherMath) {
       if (lhsType == ScalarType::Angle && !trig) {
-        fail(expression.location,
-             inverseTrig
-                 ? "inverse trigonometric functions require a float operand"
-                 : "this math function does not accept an angle operand");
+        return fail(
+            expression.location,
+            inverseTrig
+                ? "inverse trigonometric functions require a float operand"
+                : "this math function does not accept an angle operand");
       }
-      lhs = castExpression(lhs, trig ? ScalarType::Angle : ScalarType::Float,
-                           expression.location);
+      MQT_OQ3_TRY_ASSIGN(
+          convertedLhs,
+          castExpression(lhs, trig ? ScalarType::Angle : ScalarType::Float,
+                         expression.location));
+      lhs = convertedLhs;
       return addExpression(
           {.kind = kind,
            .type = inverseTrig ? ScalarType::Angle : ScalarType::Float,
@@ -1712,34 +1802,47 @@ private:
     if (expression.kind == Expr::Kind::Mod &&
         (lhsType == ScalarType::Float || lhsType == ScalarType::Angle ||
          *rhsType == ScalarType::Float || *rhsType == ScalarType::Angle)) {
-      fail(expression.location,
-           "the '%' operator requires integer operands; use mod() for "
-           "floating-point remainder");
+      return fail(expression.location,
+                  "the '%' operator requires integer operands; use mod() for "
+                  "floating-point remainder");
     }
 
     if (lhsType == ScalarType::Angle || *rhsType == ScalarType::Angle) {
       ScalarType type = ScalarType::Angle;
       if (kind == ExpressionKind::Add || kind == ExpressionKind::Subtract) {
-        lhs = castExpression(lhs, ScalarType::Angle, expression.location);
-        *rhs = castExpression(*rhs, ScalarType::Angle, expression.location);
+        MQT_OQ3_TRY_ASSIGN(convertedLhs, castExpression(lhs, ScalarType::Angle,
+                                                        expression.location));
+        MQT_OQ3_TRY_ASSIGN(convertedRhs, castExpression(*rhs, ScalarType::Angle,
+                                                        expression.location));
+        lhs = convertedLhs;
+        *rhs = convertedRhs;
       } else if (kind == ExpressionKind::Multiply &&
                  (lhsType == ScalarType::Angle) !=
                      (*rhsType == ScalarType::Angle)) {
         if (lhsType != ScalarType::Angle) {
-          lhs = castExpression(lhs, ScalarType::Float, expression.location);
+          MQT_OQ3_TRY_ASSIGN(
+              convertedLhs,
+              castExpression(lhs, ScalarType::Float, expression.location));
+          lhs = convertedLhs;
         } else {
-          *rhs = castExpression(*rhs, ScalarType::Float, expression.location);
+          MQT_OQ3_TRY_ASSIGN(
+              convertedRhs,
+              castExpression(*rhs, ScalarType::Float, expression.location));
+          *rhs = convertedRhs;
         }
       } else if (kind == ExpressionKind::Divide &&
                  lhsType == ScalarType::Angle) {
         if (*rhsType == ScalarType::Angle) {
           type = ScalarType::Float;
         } else {
-          *rhs = castExpression(*rhs, ScalarType::Float, expression.location);
+          MQT_OQ3_TRY_ASSIGN(
+              convertedRhs,
+              castExpression(*rhs, ScalarType::Float, expression.location));
+          *rhs = convertedRhs;
         }
       } else {
-        fail(expression.location,
-             "unsupported arithmetic operation on angle operands");
+        return fail(expression.location,
+                    "unsupported arithmetic operation on angle operands");
       }
       return addExpression(
           {.kind = kind, .type = type, .lhs = lhs, .rhs = *rhs});
@@ -1753,7 +1856,9 @@ private:
                  program.expressions[*rhs].kind == ExpressionKind::Constant &&
                  std::get<int64_t>(program.expressions[*rhs].constant) >= 0) {
         type = ScalarType::Int;
-        *rhs = castExpression(*rhs, ScalarType::Uint, expression.location);
+        MQT_OQ3_TRY_ASSIGN(convertedRhs, castExpression(*rhs, ScalarType::Uint,
+                                                        expression.location));
+        *rhs = convertedRhs;
       } else if (lhsType == ScalarType::Uint &&
                  (*rhsType == ScalarType::Uint ||
                   (*rhsType == ScalarType::Int &&
@@ -1761,10 +1866,16 @@ private:
                    std::get<int64_t>(program.expressions[*rhs].constant) >=
                        0))) {
         type = ScalarType::Uint;
-        *rhs = castExpression(*rhs, ScalarType::Uint, expression.location);
+        MQT_OQ3_TRY_ASSIGN(convertedRhs, castExpression(*rhs, ScalarType::Uint,
+                                                        expression.location));
+        *rhs = convertedRhs;
       } else {
-        lhs = castExpression(lhs, ScalarType::Float, expression.location);
-        *rhs = castExpression(*rhs, ScalarType::Float, expression.location);
+        MQT_OQ3_TRY_ASSIGN(convertedLhs, castExpression(lhs, ScalarType::Float,
+                                                        expression.location));
+        MQT_OQ3_TRY_ASSIGN(convertedRhs, castExpression(*rhs, ScalarType::Float,
+                                                        expression.location));
+        lhs = convertedLhs;
+        *rhs = convertedRhs;
       }
       return addExpression(
           {.kind = kind, .type = type, .lhs = lhs, .rhs = *rhs});
@@ -1776,23 +1887,28 @@ private:
     } else if (lhsType == ScalarType::Uint || *rhsType == ScalarType::Uint) {
       type = ScalarType::Uint;
     }
-    lhs = castExpression(lhs, type, expression.location);
-    *rhs = castExpression(*rhs, type, expression.location);
+    MQT_OQ3_TRY_ASSIGN(convertedLhs,
+                       castExpression(lhs, type, expression.location));
+    MQT_OQ3_TRY_ASSIGN(convertedRhs,
+                       castExpression(*rhs, type, expression.location));
+    lhs = convertedLhs;
+    *rhs = convertedRhs;
     return addExpression({.kind = kind, .type = type, .lhs = lhs, .rhs = *rhs});
   }
 
-  [[nodiscard]] uint64_t
+  [[nodiscard]] FailureOr<uint64_t>
   constantWidth(const std::optional<SyntaxExpressionId> size,
                 SMLoc location) const {
     if (!size) {
       return 1;
     }
     if (!isConstantExpression(*size)) {
-      fail(location, "register width must be a constant integer expression");
+      return fail(location,
+                  "register width must be a constant integer expression");
     }
-    const auto constant = evaluateConstant(*size);
+    MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(*size));
     if (!isInteger(constant.type)) {
-      fail(location, "register width must be an integer expression");
+      return fail(location, "register width must be an integer expression");
     }
     const auto value =
         constant.type == ScalarType::Uint
@@ -1800,117 +1916,155 @@ private:
             : static_cast<uint64_t>(std::get<int64_t>(constant.value));
     if (value == 0 || (constant.type == ScalarType::Int &&
                        std::get<int64_t>(constant.value) < 0)) {
-      fail(location, "register width must be greater than zero");
+      return fail(location, "register width must be greater than zero");
     }
     if (value > REGISTER_WIDTH_LIMIT) {
-      fail(location, Twine("register width exceeds the limit of ") +
-                         Twine(REGISTER_WIDTH_LIMIT));
+      return fail(location, Twine("register width exceeds the limit of ") +
+                                Twine(REGISTER_WIDTH_LIMIT));
     }
     return value;
   }
 
-  [[nodiscard]] std::optional<uint64_t>
+  [[nodiscard]] FailureOr<std::optional<uint64_t>>
   constantIndex(const SyntaxExpressionId id, const uint64_t width,
                 SMLoc location) const {
     if (!isConstantExpression(id)) {
-      return std::nullopt;
+      return std::optional<uint64_t>{};
     }
-    const auto constant = evaluateConstant(id);
+    MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(id));
     if (!isInteger(constant.type)) {
-      fail(location, "index must be an integer expression");
+      return fail(location, "index must be an integer expression");
     }
     auto value = asSigned(constant);
-    if (value < 0) {
-      value += static_cast<int64_t>(width);
+    if (!value) {
+      return fail(location, "unsigned value does not fit in signed i64");
     }
-    if (value < 0) {
-      fail(location, "index is out of bounds");
+    if (*value < 0) {
+      *value += static_cast<int64_t>(width);
     }
-    return static_cast<uint64_t>(value);
+    if (*value < 0) {
+      return fail(location, "index is out of bounds");
+    }
+    return std::optional<uint64_t>(static_cast<uint64_t>(*value));
   }
 
-  void analyzeTopLevelBody() {
+  [[nodiscard]] LogicalResult analyzeTopLevelBody() {
     assert(syntax.body.size() == syntax.bodyIncludeContexts.size());
     for (const auto [id, includeContext] :
          llvm::zip_equal(syntax.body, syntax.bodyIncludeContexts)) {
       currentIncludeContext = includeContext;
-      analyzeStatement(syntax.statements[id], program.body, /*global=*/true);
+      if (failed(analyzeStatement(syntax.statements[id], program.body,
+                                  /*global=*/true))) {
+        currentIncludeContext.reset();
+        return failure();
+      }
     }
     currentIncludeContext.reset();
+    return success();
   }
 
-  void analyzeBody(ArrayRef<SyntaxStatementId> source,
-                   std::vector<StatementId>& destination, const bool global) {
+  [[nodiscard]] LogicalResult analyzeBody(ArrayRef<SyntaxStatementId> source,
+                                          std::vector<StatementId>& destination,
+                                          const bool global) {
     for (const auto id : source) {
-      analyzeStatement(syntax.statements[id], destination, global);
+      if (failed(
+              analyzeStatement(syntax.statements[id], destination, global))) {
+        return failure();
+      }
     }
+    return success();
   }
 
-  void analyzeStatement(const SyntaxStatement& statement,
-                        std::vector<StatementId>& destination,
-                        const bool global) {
-    std::visit(
-        [&](const auto& data) {
+  [[nodiscard]] LogicalResult
+  analyzeStatement(const SyntaxStatement& statement,
+                   std::vector<StatementId>& destination, const bool global) {
+    return std::visit(
+        [&](const auto& data) -> LogicalResult {
           using T = std::decay_t<decltype(data)>;
           if constexpr (!std::is_same_v<T, SyntaxGateCall> &&
                         !std::is_same_v<T, SyntaxFor> &&
                         !std::is_same_v<T, SyntaxWhile>) {
             if (insideGate) {
-              fail(statement.location,
-                   "gate bodies may contain only gate calls and loops over "
-                   "gate calls");
+              return fail(
+                  statement.location,
+                  "gate bodies may contain only gate calls and loops over "
+                  "gate calls");
             }
           }
           if constexpr (std::is_same_v<T, SyntaxStandardLibraryInclude>) {
-            activateStandardLibrary(statement.location, data.kind);
+            return activateStandardLibrary(statement.location, data.kind);
           } else if constexpr (std::is_same_v<T, SyntaxScalarDeclaration>) {
-            analyzeScalarDeclaration(statement.location, data, destination,
-                                     global);
+            return analyzeScalarDeclaration(statement.location, data,
+                                            destination, global);
           } else if constexpr (std::is_same_v<T, SyntaxAssignment>) {
-            analyzeAssignment(statement.location, data, destination);
+            return analyzeAssignment(statement.location, data, destination);
           } else if constexpr (std::is_same_v<T, SyntaxQubitDeclaration> ||
                                std::is_same_v<T, SyntaxBitDeclaration>) {
-            analyzeRegisterDeclaration(statement.location, data, destination,
-                                       global);
+            return analyzeRegisterDeclaration(statement.location, data,
+                                              destination, global);
           } else if constexpr (std::is_same_v<T, SyntaxMeasurement>) {
-            destination.push_back(analyzeMeasurement(statement.location, data));
+            MQT_OQ3_TRY_ASSIGN(analyzed,
+                               analyzeMeasurement(statement.location, data));
+            destination.push_back(analyzed);
+            return success();
           } else if constexpr (std::is_same_v<T, SyntaxReset>) {
-            destination.push_back(analyzeReset(statement.location, data));
+            MQT_OQ3_TRY_ASSIGN(analyzed,
+                               analyzeReset(statement.location, data));
+            destination.push_back(analyzed);
+            return success();
           } else if constexpr (std::is_same_v<T, SyntaxBarrier>) {
-            destination.push_back(analyzeBarrier(statement.location, data));
+            MQT_OQ3_TRY_ASSIGN(analyzed,
+                               analyzeBarrier(statement.location, data));
+            destination.push_back(analyzed);
+            return success();
           } else if constexpr (std::is_same_v<T, SyntaxGateCall>) {
-            auto applications = analyzeGateApplication(data);
+            MQT_OQ3_TRY_ASSIGN(applications, analyzeGateApplication(data));
             for (auto& application : applications) {
-              destination.push_back(
+              MQT_OQ3_TRY_ASSIGN(
+                  analyzed,
                   addStatement(statement.location, std::move(application)));
+              destination.push_back(analyzed);
             }
+            return success();
           } else if constexpr (std::is_same_v<T, SyntaxGateDefinition>) {
             if (!global) {
-              fail(statement.location,
-                   "gate definitions are only allowed at global scope");
+              return fail(statement.location,
+                          "gate definitions are only allowed at global scope");
             }
-            analyzeGateDefinition(statement.location, data);
+            return analyzeGateDefinition(statement.location, data);
           } else if constexpr (std::is_same_v<T, SyntaxIf>) {
-            destination.push_back(analyzeIf(statement.location, data));
+            MQT_OQ3_TRY_ASSIGN(analyzed, analyzeIf(statement.location, data));
+            destination.push_back(analyzed);
+            return success();
           } else if constexpr (std::is_same_v<T, SyntaxFor>) {
-            destination.push_back(analyzeFor(statement.location, data));
+            MQT_OQ3_TRY_ASSIGN(analyzed, analyzeFor(statement.location, data));
+            destination.push_back(analyzed);
+            return success();
           } else if constexpr (std::is_same_v<T, SyntaxWhile>) {
-            destination.push_back(analyzeWhile(statement.location, data));
+            MQT_OQ3_TRY_ASSIGN(analyzed,
+                               analyzeWhile(statement.location, data));
+            destination.push_back(analyzed);
+            return success();
           } else if constexpr (std::is_same_v<T, SyntaxSwitch>) {
-            destination.push_back(analyzeSwitch(statement.location, data));
+            MQT_OQ3_TRY_ASSIGN(analyzed,
+                               analyzeSwitch(statement.location, data));
+            destination.push_back(analyzed);
+            return success();
           }
+          llvm_unreachable("unknown syntax statement kind");
         },
         statement.data);
   }
 
-  void activateStandardLibrary(SMLoc location, const StandardLibraryKind kind) {
+  [[nodiscard]] LogicalResult
+  activateStandardLibrary(SMLoc location, const StandardLibraryKind kind) {
     auto& alreadyIncluded = kind == StandardLibraryKind::StdGates
                                 ? program.stdGatesIncluded
                                 : program.qelib1Included;
     if (alreadyIncluded) {
-      fail(location, kind == StandardLibraryKind::StdGates
-                         ? "stdgates.inc is included more than once"
-                         : "qelib1.inc is included more than once");
+      return fail(location, kind == StandardLibraryKind::StdGates
+                                ? "stdgates.inc is included more than once"
+                                : "qelib1.inc is included more than once");
     }
     for (const auto& gate : getGateCatalog()) {
       const bool belongsToLibrary = kind == StandardLibraryKind::StdGates
@@ -1920,32 +2074,34 @@ private:
         continue;
       }
       if (customGates.contains(gate.name) || lookup(gate.name) != nullptr) {
-        fail(location,
-             "standard-library gate '" + gate.name + "' is already declared");
+        return fail(location, "standard-library gate '" + gate.name +
+                                  "' is already declared");
       }
     }
     alreadyIncluded = true;
+    return success();
   }
 
-  void analyzeScalarDeclaration(SMLoc location,
-                                const SyntaxScalarDeclaration& declaration,
-                                std::vector<StatementId>& destination,
-                                const bool global) {
+  [[nodiscard]] LogicalResult analyzeScalarDeclaration(
+      SMLoc location, const SyntaxScalarDeclaration& declaration,
+      std::vector<StatementId>& destination, const bool global) {
     if (declaration.output && !global) {
-      fail(location, "outputs must be declared at global scope");
+      return fail(location, "outputs must be declared at global scope");
     }
     const auto type = scalarType(declaration.kind);
     if (declaration.isConst) {
       if (!declaration.initializer ||
           !isConstantExpression(*declaration.initializer)) {
-        fail(location, "const declaration requires a constant initializer");
+        return fail(location,
+                    "const declaration requires a constant initializer");
       }
-      auto constant = promoteConstInitializer(
-          evaluateConstant(*declaration.initializer), type, location);
-      declare(
+      MQT_OQ3_TRY_ASSIGN(initializer,
+                         evaluateConstant(*declaration.initializer));
+      MQT_OQ3_TRY_ASSIGN(constant,
+                         promoteConstInitializer(initializer, type, location));
+      return declare(
           location, declaration.identifier,
           {.kind = SymbolKind::Constant, .type = type, .constant = constant});
-      return;
     }
 
     const auto id = static_cast<ScalarId>(program.scalars.size());
@@ -1954,8 +2110,10 @@ private:
                                .location = getSourceLocation(location)});
     initializedScalars.push_back(false);
     scalarGenerations.push_back(0);
-    declare(location, declaration.identifier,
-            {.kind = SymbolKind::Scalar, .type = type, .id = id});
+    if (failed(declare(location, declaration.identifier,
+                       {.kind = SymbolKind::Scalar, .type = type, .id = id}))) {
+      return failure();
+    }
     if (global) {
       const ProgramOutput output{.kind = OutputKind::Scalar, .symbol = id};
       implicitOutputs.push_back(output);
@@ -1966,15 +2124,24 @@ private:
     ScalarDeclarationStatement typed{.scalar = id};
     if (declaration.initializer) {
       if (type == ScalarType::Bool) {
-        typed.conditionInitializer = analyzeBoolValue(*declaration.initializer);
+        MQT_OQ3_TRY_ASSIGN(conditionInitializer,
+                           analyzeBoolValue(*declaration.initializer));
+        typed.conditionInitializer = conditionInitializer;
       } else {
-        typed.initializer = castExpression(
-            analyzeExpression(*declaration.initializer), type,
-            syntax.expressions[*declaration.initializer].location);
+        MQT_OQ3_TRY_ASSIGN(initializer,
+                           analyzeExpression(*declaration.initializer));
+        MQT_OQ3_TRY_ASSIGN(
+            convertedInitializer,
+            castExpression(
+                initializer, type,
+                syntax.expressions[*declaration.initializer].location));
+        typed.initializer = convertedInitializer;
       }
       initializedScalars[id] = true;
     }
-    destination.push_back(addStatement(location, typed));
+    MQT_OQ3_TRY_ASSIGN(statement, addStatement(location, typed));
+    destination.push_back(statement);
+    return success();
   }
 
   void markBitInitialized(const frontend::BitReference& target) {
@@ -1994,29 +2161,36 @@ private:
     }
   }
 
-  void analyzeAssignment(SMLoc location, const SyntaxAssignment& assignment,
-                         std::vector<StatementId>& destination) {
+  [[nodiscard]] LogicalResult
+  analyzeAssignment(SMLoc location, const SyntaxAssignment& assignment,
+                    std::vector<StatementId>& destination) {
     const auto* symbol = lookup(assignment.target.identifier);
     if (symbol != nullptr && symbol->kind == SymbolKind::Scalar) {
       if (assignment.target.index) {
-        fail(location, "scalar assignments cannot have an index");
+        return fail(location, "scalar assignments cannot have an index");
       }
       ScalarAssignmentStatement typed{.scalar = symbol->id};
       if (symbol->type == ScalarType::Bool) {
-        typed.condition = analyzeBoolValue(assignment.value);
+        MQT_OQ3_TRY_ASSIGN(condition, analyzeBoolValue(assignment.value));
+        typed.condition = condition;
       } else {
-        typed.value =
-            castExpression(analyzeExpression(assignment.value), symbol->type,
-                           syntax.expressions[assignment.value].location);
+        MQT_OQ3_TRY_ASSIGN(value, analyzeExpression(assignment.value));
+        MQT_OQ3_TRY_ASSIGN(
+            convertedValue,
+            castExpression(value, symbol->type,
+                           syntax.expressions[assignment.value].location));
+        typed.value = convertedValue;
       }
       initializedScalars[symbol->id] = true;
       ++scalarGenerations[symbol->id];
-      destination.push_back(addStatement(location, typed));
-      return;
+      MQT_OQ3_TRY_ASSIGN(statement, addStatement(location, typed));
+      destination.push_back(statement);
+      return success();
     }
     if (symbol == nullptr || symbol->kind != SymbolKind::Register ||
         program.registers[symbol->id].kind != RegisterKind::Bit) {
-      fail(location, "cannot assign to '" + assignment.target.identifier + "'");
+      return fail(location,
+                  "cannot assign to '" + assignment.target.identifier + "'");
     }
     const auto targetReg = static_cast<RegisterId>(symbol->id);
     const auto& value = syntax.expressions[assignment.value];
@@ -2030,46 +2204,53 @@ private:
          program.registers[valueSymbol->id].kind == RegisterKind::Bit &&
          !program.registers[valueSymbol->id].isScalar);
     if (!assignment.target.index && bitVectorValue) {
-      const auto bitVector = analyzeBitVectorExpression(assignment.value);
+      MQT_OQ3_TRY_ASSIGN(bitVector,
+                         analyzeBitVectorExpression(assignment.value));
       if (program.bitVectorExpressions[bitVector].width !=
           program.registers[targetReg].width) {
-        fail(location, "bit-register assignment widths must match");
+        return fail(location, "bit-register assignment widths must match");
       }
       for (uint64_t bit = 0; bit < program.registers[targetReg].width; ++bit) {
         markBitInitialized({.reg = targetReg, .index = bit});
       }
-      destination.push_back(
+      MQT_OQ3_TRY_ASSIGN(
+          statement,
           addStatement(location, BitVectorAssignmentStatement{
                                      .target = targetReg, .value = bitVector}));
-      return;
+      destination.push_back(statement);
+      return success();
     }
-    auto targets = resolveBits(assignment.target);
+    MQT_OQ3_TRY_ASSIGN(targets, resolveBits(assignment.target));
     if (targets.size() > 1) {
-      fail(location,
-           "whole-register bit assignment requires a bit-register value");
+      return fail(
+          location,
+          "whole-register bit assignment requires a bit-register value");
     }
-    const auto condition = analyzeBoolValue(assignment.value);
+    MQT_OQ3_TRY_ASSIGN(condition, analyzeBoolValue(assignment.value));
     markBitInitialized(targets.front());
-    destination.push_back(
+    MQT_OQ3_TRY_ASSIGN(
+        statement,
         addStatement(location, BitAssignmentStatement{.target = targets.front(),
                                                       .value = condition}));
+    destination.push_back(statement);
+    return success();
   }
 
   template <class Declaration>
-  void analyzeRegisterDeclaration(SMLoc location,
-                                  const Declaration& declaration,
-                                  std::vector<StatementId>& destination,
-                                  const bool global) {
+  [[nodiscard]] LogicalResult
+  analyzeRegisterDeclaration(SMLoc location, const Declaration& declaration,
+                             std::vector<StatementId>& destination,
+                             const bool global) {
     constexpr bool isQubit =
         std::is_same_v<Declaration, SyntaxQubitDeclaration>;
     if constexpr (isQubit) {
       if (!global) {
-        fail(location, "qubits must be declared at global scope");
+        return fail(location, "qubits must be declared at global scope");
       }
     } else if (declaration.output && !global) {
-      fail(location, "outputs must be declared at global scope");
+      return fail(location, "outputs must be declared at global scope");
     }
-    const auto width = constantWidth(declaration.size, location);
+    MQT_OQ3_TRY_ASSIGN(width, constantWidth(declaration.size, location));
     const auto id = static_cast<RegisterId>(program.registers.size());
     const bool output = [&] {
       if constexpr (isQubit) {
@@ -2079,8 +2260,9 @@ private:
       }
     }();
     if (width > TOTAL_REGISTER_ELEMENT_LIMIT - totalRegisterElements) {
-      fail(location, Twine("total register elements exceed the limit of ") +
-                         Twine(TOTAL_REGISTER_ELEMENT_LIMIT));
+      return fail(location,
+                  Twine("total register elements exceed the limit of ") +
+                      Twine(TOTAL_REGISTER_ELEMENT_LIMIT));
     }
     totalRegisterElements += width;
     program.registers.push_back(
@@ -2095,8 +2277,10 @@ private:
         std::make_shared<BitInitialization>(width, initiallyInitialized));
     dynamicBitFacts.push_back(std::make_shared<DynamicBitFactSet>());
     bitGenerations.push_back(0);
-    declare(location, declaration.identifier,
-            {.kind = SymbolKind::Register, .id = id});
+    if (failed(declare(location, declaration.identifier,
+                       {.kind = SymbolKind::Register, .id = id}))) {
+      return failure();
+    }
     if (!isQubit && global) {
       const ProgramOutput programOutput{.kind = OutputKind::BitRegister,
                                         .symbol = id};
@@ -2105,15 +2289,17 @@ private:
         explicitOutputs.push_back(programOutput);
       }
     }
-    destination.push_back(
-        addStatement(location, DeclarationStatement{.reg = id}));
+    MQT_OQ3_TRY_ASSIGN(statement,
+                       addStatement(location, DeclarationStatement{.reg = id}));
+    destination.push_back(statement);
     if constexpr (!isQubit) {
       if (declaration.initializer) {
         if (width != 1) {
-          fail(location,
-               "bit expression initializers require a scalar bit declaration");
+          return fail(
+              location,
+              "bit expression initializers require a scalar bit declaration");
         }
-        analyzeAssignment(
+        return analyzeAssignment(
             location,
             SyntaxAssignment{
                 .target =
@@ -2123,14 +2309,16 @@ private:
             destination);
       }
     }
+    return success();
   }
 
-  void analyzeGateDefinition(SMLoc location,
-                             const SyntaxGateDefinition& declaration) {
+  [[nodiscard]] LogicalResult
+  analyzeGateDefinition(SMLoc location,
+                        const SyntaxGateDefinition& declaration) {
     if (customGates.contains(declaration.identifier) ||
         lookup(declaration.identifier) != nullptr) {
-      fail(location,
-           "gate '" + declaration.identifier + "' is already declared");
+      return fail(location,
+                  "gate '" + declaration.identifier + "' is already declared");
     }
     if (const auto* catalog = lookupGate(declaration.identifier);
         catalog != nullptr && isGateAvailable(*catalog)) {
@@ -2138,7 +2326,7 @@ private:
       // (e.g. `gate sx`). Prefer the standard-library entry and skip the
       // duplicate body to avoid later inlining overhead.
       if (program.openQASM2) {
-        return;
+        return success();
       }
       // MQT-compatible OpenQASM 3 may carry portable definitions for gates
       // that the compatibility catalog lowers directly. Prefer the native
@@ -2148,14 +2336,15 @@ private:
       if (catalog->availability == GateAvailability::Compatibility) {
         if (declaration.parameters.size() != catalog->parameterCount ||
             declaration.qubits.size() != catalog->qubitCount()) {
-          fail(location, "gate '" + declaration.identifier +
-                             "' does not match its compatibility signature");
+          return fail(location,
+                      "gate '" + declaration.identifier +
+                          "' does not match its compatibility signature");
         }
-        return;
+        return success();
       }
       // OpenQASM 3 rejects shadowing language and standard-library gates.
-      fail(location,
-           "gate '" + declaration.identifier + "' is already declared");
+      return fail(location,
+                  "gate '" + declaration.identifier + "' is already declared");
     }
     customGates[declaration.identifier] = {
         .parameterCount = declaration.parameters.size(),
@@ -2167,26 +2356,37 @@ private:
     scopes.emplace_back();
     for (const auto [index, parameter] :
          llvm::enumerate(declaration.parameters)) {
-      declare(location, parameter,
-              {.kind = SymbolKind::GateParameter,
-               .type = ScalarType::Angle,
-               .id = static_cast<uint32_t>(index)});
+      if (failed(declare(location, parameter,
+                         {.kind = SymbolKind::GateParameter,
+                          .type = ScalarType::Angle,
+                          .id = static_cast<uint32_t>(index)}))) {
+        scopes.pop_back();
+        return failure();
+      }
     }
     for (const auto [index, qubit] : llvm::enumerate(declaration.qubits)) {
-      declare(
-          location, qubit,
-          {.kind = SymbolKind::GateQubit, .id = static_cast<uint32_t>(index)});
+      if (failed(declare(location, qubit,
+                         {.kind = SymbolKind::GateQubit,
+                          .id = static_cast<uint32_t>(index)}))) {
+        scopes.pop_back();
+        return failure();
+      }
     }
     insideGate = true;
-    analyzeBody(declaration.body, definition.body, /*global=*/false);
+    const auto bodyResult =
+        analyzeBody(declaration.body, definition.body, /*global=*/false);
     insideGate = false;
     scopes.pop_back();
+    if (failed(bodyResult)) {
+      return failure();
+    }
     program.gates.push_back(std::move(definition));
+    return success();
   }
 
-  [[nodiscard]] StatementId
+  [[nodiscard]] FailureOr<StatementId>
   analyzeMeasurement(SMLoc location, const SyntaxMeasurement& measurement) {
-    auto qubits = resolveQubitOperand(measurement.source);
+    MQT_OQ3_TRY_ASSIGN(qubits, resolveQubitOperand(measurement.source));
     if (!measurement.target) {
       return addStatement(location,
                           MeasurementStatement{.qubits = std::move(qubits)});
@@ -2194,17 +2394,19 @@ private:
     const auto* destination = lookup(measurement.target->identifier);
     if (destination != nullptr && destination->kind == SymbolKind::Scalar) {
       if (destination->type == ScalarType::Bool) {
-        fail(location,
-             "measurement results have type 'bit' and cannot be assigned to "
-             "'bool' without an explicit cast");
+        return fail(
+            location,
+            "measurement results have type 'bit' and cannot be assigned to "
+            "'bool' without an explicit cast");
       }
-      fail(location,
-           "measurement assignment requires a bit-register destination");
+      return fail(location,
+                  "measurement assignment requires a bit-register destination");
     }
-    auto targets = resolveBits(*measurement.target);
+    MQT_OQ3_TRY_ASSIGN(targets, resolveBits(*measurement.target));
     if (targets.size() != qubits.size()) {
-      fail(location,
-           "measurement target and qubit operand must have the same width");
+      return fail(
+          location,
+          "measurement target and qubit operand must have the same width");
     }
     for (const auto& target : targets) {
       markBitInitialized(target);
@@ -2214,14 +2416,14 @@ private:
                                              .qubits = std::move(qubits)});
   }
 
-  [[nodiscard]] StatementId analyzeReset(SMLoc location,
-                                         const SyntaxReset& reset) {
-    auto qubits = resolveQubitOperand(reset.operand);
+  [[nodiscard]] FailureOr<StatementId> analyzeReset(SMLoc location,
+                                                    const SyntaxReset& reset) {
+    MQT_OQ3_TRY_ASSIGN(qubits, resolveQubitOperand(reset.operand));
     return addStatement(location, ResetStatement{.qubits = std::move(qubits)});
   }
 
-  [[nodiscard]] StatementId analyzeBarrier(SMLoc location,
-                                           const SyntaxBarrier& barrier) {
+  [[nodiscard]] FailureOr<StatementId>
+  analyzeBarrier(SMLoc location, const SyntaxBarrier& barrier) {
     std::vector<QubitReference> qubits;
     if (barrier.operands.empty()) {
       for (const auto [registerId, declaration] :
@@ -2241,7 +2443,7 @@ private:
       }
     }
     for (const auto& operand : barrier.operands) {
-      auto selection = resolveQubitOperand(operand);
+      MQT_OQ3_TRY_ASSIGN(selection, resolveQubitOperand(operand));
       qubits.insert(qubits.end(), selection.begin(), selection.end());
     }
 
@@ -2276,9 +2478,10 @@ private:
           break;
         }
         if (!inserted) {
-          fail(location,
-               "barrier operands must not reference the same qubit more than "
-               "once");
+          return fail(
+              location,
+              "barrier operands must not reference the same qubit more than "
+              "once");
         }
       }
 
@@ -2286,9 +2489,10 @@ private:
         const auto reg = dynamicRegisterQubit.first;
         if (staticRegisterQubitCounts.lookup(reg) ==
             program.registers.at(reg).width) {
-          fail(location,
-               "barrier operands must not reference the same qubit more than "
-               "once");
+          return fail(
+              location,
+              "barrier operands must not reference the same qubit more than "
+              "once");
         }
       }
     }
@@ -2297,17 +2501,23 @@ private:
                         BarrierStatement{.qubits = std::move(qubits)});
   }
 
-  [[nodiscard]] StatementId analyzeIf(SMLoc location,
-                                      const SyntaxIf& conditional) {
-    IfStatement result{.condition = analyzeCondition(conditional.condition)};
+  [[nodiscard]] FailureOr<StatementId> analyzeIf(SMLoc location,
+                                                 const SyntaxIf& conditional) {
+    MQT_OQ3_TRY_ASSIGN(condition, analyzeCondition(conditional.condition));
+    IfStatement result{.condition = condition};
     const auto beforeBitsInitialized = initializedBits;
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
     const auto beforeBitGenerations = bitGenerations;
     const auto beforeDynamicBitFacts = dynamicBitFacts;
     scopes.emplace_back();
-    analyzeBody(conditional.thenStatements, result.thenStatements,
-                /*global=*/false);
+    const auto thenResult =
+        analyzeBody(conditional.thenStatements, result.thenStatements,
+                    /*global=*/false);
+    if (failed(thenResult)) {
+      scopes.pop_back();
+      return failure();
+    }
     const auto afterThenBitsInitialized = initializedBits;
     const auto afterThenInitialized = initializedScalars;
     const auto afterThenGenerations = scalarGenerations;
@@ -2319,8 +2529,13 @@ private:
                        beforeGenerations, beforeBitGenerations);
     restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     scopes.emplace_back();
-    analyzeBody(conditional.elseStatements, result.elseStatements,
-                /*global=*/false);
+    const auto elseResult =
+        analyzeBody(conditional.elseStatements, result.elseStatements,
+                    /*global=*/false);
+    if (failed(elseResult)) {
+      scopes.pop_back();
+      return failure();
+    }
     const auto afterElseBitsInitialized = initializedBits;
     const auto afterElseInitialized = initializedScalars;
     const auto afterElseGenerations = scalarGenerations;
@@ -2328,7 +2543,8 @@ private:
     const auto afterElseDynamicBitFacts = dynamicBitFacts;
     scopes.pop_back();
 
-    const auto knownCondition = constantCondition(conditional.condition);
+    MQT_OQ3_TRY_ASSIGN(knownCondition,
+                       constantCondition(conditional.condition));
     if (knownCondition) {
       const auto& knownBitsInitialized =
           *knownCondition ? afterThenBitsInitialized : afterElseBitsInitialized;
@@ -2383,13 +2599,15 @@ private:
     return addStatement(location, std::move(result));
   }
 
-  [[nodiscard]] StatementId analyzeFor(SMLoc location, const SyntaxFor& loop) {
-    ForStatement result{.start = analyzeExpression(loop.start),
-                        .step = analyzeExpression(loop.step),
-                        .stop = analyzeExpression(loop.stop)};
+  [[nodiscard]] FailureOr<StatementId> analyzeFor(SMLoc location,
+                                                  const SyntaxFor& loop) {
+    MQT_OQ3_TRY_ASSIGN(start, analyzeExpression(loop.start));
+    MQT_OQ3_TRY_ASSIGN(step, analyzeExpression(loop.step));
+    MQT_OQ3_TRY_ASSIGN(stop, analyzeExpression(loop.stop));
+    ForStatement result{.start = start, .step = step, .stop = stop};
     for (const auto expression : {result.start, result.step, result.stop}) {
       if (!isInteger(program.expressions[expression].type)) {
-        fail(location, "for-loop ranges require integer expressions");
+        return fail(location, "for-loop ranges require integer expressions");
       }
     }
     const auto constantIsZero = [](const Constant& value) {
@@ -2397,9 +2615,11 @@ private:
                  ? std::get<uint64_t>(value.value) == 0
                  : std::get<int64_t>(value.value) == 0;
     };
-    if (isConstantExpression(loop.step) &&
-        constantIsZero(evaluateConstant(loop.step))) {
-      fail(location, "for-loop range step must not be zero");
+    if (isConstantExpression(loop.step)) {
+      MQT_OQ3_TRY_ASSIGN(stepConstant, evaluateConstant(loop.step));
+      if (constantIsZero(stepConstant)) {
+        return fail(location, "for-loop range step must not be zero");
+      }
     }
 
     const auto beforeBitsInitialized = initializedBits;
@@ -2414,13 +2634,21 @@ private:
         {.type = type, .name = loop.inductionVariable.str()});
     initializedScalars.push_back(true);
     scalarGenerations.push_back(0);
-    declare(
-        location, loop.inductionVariable,
-        {.kind = insideGate ? SymbolKind::GateLocalScalar : SymbolKind::Scalar,
-         .type = type,
-         .id = scalar});
+    if (failed(declare(location, loop.inductionVariable,
+                       {.kind = insideGate ? SymbolKind::GateLocalScalar
+                                           : SymbolKind::Scalar,
+                        .type = type,
+                        .id = scalar}))) {
+      scopes.pop_back();
+      return failure();
+    }
     result.inductionVariable = scalar;
-    analyzeBody(loop.body, result.body, /*global=*/false);
+    const auto bodyResult =
+        analyzeBody(loop.body, result.body, /*global=*/false);
+    if (failed(bodyResult)) {
+      scopes.pop_back();
+      return failure();
+    }
     const auto afterBodyBitsInitialized = initializedBits;
     const auto afterBodyInitialized = initializedScalars;
     const auto afterBodyGenerations = scalarGenerations;
@@ -2432,9 +2660,9 @@ private:
     restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     if (isConstantExpression(loop.start) && isConstantExpression(loop.step) &&
         isConstantExpression(loop.stop)) {
-      const auto startConstant = evaluateConstant(loop.start);
-      const auto stepConstant = evaluateConstant(loop.step);
-      const auto stopConstant = evaluateConstant(loop.stop);
+      MQT_OQ3_TRY_ASSIGN(startConstant, evaluateConstant(loop.start));
+      MQT_OQ3_TRY_ASSIGN(stepConstant, evaluateConstant(loop.step));
+      MQT_OQ3_TRY_ASSIGN(stopConstant, evaluateConstant(loop.stop));
       const bool unsignedEndpoints = startConstant.type == ScalarType::Uint ||
                                      stopConstant.type == ScalarType::Uint;
       const auto compareRangeValues = [&](const Constant& lhs,
@@ -2485,17 +2713,22 @@ private:
     return addStatement(location, std::move(result));
   }
 
-  [[nodiscard]] StatementId analyzeWhile(SMLoc location,
-                                         const SyntaxWhile& loop) {
-    WhileStatement result{.condition = analyzeCondition(loop.condition)};
+  [[nodiscard]] FailureOr<StatementId> analyzeWhile(SMLoc location,
+                                                    const SyntaxWhile& loop) {
+    MQT_OQ3_TRY_ASSIGN(condition, analyzeCondition(loop.condition));
+    WhileStatement result{.condition = condition};
     const auto beforeBitsInitialized = initializedBits;
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
     const auto beforeBitGenerations = bitGenerations;
     const auto beforeDynamicBitFacts = dynamicBitFacts;
     scopes.emplace_back();
-    analyzeBody(loop.body, result.body, /*global=*/false);
+    const auto bodyResult =
+        analyzeBody(loop.body, result.body, /*global=*/false);
     scopes.pop_back();
+    if (failed(bodyResult)) {
+      return failure();
+    }
     const auto afterBodyGenerations = scalarGenerations;
     const auto afterBodyBitGenerations = bitGenerations;
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
@@ -2512,11 +2745,12 @@ private:
     return addStatement(location, std::move(result));
   }
 
-  [[nodiscard]] StatementId analyzeSwitch(SMLoc location,
-                                          const SyntaxSwitch& switchSyntax) {
-    SwitchStatement result{.control = analyzeExpression(switchSyntax.control)};
+  [[nodiscard]] FailureOr<StatementId>
+  analyzeSwitch(SMLoc location, const SyntaxSwitch& switchSyntax) {
+    MQT_OQ3_TRY_ASSIGN(control, analyzeExpression(switchSyntax.control));
+    SwitchStatement result{.control = control};
     if (!isInteger(program.expressions[result.control].type)) {
-      fail(location, "switch control expression must have integer type");
+      return fail(location, "switch control expression must have integer type");
     }
 
     std::set<int64_t> labels;
@@ -2532,24 +2766,29 @@ private:
     std::vector<std::vector<bool>> branchScalarsInitialized;
     const auto analyzeBranch =
         [&](const ArrayRef<SyntaxStatementId> syntaxStatements,
-            std::vector<StatementId>& statements) {
-          restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
-                             beforeGenerations, beforeBitGenerations);
-          restoreDynamicFactsPrefix(beforeDynamicBitFacts);
-          scopes.emplace_back();
+            std::vector<StatementId>& statements) -> LogicalResult {
+      restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
+                         beforeGenerations, beforeBitGenerations);
+      restoreDynamicFactsPrefix(beforeDynamicBitFacts);
+      scopes.emplace_back();
+      const auto branchResult =
           analyzeBody(syntaxStatements, statements, /*global=*/false);
-          scopes.pop_back();
-          branchBitsInitialized.push_back(initializedBits);
-          branchScalarsInitialized.push_back(initializedScalars);
-          for (size_t index = 0; index < beforeGenerations.size(); ++index) {
-            mergedScalarGenerations[index] = std::max(
-                mergedScalarGenerations[index], scalarGenerations[index]);
-          }
-          for (size_t index = 0; index < beforeBitGenerations.size(); ++index) {
-            mergedBitGenerations[index] =
-                std::max(mergedBitGenerations[index], bitGenerations[index]);
-          }
-        };
+      scopes.pop_back();
+      if (failed(branchResult)) {
+        return failure();
+      }
+      branchBitsInitialized.push_back(initializedBits);
+      branchScalarsInitialized.push_back(initializedScalars);
+      for (size_t index = 0; index < beforeGenerations.size(); ++index) {
+        mergedScalarGenerations[index] =
+            std::max(mergedScalarGenerations[index], scalarGenerations[index]);
+      }
+      for (size_t index = 0; index < beforeBitGenerations.size(); ++index) {
+        mergedBitGenerations[index] =
+            std::max(mergedBitGenerations[index], bitGenerations[index]);
+      }
+      return success();
+    };
 
     result.cases.reserve(switchSyntax.cases.size());
     for (const auto& syntaxCase : switchSyntax.cases) {
@@ -2557,31 +2796,38 @@ private:
       switchCase.labels.reserve(syntaxCase.labels.size());
       for (const auto labelExpression : syntaxCase.labels) {
         if (!isConstantExpression(labelExpression)) {
-          fail(syntax.expressions[labelExpression].location,
-               "switch case labels must be constant integer expressions");
+          return fail(
+              syntax.expressions[labelExpression].location,
+              "switch case labels must be constant integer expressions");
         }
-        const auto label = evaluateConstant(labelExpression);
+        MQT_OQ3_TRY_ASSIGN(label, evaluateConstant(labelExpression));
         if (!isInteger(label.type)) {
-          fail(syntax.expressions[labelExpression].location,
-               "switch case labels must have integer type");
+          return fail(syntax.expressions[labelExpression].location,
+                      "switch case labels must have integer type");
         }
         if (label.type == ScalarType::Uint &&
             std::get<uint64_t>(label.value) >
                 static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-          fail(syntax.expressions[labelExpression].location,
-               "switch case label does not fit in signed i64");
+          return fail(syntax.expressions[labelExpression].location,
+                      "switch case label does not fit in signed i64");
         }
         const auto value = asSigned(label);
-        if (!labels.insert(value).second) {
-          fail(syntax.expressions[labelExpression].location,
-               "duplicate switch case label");
+        assert(value.has_value() && "label range checked above");
+        if (!labels.insert(*value).second) {
+          return fail(syntax.expressions[labelExpression].location,
+                      "duplicate switch case label");
         }
-        switchCase.labels.push_back(value);
+        switchCase.labels.push_back(*value);
       }
-      analyzeBranch(syntaxCase.body, switchCase.body);
+      if (failed(analyzeBranch(syntaxCase.body, switchCase.body))) {
+        return failure();
+      }
       result.cases.push_back(std::move(switchCase));
     }
-    analyzeBranch(switchSyntax.defaultStatements, result.defaultStatements);
+    if (failed(analyzeBranch(switchSyntax.defaultStatements,
+                             result.defaultStatements))) {
+      return failure();
+    }
 
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                        mergedScalarGenerations, mergedBitGenerations);
@@ -2604,15 +2850,15 @@ private:
     return addStatement(location, std::move(result));
   }
 
-  [[nodiscard]] ConditionId
+  [[nodiscard]] FailureOr<ConditionId>
   analyzeCondition(const SyntaxExpressionId syntaxId) {
     const auto& condition = syntax.expressions[syntaxId];
     ConditionExpression typed{.location =
                                   getSourceLocation(condition.location)};
     if (isConstantExpression(syntaxId)) {
-      const auto constant = evaluateConstant(syntaxId);
+      MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(syntaxId));
       if (constant.type != ScalarType::Bool) {
-        fail(condition.location, "condition must have bool type");
+        return fail(condition.location, "condition must have bool type");
       }
       typed.kind = ConditionKind::Literal;
       typed.literal = std::get<bool>(constant.value);
@@ -2622,14 +2868,14 @@ private:
     case Expr::Kind::Identifier: {
       const auto* symbol = lookup(condition.identifier);
       if (symbol == nullptr) {
-        fail(condition.location,
-             "unknown condition identifier '" + condition.identifier + "'");
+        return fail(condition.location, "unknown condition identifier '" +
+                                            condition.identifier + "'");
       }
       if (symbol->kind == SymbolKind::Scalar &&
           symbol->type == ScalarType::Bool) {
         if (!initializedScalars.at(symbol->id)) {
-          fail(condition.location,
-               "scalar '" + condition.identifier + "' is uninitialized");
+          return fail(condition.location,
+                      "scalar '" + condition.identifier + "' is uninitialized");
         }
         typed.kind = ConditionKind::Scalar;
         typed.scalar = symbol->id;
@@ -2637,44 +2883,54 @@ private:
       }
       if (symbol->kind != SymbolKind::Register ||
           program.registers[symbol->id].kind != RegisterKind::Bit) {
-        fail(condition.location, "identifier '" + condition.identifier +
-                                     "' is not bool or a classical bit");
+        return fail(condition.location, "identifier '" + condition.identifier +
+                                            "' is not bool or a classical bit");
       }
-      auto bits = resolveBits(
-          {.location = condition.location, .identifier = condition.identifier});
+      MQT_OQ3_TRY_ASSIGN(bits,
+                         resolveBits({.location = condition.location,
+                                      .identifier = condition.identifier}));
       if (bits.size() != 1) {
-        fail(condition.location,
-             "condition must select exactly one classical bit");
+        return fail(condition.location,
+                    "condition must select exactly one classical bit");
       }
-      ensureBitInitialized(bits.front(), condition.location);
+      if (failed(ensureBitInitialized(bits.front(), condition.location))) {
+        return failure();
+      }
       typed.kind = ConditionKind::Bit;
       typed.bit = bits.front();
       break;
     }
     case Expr::Kind::Index: {
-      auto bits = resolveBits({.location = condition.location,
-                               .identifier = condition.identifier,
-                               .index = condition.lhs});
+      MQT_OQ3_TRY_ASSIGN(bits, resolveBits({.location = condition.location,
+                                            .identifier = condition.identifier,
+                                            .index = condition.lhs}));
       if (bits.size() != 1) {
-        fail(condition.location,
-             "condition must select exactly one classical bit");
+        return fail(condition.location,
+                    "condition must select exactly one classical bit");
       }
-      ensureBitInitialized(bits.front(), condition.location);
+      if (failed(ensureBitInitialized(bits.front(), condition.location))) {
+        return failure();
+      }
       typed.kind = ConditionKind::Bit;
       typed.bit = bits.front();
       break;
     }
-    case Expr::Kind::Not:
+    case Expr::Kind::Not: {
       typed.kind = ConditionKind::Not;
-      typed.lhs = analyzeCondition(*condition.lhs);
+      MQT_OQ3_TRY_ASSIGN(lhs, analyzeCondition(*condition.lhs));
+      typed.lhs = lhs;
       break;
+    }
     case Expr::Kind::And:
-    case Expr::Kind::Or:
+    case Expr::Kind::Or: {
       typed.kind = condition.kind == Expr::Kind::And ? ConditionKind::And
                                                      : ConditionKind::Or;
-      typed.lhs = analyzeCondition(*condition.lhs);
-      typed.rhs = analyzeCondition(*condition.rhs);
+      MQT_OQ3_TRY_ASSIGN(lhs, analyzeCondition(*condition.lhs));
+      MQT_OQ3_TRY_ASSIGN(rhs, analyzeCondition(*condition.rhs));
+      typed.lhs = lhs;
+      typed.rhs = rhs;
       break;
+    }
     case Expr::Kind::Equal:
     case Expr::Kind::NotEqual:
     case Expr::Kind::Less:
@@ -2690,8 +2946,9 @@ private:
           program.registers[lhsSymbol->id].kind == RegisterKind::Bit &&
           isConstantExpression(*condition.rhs)) {
         const auto& rhsSyntax = syntax.expressions[*condition.rhs];
-        auto bits = resolveBits({.location = lhsSyntax.location,
-                                 .identifier = lhsSyntax.identifier});
+        MQT_OQ3_TRY_ASSIGN(bits,
+                           resolveBits({.location = lhsSyntax.location,
+                                        .identifier = lhsSyntax.identifier}));
         // OpenQASM 2 classical bits default to 0, so partially written
         // registers are valid in `if (c == k)` (e.g. mid-circuit feedback).
         llvm::APInt expectedBits;
@@ -2707,12 +2964,13 @@ private:
               std::max<size_t>(bits.size(), digits.size() * 4));
           expectedBits = llvm::APInt(width, digits, /*radix=*/10);
         } else {
-          const auto expected = evaluateConstant(*condition.rhs);
+          MQT_OQ3_TRY_ASSIGN(expected, evaluateConstant(*condition.rhs));
           if (!isInteger(expected.type) ||
               (expected.type == ScalarType::Int &&
                std::get<int64_t>(expected.value) < 0)) {
-            fail(condition.location,
-                 "OpenQASM 2 register conditions require an unsigned integer");
+            return fail(
+                condition.location,
+                "OpenQASM 2 register conditions require an unsigned integer");
           }
           const auto expectedValue =
               expected.type == ScalarType::Uint
@@ -2756,8 +3014,10 @@ private:
         return result;
       }
       typed.kind = ConditionKind::Comparison;
-      typed.comparisonLhs = analyzeExpression(*condition.lhs);
-      typed.comparisonRhs = analyzeExpression(*condition.rhs);
+      MQT_OQ3_TRY_ASSIGN(comparisonLhs, analyzeExpression(*condition.lhs));
+      MQT_OQ3_TRY_ASSIGN(comparisonRhs, analyzeExpression(*condition.rhs));
+      typed.comparisonLhs = comparisonLhs;
+      typed.comparisonRhs = comparisonRhs;
       const auto lhsType = program.expressions[typed.comparisonLhs].type;
       const auto rhsType = program.expressions[typed.comparisonRhs].type;
       const bool boolComparison =
@@ -2766,8 +3026,9 @@ private:
           (lhsType != ScalarType::Bool || rhsType != ScalarType::Bool ||
            (condition.kind != Expr::Kind::Equal &&
             condition.kind != Expr::Kind::NotEqual))) {
-        fail(condition.location,
-             "bool values only support equality comparisons with bool values");
+        return fail(
+            condition.location,
+            "bool values only support equality comparisons with bool values");
       }
       if (!boolComparison) {
         auto comparisonType = ScalarType::Int;
@@ -2779,12 +3040,16 @@ private:
         } else if (lhsType == ScalarType::Uint || rhsType == ScalarType::Uint) {
           comparisonType = ScalarType::Uint;
         }
-        typed.comparisonLhs =
+        MQT_OQ3_TRY_ASSIGN(
+            convertedLhs,
             castExpression(typed.comparisonLhs, comparisonType,
-                           syntax.expressions[*condition.lhs].location);
-        typed.comparisonRhs =
+                           syntax.expressions[*condition.lhs].location));
+        MQT_OQ3_TRY_ASSIGN(
+            convertedRhs,
             castExpression(typed.comparisonRhs, comparisonType,
-                           syntax.expressions[*condition.rhs].location);
+                           syntax.expressions[*condition.rhs].location));
+        typed.comparisonLhs = convertedLhs;
+        typed.comparisonRhs = convertedRhs;
       }
       switch (condition.kind) {
       case Expr::Kind::Equal:
@@ -2839,12 +3104,12 @@ private:
     case Expr::Kind::Sin:
     case Expr::Kind::Sqrt:
     case Expr::Kind::Tan:
-      fail(condition.location, "condition must have bool type");
+      return fail(condition.location, "condition must have bool type");
     }
     return addCondition(std::move(typed));
   }
 
-  [[nodiscard]] std::vector<GateApplication>
+  [[nodiscard]] FailureOr<std::vector<GateApplication>>
   analyzeGateApplication(const SyntaxGateCall& call) {
     std::string callee = call.identifier.str();
     const GateCatalogEntry* standard = lookupGate(callee);
@@ -2873,8 +3138,8 @@ private:
       standard = nullptr;
     }
     if (standard == nullptr && custom == customGates.end()) {
-      fail(call.location,
-           "No OpenQASM definition found for gate '" + call.identifier + "'.");
+      return fail(call.location, "No OpenQASM definition found for gate '" +
+                                     call.identifier + "'.");
     }
 
     const auto signature =
@@ -2884,26 +3149,29 @@ private:
                             .variadicControls = standard->variadicControls}
             : custom->second;
     if (signature.parameterCount != call.parameters.size()) {
-      fail(call.location,
-           "Invalid number of parameters for gate '" + call.identifier + "'.");
+      return fail(call.location, "Invalid number of parameters for gate '" +
+                                     call.identifier + "'.");
     }
     std::vector<ExpressionId> parameters;
     parameters.reserve(call.parameters.size());
     for (const auto expression : call.parameters) {
-      auto parameter = analyzeExpression(expression);
+      MQT_OQ3_TRY_ASSIGN(parameter, analyzeExpression(expression));
       if (program.expressions[parameter].type == ScalarType::Bool) {
-        fail(call.location, "gate parameters require numeric expressions");
+        return fail(call.location,
+                    "gate parameters require numeric expressions");
       }
-      parameter = castExpression(parameter, ScalarType::Angle,
-                                 syntax.expressions[expression].location);
-      parameters.push_back(parameter);
+      MQT_OQ3_TRY_ASSIGN(
+          convertedParameter,
+          castExpression(parameter, ScalarType::Angle,
+                         syntax.expressions[expression].location));
+      parameters.push_back(convertedParameter);
     }
 
     std::vector<GateModifier> modifiers;
     size_t addedControls = compatibilityControls;
     if (addedControls > call.operands.size()) {
-      fail(call.location, "Invalid number of qubit operands for gate '" +
-                              call.identifier + "'.");
+      return fail(call.location, "Invalid number of qubit operands for gate '" +
+                                     call.identifier + "'.");
     }
     for (const auto& modifier : call.modifiers) {
       switch (modifier.kind) {
@@ -2912,13 +3180,14 @@ private:
         break;
       case Modifier::Kind::Pow:
         if (!modifier.argument) {
-          fail(call.location, "pow modifier requires an argument");
+          return fail(call.location, "pow modifier requires an argument");
         }
         {
-          const auto operand = analyzeExpression(*modifier.argument);
+          MQT_OQ3_TRY_ASSIGN(operand, analyzeExpression(*modifier.argument));
           if (program.expressions[operand].type == ScalarType::Bool ||
               program.expressions[operand].type == ScalarType::Angle) {
-            fail(call.location, "pow modifier requires a numeric argument");
+            return fail(call.location,
+                        "pow modifier requires a numeric argument");
           }
           modifiers.push_back({.kind = ModifierKind::Pow, .operand = operand});
         }
@@ -2929,20 +3198,23 @@ private:
         std::optional<ExpressionId> operand;
         if (modifier.argument) {
           if (!isConstantExpression(*modifier.argument)) {
-            fail(call.location,
-                 "gate control count must be a constant integer");
+            return fail(call.location,
+                        "gate control count must be a constant integer");
           }
-          const auto constant = evaluateConstant(*modifier.argument);
-          if (!isInteger(constant.type) || asSigned(constant) <= 0) {
-            fail(call.location, "gate control count must be positive");
+          MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(*modifier.argument));
+          const auto signedCount =
+              isInteger(constant.type) ? asSigned(constant) : std::nullopt;
+          if (!signedCount || *signedCount <= 0) {
+            return fail(call.location, "gate control count must be positive");
           }
-          count = static_cast<uint64_t>(asSigned(constant));
+          count = static_cast<uint64_t>(*signedCount);
           operand = addConstant(
               {.type = ScalarType::Int, .value = static_cast<int64_t>(count)});
         }
         if (count > call.operands.size() - addedControls) {
-          fail(call.location, "Invalid number of qubit operands for gate '" +
-                                  call.identifier + "'.");
+          return fail(call.location,
+                      "Invalid number of qubit operands for gate '" +
+                          call.identifier + "'.");
         }
         addedControls += static_cast<size_t>(count);
         modifiers.push_back({.kind = modifier.kind == Modifier::Kind::Ctrl
@@ -2964,8 +3236,8 @@ private:
     const auto baseOperandCount = call.operands.size() - addedControls;
     if (signature.variadicControls ? baseOperandCount < signature.qubitCount
                                    : baseOperandCount != signature.qubitCount) {
-      fail(call.location, "Invalid number of qubit operands for gate '" +
-                              call.identifier + "'.");
+      return fail(call.location, "Invalid number of qubit operands for gate '" +
+                                     call.identifier + "'.");
     }
 
     size_t emittedOperandCount = call.operands.size();
@@ -2973,8 +3245,8 @@ private:
       size_t activeBaseOperands = baseOperandCount;
       if (standard->name == "mcx_vchain") {
         if (baseOperandCount < 5) {
-          fail(call.location,
-               "mcx_vchain requires controls, a target, and ancillas");
+          return fail(call.location,
+                      "mcx_vchain requires controls, a target, and ancillas");
         }
         const auto ancillas = ((baseOperandCount + 1) / 2) - 2;
         activeBaseOperands -= ancillas;
@@ -2982,8 +3254,8 @@ private:
         --activeBaseOperands;
       }
       if (activeBaseOperands <= standard->targetCount) {
-        fail(call.location,
-             "Invalid number of controls for gate '" + call.identifier + "'.");
+        return fail(call.location, "Invalid number of controls for gate '" +
+                                       call.identifier + "'.");
       }
       const auto intrinsicControls = activeBaseOperands - standard->targetCount;
       modifiers.push_back(
@@ -2998,11 +3270,11 @@ private:
     std::vector<std::vector<QubitReference>> selections;
     size_t broadcastWidth = 1;
     for (const auto& operand : call.operands) {
-      auto selection = resolveQubitOperand(operand);
+      MQT_OQ3_TRY_ASSIGN(selection, resolveQubitOperand(operand));
       if (selection.size() > 1) {
         if (broadcastWidth != 1 && broadcastWidth != selection.size()) {
-          fail(call.location,
-               "all broadcasting operands must have the same width");
+          return fail(call.location,
+                      "all broadcasting operands must have the same width");
         }
         broadcastWidth = selection.size();
       }
@@ -3022,9 +3294,9 @@ private:
       for (const auto [position, qubit] : llvm::enumerate(application.qubits)) {
         if (llvm::is_contained(
                 ArrayRef(application.qubits).take_front(position), qubit)) {
-          fail(call.location,
-               "gate operands must not reference the same qubit more than "
-               "once");
+          return fail(call.location,
+                      "gate operands must not reference the same qubit more "
+                      "than once");
         }
       }
       applications.push_back(std::move(application));
@@ -3032,32 +3304,33 @@ private:
     return applications;
   }
 
-  [[nodiscard]] std::vector<QubitReference>
+  [[nodiscard]] FailureOr<std::vector<QubitReference>>
   resolveQubitOperand(const SyntaxOperand& operand) {
     if (operand.hardwareQubit) {
       if (insideGate) {
-        fail(operand.location,
-             "hardware qubits are not allowed in gate definitions");
+        return fail(operand.location,
+                    "hardware qubits are not allowed in gate definitions");
       }
       hardwareQubits.insert(*operand.hardwareQubit);
-      return {{.kind = QubitReferenceKind::Hardware,
-               .index = *operand.hardwareQubit}};
+      return std::vector<QubitReference>{{.kind = QubitReferenceKind::Hardware,
+                                          .index = *operand.hardwareQubit}};
     }
     const auto* symbol = lookup(operand.identifier);
     if (insideGate) {
       if (symbol == nullptr || symbol->kind != SymbolKind::GateQubit) {
-        fail(operand.location,
-             "unknown gate-local qubit '" + operand.identifier + "'");
+        return fail(operand.location,
+                    "unknown gate-local qubit '" + operand.identifier + "'");
       }
       if (operand.index) {
-        fail(operand.location, "gate-local qubits cannot be indexed");
+        return fail(operand.location, "gate-local qubits cannot be indexed");
       }
-      return {{.kind = QubitReferenceKind::GateArgument, .symbol = symbol->id}};
+      return std::vector<QubitReference>{
+          {.kind = QubitReferenceKind::GateArgument, .symbol = symbol->id}};
     }
     if (symbol == nullptr || symbol->kind != SymbolKind::Register ||
         program.registers[symbol->id].kind != RegisterKind::Qubit) {
-      fail(operand.location,
-           "unknown qubit register '" + operand.identifier + "'");
+      return fail(operand.location,
+                  "unknown qubit register '" + operand.identifier + "'");
     }
     const auto reg = static_cast<RegisterId>(symbol->id);
     const auto width = program.registers[reg].width;
@@ -3071,31 +3344,33 @@ private:
       }
       return selection;
     }
-    if (const auto index =
-            constantIndex(*operand.index, width, operand.location)) {
-      if (*index >= width) {
-        fail(operand.location, "qubit index is out of bounds");
+    MQT_OQ3_TRY_ASSIGN(constant,
+                       constantIndex(*operand.index, width, operand.location));
+    if (constant) {
+      if (*constant >= width) {
+        return fail(operand.location, "qubit index is out of bounds");
       }
-      return {{.kind = QubitReferenceKind::Register,
-               .symbol = reg,
-               .index = *index}};
+      return std::vector<QubitReference>{{.kind = QubitReferenceKind::Register,
+                                          .symbol = reg,
+                                          .index = *constant}};
     }
-    const auto dynamic = analyzeExpression(*operand.index);
+    MQT_OQ3_TRY_ASSIGN(dynamic, analyzeExpression(*operand.index));
     if (!isInteger(program.expressions[dynamic].type)) {
-      fail(operand.location, "qubit index must be an integer expression");
+      return fail(operand.location,
+                  "qubit index must be an integer expression");
     }
-    return {{.kind = QubitReferenceKind::Register,
-             .symbol = reg,
-             .dynamicIndex = dynamic}};
+    return std::vector<QubitReference>{{.kind = QubitReferenceKind::Register,
+                                        .symbol = reg,
+                                        .dynamicIndex = dynamic}};
   }
 
-  [[nodiscard]] std::vector<frontend::BitReference>
+  [[nodiscard]] FailureOr<std::vector<frontend::BitReference>>
   resolveBits(const SyntaxBitReference& reference) {
     const auto* symbol = lookup(reference.identifier);
     if (symbol == nullptr || symbol->kind != SymbolKind::Register ||
         program.registers[symbol->id].kind == RegisterKind::Qubit) {
-      fail(reference.location,
-           "unknown classical register '" + reference.identifier + "'");
+      return fail(reference.location,
+                  "unknown classical register '" + reference.identifier + "'");
     }
     const auto reg = static_cast<RegisterId>(symbol->id);
     const auto width = program.registers[reg].width;
@@ -3107,27 +3382,31 @@ private:
       }
       return result;
     }
-    if (const auto index =
-            constantIndex(*reference.index, width, reference.location)) {
-      if (*index >= width) {
-        fail(reference.location, "classical bit index is out of bounds");
+    MQT_OQ3_TRY_ASSIGN(
+        constant, constantIndex(*reference.index, width, reference.location));
+    if (constant) {
+      if (*constant >= width) {
+        return fail(reference.location, "classical bit index is out of bounds");
       }
-      return {{.reg = reg, .index = *index}};
+      return std::vector<frontend::BitReference>{
+          {.reg = reg, .index = *constant}};
     }
-    const auto dynamic = analyzeExpression(*reference.index);
+    MQT_OQ3_TRY_ASSIGN(dynamic, analyzeExpression(*reference.index));
     if (!isInteger(program.expressions[dynamic].type)) {
-      fail(reference.location,
-           "classical bit index must be an integer expression");
+      return fail(reference.location,
+                  "classical bit index must be an integer expression");
     }
-    return {{.reg = reg, .dynamicIndex = dynamic}};
+    return std::vector<frontend::BitReference>{
+        {.reg = reg, .dynamicIndex = dynamic}};
   }
 
-  void ensureBitInitialized(const frontend::BitReference& bit,
-                            SMLoc location) const {
+  [[nodiscard]] LogicalResult
+  ensureBitInitialized(const frontend::BitReference& bit,
+                       SMLoc location) const {
     if (bit.dynamicIndex) {
       if (llvm::all_of(*initializedBits[bit.reg],
                        [](const bool initialized) { return initialized; })) {
-        return;
+        return success();
       }
       std::vector<std::pair<uint64_t, uint64_t>> dependencies;
       collectDependencies(*bit.dynamicIndex, dependencies);
@@ -3135,40 +3414,42 @@ private:
             return fact.dependencies == dependencies &&
                    sameExpression(fact.expression, *bit.dynamicIndex);
           })) {
-        return;
+        return success();
       }
-      fail(location, "dynamic classical index may read an uninitialized bit");
+      return fail(location,
+                  "dynamic classical index may read an uninitialized bit");
     }
     if (!(*initializedBits[bit.reg])[bit.index]) {
-      fail(location, "classical condition bit has not been initialized");
+      return fail(location, "classical condition bit has not been initialized");
     }
+    return success();
   }
 
-  void finalizeOutputs() {
+  [[nodiscard]] LogicalResult finalizeOutputs() {
     program.outputs =
         explicitOutputs.empty() ? implicitOutputs : explicitOutputs;
     for (const auto output : program.outputs) {
       if (output.kind == OutputKind::Scalar) {
         if (!initializedScalars[output.symbol]) {
-          throw SemanticError(
-              {.location = program.scalars[output.symbol].location,
-               .message = "Output scalar '" +
-                          program.scalars[output.symbol].name +
-                          "' is not initialized."});
+          return fail(program.scalars[output.symbol].location,
+                      "Output scalar '" + program.scalars[output.symbol].name +
+                          "' is not initialized.");
         }
         continue;
       }
       const auto reg = static_cast<RegisterId>(output.symbol);
       if (llvm::any_of(*initializedBits[reg],
                        [](const bool initialized) { return !initialized; })) {
-        throw SemanticError({.location = program.registers[reg].location,
-                             .message = "Output register '" +
-                                        program.registers[reg].name +
-                                        "' is not fully initialized."});
+        return fail(program.registers[reg].location,
+                    "Output register '" + program.registers[reg].name +
+                        "' is not fully initialized.");
       }
     }
+    return success();
   }
 };
+
+#undef MQT_OQ3_TRY_ASSIGN
 
 } // namespace
 

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -305,6 +305,23 @@ TEST(OpenQASMFrontendTest, RejectsUninitializedScalarOutputs) {
             std::string::npos);
 }
 
+TEST(OpenQASMFrontendTest, RejectsRecursiveCustomGatesAfterBodyAnalysis) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+gate recursive q {
+  recursive q;
+}
+)qasm";
+
+  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  ASSERT_FALSE(analyzed);
+  ASSERT_EQ(analyzed.diagnostics.size(), 1);
+  EXPECT_EQ(analyzed.diagnostics.front().message,
+            "recursive custom gate definition involving 'recursive'");
+  EXPECT_EQ(analyzed.diagnostics.front().location.line, 4);
+  EXPECT_EQ(analyzed.diagnostics.front().location.column, 3);
+}
+
 TEST(OpenQASMFrontendTest, RejectsInvalidGateControlAndBroadcastShapes) {
   constexpr llvm::StringLiteral zeroControl = R"qasm(
 OPENQASM 3.1;


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Replace the OpenQASM semantic analyzer's private exception unwinding with explicit `mlir::LogicalResult` and `mlir::FailureOr<T>` propagation. The analyzer retains the first diagnostic and returns a typed program only after every semantic phase succeeds.

The conversion covers constant evaluation, casts, declarations, assignments, structured control flow, qubit and bit resolution, recursive-gate validation, and output initialization while preserving the public frontend result. Review remediation keeps gate-parameter expressions such as `theta + 1` valid through contextual constant promotion without allowing ordinary runtime integer/angle mixing. The small assignment helper now moves the successful value rather than the `FailureOr` wrapper and carries no clang-tidy suppression outside its definition.

## Validation

- All 98 `OpenQASMFrontendTest` cases pass locally, including recursive-gate, source-location, and gate-angle regressions.
- No throw, catch, private semantic exception, or standard exception header remains in `OpenQASMSemantics.cpp`.
- The final aggregate stack builds successfully and passes all 4,547 discovered CTests; two live QDMI job-ID tests are skipped by design.
- Repository lint, targeted clang-tidy remediation, and `git diff --check` pass.

GPT-5.6 via Codex materially assisted with implementation, review remediation, testing, rebasing, and publication under maintainer direction.

