### PR TITLE
♻️ Preserve fixed-width angles in OpenQASM export

### DIFF
--- a/docs/mlir/OpenQASM.md
+++ b/docs/mlir/OpenQASM.md
@@ -35,26 +35,57 @@ mqt-cc --input-format=qasm program.txt
 
 ### Input support
 
-| OpenQASM concept           | Support and restrictions                                                                                                                                                                        |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Versions and includes      | Versionless input and versions 3.0 and 3.1 use the maintained OpenQASM profile. `stdgates.inc`, `qelib1.inc`, and nested textual includes are supported.                                        |
-| Classical types            | Unsized `bit`, `bool`, `int`, `uint`, and `float` declarations are supported. Width-qualified numeric types, arrays, complex values, and aliases are not yet supported.                         |
-| Outputs                    | Explicit `output` declarations are preserved in source order. Without any explicit output, global classical variables become outputs.                                                           |
-| Gates                      | Language gates, the standard libraries, custom gates, broadcasting, and `inv`, `ctrl`, `negctrl`, and `pow` modifiers are supported. Recursive custom gates are rejected.                       |
-| Quantum statements         | Measurement, reset, barrier, logical qubits, and physical qubits are supported. The QC target rejects programs that mix logical allocation with physical qubits.                                |
-| Expressions                | Scalar arithmetic, comparisons, Boolean expressions, and the supported math functions are type checked before translation. `popcount`, `rotl`, and `rotr` operate on initialized bit registers. |
-| Structured control         | `if`, inclusive `for`, `while`, and `switch` lower to SCF operations. Switch controls and case labels must be integers; labels must be unique constant expressions.                             |
-| Dynamic indexing           | Dynamic qubit and bit indices are supported on input. The generated QC includes bounds checks and structured dispatch where needed.                                                             |
-| Unsupported language areas | Subroutines, `extern`, calibration and timing constructs, input declarations, arbitrary arrays, `break`, and `continue` are diagnosed.                                                          |
+| OpenQASM concept           | Support and restrictions                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Versions and includes      | Versionless input and versions 3.0 and 3.1 use the maintained OpenQASM profile. `stdgates.inc`, `qelib1.inc`, and nested textual includes are supported.                                                                                                                                                                                                                                                                                                                                    |
+| Classical types            | `bit`, `bool`, `int`, `uint`, `float`, and fixed-width `angle[N]` declarations are supported. `angle` and `uint` accept widths from 1 through 64; unsized values use 64 bits. `float[64]` is accepted explicitly. Other width-qualified numeric types, arrays, complex values, and aliases are not yet supported.                                                                                                                                                                           |
+| Inputs and outputs         | Scalar `input` declarations and explicit `output` declarations are preserved in source order. Without any explicit output, global classical variables become outputs.                                                                                                                                                                                                                                                                                                                       |
+| Gates                      | Language gates, the standard libraries, custom gates, broadcasting, and `inv`, `ctrl`, `negctrl`, and `pow` modifiers are supported. Recursive custom gates are rejected.                                                                                                                                                                                                                                                                                                                   |
+| Quantum statements         | Measurement, reset, barrier, logical qubits, and physical qubits are supported. The QC target rejects programs that mix logical allocation with physical qubits.                                                                                                                                                                                                                                                                                                                            |
+| Expressions                | Scalar arithmetic, comparisons, Boolean expressions, and the supported math functions are type checked before translation. Fixed-width angles use their OpenQASM unsigned-ring operations, promotion, comparison, trigonometric-input, and cast rules. Equal-width `bit[N]` and `uint[N]`/`angle[N]` casts are supported, as is single-bit rvalue indexing of integer and angle scalars. `popcount`, `rotl`, and `rotr` support initialized bit registers and scalar `uint`/`angle` values. |
+| Structured control         | `if`, inclusive `for`, `while`, and `switch` lower to SCF operations. Switch controls and case labels must be integers; labels must be unique constant expressions.                                                                                                                                                                                                                                                                                                                         |
+| Dynamic indexing           | Dynamic qubit and bit indices are supported on input. The generated QC includes bounds checks and structured dispatch where needed.                                                                                                                                                                                                                                                                                                                                                         |
+| Unsupported language areas | Subroutines, `extern`, calibration and timing constructs, arbitrary arrays, scalar bit slices and indexed scalar assignment, `break`, and `continue` are diagnosed.                                                                                                                                                                                                                                                                                                                         |
 
 Syntax and semantic diagnostics retain source locations and include stacks.
 Runtime integer preconditions and dynamic-index bounds are represented
-explicitly in QC. This safety machinery is supported by the normal compiler and
-QIR paths, but it is intentionally outside the export subset described below.
+explicitly in QC. This safety machinery is supported by normal QC/QCO compiler
+paths, but it is intentionally outside the OpenQASM export and strict QIR
+subsets described below.
 
 Bit outputs use `memref<nxi1>` in QC, including scalar `bit` as `memref<1xi1>`.
 Other scalar outputs use builtin MLIR scalar types. A scalar `qubit` lowers to
 `qc.alloc`, while `qubit[1]` remains a one-element qubit register.
+
+### Fixed-width angles
+
+An OpenQASM `angle[N]` stores an unsigned `N`-bit pattern representing a
+multiple of $2\pi/2^N$. MQT Core keeps the source kind and width in the typed
+frontend, then lowers its storage and arithmetic to builtin signless `iN`,
+`arith`, and `scf` constructs.
+
+QC and QCO gate parameters and the QIR QIS ABI remain `f64` radians. Canonical
+integer-to-radian bridges are inserted only at gate and angle-aware math uses.
+Float-to-angle conversion decomposes the source binary64 value and evaluates the
+quotient against the exact binary64 representation of $2\pi$ with integer
+arithmetic. This preserves the specified modulo and nearest, ties-to-even result
+through 64 angle bits, including when the source has a large exponent. Angle
+widening inserts zero least-significant bits; narrowing uses the same
+ties-to-even rule. Widths above 64 are rejected because the existing gate and
+QIR boundary is binary64.
+
+The scalar forms of `popcount`, `rotl`, and `rotr` preserve fixed-width bit
+semantics for `uint[N]` and `angle[N]`. They lower to `math.ctpop` and LLVM
+funnel-shift operations. Whole `bit` registers continue to use their existing
+packed-register lowering.
+
+MQT Core always uses the OpenQASM-permitted ties-to-even narrowing behavior.
+Pragmas selecting truncation instead of rounding are not supported.
+
+The compiler records scalar input and output kind and source name in a
+namespaced function argument/result attribute; the builtin integer type carries
+the width. Together they distinguish an `angle[N]` interface from a `uint[N]`
+interface while it traverses QC and QCO.
 
 ## Export OpenQASM
 
@@ -115,14 +146,14 @@ bypasses that QCO optimization round trip.
 
 ### Export and round-trip support
 
-| QC or MLIR concept        | Export support                                                                                                                                                                                                               |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Qubits and classical bits | Logical and physical qubits, scalar allocations, and static rank-one qubit or `i1` memrefs. Memory indices must resolve statically.                                                                                          |
-| Quantum operations        | Measurement, reset, barrier, deallocation, global phase, and QC unitary operations. The exporter uses standard gates where available; for example, `sxdg` becomes `inv @ sx` and `u2` uses the standard compatibility alias. |
-| Gate modifiers            | Nested `ctrl`, `inv`, and `pow`. A multi-operation modifier body with target qubits becomes a private generated gate.                                                                                                        |
-| Scalar values             | `i1`, `i64`, `f64`, and internal `index` values, including arithmetic, comparisons, Boolean operations, value-preserving casts, and supported math functions.                                                                |
-| Structured control        | Result-free `scf.if` and `scf.index_switch`, constant-range `scf.for` without iterated state, and zero-state expression-based `scf.while`. Index switches use native `switch`, `case`, and `default` statements.             |
-| Results                   | Multiple scalar and bit-register outputs using the canonical type and naming rules below.                                                                                                                                    |
+| QC or MLIR concept        | Export support                                                                                                                                                                                                                                                                      |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Qubits and classical bits | Logical and physical qubits, scalar allocations, and static rank-one qubit or `i1` memrefs. Memory indices must resolve statically.                                                                                                                                                 |
+| Quantum operations        | Measurement, reset, barrier, deallocation, global phase, and QC unitary operations. The exporter uses standard gates where available; for example, `sxdg` becomes `inv @ sx` and `u2` uses the standard compatibility alias.                                                        |
+| Gate modifiers            | Nested `ctrl`, `inv`, and `pow`. A multi-operation modifier body with target qubits becomes a private generated gate.                                                                                                                                                               |
+| Scalar values             | `i1`, arbitrary supported `iN`, `f64`, and internal `index` values, including signed and unsigned arithmetic, comparisons, bitwise operations, shifts, casts, and supported math functions. Canonical angle conversion and resize sequences emit official `angle[N]` casts.         |
+| Structured control        | Single-block `scf.if`, `scf.index_switch`, constant-range `scf.for`, and expression-based `scf.while`. Supported scalar results and loop-carried state become typed OpenQASM temporaries with staged updates. Index switches use native `switch`, `case`, and `default` statements. |
+| Results                   | Multiple scalar and bit-register outputs using the canonical type and naming rules below.                                                                                                                                                                                           |
 
 The exporter writes an OpenQASM 3.1 version declaration and includes
 `stdgates.inc`. Gates in MQT Core's compatibility catalog, such as `r`, `rzz`,
@@ -146,36 +177,45 @@ Output types follow a deliberately small canonical mapping:
 | `i1` produced directly by measure | `bit`           |
 | Other `i1`                        | `bool`          |
 | `i64` or `index`                  | `int`           |
+| Other `iN`                        | `uint[N]`       |
 | `f64`                             | `float`         |
 
 A lone constant-zero `i64` result is treated as the frontend's status return and
-is not emitted. Import and export do not preserve `uint`, angle spelling,
-scalar-versus-one-element bit spelling, or scalar output names. Unsigned
-constants therefore normalize to `int`. Operations whose signedness affects
-their meaning, such as unsigned division, comparison, or conversion, are
-rejected instead of being approximated. Integer sign extension and truncation
-are also rejected because OpenQASM scalar casts have different value semantics.
+is not emitted. Scalar interface metadata preserves `input` and `output`
+`angle[N]` and `uint[N]` declarations across the QC/QCO round trip. Without that
+metadata, `i64` results retain the established `int` default and narrower
+integers emit as `uint[N]`.
 
 Emitted scalar casts use standard OpenQASM conversion syntax. The MQT Core
-frontend does not yet parse that syntax, so cast-containing output is outside
-the current MQT strict round-trip subset.
+frontend reparses the scalar casts used by the angle and unsigned-integer
+subset. The round-trip contract is semantic: generated source may express erased
+internal angle state as an equivalent `uint[N]` bit computation followed by an
+exact `bit[N]` to `angle[N]` conversion.
 
 ### Export limitations
 
-Export accepts exactly one defined, argument-free function. It rejects calls,
+Export accepts exactly one defined function; scalar arguments require the
+OpenQASM interface metadata produced by the frontend. It rejects calls,
 arbitrary CFGs, multi-block SCF regions, dynamic indices or ranges, general
-memrefs, unsupported integer widths, packed bit-vector operations, unknown
-operations, and non-unitary content inside modifier regions. SCF results,
-loop-carried values, nonempty `scf.yield`, and `arith.select` are outside the
-export subset. Multi-operation modifier bodies must have a target qubit and
-cannot capture additional qubits from an enclosing scope.
+memrefs, integer widths above 64, packed bit-vector operations, unknown
+operations, and non-unitary content inside modifier regions. SCF regions must
+contain one block. `scf.for` requires constant bounds and a positive constant
+step. An `scf.while` condition region must be side-effect free and forward its
+carried state unchanged; updates belong in the loop body. Carried values are
+limited to the supported scalar export types. General `arith.select` is outside
+the export subset, although the canonical guarded sequence for an OpenQASM
+dynamic shift is recognized and collapsed. Multi-operation modifier bodies must
+have a target qubit and cannot capture additional qubits from an enclosing
+scope.
 
-The exporter does not reconstruct the runtime checks created for dynamic indices
-or checked integer arithmetic. Surviving assertions, checked-index control flow,
-or live poison values cause an explicit diagnostic. Programs with static qubit
-and bit indices and without scalar casts can be exported and parsed again
-through the strict frontend. Programs that rely on the input safety machinery
-must continue through another output path such as QIR.
+The exporter recognizes the canonical nonzero guard around unsigned division and
+modulo and reconstructs the corresponding source operator. It does not
+reconstruct other runtime checks created for dynamic indices or checked integer
+arithmetic. Other surviving assertions, checked-index control flow, or live
+poison values cause an explicit diagnostic. Programs with static qubit and bit
+indices and scalar casts from the documented subset can be exported and parsed
+again through the strict frontend. Programs that rely on the remaining input
+safety machinery must continue through another output path such as QIR.
 
 :::{important}
 The compiler removes dead code. A circuit that only prepares a state has no

--- a/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/Dialect/QC/Translation/OpenQASMAttributes.h"
 #include "mlir/Dialect/Utils/AngleConversion.h"
 #include "mlir/Dialect/Utils/Utils.h"
 #include "mlir/Target/OpenQASM/GateCatalog.h"
