### PR TITLE
✨ Add terminal QCO gate-angle quantization

### DIFF
--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -638,6 +638,10 @@ operations.)pb");
            &BooleanMemberAdapter<
                &mlir::QCOProgram::mergeSingleQubitRotationGates>::call,
            "Merge compatible consecutive single-qubit rotation gates.")
+      .def("quantize_gate_angles",
+           &BooleanMemberAdapter<&mlir::QCOProgram::quantizeGateAngles>::call,
+           nb::kw_only(), "precision_bits"_a,
+           "Quantize gate parameters to fixed-width OpenQASM angles.")
       .def(
           "fuse_single_qubit_unitary_runs",
           &BooleanMemberAdapter<

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -149,6 +149,22 @@ assert not qco.is_valid
 print(final_qc.ir)
 ```
 
+Hardware angle precision is an explicit post-synthesis choice. Apply it after
+the last synthesis or fusion pass, because those transformations may introduce
+new parameters:
+
+```{code-cell} ipython3
+qco = qc.to_qco(copy=True)
+qco.merge_single_qubit_rotation_gates()
+qco.quantize_gate_angles(precision_bits=8)
+quantized_qc = qco.to_qc()
+```
+
+The equivalent textual module pass is `quantize-gate-angles{precision-bits=8}`.
+Valid precision values are 1 through 64. Repeating the pass at the same
+precision is idempotent; applying another precision composes another
+OpenQASM-defined angle conversion.
+
 Architecture-independent QCO transformations can also be composed with MLIR's
 textual pass-pipeline syntax. The same pass names and options are accepted by
 {code}`mqt-cc`:
@@ -187,7 +203,14 @@ controls before applying the raw {code}`reuse-qubits` pass.
 
 The {code}`qco_pipeline` argument replaces the default QCO optimization
 pipeline. It is applied when compilation proceeds beyond the raw
-{code}`OutputFormat.QCO` checkpoint.
+{code}`OutputFormat.QCO` checkpoint. The compiler applies full cleanup before a
+custom pipeline and normally cleans up its result again. Keep
+`quantize-gate-angles` last so no later synthesis or fusion pass creates
+unquantized parameters. The pass marks that terminal precision stage; subsequent
+QC and QCO cleanup calls become no-ops so the canonical conversion sequences and
+emitted OpenQASM `angle[N]` casts remain intact. Export rejects a marked module
+if a later transformation changed a gate parameter. Code using the program API
+should therefore call `cleanup()` before `quantize_gate_angles()`.
 
 ## Serialize programs and generate QIR
 

--- a/mlir/include/mlir/Compiler/Programs.h
+++ b/mlir/include/mlir/Compiler/Programs.h
@@ -211,6 +211,9 @@ public:
   /// Merge consecutive single-qubit rotation gates.
   [[nodiscard]] bool mergeSingleQubitRotationGates();
 
+  /// Quantize gate parameters to fixed-width OpenQASM angles.
+  [[nodiscard]] bool quantizeGateAngles(uint32_t precisionBits);
+
   /// Fuse single-qubit unitary runs into the selected Euler basis.
   [[nodiscard]] bool fuseSingleQubitUnitaryRuns(std::string_view basis = "zyz");
 

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -90,6 +90,24 @@ def FuseSingleQubitUnitaryRuns
       "Target Euler basis (zyz, zxz, xzx, xyx, u, zsxx, r).">];
 }
 
+def QuantizeGateAngles : Pass<"quantize-gate-angles", "mlir::ModuleOp"> {
+  let dependentDialects = ["mlir::qco::QCODialect",
+                           "::mlir::arith::ArithDialect"];
+  let summary = "Quantize QCO gate parameters as fixed-width OpenQASM angles";
+  let description = [{
+    Replaces every actual gate parameter with its nearest OpenQASM
+    `angle[N]` value, where `N` is selected by `precision-bits`. Conversion is
+    modulo 2*pi and uses round-to-nearest, ties-to-even. Both compile-time
+    constants and run-time SSA values are supported.
+
+    The pass walks gates nested in control, inverse, and power modifiers.
+    Run this opt-in pass after the final synthesis or fusion pass, because
+    later transformations may introduce new gate parameters.
+  }];
+  let options = [Option<"precisionBits", "precision-bits", "uint32_t", "0",
+                        "Required angle precision in bits (1 through 64).">];
+}
+
 //===----------------------------------------------------------------------===//
 
 def QuantumLoopUnroll

--- a/mlir/include/mlir/Support/Passes.h
+++ b/mlir/include/mlir/Support/Passes.h
@@ -51,15 +51,21 @@ runPassPipeline(mlir::ModuleOp module, mlir::StringRef pipeline,
 
 /**
  * @brief Populate a QC-oriented cleanup pipeline on the given pass manager.
- * @details Adds generic cleanup and QC qubit-register shrinking.
+ * @details Adds generic cleanup and QC qubit-register shrinking. A terminally
+ * quantized module must pass @p preserveQuantizedAngles to keep its canonical
+ * angle-conversion sequences intact; no cleanup passes are added in that case.
  */
-void populateQCCleanupPipeline(mlir::OpPassManager& pm);
+void populateQCCleanupPipeline(mlir::OpPassManager& pm,
+                               bool preserveQuantizedAngles = false);
 
 /**
  * @brief Populate a QCO-oriented cleanup pipeline on the given pass manager.
- * @details Adds generic cleanup and qtensor shrink-to-fit.
+ * @details Adds generic cleanup and qtensor shrink-to-fit. A terminally
+ * quantized module must pass @p preserveQuantizedAngles to keep its canonical
+ * angle-conversion sequences intact; no cleanup passes are added in that case.
  */
-void populateQCOCleanupPipeline(mlir::OpPassManager& pm);
+void populateQCOCleanupPipeline(mlir::OpPassManager& pm,
+                                bool preserveQuantizedAngles = false);
 
 /**
  * @brief Populate a QIR-oriented cleanup pipeline on the given pass manager.

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -300,10 +300,7 @@ QCProgram::fromQuantumComputation(const ::qc::QuantumComputation& computation) {
 
 QCProgram QCProgram::copy() const { return QCProgram(cloneStorage()); }
 
-bool QCProgram::cleanup() {
-  return succeeded(runPasses(mod(), populateQCCleanupPipeline,
-                             "failed to run the QC cleanup pipeline"));
-}
+bool QCProgram::cleanup() { return succeeded(runQCCleanupPipeline(mod())); }
 
 bool QCProgram::normalizeGlobalPhases() {
   return succeeded(mlir::mqt::normalizeGlobalPhases(mod()));
@@ -371,10 +368,7 @@ QCOProgram::fromMLIRFile(const std::filesystem::path& path) {
 
 QCOProgram QCOProgram::copy() const { return QCOProgram(cloneStorage()); }
 
-bool QCOProgram::cleanup() {
-  return succeeded(runPasses(mod(), populateQCOCleanupPipeline,
-                             "failed to run the QCO cleanup pipeline"));
-}
+bool QCOProgram::cleanup() { return succeeded(runQCOCleanupPipeline(mod())); }
 
 bool QCOProgram::normalizeGlobalPhases() {
   return succeeded(mlir::mqt::normalizeGlobalPhases(mod()));
@@ -394,6 +388,17 @@ bool QCOProgram::mergeSingleQubitRotationGates() {
         pm.addPass(qco::createMergeSingleQubitRotationGates());
       },
       "failed to merge single-qubit rotation gates"));
+}
+
+bool QCOProgram::quantizeGateAngles(const uint32_t precisionBits) {
+  qco::QuantizeGateAnglesOptions options;
+  options.precisionBits = precisionBits;
+  return succeeded(runPasses(
+      mod(),
+      [&options](OpPassManager& pm) {
+        pm.addPass(qco::createQuantizeGateAngles(options));
+      },
+      "failed to quantize QCO gate angles"));
 }
 
 bool QCOProgram::fuseSingleQubitUnitaryRuns(const std::string_view basis) {

--- a/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_library(
   MLIRQTensorUtils
   MLIRArithDialect
   MLIRMathDialect
+  MLIRMQTAngleUtils
   MLIRMQTTransforms
   MLIRSCFUtils
   DEPENDS

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/QuantizeGateAngles.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/QuantizeGateAngles.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+#include "mlir/Dialect/Utils/AngleConversion.h"
+#include "mlir/Dialect/Utils/Utils.h"
+
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Visitors.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/WalkResult.h>
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+
+namespace mlir::qco {
+
+#define GEN_PASS_DEF_QUANTIZEGATEANGLES
+#include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
+
+[[nodiscard]] static std::optional<uint32_t>
+precisionWidth(const IntegerAttr precision) {
+  const auto& value = precision.getValue();
+  if (value.isZero() || value.ugt(mqt::angle::MACHINE_WIDTH)) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(value.getZExtValue());
+}
+
+namespace {
+
+struct QuantizeGateAngles final
+    : impl::QuantizeGateAnglesBase<QuantizeGateAngles> {
+  using QuantizeGateAnglesBase::QuantizeGateAnglesBase;
+
+protected:
+  void runOnOperation() override {
+    if (!mqt::angle::isSupportedWidth(precisionBits)) {
+      getOperation().emitError() << "precision-bits must be between 1 and "
+                                 << mqt::angle::MACHINE_WIDTH;
+      signalPassFailure();
+      return;
+    }
+
+    if (const auto existing =
+            getOperation()->getAttr(mqt::angle::FINAL_QUANTIZATION_ATTR)) {
+      const auto integer = dyn_cast<IntegerAttr>(existing);
+      if (!integer || !precisionWidth(integer)) {
+        getOperation().emitError()
+            << "invalid final gate-angle precision metadata";
+        signalPassFailure();
+        return;
+      }
+    }
+
+    const auto preflight = getOperation().walk([&](UnitaryOpInterface unitary) {
+      if (isa<PowOp>(unitary.getOperation())) {
+        return WalkResult::advance();
+      }
+      for (const auto parameter : unitary.getParameters()) {
+        const auto constant = utils::valueToConstantDouble(parameter);
+        if (constant && !std::isfinite(*constant)) {
+          unitary.emitError() << "cannot quantize a non-finite gate parameter";
+          return WalkResult::interrupt();
+        }
+      }
+      return WalkResult::advance();
+    });
+    if (preflight.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+
+    IRRewriter rewriter(&getContext());
+    DenseMap<Block*, DenseMap<Value, Value>> blockConversions;
+    getOperation().walk([&](UnitaryOpInterface unitary) {
+      if (isa<PowOp>(unitary.getOperation())) {
+        return;
+      }
+      const auto parameters = unitary.getParameters();
+      if (parameters.empty()) {
+        return;
+      }
+      rewriter.setInsertionPoint(unitary);
+      const auto firstParameter = parameters.getBeginOperandIndex();
+      for (const auto [index, parameter] : llvm::enumerate(parameters)) {
+        const auto existing = mqt::angle::matchQuantizedRadians(parameter);
+        if (existing && existing->bitWidth == precisionBits) {
+          continue;
+        }
+        auto& conversions = blockConversions[unitary->getBlock()];
+        Value quantized;
+        if (const auto found = conversions.find(parameter);
+            found != conversions.end()) {
+          quantized = found->second;
+        } else {
+          quantized = mqt::angle::buildQuantizedRadians(
+              rewriter, unitary.getLoc(), parameter, precisionBits);
+          conversions.try_emplace(parameter, quantized);
+        }
+        unitary->setOperand(firstParameter + index, quantized);
+      }
+    });
+    getOperation()->setAttr(
+        mqt::angle::FINAL_QUANTIZATION_ATTR,
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(precisionBits)));
+  }
+};
+
+} // namespace
+
+} // namespace mlir::qco

--- a/mlir/lib/Support/Passes.cpp
+++ b/mlir/lib/Support/Passes.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 #include "mlir/Dialect/QIR/Transforms/Passes.h"
 #include "mlir/Dialect/QTensor/Transforms/Passes.h"
+#include "mlir/Dialect/Utils/AngleConversion.h"
 #include "mlir/Dialect/Utils/Transforms/Passes.h"
 
 #include <llvm/ADT/StringRef.h>
@@ -54,6 +55,7 @@ void registerMQTCompilerPasses() {
     qco::registerHadamardLifting();
     qco::registerMeasurementLifting();
     qco::registerMergeSingleQubitRotationGates();
+    qco::registerQuantizeGateAngles();
     qco::registerQuantumLoopUnroll();
     qco::registerReplaceClassicalControls();
     qco::registerReuseQubits();
@@ -111,7 +113,11 @@ LogicalResult runPassPipeline(ModuleOp mod, const StringRef pipeline,
   return pm.run(mod);
 }
 
-void populateQCCleanupPipeline(OpPassManager& pm) {
+void populateQCCleanupPipeline(OpPassManager& pm,
+                               const bool preserveQuantizedAngles) {
+  if (preserveQuantizedAngles) {
+    return;
+  }
   pm.addPass(createCanonicalizerPass());
   pm.addPass(mlir::mqt::createNormalizeGlobalPhases());
   pm.addPass(createCSEPass());
@@ -119,7 +125,11 @@ void populateQCCleanupPipeline(OpPassManager& pm) {
   pm.addPass(createRemoveDeadValuesPass());
 }
 
-void populateQCOCleanupPipeline(OpPassManager& pm) {
+void populateQCOCleanupPipeline(OpPassManager& pm,
+                                const bool preserveQuantizedAngles) {
+  if (preserveQuantizedAngles) {
+    return;
+  }
   pm.addPass(createCanonicalizerPass(
       GreedyRewriteConfig{}.setMaxIterations(GreedyRewriteConfig::kNoLimit)));
   pm.addPass(mlir::mqt::createNormalizeGlobalPhases());
@@ -141,13 +151,23 @@ void populateJeffCleanupPipeline(OpPassManager& pm) {
 }
 
 [[nodiscard]] LogicalResult runQCCleanupPipeline(ModuleOp mod) {
-  return runWithPassManager(mod, populateQCCleanupPipeline,
-                            "Failed to run the QC cleanup pipeline.");
+  return runWithPassManager(
+      mod,
+      [&](OpPassManager& pm) {
+        populateQCCleanupPipeline(
+            pm, mod->hasAttr(mqt::angle::FINAL_QUANTIZATION_ATTR));
+      },
+      "Failed to run the QC cleanup pipeline.");
 }
 
 [[nodiscard]] LogicalResult runQCOCleanupPipeline(ModuleOp mod) {
-  return runWithPassManager(mod, populateQCOCleanupPipeline,
-                            "Failed to run the QCO cleanup pipeline.");
+  return runWithPassManager(
+      mod,
+      [&](OpPassManager& pm) {
+        populateQCOCleanupPipeline(
+            pm, mod->hasAttr(mqt::angle::FINAL_QUANTIZATION_ATTR));
+      },
+      "Failed to run the QCO cleanup pipeline.");
 }
 
 [[nodiscard]] LogicalResult runQIRCleanupPipeline(ModuleOp mod,

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/CMakeLists.txt
@@ -9,9 +9,13 @@
 set(target_name mqt-core-mlir-unittest-optimizations)
 add_executable(
   ${target_name}
-  test_qco_hadamard_lifting.cpp test_qco_measurement_lifting.cpp
-  test_qco_merge_single_qubit_rotation.cpp test_qco_replace_classical_controls.cpp
-  test_qco_reuse_qubits.cpp test_quantum_loop_unroll.cpp)
+  test_qco_hadamard_lifting.cpp
+  test_qco_measurement_lifting.cpp
+  test_qco_merge_single_qubit_rotation.cpp
+  test_qco_quantize_gate_angles.cpp
+  test_qco_replace_classical_controls.cpp
+  test_qco_reuse_qubits.cpp
+  test_quantum_loop_unroll.cpp)
 
 target_link_libraries(
   ${target_name}

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_quantize_gate_angles.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_quantize_gate_angles.cpp
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+#include "mlir/Dialect/Utils/AngleConversion.h"
+
+#include <gtest/gtest.h>
+#include <llvm/ADT/APFloat.h>
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/SmallVector.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/Value.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <numbers>
+#include <tuple>
+
+[[nodiscard]] static mlir::LogicalResult quantize(mlir::ModuleOp moduleOp,
+                                                  const uint32_t width) {
+  mlir::qco::QuantizeGateAnglesOptions options;
+  options.precisionBits = width;
+  mlir::PassManager manager(moduleOp.getContext());
+  manager.addPass(mlir::qco::createQuantizeGateAngles(options));
+  return manager.run(moduleOp);
+}
+
+[[nodiscard]] static mlir::Value addDynamicF64Input(mlir::ModuleOp moduleOp) {
+  auto funcOp = moduleOp.lookupSymbol<mlir::func::FuncOp>("main");
+  assert(funcOp && "QCOProgramBuilder must create @main");
+  funcOp.insertArgument(0, mlir::Float64Type::get(moduleOp.getContext()), {},
+                        funcOp.getLoc());
+  return funcOp.getArgument(0);
+}
+
+namespace {
+
+using namespace mlir;
+using namespace mlir::qco;
+
+TEST(QCOQuantizeGateAnglesTest, QuantizesConstantsAndIsIdempotent) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    q = b.rx(-std::numbers::pi / 2.0, q);
+    return b.intConstant(0);
+  });
+
+  ASSERT_TRUE(succeeded(quantize(*module, 8)));
+  RXOp rotation;
+  module->walk([&](RXOp op) { rotation = op; });
+  ASSERT_TRUE(rotation);
+  const auto precision = module->getOperation()->getAttrOfType<IntegerAttr>(
+      mqt::angle::FINAL_QUANTIZATION_ATTR);
+  ASSERT_TRUE(precision);
+  EXPECT_EQ(precision.getInt(), 8);
+  const auto converted = mqt::angle::matchQuantizedRadians(rotation.getTheta());
+  ASSERT_TRUE(converted);
+  EXPECT_EQ(converted->bitWidth, 8);
+  llvm::APInt bits;
+  ASSERT_TRUE(matchPattern(converted->bits, m_ConstantInt(&bits)));
+  EXPECT_EQ(bits.getZExtValue(), 192);
+
+  const auto parameter = rotation.getTheta();
+  ASSERT_TRUE(succeeded(quantize(*module, 8)));
+  EXPECT_EQ(rotation.getTheta(), parameter);
+}
+
+TEST(QCOQuantizeGateAnglesTest, FoldsConstantPrecisionComposition) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    auto sourceBits = arith::ConstantOp::create(
+        b, b.getUnknownLoc(),
+        IntegerAttr::get(b.getI64Type(), llvm::APInt(64, uint64_t{1} << 63U)));
+    auto radians = mqt::angle::buildBitsToRadians(b, b.getUnknownLoc(),
+                                                  sourceBits.getResult());
+    q = b.rz(radians, q);
+    return b.intConstant(0);
+  });
+
+  ASSERT_TRUE(succeeded(quantize(*module, 8)));
+  RZOp rotation;
+  module->walk([&](RZOp op) { rotation = op; });
+  ASSERT_TRUE(rotation);
+  const auto converted = mqt::angle::matchQuantizedRadians(rotation.getTheta());
+  ASSERT_TRUE(converted);
+  llvm::APInt bits;
+  ASSERT_TRUE(matchPattern(converted->bits, m_ConstantInt(&bits)));
+  EXPECT_EQ(bits.getZExtValue(), 128);
+}
+
+TEST(QCOQuantizeGateAnglesTest, WidensConstantPrecisionCompositionExactly) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    auto sourceBits = arith::ConstantOp::create(
+        b, b.getUnknownLoc(),
+        IntegerAttr::get(b.getI8Type(), llvm::APInt(8, 165)));
+    auto radians = mqt::angle::buildBitsToRadians(b, b.getUnknownLoc(),
+                                                  sourceBits.getResult());
+    q = b.rz(radians, q);
+    return b.intConstant(0);
+  });
+
+  ASSERT_TRUE(succeeded(quantize(*module, 53)));
+  RZOp rotation;
+  module->walk([&](RZOp op) { rotation = op; });
+  ASSERT_TRUE(rotation);
+  const auto converted = mqt::angle::matchQuantizedRadians(rotation.getTheta());
+  ASSERT_TRUE(converted);
+  llvm::APInt bits;
+  ASSERT_TRUE(matchPattern(converted->bits, m_ConstantInt(&bits)));
+  EXPECT_EQ(bits.getZExtValue(), 0x14A00000000000ULL);
+}
+
+TEST(QCOQuantizeGateAnglesTest, QuantizesLargeFiniteConstantsExactly) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    q = b.rx(1.0e20, q);
+    return b.intConstant(0);
+  });
+
+  ASSERT_TRUE(succeeded(quantize(*module, 8)));
+  RXOp rotation;
+  module->walk([&](RXOp op) { rotation = op; });
+  ASSERT_TRUE(rotation);
+  const auto converted = mqt::angle::matchQuantizedRadians(rotation.getTheta());
+  ASSERT_TRUE(converted);
+  llvm::APInt bits;
+  ASSERT_TRUE(matchPattern(converted->bits, m_ConstantInt(&bits)));
+  EXPECT_EQ(bits.getZExtValue(), 77);
+}
+
+TEST(QCOQuantizeGateAnglesTest, QuantizesDynamicAndNestedGateParametersOnly) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    q = b.pow(0.75, q, [&](Value nested) { return b.rz(0.25, nested); });
+    return b.intConstant(0);
+  });
+
+  PowOp power;
+  RZOp rotation;
+  module->walk([&](PowOp op) { power = op; });
+  module->walk([&](RZOp op) { rotation = op; });
+  ASSERT_TRUE(power);
+  ASSERT_TRUE(rotation);
+  const auto dynamicInput = addDynamicF64Input(*module);
+  rotation.getThetaMutable().assign(dynamicInput);
+  const auto exponent = power.getExponent();
+  ASSERT_TRUE(succeeded(quantize(*module, 53)));
+  EXPECT_EQ(power.getExponent(), exponent);
+  const auto converted = mqt::angle::matchQuantizedRadians(rotation.getTheta());
+  ASSERT_TRUE(converted);
+  EXPECT_EQ(converted->bitWidth, 53);
+  EXPECT_TRUE(converted->bits.getDefiningOp<arith::TruncIOp>());
+  EXPECT_EQ(mqt::angle::matchFloatToBits(converted->bits), dynamicInput);
+}
+
+TEST(QCOQuantizeGateAnglesTest, ReusesDynamicConversionWithinOneBlock) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    q = b.rx(0.25, q);
+    q = b.rz(0.5, q);
+    return b.intConstant(0);
+  });
+
+  SmallVector<UnitaryOpInterface> rotations;
+  module->walk([&](UnitaryOpInterface op) {
+    if (isa<RXOp, RZOp>(op.getOperation())) {
+      rotations.push_back(op);
+    }
+  });
+  ASSERT_EQ(rotations.size(), 2);
+  const auto dynamicInput = addDynamicF64Input(*module);
+  for (auto rotation : rotations) {
+    rotation->setOperand(rotation.getParameters().getBeginOperandIndex(),
+                         dynamicInput);
+  }
+
+  ASSERT_TRUE(succeeded(quantize(*module, 64)));
+  EXPECT_EQ(rotations[0].getParameters().front(),
+            rotations[1].getParameters().front());
+}
+
+TEST(QCOQuantizeGateAnglesTest, QuantizesGlobalPhaseAtBoundaryPrecisions) {
+  struct Case {
+    uint32_t width;
+    double radians;
+  };
+  constexpr auto cases = std::to_array<Case>({
+      {.width = 1, .radians = std::numbers::pi},
+      {.width = 8, .radians = -9.0 * std::numbers::pi / 2.0},
+      {.width = 64, .radians = std::numbers::pi / 2.0},
+  });
+  for (const auto& testCase : cases) {
+    MLIRContext context;
+    context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+    const auto multiTurnRadians = testCase.radians + (10.0 * std::numbers::pi);
+    auto module = QCOProgramBuilder::build(&context, [&](QCOProgramBuilder& b) {
+      b.gphase(multiTurnRadians);
+      return b.intConstant(0);
+    });
+
+    ASSERT_TRUE(succeeded(quantize(*module, testCase.width)));
+    GPhaseOp phase;
+    module->walk([&](GPhaseOp op) { phase = op; });
+    ASSERT_TRUE(phase);
+    const auto converted = mqt::angle::matchQuantizedRadians(phase.getTheta());
+    ASSERT_TRUE(converted);
+    EXPECT_EQ(converted->bitWidth, testCase.width);
+    llvm::APInt bits;
+    ASSERT_TRUE(matchPattern(converted->bits, m_ConstantInt(&bits)));
+    const auto expected =
+        mqt::angle::quantize(multiTurnRadians, testCase.width);
+    ASSERT_TRUE(expected);
+    EXPECT_EQ(bits.getZExtValue(), *expected);
+  }
+}
+
+TEST(QCOQuantizeGateAnglesTest, VisitsControlAndInverseRegions) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto control = b.allocQubit();
+    auto target = b.allocQubit();
+    target = b.inv(target, [&](Value nested) {
+      b.gphase(0.125);
+      return b.rx(0.25, nested);
+    });
+    std::tie(control, target) = b.ctrl(
+        control, target, [&](Value nested) { return b.ry(0.5, nested); });
+    std::tie(control, target) = b.rzz(0.75, control, target);
+    return b.intConstant(0);
+  });
+
+  ASSERT_TRUE(succeeded(quantize(*module, 8)));
+  size_t quantizedParameters = 0;
+  module->walk([&](UnitaryOpInterface unitary) {
+    if (isa<PowOp>(unitary.getOperation())) {
+      return;
+    }
+    for (const auto parameter : unitary.getParameters()) {
+      const auto converted = mqt::angle::matchQuantizedRadians(parameter);
+      ASSERT_TRUE(converted);
+      EXPECT_EQ(converted->bitWidth, 8);
+      ++quantizedParameters;
+    }
+  });
+  EXPECT_EQ(quantizedParameters, 4);
+}
+
+TEST(QCOQuantizeGateAnglesTest, DifferentPrecisionsComposeConversions) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    q = b.rz(0.25, q);
+    return b.intConstant(0);
+  });
+
+  RZOp rotation;
+  module->walk([&](RZOp op) { rotation = op; });
+  ASSERT_TRUE(rotation);
+  rotation.getThetaMutable().assign(addDynamicF64Input(*module));
+
+  ASSERT_TRUE(succeeded(quantize(*module, 8)));
+  ASSERT_TRUE(succeeded(quantize(*module, 53)));
+  const auto outer = mqt::angle::matchQuantizedRadians(rotation.getTheta());
+  ASSERT_TRUE(outer);
+  EXPECT_EQ(outer->bitWidth, 53);
+  const auto resize = mqt::angle::matchResize(outer->bits);
+  ASSERT_TRUE(resize);
+  EXPECT_EQ(resize->sourceWidth, 8);
+  EXPECT_EQ(resize->targetWidth, 53);
+  const auto original = mqt::angle::matchFloatToBits(resize->source);
+  ASSERT_TRUE(original);
+}
+
+TEST(QCOQuantizeGateAnglesTest, RejectsOversizedPrecisionMetadata) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    q = b.rz(0.1, q);
+    return b.intConstant(0);
+  });
+  module->getOperation()->setAttr(
+      mqt::angle::FINAL_QUANTIZATION_ATTR,
+      IntegerAttr::get(IntegerType::get(&context, 128),
+                       llvm::APInt::getOneBitSet(128, 100)));
+
+  EXPECT_TRUE(failed(quantize(*module, 53)));
+}
+
+TEST(QCOQuantizeGateAnglesTest, RejectsInvalidPrecisions) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  for (const auto width : {0U, 65U}) {
+    auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+      auto q = b.allocQubit();
+      q = b.rz(0.5, q);
+      return b.intConstant(0);
+    });
+    EXPECT_TRUE(failed(quantize(*module, width)));
+  }
+}
+
+TEST(QCOQuantizeGateAnglesTest, RejectsNonFiniteConstantsBeforeMutation) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    q = b.rx(0.5, q);
+    q = b.rz(std::numeric_limits<double>::infinity(), q);
+    return b.intConstant(0);
+  });
+  RXOp rotation;
+  module->walk([&](RXOp op) { rotation = op; });
+  ASSERT_TRUE(rotation);
+  const auto originalParameter = rotation.getTheta();
+
+  EXPECT_TRUE(failed(quantize(*module, 8)));
+  EXPECT_EQ(rotation.getTheta(), originalParameter);
+}
+
+TEST(QCOQuantizeGateAnglesTest,
+     RejectsFoldableNonFiniteExpressionsBeforeMutation) {
+  MLIRContext context;
+  context.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  auto module = QCOProgramBuilder::build(&context, [](QCOProgramBuilder& b) {
+    auto q = b.allocQubit();
+    q = b.rx(0.5, q);
+    q = b.rz(0.25, q);
+    return b.intConstant(0);
+  });
+  RXOp first;
+  RZOp invalid;
+  module->walk([&](RXOp op) { first = op; });
+  module->walk([&](RZOp op) { invalid = op; });
+  ASSERT_TRUE(first);
+  ASSERT_TRUE(invalid);
+  const auto originalParameter = first.getTheta();
+
+  OpBuilder builder(invalid);
+  auto infinity = arith::ConstantFloatOp::create(
+      builder, invalid.getLoc(), builder.getF64Type(),
+      llvm::APFloat(std::numeric_limits<double>::infinity()));
+  auto negativeInfinity =
+      arith::NegFOp::create(builder, invalid.getLoc(), infinity);
+  invalid.getThetaMutable().assign(negativeInfinity);
+
+  EXPECT_TRUE(failed(quantize(*module, 8)));
+  EXPECT_EQ(first.getTheta(), originalParameter);
+  EXPECT_EQ(invalid.getTheta(), negativeInfinity.getResult());
+}
+
+} // namespace

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -400,6 +400,9 @@ class QCOProgram(Program):
     def merge_single_qubit_rotation_gates(self) -> None:
         """Merge compatible consecutive single-qubit rotation gates."""
 
+    def quantize_gate_angles(self, *, precision_bits: int) -> None:
+        """Quantize gate parameters to fixed-width OpenQASM angles."""
+
     def fuse_single_qubit_unitary_runs(self, *, basis: str = "zyz") -> None:
         """Fuse single-qubit unitary runs into the chosen decomposition basis."""
 

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -459,6 +459,26 @@ def test_qco_program_runs_textual_pipeline() -> None:
         qco.run_pass_pipeline("not-a-pass")
 
 
+def test_qco_program_quantizes_gate_angles_explicitly() -> None:
+    """Quantize QCO gate parameters through the keyword-only Python API."""
+    source = """OPENQASM 3.1;
+include "stdgates.inc";
+qubit q;
+rz(0.371) q;
+"""
+    qco = compile_program(source, output=OutputFormat.QCO)
+    assert isinstance(qco, QCOProgram)
+
+    qco.quantize_gate_angles(precision_bits=8)
+    width_eight = qco.ir
+    assert "i8" in width_eight
+    qco.quantize_gate_angles(precision_bits=8)
+    assert qco.ir == width_eight
+
+    with pytest.raises(RuntimeError, match="MLIR operation failed"):
+        qco.quantize_gate_angles(precision_bits=0)
+
+
 def test_qco_program_reuses_qubits() -> None:
     """Expose the raw and composite qubit-reuse flows."""
     independent_qubits = """


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Add an explicit, opt-in QCO pass for quantizing actual gate parameters to OpenQASM fixed-width angle precision.

- Add `quantize-gate-angles{precision-bits=N}` with required precision in `[1,64]`.
- Expose `QCOProgram::quantizeGateAngles` and `QCOProgram.quantize_gate_angles`.
- Quantize constants and runtime parameters with exact modulo-2π, ties-to-even semantics, including nested control, inverse, and power regions without changing power exponents.
- Make quantization terminal so ordinary cleanup runs before it and cannot erase its canonical angle conversions afterward.
- Preserve same-width idempotence and exact different-width angle resizing.

Depends on #2061.

## Validation

- QCO optimization and compiler suites pass locally.
- Tests cover constant and dynamic values, negative and multi-turn inputs, widths 1/8/53/64, modifiers, global phases, repeated passes, cleanup boundaries, C++ and Python APIs, and OpenQASM export.
- The final aggregate stack builds successfully and passes all 4,547 discovered CTests; two live QDMI job-ID tests are skipped by design.
- Repository lint and `git diff --check` pass.

GPT-5.6 via Codex materially assisted with implementation, independent review remediation, testing, restacking, and publication under maintainer direction.