### PR TITLE
📝 Document missing passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ releases may include breaking changes.
 ### Added
 
 - ✨ Add an `unroll-modifiers` pass for unrolling multi-operation modifiers
-  ([#2015]) ([**@denialhaag**])
+  ([#2015]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add generic C++ and Python FoMaC support for custom device properties that
   contain operation handles ([#2042]) ([**@burgholzer**])
 - ✨ Support retrieving existing jobs by ID through the QDMI client API and C++
@@ -105,9 +105,10 @@ releases may include breaking changes.
   [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
   [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
   [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938], [#1975],
-  [#1976], [#2006], [#2014], [#2017], [#2026], [#2028]) ([**@burgholzer**],
-  [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**],
-  [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
+  [#1976], [#2006], [#2014], [#2015], [#2017], [#2026], [#2028], [#2058])
+  ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**],
+  [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
+  [**@simon1hofmann**], [**@J4MMlE**])
 
 ### Changed
 
@@ -736,6 +737,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2058]: https://github.com/munich-quantum-toolkit/core/pull/2058
 [#2030]: https://github.com/munich-quantum-toolkit/core/pull/2030
 [#2042]: https://github.com/munich-quantum-toolkit/core/pull/2042
 [#2036]: https://github.com/munich-quantum-toolkit/core/pull/2036

--- a/docs/mlir/QTensor.md
+++ b/docs/mlir/QTensor.md
@@ -5,3 +5,9 @@ tocdepth: 3
 ```{include} Dialects/QTensorDialect.md
 
 ```
+
+## Passes
+
+```{include} Passes/QTensorTransforms.md
+
+```

--- a/docs/mlir/Transforms.md
+++ b/docs/mlir/Transforms.md
@@ -1,0 +1,27 @@
+---
+tocdepth: 3
+---
+
+# Passes
+
+Passes that belong to a single dialect are documented on that dialect's page:
+{doc}`QC <QC>`, {doc}`QCO <QCO>`, and {doc}`QTensor <QTensor>`. The remaining
+passes are documented here.
+
+## Shared Passes
+
+The following passes are not tied to a single dialect.
+
+```{include} Passes/MQTTransforms.md
+
+```
+
+## QIR Passes
+
+The following passes operate on modules that have already been lowered to the
+LLVM dialect by the {doc}`QIR conversions <Conversions>`. They prepare such a
+module for emission as QIR.
+
+```{include} Passes/QIRTransforms.md
+
+```

--- a/docs/mlir/index.md
+++ b/docs/mlir/index.md
@@ -20,12 +20,15 @@ We define multiple dialects, each with its dedicated purpose:
 - The {doc}`QTensor dialect <QTensor>` adds support for one-dimensional tensors
   of qubits with linear typing and is used in the QCO dialect to represent
   collections of qubits such as registers.
-- The {doc}`OpenQASM support <OpenQASM>` translates supported OpenQASM input
-  directly to QC and emits structured OpenQASM from QC.
 
 These dialects define various canonicalization and transformation passes that
-enable the compilation of quantum programs to native quantum hardware. For
-interoperability, we provide {doc}`conversions <Conversions>` between dialects.
+enable the compilation of quantum programs to native quantum hardware. Passes
+that are not tied to a single dialect are documented on the
+{doc}`passes <Transforms>` page. For interoperability, we provide
+{doc}`conversions <Conversions>` between dialects.
+
+The {doc}`OpenQASM interface <OpenQASM>` translates supported OpenQASM input
+directly to QC and emits structured OpenQASM from QC.
 
 ```{toctree}
 :maxdepth: 2
@@ -35,8 +38,9 @@ target_compilation
 QC
 QCO
 QTensor
-OpenQASM
+Transforms
 Conversions
+OpenQASM
 ```
 
 :::{note}


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

The `MQTTransforms`, `QIRTransforms`, and `QTensorTransforms` pass docs were generated by `mlir-doc` but never included anywhere, so they did not show up in the rendered documentation.

This adds a `Passes` page that includes the dialect-agnostic (`normalize-global-phases`, `unroll-modifiers`) and QIR passes, and adds a `Passes` section to the QTensor page, mirroring the QC and QCO pages.

## AI Notice

Opus 5 via Claude Code assisted in updating the documentation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