@@ -20,6 +21,7 @@
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/Sequence.h>
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringExtras.h>
@@ -29,6 +31,8 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/UB/IR/UBOps.h>
@@ -37,8 +41,10 @@
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/IR/Visitors.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
@@ -50,6 +56,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -76,6 +83,7 @@ struct ScalarOutput {
   Value value;
   std::string name;
   std::string kind;
+  std::optional<uint32_t> angleWidth;
 };
 
 struct GateCall {
@@ -169,6 +177,12 @@ private:
   DenseMap<Value, std::string> valueNames;
   DenseSet<Value> returnedMemrefs;
   SmallVector<ScalarOutput> scalarOutputs;
+  SmallVector<ScalarOutput> scalarInputs;
+  DenseMap<Value, uint32_t> angleValues;
+  DenseSet<Value> uintValues;
+  DenseSet<Value> bitValues;
+  DenseSet<Operation*> canonicalAngleOperations;
+  std::optional<uint32_t> finalGatePrecision;
   llvm::StringSet<> usedNames;
   llvm::StringSet<> fixedHelpers;
   SmallVector<std::string> compositeHelpers;
@@ -177,6 +191,24 @@ private:
   size_t nextScalar = 0;
   size_t nextLoop = 0;
   size_t nextHelper = 0;
+
+  struct SafeShift {
+    Value lhs;
+    Value rhs;
+    StringRef operation;
+    arith::SelectOp distanceSelect;
+    arith::SelectOp resultSelect;
+    Operation* shift = nullptr;
+    Operation* result = nullptr;
+  };
+
+  struct CarriedVariable {
+    std::string name;
+    std::string kind;
+    std::optional<uint32_t> angleWidth;
+    bool unsignedInteger = false;
+    bool bit = false;
+  };
 
   [[nodiscard]] static LogicalResult fail(Operation* operation,
                                           const Twine& message) {
@@ -207,6 +239,85 @@ private:
     return uniqueName("out", nextScalar);
   }
 
+  [[nodiscard]] FailureOr<ScalarOutput>
+  scalarInterface(const DictionaryAttr metadata, const Value value,
+                  const StringRef expectedDirection) {
+    const auto failInterface =
+        [&](const Twine& message) -> FailureOr<ScalarOutput> {
+      emitError(value.getLoc()) << "OpenQASM emission error: " << message;
+      return failure();
+    };
+    if (!metadata) {
+      return failInterface("missing OpenQASM scalar interface metadata");
+    }
+    const auto kind = metadata.getAs<StringAttr>("kind");
+    const auto name = metadata.getAs<StringAttr>("name");
+    if (!kind || !name) {
+      return failInterface("malformed OpenQASM scalar interface metadata");
+    }
+
+    std::string declarationKind;
+    std::optional<uint32_t> angleWidth;
+    const auto type = value.getType();
+    if (kind.getValue() == "angle") {
+      const auto integerType = dyn_cast<IntegerType>(type);
+      if (!integerType ||
+          !mqt::angle::isSupportedWidth(integerType.getWidth())) {
+        return failInterface(
+            "angle interface metadata does not match its type");
+      }
+      const auto bitWidth = integerType.getWidth();
+      declarationKind = (Twine("angle[") + Twine(bitWidth) + "]").str();
+      angleWidth = bitWidth;
+      if (expectedDirection == "input") {
+        angleValues[value] = bitWidth;
+      }
+    } else if (kind.getValue() == "uint") {
+      const auto integerType = dyn_cast<IntegerType>(type);
+      if (!integerType ||
+          !mqt::angle::isSupportedWidth(integerType.getWidth())) {
+        return failInterface("uint interface metadata does not match its type");
+      }
+      const auto bitWidth = integerType.getWidth();
+      declarationKind = (Twine("uint[") + Twine(bitWidth) + "]").str();
+      if (expectedDirection == "input") {
+        uintValues.insert(value);
+      }
+    } else if (kind.getValue() == "int") {
+      if (!type.isInteger(64)) {
+        return failInterface("int interface metadata does not match its type");
+      }
+      declarationKind = "int";
+    } else if (kind.getValue() == "float") {
+      if (!type.isF64()) {
+        return failInterface(
+            "float interface metadata does not match its type");
+      }
+      declarationKind = "float";
+    } else if (kind.getValue() == "bool") {
+      if (!type.isInteger(1)) {
+        return failInterface("bool interface metadata does not match its type");
+      }
+      declarationKind = "bool";
+    } else {
+      return failInterface("unknown OpenQASM scalar interface kind");
+    }
+
+    std::string interfaceName;
+    if (expectedDirection == "output") {
+      interfaceName = outputName(name.getValue());
+    } else if (isValidOutputName(name.getValue()) &&
+               usedNames.insert(name.getValue()).second) {
+      interfaceName = name.getValue().str();
+    } else {
+      interfaceName = uniqueName("in", nextScalar);
+    }
+    return ScalarOutput{.value = value,
+                        .name = std::move(interfaceName),
+                        .kind = std::move(declarationKind),
+                        .angleWidth = angleWidth};
+  }
+
   [[nodiscard]] std::string qubitRegisterName(const StringRef requested) {
     if (isValidOutputName(requested) && usedNames.insert(requested).second) {
       return requested.str();
@@ -215,6 +326,16 @@ private:
   }
 
   [[nodiscard]] LogicalResult preflight() {
+    if (const auto rawPrecision =
+            moduleOp->getAttr(mqt::angle::FINAL_QUANTIZATION_ATTR)) {
+      const auto precision = dyn_cast<IntegerAttr>(rawPrecision);
+      if (!precision || precision.getValue().isZero() ||
+          precision.getValue().ugt(mqt::angle::MACHINE_WIDTH)) {
+        return fail(moduleOp, "invalid final gate-angle precision metadata");
+      }
+      finalGatePrecision =
+          static_cast<uint32_t>(precision.getValue().getZExtValue());
+    }
     SmallVector<func::FuncOp> functions(moduleOp.getOps<func::FuncOp>());
     if (functions.size() != 1) {
       return fail(moduleOp, "expected exactly one function");
@@ -223,10 +344,6 @@ private:
     if (function.isExternal() || function.getBody().getBlocks().size() != 1) {
       return fail(function,
                   "expected one defined function with one entry block");
-    }
-    if (function.getNumArguments() != 0) {
-      return fail(function, "function arguments and OpenQASM inputs are not "
-                            "supported");
     }
     const auto walkResult = function.walk([&](Operation* operation) {
       if (isa<func::CallOp>(operation)) {
@@ -251,10 +368,23 @@ private:
                                 "scope");
       }
     }
+    collectCanonicalAngleOperations();
     return success();
   }
 
   [[nodiscard]] LogicalResult collectProgramShape() {
+    for (const auto [index, argument] :
+         llvm::enumerate(function.getArguments())) {
+      auto metadata = dyn_cast_or_null<DictionaryAttr>(
+          function.getArgAttr(index, openqasm::SCALAR_ATTR));
+      auto input = scalarInterface(metadata, argument, "input");
+      if (failed(input)) {
+        return failure();
+      }
+      valueNames[argument] = input->name;
+      scalarInputs.push_back(std::move(*input));
+    }
+
     auto returnOp =
         dyn_cast<func::ReturnOp>(function.getBody().front().getTerminator());
     if (!returnOp) {
@@ -268,14 +398,24 @@ private:
         returnedMemrefs.insert(value);
         continue;
       }
-      auto kind = inferScalarKind(value);
-      if (kind.empty()) {
-        return fail(returnOp, "unsupported scalar output type for function "
-                              "result " +
-                                  Twine(index));
+      auto metadata = dyn_cast_or_null<DictionaryAttr>(
+          function.getResultAttr(index, openqasm::SCALAR_ATTR));
+      if (metadata) {
+        auto interface = scalarInterface(metadata, value, "output");
+        if (failed(interface)) {
+          return failure();
+        }
+        scalarOutputs.push_back(std::move(*interface));
+      } else {
+        auto kind = inferScalarKind(value);
+        if (kind.empty()) {
+          return fail(returnOp, "unsupported scalar output type for function "
+                                "result " +
+                                    Twine(index));
+        }
+        scalarOutputs.push_back(
+            {.value = value, .name = outputName({}), .kind = std::move(kind)});
       }
-      scalarOutputs.push_back(
-          {.value = value, .name = outputName({}), .kind = std::move(kind)});
     }
 
     for (Operation& operation : function.getBody().front().getOperations()) {
@@ -353,13 +493,33 @@ private:
     return integer && integer.getValue().isZero();
   }
 
-  [[nodiscard]] static std::string inferScalarKind(const Value value) {
+  [[nodiscard]] bool isBitValue(const Value value) const {
+    if (!value.getType().isInteger(1)) {
+      return false;
+    }
+    if (bitValues.contains(value) || value.getDefiningOp<qc::MeasureOp>()) {
+      return true;
+    }
+    auto load = value.getDefiningOp<memref::LoadOp>();
+    if (!load) {
+      return false;
+    }
+    const auto resource = resources.find(load.getMemRef());
+    return resource != resources.end() &&
+           resource->second.kind == ResourceKind::Bit;
+  }
+
+  [[nodiscard]] std::string inferScalarKind(const Value value) const {
     const auto type = value.getType();
     if (type.isInteger(1)) {
-      return value.getDefiningOp<qc::MeasureOp>() ? "bit" : "bool";
+      return isBitValue(value) ? "bit" : "bool";
     }
     if (type.isInteger(64) || type.isIndex()) {
       return "int";
+    }
+    if (const auto integer = dyn_cast<IntegerType>(type);
+        integer && integer.getWidth() <= mqt::angle::MACHINE_WIDTH) {
+      return (Twine("uint[") + Twine(integer.getWidth()) + "]").str();
     }
     if (type.isF64()) {
       return "float";
@@ -367,7 +527,121 @@ private:
     return {};
   }
 
+  void mapCarriedValue(const Value value, const CarriedVariable& variable) {
+    valueNames[value] = variable.name;
+    if (variable.angleWidth) {
+      angleValues[value] = *variable.angleWidth;
+    } else if (variable.unsignedInteger) {
+      uintValues.insert(value);
+    } else if (variable.bit) {
+      bitValues.insert(value);
+    }
+  }
+
+  [[nodiscard]] FailureOr<std::string>
+  emitCarriedValue(const Value value, const CarriedVariable& variable) {
+    if (variable.angleWidth) {
+      return emitAngleUse(value, *variable.angleWidth);
+    }
+    if (variable.unsignedInteger) {
+      return emitUnsignedOperand(value);
+    }
+    return emitExpression(value);
+  }
+
+  [[nodiscard]] FailureOr<SmallVector<CarriedVariable>>
+  declareCarriedVariables(const ValueRange results,
+                          const ArrayRef<SmallVector<Value>> sources,
+                          const ValueRange initialValues = {}) {
+    if (results.size() != sources.size() ||
+        (!initialValues.empty() && initialValues.size() != results.size())) {
+      return failure();
+    }
+    SmallVector<CarriedVariable> variables;
+    variables.reserve(results.size());
+    for (const auto [index, result] : llvm::enumerate(results)) {
+      std::optional<uint32_t> angle;
+      bool isUnsigned = false;
+      bool isBit = false;
+      for (const auto source : sources[index]) {
+        if (!angle) {
+          angle = angleWidth(source);
+        }
+        isUnsigned |= isUnsignedValue(source);
+        isBit |= isBitValue(source);
+      }
+      auto kind = inferScalarKind(result);
+      if (angle) {
+        const auto integer = dyn_cast<IntegerType>(result.getType());
+        if (!integer || integer.getWidth() != *angle) {
+          return failure();
+        }
+        kind = (Twine("angle[") + Twine(*angle) + "]").str();
+        isUnsigned = false;
+      } else if (isUnsigned) {
+        const auto integer = dyn_cast<IntegerType>(result.getType());
+        if (!integer || !mqt::angle::isSupportedWidth(integer.getWidth())) {
+          return failure();
+        }
+        kind = (Twine("uint[") + Twine(integer.getWidth()) + "]").str();
+      } else if (isBit) {
+        if (!result.getType().isInteger(1)) {
+          return failure();
+        }
+        kind = "bit";
+      }
+      if (kind.empty()) {
+        return failure();
+      }
+      CarriedVariable variable{.name = uniqueName("s", nextScalar),
+                               .kind = std::move(kind),
+                               .angleWidth = angle,
+                               .unsignedInteger = isUnsigned,
+                               .bit = isBit};
+      *output << variable.kind << ' ' << variable.name;
+      if (!initialValues.empty()) {
+        auto initializer = emitCarriedValue(initialValues[index], variable);
+        if (failed(initializer)) {
+          return failure();
+        }
+        *output << " = " << *initializer;
+      }
+      *output << ";\n";
+      mapCarriedValue(result, variable);
+      variables.push_back(std::move(variable));
+    }
+    return variables;
+  }
+
+  [[nodiscard]] LogicalResult
+  emitCarriedAssignments(const ValueRange values,
+                         const ArrayRef<CarriedVariable> variables) {
+    if (values.size() != variables.size()) {
+      return failure();
+    }
+    SmallVector<std::string> stagedNames;
+    stagedNames.reserve(values.size());
+    for (const auto [value, variable] : llvm::zip_equal(values, variables)) {
+      auto expression = emitCarriedValue(value, variable);
+      if (failed(expression)) {
+        return failure();
+      }
+      auto staged = uniqueName("next", nextScalar);
+      *output << variable.kind << ' ' << staged << " = " << *expression
+              << ";\n";
+      stagedNames.push_back(std::move(staged));
+    }
+    for (const auto [variable, staged] :
+         llvm::zip_equal(variables, stagedNames)) {
+      *output << variable.name << " = " << staged << ";\n";
+    }
+    return success();
+  }
+
   [[nodiscard]] LogicalResult emitDeclarations() {
+    for (const auto& scalar : scalarInputs) {
+      *output << "input " << scalar.kind << ' ' << scalar.name << ";\n";
+    }
     for (const auto value : resourceOrder) {
       const auto& resource = resources.at(value);
       if (resource.output) {
@@ -382,7 +656,8 @@ private:
     for (const auto& scalar : scalarOutputs) {
       *output << "output " << scalar.kind << ' ' << scalar.name << ";\n";
     }
-    if (!resourceOrder.empty() || !scalarOutputs.empty()) {
+    if (!scalarInputs.empty() || !resourceOrder.empty() ||
+        !scalarOutputs.empty()) {
       *output << '\n';
     }
     return success();
@@ -402,18 +677,26 @@ private:
 
   [[nodiscard]] LogicalResult emitOperation(Operation& operation) {
     if (isa<arith::SelectOp>(&operation)) {
-      return fail(&operation, "arith.select is not supported");
+      return (canonicalAngleOperations.contains(&operation) ||
+              isSafeShiftMember(operation))
+                 ? success()
+                 : fail(&operation, "arith.select is not supported");
     }
     if (isa<arith::ConstantOp, memref::LoadOp, memref::AllocOp,
             memref::DeallocOp, qc::AllocOp, qc::DeallocOp, qc::StaticOp>(
             &operation)) {
       return success();
     }
-    if (isCanonicalAngleBridgeMember(operation)) {
-      return success();
-    }
     if (isInlineExpressionOperation(operation)) {
+      if (llvm::all_of(operation.getResults(),
+                       [](const Value result) { return result.use_empty(); })) {
+        return success();
+      }
       return validateInlineExpressionOperation(operation);
+    }
+    if (auto assertion = dyn_cast<cf::AssertOp>(&operation);
+        assertion && isUnsignedDivisionSafetyAssert(assertion)) {
+      return success();
     }
     if (isa<cf::AssertOp>(&operation) ||
         (isa<ub::PoisonOp>(&operation) &&
@@ -480,39 +763,62 @@ private:
 
   [[nodiscard]] static bool isInlineExpressionOperation(Operation& operation) {
     const auto name = operation.getName().getStringRef();
-    return isa<arith::ConstantOp, arith::CmpIOp, arith::CmpFOp>(&operation) ||
+    return isa<arith::ConstantOp, arith::CmpIOp, arith::CmpFOp, arith::SelectOp,
+               arith::BitcastOp, math::CtPopOp, LLVM::FshlOp, LLVM::FshrOp>(
+               &operation) ||
            !binaryOperator(name).empty() || name == "arith.negf" ||
            name == "arith.remf" || isScalarCast(name) ||
            !mathFunction(name).empty();
   }
 
-  [[nodiscard]] static bool isCanonicalAngleBridgeMember(Operation& operation) {
-    const auto isCanonicalResult = [](const Value value) {
-      return mqt::angle::matchQuantizedRadians(value).has_value();
-    };
-    if (llvm::any_of(operation.getResults(), isCanonicalResult)) {
-      return true;
-    }
-    if (!isa<arith::UIToFPOp>(operation)) {
+  [[nodiscard]] static bool
+  isUnsignedDivisionSafetyAssert(cf::AssertOp assertion) {
+    const auto message = assertion.getMsg();
+    if (message != "division by zero" && message != "modulo by zero") {
       return false;
     }
-    for (const auto result : operation.getResults()) {
-      for (Operation* user : result.getUsers()) {
-        if (llvm::any_of(user->getResults(), isCanonicalResult)) {
-          return true;
-        }
+    Value divisor;
+    if (auto comparison = assertion.getArg().getDefiningOp<arith::CmpIOp>()) {
+      if (comparison.getPredicate() != arith::CmpIPredicate::ne) {
+        return false;
       }
+      if (getConstantInteger(comparison.getRhs()) == 0) {
+        divisor = comparison.getLhs();
+      } else if (getConstantInteger(comparison.getLhs()) == 0) {
+        divisor = comparison.getRhs();
+      } else {
+        return false;
+      }
+    } else if (assertion.getArg().getType().isInteger(1)) {
+      divisor = assertion.getArg();
+    } else {
+      return false;
     }
-    return false;
+    return llvm::any_of(divisor.getUsers(), [&](Operation* user) {
+      if (message == "division by zero") {
+        auto division = dyn_cast<arith::DivUIOp>(user);
+        return division && division.getRhs() == divisor;
+      }
+      auto remainder = dyn_cast<arith::RemUIOp>(user);
+      return remainder && remainder.getRhs() == divisor;
+    });
   }
 
   [[nodiscard]] LogicalResult
   validateInlineExpressionOperation(Operation& operation) {
+    if (canonicalAngleOperations.contains(&operation) ||
+        isCanonicalAngleBridgeMember(operation) ||
+        isSafeShiftMember(operation)) {
+      return success();
+    }
     for (const auto result : operation.getResults()) {
       const auto type = result.getType();
-      if (!type.isInteger(1) && !type.isInteger(64) && !type.isIndex() &&
-          !type.isF64()) {
-        return fail(&operation, "unsupported scalar expression result type");
+      const auto integer = dyn_cast<IntegerType>(type);
+      if ((!integer || integer.getWidth() > mqt::angle::MACHINE_WIDTH) &&
+          !type.isIndex() && !type.isF64()) {
+        return fail(&operation,
+                    "unsupported scalar expression result type on '" +
+                        operation.getName().getStringRef() + "'");
       }
       if (failed(emitExpression(result))) {
         return failure();
@@ -561,21 +867,349 @@ private:
     return (Twine(resource->second.name) + "[" + Twine(*index) + "]").str();
   }
 
-  [[nodiscard]] FailureOr<std::string> emitExpression(const Value value) {
+  void collectCanonicalAngleOperations() {
+    function.walk([&](Operation* operation) {
+      if (!operation->hasAttrOfType<UnitAttr>(openqasm::ANGLE_VALUE_ATTR)) {
+        return;
+      }
+      for (const auto result : operation->getResults()) {
+        const auto integerType = dyn_cast<IntegerType>(result.getType());
+        if (!integerType) {
+          continue;
+        }
+        const auto resize = mqt::angle::matchResize(result);
+        if (!resize || resize->targetWidth != integerType.getWidth()) {
+          continue;
+        }
+        canonicalAngleOperations.insert(resize->operations.begin(),
+                                        resize->operations.end());
+      }
+    });
+
+    function.walk([&](Operation* operation) {
+      for (const auto result : operation->getResults()) {
+        const auto source = mqt::angle::matchFloatToBits(result);
+        if (!source) {
+          continue;
+        }
+        SmallVector<Value> worklist{result};
+        DenseSet<Value> visited;
+        while (!worklist.empty()) {
+          const auto value = worklist.pop_back_val();
+          if (value == *source || !visited.insert(value).second) {
+            continue;
+          }
+          auto* definingOp = value.getDefiningOp();
+          if (definingOp == nullptr) {
+            continue;
+          }
+          canonicalAngleOperations.insert(definingOp);
+          llvm::append_range(worklist, definingOp->getOperands());
+        }
+      }
+    });
+  }
+
+  [[nodiscard]] static std::optional<SafeShift>
+  matchSafeShift(const Value value) {
+    Value selected = value;
+    Operation* result = value.getDefiningOp();
+    if (auto truncation = value.getDefiningOp<arith::TruncIOp>()) {
+      selected = truncation.getIn();
+    }
+    auto resultSelect = selected.getDefiningOp<arith::SelectOp>();
+    if (!resultSelect || !getConstantInteger(resultSelect.getFalseValue()) ||
+        *getConstantInteger(resultSelect.getFalseValue()) != 0) {
+      return std::nullopt;
+    }
+
+    auto* shift = resultSelect.getTrueValue().getDefiningOp();
+    StringRef operation;
+    if (isa_and_nonnull<arith::ShLIOp>(shift)) {
+      operation = "<<";
+    } else if (isa_and_nonnull<arith::ShRUIOp>(shift)) {
+      operation = ">>";
+    } else {
+      return std::nullopt;
+    }
+    auto lhs = shift->getOperand(0);
+    auto safeDistance = shift->getOperand(1);
+    auto distanceSelect = safeDistance.getDefiningOp<arith::SelectOp>();
+    if (!distanceSelect ||
+        distanceSelect.getCondition() != resultSelect.getCondition() ||
+        !getConstantInteger(distanceSelect.getFalseValue()) ||
+        *getConstantInteger(distanceSelect.getFalseValue()) != 0) {
+      return std::nullopt;
+    }
+
+    auto comparison =
+        resultSelect.getCondition().getDefiningOp<arith::CmpIOp>();
+    if (!comparison || comparison.getPredicate() != arith::CmpIPredicate::ult ||
+        comparison.getLhs() != distanceSelect.getTrueValue()) {
+      return std::nullopt;
+    }
+    const auto limit = getConstantInteger(comparison.getRhs());
+    if (!limit || *limit <= 0) {
+      return std::nullopt;
+    }
+
+    if (auto extension = lhs.getDefiningOp<arith::ExtUIOp>()) {
+      lhs = extension.getIn();
+    }
+    auto rhs = distanceSelect.getTrueValue();
+    if (auto extension = rhs.getDefiningOp<arith::ExtUIOp>()) {
+      rhs = extension.getIn();
+    }
+    const auto lhsType = dyn_cast<IntegerType>(lhs.getType());
+    if (!lhsType || std::cmp_not_equal(lhsType.getWidth(), *limit)) {
+      return std::nullopt;
+    }
+    return SafeShift{.lhs = lhs,
+                     .rhs = rhs,
+                     .operation = operation,
+                     .distanceSelect = distanceSelect,
+                     .resultSelect = resultSelect,
+                     .shift = shift,
+                     .result = result};
+  }
+
+  [[nodiscard]] static bool isSafeShiftMember(Operation& operation) {
+    const auto matchesOperation = [&](SafeShift shift) {
+      return shift.distanceSelect.getOperation() == &operation ||
+             shift.resultSelect.getOperation() == &operation ||
+             shift.shift == &operation || shift.result == &operation;
+    };
+    for (const auto result : operation.getResults()) {
+      if (const auto shift = matchSafeShift(result);
+          shift && matchesOperation(*shift)) {
+        return true;
+      }
+      for (Operation* user : result.getUsers()) {
+        for (const auto userResult : user->getResults()) {
+          if (const auto shift = matchSafeShift(userResult);
+              shift && matchesOperation(*shift)) {
+            return true;
+          }
+          for (Operation* finalUser : userResult.getUsers()) {
+            for (const auto finalResult : finalUser->getResults()) {
+              if (const auto shift = matchSafeShift(finalResult);
+                  shift && matchesOperation(*shift)) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] static bool isCanonicalAngleBridgeMember(Operation& operation) {
+    const auto isCanonicalResult = [](const Value value) {
+      return mqt::angle::matchQuantizedRadians(value).has_value();
+    };
+    if (llvm::any_of(operation.getResults(), isCanonicalResult)) {
+      return true;
+    }
+    if (!isa<arith::UIToFPOp>(operation)) {
+      return false;
+    }
+    for (const auto result : operation.getResults()) {
+      for (Operation* user : result.getUsers()) {
+        if (llvm::any_of(user->getResults(), isCanonicalResult)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] std::optional<uint32_t> angleWidth(const Value value) const {
+    if (const auto known = angleValues.find(value);
+        known != angleValues.end()) {
+      return known->second;
+    }
+    const auto integerType = dyn_cast<IntegerType>(value.getType());
+    auto* definingOp = value.getDefiningOp();
+    if (!integerType || definingOp == nullptr) {
+      return std::nullopt;
+    }
+    if (!definingOp->hasAttrOfType<UnitAttr>(openqasm::ANGLE_VALUE_ATTR)) {
+      return std::nullopt;
+    }
+    return integerType.getWidth();
+  }
+
+  [[nodiscard]] static bool isAngleOperand(Operation* operation,
+                                           const int32_t position) {
+    const auto operands = operation->getAttrOfType<DenseI32ArrayAttr>(
+        openqasm::ANGLE_OPERANDS_ATTR);
+    return operands && llvm::is_contained(operands.asArrayRef(), position);
+  }
+
+  [[nodiscard]] bool isUnsignedValue(const Value value) const {
+    if (uintValues.contains(value)) {
+      return true;
+    }
+    auto* definingOp = value.getDefiningOp();
+    return definingOp != nullptr &&
+           definingOp->hasAttrOfType<UnitAttr>(openqasm::UINT_VALUE_ATTR);
+  }
+
+  [[nodiscard]] FailureOr<std::string>
+  emitSourceOperand(const Value value, const bool unsignedIntegers = false) {
+    if (const auto width = angleWidth(value)) {
+      return emitAngleUse(value, *width);
+    }
+    if (isUnsignedValue(value)) {
+      return emitExpression(value, /*unsignedIntegers=*/true);
+    }
+    return emitExpression(value, unsignedIntegers);
+  }
+
+  [[nodiscard]] FailureOr<std::string> emitUnsignedOperand(const Value value) {
+    const auto width = angleWidth(value);
+    if (!width) {
+      return emitExpression(value, /*unsignedIntegers=*/true);
+    }
+    auto expression = emitAngleUse(value, *width);
+    if (failed(expression)) {
+      return failure();
+    }
+    return (Twine("uint[") + Twine(*width) + "](bit[" + Twine(*width) + "](" +
+            *expression + "))")
+        .str();
+  }
+
+  [[nodiscard]] FailureOr<std::string> emitRotation(const Value value) {
+    auto* operation = value.getDefiningOp();
+    if (operation == nullptr || operation->getNumOperands() != 3 ||
+        operation->getOperand(0) != operation->getOperand(1)) {
+      return failExpression(value,
+                            "only funnel shifts representing rotations are "
+                            "supported");
+    }
+    auto operand =
+        angleWidth(value)
+            ? emitAngleUse(operation->getOperand(0),
+                           cast<IntegerType>(value.getType()).getWidth())
+            : emitUnsignedOperand(operation->getOperand(0));
+    auto distance = emitExpression(operation->getOperand(2),
+                                   /*unsignedIntegers=*/true);
+    if (failed(operand) || failed(distance)) {
+      return failure();
+    }
+    return (Twine(isa<LLVM::FshlOp>(operation) ? "rotl(" : "rotr(") + *operand +
+            ", int(" + *distance + "))")
+        .str();
+  }
+
+  [[nodiscard]] FailureOr<std::string> emitAngleUse(const Value bits,
+                                                    const uint32_t bitWidth) {
+    if (const auto known = angleValues.find(bits);
+        known != angleValues.end() && known->second == bitWidth) {
+      return emitExpression(bits);
+    }
+    if (const auto resize = mqt::angle::matchResize(bits);
+        resize && resize->targetWidth == bitWidth) {
+      auto expression = emitAngleUse(resize->source, resize->sourceWidth);
+      if (failed(expression)) {
+        return failure();
+      }
+      return (Twine("angle[") + Twine(bitWidth) + "](" + *expression + ")")
+          .str();
+    }
+    if (const auto shift = matchSafeShift(bits)) {
+      return emitBinary(shift->lhs, shift->operation, shift->rhs,
+                        /*unsignedIntegers=*/true,
+                        /*lhsAngle=*/true, /*rhsAngle=*/false);
+    }
+    if (const auto radians = mqt::angle::matchFloatToBits(bits)) {
+      auto expression = emitExpression(*radians);
+      if (failed(expression)) {
+        return failure();
+      }
+      return (Twine("angle[") + Twine(bitWidth) + "](" + *expression + ")")
+          .str();
+    }
+    if (auto* operation = bits.getDefiningOp();
+        operation != nullptr && isa<LLVM::FshlOp, LLVM::FshrOp>(operation)) {
+      return emitRotation(bits);
+    }
+    if (auto* operation = bits.getDefiningOp()) {
+      if (operation->hasAttrOfType<UnitAttr>(openqasm::ANGLE_VALUE_ATTR) &&
+          operation->getNumOperands() == 2 &&
+          !binaryOperator(operation->getName().getStringRef()).empty()) {
+        auto emittedOperator =
+            binaryOperator(operation->getName().getStringRef());
+        if (operation->getName().getStringRef() == "arith.andi") {
+          emittedOperator = "&";
+        } else if (operation->getName().getStringRef() == "arith.ori") {
+          emittedOperator = "|";
+        } else if (operation->getName().getStringRef() == "arith.xori") {
+          emittedOperator = "^";
+        }
+        if (operation->getName().getStringRef() == "arith.xori") {
+          llvm::APInt constant;
+          Value operand;
+          if (matchPattern(operation->getOperand(0),
+                           m_ConstantInt(&constant)) &&
+              constant.isAllOnes()) {
+            operand = operation->getOperand(1);
+          } else if (matchPattern(operation->getOperand(1),
+                                  m_ConstantInt(&constant)) &&
+                     constant.isAllOnes()) {
+            operand = operation->getOperand(0);
+          }
+          if (operand) {
+            auto expression = emitAngleUse(operand, bitWidth);
+            if (failed(expression)) {
+              return failure();
+            }
+            return (Twine("(~") + *expression + ")").str();
+          }
+        }
+        if (operation->getName().getStringRef() == "arith.subi" &&
+            getConstantInteger(operation->getOperand(0)) == 0) {
+          auto operand = emitAngleUse(operation->getOperand(1), bitWidth);
+          if (failed(operand)) {
+            return failure();
+          }
+          return (Twine("(-") + *operand + ")").str();
+        }
+        return emitBinary(
+            operation->getOperand(0), emittedOperator, operation->getOperand(1),
+            /*unsignedIntegers=*/true, isAngleOperand(operation, 0),
+            isAngleOperand(operation, 1));
+      }
+    }
+    auto expression = emitExpression(bits, /*unsignedIntegers=*/true);
+    if (failed(expression)) {
+      return failure();
+    }
+    if (isUnsignedValue(bits)) {
+      return (Twine("angle[") + Twine(bitWidth) + "](bit[" + Twine(bitWidth) +
+              "](" + *expression + "))")
+          .str();
+    }
+    return (Twine("angle[") + Twine(bitWidth) + "](bit[" + Twine(bitWidth) +
+            "](uint[" + Twine(bitWidth) + "](" + *expression + ")))")
+        .str();
+  }
+
+  [[nodiscard]] FailureOr<std::string>
+  emitExpression(const Value value, const bool unsignedIntegers = false) {
     if (const auto found = valueNames.find(value); found != valueNames.end()) {
       return found->second;
     }
     if (const auto quantized = mqt::angle::matchQuantizedRadians(value)) {
-      if (auto constant = quantized->bits.getDefiningOp<arith::ConstantOp>()) {
-        if (const auto integer = dyn_cast<IntegerAttr>(constant.getValue())) {
-          llvm::SmallString<32> bits;
-          integer.getValue().toString(bits, 10, false);
-          const auto width = quantized->bitWidth;
-          return (Twine("angle[") + Twine(width) + "](bit[" + Twine(width) +
-                  "](uint[" + Twine(width) + "](" + bits + ")))")
-              .str();
-        }
-      }
+      return emitAngleUse(quantized->bits, quantized->bitWidth);
+    }
+    if (const auto shift = matchSafeShift(value)) {
+      return emitBinary(shift->lhs, shift->operation, shift->rhs,
+                        /*unsignedIntegers=*/true,
+                        /*lhsAngle=*/angleWidth(value).has_value(),
+                        /*rhsAngle=*/false);
     }
     if (auto load = value.getDefiningOp<memref::LoadOp>()) {
       if (load.getIndices().size() != 1) {
@@ -588,17 +1222,98 @@ private:
       return failExpression(value, "unmapped block argument");
     }
     if (auto constant = dyn_cast<arith::ConstantOp>(operation)) {
-      return emitConstant(constant);
+      const auto integerType = dyn_cast<IntegerType>(value.getType());
+      const bool printUnsigned =
+          unsignedIntegers ||
+          (integerType && integerType.getWidth() != 1 &&
+           integerType.getWidth() != mqt::angle::MACHINE_WIDTH);
+      return emitConstant(constant, printUnsigned);
     }
     if (isa<ub::PoisonOp>(operation)) {
       return failExpression(value, "poison values are not supported");
     }
+    if (value.getType().isInteger(1) &&
+        operation->hasAttrOfType<UnitAttr>(openqasm::BIT_EXTRACT_ATTR)) {
+      Value source;
+      uint64_t bit = 0;
+      if (auto truncation = dyn_cast<arith::TruncIOp>(operation)) {
+        source = truncation.getIn();
+      } else if (auto mask = dyn_cast<arith::AndIOp>(operation)) {
+        if (getConstantInteger(mask.getLhs()) == 1) {
+          source = mask.getRhs();
+        } else if (getConstantInteger(mask.getRhs()) == 1) {
+          source = mask.getLhs();
+        }
+      }
+      if (!source) {
+        return failExpression(value, "malformed scalar bit extraction");
+      }
+      if (auto shift = source.getDefiningOp<arith::ShRUIOp>()) {
+        const auto distance = getConstantInteger(shift.getRhs());
+        if (!distance || *distance < 0) {
+          return failExpression(value, "dynamic scalar bit extraction is not "
+                                       "supported");
+        }
+        source = shift.getLhs();
+        bit = static_cast<uint64_t>(*distance);
+      }
+      const auto sourceType = dyn_cast<IntegerType>(source.getType());
+      if (sourceType && bit < sourceType.getWidth()) {
+        auto expression = emitSourceOperand(source,
+                                            /*unsignedIntegers=*/true);
+        if (failed(expression)) {
+          return failure();
+        }
+        return (Twine(*expression) + "[" + Twine(bit) + "]").str();
+      }
+    }
     if (auto cmp = dyn_cast<arith::CmpIOp>(operation)) {
+      if (cmp.getLhs().getType().isInteger(1) &&
+          (cmp.getPredicate() == arith::CmpIPredicate::eq ||
+           cmp.getPredicate() == arith::CmpIPredicate::ne)) {
+        const auto booleanConstant =
+            [](const Value candidate) -> std::optional<bool> {
+          auto constant = candidate.getDefiningOp<arith::ConstantOp>();
+          const auto integer = constant
+                                   ? dyn_cast<IntegerAttr>(constant.getValue())
+                                   : IntegerAttr{};
+          if (!integer || !integer.getType().isInteger(1)) {
+            return std::nullopt;
+          }
+          return !integer.getValue().isZero();
+        };
+        Value operand;
+        std::optional<bool> constant;
+        if (const auto rhs = booleanConstant(cmp.getRhs())) {
+          operand = cmp.getLhs();
+          constant = rhs;
+        } else if (const auto lhs = booleanConstant(cmp.getLhs())) {
+          operand = cmp.getRhs();
+          constant = lhs;
+        }
+        if (operand && constant) {
+          auto expression = emitExpression(operand);
+          if (failed(expression)) {
+            return failure();
+          }
+          const bool preserve =
+              (cmp.getPredicate() == arith::CmpIPredicate::eq) == *constant;
+          return preserve ? *expression
+                          : (Twine("(!") + *expression + ")").str();
+        }
+      }
       auto predicate = integerPredicate(cmp.getPredicate());
       if (predicate.empty()) {
         return failExpression(value, "unsupported integer comparison");
       }
-      return emitBinary(cmp.getLhs(), predicate, cmp.getRhs());
+      const auto unsignedPredicate =
+          cmp.getPredicate() == arith::CmpIPredicate::ult ||
+          cmp.getPredicate() == arith::CmpIPredicate::ule ||
+          cmp.getPredicate() == arith::CmpIPredicate::ugt ||
+          cmp.getPredicate() == arith::CmpIPredicate::uge;
+      return emitBinary(cmp.getLhs(), predicate, cmp.getRhs(),
+                        unsignedPredicate, isAngleOperand(operation, 0),
+                        isAngleOperand(operation, 1));
     }
     if (auto cmp = dyn_cast<arith::CmpFOp>(operation)) {
       auto predicate = floatPredicate(cmp.getPredicate());
@@ -606,6 +1321,17 @@ private:
         return failExpression(value, "unsupported floating-point comparison");
       }
       return emitBinary(cmp.getLhs(), predicate, cmp.getRhs());
+    }
+    if (isa<math::CtPopOp>(operation)) {
+      auto operand = emitSourceOperand(operation->getOperand(0),
+                                       /*unsignedIntegers=*/true);
+      if (failed(operand)) {
+        return failure();
+      }
+      return (Twine("popcount(") + *operand + ")").str();
+    }
+    if (isa<LLVM::FshlOp, LLVM::FshrOp>(operation)) {
+      return emitRotation(value);
     }
     const auto name = operation->getName().getStringRef();
     if (name == "arith.remf") {
@@ -620,15 +1346,27 @@ private:
       if (operation->getNumOperands() != 2) {
         return failExpression(value, "malformed binary expression");
       }
-      if ((name == "arith.andi" || name == "arith.ori" ||
-           name == "arith.xori") &&
-          !value.getType().isInteger(1)) {
-        return failExpression(value,
-                              "packed integer bitwise operations are not "
-                              "supported");
+      auto emittedOperator = binary;
+      if (!value.getType().isInteger(1) || unsignedIntegers ||
+          isUnsignedValue(value)) {
+        if (name == "arith.andi") {
+          emittedOperator = "&";
+        } else if (name == "arith.ori") {
+          emittedOperator = "|";
+        } else if (name == "arith.xori") {
+          emittedOperator = "^";
+        }
       }
-      return emitBinary(operation->getOperand(0), binary,
-                        operation->getOperand(1));
+      const bool unsignedOperands =
+          unsignedIntegers || name == "arith.divui" || name == "arith.remui" ||
+          name == "arith.shrui" ||
+          ((name == "arith.andi" || name == "arith.ori" ||
+            name == "arith.xori" || name == "arith.shli") &&
+           !value.getType().isInteger(1));
+      return emitBinary(operation->getOperand(0), emittedOperator,
+                        operation->getOperand(1), unsignedOperands,
+                        isAngleOperand(operation, 0),
+                        isAngleOperand(operation, 1));
     }
     if (name == "arith.negf") {
       auto operand = emitExpression(operation->getOperand(0));
@@ -638,7 +1376,14 @@ private:
       return (Twine("(-") + *operand + ")").str();
     }
     if (isScalarCast(name)) {
-      auto operand = emitExpression(operation->getOperand(0));
+      const auto source = operation->getOperand(0);
+      const bool angleResult =
+          operation->hasAttrOfType<UnitAttr>(openqasm::ANGLE_VALUE_ATTR);
+      auto operand = angleWidth(source) && !angleResult
+                         ? emitUnsignedOperand(source)
+                         : emitExpression(source, unsignedIntegers ||
+                                                      name == "arith.extui" ||
+                                                      name == "arith.uitofp");
       if (failed(operand)) {
         return failure();
       }
@@ -651,6 +1396,13 @@ private:
       auto type = castTarget(name, value.getType());
       if (type.empty()) {
         return failExpression(value, "unsupported scalar conversion");
+      }
+      if (value.getType().isInteger(1) && unsignedIntegers) {
+        type = "uint[1]";
+      }
+      if (name == "arith.extui" && bitValues.contains(source) &&
+          value.getType().getIntOrFloatBitWidth() > 1) {
+        return (Twine(type) + "(uint[1](" + *operand + "))").str();
       }
       return (Twine(type) + "(" + *operand + ")").str();
     }
@@ -671,14 +1423,14 @@ private:
   }
 
   [[nodiscard]] static FailureOr<std::string>
-  emitConstant(arith::ConstantOp constant) {
+  emitConstant(arith::ConstantOp constant, const bool unsignedInteger) {
     if (auto integer = dyn_cast<IntegerAttr>(constant.getValue())) {
       if (integer.getType().isInteger(1)) {
         return integer.getValue().isZero() ? std::string("false")
                                            : std::string("true");
       }
       llvm::SmallString<32> text;
-      integer.getValue().toString(text, 10, true);
+      integer.getValue().toString(text, 10, !unsignedInteger);
       return text.str().str();
     }
     if (auto floating = dyn_cast<FloatAttr>(constant.getValue())) {
@@ -703,11 +1455,25 @@ private:
     return failure();
   }
 
-  [[nodiscard]] FailureOr<std::string> emitBinary(const Value lhsValue,
-                                                  const StringRef operation,
-                                                  const Value rhsValue) {
-    auto lhs = emitExpression(lhsValue);
-    auto rhs = emitExpression(rhsValue);
+  [[nodiscard]] FailureOr<std::string>
+  emitBinary(const Value lhsValue, const StringRef operation,
+             const Value rhsValue, const bool unsignedIntegers = false,
+             const bool lhsAngle = false, const bool rhsAngle = false) {
+    auto emitOperand = [&](const Value operand, const bool forceAngle) {
+      if (forceAngle) {
+        const auto type = dyn_cast<IntegerType>(operand.getType());
+        if (!type || !mqt::angle::isSupportedWidth(type.getWidth())) {
+          return failExpression(operand, "angle operand is not a supported "
+                                         "fixed-width integer");
+        }
+        return emitAngleUse(operand, type.getWidth());
+      }
+      return unsignedIntegers ? emitUnsignedOperand(operand)
+                              : emitSourceOperand(operand,
+                                                  /*unsignedIntegers=*/false);
+    };
+    auto lhs = emitOperand(lhsValue, lhsAngle);
+    auto rhs = emitOperand(rhsValue, rhsAngle);
     if (failed(lhs) || failed(rhs)) {
       return failure();
     }
@@ -719,8 +1485,10 @@ private:
         .Cases("arith.addi", "arith.addf", "+")
         .Cases("arith.subi", "arith.subf", "-")
         .Cases("arith.muli", "arith.mulf", "*")
-        .Cases("arith.divsi", "arith.divf", "/")
-        .Case("arith.remsi", "%")
+        .Cases("arith.divsi", "arith.divui", "arith.divf", "/")
+        .Cases("arith.remsi", "arith.remui", "%")
+        .Case("arith.shli", "<<")
+        .Case("arith.shrui", ">>")
         .Case("arith.andi", "&&")
         .Case("arith.ori", "||")
         .Case("arith.xori", "!=")
@@ -743,10 +1511,13 @@ private:
     case arith::CmpIPredicate::sge:
       return ">=";
     case arith::CmpIPredicate::ult:
+      return "<";
     case arith::CmpIPredicate::ule:
+      return "<=";
     case arith::CmpIPredicate::ugt:
+      return ">";
     case arith::CmpIPredicate::uge:
-      return {};
+      return ">=";
     }
     return {};
   }
@@ -757,6 +1528,7 @@ private:
     case arith::CmpFPredicate::OEQ:
       return "==";
     case arith::CmpFPredicate::ONE:
+    case arith::CmpFPredicate::UNE:
       return "!=";
     case arith::CmpFPredicate::OLT:
       return "<";
@@ -775,20 +1547,30 @@ private:
     return llvm::StringSwitch<bool>(name)
         .Case("arith.index_cast", true)
         .Case("arith.sitofp", true)
+        .Case("arith.uitofp", true)
         .Case("arith.fptosi", true)
+        .Case("arith.fptoui", true)
+        .Case("arith.extsi", true)
+        .Case("arith.extui", true)
+        .Case("arith.trunci", true)
         .Default(false);
   }
 
-  [[nodiscard]] static StringRef castTarget(const StringRef name,
-                                            const Type resultType) {
-    if (name == "arith.sitofp" || resultType.isF64()) {
+  [[nodiscard]] static std::string castTarget(const StringRef name,
+                                              const Type resultType) {
+    if (name == "arith.sitofp" || name == "arith.uitofp" ||
+        resultType.isF64()) {
       return "float";
     }
     if (resultType.isInteger(1)) {
       return "bool";
     }
     if (resultType.isInteger(64) || resultType.isIndex()) {
-      return "int";
+      return name == "arith.fptoui" || name == "arith.extui" ? "uint[64]"
+                                                             : "int";
+    }
+    if (const auto integer = dyn_cast<IntegerType>(resultType)) {
+      return (Twine("uint[") + Twine(integer.getWidth()) + "]").str();
     }
     return {};
   }
@@ -831,13 +1613,35 @@ private:
     }
     const auto name = uniqueName("b", nextBit);
     valueNames.try_emplace(measurement.getResult(), name);
+    bitValues.insert(measurement.getResult());
     *output << "bit " << name << " = measure " << *qubit << ";\n";
     return success();
   }
 
   [[nodiscard]] LogicalResult emitIf(scf::IfOp ifOp) {
+    SmallVector<CarriedVariable> variables;
     if (ifOp.getNumResults() != 0) {
-      return fail(ifOp, "scf.if results are not supported");
+      if (ifOp.getElseRegion().empty()) {
+        return fail(ifOp, "result-bearing scf.if requires an else region");
+      }
+      auto thenYield =
+          cast<scf::YieldOp>(ifOp.getThenRegion().front().getTerminator());
+      auto elseYield =
+          cast<scf::YieldOp>(ifOp.getElseRegion().front().getTerminator());
+      if (thenYield.getNumOperands() != ifOp.getNumResults() ||
+          elseYield.getNumOperands() != ifOp.getNumResults()) {
+        return fail(ifOp, "malformed result-bearing scf.if");
+      }
+      SmallVector<SmallVector<Value>> sources(ifOp.getNumResults());
+      for (const auto index : llvm::seq<size_t>(0, ifOp.getNumResults())) {
+        sources[index].append(
+            {thenYield.getOperand(index), elseYield.getOperand(index)});
+      }
+      auto declared = declareCarriedVariables(ifOp.getResults(), sources);
+      if (failed(declared)) {
+        return fail(ifOp, "unsupported scf.if result type");
+      }
+      variables = std::move(*declared);
     }
     auto condition = emitExpression(ifOp.getCondition());
     if (failed(condition)) {
@@ -848,11 +1652,25 @@ private:
     if (failed(emitBlock(ifOp.getThenRegion().front()))) {
       return failure();
     }
+    if (!variables.empty() &&
+        failed(emitCarriedAssignments(
+            cast<scf::YieldOp>(ifOp.getThenRegion().front().getTerminator())
+                .getOperands(),
+            variables))) {
+      return failure();
+    }
     output->unindent();
     if (!ifOp.getElseRegion().empty()) {
       *output << "} else {\n";
       output->indent();
       if (failed(emitBlock(ifOp.getElseRegion().front()))) {
+        return failure();
+      }
+      if (!variables.empty() &&
+          failed(emitCarriedAssignments(
+              cast<scf::YieldOp>(ifOp.getElseRegion().front().getTerminator())
+                  .getOperands(),
+              variables))) {
         return failure();
       }
       output->unindent();
@@ -862,8 +1680,31 @@ private:
   }
 
   [[nodiscard]] LogicalResult emitFor(scf::ForOp forOp) {
-    if (!forOp.getInitArgs().empty() || forOp.getNumResults() != 0) {
-      return fail(forOp, "scf.for loop-carried values are not supported");
+    if (forOp.getInitArgs().size() != forOp.getNumResults() ||
+        forOp.getRegionIterArgs().size() != forOp.getNumResults()) {
+      return fail(forOp, "malformed scf.for loop-carried state");
+    }
+    SmallVector<CarriedVariable> variables;
+    if (forOp.getNumResults() != 0) {
+      auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+      if (yield.getNumOperands() != forOp.getNumResults()) {
+        return fail(forOp, "malformed scf.for yield");
+      }
+      SmallVector<SmallVector<Value>> sources(forOp.getNumResults());
+      for (const auto index : llvm::seq<size_t>(0, forOp.getNumResults())) {
+        sources[index].append(
+            {forOp.getInitArgs()[index], yield.getOperand(index)});
+      }
+      auto declared = declareCarriedVariables(forOp.getResults(), sources,
+                                              forOp.getInitArgs());
+      if (failed(declared)) {
+        return fail(forOp, "unsupported scf.for result type");
+      }
+      variables = std::move(*declared);
+      for (const auto [argument, variable] :
+           llvm::zip_equal(forOp.getRegionIterArgs(), variables)) {
+        mapCarriedValue(argument, variable);
+      }
     }
     const auto lower = getConstantInteger(forOp.getLowerBound());
     const auto upper = getConstantInteger(forOp.getUpperBound());
@@ -894,6 +1735,12 @@ private:
     if (failed(emitBlock(*forOp.getBody()))) {
       return failure();
     }
+    if (!variables.empty() &&
+        failed(emitCarriedAssignments(
+            cast<scf::YieldOp>(forOp.getBody()->getTerminator()).getOperands(),
+            variables))) {
+      return failure();
+    }
     output->unindent();
     *output << "}\n";
     return success();
@@ -904,10 +1751,40 @@ private:
     auto& after = whileOp.getAfter().front();
     auto conditionOp = cast<scf::ConditionOp>(before.getTerminator());
     auto yieldOp = cast<scf::YieldOp>(after.getTerminator());
-    if (!whileOp.getInits().empty() || whileOp.getNumResults() != 0 ||
-        before.getNumArguments() != 0 || after.getNumArguments() != 0 ||
-        !conditionOp.getArgs().empty() || yieldOp.getNumOperands() != 0) {
-      return fail(whileOp, "scf.while loop-carried values are not supported");
+    const auto stateCount = whileOp.getInits().size();
+    const auto resultCount = whileOp.getNumResults();
+    if (before.getNumArguments() != stateCount ||
+        yieldOp.getNumOperands() != stateCount ||
+        after.getNumArguments() != resultCount ||
+        conditionOp.getArgs().size() != resultCount) {
+      return fail(whileOp, "malformed scf.while loop-carried state");
+    }
+    SmallVector<CarriedVariable> variables;
+    if (stateCount != 0) {
+      SmallVector<SmallVector<Value>> sources(stateCount);
+      for (const auto index : llvm::seq<size_t>(0, stateCount)) {
+        sources[index].append(
+            {whileOp.getInits()[index], yieldOp.getOperand(index)});
+      }
+      auto declared = declareCarriedVariables(before.getArguments(), sources,
+                                              whileOp.getInits());
+      if (failed(declared)) {
+        return fail(whileOp, "unsupported scf.while result type");
+      }
+      variables = std::move(*declared);
+      for (const auto resultIndex : llvm::seq<size_t>(0, resultCount)) {
+        const auto forwarded = conditionOp.getArgs()[resultIndex];
+        auto* const found = llvm::find(before.getArguments(), forwarded);
+        if (found == before.getArguments().end()) {
+          return fail(whileOp,
+                      "scf.while condition-region state updates are not "
+                      "supported");
+        }
+        const auto stateIndex = static_cast<size_t>(
+            std::distance(before.getArguments().begin(), found));
+        mapCarriedValue(after.getArgument(resultIndex), variables[stateIndex]);
+        mapCarriedValue(whileOp.getResult(resultIndex), variables[stateIndex]);
+      }
     }
     for (Operation& operation : before.without_terminator()) {
       if (auto load = dyn_cast<memref::LoadOp>(operation)) {
@@ -934,14 +1811,43 @@ private:
     if (failed(emitBlock(after))) {
       return failure();
     }
+    if (!variables.empty() &&
+        failed(emitCarriedAssignments(yieldOp.getOperands(), variables))) {
+      return failure();
+    }
     output->unindent();
     *output << "}\n";
     return success();
   }
 
   [[nodiscard]] LogicalResult emitIndexSwitch(scf::IndexSwitchOp switchOp) {
+    SmallVector<CarriedVariable> variables;
     if (switchOp.getNumResults() != 0) {
-      return fail(switchOp, "scf.index_switch results are not supported");
+      SmallVector<SmallVector<Value>> sources(switchOp.getNumResults());
+      const auto collectYield = [&](Block& block) {
+        auto yield = cast<scf::YieldOp>(block.getTerminator());
+        if (yield.getNumOperands() != switchOp.getNumResults()) {
+          return failure();
+        }
+        for (const auto index :
+             llvm::seq<size_t>(0, switchOp.getNumResults())) {
+          sources[index].push_back(yield.getOperand(index));
+        }
+        return success();
+      };
+      for (Region& region : switchOp.getCaseRegions()) {
+        if (failed(collectYield(region.front()))) {
+          return fail(switchOp, "malformed scf.index_switch case yield");
+        }
+      }
+      if (failed(collectYield(switchOp.getDefaultBlock()))) {
+        return fail(switchOp, "malformed scf.index_switch default yield");
+      }
+      auto declared = declareCarriedVariables(switchOp.getResults(), sources);
+      if (failed(declared)) {
+        return fail(switchOp, "unsupported scf.index_switch result type");
+      }
+      variables = std::move(*declared);
     }
     auto argument = emitExpression(switchOp.getArg());
     if (failed(argument)) {
@@ -950,7 +1856,17 @@ private:
 
     const auto cases = switchOp.getCases();
     if (cases.empty()) {
-      return emitBlock(switchOp.getDefaultBlock());
+      if (failed(emitBlock(switchOp.getDefaultBlock()))) {
+        return failure();
+      }
+      if (!variables.empty() &&
+          failed(emitCarriedAssignments(
+              cast<scf::YieldOp>(switchOp.getDefaultBlock().getTerminator())
+                  .getOperands(),
+              variables))) {
+        return failure();
+      }
+      return success();
     }
     *output << "switch (" << *argument << ") {\n";
     output->indent();
@@ -961,12 +1877,28 @@ private:
               emitBlock(switchOp.getCaseBlock(static_cast<unsigned>(index))))) {
         return failure();
       }
+      if (!variables.empty() &&
+          failed(emitCarriedAssignments(
+              cast<scf::YieldOp>(
+                  switchOp.getCaseBlock(static_cast<unsigned>(index))
+                      .getTerminator())
+                  .getOperands(),
+              variables))) {
+        return failure();
+      }
       output->unindent();
       *output << "}\n";
     }
     *output << "default {\n";
     output->indent();
     if (failed(emitBlock(switchOp.getDefaultBlock()))) {
+      return failure();
+    }
+    if (!variables.empty() &&
+        failed(emitCarriedAssignments(
+            cast<scf::YieldOp>(switchOp.getDefaultBlock().getTerminator())
+                .getOperands(),
+            variables))) {
       return failure();
     }
     output->unindent();
@@ -985,15 +1917,38 @@ private:
       if (isa<MemRefType>(value.getType())) {
         continue;
       }
-      auto expression = emitExpression(value);
+      const auto& scalar = scalarOutputs[scalarIndex];
+      FailureOr<std::string> expression;
+      if (scalar.angleWidth) {
+        expression = emitAngleUse(value, *scalar.angleWidth);
+      } else if (scalar.kind.starts_with("uint[")) {
+        expression = emitUnsignedOperand(value);
+      } else {
+        expression = emitExpression(value);
+      }
       if (failed(expression)) {
         return failure();
       }
-      *output << scalarOutputs[scalarIndex].name << " = " << *expression
-              << ";\n";
+      *output << scalar.name << " = " << *expression << ";\n";
       ++scalarIndex;
     }
     return success();
+  }
+
+  [[nodiscard]] FailureOr<std::string>
+  emitQuantizedGateParameter(const Value parameter,
+                             const uint32_t precisionBits) {
+    if (const auto quantized = mqt::angle::matchQuantizedRadians(parameter)) {
+      if (quantized->bitWidth != precisionBits) {
+        return failExpression(parameter,
+                              "gate-angle precision metadata does not match "
+                              "the canonical parameter bridge");
+      }
+      return emitAngleUse(quantized->bits, precisionBits);
+    }
+    return failExpression(
+        parameter,
+        "final gate-angle quantization does not match its parameter");
   }
 
   [[nodiscard]] FailureOr<GateCall> emitGateCall(UnitaryOpInterface unitary) {
@@ -1018,7 +1973,10 @@ private:
       call.modifiers = "inv @ ";
     }
     for (const auto parameter : unitary.getParameters()) {
-      auto expression = emitExpression(parameter);
+      auto expression =
+          finalGatePrecision
+              ? emitQuantizedGateParameter(parameter, *finalGatePrecision)
+              : emitExpression(parameter);
       if (failed(expression)) {
         return failure();
       }
@@ -1039,9 +1997,12 @@ private:
     auto& body = modifier.getRegion().front();
     SmallVector<Operation*> unitaries;
     for (Operation& operation : body.without_terminator()) {
+      if (auto assertion = dyn_cast<cf::AssertOp>(&operation);
+          assertion && isUnsignedDivisionSafetyAssert(assertion)) {
+        continue;
+      }
       if (!isa<UnitaryOpInterface>(&operation) &&
-          !isInlineExpressionOperation(operation) &&
-          !isCanonicalAngleBridgeMember(operation)) {
+          !isInlineExpressionOperation(operation)) {
         fail(&operation, "modifier bodies may only contain unitary operations "
                          "and scalar expressions");
         return failure();
@@ -1130,16 +2091,45 @@ private:
 
     SmallVector<Value> captures;
     DenseSet<Value> captured;
+    DenseMap<Value, uint32_t> capturedAngles;
     Value capturedQubit;
+    const auto addCapture = [&](const Value value,
+                                const std::optional<uint32_t> angle = {}) {
+      if (captured.insert(value).second) {
+        captures.push_back(value);
+      }
+      if (angle) {
+        capturedAngles[value] = *angle;
+      }
+    };
     modifier.getRegion().walk([&](Operation* operation) {
+      for (const auto result : operation->getResults()) {
+        if (const auto angle = mqt::angle::matchQuantizedRadians(result);
+            angle) {
+          Value bits = angle->bits;
+          if (!bits.getDefiningOp<arith::ConstantOp>() &&
+              !modifier.getRegion().isAncestor(bits.getParentRegion())) {
+            addCapture(bits, angle->bitWidth);
+          }
+        }
+      }
+      if (canonicalAngleOperations.contains(operation) ||
+          isCanonicalAngleBridgeMember(*operation) ||
+          (isa<cf::AssertOp>(operation) &&
+           isUnsignedDivisionSafetyAssert(cast<cf::AssertOp>(operation)))) {
+        return;
+      }
       for (auto operand : operation->getOperands()) {
         if (modifier.getRegion().isAncestor(operand.getParentRegion())) {
           continue;
         }
+        if (isa_and_nonnull<arith::ConstantOp>(operand.getDefiningOp())) {
+          continue;
+        }
         if (isa<QubitType>(operand.getType())) {
           capturedQubit = operand;
-        } else if (captured.insert(operand).second) {
-          captures.push_back(operand);
+        } else {
+          addCapture(operand, angleWidth(operand));
         }
       }
     });
@@ -1148,11 +2138,19 @@ private:
            "multi-operation modifier bodies cannot capture extra qubits");
       return failure();
     }
+    if (llvm::any_of(captures, [&](const Value capture) {
+          return !capturedAngles.contains(capture);
+        })) {
+      fail(modifier,
+           "multi-operation modifier bodies cannot capture non-angle scalar "
+           "values");
+      return failure();
+    }
 
     GateCall helperCall;
     helperCall.symbol = helperName;
     for (const auto capture : captures) {
-      auto expression = emitExpression(capture);
+      auto expression = emitAngleUse(capture, capturedAngles.at(capture));
       if (failed(expression)) {
         return failure();
       }
@@ -1160,12 +2158,21 @@ private:
     }
 
     DenseMap<Value, std::string> savedNames;
+    DenseMap<Value, uint32_t> savedAngleWidths;
     auto saveAndMap = [&](const Value value, std::string name) {
       if (const auto found = valueNames.find(value);
           found != valueNames.end()) {
         savedNames.try_emplace(value, found->second);
       }
       valueNames[value] = std::move(name);
+      if (const auto angle = capturedAngles.find(value);
+          angle != capturedAngles.end()) {
+        if (const auto previous = angleValues.find(value);
+            previous != angleValues.end()) {
+          savedAngleWidths[value] = previous->second;
+        }
+        angleValues[value] = angle->second;
+      }
     };
 
     SmallVector<std::string> parameterNames;
@@ -1212,6 +2219,12 @@ private:
         valueNames[value] = found->second;
       } else {
         valueNames.erase(value);
+      }
+      if (const auto found = savedAngleWidths.find(value);
+          found != savedAngleWidths.end()) {
+        angleValues[value] = found->second;
+      } else if (capturedAngles.contains(value)) {
+        angleValues.erase(value);
       }
     }
     for (const auto argument : body.getArguments()) {

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -584,10 +584,9 @@ ratio = 2.0;
   ASSERT_TRUE(restoredQC);
   auto emitted = restoredQC->toOpenQASM3();
   ASSERT_TRUE(emitted);
-  EXPECT_NE(emitted->source().find("output int _mqt_out0;"), std::string::npos);
+  EXPECT_NE(emitted->source().find("output int count;"), std::string::npos);
   EXPECT_NE(emitted->source().find("output bit[2] bits;"), std::string::npos);
-  EXPECT_NE(emitted->source().find("output float _mqt_out1;"),
-            std::string::npos);
+  EXPECT_NE(emitted->source().find("output float ratio;"), std::string::npos);
   EXPECT_TRUE(QCProgram::fromQASMString(emitted->source()));
 }
 

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -10,12 +10,16 @@
 
 #include "mlir/Dialect/QC/Builder/QCProgramBuilder.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/Dialect/QC/Translation/OpenQASMAttributes.h"
 #include "mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h"
 #include "mlir/Dialect/QC/Translation/TranslateQCToOpenQASM3.h"
+#include "mlir/Dialect/Utils/AngleConversion.h"
 #include "mlir/Support/Passes.h"
 #include "mlir/Target/OpenQASM/Frontend.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/APInt.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -29,9 +33,13 @@
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/Parser/Parser.h>
+#include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/Passes.h>
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <tuple>
 
@@ -80,7 +88,7 @@ TEST(OpenQASM3EmissionTest, EmitsStrictPortableBellProgram) {
   EXPECT_TRUE(qc::translateQASM3ToQC(*source, &context));
 }
 
-TEST(OpenQASM3EmissionTest, UsesCanonicalOutputTypesWithResultMetadata) {
+TEST(OpenQASM3EmissionTest, PreservesScalarOutputTypesWithResultMetadata) {
   constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
 include "stdgates.inc";
 output bit measured;
@@ -102,18 +110,57 @@ real = 3.0;
   ASSERT_TRUE(moduleOp);
   auto function = *moduleOp->getOps<func::FuncOp>().begin();
   ASSERT_EQ(function.getNumResults(), 6U);
-  EXPECT_TRUE(function.getAllResultAttrs());
+  ASSERT_TRUE(function.getAllResultAttrs());
+  for (size_t result = 2; result < function.getNumResults(); ++result) {
+    EXPECT_TRUE(function.getResultAttr(result, qc::openqasm::SCALAR_ATTR));
+  }
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("output bit[1] measured;"), std::string::npos);
   EXPECT_NE(emitted->find("output bit[1] vector;"), std::string::npos);
-  EXPECT_NE(emitted->find("output bool _mqt_out"), std::string::npos);
-  EXPECT_NE(emitted->find("output int _mqt_out"), std::string::npos);
-  EXPECT_NE(emitted->find("output float _mqt_out"), std::string::npos);
-  EXPECT_EQ(emitted->find("output uint "), std::string::npos);
+  EXPECT_NE(emitted->find("output bool flag;"), std::string::npos);
+  EXPECT_NE(emitted->find("output int signed_value;"), std::string::npos);
+  EXPECT_NE(emitted->find("output uint[64] unsigned_value;"),
+            std::string::npos);
+  EXPECT_NE(emitted->find("output float real;"), std::string::npos);
+  EXPECT_NE(emitted->find("vector[0] = _mqt_b0;"), std::string::npos);
   EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+}
+
+TEST(OpenQASM3EmissionTest, PreservesAngleCastsAcrossCanonicalization) {
+  constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
+include "stdgates.inc";
+input angle[8] narrow;
+input angle[16] wide;
+input float theta;
+output angle[16] widened;
+output angle[8] narrowed;
+output angle[8] quantized;
+widened = angle[16](narrow);
+narrowed = angle[8](wide);
+quantized = theta;
+qubit q;
+rx(quantized) q;
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  PassManager manager(&context);
+  manager.addPass(createCanonicalizerPass());
+  ASSERT_TRUE(succeeded(manager.run(*moduleOp)));
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("angle[16](narrow)"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("angle[8](wide)"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("angle[8](theta)"), std::string::npos) << *emitted;
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+      << *emitted;
 }
 
 TEST(OpenQASM3EmissionTest, RenamesOutputsThatCollideWithCompatibilityHelpers) {
@@ -132,7 +179,6 @@ r = measure q;
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("gate r("), std::string::npos);
-  EXPECT_NE(emitted->find("angle[64](bit[64](uint[64]("), std::string::npos);
   EXPECT_NE(emitted->find("output bit[1] _mqt_out0;"), std::string::npos);
   EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
       *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
@@ -317,8 +363,8 @@ gate pair(p0) q {
   z q;
 }
 qubit q;
-float theta = 0.25;
-inv @ pair(theta) q;
+input float theta;
+inv @pair(theta) q;
 )qasm";
   MLIRContext context;
   auto moduleOp = qc::translateQASM3ToQC(source, &context);
@@ -327,12 +373,202 @@ inv @ pair(theta) q;
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_NE(emitted->find("gate _mqt_gate0(p0)"), std::string::npos);
-  EXPECT_NE(emitted->find("angle[64](bit[64](uint[64]("), std::string::npos);
-  EXPECT_NE(emitted->find("inv @ _mqt_gate0("), std::string::npos);
+  EXPECT_NE(emitted->find("gate _mqt_gate0(p0)"), std::string::npos)
+      << *emitted;
+  EXPECT_NE(emitted->find("rx(p0)"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("inv @ _mqt_gate0(angle[64](theta))"),
+            std::string::npos)
+      << *emitted;
   EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
       *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
       << *emitted;
+}
+
+TEST(OpenQASM3EmissionTest,
+     ForwardsBitPatternAngleParametersWithoutBridgeCaptures) {
+  constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
+include "stdgates.inc";
+gate pair(theta) q {
+  rx(theta) q;
+  rz(theta) q;
+}
+input uint[64] raw;
+qubit q;
+inv @ pair(angle[64](bit[64](raw))) q;
+)qasm";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("gate _mqt_gate0(p0)"), std::string::npos)
+      << *emitted;
+  EXPECT_EQ(emitted->find("gate _mqt_gate0(p0, p1)"), std::string::npos)
+      << *emitted;
+  EXPECT_NE(emitted->find("rx(p0)"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("rz(p0)"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("inv @ _mqt_gate0(angle[64](bit[64](raw)))"),
+            std::string::npos)
+      << *emitted;
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+      << *emitted;
+}
+
+TEST(OpenQASM3EmissionTest,
+     ForwardsCompositeAngleDivisionWithoutSafetyMachinery) {
+  constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
+include "stdgates.inc";
+gate pair(theta, phi) q {
+  rx(angle[64](bit[64](theta / phi))) q;
+  rz(angle[64](bit[64](theta / phi))) q;
+}
+input angle[64] a;
+input angle[64] b;
+qubit q;
+inv @ pair(a, b) q;
+)qasm";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_EQ(emitted->find("division by zero"), std::string::npos) << *emitted;
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+      << *emitted;
+  EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+}
+
+TEST(OpenQASM3EmissionTest, OmitsCompositeAngleConversionInternals) {
+  constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
+include "stdgates.inc";
+gate pair(theta) q {
+  rx(sin(theta)) q;
+  rz(sin(theta)) q;
+}
+input angle[64] a;
+qubit q;
+inv @ pair(a) q;
+)qasm";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("gate _mqt_gate0(p0)"), std::string::npos)
+      << *emitted;
+  EXPECT_EQ(emitted->find("gate _mqt_gate0(p0,"), std::string::npos)
+      << *emitted;
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+      << *emitted;
+  EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+}
+
+TEST(OpenQASM3EmissionTest, InlinesCompositeIntegerConstants) {
+  constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
+include "stdgates.inc";
+gate pair(theta) q {
+  rx(theta << uint[64](1)) q;
+  rz(theta << uint[64](1)) q;
+}
+input angle[64] a;
+qubit q;
+inv @ pair(a) q;
+)qasm";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("gate _mqt_gate0(p0)"), std::string::npos)
+      << *emitted;
+  EXPECT_EQ(emitted->find("gate _mqt_gate0(p0, p1)"), std::string::npos)
+      << *emitted;
+  EXPECT_NE(emitted->find("p0 << 1"), std::string::npos) << *emitted;
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+      << *emitted;
+  EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+}
+
+TEST(OpenQASM3EmissionTest, RoundTripsAngleBitRegistersAndIndexing) {
+  constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
+include "stdgates.inc";
+input angle[8] source;
+qubit[8] q;
+bit[8] measured = measure q;
+output angle[8] packed;
+packed = angle[8](measured);
+output bit[8] unpacked;
+unpacked = bit[8](source);
+output bit selected;
+selected = source[-1];
+output bool any;
+any = bool(measured);
+)qasm";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("unpacked[3] = source[3];"), std::string::npos)
+      << *emitted;
+  EXPECT_NE(emitted->find("selected[0] = source[7];"), std::string::npos)
+      << *emitted;
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+      << *emitted;
+  EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+}
+
+TEST(OpenQASM3EmissionTest, RoundTripsWidthOneScalarArithmetic) {
+  constexpr std::array sources{
+      R"qasm(OPENQASM 3.1;
+input uint[1] a;
+output uint[1] b;
+b = a + uint[1](1);
+)qasm",
+      R"qasm(OPENQASM 3.1;
+input angle[1] a;
+input angle[1] b;
+output uint[1] ratio;
+ratio = a / b;
+)qasm",
+      R"qasm(OPENQASM 3.1;
+input uint[1] a;
+input uint[1] b;
+output uint[1] and_result;
+and_result = a & b;
+output uint[1] or_result;
+or_result = a | b;
+output uint[1] xor_result;
+xor_result = a ^ b;
+output bool nested;
+nested = (a & b) == a;
+)qasm",
+  };
+  for (const auto* const source : sources) {
+    SCOPED_TRACE(source);
+    MLIRContext context;
+    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    ASSERT_TRUE(moduleOp);
+    auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+    ASSERT_TRUE(succeeded(emitted));
+    EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted)) << *emitted;
+    EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+  }
 }
 
 TEST(OpenQASM3EmissionTest, EmitsSignedBooleanAndFloatingExpressions) {
@@ -588,6 +824,68 @@ TEST(OpenQASM3EmissionTest, LeavesDestinationEmptyOnFailure) {
   EXPECT_TRUE(output.empty());
 }
 
+TEST(OpenQASM3EmissionTest, RejectsNoncanonicalFinalGateAngleParameter) {
+  DialectRegistry registry = emissionDialects();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  builder.rz(0.1, qubit);
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  moduleOp->getOperation()->setAttr(mqt::angle::FINAL_QUANTIZATION_ATTR,
+                                    builder.getI32IntegerAttr(8));
+
+  EXPECT_TRUE(failed(qc::translateQCToOpenQASM3(*moduleOp)));
+}
+
+TEST(OpenQASM3EmissionTest, EmitsCanonicalConstantGateAngleBitsExactly) {
+  constexpr uint64_t bits = 5606474087937741380ULL;
+  constexpr double radians = -331.099188042606;
+  DialectRegistry registry = emissionDialects();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  builder.rz(radians, qubit);
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  qc::RZOp rz;
+  moduleOp->walk([&](qc::RZOp operation) { rz = operation; });
+  ASSERT_TRUE(rz);
+  builder.setInsertionPoint(rz);
+  rz.getThetaMutable().assign(mqt::angle::buildQuantizedRadians(
+      builder, rz.getLoc(), rz.getTheta(), 64));
+  moduleOp->getOperation()->setAttr(mqt::angle::FINAL_QUANTIZATION_ATTR,
+                                    builder.getI32IntegerAttr(64));
+
+  const auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("5606474087937741380"), std::string::npos)
+      << *emitted;
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted)) << *emitted;
+}
+
+TEST(OpenQASM3EmissionTest, RejectsOversizedGateAnglePrecisionMetadata) {
+  DialectRegistry registry = emissionDialects();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  builder.rz(0.1, qubit);
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  moduleOp->getOperation()->setAttr(
+      mqt::angle::FINAL_QUANTIZATION_ATTR,
+      IntegerAttr::get(IntegerType::get(&context, 128),
+                       llvm::APInt::getOneBitSet(128, 100)));
+
+  EXPECT_TRUE(failed(qc::translateQCToOpenQASM3(*moduleOp)));
+}
+
 TEST(OpenQASM3EmissionTest, RejectsInvalidModifierBodies) {
   DialectRegistry registry = emissionDialects();
   MLIRContext context(registry);
@@ -684,34 +982,6 @@ TEST(OpenQASM3EmissionTest, RejectsUnsupportedSubsetConcerns) {
           return %memory : memref<1x!qc.qubit>
         }
       })mlir"},
-      Fixture{.name = "unsupported-expression-width", .source = R"mlir(module {
-        func.func @main() {
-          %one = arith.constant 1 : i32
-          %sum = arith.addi %one, %one : i32
-          return
-        }
-      })mlir"},
-      Fixture{.name = "sign-extension", .source = R"mlir(module {
-        func.func @main() -> i64 {
-          %value = arith.constant true
-          %extended = arith.extsi %value : i1 to i64
-          return %extended : i64
-        }
-      })mlir"},
-      Fixture{.name = "integer-truncation", .source = R"mlir(module {
-        func.func @main() -> i1 {
-          %value = arith.constant 2 : i64
-          %truncated = arith.trunci %value : i64 to i1
-          return %truncated : i1
-        }
-      })mlir"},
-      Fixture{.name = "packed-bitwise", .source = R"mlir(module {
-        func.func @main() -> i64 {
-          %one = arith.constant 1 : i64
-          %value = arith.andi %one, %one : i64
-          return %value : i64
-        }
-      })mlir"},
       Fixture{.name = "unordered-float-comparison", .source = R"mlir(module {
         func.func @main() -> i1 {
           %one = arith.constant 1.0 : f64
@@ -774,79 +1044,10 @@ TEST(OpenQASM3EmissionTest, RejectsUnsupportedSubsetConcerns) {
           return %value : i64
         }
       })mlir"},
-      Fixture{.name = "unsigned-arithmetic", .source = R"mlir(module {
-        func.func @main() -> i64 {
-          %one = arith.constant 1 : i64
-          %value = arith.divui %one, %one : i64
-          return %value : i64
-        }
-      })mlir"},
-      Fixture{.name = "unsigned-comparison", .source = R"mlir(module {
-        func.func @main() -> i1 {
-          %one = arith.constant 1 : i64
-          %value = arith.cmpi ult, %one, %one : i64
-          return %value : i1
-        }
-      })mlir"},
-      Fixture{.name = "unsigned-cast", .source = R"mlir(module {
-        func.func @main() -> f64 {
-          %one = arith.constant 1 : i64
-          %value = arith.uitofp %one : i64 to f64
-          return %value : f64
-        }
-      })mlir"},
       Fixture{.name = "unsupported-output", .source = R"mlir(module {
         func.func @main() -> f32 {
           %value = arith.constant 1.0 : f32
           return %value : f32
-        }
-      })mlir"},
-      Fixture{.name = "if-result", .source = R"mlir(module {
-        func.func @main() -> i64 {
-          %condition = arith.constant true
-          %one = arith.constant 1 : i64
-          %value = scf.if %condition -> i64 {
-            scf.yield %one : i64
-          } else {
-            scf.yield %one : i64
-          }
-          return %value : i64
-        }
-      })mlir"},
-      Fixture{.name = "for-iterated-state", .source = R"mlir(module {
-        func.func @main() -> i64 {
-          %zero = arith.constant 0 : index
-          %one = arith.constant 1 : index
-          %initial = arith.constant 0 : i64
-          %value = scf.for %i = %zero to %one step %one
-              iter_args(%state = %initial) -> i64 {
-            scf.yield %state : i64
-          }
-          return %value : i64
-        }
-      })mlir"},
-      Fixture{.name = "while-state", .source = R"mlir(module {
-        func.func @main() {
-          %initial = arith.constant 0 : i64
-          %value = scf.while (%state = %initial) : (i64) -> i64 {
-            %condition = arith.constant false
-            scf.condition(%condition) %state : i64
-          } do {
-          ^bb0(%state: i64):
-            scf.yield %state : i64
-          }
-          return
-        }
-      })mlir"},
-      Fixture{.name = "switch-result", .source = R"mlir(module {
-        func.func @main() -> i64 {
-          %index = arith.constant 0 : index
-          %one = arith.constant 1 : i64
-          %value = scf.index_switch %index -> i64
-          default {
-            scf.yield %one : i64
-          }
-          return %value : i64
         }
       })mlir"},
       Fixture{.name = "dynamic-index", .source = R"mlir(module {

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -11,16 +11,21 @@
 #include "OpenQASMTestUtils.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/Dialect/QC/Translation/OpenQASMAttributes.h"
 #include "mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h"
+#include "mlir/Dialect/QC/Translation/TranslateQCToOpenQASM3.h"
 #include "mlir/Dialect/Utils/AngleConversion.h"
+#include "mlir/Support/Passes.h"
 #include "mlir/Target/OpenQASM/Frontend.h"
 #include "qasm_programs.h"
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/Sequence.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -53,6 +58,631 @@ using namespace mlir::oq3::test;
 
 namespace {
 
+TEST(OpenQASMTargetTest, LowersAnglesToBuiltinIntegersAndRoundTripsMetadata) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+input angle[8] theta;
+output angle[8] result;
+result = theta + angle[8](pi / 2.0);
+qubit q;
+rx(result) q;
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto function = *moduleOp->getOps<func::FuncOp>().begin();
+  ASSERT_EQ(function.getNumArguments(), 1);
+  ASSERT_EQ(function.getNumResults(), 1);
+  EXPECT_TRUE(function.getArgumentTypes().front().isInteger(8));
+  EXPECT_TRUE(function.getResultTypes().front().isInteger(8));
+  EXPECT_TRUE(function.getArgAttr(0, qc::openqasm::SCALAR_ATTR));
+  EXPECT_TRUE(function.getResultAttr(0, qc::openqasm::SCALAR_ATTR));
+
+  size_t angleAdds = 0;
+  size_t angleBridges = 0;
+  moduleOp->walk([&](Operation* operation) {
+    if (auto add = dyn_cast<arith::AddIOp>(operation)) {
+      angleAdds += add.getType().isInteger(8);
+    }
+    if (auto conversion = dyn_cast<arith::UIToFPOp>(operation)) {
+      angleBridges += conversion.getIn().getType().isInteger(64);
+    }
+  });
+  EXPECT_EQ(angleAdds, 1);
+  EXPECT_EQ(angleBridges, 1);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("input angle[8] theta;"), std::string::npos);
+  EXPECT_NE(emitted->find("output angle[8] result;"), std::string::npos);
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << "\n"
+                        << *emitted;
+}
+
+TEST(OpenQASMTargetTest, RoundTripsEveryScalarInterfaceKind) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input bool input_bool;
+input int input_int;
+input uint[8] input_uint;
+input float input_float;
+input angle[8] input_angle;
+output bool output_bool;
+output int output_int;
+output uint[8] output_uint;
+output float output_float;
+output angle[8] output_angle;
+output_bool = bool(input_angle);
+output_int = int(input_uint);
+output_uint = uint[8](input_int);
+output_float = float(input_int);
+output_angle = angle[8](input_float);
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  auto function = *moduleOp->getOps<func::FuncOp>().begin();
+  ASSERT_EQ(function.getNumArguments(), 5);
+  ASSERT_EQ(function.getNumResults(), 5);
+  for (const auto index : llvm::seq<size_t>(0, 5)) {
+    EXPECT_TRUE(function.getArgAttr(index, qc::openqasm::SCALAR_ATTR));
+    EXPECT_TRUE(function.getResultAttr(index, qc::openqasm::SCALAR_ATTR));
+  }
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  for (const llvm::StringRef declaration :
+       {"input bool input_bool;", "input int input_int;",
+        "input uint[8] input_uint;", "input float input_float;",
+        "input angle[8] input_angle;", "output bool output_bool;",
+        "output int output_int;", "output uint[8] output_uint;",
+        "output float output_float;", "output angle[8] output_angle;"}) {
+    EXPECT_NE(emitted->find(declaration), std::string::npos) << *emitted;
+  }
+
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+  auto reimported = qc::translateQASM3ToQC(*emitted, &context);
+  ASSERT_TRUE(reimported);
+  EXPECT_TRUE(succeeded(verify(*reimported)));
+}
+
+TEST(OpenQASMTargetTest, EmitsCanonicalRuntimeFloatToAngleConversion) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input float theta;
+output angle[8] result;
+result = theta;
+qubit q;
+gphase(result);
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  size_t truncations = 0;
+  size_t exactConversions = 0;
+  moduleOp->walk([&](Operation* operation) {
+    if (auto truncation = dyn_cast<arith::TruncIOp>(operation)) {
+      truncations += truncation.getType().isInteger(8);
+      exactConversions += mqt::angle::matchFloatToBits(truncation).has_value();
+    }
+  });
+  EXPECT_EQ(truncations, 1);
+  EXPECT_EQ(exactConversions, 1);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("angle[8](theta)"), std::string::npos);
+  EXPECT_EQ(emitted->find("_mqt_roundeven"), std::string::npos) << *emitted;
+}
+
+TEST(OpenQASMTargetTest, RecognizesCommutedCanonicalAngleConversions) {
+  MLIRContext context;
+  context
+      .loadDialect<arith::ArithDialect, func::FuncDialect, math::MathDialect>();
+  OpBuilder builder(&context);
+  auto module = ModuleOp::create(builder.getUnknownLoc());
+  const auto loc = builder.getUnknownLoc();
+  auto function =
+      func::FuncOp::create(builder, loc, "conversion_matchers",
+                           builder.getFunctionType({builder.getF64Type()}, {}));
+  module.push_back(function);
+  auto* block = function.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  auto bits = arith::ConstantIntOp::create(builder, loc, 64, 8).getResult();
+  EXPECT_EQ(mqt::angle::buildResize(builder, loc, bits, 8), bits);
+
+  auto radians = mqt::angle::buildBitsToRadians(builder, loc, bits);
+  auto scaledRadians = radians.getDefiningOp<arith::MulFOp>();
+  ASSERT_TRUE(scaledRadians);
+  const auto converted = scaledRadians.getLhs();
+  const auto scale = scaledRadians.getRhs();
+  scaledRadians->setOperand(0, scale);
+  scaledRadians->setOperand(1, converted);
+  const auto quantized = mqt::angle::matchQuantizedRadians(radians);
+  ASSERT_TRUE(quantized);
+  EXPECT_EQ(quantized->bits, bits);
+
+  auto one =
+      arith::ConstantOp::create(builder, loc, builder.getF64FloatAttr(1.0))
+          .getResult();
+  auto nonCanonical = arith::MulFOp::create(builder, loc, one, one).getResult();
+  EXPECT_FALSE(mqt::angle::matchQuantizedRadians(nonCanonical));
+  auto invalidScale =
+      arith::MulFOp::create(builder, loc, converted, one).getResult();
+  EXPECT_FALSE(mqt::angle::matchQuantizedRadians(invalidScale));
+
+  const auto input = block->getArgument(0);
+  auto encoded = mqt::angle::buildFloatToBits(builder, loc, input, 8);
+  auto truncated = encoded.getDefiningOp<arith::TruncIOp>();
+  ASSERT_TRUE(truncated);
+  const auto decoded = mqt::angle::matchFloatToBits(encoded);
+  ASSERT_TRUE(decoded);
+  EXPECT_EQ(*decoded, input);
+}
+
+TEST(OpenQASMTargetTest, LowersAndRoundTripsScalarAngleBitBuiltins) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+input angle[8] theta;
+input uint[8] bits;
+input int distance;
+output angle[8] rotated_angle;
+output uint[8] rotated_uint;
+output uint count;
+rotated_angle = rotl(theta, distance);
+rotated_uint = rotr(bits, distance);
+count = popcount(rotated_angle);
+qubit q;
+rz(rotated_angle) q;
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  const auto countOperations = [](ModuleOp module) {
+    std::array<size_t, 3> counts{};
+    module.walk([&](Operation* operation) {
+      counts[0] += isa<LLVM::FshlOp>(operation);
+      counts[1] += isa<LLVM::FshrOp>(operation);
+      counts[2] += isa<math::CtPopOp>(operation);
+    });
+    return counts;
+  };
+  EXPECT_EQ(countOperations(*moduleOp), (std::array<size_t, 3>{1, 1, 1}));
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("rotated_angle = rotl(theta, int("),
+            std::string::npos)
+      << *emitted;
+  EXPECT_NE(emitted->find("rotated_uint = rotr(bits, int("), std::string::npos)
+      << *emitted;
+  EXPECT_NE(emitted->find("count = uint[64](popcount(rotl(theta, int("),
+            std::string::npos)
+      << *emitted;
+
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+  auto reimported = qc::translateQASM3ToQC(*emitted, &context);
+  ASSERT_TRUE(reimported);
+  ASSERT_TRUE(succeeded(verify(*reimported)));
+  const auto reimportedCounts = countOperations(*reimported);
+  EXPECT_GE(reimportedCounts[0], 1);
+  EXPECT_EQ(reimportedCounts[1], 1);
+  EXPECT_EQ(reimportedCounts[2], 1);
+}
+
+TEST(OpenQASMTargetTest, EmitsCanonicalRuntimeFloatToAngle64Conversion) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input float theta;
+output angle[64] result;
+result = theta;
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("angle[64](theta)"), std::string::npos) << *emitted;
+  EXPECT_EQ(emitted->find("roundeven"), std::string::npos) << *emitted;
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted));
+}
+
+TEST(OpenQASMTargetTest, EmitsUnsignedHighBitPatternsExactly) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+const uint maximum = 18446744073709551615;
+output uint[8] byte;
+output angle[64] angle_bits;
+byte = uint[8](255);
+angle_bits = angle[64](bit[64](uint[64](maximum)));
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("byte = 255;"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("18446744073709551615"), std::string::npos)
+      << *emitted;
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+}
+
+TEST(OpenQASMTargetTest, PreservesAngleBitPatternCastsInUintContexts) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input angle[8] theta;
+output uint[8] bits;
+output bool high_half;
+bits = uint[8](bit[8](theta));
+high_half = bits >= uint[8](128);
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("uint[8](bit[8](theta))"), std::string::npos)
+      << *emitted;
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+}
+
+TEST(OpenQASMTargetTest, KeepsCustomGateParametersAsAngleBits) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+gate half(theta) q {
+  rz(theta / 2) q;
+}
+input angle[64] theta;
+qubit q;
+half(theta) q;
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  size_t radiansBridges = 0;
+  size_t floatToAngleConversions = 0;
+  moduleOp->walk([&](Operation* operation) {
+    radiansBridges += isa<arith::UIToFPOp>(operation);
+    for (const auto result : operation->getResults()) {
+      floatToAngleConversions +=
+          mqt::angle::matchFloatToBits(result).has_value();
+    }
+  });
+  EXPECT_EQ(radiansBridges, 1);
+  EXPECT_EQ(floatToAngleConversions, 0);
+}
+
+TEST(OpenQASMTargetTest, LowersDynamicAngleAndUintBooleanCasts) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input angle[8] theta;
+input uint[8] count;
+input float value;
+output bool has_theta;
+output bool has_count;
+output bool has_value;
+has_theta = bool(theta);
+has_count = bool(count);
+has_value = bool(value);
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("theta != angle[8](bit[8](uint[8](0)))"),
+            std::string::npos)
+      << *emitted;
+  EXPECT_NE(emitted->find("count != 0"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("value != 0.0"), std::string::npos) << *emitted;
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+}
+
+TEST(OpenQASMTargetTest, CollapsesSafeDynamicAngleShifts) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+input angle[8] theta;
+input uint distance;
+output angle[8] left;
+output angle[8] right;
+left = theta << distance;
+right = theta >> distance;
+qubit q;
+rx(left) q;
+rz(right) q;
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("theta << distance"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("theta >> distance"), std::string::npos) << *emitted;
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+}
+
+TEST(OpenQASMTargetTest, CollapsesCanonicalAngleWideningAndNarrowing) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input angle[4] narrow;
+input angle[8] wide;
+output angle[8] widened;
+output angle[4] narrowed;
+widened = angle[8](narrow);
+narrowed = angle[4](wide);
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("angle[8](narrow)"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("angle[4](wide)"), std::string::npos) << *emitted;
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+}
+
+TEST(OpenQASMTargetTest, CarriesBuiltinIntegerAnglesThroughStructuredControl) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+input angle[8] theta;
+input uint[8] factor;
+input bool repeat;
+input int selector;
+output angle[8] result;
+result = theta;
+if (factor != uint[8](0)) { result = result * factor; }
+for int i in [0:1] {
+  result = result + angle[8](pi / 4.0);
+}
+while (repeat) {
+  result = -result;
+  repeat = false;
+}
+switch (selector) {
+  case 1 { result = result + angle[8](pi / 2.0); }
+  default { result = result + angle[8](pi / 4.0); }
+}
+qubit q;
+rx(result) q;
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  size_t angleMultiplications = 0;
+  size_t angleAdditions = 0;
+  size_t angleNegations = 0;
+  size_t angleIfResults = 0;
+  size_t angleForResults = 0;
+  size_t angleWhileResults = 0;
+  size_t angleSwitchResults = 0;
+  moduleOp->walk([&](Operation* operation) {
+    if (auto multiplication = dyn_cast<arith::MulIOp>(operation)) {
+      angleMultiplications += multiplication.getType().isInteger(8);
+    }
+    if (auto addition = dyn_cast<arith::AddIOp>(operation)) {
+      angleAdditions += addition.getType().isInteger(8);
+    }
+    if (auto subtraction = dyn_cast<arith::SubIOp>(operation)) {
+      angleNegations += subtraction.getType().isInteger(8);
+    }
+    if (auto conditional = dyn_cast<scf::IfOp>(operation)) {
+      angleIfResults +=
+          llvm::count_if(conditional.getResultTypes(),
+                         [](Type type) { return type.isInteger(8); });
+    }
+    if (auto loop = dyn_cast<scf::ForOp>(operation)) {
+      angleForResults += llvm::count_if(
+          loop.getResultTypes(), [](Type type) { return type.isInteger(8); });
+    }
+    if (auto loop = dyn_cast<scf::WhileOp>(operation)) {
+      angleWhileResults += llvm::count_if(
+          loop.getResultTypes(), [](Type type) { return type.isInteger(8); });
+    }
+    if (auto switchOp = dyn_cast<scf::IndexSwitchOp>(operation)) {
+      angleSwitchResults +=
+          llvm::count_if(switchOp.getResultTypes(),
+                         [](Type type) { return type.isInteger(8); });
+    }
+  });
+  EXPECT_EQ(angleMultiplications, 1);
+  EXPECT_GE(angleAdditions, 1);
+  EXPECT_EQ(angleNegations, 1);
+  EXPECT_GE(angleIfResults, 1);
+  EXPECT_GE(angleForResults, 1);
+  EXPECT_GE(angleWhileResults, 1);
+  EXPECT_GE(angleSwitchResults, 1);
+
+  std::string ir;
+  llvm::raw_string_ostream stream(ir);
+  moduleOp->print(stream);
+  EXPECT_EQ(ir.find("!quant."), std::string::npos);
+  EXPECT_EQ(ir.find("mqt.angle"), std::string::npos);
+
+  ASSERT_TRUE(succeeded(runQCCleanupPipeline(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("angle[8] _mqt_s"), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("while ("), std::string::npos) << *emitted;
+  EXPECT_NE(emitted->find("switch (selector)"), std::string::npos) << *emitted;
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+}
+
+TEST(OpenQASMTargetTest, UsesUnsignedIntegerAngleOperations) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input angle[8] lhs;
+input angle[8] rhs;
+input uint[8] divisor;
+output angle[8] quotient;
+output uint[8] ratio;
+output angle[8] bits;
+output angle[8] conjunction;
+output angle[8] disjunction;
+output angle[8] negated;
+output bool less;
+quotient = lhs / divisor;
+ratio = lhs / rhs;
+bits = ~(lhs ^ rhs);
+conjunction = lhs & rhs;
+disjunction = lhs | rhs;
+negated = -lhs;
+less = lhs < rhs;
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  size_t unsignedDivisions = 0;
+  size_t bitwiseAnd = 0;
+  size_t bitwiseOrs = 0;
+  size_t bitwiseXors = 0;
+  size_t unsignedComparisons = 0;
+  moduleOp->walk([&](Operation* operation) {
+    unsignedDivisions += isa<arith::DivUIOp>(operation);
+    if (auto bitwise = dyn_cast<arith::AndIOp>(operation)) {
+      bitwiseAnd += bitwise.getType().isInteger(8);
+    }
+    if (auto bitwise = dyn_cast<arith::OrIOp>(operation)) {
+      bitwiseOrs += bitwise.getType().isInteger(8);
+    }
+    if (auto bitwise = dyn_cast<arith::XOrIOp>(operation)) {
+      bitwiseXors += bitwise.getType().isInteger(8);
+    }
+    if (auto comparison = dyn_cast<arith::CmpIOp>(operation)) {
+      unsignedComparisons +=
+          comparison.getPredicate() == arith::CmpIPredicate::ult;
+    }
+  });
+  EXPECT_EQ(unsignedDivisions, 2);
+  EXPECT_EQ(bitwiseAnd, 1);
+  EXPECT_EQ(bitwiseOrs, 1);
+  EXPECT_EQ(bitwiseXors, 2);
+  EXPECT_EQ(unsignedComparisons, 1);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+}
+
+TEST(OpenQASMTargetTest, PreservesAngleOperandsOfComparisonsAndAngleDivision) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input angle[8] theta;
+output bool less_than_pi;
+output uint[8] ratio_to_pi;
+output bool less_than_computed;
+less_than_pi = theta < angle[8](pi);
+ratio_to_pi = theta / angle[8](pi);
+less_than_computed = theta < (theta + angle[8](pi));
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
+
+  bool sawConstantComparison = false;
+  bool sawAngleDivision = false;
+  bool sawComputedComparison = false;
+  for (const auto statementId : reparsed.program->body) {
+    const auto* assignment =
+        std::get_if<oq3::frontend::ScalarAssignmentStatement>(
+            &reparsed.program->statements[statementId].data);
+    if (assignment == nullptr) {
+      continue;
+    }
+    const auto& scalar = reparsed.program->scalars[assignment->scalar];
+    if (scalar.name == "ratio_to_pi") {
+      ASSERT_TRUE(assignment->value);
+      const auto& division = reparsed.program->expressions[*assignment->value];
+      ASSERT_EQ(division.kind, oq3::frontend::ExpressionKind::Divide);
+      const auto& denominator = reparsed.program->expressions[division.rhs];
+      EXPECT_EQ(denominator.type, oq3::frontend::ScalarType::Angle);
+      ASSERT_EQ(denominator.kind, oq3::frontend::ExpressionKind::Constant);
+      EXPECT_EQ(std::get<uint64_t>(denominator.constant), 128);
+      sawAngleDivision = true;
+      continue;
+    }
+    ASSERT_TRUE(assignment->condition);
+    const auto& comparison =
+        reparsed.program->conditions[*assignment->condition];
+    ASSERT_EQ(comparison.kind, oq3::frontend::ConditionKind::Comparison);
+    const auto& rhs = reparsed.program->expressions[comparison.comparisonRhs];
+    EXPECT_EQ(rhs.type, oq3::frontend::ScalarType::Angle);
+    if (scalar.name == "less_than_pi") {
+      ASSERT_EQ(rhs.kind, oq3::frontend::ExpressionKind::Constant);
+      EXPECT_EQ(std::get<uint64_t>(rhs.constant), 128);
+      sawConstantComparison = true;
+    } else if (scalar.name == "less_than_computed") {
+      EXPECT_EQ(rhs.kind, oq3::frontend::ExpressionKind::Add);
+      EXPECT_EQ(rhs.type, oq3::frontend::ScalarType::Angle);
+      sawComputedComparison = true;
+    }
+  }
+  EXPECT_TRUE(sawConstantComparison);
+  EXPECT_TRUE(sawAngleDivision);
+  EXPECT_TRUE(sawComputedComparison);
+}
+
 TEST(OpenQASMTargetTest, EmitsVerifiedQCDirectly) {
   MLIRContext context;
   auto moduleOp = qc::translateQASM3ToQC(BROADCAST_PROGRAM, &context);
@@ -82,7 +712,7 @@ TEST(OpenQASMTargetTest, EmitsTypedGateAngleExpressions) {
 OPENQASM 3.0;
 include "stdgates.inc";
 gate shifted(theta) q {
-  rx(theta + angle[64](1.0)) q;
+  rx(theta + angle(1.0)) q;
 }
 qubit q;
 shifted(0.5) q;
@@ -92,6 +722,30 @@ shifted(0.5) q;
   auto moduleOp = qc::translateQASM3ToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
+}
+
+TEST(OpenQASMTargetTest, NormalizesDynamicSignedScalarBitIndices) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input angle[8] value;
+input int index;
+output bit selected;
+selected = value[index];
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  bool sawNormalization = false;
+  bool sawBoundsCheck = false;
+  moduleOp->walk([&](arith::SelectOp) { sawNormalization = true; });
+  moduleOp->walk([&](cf::AssertOp assertion) {
+    sawBoundsCheck |= assertion.getMsg() == "scalar bit index out of bounds";
+  });
+  EXPECT_TRUE(sawNormalization);
+  EXPECT_TRUE(sawBoundsCheck);
 }
 
 TEST(OpenQASMTargetTest, EmitsScalarMathFunctions) {
@@ -1494,6 +2148,26 @@ bit[2] result = measure q;
   EXPECT_GE(aliasAssertions, 3);
 }
 
