### PR TITLE
🔧 Use standard dynamic metadata configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ install.components = [
   "qdmi_Development",
 ]
 
-metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.include = ["python/mqt/core/_version.py"]
 sdist.exclude = [
     "**/.github",
@@ -113,6 +112,9 @@ sdist.exclude = [
     "**/test",
     "**/tests",
 ]
+
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.check-sdist]
 sdist-only = ["python/mqt/core/_version.py"]


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- migrate the setuptools-scm version provider from the deprecated `tool.scikit-build.metadata` table to the top-level `[[tool.dynamic-metadata]]` interface
- keep the existing SCM-derived version and generated `_version.py` behavior unchanged

## Motivation

scikit-build-core 1.0 deprecates `tool.scikit-build.metadata` and emits a warning during wheel builds. MQT Core already requires scikit-build-core 1.0.3, so using the standard dynamic-metadata interface removes the warning without changing dependencies or package behavior.

## Validation

- `MLIR_DIR=/Users/burgholzer/CLionProjects/llvm-22.1.3/lib/cmake/mlir ./.agent/run.sh uv build --wheel -v`
  - built `mqt_core-3.3.4.dev1432+g4b7a5ac73.d20260812-cp312-abi3-macosx_26_0_arm64.whl`
  - preserved the SCM-derived version and generated `mqt/core/_version.py`
  - no `tool.scikit-build.metadata` deprecation warning
- `./.agent/run.sh uvx nox -s lint`
