### PR TITLE
🐛 Emit QIR 2.1 profile metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ releases may include breaking changes.
   ([#1264], [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570],
   [#1572], [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751],
   [#1755], [#1787], [#1815], [#1823], [#1830], [#1886], [#1933], [#1978],
-  [#1979], [#2007], [#2026], [#2030]) ([**@burgholzer**], [**@denialhaag**],
-  [**@simon1hofmann**], [**@li-mingbao**], [**@DRovara**],
+  [#1979], [#2007], [#2026], [#2030], [#2066]) ([**@burgholzer**],
+  [**@denialhaag**], [**@simon1hofmann**], [**@li-mingbao**], [**@DRovara**],
   [**@MatthiasReumann**])
 - ✨ Add decision diagram-based construction and simulation of static unitary
   QCO functions ([#1915]) ([**@simon1hofmann**])
@@ -737,6 +737,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2066]: https://github.com/munich-quantum-toolkit/core/pull/2066
 [#2060]: https://github.com/munich-quantum-toolkit/core/pull/2060
 [#2058]: https://github.com/munich-quantum-toolkit/core/pull/2058
 [#2042]: https://github.com/munich-quantum-toolkit/core/pull/2042

--- a/docs/qir/index.md
+++ b/docs/qir/index.md
@@ -98,13 +98,6 @@ QIR entry points take no arguments and return an `i64` exit code. Runtime and
 QIS declarations are checked before JIT compilation; a mismatched or unsupported
 declaration is reported with its actual and accepted LLVM function types.
 
-The QIR 2.1 profile publication identifies its bitcode format with
-`qir_major_version = 2` and `qir_minor_version = 0`. MQT Core emits those
-version flags and uses the integer widths prescribed by the profiles for
-resource-management and Adaptive capability flags. Adaptive output also records
-the integer and floating-point widths used by classical computations. Here, “QIR
-2.1” names the profile publication, not a `2.1` module-version tuple.
-
 MQT Core implements the QIR 2.1 Base and Adaptive Profile runtime APIs. The JIT
 accepts one exact LLVM type for each runtime declaration, so unsupported or
 outdated overloads fail before execution.

--- a/docs/qir/index.md
+++ b/docs/qir/index.md
@@ -98,6 +98,13 @@ QIR entry points take no arguments and return an `i64` exit code. Runtime and
 QIS declarations are checked before JIT compilation; a mismatched or unsupported
 declaration is reported with its actual and accepted LLVM function types.
 
+The QIR 2.1 profile publication identifies its bitcode format with
+`qir_major_version = 2` and `qir_minor_version = 0`. MQT Core emits those
+version flags and uses the integer widths prescribed by the profiles for
+resource-management and Adaptive capability flags. Adaptive output also records
+the integer and floating-point widths used by classical computations. Here, “QIR
+2.1” names the profile publication, not a `2.1` module-version tuple.
+
 MQT Core implements the QIR 2.1 Base and Adaptive Profile runtime APIs. The JIT
 accepts one exact LLVM type for each runtime declaration, so unsupported or
 outdated overloads fail before execution.

--- a/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
+++ b/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
@@ -26,6 +26,10 @@
 #include <string>
 #include <variant>
 
+namespace llvm {
+class Module;
+} // namespace llvm
+
 namespace mlir {
 class OpBuilder;
 class Operation;
@@ -36,6 +40,16 @@ class LLVMFuncOp;
 } // namespace mlir
 
 namespace mlir::qir {
+
+/// Normalize QIR profile module flags after MLIR-to-LLVM translation.
+///
+/// MLIR 22 translates integer-valued `llvm.module_flags` attributes to i32
+/// metadata and only supports array-valued flags for LLVM's own CG profile.
+/// QIR instead requires i1/i2 capability flags and metadata tuples describing
+/// the integer and floating-point widths used by Adaptive Profile classical
+/// computations. This function repairs the scalar flag widths and derives the
+/// optional Adaptive Profile flags from the translated LLVM module.
+void normalizeQIRModuleFlags(llvm::Module& module, bool useAdaptive);
 
 // QIR function names
 

--- a/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
+++ b/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
@@ -49,7 +49,7 @@ namespace mlir::qir {
 /// the integer and floating-point widths used by Adaptive Profile classical
 /// computations. This function repairs the scalar flag widths and derives the
 /// optional Adaptive Profile flags from the translated LLVM module.
-void normalizeQIRModuleFlags(llvm::Module& module, bool useAdaptive);
+void normalizeQIRModuleFlags(llvm::Module& moduleOp, bool useAdaptive);
 
 // QIR function names
 

--- a/mlir/lib/Compiler/CMakeLists.txt
+++ b/mlir/lib/Compiler/CMakeLists.txt
@@ -61,6 +61,7 @@ add_mlir_library(
   MLIRQCOToJeff
   MLIRQCToQIRBase
   MLIRQCToQIRAdaptive
+  MLIRQIRUtils
   MLIRQCOTransforms
   MLIRQCTranslation
   MLIRParser

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/QC/Translation/TranslateQuantumComputationToQC.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
+#include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/Utils/Transforms/GlobalPhaseNormalization.h"
 #include "mlir/Dialect/Utils/Transforms/Passes.h"
@@ -580,17 +581,20 @@ bool QIRProgram::cleanup() {
 QIRProfile QIRProgram::profile() const noexcept { return profile_; }
 
 [[nodiscard]] static std::unique_ptr<llvm::Module>
-translateToLLVM(ModuleOp mod, llvm::LLVMContext& context) {
+translateToLLVM(ModuleOp mod, llvm::LLVMContext& context,
+                const QIRProfile profile) {
   auto llvmModule = translateModuleToLLVMIR(mod, context);
   if (!llvmModule) {
     mod.emitError("failed to translate QIR MLIR to LLVM IR");
+    return nullptr;
   }
+  qir::normalizeQIRModuleFlags(*llvmModule, profile == QIRProfile::Adaptive);
   return llvmModule;
 }
 
 std::optional<std::string> QIRProgram::llvmIR() const {
   llvm::LLVMContext context;
-  auto llvmModule = translateToLLVM(mod(), context);
+  auto llvmModule = translateToLLVM(mod(), context, profile_);
   if (!llvmModule) {
     return std::nullopt;
   }
@@ -602,7 +606,7 @@ std::optional<std::string> QIRProgram::llvmIR() const {
 
 std::optional<std::vector<std::byte>> QIRProgram::toBitcode() const {
   llvm::LLVMContext context;
-  auto llvmModule = translateToLLVM(mod(), context);
+  auto llvmModule = translateToLLVM(mod(), context, profile_);
   if (!llvmModule) {
     return std::nullopt;
   }
@@ -617,7 +621,7 @@ std::optional<std::vector<std::byte>> QIRProgram::toBitcode() const {
 
 bool QIRProgram::writeBitcode(const std::filesystem::path& path) const {
   llvm::LLVMContext context;
-  auto llvmModule = translateToLLVM(mod(), context);
+  auto llvmModule = translateToLLVM(mod(), context, profile_);
   if (!llvmModule) {
     return false;
   }

--- a/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
@@ -84,7 +84,7 @@ private:
   /// - `required_num_qubits`: Number of qubits used
   /// - `required_num_results`: Number of measurement results
   /// - `qir_major_version`: 2
-  /// - `qir_minor_version`: 0
+  /// - `qir_minor_version`: 1
   /// - `dynamic_qubit_management`: true/false
   /// - `dynamic_result_management`: true/false
   ///
@@ -124,7 +124,7 @@ private:
 
     SmallVector<Attribute> flags{
         createI32Flag(LLVM::ModFlagBehavior::Error, "qir_major_version", 2),
-        createI32Flag(LLVM::ModFlagBehavior::Max, "qir_minor_version", 0),
+        createI32Flag(LLVM::ModFlagBehavior::Max, "qir_minor_version", 1),
         createBoolFlag(LLVM::ModFlagBehavior::Error, "dynamic_qubit_management",
                        metadata.useDynamicQubit),
         createBoolFlag(LLVM::ModFlagBehavior::Error,

--- a/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
@@ -16,6 +16,7 @@
 #include <llvm/ADT/StringRef.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/IR/Attributes.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Dominance.h>
@@ -83,7 +84,7 @@ private:
   /// - `required_num_qubits`: Number of qubits used
   /// - `required_num_results`: Number of measurement results
   /// - `qir_major_version`: 2
-  /// - `qir_minor_version`: 1
+  /// - `qir_minor_version`: 0
   /// - `dynamic_qubit_management`: true/false
   /// - `dynamic_result_management`: true/false
   ///
@@ -93,10 +94,17 @@ private:
                    IRRewriter& rewriter) {
     auto m = getOperation();
     const auto createFlag = [&](LLVM::ModFlagBehavior behavior, StringRef name,
-                                int32_t val) {
+                                Attribute value) {
       return LLVM::ModuleFlagAttr::get(m->getContext(), behavior,
-                                       rewriter.getStringAttr(name),
-                                       rewriter.getI32IntegerAttr(val));
+                                       rewriter.getStringAttr(name), value);
+    };
+    const auto createI32Flag = [&](LLVM::ModFlagBehavior behavior,
+                                   StringRef name, int32_t value) {
+      return createFlag(behavior, name, rewriter.getI32IntegerAttr(value));
+    };
+    const auto createBoolFlag = [&](LLVM::ModFlagBehavior behavior,
+                                    StringRef name, bool value) {
+      return createFlag(behavior, name, rewriter.getBoolAttr(value));
     };
 
     const SmallVector<Attribute> attributes{
@@ -115,19 +123,20 @@ private:
     rewriter.setInsertionPointToEnd(m.getBody());
 
     SmallVector<Attribute> flags{
-        createFlag(LLVM::ModFlagBehavior::Error, "qir_major_version", 2),
-        createFlag(LLVM::ModFlagBehavior::Max, "qir_minor_version", 1),
-        createFlag(LLVM::ModFlagBehavior::Error, "dynamic_qubit_management",
-                   static_cast<int32_t>(metadata.useDynamicQubit)),
-        createFlag(LLVM::ModFlagBehavior::Error, "dynamic_result_management",
-                   static_cast<int32_t>(metadata.useDynamicResult))};
+        createI32Flag(LLVM::ModFlagBehavior::Error, "qir_major_version", 2),
+        createI32Flag(LLVM::ModFlagBehavior::Max, "qir_minor_version", 0),
+        createBoolFlag(LLVM::ModFlagBehavior::Error, "dynamic_qubit_management",
+                       metadata.useDynamicQubit),
+        createBoolFlag(LLVM::ModFlagBehavior::Error,
+                       "dynamic_result_management", metadata.useDynamicResult)};
 
     if (useAdaptive) {
-      flags.emplace_back(createFlag(LLVM::ModFlagBehavior::Error,
-                                    "backwards_branching",
-                                    metadata.backwardsBranching));
-      flags.emplace_back(createFlag(LLVM::ModFlagBehavior::Error, "arrays",
-                                    static_cast<int32_t>(metadata.useArrays)));
+      flags.emplace_back(
+          createFlag(LLVM::ModFlagBehavior::Error, "backwards_branching",
+                     rewriter.getIntegerAttr(rewriter.getIntegerType(2),
+                                             metadata.backwardsBranching)));
+      flags.emplace_back(createBoolFlag(LLVM::ModFlagBehavior::Error, "arrays",
+                                        metadata.useArrays));
     }
 
     removeExistingModuleFlags(m, rewriter);

--- a/mlir/lib/Dialect/QIR/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/QIR/Utils/CMakeLists.txt
@@ -8,7 +8,14 @@
 
 file(GLOB QIR_UTILS_SOURCES *.cpp)
 
-add_mlir_library(MLIRQIRUtils ${QIR_UTILS_SOURCES} LINK_LIBS PUBLIC MLIRLLVMDialect MLIRIR)
+add_mlir_library(
+  MLIRQIRUtils
+  ${QIR_UTILS_SOURCES}
+  LINK_LIBS
+  PUBLIC
+  LLVMCore
+  MLIRLLVMDialect
+  MLIRIR)
 
 mqt_mlir_target_use_project_options(MLIRQIRUtils)
 

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -11,6 +11,13 @@
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Metadata.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
@@ -26,12 +33,167 @@
 #include <mlir/Support/LLVM.h>
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <limits>
+#include <set>
 #include <string>
 
 namespace mlir::qir {
+
+[[nodiscard]] static uint64_t moduleFlagIntegerValue(llvm::Module& module,
+                                                     const StringRef key) {
+  const auto* constant = llvm::dyn_cast_or_null<llvm::ConstantAsMetadata>(
+      module.getModuleFlag(key));
+  const auto* integer =
+      constant != nullptr
+          ? llvm::dyn_cast<llvm::ConstantInt>(constant->getValue())
+          : nullptr;
+  return integer != nullptr ? integer->getZExtValue() : 0;
+}
+
+static void setIntegerModuleFlag(llvm::Module& module,
+                                 const llvm::Module::ModFlagBehavior behavior,
+                                 const StringRef key, const unsigned bitWidth,
+                                 const uint64_t value) {
+  auto& context = module.getContext();
+  module.setModuleFlag(
+      behavior, key,
+      llvm::ConstantInt::get(llvm::IntegerType::get(context, bitWidth), value));
+}
+
+[[nodiscard]] static llvm::MDNode*
+stringTuple(llvm::LLVMContext& context, const std::set<std::string>& values) {
+  SmallVector<llvm::Metadata*> entries;
+  entries.reserve(values.size());
+  llvm::transform(values, std::back_inserter(entries), [&](const auto& value) {
+    return llvm::MDString::get(context, value);
+  });
+  return llvm::MDTuple::get(context, entries);
+}
+
+static void removeModuleFlags(llvm::Module& module,
+                              const ArrayRef<StringRef> keys) {
+  auto* flags = module.getModuleFlagsMetadata();
+  if (flags == nullptr) {
+    return;
+  }
+  SmallVector<llvm::MDNode*> retained;
+  for (auto* flag : flags->operands()) {
+    const auto* key = llvm::dyn_cast<llvm::MDString>(flag->getOperand(1));
+    if (key == nullptr || !llvm::is_contained(keys, key->getString())) {
+      retained.emplace_back(flag);
+    }
+  }
+  flags->clearOperands();
+  for (auto* flag : retained) {
+    flags->addOperand(flag);
+  }
+}
+
+void normalizeQIRModuleFlags(llvm::Module& module, const bool useAdaptive) {
+  for (const auto* const key :
+       {"dynamic_qubit_management", "dynamic_result_management", "arrays"}) {
+    if (module.getModuleFlag(key) != nullptr) {
+      setIntegerModuleFlag(module, llvm::Module::Error, key, 1,
+                           moduleFlagIntegerValue(module, key));
+    }
+  }
+  if (module.getModuleFlag("backwards_branching") != nullptr) {
+    setIntegerModuleFlag(module, llvm::Module::Error, "backwards_branching", 2,
+                         moduleFlagIntegerValue(module, "backwards_branching"));
+  }
+  if (!useAdaptive) {
+    removeModuleFlags(module,
+                      {"int_computations", "float_computations", "ir_functions",
+                       "backwards_branching", "multiple_target_branching",
+                       "multiple_return_points", "arrays"});
+    return;
+  }
+
+  removeModuleFlags(module,
+                    {"int_computations", "float_computations", "ir_functions",
+                     "multiple_target_branching", "multiple_return_points"});
+
+  std::set<std::string> integerTypes;
+  std::set<std::string> floatingTypes;
+  bool usesIRFunctions = false;
+  bool usesMultipleTargetBranching = false;
+  bool usesMultipleReturnPoints = false;
+
+  const auto recordType = [&](const llvm::Type* type) {
+    if (const auto* integer = llvm::dyn_cast<llvm::IntegerType>(type)) {
+      if (integer->getBitWidth() > 1) {
+        integerTypes.emplace("i" + std::to_string(integer->getBitWidth()));
+      }
+    } else if (type->isHalfTy()) {
+      floatingTypes.emplace("half");
+    } else if (type->isFloatTy()) {
+      floatingTypes.emplace("float");
+    } else if (type->isDoubleTy()) {
+      floatingTypes.emplace("double");
+    }
+  };
+
+  for (const auto& function : module.functions()) {
+    if (function.isDeclaration()) {
+      continue;
+    }
+    const auto isEntryPoint = function.hasFnAttribute("entry_point");
+    usesIRFunctions |= !isEntryPoint;
+    if (!isEntryPoint) {
+      recordType(function.getReturnType());
+      for (const auto& argument : function.args()) {
+        recordType(argument.getType());
+      }
+    }
+
+    size_t returnCount = 0;
+    for (const auto& block : function) {
+      for (const auto& instruction : block) {
+        if (llvm::isa<llvm::ReturnInst>(instruction)) {
+          ++returnCount;
+          continue;
+        }
+        usesMultipleTargetBranching |= llvm::isa<llvm::SwitchInst>(instruction);
+        recordType(instruction.getType());
+#ifndef __clang_analyzer__
+        // LLVM stores operands in an intrusive allocation adjacent to User.
+        // The static analyzer cannot model that representation and reports
+        // the canonical operands() accessor as an out-of-bounds access.
+        for (const auto& operand : instruction.operands()) {
+          if (!llvm::isa<llvm::Constant>(operand.get())) {
+            recordType(operand->getType());
+          }
+        }
+#endif
+      }
+    }
+    usesMultipleReturnPoints |= returnCount > 1;
+  }
+
+  auto& context = module.getContext();
+  if (!integerTypes.empty()) {
+    module.setModuleFlag(llvm::Module::Append, "int_computations",
+                         stringTuple(context, integerTypes));
+  }
+  if (!floatingTypes.empty()) {
+    module.setModuleFlag(llvm::Module::Append, "float_computations",
+                         stringTuple(context, floatingTypes));
+  }
+  if (usesIRFunctions) {
+    setIntegerModuleFlag(module, llvm::Module::Error, "ir_functions", 1, 1);
+  }
+  if (usesMultipleTargetBranching) {
+    setIntegerModuleFlag(module, llvm::Module::Error,
+                         "multiple_target_branching", 1, 1);
+  }
+  if (usesMultipleReturnPoints) {
+    setIntegerModuleFlag(module, llvm::Module::Error, "multiple_return_points",
+                         1, 1);
+  }
+}
 
 void emitQISCall(OpBuilder& builder, Operation* anchor, const Location loc,
                  const ValueRange parameters, const ValueRange controls,

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -42,10 +42,10 @@
 
 namespace mlir::qir {
 
-[[nodiscard]] static uint64_t moduleFlagIntegerValue(llvm::Module& module,
+[[nodiscard]] static uint64_t moduleFlagIntegerValue(llvm::Module& moduleOp,
                                                      const StringRef key) {
   const auto* constant = llvm::dyn_cast_or_null<llvm::ConstantAsMetadata>(
-      module.getModuleFlag(key));
+      moduleOp.getModuleFlag(key));
   const auto* integer =
       constant != nullptr
           ? llvm::dyn_cast<llvm::ConstantInt>(constant->getValue())
@@ -53,12 +53,12 @@ namespace mlir::qir {
   return integer != nullptr ? integer->getZExtValue() : 0;
 }
 
-static void setIntegerModuleFlag(llvm::Module& module,
+static void setIntegerModuleFlag(llvm::Module& moduleOp,
                                  const llvm::Module::ModFlagBehavior behavior,
                                  const StringRef key, const unsigned bitWidth,
                                  const uint64_t value) {
-  auto& context = module.getContext();
-  module.setModuleFlag(
+  auto& context = moduleOp.getContext();
+  moduleOp.setModuleFlag(
       behavior, key,
       llvm::ConstantInt::get(llvm::IntegerType::get(context, bitWidth), value));
 }
@@ -73,9 +73,9 @@ stringTuple(llvm::LLVMContext& context, const std::set<std::string>& values) {
   return llvm::MDTuple::get(context, entries);
 }
 
-static void removeModuleFlags(llvm::Module& module,
+static void removeModuleFlags(llvm::Module& moduleOp,
                               const ArrayRef<StringRef> keys) {
-  auto* flags = module.getModuleFlagsMetadata();
+  auto* flags = moduleOp.getModuleFlagsMetadata();
   if (flags == nullptr) {
     return;
   }
@@ -92,27 +92,28 @@ static void removeModuleFlags(llvm::Module& module,
   }
 }
 
-void normalizeQIRModuleFlags(llvm::Module& module, const bool useAdaptive) {
+void normalizeQIRModuleFlags(llvm::Module& moduleOp, const bool useAdaptive) {
   for (const auto* const key :
        {"dynamic_qubit_management", "dynamic_result_management", "arrays"}) {
-    if (module.getModuleFlag(key) != nullptr) {
-      setIntegerModuleFlag(module, llvm::Module::Error, key, 1,
-                           moduleFlagIntegerValue(module, key));
+    if (moduleOp.getModuleFlag(key) != nullptr) {
+      setIntegerModuleFlag(moduleOp, llvm::Module::Error, key, 1,
+                           moduleFlagIntegerValue(moduleOp, key));
     }
   }
-  if (module.getModuleFlag("backwards_branching") != nullptr) {
-    setIntegerModuleFlag(module, llvm::Module::Error, "backwards_branching", 2,
-                         moduleFlagIntegerValue(module, "backwards_branching"));
+  if (moduleOp.getModuleFlag("backwards_branching") != nullptr) {
+    setIntegerModuleFlag(
+        moduleOp, llvm::Module::Error, "backwards_branching", 2,
+        moduleFlagIntegerValue(moduleOp, "backwards_branching"));
   }
   if (!useAdaptive) {
-    removeModuleFlags(module,
+    removeModuleFlags(moduleOp,
                       {"int_computations", "float_computations", "ir_functions",
                        "backwards_branching", "multiple_target_branching",
                        "multiple_return_points", "arrays"});
     return;
   }
 
-  removeModuleFlags(module,
+  removeModuleFlags(moduleOp,
                     {"int_computations", "float_computations", "ir_functions",
                      "multiple_target_branching", "multiple_return_points"});
 
@@ -136,7 +137,7 @@ void normalizeQIRModuleFlags(llvm::Module& module, const bool useAdaptive) {
     }
   };
 
-  for (const auto& function : module.functions()) {
+  for (const auto& function : moduleOp.functions()) {
     if (function.isDeclaration()) {
       continue;
     }
@@ -158,40 +159,30 @@ void normalizeQIRModuleFlags(llvm::Module& module, const bool useAdaptive) {
         }
         usesMultipleTargetBranching |= llvm::isa<llvm::SwitchInst>(instruction);
         recordType(instruction.getType());
-#ifndef __clang_analyzer__
-        // LLVM stores operands in an intrusive allocation adjacent to User.
-        // The static analyzer cannot model that representation and reports
-        // the canonical operands() accessor as an out-of-bounds access.
-        for (const auto& operand : instruction.operands()) {
-          if (!llvm::isa<llvm::Constant>(operand.get())) {
-            recordType(operand->getType());
-          }
-        }
-#endif
       }
     }
     usesMultipleReturnPoints |= returnCount > 1;
   }
 
-  auto& context = module.getContext();
+  auto& context = moduleOp.getContext();
   if (!integerTypes.empty()) {
-    module.setModuleFlag(llvm::Module::Append, "int_computations",
-                         stringTuple(context, integerTypes));
+    moduleOp.setModuleFlag(llvm::Module::Append, "int_computations",
+                           stringTuple(context, integerTypes));
   }
   if (!floatingTypes.empty()) {
-    module.setModuleFlag(llvm::Module::Append, "float_computations",
-                         stringTuple(context, floatingTypes));
+    moduleOp.setModuleFlag(llvm::Module::Append, "float_computations",
+                           stringTuple(context, floatingTypes));
   }
   if (usesIRFunctions) {
-    setIntegerModuleFlag(module, llvm::Module::Error, "ir_functions", 1, 1);
+    setIntegerModuleFlag(moduleOp, llvm::Module::Error, "ir_functions", 1, 1);
   }
   if (usesMultipleTargetBranching) {
-    setIntegerModuleFlag(module, llvm::Module::Error,
+    setIntegerModuleFlag(moduleOp, llvm::Module::Error,
                          "multiple_target_branching", 1, 1);
   }
   if (usesMultipleReturnPoints) {
-    setIntegerModuleFlag(module, llvm::Module::Error, "multiple_return_points",
-                         1, 1);
+    setIntegerModuleFlag(moduleOp, llvm::Module::Error,
+                         "multiple_return_points", 1, 1);
   }
 }
 
@@ -333,16 +324,16 @@ void emitQISCall(OpBuilder& builder, Operation* anchor, const Location loc,
 }
 
 LLVM::LLVMFuncOp getMainFunction(Operation* op) {
-  auto module = dyn_cast<ModuleOp>(op);
-  if (!module) {
-    module = op->getParentOfType<ModuleOp>();
+  auto moduleOp = dyn_cast<ModuleOp>(op);
+  if (!moduleOp) {
+    moduleOp = op->getParentOfType<ModuleOp>();
   }
-  if (!module) {
+  if (!moduleOp) {
     return nullptr;
   }
 
   // Search for function with entry_point attribute
-  for (const auto funcOp : module.getOps<LLVM::LLVMFuncOp>()) {
+  for (const auto funcOp : moduleOp.getOps<LLVM::LLVMFuncOp>()) {
     auto passthrough = funcOp->getAttrOfType<ArrayAttr>("passthrough");
     if (!passthrough) {
       continue;
@@ -369,14 +360,14 @@ LLVM::LLVMFuncOp getOrCreateFunctionDeclaration(OpBuilder& builder,
     const OpBuilder::InsertionGuard guard(builder);
 
     // Create the declaration at the end of the module
-    auto module = dyn_cast<ModuleOp>(op);
-    if (!module) {
-      module = op->getParentOfType<ModuleOp>();
+    auto moduleOp = dyn_cast<ModuleOp>(op);
+    if (!moduleOp) {
+      moduleOp = op->getParentOfType<ModuleOp>();
     }
-    if (!module) {
+    if (!moduleOp) {
       llvm::reportFatalInternalError("Module not found");
     }
-    builder.setInsertionPointToEnd(module.getBody());
+    builder.setInsertionPointToEnd(moduleOp.getBody());
 
     fnDecl = LLVM::LLVMFuncOp::create(builder, op->getLoc(), fnName, fnType);
 
@@ -395,24 +386,24 @@ LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
   // Save current insertion point
   const OpBuilder::InsertionGuard guard(builder);
 
-  auto module = dyn_cast<ModuleOp>(op);
-  if (!module) {
-    module = op->getParentOfType<ModuleOp>();
+  auto moduleOp = dyn_cast<ModuleOp>(op);
+  if (!moduleOp) {
+    moduleOp = op->getParentOfType<ModuleOp>();
   }
-  if (!module) {
+  if (!moduleOp) {
     llvm::reportFatalInternalError("Module not found");
   }
 
   const auto symbolName =
       builder.getStringAttr((symbolPrefix + "_" + label).str());
 
-  if (!module.lookupSymbol<LLVM::GlobalOp>(symbolName)) {
+  if (!moduleOp.lookupSymbol<LLVM::GlobalOp>(symbolName)) {
     const auto llvmArrayType = LLVM::LLVMArrayType::get(
         builder.getIntegerType(8), static_cast<unsigned>(label.size() + 1));
     const auto stringInitializer = builder.getStringAttr(label.str() + '\0');
 
     // Create the declaration at the start of the module
-    builder.setInsertionPointToStart(module.getBody());
+    builder.setInsertionPointToStart(moduleOp.getBody());
 
     const auto globalOp = LLVM::GlobalOp::create(
         builder, op->getLoc(), llvmArrayType, /*isConstant=*/true,

--- a/mlir/tools/mqt-cc/CMakeLists.txt
+++ b/mlir/tools/mqt-cc/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(
           MLIRJeffToQCO
           MLIRBytecodeWriter
           MLIRMathDialect
+          MLIRQIRUtils
           MLIRTargetLLVMIRExport
           MLIRBuiltinToLLVMIRTranslation
           MLIRLLVMToLLVMIRTranslation

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h"
 #include "mlir/Dialect/QC/Translation/TranslateQCToOpenQASM3.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/Utils/Transforms/Passes.h"
 #include "mlir/Support/Passes.h"
@@ -619,6 +620,8 @@ static int runCompiler(int argc, char** argv) {
       llvm::errs() << "Failed to translate MLIR module to LLVM IR\n";
       return 1;
     }
+    qir::normalizeQIRModuleFlags(*llvmMod, *parsedOutputFormat ==
+                                               OutputFormat::QIRAdaptive);
     if (writeOutput<llvm::Module*>(llvmMod.get(), outputFilename).failed()) {
       return 1;
     }

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -632,6 +632,44 @@ if (flag) {
   EXPECT_TRUE(qir->llvmIR().has_value());
 }
 
+TEST_F(CompilerPipelineTest, EmitsQIR21ProfileModuleFlags) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.0;
+qubit q;
+bit result;
+h q;
+result = measure q;
+)qasm";
+
+  auto input = QCProgram::fromQASMString(source.str());
+  ASSERT_TRUE(input);
+  for (const auto profile : {QIRProfile::Base, QIRProfile::Adaptive}) {
+    auto qir = std::move(input->copy()).intoQIR(profile);
+    ASSERT_TRUE(qir);
+    const auto llvmIR = qir->llvmIR();
+    ASSERT_TRUE(llvmIR);
+    EXPECT_NE(llvmIR->find("define i64 @main()"), std::string::npos);
+    EXPECT_NE(llvmIR->find("!\"qir_major_version\", i32 2"), std::string::npos);
+    EXPECT_NE(llvmIR->find("!\"qir_minor_version\", i32 0"), std::string::npos);
+    if (profile == QIRProfile::Adaptive) {
+      EXPECT_NE(llvmIR->find("!\"dynamic_qubit_management\", i1 true"),
+                std::string::npos);
+      EXPECT_NE(llvmIR->find("!\"dynamic_result_management\", i1 true"),
+                std::string::npos);
+      EXPECT_NE(llvmIR->find("!\"backwards_branching\", i2 0"),
+                std::string::npos);
+      EXPECT_NE(llvmIR->find("!\"arrays\", i1 true"), std::string::npos);
+    } else {
+      EXPECT_NE(llvmIR->find("!\"dynamic_qubit_management\", i1 false"),
+                std::string::npos);
+      EXPECT_NE(llvmIR->find("!\"dynamic_result_management\", i1 false"),
+                std::string::npos);
+      EXPECT_EQ(llvmIR->find("!\"backwards_branching\""), std::string::npos);
+      EXPECT_EQ(llvmIR->find("!\"arrays\""), std::string::npos);
+    }
+  }
+}
+
 enum class OutputRecordingShape : std::uint8_t { AdaptiveArrays, BaseArrays };
 
 } // namespace

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -650,7 +650,7 @@ result = measure q;
     ASSERT_TRUE(llvmIR);
     EXPECT_NE(llvmIR->find("define i64 @main()"), std::string::npos);
     EXPECT_NE(llvmIR->find("!\"qir_major_version\", i32 2"), std::string::npos);
-    EXPECT_NE(llvmIR->find("!\"qir_minor_version\", i32 0"), std::string::npos);
+    EXPECT_NE(llvmIR->find("!\"qir_minor_version\", i32 1"), std::string::npos);
     if (profile == QIRProfile::Adaptive) {
       EXPECT_NE(llvmIR->find("!\"dynamic_qubit_management\", i1 true"),
                 std::string::npos);

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -17,9 +17,13 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
+#include <llvm/Support/Casting.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
@@ -232,9 +236,9 @@ TEST_F(QIRTest, UsesQIR21ModuleFlagWidths) {
         [](QIRProgramBuilder& builder) { return builder.intConstant(0); },
         profile);
   };
-  const auto findFlag = [](ModuleOp module, const StringRef name) {
+  const auto findFlag = [](ModuleOp moduleOp, const StringRef name) {
     LLVM::ModuleFlagAttr result;
-    module->walk([&](LLVM::ModuleFlagsOp flagsOp) {
+    moduleOp->walk([&](LLVM::ModuleFlagsOp flagsOp) {
       for (const auto flag :
            flagsOp.getFlags().getAsRange<LLVM::ModuleFlagAttr>()) {
         if (flag.getKey().getValue() == name) {
@@ -269,40 +273,38 @@ TEST_F(QIRTest, UsesQIR21ModuleFlagWidths) {
 
 TEST(QIRModuleFlagsTest, RecordsAdaptiveClassicalCapabilities) {
   llvm::LLVMContext context;
-  llvm::Module module("adaptive", context);
+  llvm::Module moduleOp("adaptive", context);
   auto* function = llvm::Function::Create(
       llvm::FunctionType::get(llvm::Type::getInt64Ty(context), false),
-      llvm::Function::ExternalLinkage, "main", module);
+      llvm::Function::ExternalLinkage, "main", moduleOp);
   function->addFnAttr("entry_point");
   auto* entry = llvm::BasicBlock::Create(context, "entry", function);
   llvm::IRBuilder builder(entry);
   builder.CreateRet(builder.getInt64(0));
 
   auto* helper = llvm::Function::Create(
-      llvm::FunctionType::get(builder.getInt8Ty(),
-                              {builder.getInt8Ty(), builder.getDoubleTy()},
+      llvm::FunctionType::get(builder.getInt8Ty(), {builder.getInt8Ty()},
                               false),
-      llvm::Function::InternalLinkage, "helper", module);
+      llvm::Function::InternalLinkage, "helper", moduleOp);
   auto* helperEntry = llvm::BasicBlock::Create(context, "entry", helper);
   builder.SetInsertPoint(helperEntry);
-  auto argument = helper->arg_begin();
-  auto* integer = &*argument++;
-  auto* floating = &*argument;
+  auto* integer = helper->getArg(0);
+  auto* floating = builder.CreateUIToFP(integer, builder.getDoubleTy());
   builder.CreateFAdd(floating,
                      llvm::ConstantFP::get(builder.getDoubleTy(), 1.0));
   builder.CreateRet(builder.CreateAdd(integer, builder.getInt8(1)));
 
-  normalizeQIRModuleFlags(module, true);
+  normalizeQIRModuleFlags(moduleOp, true);
 
   const auto* integerTypes =
-      llvm::dyn_cast<llvm::MDNode>(module.getModuleFlag("int_computations"));
+      llvm::dyn_cast<llvm::MDNode>(moduleOp.getModuleFlag("int_computations"));
   ASSERT_NE(integerTypes, nullptr);
   ASSERT_EQ(integerTypes->getNumOperands(), 1U);
   EXPECT_EQ(
       llvm::cast<llvm::MDString>(integerTypes->getOperand(0))->getString(),
       "i8");
-  const auto* floatingTypes =
-      llvm::dyn_cast<llvm::MDNode>(module.getModuleFlag("float_computations"));
+  const auto* floatingTypes = llvm::dyn_cast<llvm::MDNode>(
+      moduleOp.getModuleFlag("float_computations"));
   ASSERT_NE(floatingTypes, nullptr);
   ASSERT_EQ(floatingTypes->getNumOperands(), 1U);
   EXPECT_EQ(
@@ -310,28 +312,28 @@ TEST(QIRModuleFlagsTest, RecordsAdaptiveClassicalCapabilities) {
       "double");
 
   std::string text;
-  llvm::raw_string_ostream(text) << module;
+  llvm::raw_string_ostream(text) << moduleOp;
   EXPECT_NE(text.find("!\"ir_functions\", i1 true"), std::string::npos);
 
   helper->eraseFromParent();
-  normalizeQIRModuleFlags(module, true);
-  EXPECT_EQ(module.getModuleFlag("int_computations"), nullptr);
-  EXPECT_EQ(module.getModuleFlag("float_computations"), nullptr);
-  EXPECT_EQ(module.getModuleFlag("ir_functions"), nullptr);
+  normalizeQIRModuleFlags(moduleOp, true);
+  EXPECT_EQ(moduleOp.getModuleFlag("int_computations"), nullptr);
+  EXPECT_EQ(moduleOp.getModuleFlag("float_computations"), nullptr);
+  EXPECT_EQ(moduleOp.getModuleFlag("ir_functions"), nullptr);
 }
 
 TEST(QIRModuleFlagsTest, RemovesAdaptiveFlagsFromBaseModules) {
   llvm::LLVMContext context;
-  llvm::Module module("base", context);
-  module.addModuleFlag(llvm::Module::Error, "backwards_branching", 3U);
-  module.addModuleFlag(llvm::Module::Error, "arrays", 1U);
-  module.addModuleFlag(llvm::Module::Error, "ir_functions", 1U);
+  llvm::Module moduleOp("base", context);
+  moduleOp.addModuleFlag(llvm::Module::Error, "backwards_branching", 3U);
+  moduleOp.addModuleFlag(llvm::Module::Error, "arrays", 1U);
+  moduleOp.addModuleFlag(llvm::Module::Error, "ir_functions", 1U);
 
-  normalizeQIRModuleFlags(module, false);
+  normalizeQIRModuleFlags(moduleOp, false);
 
-  EXPECT_EQ(module.getModuleFlag("backwards_branching"), nullptr);
-  EXPECT_EQ(module.getModuleFlag("arrays"), nullptr);
-  EXPECT_EQ(module.getModuleFlag("ir_functions"), nullptr);
+  EXPECT_EQ(moduleOp.getModuleFlag("backwards_branching"), nullptr);
+  EXPECT_EQ(moduleOp.getModuleFlag("arrays"), nullptr);
+  EXPECT_EQ(moduleOp.getModuleFlag("ir_functions"), nullptr);
 }
 
 /// \name QIR/Operations/StandardGates/DcxOp.cpp

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -17,6 +17,11 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/raw_ostream.h>
+#include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/LLVMTypes.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -218,6 +223,115 @@ TEST_F(QIRTest, BaseBuilderUsesGenericSpecializationForThreeControls) {
       ArrayAttr::get(context.get(),
                      {StringAttr::get(context.get(), "qir_profiles"),
                       StringAttr::get(context.get(), "base_profile")})));
+}
+
+TEST_F(QIRTest, UsesQIR21ModuleFlagWidths) {
+  const auto build = [&](const QIRProgramBuilder::Profile profile) {
+    return QIRProgramBuilder::build(
+        context.get(),
+        [](QIRProgramBuilder& builder) { return builder.intConstant(0); },
+        profile);
+  };
+  const auto findFlag = [](ModuleOp module, const StringRef name) {
+    LLVM::ModuleFlagAttr result;
+    module->walk([&](LLVM::ModuleFlagsOp flagsOp) {
+      for (const auto flag :
+           flagsOp.getFlags().getAsRange<LLVM::ModuleFlagAttr>()) {
+        if (flag.getKey().getValue() == name) {
+          result = flag;
+        }
+      }
+    });
+    return result;
+  };
+
+  auto base = build(QIRProgramBuilder::Profile::Base);
+  ASSERT_TRUE(base);
+  const auto baseDynamicQubits =
+      findFlag(base.get(), "dynamic_qubit_management");
+  ASSERT_TRUE(baseDynamicQubits);
+  EXPECT_TRUE(isa<BoolAttr>(baseDynamicQubits.getValue()));
+  EXPECT_FALSE(findFlag(base.get(), "backwards_branching"));
+
+  auto adaptive = build(QIRProgramBuilder::Profile::Adaptive);
+  ASSERT_TRUE(adaptive);
+  const auto backwardsBranching =
+      findFlag(adaptive.get(), "backwards_branching");
+  ASSERT_TRUE(backwardsBranching);
+  const auto backwardsBranchingValue =
+      dyn_cast<IntegerAttr>(backwardsBranching.getValue());
+  ASSERT_TRUE(backwardsBranchingValue);
+  EXPECT_EQ(backwardsBranchingValue.getType().getIntOrFloatBitWidth(), 2U);
+  const auto arrays = findFlag(adaptive.get(), "arrays");
+  ASSERT_TRUE(arrays);
+  EXPECT_TRUE(isa<BoolAttr>(arrays.getValue()));
+}
+
+TEST(QIRModuleFlagsTest, RecordsAdaptiveClassicalCapabilities) {
+  llvm::LLVMContext context;
+  llvm::Module module("adaptive", context);
+  auto* function = llvm::Function::Create(
+      llvm::FunctionType::get(llvm::Type::getInt64Ty(context), false),
+      llvm::Function::ExternalLinkage, "main", module);
+  function->addFnAttr("entry_point");
+  auto* entry = llvm::BasicBlock::Create(context, "entry", function);
+  llvm::IRBuilder builder(entry);
+  builder.CreateRet(builder.getInt64(0));
+
+  auto* helper = llvm::Function::Create(
+      llvm::FunctionType::get(builder.getInt8Ty(),
+                              {builder.getInt8Ty(), builder.getDoubleTy()},
+                              false),
+      llvm::Function::InternalLinkage, "helper", module);
+  auto* helperEntry = llvm::BasicBlock::Create(context, "entry", helper);
+  builder.SetInsertPoint(helperEntry);
+  auto argument = helper->arg_begin();
+  auto* integer = &*argument++;
+  auto* floating = &*argument;
+  builder.CreateFAdd(floating,
+                     llvm::ConstantFP::get(builder.getDoubleTy(), 1.0));
+  builder.CreateRet(builder.CreateAdd(integer, builder.getInt8(1)));
+
+  normalizeQIRModuleFlags(module, true);
+
+  const auto* integerTypes =
+      llvm::dyn_cast<llvm::MDNode>(module.getModuleFlag("int_computations"));
+  ASSERT_NE(integerTypes, nullptr);
+  ASSERT_EQ(integerTypes->getNumOperands(), 1U);
+  EXPECT_EQ(
+      llvm::cast<llvm::MDString>(integerTypes->getOperand(0))->getString(),
+      "i8");
+  const auto* floatingTypes =
+      llvm::dyn_cast<llvm::MDNode>(module.getModuleFlag("float_computations"));
+  ASSERT_NE(floatingTypes, nullptr);
+  ASSERT_EQ(floatingTypes->getNumOperands(), 1U);
+  EXPECT_EQ(
+      llvm::cast<llvm::MDString>(floatingTypes->getOperand(0))->getString(),
+      "double");
+
+  std::string text;
+  llvm::raw_string_ostream(text) << module;
+  EXPECT_NE(text.find("!\"ir_functions\", i1 true"), std::string::npos);
+
+  helper->eraseFromParent();
+  normalizeQIRModuleFlags(module, true);
+  EXPECT_EQ(module.getModuleFlag("int_computations"), nullptr);
+  EXPECT_EQ(module.getModuleFlag("float_computations"), nullptr);
+  EXPECT_EQ(module.getModuleFlag("ir_functions"), nullptr);
+}
+
+TEST(QIRModuleFlagsTest, RemovesAdaptiveFlagsFromBaseModules) {
+  llvm::LLVMContext context;
+  llvm::Module module("base", context);
+  module.addModuleFlag(llvm::Module::Error, "backwards_branching", 3U);
+  module.addModuleFlag(llvm::Module::Error, "arrays", 1U);
+  module.addModuleFlag(llvm::Module::Error, "ir_functions", 1U);
+
+  normalizeQIRModuleFlags(module, false);
+
+  EXPECT_EQ(module.getModuleFlag("backwards_branching"), nullptr);
+  EXPECT_EQ(module.getModuleFlag("arrays"), nullptr);
+  EXPECT_EQ(module.getModuleFlag("ir_functions"), nullptr);
 }
 
 /// \name QIR/Operations/StandardGates/DcxOp.cpp


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Emit the module metadata required by the frozen QIR 2.1 Base and Adaptive Profile publication.

- Emit the publication's `qir_major_version = 2` and `qir_minor_version = 0` tuple.
- Preserve `i32` version flags while using the required `i1` resource/capability flags and `i2` `backwards_branching` flag.
- Normalize flags after MLIR-to-LLVM translation because MLIR 22 otherwise widens integer-valued module flags to `i32`.
- Derive Adaptive `int_computations`, `float_computations`, `ir_functions`, multiple-target branching, and multiple-return capability metadata from the final LLVM module.
- Apply the same normalization in the typed compiler API and `mqt-cc` output paths.

This is the generic QIR metadata correction extracted from #2063. It is based directly on `main` and contains no fixed-angle implementation or angle-specific QIR policy.

The QIR 2.1 entry-point contract remains unchanged: entry points take no arguments and return an `i64` status code. This PR corrects profile metadata rather than changing source-interface lowering.

## Validation

- Independently cross-checked against the official QIR 2.1 Base and Adaptive Profile documents at tag `2.1` (`a177eee5885d99e965f5cb919c8d70b0ab7a6a15`).
- QIR IR tests: 116 passed.
- Compiler pipeline tests: 233 passed.
- Manual `mqt-cc` inspection confirms exact `i32`/`i1`/`i2` module metadata.
- Repository lint and `git diff --check` pass.

GPT-5.6 via Codex materially assisted with extraction, specification validation, implementation, testing, review, and publication under maintainer direction.