+TEST(OpenQASMTargetTest, ExtendsNarrowUnsignedDynamicIndices) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+input uint[8] index;
+qubit[3] q;
+x q[index];
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  size_t indexExtensions = 0;
+  moduleOp->walk([&](arith::ExtUIOp extension) {
+    indexExtensions += extension.getIn().getType().isInteger(8) &&
+                       extension.getType().isInteger(64);
+  });
+  EXPECT_EQ(indexExtensions, 1);
+}
+
 TEST(OpenQASMTargetTest, LoadsDynamicQubitGatesDirectly) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
@@ -2291,6 +2965,14 @@ result = measure q;
     EXPECT_EQ(loop.getBeforeBody()->getTerminator()->getNumOperands(), 2);
     EXPECT_EQ(loop.getAfterBody()->getTerminator()->getNumOperands(), 1);
   });
+
+  ASSERT_TRUE(succeeded(runQCCleanupPipeline(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_NE(emitted->find("bit _mqt_s"), std::string::npos) << *emitted;
+  auto reparsed = oq3::frontend::analyzeOpenQASM(*emitted);
+  ASSERT_TRUE(reparsed) << reparsed.diagnostics.front().message << '\n'
+                        << *emitted;
 }
 
 TEST(OpenQASMTargetTest, CarriesEveryPotentiallyMutatedDynamicBit) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Preserve fixed-width angle semantics when exporting QC MLIR back to OpenQASM 3.

- Reconstruct canonical integer-to-angle and float-to-angle conversions as official `angle[N]` casts.
- Preserve angle-valued inputs, outputs, arithmetic, comparisons, divisions, casts, custom-gate captures, and structured loop-carried state.
- Emit legal bit-register intermediates where exact angle bit patterns must be reconstructed.
- Keep the contract semantic: exported OpenQASM reparses to the same angle bit patterns and gate parameters.

Depends on #2040.

## Validation

- OpenQASM target and QC translation suites pass locally.
- Round-trip coverage includes constants, dynamic values, bit-pattern casts, composite helpers, scalar widths 1 through 64, and structured control flow.
- The final aggregate stack builds successfully and passes all 4,547 discovered CTests; two live QDMI job-ID tests are skipped by design.
- Repository lint and `git diff --check` pass.

GPT-5.6 via Codex materially assisted with implementation, independent review remediation, testing, restacking, and publication under maintainer direction.