### PR TITLE
⚡ Extend QCO DD execution for circuit-free DDSIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,9 @@ releases may include breaking changes.
   instance specifications, analytic references, deterministic manifests, and
   C++, Python, and command-line interfaces ([#2135], [#2315])
   ([**@burgholzer**], [**@denialhaag**])
-- ✨ Add decision diagram-based construction, simulation, and output-aware
-  sampling for QCO programs, with C++ and Python APIs and support for classical
-  control flow and dynamic quantum data ([#1915], [#1973], [#2077], [#2078])
-  ([**@simon1hofmann**], [**@burgholzer**])
+- ✨ Add DD construction, simulation, statevector extraction, and sampling for
+  QCO programs with structured control and dynamic quantum data ([#1915],
+  [#1973], [#2077], [#2078], [#2079]) ([**@simon1hofmann**], [**@burgholzer**])
 - ✨ Add immutable MLIR compiler targets, QDMI device integration, and target
   compilation through C++, Python, and `mqt-cc` ([#1687], [#1993], [#1999],
   [#2049]) ([**@MatthiasReumann**], [**@simon1hofmann**], [**@burgholzer**])
@@ -924,6 +923,7 @@ for previous changelogs._
 [#2105]: https://github.com/munich-quantum-toolkit/core/pull/2105
 [#2084]: https://github.com/munich-quantum-toolkit/core/pull/2084
 [#2082]: https://github.com/munich-quantum-toolkit/core/pull/2082
+[#2079]: https://github.com/munich-quantum-toolkit/core/pull/2079
 [#2078]: https://github.com/munich-quantum-toolkit/core/pull/2078
 [#2077]: https://github.com/munich-quantum-toolkit/core/pull/2077
 [#2074]: https://github.com/munich-quantum-toolkit/core/pull/2074

--- a/mlir/include/mlir/Dialect/QCO/Utils/DDFunctionality.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/DDFunctionality.h
@@ -80,7 +80,11 @@ simulate(func::FuncOp func, const dd::VectorDD& in, dd::Package& dd,
 /// The function must have one block. Measurement results can be unused or can
 /// set returned CBit registers. No later operation can use a measured wire.
 /// Called functions cannot measure or reset qubits.
-FailureOr<dd::VectorDD> simulateStatevector(func::FuncOp func, dd::Package& dd);
+///
+/// @param argumentBindings Scalar values and dynamic QTensor argument sizes.
+FailureOr<dd::VectorDD> simulateStatevector(
+    func::FuncOp func, dd::Package& dd,
+    const DDArgumentBindings& argumentBindings = DDArgumentBindings());
 
 /// Sample a single-block QCO function from the zero state.
 ///

--- a/mlir/include/mlir/Dialect/QCO/Utils/DDFunctionality.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/DDFunctionality.h
@@ -25,116 +25,79 @@
 
 namespace mlir::qco {
 
-/**
- * @brief Concrete values for symbolic QCO DD inputs.
- *
- * Exactly typed integer, index, and `f64` attributes bind scalar entry-function
- * arguments. A non-negative index attribute bound to a dynamic one-dimensional
- * qtensor argument gives its runtime extent. Other bindings are rejected.
- */
+/// Concrete values for QCO DD entry arguments.
+///
+/// Values must be integer, index, or `f64` attributes. An index value sets the
+/// size of a dynamic one-dimensional QTensor argument.
 using DDArgumentBindings = DenseMap<Value, Attribute>;
 
-/**
- * @brief Sequentially build a matrix DD for a static unitary QCO `func.func`.
- *
- * @details Walks the entry block of @p func, maps `qco.static` SSA values to
- * wire indices (or, if none are present, qubit-typed function arguments as
- * wires `0..n-1`), assigns entry-block `qco.alloc` operations subsequent
- * wires, and applies unitary operations via decision-diagram multiplication.
- *
- * Supported programs:
- * - Standard single-, two-, and three-qubit gates with constant or bound
- *   parameters (sparse DD path)
- * - `ctrl` with a sole standard-gate body (same sparse path)
- * - Other `UnitaryOpInterface` ops with a compile-time known matrix (`inv`,
- *   compound `ctrl`, ...), including `gphase` and `barrier`
- * - QTensor bookkeeping over existing input wires
- * - Concrete QCO and SCF control flow and non-recursive single-block calls
- * - Concrete integer, index, and `f64` arithmetic and one-dimensional memrefs
- *   of those scalar types
- * - `qco.static` establishes the wire map (or qubit-typed `func` args if none),
- *   followed by entry-block `qco.alloc`; `sink` is ignored; returned qubits
- *   and qtensors must preserve canonical wire order
- *
- * Known one-, two-, and three-qubit matrices are constructed directly as DD
- * gates. Larger compile-time unitaries are embedded directly into a DD over
- * their target wires, so idle register qubits do not enlarge the local matrix.
- * Measurements, resets, unbound parameters, and non-concrete control flow are
- * not supported.
- *
- * @pre The containing module has passed MLIR verification and
- * `qco::verifyLinearity`.
- *
- * @param func The QCO function to construct the functionality for
- * @param dd The DD package to use (must hold at least the function's qubits)
- * @param argumentBindings Concrete scalar values and dynamic QTensor extents
- * for entry arguments
- * @return The matrix DD on success, or failure for unsupported programs
- */
+/// Build a matrix DD for a unitary QCO function.
+///
+/// The function must have one block. The interpreter supports concrete QCO and
+/// SCF structured control, non-recursive calls, common scalar math,
+/// one-dimensional memrefs, and QTensor bookkeeping. `qco.static` values, or
+/// qubit arguments when no static values exist, set the wire map. Entry-block
+/// `qco.alloc` operations add subsequent wires. Measurements, resets, symbolic
+/// control, and other runtime allocation are not supported.
+///
+/// The containing module must pass MLIR verification and
+/// `qco::verifyLinearity`.
+///
+/// @param func QCO function to interpret.
+/// @param dd DD package. The function grows it when needed.
+/// @param argumentBindings Scalar values and dynamic QTensor argument sizes.
+/// @return Matrix DD, or failure for an unsupported program.
 FailureOr<dd::MatrixDD> buildFunctionality(
     func::FuncOp func, dd::Package& dd,
     const DDArgumentBindings& argumentBindings = DDArgumentBindings());
 
-/**
- * @brief Simulate a QCO `func.func` that may contain measurements, resets, and
- * concrete control-flow.
- *
- * @details Supports the unitary op set of @ref buildFunctionality, plus
- * `qco.measure` / `qco.reset` (collapsing via @p rng) and `qco.if` /
- * `qco.index_switch` when the branch selector is a concrete classical SSA value
- * (`arith.constant`, a prior measurement, integer and `f64`
- * arithmetic, comparisons, casts, shifts, and `arith.select`). Dynamic quantum
- * allocation, qtensors, memrefs, CBit registers, loops, regions, and calls are
- * supported. QTensor sizes and indices must be concrete; dynamic qtensor
- * arguments require an extent in @p argumentBindings. A shared 10000-step
- * budget bounds loop iterations and executed control-flow regions and calls.
- * Multi-block function bodies remain unsupported. Allocated wires stay in the
- * returned state after deallocation.
- * Consumes one reference to @p in regardless of success or failure.
- *
- * @pre The containing module has passed MLIR verification and
- * `qco::verifyLinearity`.
- *
- * @param func The QCO function to simulate
- * @param in The input state, which must span at least the function's qubits;
- * higher wires are preserved; one reference is consumed
- * @param dd The DD package to use
- * @param rng RNG used for collapsing measurements and resets
- * @param argumentBindings Concrete scalar values and dynamic QTensor extents
- * for entry arguments
- * @return The output statevector DD on success, or failure for unsupported
- *         programs
- */
+/// Simulate a single-block QCO function.
+///
+/// In addition to the operations supported by `buildFunctionality`, simulation
+/// supports measurements, resets, CBit registers, and runtime qubit and QTensor
+/// allocation. QCO and SCF structured control requires concrete values. A
+/// shared 10000-step limit bounds loops and calls. `qco.sink` and
+/// `qtensor.dealloc` mark lifetimes but do not remove DD wires.
+///
+/// The containing module must pass MLIR verification and
+/// `qco::verifyLinearity`. The function consumes one reference to `in`, also on
+/// failure.
+///
+/// @param func QCO function to simulate.
+/// @param in Input state. It must contain every function qubit.
+/// @param dd DD package. The function grows it when needed.
+/// @param rng Random-number generator for measurements and resets.
+/// @param argumentBindings Scalar values and dynamic QTensor argument sizes.
+/// @return Output state DD, or failure for an unsupported program.
 FailureOr<dd::VectorDD>
 simulate(func::FuncOp func, const dd::VectorDD& in, dd::Package& dd,
          std::mt19937_64& rng,
          const DDArgumentBindings& argumentBindings = DDArgumentBindings());
 
-/**
- * @brief Sample measurement outcomes from a QCO `func.func`.
- *
- * @details Starts from the all-zero state. If the entry function returns CBit
- * registers, their initialized cells form the outcome in return order and from
- * bit `N-1` to bit `0` within each register. Mixed CBit/non-CBit results are
- * rejected. Programs without CBit results fall back to final computational-
- * basis sampling via `Package::measureAll` (qubit `n-1` … `0`). Terminal entry-
- * block measurements that only produce returned CBit cells are sampled from
- * one DD evolution; resets and execution-dependent measurements are executed
- * once per shot. Dynamically allocated wires are included in fallback basis
- * outcomes even after deallocation.
- *
- * @pre The containing module has passed MLIR verification and
- * `qco::verifyLinearity`.
- *
- * @param func The QCO function to sample
- * @param dd The DD package to use
- * @param shots Number of shots
- * @param rng RNG for collapsing measurements and non-collapsing sampling
- * @param argumentBindings Concrete scalar values and dynamic QTensor extents
- * for entry arguments
- * @return Histogram of outcome strings on success, or failure for unsupported
- *         programs
- */
+/// Simulate a zero-state QCO function without collapsing terminal
+/// measurements.
+///
+/// The function must have one block. Measurement results can be unused or can
+/// set returned CBit registers. No later operation can use a measured wire.
+/// Called functions cannot measure or reset qubits.
+FailureOr<dd::VectorDD> simulateStatevector(func::FuncOp func, dd::Package& dd);
+
+/// Sample a single-block QCO function from the zero state.
+///
+/// Returned CBit registers set the outcome in return order and from high to low
+/// bit. Without CBit results, the function samples all DD wires. Terminal
+/// measurements use one simulation for all shots. Programs that use a measured
+/// value or wire, or reset a qubit, run once per shot.
+///
+/// The containing module must pass MLIR verification and
+/// `qco::verifyLinearity`.
+///
+/// @param func QCO function to sample.
+/// @param dd DD package. The function grows it when needed.
+/// @param shots Number of samples.
+/// @param rng Random-number generator.
+/// @param argumentBindings Scalar values and dynamic QTensor argument sizes.
+/// @return Outcome counts, or failure for an unsupported program.
 FailureOr<std::map<std::string, size_t>>
 sample(func::FuncOp func, dd::Package& dd, size_t shots, std::mt19937_64& rng,
        const DDArgumentBindings& argumentBindings = DDArgumentBindings());

--- a/mlir/lib/Dialect/QCO/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCO/Utils/CMakeLists.txt
@@ -70,6 +70,7 @@ add_mlir_library(
   MLIRQCOMatrix
   MLIRArithDialect
   MLIRFuncDialect
+  MLIRMathDialect
   MLIRSCFDialect
   MQT::CoreDD
   PRIVATE

--- a/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
@@ -41,6 +41,7 @@
 #include <llvm/ADT/TypeSwitch.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -131,8 +132,6 @@ struct TensorMap {
     return it == tensors.end() ? nullptr : it->second;
   }
 
-  void erase(Value value) { tensors.erase(value); }
-
   [[nodiscard]] TensorMap clone() const {
     TensorMap copy;
     for (const auto& [value, slots] : tensors) {
@@ -152,6 +151,7 @@ struct ClassicalEnv {
 
   DenseMap<Value, Attribute> values;
   DenseMap<Value, qc::Qubit> deferredMeasurements;
+  Operation** deferredMeasurementUse = nullptr;
   /// Shared storage preserves CBit register identity across `func.call`.
   DenseMap<Value, std::shared_ptr<RegisterState>> registers;
   /// Shared storage preserves caller-visible writes through `func.call`.
@@ -160,6 +160,11 @@ struct ClassicalEnv {
   LogicalResult bindFrom(Value source, Value dest, Operation* op) {
     const auto it = values.find(source);
     if (it == values.end()) {
+      if (deferredMeasurements.contains(source) &&
+          deferredMeasurementUse != nullptr) {
+        *deferredMeasurementUse = op;
+        return failure();
+      }
       return op->emitError()
              << "classical SSA value is not mapped for QCO DD simulation";
     }
@@ -180,6 +185,7 @@ struct WalkState {
   dd::Package* dd;
   std::mt19937_64* rng = nullptr;
   const DenseSet<Operation*>* deferredMeasurements = nullptr;
+  DenseSet<qc::Qubit>* deferredMeasuredWires = nullptr;
   size_t remainingExecutionSteps = MAX_CONTROL_FLOW_STEPS;
   DenseSet<Operation*> activeCalls;
 };
@@ -217,6 +223,11 @@ static FailureOr<Attribute>
 lookupAttribute(Value value, const ClassicalEnv& classical, Operation* op) {
   const auto it = classical.values.find(value);
   if (it == classical.values.end()) {
+    if (classical.deferredMeasurements.contains(value) &&
+        classical.deferredMeasurementUse != nullptr) {
+      *classical.deferredMeasurementUse = op;
+      return failure();
+    }
     return op->emitError()
            << "classical SSA value is not mapped for QCO DD simulation";
   }
@@ -662,6 +673,10 @@ static LogicalResult loadRegister(cbit::LoadOp load, ClassicalEnv& classical) {
     return failure();
   }
   const auto& cell = (*regIt->second)[*index];
+  if (cell.deferredWire && classical.deferredMeasurementUse != nullptr) {
+    *classical.deferredMeasurementUse = load.getOperation();
+    return failure();
+  }
   if (!cell.value) {
     return load.emitError() << "read from an undefined CBit register element";
   }
@@ -862,7 +877,11 @@ static LogicalResult applyClassicalOp(Operation& op, ClassicalEnv& classical) {
             arith::SubIOp, arith::MulIOp, arith::ShLIOp, arith::ShRUIOp,
             arith::ShRSIOp, arith::CmpIOp, arith::AddFOp, arith::SubFOp,
             arith::MulFOp, arith::DivFOp, arith::RemFOp, arith::NegFOp,
-            arith::CmpFOp, arith::SIToFPOp, arith::UIToFPOp>(
+            arith::CmpFOp, arith::SIToFPOp, arith::UIToFPOp, arith::MaxSIOp,
+            arith::MinSIOp, arith::MaxUIOp, arith::MinUIOp, arith::MaximumFOp,
+            arith::MinimumFOp, arith::MaxNumFOp, arith::MinNumFOp, math::AbsFOp,
+            math::CeilOp, math::CosOp, math::ExpOp, math::FloorOp, math::LogOp,
+            math::SinOp, math::SqrtOp, math::TanOp, math::PowFOp>(
           [&](Operation* foldable) {
             return foldClassicalOp(*foldable, classical);
           })
@@ -1019,6 +1038,11 @@ static LogicalResult bindValuePairs(ValueRange sources, ValueRange dests,
       }
       values.emplace_back(it->second);
     } else {
+      if (const auto deferred = walk.classical->deferredMeasurements.find(src);
+          deferred != walk.classical->deferredMeasurements.end()) {
+        values.emplace_back(deferred->second);
+        continue;
+      }
       const auto value = walk.classical->values.find(src);
       if (value == walk.classical->values.end()) {
         return op->emitError()
@@ -1039,7 +1063,11 @@ static LogicalResult bindValuePairs(ValueRange sources, ValueRange dests,
     } else if (isa<MemRefType>(dest.getType())) {
       walk.classical->memrefs[dest] =
           std::get<std::shared_ptr<ClassicalEnv::MemRefState>>(value);
+    } else if (std::holds_alternative<qc::Qubit>(value)) {
+      walk.classical->values.erase(dest);
+      walk.classical->deferredMeasurements[dest] = std::get<qc::Qubit>(value);
     } else {
+      walk.classical->deferredMeasurements.erase(dest);
       walk.classical->values[dest] = std::get<Attribute>(value);
     }
   }
@@ -1061,6 +1089,10 @@ static LogicalResult bindYieldResults(YieldOp yield,
 
 template <typename StateDD>
 static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state);
+
+template <typename StateDD>
+static FailureOr<func::ReturnOp>
+walkFunctionBody(func::FuncOp func, WalkState& walk, StateDD& state);
 
 template <typename StateDD>
 static LogicalResult walkBlock(Block& block, WalkState& walk, StateDD& state) {
@@ -1095,33 +1127,26 @@ template <typename StateDD>
 static LogicalResult applyScfRegion(Region& region, ValueRange results,
                                     WalkState& walk, StateDD& state,
                                     Operation* parent) {
-  if (!region.hasOneBlock()) {
-    return parent->emitError()
-           << "SCF region must contain exactly one block for QCO DD simulation";
-  }
-  Block& block = region.front();
   if (failed(consumeExecutionStep(walk, parent))) {
     return failure();
   }
+  Block& block = region.front();
   if (failed(walkBlock(block, walk, state))) {
     return failure();
   }
-  auto yield = dyn_cast<scf::YieldOp>(block.getTerminator());
-  if (!yield || yield.getNumOperands() != results.size()) {
-    return parent->emitError()
-           << "SCF region must yield one value for each result";
-  }
+  auto yield = cast<scf::YieldOp>(block.getTerminator());
   return bindValuePairs(yield.getOperands(), results, walk, parent);
 }
 
 static FailureOr<TensorSlots> allocateZeroQubits(size_t count, WalkState& walk,
                                                  dd::VectorDD& state,
                                                  Operation* op) {
-  if (walk.qubits->numQubits > walk.dd->qubits() ||
-      count > walk.dd->qubits() - walk.qubits->numQubits) {
-    return op->emitError() << "DD package has " << walk.dd->qubits()
-                           << " qubits but allocation requires "
-                           << walk.qubits->numQubits + count;
+  if (count > dd::Package::MAX_POSSIBLE_QUBITS - walk.qubits->numQubits) {
+    return op->emitError() << "QCO function exceeds the supported qubit range";
+  }
+  const size_t required = walk.qubits->numQubits + count;
+  if (walk.dd->qubits() < required) {
+    walk.dd->resize(required);
   }
 
   const size_t first = walk.qubits->numQubits;
@@ -1141,10 +1166,31 @@ static FailureOr<TensorSlots> allocateZeroQubits(size_t count, WalkState& walk,
   return slots;
 }
 
+static LogicalResult checkDeferredMeasurementUse(UnitaryOpInterface unitary,
+                                                 WalkState& walk) {
+  if (walk.deferredMeasuredWires == nullptr ||
+      isa<BarrierOp>(unitary.getOperation())) {
+    return success();
+  }
+  auto wires = walk.qubits->lookupRange(unitary.getInputQubits(),
+                                        unitary.getOperation());
+  if (failed(wires)) {
+    return failure();
+  }
+  if (llvm::none_of(*wires, [&](qc::Qubit wire) {
+        return walk.deferredMeasuredWires->contains(wire);
+      })) {
+    return success();
+  }
+  *walk.classical->deferredMeasurementUse = unitary.getOperation();
+  return failure();
+}
+
 template <typename StateDD>
 static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
   return TypeSwitch<Operation*, LogicalResult>(&op)
-      .template Case<StaticOp, SinkOp>([](auto) { return success(); })
+      .template Case<StaticOp, SinkOp, qtensor::DeallocOp>(
+          [](auto) { return success(); })
       .template Case<arith::ConstantOp>([&](arith::ConstantOp constant) {
         return recordConstant(constant, *walk.classical);
       })
@@ -1252,15 +1298,6 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
             walk.tensors->bind(insert.getResult(), input);
             return success();
           })
-      .template Case<qtensor::DeallocOp>(
-          [&](qtensor::DeallocOp dealloc) -> LogicalResult {
-            if (!walk.tensors->lookup(dealloc.getTensor())) {
-              return dealloc.emitError()
-                     << "qtensor is not mapped for QCO DD simulation";
-            }
-            walk.tensors->erase(dealloc.getTensor());
-            return success();
-          })
       .template Case<memref::AllocOp>([&](memref::AllocOp alloc) {
         return applyMemRefAlloc(alloc, *walk.classical);
       })
@@ -1280,9 +1317,6 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
         return storeRegister(store, *walk.classical);
       })
       .template Case<memref::DeallocOp>([](auto) { return success(); })
-      .template Case<func::ReturnOp>([&](func::ReturnOp returnOp) {
-        return validateReturn(returnOp, *walk.qubits, *walk.tensors);
-      })
       .template Case<MeasureOp>([&](MeasureOp measureOp) -> LogicalResult {
         if constexpr (!std::is_same_v<StateDD, dd::VectorDD>) {
           return measureOp.emitError()
@@ -1303,6 +1337,7 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
           }
           if (deferred) {
             walk.classical->deferredMeasurements[measureOp.getResult()] = *q;
+            walk.deferredMeasuredWires->insert(*q);
             walk.qubits->bind(measureOp.getQubitOut(), *q);
             return success();
           }
@@ -1398,11 +1433,6 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
             return applyScfRegion(*selected, switchOp.getResults(), walk, state,
                                   switchOp);
           })
-      .template Case<scf::ExecuteRegionOp>(
-          [&](scf::ExecuteRegionOp execute) -> LogicalResult {
-            return applyScfRegion(execute.getRegion(), execute.getResults(),
-                                  walk, state, execute);
-          })
       .template Case<scf::ForOp>([&](scf::ForOp forOp) -> LogicalResult {
         auto range = resolveLoop(forOp, *walk.classical);
         if (failed(range)) {
@@ -1474,12 +1504,13 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
       .template Case<func::CallOp>([&](func::CallOp call) -> LogicalResult {
         auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
             call, call.getCalleeAttr());
-        if (!callee.getBody().hasOneBlock()) {
-          return call.emitError()
-                 << "func.call callee must have a single-block body";
+        if (!callee) {
+          return call.emitError() << "func.call callee '" << call.getCallee()
+                                  << "' could not be resolved";
         }
-        auto returnOp =
-            cast<func::ReturnOp>(callee.getBody().front().getTerminator());
+        if (callee.isDeclaration()) {
+          return call.emitError() << "func.call callee must have a body";
+        }
         Operation* calleeOp = callee.getOperation();
         if (!walk.activeCalls.insert(calleeOp).second) {
           return call.emitError()
@@ -1498,13 +1529,19 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
           return failure();
         }
 
-        if (failed(walkBlock(callee.getBody().front(), walk, state))) {
+        auto returnOp = walkFunctionBody(callee, walk, state);
+        if (failed(returnOp)) {
           return failure();
         }
-        return bindValuePairs(returnOp.getOperands(), call.getResults(), walk,
+
+        /// Map callee return operands onto call results via the return op.
+        return bindValuePairs(returnOp->getOperands(), call.getResults(), walk,
                               call);
       })
       .template Case<CtrlOp>([&](CtrlOp ctrlOp) -> LogicalResult {
+        if (failed(checkDeferredMeasurementUse(ctrlOp, walk))) {
+          return failure();
+        }
         if (auto inner = mqt::getSoleBodyUnitary<UnitaryOpInterface>(
                 *ctrlOp.getBody())) {
           auto decoded = decodeStandardGate(inner, *walk.classical);
@@ -1529,6 +1566,9 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
       })
       .template Case<UnitaryOpInterface>(
           [&](UnitaryOpInterface unitary) -> LogicalResult {
+            if (failed(checkDeferredMeasurementUse(unitary, walk))) {
+              return failure();
+            }
             auto decoded = decodeStandardGate(unitary, *walk.classical);
             if (failed(decoded)) {
               return failure();
@@ -1539,8 +1579,9 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
             return applyUnitaryMatrix(unitary, walk, state);
           })
       .Default([&](Operation* unsupported) -> LogicalResult {
-        if (unsupported->getName().getDialectNamespace() ==
-            arith::ArithDialect::getDialectNamespace()) {
+        const StringRef dialect = unsupported->getName().getDialectNamespace();
+        if (dialect == arith::ArithDialect::getDialectNamespace() ||
+            dialect == math::MathDialect::getDialectNamespace()) {
           return applyClassicalOp(*unsupported, *walk.classical);
         }
         return unsupported->emitError()
@@ -1550,17 +1591,26 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
 }
 
 template <typename StateDD>
-static LogicalResult walkFunction(func::FuncOp func, WalkState& walkState,
-                                  StateDD& state) {
-  walkState.activeCalls.insert(func.getOperation());
-  // Function bodies include `func.return` as terminator; region walks skip
-  // `qco.yield` and bind it separately.
-  for (Operation& op : func.getBody().front()) {
-    if (failed(applyOp(op, walkState, state))) {
-      return failure();
-    }
+static FailureOr<func::ReturnOp>
+walkFunctionBody(func::FuncOp func, WalkState& walk, StateDD& state) {
+  if (!func.getBody().hasOneBlock()) {
+    return func.emitError() << "QCO DD execution requires one-block functions";
   }
-  return success();
+  Block& block = func.getBody().front();
+  if (failed(walkBlock(block, walk, state))) {
+    return failure();
+  }
+  return cast<func::ReturnOp>(block.getTerminator());
+}
+
+template <typename StateDD>
+static LogicalResult walkFunction(func::FuncOp func, WalkState& walk,
+                                  StateDD& state) {
+  auto returnOp = walkFunctionBody(func, walk, state);
+  if (failed(returnOp)) {
+    return failure();
+  }
+  return validateReturn(*returnOp, *walk.qubits, *walk.tensors);
 }
 
 namespace {
@@ -1568,16 +1618,46 @@ struct PreparedState {
   QubitMap qubits;
   TensorMap tensors;
   ClassicalEnv classical;
+  size_t knownAllocations = 0;
 };
 } // namespace
 
+static size_t countKnownAllocations(func::FuncOp func,
+                                    const ClassicalEnv& classical) {
+  size_t count = 0;
+  func.walk([&](Operation* op) {
+    size_t allocation = isa<AllocOp>(op) ? 1U : 0U;
+    if (auto alloc = dyn_cast<qtensor::AllocOp>(op)) {
+      const auto type = cast<RankedTensorType>(alloc.getType());
+      if (!type.isDynamicDim(0)) {
+        allocation = static_cast<size_t>(type.getDimSize(0));
+      } else {
+        Attribute size;
+        if (const auto it = classical.values.find(alloc.getSize());
+            it != classical.values.end()) {
+          size = it->second;
+        } else if (const auto folded =
+                       mqt::valueToConstantAttr(alloc.getSize())) {
+          size = *folded;
+        }
+        if (const auto integer = dyn_cast_if_present<IntegerAttr>(size)) {
+          const int64_t value = integer.getValue().getSExtValue();
+          allocation = value > 0 ? static_cast<size_t>(value) : 0U;
+        }
+      }
+    }
+    count += std::min(allocation, dd::Package::MAX_POSSIBLE_QUBITS - count);
+  });
+  return count;
+}
+
 static FailureOr<PreparedState>
-prepare(func::FuncOp func, const dd::Package& dd,
+prepare(func::FuncOp func, dd::Package& dd,
         const DDArgumentBindings& argumentBindings,
         bool bindEntryAllocations = false) {
-  if (!func.getBody().hasOneBlock()) {
+  if (func.isDeclaration() || !func.getBody().hasOneBlock()) {
     return func.emitError()
-           << "QCO DD construction expects a single-block function body";
+           << "QCO DD execution requires a one-block function body";
   }
 
   PreparedState prepared;
@@ -1646,9 +1726,11 @@ prepare(func::FuncOp func, const dd::Package& dd,
                   static_cast<qc::Qubit>(qubits.numQubits++));
     }
   }
+  if (!bindEntryAllocations) {
+    prepared.knownAllocations = countKnownAllocations(func, prepared.classical);
+  }
   if (dd.qubits() < qubits.numQubits) {
-    return func.emitError() << "DD package has " << dd.qubits()
-                            << " qubits but function uses " << qubits.numQubits;
+    dd.resize(qubits.numQubits);
   }
   return prepared;
 }
@@ -1669,6 +1751,7 @@ buildFunctionality(func::FuncOp func, dd::Package& dd,
                       .classical = &classical,
                       .dd = &dd,
                       .rng = nullptr};
+  walkState.activeCalls.insert(func.getOperation());
 
   dd::MatrixDD state =
       qubits.numQubits == 0
@@ -1687,7 +1770,10 @@ static FailureOr<dd::VectorDD>
 simulateImpl(func::FuncOp func, const dd::VectorDD& in, dd::Package& dd,
              const PreparedState& prepared, std::mt19937_64* rng,
              const DenseSet<Operation*>* deferredMeasurements = nullptr,
-             ClassicalEnv* finalClassical = nullptr) {
+             ClassicalEnv* finalClassical = nullptr,
+             DenseSet<qc::Qubit>* deferredMeasuredWires = nullptr,
+             Operation** deferredMeasurementUse = nullptr,
+             bool validateQuantumReturn = true) {
   const size_t inputQubits =
       in.isTerminal() ? 0U : static_cast<size_t>(in.p->v) + 1U;
   if (inputQubits < prepared.qubits.numQubits) {
@@ -1696,19 +1782,32 @@ simulateImpl(func::FuncOp func, const dd::VectorDD& in, dd::Package& dd,
            << "input state has " << inputQubits << " qubits but function uses "
            << prepared.qubits.numQubits;
   }
+  if (prepared.knownAllocations <=
+      dd::Package::MAX_POSSIBLE_QUBITS - inputQubits) {
+    const size_t required = inputQubits + prepared.knownAllocations;
+    if (dd.qubits() < required) {
+      dd.resize(required);
+    }
+  }
   QubitMap qubits = prepared.qubits;
   qubits.numQubits = inputQubits;
   TensorMap tensors = prepared.tensors.clone();
   ClassicalEnv classical = prepared.classical;
+  classical.deferredMeasurementUse = deferredMeasurementUse;
   WalkState walkState{.qubits = &qubits,
                       .tensors = &tensors,
                       .classical = &classical,
                       .dd = &dd,
                       .rng = rng,
-                      .deferredMeasurements = deferredMeasurements};
+                      .deferredMeasurements = deferredMeasurements,
+                      .deferredMeasuredWires = deferredMeasuredWires};
+  walkState.activeCalls.insert(func.getOperation());
 
   dd::VectorDD state = in;
-  if (failed(walkFunction(func, walkState, state))) {
+  auto returnOp = walkFunctionBody(func, walkState, state);
+  if (failed(returnOp) ||
+      (validateQuantumReturn &&
+       failed(validateReturn(*returnOp, qubits, tensors)))) {
     dd.decRef(state);
     return failure();
   }
@@ -1729,72 +1828,63 @@ FailureOr<dd::VectorDD> simulate(func::FuncOp func, const dd::VectorDD& in,
   return simulateImpl(func, in, dd, *prepared, &rng);
 }
 
-static bool isOutputOnlyRegister(Value reg, ArrayRef<Value> outputs) {
-  return llvm::is_contained(outputs, reg) &&
-         llvm::all_of(reg.getUses(), [reg](const OpOperand& use) {
-           if (auto store = dyn_cast<cbit::StoreOp>(use.getOwner())) {
-             return store.getReg() == reg;
-           }
-           return isa<func::ReturnOp>(use.getOwner());
-         });
-}
-
-static bool hasOutputOnlyMeasurementResult(MeasureOp measure,
-                                           ArrayRef<Value> outputs) {
-  return llvm::all_of(measure.getResult().getUses(), [&](const OpOperand& use) {
-    auto store = dyn_cast<cbit::StoreOp>(use.getOwner());
-    return store && isOutputOnlyRegister(store.getReg(), outputs);
-  });
-}
-
-static bool isDeferrableMeasurement(MeasureOp measure, Block* entry,
-                                    ArrayRef<Value> outputs) {
-  if (measure->getBlock() != entry ||
-      !hasOutputOnlyMeasurementResult(measure, outputs)) {
-    return false;
+static bool mayMeasureOrReset(func::FuncOp func, DenseSet<Operation*>& active) {
+  if (!active.insert(func).second) {
+    return true;
   }
-  return llvm::all_of(measure.getQubitOut().getUses(), [&](OpOperand& use) {
-    Operation* owner = use.getOwner();
-    return isa<SinkOp>(owner) ||
-           (owner == entry->getTerminator() && isa<func::ReturnOp>(owner));
+  const auto guard = llvm::make_scope_exit([&] { active.erase(func); });
+  bool found = false;
+  func.getBody().walk([&](Operation* op) {
+    if (found || isa<MeasureOp, ResetOp>(op)) {
+      found = true;
+      return;
+    }
+    auto call = dyn_cast<func::CallOp>(op);
+    if (!call) {
+      return;
+    }
+    auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+        call, call.getCalleeAttr());
+    found =
+        !callee || callee.isDeclaration() || mayMeasureOrReset(callee, active);
   });
+  return found;
 }
 
-static void analyzeSampling(func::FuncOp func, Block* sampledEntry,
-                            ArrayRef<Value> outputs,
-                            DenseSet<Operation*>& active, SamplingPlan& plan) {
-  Operation* funcOp = func.getOperation();
-  if (!active.insert(funcOp).second) {
-    plan.dynamic = true;
-    return;
-  }
+static void analyzeSampling(func::FuncOp func, SamplingPlan& plan) {
   func.getBody().walk([&](Operation* op) {
     if (isa<ResetOp>(op)) {
       plan.dynamic = true;
-    } else if (auto measure = dyn_cast<MeasureOp>(op)) {
-      if (isDeferrableMeasurement(measure, sampledEntry, outputs)) {
-        plan.deferredMeasurements.insert(op);
-      } else {
-        plan.dynamic = true;
-      }
-    } else if (auto call = dyn_cast<func::CallOp>(op)) {
-      auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
-          call, call.getCalleeAttr());
-      if (!callee || callee.isDeclaration() ||
-          !callee.getBody().hasOneBlock()) {
-        plan.dynamic = true;
-      } else {
-        analyzeSampling(callee, sampledEntry, outputs, active, plan);
-      }
+      return;
+    }
+    if (isa<MeasureOp>(op)) {
+      plan.deferredMeasurements.insert(op);
+      return;
+    }
+    auto call = dyn_cast<func::CallOp>(op);
+    if (!call) {
+      return;
+    }
+    auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+        call, call.getCalleeAttr());
+    DenseSet<Operation*> active;
+    if (!callee || callee.isDeclaration() ||
+        mayMeasureOrReset(callee, active)) {
+      plan.dynamic = true;
     }
   });
-  active.erase(funcOp);
 }
 
-static FailureOr<SamplingPlan> getSamplingPlan(func::FuncOp func) {
+static FailureOr<SamplingPlan>
+getSamplingPlan(func::FuncOp func, bool statevectorAnalysis = false) {
   Block& entry = func.getBody().front();
-  auto returnOp = cast<func::ReturnOp>(entry.getTerminator());
   SamplingPlan plan;
+  auto returnOp = dyn_cast<func::ReturnOp>(entry.getTerminator());
+  if (!returnOp) {
+    return func.emitError()
+           << "single-block QCO DD execution requires func.return";
+  }
+
   bool hasOther = false;
   for (Value value : returnOp.getOperands()) {
     if (isa<cbit::RegisterType>(value.getType())) {
@@ -1803,15 +1893,43 @@ static FailureOr<SamplingPlan> getSamplingPlan(func::FuncOp func) {
       hasOther = true;
     }
   }
-  if (!plan.outputs.empty() && hasOther) {
+  if (!statevectorAnalysis && !plan.outputs.empty() && hasOther) {
     return returnOp.emitError()
            << "QCO DD sampling does not support mixed CBit and non-CBit "
               "results";
   }
 
-  DenseSet<Operation*> active;
-  analyzeSampling(func, &entry, plan.outputs, active, plan);
+  analyzeSampling(func, plan);
   return plan;
+}
+
+FailureOr<dd::VectorDD> simulateStatevector(func::FuncOp func,
+                                            dd::Package& dd) {
+  auto prepared = prepare(func, dd, DDArgumentBindings{});
+  if (failed(prepared)) {
+    return failure();
+  }
+  auto plan = getSamplingPlan(func, /*statevectorAnalysis=*/true);
+  if (failed(plan)) {
+    return failure();
+  }
+  if (plan->dynamic) {
+    return func.emitError()
+           << "statevector extraction supports only terminal measurements "
+              "that assemble returned CBit registers";
+  }
+  DenseSet<qc::Qubit> measuredWires;
+  Operation* deferredMeasurementUse = nullptr;
+  auto state = simulateImpl(
+      func, dd::makeZeroState(prepared->qubits.numQubits, dd), dd, *prepared,
+      nullptr, &plan->deferredMeasurements, nullptr, &measuredWires,
+      &deferredMeasurementUse, /*validateQuantumReturn=*/false);
+  if (failed(state) && deferredMeasurementUse != nullptr) {
+    return deferredMeasurementUse->emitError()
+           << "statevector extraction cannot use a measurement result or "
+              "measured qubit before program end";
+  }
+  return state;
 }
 
 static FailureOr<std::string> encodeOutcome(ArrayRef<Value> outputs,
@@ -1843,16 +1961,21 @@ static FailureOr<std::string> encodeOutcome(ArrayRef<Value> outputs,
   return outcome;
 }
 
-FailureOr<std::map<std::string, size_t>>
-sample(func::FuncOp func, dd::Package& dd, size_t shots, std::mt19937_64& rng,
-       const DDArgumentBindings& argumentBindings) {
-  auto prepared = prepare(func, dd, argumentBindings);
-  if (failed(prepared)) {
-    return failure();
-  }
+static FailureOr<std::map<std::string, size_t>>
+sampleImpl(func::FuncOp func, const dd::VectorDD& in, dd::Package& dd,
+           size_t shots, std::mt19937_64& rng, const PreparedState& prepared) {
+  const auto inputGuard = llvm::make_scope_exit([&] { dd.decRef(in); });
   auto plan = getSamplingPlan(func);
   if (failed(plan)) {
     return failure();
+  }
+
+  const size_t inputQubits =
+      in.isTerminal() ? 0U : static_cast<size_t>(in.p->v) + 1U;
+  if (inputQubits < prepared.qubits.numQubits) {
+    return func.emitError()
+           << "input state has " << inputQubits << " qubits but function uses "
+           << prepared.qubits.numQubits;
   }
 
   std::map<std::string, size_t> counts;
@@ -1860,7 +1983,6 @@ sample(func::FuncOp func, dd::Package& dd, size_t shots, std::mt19937_64& rng,
     return counts;
   }
 
-  const size_t numQubits = prepared->qubits.numQubits;
   const auto record = [&](const ClassicalEnv& classical,
                           StringRef basis) -> LogicalResult {
     auto outcome = encodeOutcome(plan->outputs, classical, basis);
@@ -1873,25 +1995,31 @@ sample(func::FuncOp func, dd::Package& dd, size_t shots, std::mt19937_64& rng,
 
   if (!plan->dynamic) {
     ClassicalEnv classical;
-    auto state =
-        simulateImpl(func, dd::makeZeroState(numQubits, dd), dd, *prepared,
-                     nullptr, &plan->deferredMeasurements, &classical);
-    if (failed(state)) {
+    DenseSet<qc::Qubit> measuredWires;
+    Operation* deferredMeasurementUse = nullptr;
+    dd.incRef(in);
+    auto state = simulateImpl(func, in, dd, prepared, nullptr,
+                              &plan->deferredMeasurements, &classical,
+                              &measuredWires, &deferredMeasurementUse);
+    if (succeeded(state)) {
+      const auto guard = llvm::make_scope_exit([&] { dd.decRef(*state); });
+      for (size_t i = 0; i < shots; ++i) {
+        if (failed(record(classical, dd.measureAll(*state, false, rng)))) {
+          return failure();
+        }
+      }
+      return counts;
+    }
+    if (deferredMeasurementUse == nullptr) {
       return failure();
     }
-    const auto guard = llvm::make_scope_exit([&] { dd.decRef(*state); });
-    for (size_t i = 0; i < shots; ++i) {
-      if (failed(record(classical, dd.measureAll(*state, false, rng)))) {
-        return failure();
-      }
-    }
-    return counts;
   }
 
   for (size_t i = 0; i < shots; ++i) {
     ClassicalEnv classical;
-    auto state = simulateImpl(func, dd::makeZeroState(numQubits, dd), dd,
-                              *prepared, &rng, nullptr, &classical);
+    dd.incRef(in);
+    auto state =
+        simulateImpl(func, in, dd, prepared, &rng, nullptr, &classical);
     if (failed(state)) {
       return failure();
     }
@@ -1904,6 +2032,17 @@ sample(func::FuncOp func, dd::Package& dd, size_t shots, std::mt19937_64& rng,
     }
   }
   return counts;
+}
+
+FailureOr<std::map<std::string, size_t>>
+sample(func::FuncOp func, dd::Package& dd, size_t shots, std::mt19937_64& rng,
+       const DDArgumentBindings& argumentBindings) {
+  auto prepared = prepare(func, dd, argumentBindings);
+  if (failed(prepared)) {
+    return failure();
+  }
+  return sampleImpl(func, dd::makeZeroState(prepared->qubits.numQubits, dd), dd,
+                    shots, rng, *prepared);
 }
 
 } // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
@@ -1617,38 +1617,8 @@ struct PreparedState {
   QubitMap qubits;
   TensorMap tensors;
   ClassicalEnv classical;
-  size_t knownAllocations = 0;
 };
 } // namespace
-
-static size_t countKnownAllocations(func::FuncOp func,
-                                    const ClassicalEnv& classical) {
-  size_t count = 0;
-  func.walk([&](Operation* op) {
-    size_t allocation = isa<AllocOp>(op) ? 1U : 0U;
-    if (auto alloc = dyn_cast<qtensor::AllocOp>(op)) {
-      const auto type = cast<RankedTensorType>(alloc.getType());
-      if (!type.isDynamicDim(0)) {
-        allocation = static_cast<size_t>(type.getDimSize(0));
-      } else {
-        Attribute size;
-        if (const auto it = classical.values.find(alloc.getSize());
-            it != classical.values.end()) {
-          size = it->second;
-        } else if (const auto folded =
-                       mqt::valueToConstantAttr(alloc.getSize())) {
-          size = *folded;
-        }
-        if (const auto integer = dyn_cast_if_present<IntegerAttr>(size)) {
-          const int64_t value = integer.getValue().getSExtValue();
-          allocation = value > 0 ? static_cast<size_t>(value) : 0U;
-        }
-      }
-    }
-    count += std::min(allocation, dd::Package::MAX_POSSIBLE_QUBITS - count);
-  });
-  return count;
-}
 
 static FailureOr<PreparedState>
 prepare(func::FuncOp func, dd::Package& dd,
@@ -1725,9 +1695,6 @@ prepare(func::FuncOp func, dd::Package& dd,
                   static_cast<qc::Qubit>(qubits.numQubits++));
     }
   }
-  if (!bindEntryAllocations) {
-    prepared.knownAllocations = countKnownAllocations(func, prepared.classical);
-  }
   if (dd.qubits() < qubits.numQubits) {
     dd.resize(qubits.numQubits);
   }
@@ -1780,13 +1747,6 @@ simulateImpl(func::FuncOp func, const dd::VectorDD& in, dd::Package& dd,
     return func.emitError()
            << "input state has " << inputQubits << " qubits but function uses "
            << prepared.qubits.numQubits;
-  }
-  if (prepared.knownAllocations <=
-      dd::Package::MAX_POSSIBLE_QUBITS - inputQubits) {
-    const size_t required = inputQubits + prepared.knownAllocations;
-    if (dd.qubits() < required) {
-      dd.resize(required);
-    }
   }
   QubitMap qubits = prepared.qubits;
   qubits.numQubits = inputQubits;

--- a/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
@@ -1903,9 +1903,10 @@ getSamplingPlan(func::FuncOp func, bool statevectorAnalysis = false) {
   return plan;
 }
 
-FailureOr<dd::VectorDD> simulateStatevector(func::FuncOp func,
-                                            dd::Package& dd) {
-  auto prepared = prepare(func, dd, DDArgumentBindings{});
+FailureOr<dd::VectorDD>
+simulateStatevector(func::FuncOp func, dd::Package& dd,
+                    const DDArgumentBindings& argumentBindings) {
+  auto prepared = prepare(func, dd, argumentBindings);
   if (failed(prepared)) {
     return failure();
   }

--- a/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
@@ -745,15 +745,14 @@ static LogicalResult applyMemRefStore(memref::StoreOp store,
                                       ClassicalEnv& classical) {
   auto slot =
       lookupMemRefSlot(store.getMemref(), store.getIndices(), classical, store);
-  const auto value = classical.values.find(store.getValue());
-  if (failed(slot) || value == classical.values.end()) {
-    if (value == classical.values.end()) {
-      store.emitError()
-          << "stored classical value is not mapped for QCO DD simulation";
-    }
+  if (failed(slot)) {
     return failure();
   }
-  **slot = value->second;
+  auto value = lookupAttribute(store.getValue(), classical, store);
+  if (failed(value)) {
+    return failure();
+  }
+  **slot = *value;
   return success();
 }
 

--- a/mlir/unittests/Dialect/QCO/Utils/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Utils/CMakeLists.txt
@@ -10,8 +10,14 @@ set(qco_utils_target mqt-core-mlir-unittest-qco-utils)
 add_executable(${qco_utils_target} test_dd_functionality.cpp test_drivers.cpp test_layout.cpp
                                    test_unitary_matrix.cpp test_wireiterator.cpp)
 target_link_libraries(
-  ${qco_utils_target} PRIVATE GTest::gtest_main MLIRParser MLIRQCODDFunctionality MLIRQCOUtils
-                              MLIRQCOProgramBuilder MLIRQCOMatrix)
+  ${qco_utils_target}
+  PRIVATE GTest::gtest_main
+          MLIRParser
+          MLIRQCODDFunctionality
+          MLIRQCOUtils
+          MLIRQCOProgramBuilder
+          MLIRQCOMatrix
+          MLIRControlFlowDialect)
 mqt_mlir_configure_unittest_target(${qco_utils_target} REQUIRES_EH)
 
 gtest_discover_tests(${qco_utils_target} PROPERTIES LABELS mqt-mlir-unittests DISCOVERY_TIMEOUT 60)

--- a/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
@@ -27,7 +27,9 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Builders.h>
@@ -65,9 +67,10 @@ protected:
 
   void SetUp() override {
     DialectRegistry registry;
-    registry.insert<cbit::CBitDialect, QCODialect, qtensor::QTensorDialect,
-                    arith::ArithDialect, func::FuncDialect,
-                    memref::MemRefDialect, scf::SCFDialect>();
+    registry
+        .insert<cbit::CBitDialect, QCODialect, qtensor::QTensorDialect,
+                arith::ArithDialect, cf::ControlFlowDialect, func::FuncDialect,
+                math::MathDialect, memref::MemRefDialect, scf::SCFDialect>();
     context = std::make_unique<MLIRContext>();
     context->appendDialectRegistry(registry);
     context->loadAllAvailableDialects();
@@ -1116,7 +1119,10 @@ TEST_F(QCODDFunctionalityTest, SampleHandlesZeroShotsAndSimulationFailure) {
   EXPECT_TRUE(failed(sample(mainFunc(*measuredDynamic), *dd, 1, rng)));
 
   auto tooSmall = std::make_unique<dd::Package>(0);
-  EXPECT_TRUE(failed(sample(mainFunc(*unitary), *tooSmall, 1, rng)));
+  const auto grown = sample(mainFunc(*unitary), *tooSmall, 1, rng);
+  ASSERT_TRUE(succeeded(grown));
+  EXPECT_EQ(*grown, (std::map<std::string, size_t>{{"1", 1}}));
+  EXPECT_EQ(tooSmall->qubits(), 1U);
   EXPECT_TRUE(dd->getRootSet<dd::vNode>().empty());
 }
 
@@ -1200,8 +1206,8 @@ TEST_F(QCODDFunctionalityTest, RejectsUnsupportedOrUnboundClassicalOperations) {
            R"mlir(module {
              func.func @main() {
                %q = qco.static 0 : !qco.qubit
-               %one = arith.constant 1 : i64
-               %bad = arith.maxsi %one, %one : i64
+               %one = arith.constant 1.0 : f64
+               %bad = math.erf %one : f64
                qco.sink %q : !qco.qubit
                return
              }
@@ -1395,7 +1401,10 @@ TEST_F(QCODDFunctionalityTest, Rejects) {
     });
     ASSERT_TRUE(mod);
     auto dd = std::make_unique<dd::Package>(1);
-    EXPECT_TRUE(failed(buildFunctionality(mainFunc(*mod), *dd)));
+    const auto functionality = buildFunctionality(mainFunc(*mod), *dd);
+    ASSERT_TRUE(succeeded(functionality));
+    EXPECT_EQ(dd->qubits(), 2U);
+    dd->decRef(*functionality);
     EXPECT_TRUE(
         failed(simulate(mainFunc(*mod), dd::makeZeroState(1, *dd), *dd, rng)));
   }
@@ -1520,21 +1529,6 @@ TEST_F(QCODDFunctionalityTest, Rejects) {
     auto wideDD = std::make_unique<dd::Package>(11);
     EXPECT_TRUE(failed(buildFunctionality(mainFunc(*wideModifier), *wideDD)));
   }
-
-  OwningOpRef<ModuleOp> multi =
-      ModuleOp::create(UnknownLoc::get(context.get()));
-  OpBuilder builder(context.get());
-  builder.setInsertionPointToStart(multi->getBody());
-  auto func = func::FuncOp::create(builder, multi->getLoc(), "main",
-                                   builder.getFunctionType({}, {}));
-  auto* entry = func.addEntryBlock();
-  auto* second = func.addBlock();
-  builder.setInsertionPointToStart(entry);
-  func::ReturnOp::create(builder, func.getLoc());
-  builder.setInsertionPointToStart(second);
-  func::ReturnOp::create(builder, func.getLoc());
-  auto dd = std::make_unique<dd::Package>(0);
-  EXPECT_TRUE(failed(buildFunctionality(func, *dd)));
 }
 
 TEST_F(QCODDFunctionalityTest, SimulateScfForAndFuncCallWithClassicalValues) {
@@ -2048,7 +2042,7 @@ TEST_F(QCODDFunctionalityTest, SampleExecutesControlMeasurementPerShot) {
   std::mt19937_64 rng(11);
   auto singleDD = std::make_unique<dd::Package>(1);
   ASSERT_TRUE(succeeded(sample(mainFunc(*mod), *singleDD, 1, rng)));
-  const auto perShotLookups =
+  const auto singleShotLookups =
       singleDD->matrixVectorMultiplication.getStats().lookups;
 
   auto dd = std::make_unique<dd::Package>(1);
@@ -2057,7 +2051,7 @@ TEST_F(QCODDFunctionalityTest, SampleExecutesControlMeasurementPerShot) {
   ASSERT_TRUE(succeeded(histogram));
   EXPECT_EQ(*histogram, (std::map<std::string, size_t>{{"1", shots}}));
   EXPECT_EQ(dd->matrixVectorMultiplication.getStats().lookups,
-            perShotLookups * shots);
+            1U + (singleShotLookups - 1U) * shots);
   EXPECT_TRUE(dd->getRootSet<dd::vNode>().empty());
 }
 
@@ -2170,7 +2164,7 @@ TEST_F(QCODDFunctionalityTest,
   EXPECT_TRUE(dd->getRootSet<dd::vNode>().empty());
 }
 
-TEST_F(QCODDFunctionalityTest, SampleExecutesNestedMeasurementPerShot) {
+TEST_F(QCODDFunctionalityTest, SampleDefersNestedTerminalMeasurement) {
   auto mod = parseSourceString<ModuleOp>(R"mlir(
     module {
       func.func @main() -> !cbit.reg<1> {
@@ -2197,7 +2191,7 @@ TEST_F(QCODDFunctionalityTest, SampleExecutesNestedMeasurementPerShot) {
   std::mt19937_64 rng(9);
   auto singleDD = std::make_unique<dd::Package>(1);
   ASSERT_TRUE(succeeded(sample(mainFunc(*mod), *singleDD, 1, rng)));
-  const auto perShotLookups =
+  const auto singleEvolutionLookups =
       singleDD->matrixVectorMultiplication.getStats().lookups;
 
   auto dd = std::make_unique<dd::Package>(1);
@@ -2207,7 +2201,7 @@ TEST_F(QCODDFunctionalityTest, SampleExecutesNestedMeasurementPerShot) {
   ASSERT_EQ(histogram->size(), 2U);
   EXPECT_EQ(histogram->at("0") + histogram->at("1"), shots);
   EXPECT_EQ(dd->matrixVectorMultiplication.getStats().lookups,
-            perShotLookups * shots);
+            singleEvolutionLookups);
   EXPECT_TRUE(dd->getRootSet<dd::vNode>().empty());
 }
 
@@ -2326,15 +2320,12 @@ TEST_F(QCODDFunctionalityTest, BuildsThroughConcreteControlFlow) {
   expectEqualToQc(mainFunc(*mod), qc);
 }
 
-TEST_F(QCODDFunctionalityTest, StandardScfRegionsAndWhileCarryValues) {
+TEST_F(QCODDFunctionalityTest, StructuredScfAndWhileCarryValues) {
   auto mod = parseSourceString<ModuleOp>(R"mlir(
     module {
       func.func @main() {
         %q = qco.static 0 : !qco.qubit
-        %q1 = scf.execute_region -> !qco.qubit {
-          %out = qco.x %q : !qco.qubit -> !qco.qubit
-          scf.yield %out : !qco.qubit
-        }
+        %q1 = qco.x %q : !qco.qubit -> !qco.qubit
         %true = arith.constant true
         %selector = scf.if %true -> index {
           %one = arith.constant 1 : index
@@ -2395,21 +2386,6 @@ TEST_F(QCODDFunctionalityTest, StandardScfRegionsAndWhileCarryValues) {
   expectEqualToQc(mainFunc(*mod), qc);
 }
 
-TEST_F(QCODDFunctionalityTest, RejectsMultiBlockScfExecuteRegion) {
-  expectMlirSimulationFails(0, R"mlir(
-    module {
-      func.func @main() {
-        scf.execute_region {
-          scf.yield
-        ^next:
-          scf.yield
-        }
-        return
-      }
-    }
-  )mlir");
-}
-
 TEST_F(QCODDFunctionalityTest, DynamicAllocationsAndQTensorBookkeeping) {
   auto mod = buildModule([](QCOProgramBuilder& b) {
     auto q0 = b.x(b.allocQubit());
@@ -2431,7 +2407,10 @@ TEST_F(QCODDFunctionalityTest, DynamicAllocationsAndQTensorBookkeeping) {
   EXPECT_EQ(*histogram, (std::map<std::string, size_t>{{"11", 8}}));
 
   auto smallDd = std::make_unique<dd::Package>(1);
-  EXPECT_TRUE(failed(sample(mainFunc(*mod), *smallDd, 1, rng)));
+  const auto grown = sample(mainFunc(*mod), *smallDd, 1, rng);
+  ASSERT_TRUE(succeeded(grown));
+  EXPECT_EQ(*grown, (std::map<std::string, size_t>{{"11", 1}}));
+  EXPECT_EQ(smallDd->qubits(), 2U);
 
   auto invalidIndex = parseSourceString<ModuleOp>(R"mlir(
     module {
@@ -2827,6 +2806,180 @@ TEST_F(QCODDFunctionalityTest, BuildFunctionalityRestrictsRuntimeAllocations) {
   const auto functionality = buildFunctionality(mainFunc(*topLevel), *dd);
   ASSERT_TRUE(succeeded(functionality));
   dd->decRef(*functionality);
+}
+
+TEST_F(QCODDFunctionalityTest, RejectsMultiBlockAndExecuteRegion) {
+  for (const StringRef source : {
+           R"mlir(module {
+             func.func @main() {
+               %q = qco.static 0 : !qco.qubit
+               cf.br ^next(%q : !qco.qubit)
+             ^next(%arg: !qco.qubit):
+               qco.sink %arg : !qco.qubit
+               return
+             }
+           })mlir",
+           R"mlir(module {
+             func.func @main() {
+               %q = qco.static 0 : !qco.qubit
+               %out = scf.execute_region -> !qco.qubit {
+                 scf.yield %q : !qco.qubit
+               }
+               qco.sink %out : !qco.qubit
+               return
+             }
+           })mlir"}) {
+    auto mod = parseSourceString<ModuleOp>(source, context.get());
+    ASSERT_TRUE(mod);
+    auto dd = std::make_unique<dd::Package>(1);
+    EXPECT_TRUE(failed(buildFunctionality(mainFunc(*mod), *dd)));
+  }
+}
+
+TEST_F(QCODDFunctionalityTest, InterpretsMinMaxAndCommonMathOperations) {
+  auto mod = buildModule([](QCOProgramBuilder& b) {
+    auto q = b.staticQubit(0);
+    Value minusOne = arith::ConstantIntOp::create(b, -1, 8);
+    Value three = arith::ConstantIntOp::create(b, 3, 8);
+    Value maxMatches = arith::CmpIOp::create(
+        b, arith::CmpIPredicate::eq, arith::MaxSIOp::create(b, minusOne, three),
+        three);
+    Value zero =
+        arith::ConstantFloatOp::create(b, b.getF64Type(), llvm::APFloat(0.0));
+    Value sinMatches = arith::CmpFOp::create(
+        b, arith::CmpFPredicate::OEQ, math::SinOp::create(b, zero), zero);
+    Value all = arith::AndIOp::create(b, maxMatches, sinMatches);
+    q = b.qcoIf(
+        all, q, [&](Value arg) { return b.x(arg); },
+        [&](Value arg) { return arg; });
+    b.sink(q);
+    return b.intConstant(0);
+  });
+  ASSERT_TRUE(mod);
+
+  qc::QuantumComputation qc(1);
+  qc.x(0);
+  expectEqualToQc(mainFunc(*mod), qc);
+}
+
+TEST_F(QCODDFunctionalityTest, StatevectorSupportsTerminalMeasurements) {
+  auto empty =
+      buildModule([](QCOProgramBuilder& b) { return b.intConstant(0); });
+  auto mod = buildModule([](QCOProgramBuilder& b) {
+    auto reg =
+        b.allocClassicalBitRegister(1, {}, cbit::Initialization::Undefined);
+    auto q = b.h(b.staticQubit(0));
+    std::tie(q, std::ignore) = b.measure(q, reg, 0);
+    b.sink(q);
+    return reg;
+  });
+  ASSERT_TRUE(empty);
+  ASSERT_TRUE(mod);
+
+  auto dd = std::make_unique<dd::Package>(0);
+  const auto emptyState = simulateStatevector(mainFunc(*empty), *dd);
+  ASSERT_TRUE(succeeded(emptyState));
+  EXPECT_TRUE(emptyState->isTerminal());
+
+  const auto state = simulateStatevector(mainFunc(*mod), *dd);
+  ASSERT_TRUE(succeeded(state));
+  EXPECT_EQ(dd->qubits(), 1U);
+  const auto vector = state->getVector();
+  ASSERT_EQ(vector.size(), 2U);
+  EXPECT_NEAR(std::norm(vector[0]), 0.5, 1e-12);
+  EXPECT_NEAR(std::norm(vector[1]), 0.5, 1e-12);
+  dd->decRef(*state);
+}
+
+TEST_F(QCODDFunctionalityTest, StatevectorRejectsNonTerminalMeasurement) {
+  auto reuse = buildModule([](QCOProgramBuilder& b) {
+    auto q = b.h(b.staticQubit(0));
+    std::tie(q, std::ignore) = b.measure(q);
+    b.sink(b.h(q));
+    return b.intConstant(0);
+  });
+  auto reset = buildModule([](QCOProgramBuilder& b) {
+    b.sink(b.reset(b.staticQubit(0)));
+    return b.intConstant(0);
+  });
+  auto call = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @measure(%q: !qco.qubit) -> !qco.qubit {
+        %out, %bit = qco.measure %q : !qco.qubit
+        return %out : !qco.qubit
+      }
+      func.func @main() {
+        %q = qco.static 0 : !qco.qubit
+        %out = func.call @measure(%q) : (!qco.qubit) -> !qco.qubit
+        qco.sink %out : !qco.qubit
+        return
+      }
+    }
+  )mlir",
+                                          context.get());
+  ASSERT_TRUE(reuse);
+  ASSERT_TRUE(reset);
+  ASSERT_TRUE(call);
+
+  auto dd = std::make_unique<dd::Package>(1);
+  EXPECT_TRUE(failed(simulateStatevector(mainFunc(*reuse), *dd)));
+  EXPECT_TRUE(failed(simulateStatevector(mainFunc(*reset), *dd)));
+  EXPECT_TRUE(failed(simulateStatevector(mainFunc(*call), *dd)));
+}
+
+TEST_F(QCODDFunctionalityTest, LifetimeMarkersPreserveEntangledState) {
+  auto mod = buildModule([](QCOProgramBuilder& b) {
+    auto q0 = b.h(b.staticQubit(0));
+    auto q1 = b.staticQubit(1);
+    std::tie(q0, q1) = b.cx(q0, q1);
+    b.qtensorDealloc(b.qtensorFromElements({q0, q1}));
+    b.sink(b.x(b.staticQubit(2)));
+    return b.intConstant(0);
+  });
+  ASSERT_TRUE(mod);
+
+  auto dd = std::make_unique<dd::Package>(0);
+  const auto state = simulateStatevector(mainFunc(*mod), *dd);
+  ASSERT_TRUE(succeeded(state));
+  const auto vector = state->getVector();
+  ASSERT_EQ(vector.size(), 8U);
+  EXPECT_NEAR(std::norm(vector[4]), 0.5, 1e-12);
+  EXPECT_NEAR(std::norm(vector[7]), 0.5, 1e-12);
+  dd->decRef(*state);
+
+  const auto histogram = sample(mainFunc(*mod), *dd, 64, rng);
+  ASSERT_TRUE(succeeded(histogram));
+  EXPECT_EQ(histogram->at("100") + histogram->at("111"), 64U);
+}
+
+TEST_F(QCODDFunctionalityTest, StatevectorPreallocatesKnownQubits) {
+  auto mod = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @main() {
+        %false = arith.constant false
+        scf.if %false {
+          %q0 = qco.alloc : !qco.qubit
+          %q1 = qco.alloc : !qco.qubit
+          %q2 = qco.alloc : !qco.qubit
+          qco.sink %q0 : !qco.qubit
+          qco.sink %q1 : !qco.qubit
+          qco.sink %q2 : !qco.qubit
+        }
+        return
+      }
+    }
+  )mlir",
+                                         context.get());
+  ASSERT_TRUE(mod);
+
+  auto dd = std::make_unique<dd::Package>(0);
+  const auto state = simulateStatevector(mainFunc(*mod), *dd);
+  ASSERT_TRUE(succeeded(state));
+  EXPECT_EQ(dd->qubits(), 3U);
+  const auto vector = state->getVector();
+  ASSERT_EQ(vector.size(), 1U);
+  EXPECT_NEAR(std::norm(vector[0]), 1.0, 1e-12);
+  dd->decRef(*state);
 }
 
 } // namespace

--- a/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
@@ -2055,6 +2055,38 @@ TEST_F(QCODDFunctionalityTest, SampleExecutesControlMeasurementPerShot) {
   EXPECT_TRUE(dd->getRootSet<dd::vNode>().empty());
 }
 
+TEST_F(QCODDFunctionalityTest,
+       SampleFallsBackWhenDeferredMeasurementIsStoredInMemRef) {
+  auto mod = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @main() -> !cbit.reg<1> {
+        %out = cbit.alloc(#cbit.init<undefined>) : !cbit.reg<1>
+        %memory = memref.alloc() : memref<1xi1>
+        %zero = arith.constant 0 : index
+        %q = qco.static 0 : !qco.qubit
+        %q1 = qco.h %q : !qco.qubit -> !qco.qubit
+        %q2, %bit = qco.measure %q1 : !qco.qubit
+        memref.store %bit, %memory[%zero] : memref<1xi1>
+        %loaded = memref.load %memory[%zero] : memref<1xi1>
+        cbit.store %loaded, %out[%zero] : !cbit.reg<1>
+        memref.dealloc %memory : memref<1xi1>
+        qco.sink %q2 : !qco.qubit
+        return %out : !cbit.reg<1>
+      }
+    }
+  )mlir",
+                                         context.get());
+  ASSERT_TRUE(mod);
+
+  auto dd = std::make_unique<dd::Package>(1);
+  constexpr size_t shots = 128;
+  const auto histogram = sample(mainFunc(*mod), *dd, shots, rng);
+  ASSERT_TRUE(succeeded(histogram));
+  ASSERT_EQ(histogram->size(), 2U);
+  EXPECT_EQ(histogram->at("0") + histogram->at("1"), shots);
+  EXPECT_TRUE(dd->getRootSet<dd::vNode>().empty());
+}
+
 TEST_F(QCODDFunctionalityTest, FuncCallSharesClassicalCBitStorage) {
   auto mod = parseSourceString<ModuleOp>(R"mlir(
     module {

--- a/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
@@ -2992,7 +2992,7 @@ TEST_F(QCODDFunctionalityTest, LifetimeMarkersPreserveEntangledState) {
   EXPECT_EQ(histogram->at("100") + histogram->at("111"), 64U);
 }
 
-TEST_F(QCODDFunctionalityTest, StatevectorPreallocatesKnownQubits) {
+TEST_F(QCODDFunctionalityTest, StatevectorSkipsUnreachedAllocations) {
   auto mod = parseSourceString<ModuleOp>(R"mlir(
     module {
       func.func @main() {
@@ -3015,7 +3015,7 @@ TEST_F(QCODDFunctionalityTest, StatevectorPreallocatesKnownQubits) {
   auto dd = std::make_unique<dd::Package>(0);
   const auto state = simulateStatevector(mainFunc(*mod), *dd);
   ASSERT_TRUE(succeeded(state));
-  EXPECT_EQ(dd->qubits(), 3U);
+  EXPECT_EQ(dd->qubits(), 0U);
   const auto vector = state->getVector();
   ASSERT_EQ(vector.size(), 1U);
   EXPECT_NEAR(std::norm(vector[0]), 1.0, 1e-12);

--- a/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
@@ -2246,6 +2246,14 @@ TEST_F(QCODDFunctionalityTest, SymbolicParametersUseBindings) {
   ASSERT_TRUE(succeeded(histogram));
   EXPECT_EQ(*histogram, (std::map<std::string, size_t>{{"1", 8}}));
 
+  const auto state = simulateStatevector(func, *dd, bindings);
+  ASSERT_TRUE(succeeded(state));
+  const auto vector = state->getVector();
+  ASSERT_EQ(vector.size(), 2U);
+  EXPECT_NEAR(std::norm(vector[0]), 0.0, 1e-12);
+  EXPECT_NEAR(std::norm(vector[1]), 1.0, 1e-12);
+  dd->decRef(*state);
+
   EXPECT_TRUE(failed(buildFunctionality(func, *dd)));
   bindings[func.getArgument(0)] =
       IntegerAttr::get(IntegerType::get(context.get(), 64), 1);


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

Extends the QCO DD interpreter needed by #2288 so DDSIM can execute QCO directly after the legacy circuit layer is removed.

- Execute single-block QCO functions with structured QCO and SCF control flow, function calls, and the common arithmetic and Math dialect operations needed by QCO programs. Multi-block CFG execution is out of scope.
- Treat `qco.sink` and `qtensor.dealloc` as lifetime markers. Grow DD packages on demand instead of exposing qubit-count bookkeeping.
- Extract statevectors for programs with no measurements or terminal measurements only. A measured physical wire or measurement result cannot affect later execution.
- Sample terminal-measurement programs by evolving one DD once and sampling it repeatedly. Programs with dynamic measurement use fall back to per-shot execution.
- Keep concrete C++ argument bindings. Symbolic Python execution, density simulation, compatibility shims, and legacy circuit constructs are outside this stack.

This remains layer 4 of the QCO DD functionality stack, following #1915, #1973, #2077, and #2078. #2288 consumes this functionality while removing the legacy circuit paths.

## Validation

- Focused regressions: 4/4 tests passed.
- QCO utility binary: 166/166 tests passed, including all 75 QCO DD functionality tests.
- Repository lint passed.
- Clang 22 format and tidy checks passed.
- Generated Python stubs are unchanged and up to date.
- `git diff --check` passed.

GPT-5.6 via Codex materially assisted with implementation, testing, review, and stack restructuring under maintainer direction. Maintainer review remains required.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
