### PR TITLE
🚸 Simplify QDMI adapter construction

### DIFF
--- a/.agent/plans/qdmi-adapter-convenience.md
+++ b/.agent/plans/qdmi-adapter-convenience.md
@@ -1,0 +1,233 @@
+# Add convenient framework adapters for registered and Slurm-selected QDMI devices
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+MQT Core registers QDMI devices under stable string identifiers, but users still
+need to assemble framework adapters manually. This change makes the stable ID
+the common entry point for Qiskit backends and MLIR compiler targets. It also
+lets a program inside a Slurm allocation obtain Qiskit, PennyLane, and compiler
+adapters for the allocated device without parsing the license environment or
+opening a second device session.
+
+After the change, a user can call `QDMIBackend.from_device_id`, then construct a
+sampler or estimator from that backend. A user can also call
+`CompilerTarget.from_device_id`. Inside a Slurm job, the functions
+`slurm.qiskit_backend`, `slurm.pennylane_device`, and `slurm.compiler_target`
+adapt the one device selected by the license environment.
+
+## Progress
+
+- [x] (2026-08-13 19:00Z) Verified the new worktree starts at the exact reviewed
+      head of PR #2043.
+- [x] (2026-08-13 19:15Z) Added public typed dictionaries, the Python 3.10
+      compatibility dependency, and typed stable-ID keyword arguments.
+- [ ] Preserve stable IDs on Qiskit backends.
+- [ ] Make Qiskit provider discovery lazy and resilient.
+- [ ] Add backend factories for Qiskit primitives and simplify primitive
+      constructors.
+- [ ] Add the MLIR compiler-target stable-ID factory and regenerate stubs.
+- [ ] Add Slurm framework shortcuts, focused tests, and documentation.
+- [ ] Run focused and aggregate validation, review the complete diff, and
+      publish the stack.
+
+## Surprises & Discoveries
+
+- Observation: `QDMIProvider` currently opens every registered device in its
+  constructor and silently skips failures. Evidence:
+  `python/mqt/core/plugins/qiskit/provider.py` stores a populated `_backends`
+  list in `__init__`.
+- Observation: QDMI session fields include path-like values for `auth_file` and
+  `device_config_file`, while job custom fields accept strings, booleans,
+  floats, or `None`. Evidence: the generated signatures in
+  `python/mqt/core/qdmi/driver.pyi` and `python/mqt/core/qdmi/__init__.pyi`.
+- Observation: The real Slurm test image installs the wheel without optional
+  Python dependencies. Evidence: `.github/workflows/slurm.yml` and
+  `test/slurm/Dockerfile` install the wheel with `--no-deps`.
+
+## Decision Log
+
+- Decision: Keep session and job parameters in separate total-false `TypedDict`
+  classes. Rationale: both namespaces contain `custom1` through `custom5`, but
+  they are consumed at different lifecycle points and have different value
+  types. Date/Author: 2026-08-13, Codex.
+- Decision: Use `Unpack[QDMISessionParameters]` for stable-ID factories and
+  retain mappings for the two PennyLane parameter namespaces. Rationale:
+  keywords give callers completion and reject misspelled fields statically,
+  while mappings keep the overlapping PennyLane namespaces explicit.
+  Date/Author: 2026-08-13, Codex.
+- Decision: Keep Slurm sampler and estimator construction fluent through
+  `slurm.qiskit_backend()`. Rationale: direct Slurm primitive factories would
+  duplicate backend methods without shortening the normal path materially.
+  Date/Author: 2026-08-13, Codex.
+- Decision: Resolve the Slurm environment and open the device once per shortcut
+  call. Rationale: the environment selects the allocation device, and each
+  returned adapter must own the same fresh session used for validation.
+  Date/Author: 2026-08-13, Codex.
+
+## Outcomes & Retrospective
+
+Implementation is in progress. This section will record the completed behavior,
+validation evidence, and any remaining external CI work.
+
+## Context and Orientation
+
+QDMI is the Quantum Device Management Interface. MQT Core exposes its device
+registry and opened-device handles through the native `mqt.core.qdmi` module.
+`python/mqt/core/plugins/qiskit` adapts an opened handle to Qiskit.
+`python/mqt/core/plugins/pennylane` adapts it to PennyLane. The native
+`mqt.core.mlir.CompilerTarget` class snapshots a device for compilation.
+
+The stable registry API is declared in `python/mqt/core/qdmi/driver.pyi` and
+implemented by `bindings/qdmi/qdmi.cpp`. The Qiskit backend factory is in
+`python/mqt/core/plugins/qiskit/backend.py`. Provider discovery is in
+`python/mqt/core/plugins/qiskit/provider.py`, and primitive implementations are
+in `sampler.py` and `estimator.py`. PennyLane construction is in
+`python/mqt/core/plugins/pennylane/device.py`.
+
+Slurm selection is split between `src/fomac/Slurm.cpp`, which parses and
+validates the allocation license, and `bindings/qdmi/slurm.cpp`, which exposes
+Python functions. The selector must retain its existing grammar and accept only
+a single local license with quantity one and device state `IDLE` or `BUSY`.
+Selection does not authorize access; persistent registration and provider
+credentials remain authoritative.
+
+Generated `.pyi` files under `python/mqt/core/qdmi` and
+`python/mqt/core/mlir.pyi` must never be edited by hand. Binding signatures are
+adjusted through `bindings/patterns.txt` and regenerated with the `stubs` Nox
+session.
+
+## Plan of Work
+
+First, add `python/mqt/core/typing.py` with `QDMISessionParameters` and
+`QDMIJobParameters`. Add `typing-extensions` only for Python 3.10 and update the
+lock file. Change stable-ID Python factories to accept unpacked typed keywords.
+Apply the two mapping types to PennyLane and retain explicit runtime validation.
+
+Second, let `QDMIBackend` retain an optional stable ID. Its stable-ID factory
+sets the ID, while direct construction leaves it unset. Third, remove eager
+provider state. Each discovery call reads current registered IDs, opens fresh
+backends, warns using only a failing ID, and continues. Exact-ID lookup opens
+only the requested device and accepts typed session overrides.
+
+Fourth, add `sampler` and `estimator` methods to `QDMIBackend`. Remove the
+MQT-specific `options` arguments from the direct primitive constructors and make
+estimator shots an explicit parameter. Record this API change in `UPGRADING.md`.
+
+Fifth, add `CompilerTarget.from_device_id`. Move the C++ conversion of typed
+session overrides into one binding helper shared by `open_device` and MLIR.
+Regenerate recursive stubs and override the generated callable signature with a
+pattern that uses `Unpack[QDMISessionParameters]`.
+
+Sixth, factor Slurm selection into an internal resolver that returns the stable
+ID and one opened handle from one environment snapshot. The existing open
+function delegates to it. Native Python bindings lazily import only the adapter
+requested by the caller. PennyLane receives a private constructor for an
+already-open handle. Add focused Python tests, update the real Slurm SC job to
+exercise only the compiler target, and extend `docs/qdmi/slurm.md` with all
+public paths.
+
+Keep these six units as signed commits in the order above. Each commit message
+must include the repository's AI-assistance trailer. Do not modify the two lower
+stack branches.
+
+## Concrete Steps
+
+Run all commands from the repository root through `.agent/run.sh` when they can
+create caches. During implementation, use focused tests such as:
+
+    ./.agent/run.sh uv run --no-sync pytest test/python/plugins/qiskit/test_backend.py
+    ./.agent/run.sh uv run --no-sync pytest test/python/plugins/qiskit/test_provider.py
+    ./.agent/run.sh uv run --no-sync pytest test/python/plugins/qiskit/test_sampler.py test/python/plugins/qiskit/test_estimator.py
+    ./.agent/run.sh uv run --no-sync pytest test/python/plugins/qdmi_pennylane/test_device.py
+    ./.agent/run.sh uv run --no-sync pytest test/python/test_mlir.py
+    ./.agent/run.sh uv run --no-sync pytest test/python/qdmi/test_slurm.py
+
+For native bindings, configure and rebuild the release preset, then regenerate
+stubs:
+
+    ./.agent/run.sh cmake --preset release
+    ./.agent/run.sh cmake --build --preset release
+    ./.agent/run.sh uvx nox -s stubs
+
+At completion, run the supported Python 3.10 and 3.14 sessions, minimum-Qiskit
+coverage, native selector tests, strict documentation, wheel inspection, full
+lint, and whitespace validation. The GitHub real-Slurm workflow supplies the
+cluster proof after publication.
+
+## Validation and Acceptance
+
+Type checking must accept every documented QDMI session and job field and flag
+unknown fields. Runtime tests must prove that all accepted fields are forwarded
+unchanged, unknown fields are rejected, and inline and file device configuration
+remain mutually exclusive.
+
+A backend created from a stable ID must report that ID. A backend created from
+an opened handle without an explicit ID must report `None`. Provider creation
+must open no device, subsequent registry changes must be visible, exact-ID
+lookup must open one fresh session, and enumeration failures must emit a warning
+containing only the stable ID before continuing.
+
+Both Qiskit primitives must work through direct constructors and backend
+methods. Defaults must be 1024 shots and zero estimator precision unless the
+caller overrides them. Sampling and estimation must still execute against DDSIM.
+
+`CompilerTarget.from_device_id("mqt.ddsim.default")` must equal the target made
+from an explicitly opened DDSIM handle. Unknown and incompatible devices must
+retain their existing errors.
+
+Each Slurm shortcut must read one environment snapshot and open one device.
+Qiskit and PennyLane shortcuts must execute against DDSIM in focused tests. The
+compiler shortcut must match the direct target. Existing malformed, compound,
+remote, non-unit, unknown, and unavailable-device errors must remain unchanged.
+Missing optional dependencies must produce the established installation hint.
+
+The aggregate branch is accepted when focused tests, recursive stubs, supported
+test sessions, documentation, lint, wheel inspection, and `git diff --check`
+pass locally or have a recorded environment boundary, and remote CI reaches a
+terminal state for the exact published revision.
+
+## Idempotence and Recovery
+
+Formatting, stub generation, builds, and tests are repeatable. Keep all build
+and tool caches within this worktree through `.agent/run.sh`. If a generator
+changes unrelated output, inspect and exclude it rather than discarding user
+work. If a lower pull-request head advances, rebase only this top branch onto
+the new #2043 head and rerun affected checks. Never rewrite either reviewed
+lower branch.
+
+## Artifacts and Notes
+
+The starting revision is `a0c21c5826f54fa25d2d16bac65b65c6b59efc58`, the
+reviewed head of PR #2043. PR #2043 targets the branch of PR #2025. Publication
+must preserve that immediate-parent topology and link all three pull requests
+with the native GitHub stack workflow.
+
+## Interfaces and Dependencies
+
+The public Python types are `mqt.core.typing.QDMISessionParameters` and
+`mqt.core.typing.QDMIJobParameters`. Stable-ID factories use
+`Unpack[QDMISessionParameters]`, supplied by the standard library on Python 3.11
+and newer and by `typing-extensions` on Python 3.10.
+
+The final Qiskit backend constructor accepts an opened QDMI device, an optional
+provider, and a keyword-only optional stable ID. It exposes `device_id`,
+`sampler(default_shots=1024)`, and
+`estimator(default_precision=0.0, default_shots=1024)`.
+
+The provider exposes `device_ids`, `backends`, `get_backend`, and
+`get_backend_by_device_id`. The compiler target exposes `from_device_id`. The
+Slurm module exposes `open_device_from_license`, `qiskit_backend`,
+`pennylane_device`, and `compiler_target`. Slurm shortcuts do not accept session
+or credential overrides; only the PennyLane shortcut accepts typed job
+parameters.
+
+Revision note (2026-08-13): Created the implementation plan after verifying the
+reviewed stack base and inspecting the existing adapter, registry, binding, and
+Slurm boundaries.

--- a/.agent/plans/qdmi-adapter-convenience.md
+++ b/.agent/plans/qdmi-adapter-convenience.md
@@ -28,7 +28,8 @@ adapt the one device selected by the license environment.
       head of PR #2043.
 - [x] (2026-08-13 19:15Z) Added public typed dictionaries, the Python 3.10
       compatibility dependency, and typed stable-ID keyword arguments.
-- [ ] Preserve stable IDs on Qiskit backends.
+- [x] (2026-08-13 19:18Z) Preserved known stable IDs on Qiskit backends without
+      changing direct construction.
 - [ ] Make Qiskit provider discovery lazy and resilient.
 - [ ] Add backend factories for Qiskit primitives and simplify primitive
       constructors.

--- a/.agent/plans/qdmi-adapter-convenience.md
+++ b/.agent/plans/qdmi-adapter-convenience.md
@@ -30,7 +30,8 @@ adapt the one device selected by the license environment.
       compatibility dependency, and typed stable-ID keyword arguments.
 - [x] (2026-08-13 19:18Z) Preserved known stable IDs on Qiskit backends without
       changing direct construction.
-- [ ] Make Qiskit provider discovery lazy and resilient.
+- [x] (2026-08-13 19:22Z) Made provider discovery lazy, current-registry based,
+      exact-ID addressable, and resilient to unavailable devices.
 - [ ] Add backend factories for Qiskit primitives and simplify primitive
       constructors.
 - [ ] Add the MLIR compiler-target stable-ID factory and regenerate stubs.

--- a/.agent/plans/qdmi-adapter-convenience.md
+++ b/.agent/plans/qdmi-adapter-convenience.md
@@ -1,4 +1,4 @@
-# Add convenient framework adapters for registered and Slurm-selected QDMI devices
+# Add convenient framework adapters for registered QDMI devices
 
 This ExecPlan is a living document. The sections `Progress`,
 `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
@@ -11,16 +11,11 @@ repository root.
 
 MQT Core registers QDMI devices under stable string identifiers, but users still
 need to assemble framework adapters manually. This change makes the stable ID
-the common entry point for Qiskit backends and MLIR compiler targets. It also
-lets a program inside a Slurm allocation obtain Qiskit, PennyLane, and compiler
-adapters for the allocated device without parsing the license environment or
-opening a second device session.
+the common entry point for Qiskit backends and MLIR compiler targets.
 
 After the change, a user can call `QDMIBackend.from_device_id`, then construct a
 sampler or estimator from that backend. A user can also call
-`CompilerTarget.from_device_id`. Inside a Slurm job, the functions
-`slurm.qiskit_backend`, `slurm.pennylane_device`, and `slurm.compiler_target`
-adapt the one device selected by the license environment.
+`CompilerTarget.from_device_id`.
 
 ## Progress
 
@@ -36,9 +31,29 @@ adapt the one device selected by the license environment.
       MQT-specific options mappings with explicit defaults.
 - [x] (2026-08-13 19:34Z) Added the MLIR compiler-target stable-ID factory with
       shared native session conversion and a typed stub pattern.
-- [ ] Add Slurm framework shortcuts, focused tests, and documentation.
-- [ ] Run focused and aggregate validation, review the complete diff, and
-      publish the stack.
+- [x] (2026-08-13 20:35Z) Completed focused and aggregate validation, including
+      the full supported Python and minimum-dependency matrices, native tests,
+      strict docs, recursive stubs, lint, and wheel inspection; then reviewed
+      the complete six-commit diff.
+- [x] (2026-08-13 20:46Z) Published PR #2084 against `agent/slurm-integration`
+      after re-verifying both lower stack heads and bases.
+- [x] (2026-08-13 21:20Z) Addressed review feedback by moving shared session
+      conversion out of the bindings tree and withdrawing the proposed Slurm
+      framework shortcuts.
+- [x] (2026-08-13 22:58Z) Rebased the six commits onto `main`, reran affected
+      validation, published with an exact lease, and monitored the revised head
+      to terminal CI except for the external documentation status.
+- [x] (2026-08-14 09:12Z) Addressed the second review by defining parameter
+      types in `mqt.core.typing`, replacing the native import hook with real
+      aliases, installing the shared driver header, and rerunning affected
+      validation.
+- [x] (2026-08-14 11:30Z) Centralized lazy provider enumeration so exact-name
+      lookup stops after its match, expanded compiler-target equivalence to all
+      exposed metadata, and adopted the Scientific Python compatibility-module
+      pattern for `Unpack` with verified wheel contents.
+- [x] (2026-08-14 13:05Z) Simplified provider enumeration without Ruff
+      suppressions, kept runtime path annotations introspectable, removed the
+      redundant QDMI type re-exports, and documented the primitive migration.
 
 ## Surprises & Discoveries
 
@@ -53,6 +68,10 @@ adapt the one device selected by the license environment.
 - Observation: The real Slurm test image installs the wheel without optional
   Python dependencies. Evidence: `.github/workflows/slurm.yml` and
   `test/slurm/Dockerfile` install the wheel with `--no-deps`.
+- Observation: PR #2043's Read the Docs build is terminal-cancelled according to
+  the Read the Docs API, but its GitHub status callback remains stale as
+  pending. All other lower-stack checks are terminal and successful, including
+  the real Slurm integration workflow.
 
 ## Decision Log
 
@@ -65,19 +84,46 @@ adapt the one device selected by the license environment.
   keywords give callers completion and reject misspelled fields statically,
   while mappings keep the overlapping PennyLane namespaces explicit.
   Date/Author: 2026-08-13, Codex.
-- Decision: Keep Slurm sampler and estimator construction fluent through
-  `slurm.qiskit_backend()`. Rationale: direct Slurm primitive factories would
-  duplicate backend methods without shortening the normal path materially.
-  Date/Author: 2026-08-13, Codex.
-- Decision: Resolve the Slurm environment and open the device once per shortcut
-  call. Rationale: the environment selects the allocation device, and each
-  returned adapter must own the same fresh session used for validation.
-  Date/Author: 2026-08-13, Codex.
+- Decision: Keep domain-specific public types in `mqt.core.typing`, but isolate
+  the version-dependent `Unpack` import in `mqt.core._compat.typing` and list
+  only that private bridge in Ruff's `typing-modules`. Rationale: Ruff reserves
+  this setting for modules that re-export `typing` or `typing_extensions`
+  members; treating the public runtime `TypedDict`s as typing primitives would
+  be incorrect. Date/Author: 2026-08-14, Codex.
+- Decision: Keep the narrow Ruff suppression on the runtime `os` import in
+  `mqt.core.typing`. Rationale: `typing.get_type_hints` resolves the public
+  `os.PathLike` annotations at runtime; moving the import behind `TYPE_CHECKING`
+  raises `NameError`, while hiding it behind a private alias leaks that alias
+  into generated API documentation. Date/Author: 2026-08-14, Codex.
+- Decision: Keep the Slurm adapter limited to `open_device_from_license` in this
+  PR. Rationale: review requested that the proposed framework-specific Slurm
+  shortcuts be reconsidered separately. Date/Author: 2026-08-13, Codex.
+- Decision: Keep `TypedDict` and `Unpack` instead of using data classes.
+  Rationale: `Unpack` requires a `TypedDict`, and unpacked keyword arguments are
+  the convenient API this change provides. Date/Author: 2026-08-14, Codex.
+- Decision: Keep direct primitive constructors compatible, but document backend
+  factories as the canonical path. Rationale: removing public concrete Qiskit
+  primitive classes is a separate breaking API decision and requires an explicit
+  deprecation plan. Date/Author: 2026-08-14, Codex.
+- Decision: Export the parameter dictionaries only from `mqt.core.typing`.
+  Rationale: a second path through the native `mqt.core.qdmi` module adds
+  binding and stub machinery without improving discoverability or compatibility
+  for this unreleased API. Date/Author: 2026-08-14, Codex.
+- Decision: Silently skip registered devices that open successfully but cannot
+  be represented as Qiskit backends. Rationale: incompatibility is an expected
+  result of enumerating a framework-independent registry, not an availability
+  failure that should warn users. Date/Author: 2026-08-14, Codex.
 
 ## Outcomes & Retrospective
 
-Implementation is in progress. This section will record the completed behavior,
-validation evidence, and any remaining external CI work.
+The six commits implement the typed configuration layer, stable backend
+identity, lazy provider discovery, fluent primitives, and stable-ID compiler
+targets; the proposed Slurm shortcuts were withdrawn during review. Focused
+tests and the full Python 3.10 through 3.14 current/minimum dependency matrices
+pass. Native Slurm and compiler tests, recursive stubs, strict documentation,
+full lint, a local ABI3 wheel build, wheel-content inspection, and whitespace
+validation also pass. PR #2084 now targets `main` because both lower pull
+requests merged.
 
 ## Context and Orientation
 
@@ -94,13 +140,6 @@ implemented by `bindings/qdmi/qdmi.cpp`. The Qiskit backend factory is in
 in `sampler.py` and `estimator.py`. PennyLane construction is in
 `python/mqt/core/plugins/pennylane/device.py`.
 
-Slurm selection is split between `src/fomac/Slurm.cpp`, which parses and
-validates the allocation license, and `bindings/qdmi/slurm.cpp`, which exposes
-Python functions. The selector must retain its existing grammar and accept only
-a single local license with quantity one and device state `IDLE` or `BUSY`.
-Selection does not authorize access; persistent registration and provider
-credentials remain authoritative.
-
 Generated `.pyi` files under `python/mqt/core/qdmi` and
 `python/mqt/core/mlir.pyi` must never be edited by hand. Binding signatures are
 adjusted through `bindings/patterns.txt` and regenerated with the `stubs` Nox
@@ -108,10 +147,11 @@ session.
 
 ## Plan of Work
 
-First, add `python/mqt/core/typing.py` with `QDMISessionParameters` and
-`QDMIJobParameters`. Add `typing-extensions` only for Python 3.10 and update the
-lock file. Change stable-ID Python factories to accept unpacked typed keywords.
-Apply the two mapping types to PennyLane and retain explicit runtime validation.
+First, define `QDMISessionParameters` and `QDMIJobParameters` in the public
+`mqt.core.typing` module. Add `typing-extensions` only for Python 3.10 and
+update the lock file. Change stable-ID Python factories to accept unpacked typed
+keywords. Apply the two mapping types to PennyLane and retain explicit runtime
+validation.
 
 Second, let `QDMIBackend` retain an optional stable ID. Its stable-ID factory
 sets the ID, while direct construction leaves it unset. Third, remove eager
@@ -121,20 +161,16 @@ only the requested device and accepts typed session overrides.
 
 Fourth, add `sampler` and `estimator` methods to `QDMIBackend`. Remove the
 MQT-specific `options` arguments from the direct primitive constructors and make
-estimator shots an explicit parameter. Record this API change in `UPGRADING.md`.
+estimator shots an explicit parameter.
 
-Fifth, add `CompilerTarget.from_device_id`. Move the C++ conversion of typed
-session overrides into one binding helper shared by `open_device` and MLIR.
-Regenerate recursive stubs and override the generated callable signature with a
-pattern that uses `Unpack[QDMISessionParameters]`.
+Fifth, add `CompilerTarget.from_device_id`. Put the C++ conversion of typed
+session overrides in the installed QDMI driver interface shared by `open_device`
+and MLIR. Regenerate recursive stubs and override the generated callable
+signature with a pattern that uses `Unpack[QDMISessionParameters]`.
 
-Sixth, factor Slurm selection into an internal resolver that returns the stable
-ID and one opened handle from one environment snapshot. The existing open
-function delegates to it. Native Python bindings lazily import only the adapter
-requested by the caller. PennyLane receives a private constructor for an
-already-open handle. Add focused Python tests, update the real Slurm SC job to
-exercise only the compiler target, and extend `docs/qdmi/slurm.md` with all
-public paths.
+Sixth, add the changelog entries and record the completed implementation and
+validation. The Slurm framework shortcuts explored in the original plan are out
+of scope following review.
 
 Keep these six units as signed commits in the order above. Each commit message
 must include the repository's AI-assistance trailer. Do not modify the two lower
@@ -177,19 +213,14 @@ must open no device, subsequent registry changes must be visible, exact-ID
 lookup must open one fresh session, and enumeration failures must emit a warning
 containing only the stable ID before continuing.
 
-Both Qiskit primitives must work through direct constructors and backend
-methods. Defaults must be 1024 shots and zero estimator precision unless the
-caller overrides them. Sampling and estimation must still execute against DDSIM.
+The documentation uses backend methods as the canonical Qiskit primitive
+construction path. Direct constructors remain compatible. Defaults must be 1024
+shots and zero estimator precision unless the caller overrides them. Sampling
+and estimation must still execute against DDSIM.
 
 `CompilerTarget.from_device_id("mqt.ddsim.default")` must equal the target made
 from an explicitly opened DDSIM handle. Unknown and incompatible devices must
 retain their existing errors.
-
-Each Slurm shortcut must read one environment snapshot and open one device.
-Qiskit and PennyLane shortcuts must execute against DDSIM in focused tests. The
-compiler shortcut must match the direct target. Existing malformed, compound,
-remote, non-unit, unknown, and unavailable-device errors must remain unchanged.
-Missing optional dependencies must produce the established installation hint.
 
 The aggregate branch is accepted when focused tests, recursive stubs, supported
 test sessions, documentation, lint, wheel inspection, and `git diff --check`
@@ -201,16 +232,14 @@ terminal state for the exact published revision.
 Formatting, stub generation, builds, and tests are repeatable. Keep all build
 and tool caches within this worktree through `.agent/run.sh`. If a generator
 changes unrelated output, inspect and exclude it rather than discarding user
-work. If a lower pull-request head advances, rebase only this top branch onto
-the new #2043 head and rerun affected checks. Never rewrite either reviewed
-lower branch.
+work. If `main` advances before publication, rebase this branch and rerun
+affected checks.
 
 ## Artifacts and Notes
 
-The starting revision is `a0c21c5826f54fa25d2d16bac65b65c6b59efc58`, the
-reviewed head of PR #2043. PR #2043 targets the branch of PR #2025. Publication
-must preserve that immediate-parent topology and link all three pull requests
-with the native GitHub stack workflow.
+The branch started at `a0c21c5826f54fa25d2d16bac65b65c6b59efc58`, the reviewed
+head of PR #2043. PRs #2025 and #2043 have since merged, so PR #2084 now targets
+`main`.
 
 ## Interfaces and Dependencies
 
@@ -226,11 +255,22 @@ provider, and a keyword-only optional stable ID. It exposes `device_id`,
 
 The provider exposes `device_ids`, `backends`, `get_backend`, and
 `get_backend_by_device_id`. The compiler target exposes `from_device_id`. The
-Slurm module exposes `open_device_from_license`, `qiskit_backend`,
-`pennylane_device`, and `compiler_target`. Slurm shortcuts do not accept session
-or credential overrides; only the PennyLane shortcut accepts typed job
-parameters.
+existing Slurm API remains unchanged.
 
 Revision note (2026-08-13): Created the implementation plan after verifying the
 reviewed stack base and inspecting the existing adapter, registry, binding, and
 Slurm boundaries.
+
+Revision note (2026-08-13): Recorded the completed local implementation and
+validation, the terminal-cancelled lower Read the Docs build, and publication of
+PR #2084.
+
+Revision note (2026-08-13): Updated the plan after review moved the parameter
+types into the QDMI namespace and removed the proposed Slurm shortcuts.
+
+Revision note (2026-08-14): Replaced the native typing import hook with real
+aliases to canonical public types and moved shared session conversion into the
+installed driver interface.
+
+Revision note (2026-08-14): Applied the two internal follow-ups and aligned the
+typing-module split with current Scientific Python and Boost.Histogram practice.

--- a/.agent/plans/qdmi-adapter-convenience.md
+++ b/.agent/plans/qdmi-adapter-convenience.md
@@ -34,7 +34,8 @@ adapt the one device selected by the license environment.
       exact-ID addressable, and resilient to unavailable devices.
 - [x] (2026-08-13 19:27Z) Added backend primitive factories and replaced the
       MQT-specific options mappings with explicit defaults.
-- [ ] Add the MLIR compiler-target stable-ID factory and regenerate stubs.
+- [x] (2026-08-13 19:34Z) Added the MLIR compiler-target stable-ID factory with
+      shared native session conversion and a typed stub pattern.
 - [ ] Add Slurm framework shortcuts, focused tests, and documentation.
 - [ ] Run focused and aggregate validation, review the complete diff, and
       publish the stack.

--- a/.agent/plans/qdmi-adapter-convenience.md
+++ b/.agent/plans/qdmi-adapter-convenience.md
@@ -32,8 +32,8 @@ adapt the one device selected by the license environment.
       changing direct construction.
 - [x] (2026-08-13 19:22Z) Made provider discovery lazy, current-registry based,
       exact-ID addressable, and resilient to unavailable devices.
-- [ ] Add backend factories for Qiskit primitives and simplify primitive
-      constructors.
+- [x] (2026-08-13 19:27Z) Added backend primitive factories and replaced the
+      MQT-specific options mappings with explicit defaults.
 - [ ] Add the MLIR compiler-target stable-ID factory and regenerate stubs.
 - [ ] Add Slurm framework shortcuts, focused tests, and documentation.
 - [ ] Run focused and aggregate validation, review the complete diff, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ releases may include breaking changes.
 
 ### Added
 
+- 🚸 Add typed stable-ID construction for Qiskit backends and compiler targets,
+  fluent Qiskit primitives, and lazy provider discovery ([#2084])
+  ([**@burgholzer**])
 - 🧪 Test static Slurm license admission and QDMI execution with DDSIM and SC,
   and document the cluster setup ([#2043]) ([**@burgholzer**])
 - ✨ Add C++ and Python adapters that open the QDMI device named by one local
@@ -124,6 +127,8 @@ releases may include breaking changes.
 - 💥 Remove the unused `pybind11` CMake helper and rename
   `add_mqt_python_binding_nanobind` to `add_mqt_python_binding` ([#2106])
   ([**@denialhaag**])
+- 💥 Replace the MQT-specific QDMI primitive `options` mappings with explicit
+  shot and precision defaults ([#2084]) ([**@burgholzer**])
 - 💥 Move Python QDMI entities and the neutral-atom specialization to QDMI
   namespaces, expose device registration and opening through
   `mqt.core.qdmi.driver`, retain v3 FoMaC compatibility aliases, and let the
@@ -762,6 +767,7 @@ for previous changelogs._
 [#2108]: https://github.com/munich-quantum-toolkit/core/pull/2108
 [#2106]: https://github.com/munich-quantum-toolkit/core/pull/2106
 [#2105]: https://github.com/munich-quantum-toolkit/core/pull/2105
+[#2084]: https://github.com/munich-quantum-toolkit/core/pull/2084
 [#2074]: https://github.com/munich-quantum-toolkit/core/pull/2074
 [#2073]: https://github.com/munich-quantum-toolkit/core/pull/2073
 [#2066]: https://github.com/munich-quantum-toolkit/core/pull/2066

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -105,6 +105,21 @@ will be removed in MQT Core 4.0.
 The C++ FoMaC namespace, headers, library, and `MQT::CoreFoMaC` target do not
 change.
 
+### QDMI Qiskit primitive options
+
+`QDMISampler` and `QDMIEstimator` no longer accept the MQT-specific `options`
+mapping. Pass shot and precision defaults directly, preferably through the
+backend factories:
+
+```python
+sampler = backend.sampler(default_shots=2048)
+estimator = backend.estimator(default_precision=0.01, default_shots=2048)
+```
+
+Replace `QDMIEstimator(..., options={"default_shots": shots})` with
+`QDMIEstimator(..., default_shots=shots)`. The sampler ignored its former
+`options` mapping, so remove that argument without replacement.
+
 ### QIR runner
 
 The QIR runner now invokes a selected QIR entry point as a parameterless `i64`

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Compiler/FoMaCAdapter.h"
 #include "mlir/Compiler/Programs.h"
 #include "mlir/Compiler/Target.h"
+#include "qdmi/driver/SessionConfig.hpp"
 #include "qiskit/Qiskit.h"
 
 #include <llvm/Support/Error.h>
@@ -538,6 +539,38 @@ means every operation is native.)pb");
             return takeResult(mlir::compilerTargetFromDevice(device));
           },
           "device"_a, "Snapshot a circuit-model QDMI device.")
+      .def_static(
+          "from_device_id",
+          [](const std::string& deviceId, std::optional<std::string> baseUrl,
+             std::optional<std::string> token,
+             std::optional<std::filesystem::path> authFile,
+             std::optional<std::string> authUrl,
+             std::optional<std::string> username,
+             std::optional<std::string> password,
+             std::optional<std::string> deviceConfig,
+             std::optional<std::filesystem::path> deviceConfigFile,
+             std::optional<std::string> custom1,
+             std::optional<std::string> custom2,
+             std::optional<std::string> custom3,
+             std::optional<std::string> custom4,
+             std::optional<std::string> custom5) {
+            const auto overrides = qdmi::makeDeviceSessionConfig(
+                std::move(baseUrl), std::move(token), std::move(authFile),
+                std::move(authUrl), std::move(username), std::move(password),
+                std::move(deviceConfig), std::move(deviceConfigFile),
+                std::move(custom1), std::move(custom2), std::move(custom3),
+                std::move(custom4), std::move(custom5));
+            auto device = fomac::Session::openDevice(deviceId, overrides);
+            return takeResult(mlir::compilerTargetFromDevice(device));
+          },
+          "device_id"_a, nb::kw_only(), "base_url"_a = std::nullopt,
+          "token"_a = std::nullopt, "auth_file"_a = std::nullopt,
+          "auth_url"_a = std::nullopt, "username"_a = std::nullopt,
+          "password"_a = std::nullopt, "device_config"_a = std::nullopt,
+          "device_config_file"_a = std::nullopt, "custom1"_a = std::nullopt,
+          "custom2"_a = std::nullopt, "custom3"_a = std::nullopt,
+          "custom4"_a = std::nullopt, "custom5"_a = std::nullopt,
+          "Open a registered device and snapshot its compiler target.")
       .def_prop_ro(
           "name",
           [](const mlir::CompilerTarget& target) {

--- a/bindings/patterns.txt
+++ b/bindings/patterns.txt
@@ -134,6 +134,13 @@ mqt\.core\.mlir\.CompilerTarget\.from_device$:
     def from_device(device: Device) -> CompilerTarget:
         \doc
 
+mqt\.core\.mlir\.CompilerTarget\.from_device_id$:
+    \from mqt.core._compat.typing import Unpack
+    \from mqt.core.typing import QDMISessionParameters
+    @staticmethod
+    def from_device_id(device_id: str, **session_parameters: Unpack[QDMISessionParameters]) -> CompilerTarget:
+        \doc
+
 mqt.core.mlir.compile_program:
     \from typing import overload, Literal
     @overload

--- a/bindings/qdmi/qdmi.cpp
+++ b/bindings/qdmi/qdmi.cpp
@@ -10,6 +10,7 @@
 
 #include "fomac/FoMaC.hpp"
 #include "qdmi/driver/Driver.hpp"
+#include "qdmi/driver/SessionConfig.hpp"
 
 #include <nanobind/nanobind.h>
 #include <nanobind/operators.h>
@@ -84,42 +85,6 @@ template <typename Query>
   }
   throw nb::type_error(
       "value_type must be exactly str, bool, int, float, or bytes");
-}
-
-[[nodiscard]] auto makeDeviceSessionConfig(
-    std::optional<std::string> baseUrl, std::optional<std::string> token,
-    std::optional<std::filesystem::path> authFile,
-    std::optional<std::string> authUrl, std::optional<std::string> username,
-    std::optional<std::string> password,
-    std::optional<std::string> deviceConfig,
-    std::optional<std::filesystem::path> deviceConfigFile,
-    std::optional<std::string> custom1, std::optional<std::string> custom2,
-    std::optional<std::string> custom3, std::optional<std::string> custom4,
-    std::optional<std::string> custom5) -> qdmi::DeviceSessionConfig {
-  if (deviceConfig && deviceConfigFile) {
-    throw nb::value_error(
-        "device_config and device_config_file are mutually exclusive");
-  }
-  std::optional<qdmi::DeviceConfigurationSource> configuration;
-  if (deviceConfig) {
-    configuration =
-        qdmi::InlineDeviceConfiguration{.json = std::move(*deviceConfig)};
-  } else if (deviceConfigFile) {
-    configuration =
-        qdmi::FileDeviceConfiguration{.path = std::move(*deviceConfigFile)};
-  }
-  return {.baseUrl = std::move(baseUrl),
-          .token = std::move(token),
-          .authFile = std::move(authFile),
-          .authUrl = std::move(authUrl),
-          .username = std::move(username),
-          .password = std::move(password),
-          .deviceConfiguration = std::move(configuration),
-          .custom1 = std::move(custom1),
-          .custom2 = std::move(custom2),
-          .custom3 = std::move(custom3),
-          .custom4 = std::move(custom4),
-          .custom5 = std::move(custom5)};
 }
 
 } // namespace
@@ -717,7 +682,7 @@ when the custom slot is unsupported.)pb");
                 .id = std::move(deviceId),
                 .library = std::move(libraryPath),
                 .prefix = std::move(prefix),
-                .session = makeDeviceSessionConfig(
+                .session = qdmi::makeDeviceSessionConfig(
                     baseUrl, token, authFile, authUrl, username, password,
                     deviceConfig, deviceConfigFile, custom1, custom2, custom3,
                     custom4, custom5)};
@@ -814,7 +779,7 @@ libraries or expose their definitions.)pb");
          std::optional<std::string> custom1, std::optional<std::string> custom2,
          std::optional<std::string> custom3, std::optional<std::string> custom4,
          std::optional<std::string> custom5) {
-        const auto overrides = makeDeviceSessionConfig(
+        const auto overrides = qdmi::makeDeviceSessionConfig(
             std::move(baseUrl), std::move(token), std::move(authFile),
             std::move(authUrl), std::move(username), std::move(password),
             std::move(deviceConfig), std::move(deviceConfigFile),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,6 +171,7 @@ napoleon_numpy_docstring = False
 nitpick_ignore_regex = [
     ("py:class", r"Annotated\[numpy\.typing\.NDArray\[numpy\.complex128\], \{'shape': \(.*\)\}\]"),
     ("py:class", r"Ellipsis"),
+    ("py:class", r"mqt\.core\._compat\.typing\.Unpack"),
     ("py:class", r"ParametersType"),
     ("py:class", r"pennylane\.tape\.QuantumScriptOrBatch"),
     ("py:class", r"pennylane\.transforms\.core\.CompilePipeline"),

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -15,9 +15,8 @@ Open a configured QDMI device and snapshot it as a compiler target:
 
 ```python
 from mqt.core.mlir import CompilerTarget, OutputFormat, compile_program
-from mqt.core.qdmi.driver import open_device
 
-target = CompilerTarget.from_device(open_device("mqt.sc.iqm.garnet"))
+target = CompilerTarget.from_device_id("mqt.sc.iqm.garnet")
 compiled = compile_program(
     "bell.qasm",
     target=target,

--- a/docs/qdmi/qdmi_backend.md
+++ b/docs/qdmi/qdmi_backend.md
@@ -95,7 +95,7 @@ print(f"Qubits: {backend.target.num_qubits}")
 
 Optional session keywords apply explicit overrides to this fresh device session.
 Their names and value types are described by
-{py:class}`mqt.core.qdmi.QDMISessionParameters`; persistent configuration
+{py:class}`mqt.core.typing.QDMISessionParameters`; persistent configuration
 remains the default:
 
 ```python
@@ -366,9 +366,6 @@ std = pub_result.data.stds
 print(f"Expectation value: {ev}")
 print(f"Standard deviation: {std}")
 ```
-
-Direct construction of `QDMISampler(backend, ...)` and
-`QDMIEstimator(backend, ...)` remains available for applications that prefer it.
 
 You can also use parameterized circuits with the estimator:
 

--- a/docs/qdmi/qdmi_backend.md
+++ b/docs/qdmi/qdmi_backend.md
@@ -93,8 +93,18 @@ print(f"Backend: {backend.name}")
 print(f"Qubits: {backend.target.num_qubits}")
 ```
 
-The optional `session_parameters` mapping applies explicit overrides to this
-fresh device session. Persistent configuration remains the default.
+Optional session keywords apply explicit overrides to this fresh device session.
+Their names and value types are described by
+{py:class}`mqt.core.qdmi.QDMISessionParameters`; persistent configuration
+remains the default:
+
+```python
+backend = QDMIBackend.from_device_id(
+    "provider.device",
+    token="access-token",
+    custom1="provider-specific-value",
+)
+```
 
 ### Filtering Backends
 

--- a/docs/qdmi/qdmi_backend.md
+++ b/docs/qdmi/qdmi_backend.md
@@ -311,11 +311,10 @@ The {py:class}`~mqt.core.plugins.qiskit.sampler.QDMISampler` implements the
 measurement counts (bitstrings).
 
 ```{code-cell} ipython3
-from mqt.core.plugins.qiskit import QDMISampler
 from qiskit import QuantumCircuit
 
-# Initialize sampler with the backend
-sampler = QDMISampler(backend)
+# Construct a sampler from the backend
+sampler = backend.sampler(default_shots=1024)
 
 # Create a circuit
 qc = QuantumCircuit(2)
@@ -341,13 +340,12 @@ The {py:class}`~mqt.core.plugins.qiskit.estimator.QDMIEstimator` implements the
 observables.
 
 ```{code-cell} ipython3
-from mqt.core.plugins.qiskit import QDMIEstimator
 from qiskit import QuantumCircuit
 from qiskit.quantum_info import SparsePauliOp
 import numpy as np
 
-# Initialize estimator
-estimator = QDMIEstimator(backend)
+# Construct an estimator from the backend
+estimator = backend.estimator(default_precision=0.0, default_shots=1024)
 
 # Create a circuit and observable
 qc = QuantumCircuit(2)
@@ -368,6 +366,9 @@ std = pub_result.data.stds
 print(f"Expectation value: {ev}")
 print(f"Standard deviation: {std}")
 ```
+
+Direct construction of `QDMISampler(backend, ...)` and
+`QDMIEstimator(backend, ...)` remains available for applications that prefer it.
 
 You can also use parameterized circuits with the estimator:
 

--- a/include/mqt-core/qdmi/driver/SessionConfig.hpp
+++ b/include/mqt-core/qdmi/driver/SessionConfig.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/** @file SessionConfig.hpp
+ * @brief Construction helpers for QDMI device session configuration.
+ */
+
+#pragma once
+
+#include "qdmi/driver/Driver.hpp"
+
+#include <filesystem>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace qdmi {
+
+/**
+ * @brief Construct a device session configuration from individual parameters.
+ * @throws std::invalid_argument If both an inline device configuration and a
+ * device configuration file are set.
+ */
+[[nodiscard]] inline auto makeDeviceSessionConfig(
+    std::optional<std::string> baseUrl, std::optional<std::string> token,
+    std::optional<std::filesystem::path> authFile,
+    std::optional<std::string> authUrl, std::optional<std::string> username,
+    std::optional<std::string> password,
+    std::optional<std::string> deviceConfig,
+    std::optional<std::filesystem::path> deviceConfigFile,
+    std::optional<std::string> custom1, std::optional<std::string> custom2,
+    std::optional<std::string> custom3, std::optional<std::string> custom4,
+    std::optional<std::string> custom5) -> DeviceSessionConfig {
+  if (deviceConfig && deviceConfigFile) {
+    throw std::invalid_argument(
+        "device_config and device_config_file are mutually exclusive");
+  }
+  std::optional<DeviceConfigurationSource> configuration;
+  if (deviceConfig) {
+    configuration = InlineDeviceConfiguration{.json = std::move(*deviceConfig)};
+  } else if (deviceConfigFile) {
+    configuration =
+        FileDeviceConfiguration{.path = std::move(*deviceConfigFile)};
+  }
+  return {.baseUrl = std::move(baseUrl),
+          .token = std::move(token),
+          .authFile = std::move(authFile),
+          .authUrl = std::move(authUrl),
+          .username = std::move(username),
+          .password = std::move(password),
+          .deviceConfiguration = std::move(configuration),
+          .custom1 = std::move(custom1),
+          .custom2 = std::move(custom2),
+          .custom3 = std::move(custom3),
+          .custom4 = std::move(custom4),
+          .custom5 = std::move(custom5)};
+}
+
+} // namespace qdmi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dynamic = ["version"]
+dependencies = [
+  "typing-extensions>=4.12; python_version < '3.11'",
+]
 
 [project.optional-dependencies]
 pennylane = [
@@ -221,6 +224,7 @@ ignore = [
     "TID252"   # Prefer absolute imports over relative imports from parent modules
 ]
 future-annotations = true
+typing-modules = ["mqt.core._compat.typing"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["mqt.core"]

--- a/python/mqt/core/_compat/typing.py
+++ b/python/mqt/core/_compat/typing.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Compatibility imports for typing features."""
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack as _Unpack
+else:
+    from typing_extensions import Unpack as _Unpack
+
+# Give introspection tools an unconditional module-level export.
+Unpack = _Unpack
+
+__all__ = ["Unpack"]
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -16,7 +16,9 @@ from typing import Literal, overload
 import qiskit
 
 import mqt.core.ir
+from mqt.core._compat.typing import Unpack
 from mqt.core.qdmi import Device
+from mqt.core.typing import QDMISessionParameters
 
 class QIRProfile(enum.Enum):
     """QIR target profiles."""
@@ -256,6 +258,10 @@ class CompilerTarget:
     @staticmethod
     def from_device(device: Device) -> CompilerTarget:
         """Snapshot a circuit-model QDMI device."""
+
+    @staticmethod
+    def from_device_id(device_id: str, **session_parameters: Unpack[QDMISessionParameters]) -> CompilerTarget:
+        """Open a registered device and snapshot its compiler target."""
 
     @property
     def name(self) -> str | None:

--- a/python/mqt/core/plugins/pennylane/device.py
+++ b/python/mqt/core/plugins/pennylane/device.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
     from pennylane.tape import QuantumScript, QuantumScriptOrBatch
     from pennylane.typing import Result, ResultBatch
 
+    from mqt.core.typing import QDMIJobParameters, QDMISessionParameters
+
 __all__ = ["DDSIMDevice", "QDMIDevice"]
 
 _SESSION_PARAMETERS = frozenset({
@@ -122,8 +124,8 @@ class QDMIDevice(Device):
         wires: int | Sequence[Hashable] | None = None,
         shots: int | Sequence[int | tuple[int, int]] | Shots | None = 1024,
         *,
-        session_parameters: Mapping[str, Any] | None = None,
-        job_parameters: Mapping[str, str | bool | float | None] | None = None,
+        session_parameters: QDMISessionParameters | None = None,
+        job_parameters: QDMIJobParameters | None = None,
     ) -> None:
         """Initialize and open a fresh QDMI device session.
 
@@ -378,8 +380,8 @@ class DDSIMDevice(QDMIDevice):
         wires: int | Sequence[Hashable] | None = None,
         shots: int | Sequence[int | tuple[int, int]] | Shots | None = 1024,
         *,
-        session_parameters: Mapping[str, object] | None = None,
-        job_parameters: Mapping[str, str | bool | float | None] | None = None,
+        session_parameters: QDMISessionParameters | None = None,
+        job_parameters: QDMIJobParameters | None = None,
     ) -> None:
         """Open the built-in DDSIM device by its stable QDMI ID."""
         super().__init__(

--- a/python/mqt/core/plugins/qiskit/backend.py
+++ b/python/mqt/core/plugins/qiskit/backend.py
@@ -170,12 +170,19 @@ class QDMIBackend(BackendV2):
     # Initialize derived mappings at class definition time
     _QISKIT_TO_QDMI_GATE_MAP, _OPERATION_TO_GATE_MAP = _build_gate_mappings_for_backend(_GATE_ALIASES)
 
-    def __init__(self, device: QDMIDevice, provider: QDMIProvider | None = None) -> None:
+    def __init__(
+        self,
+        device: QDMIDevice,
+        provider: QDMIProvider | None = None,
+        *,
+        device_id: str | None = None,
+    ) -> None:
         """Initialize the backend with a QDMI device wrapper.
 
         Args:
             device: QDMI device wrapper.
             provider: Provider instance that created this backend.
+            device_id: Stable registry ID for the opened device, if known.
 
         Raises:
             UnsupportedDeviceError: If the device cannot be represented in Qiskit's Target model.
@@ -186,6 +193,7 @@ class QDMIBackend(BackendV2):
 
         super().__init__(name=device.name(), provider=provider, backend_version=device.version())
         self._device = device
+        self._device_id = device_id
 
         # Build Target from device
         self._target = self._build_target()
@@ -211,7 +219,13 @@ class QDMIBackend(BackendV2):
         return cls(
             device=open_device(device_id, **session_parameters),
             provider=provider,
+            device_id=device_id,
         )
+
+    @property
+    def device_id(self) -> str | None:
+        """Stable QDMI device ID, if known."""
+        return self._device_id
 
     @property
     def target(self) -> Target:

--- a/python/mqt/core/plugins/qiskit/backend.py
+++ b/python/mqt/core/plugins/qiskit/backend.py
@@ -50,6 +50,8 @@ if TYPE_CHECKING:
     from qiskit.circuit import Instruction, Parameter
     from qiskit.circuit.parameterexpression import ParameterValueType
 
+    from ..._compat.typing import Unpack
+    from ...typing import QDMISessionParameters
     from .provider import QDMIProvider
 
     # Type alias for parameter values
@@ -194,7 +196,7 @@ class QDMIBackend(BackendV2):
         device_id: str,
         *,
         provider: QDMIProvider | None = None,
-        session_parameters: Mapping[str, Any] | None = None,
+        **session_parameters: Unpack[QDMISessionParameters],
     ) -> QDMIBackend:
         """Open a registered QDMI device and adapt it for Qiskit.
 
@@ -207,7 +209,7 @@ class QDMIBackend(BackendV2):
             A Qiskit backend for a fresh QDMI device session.
         """
         return cls(
-            device=open_device(device_id, **dict(session_parameters or {})),
+            device=open_device(device_id, **session_parameters),
             provider=provider,
         )
 

--- a/python/mqt/core/plugins/qiskit/backend.py
+++ b/python/mqt/core/plugins/qiskit/backend.py
@@ -33,6 +33,7 @@ from ...qdmi import Job as QDMIJobHandle
 from ...qdmi import ProgramFormat
 from ...qdmi.driver import open_device
 from .converters import qiskit_to_iqm_json
+from .estimator import QDMIEstimator
 from .exceptions import (
     CircuitValidationError,
     JobSubmissionError,
@@ -43,6 +44,7 @@ from .exceptions import (
 )
 from .gates import MoveGate
 from .job import QDMIJob
+from .sampler import QDMISampler
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, MutableSet, Sequence
@@ -226,6 +228,31 @@ class QDMIBackend(BackendV2):
     def device_id(self) -> str | None:
         """Stable QDMI device ID, if known."""
         return self._device_id
+
+    def sampler(self, *, default_shots: int = 1024) -> QDMISampler:
+        """Construct a QDMI sampler for this backend.
+
+        Returns:
+            A sampler that executes on this backend.
+        """
+        return QDMISampler(self, default_shots=default_shots)
+
+    def estimator(
+        self,
+        *,
+        default_precision: float = 0.0,
+        default_shots: int = 1024,
+    ) -> QDMIEstimator:
+        """Construct a QDMI estimator for this backend.
+
+        Returns:
+            An estimator that executes on this backend.
+        """
+        return QDMIEstimator(
+            self,
+            default_precision=default_precision,
+            default_shots=default_shots,
+        )
 
     @property
     def target(self) -> Target:

--- a/python/mqt/core/plugins/qiskit/estimator.py
+++ b/python/mqt/core/plugins/qiskit/estimator.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit
@@ -50,18 +50,18 @@ class QDMIEstimator(BaseEstimatorV2):
         backend: QDMIBackend,
         *,
         default_precision: float = 0.0,
-        options: dict[str, Any] | None = None,
+        default_shots: int = 1024,
     ) -> None:
         """Initialize the QDMI Estimator.
 
         Args:
             backend: The QDMI backend to execute circuits on.
             default_precision: The default precision for expectation-value estimates.
-            options: Default options for the estimator.
+            default_shots: The number of shots used when no positive precision is set.
         """
         self._backend = backend
         self._default_precision = default_precision
-        self._options = options or {}
+        self._default_shots = default_shots
 
     @property
     def backend(self) -> QDMIBackend:
@@ -119,7 +119,7 @@ class QDMIEstimator(BaseEstimatorV2):
         precision = pub.precision
 
         # Calculate shots based on precision (if provided), otherwise use default
-        shots = self._options.get("default_shots", 1024)
+        shots = self._default_shots
         if precision is not None and precision > 0:
             shots = int(np.ceil(1.0 / precision**2))
 

--- a/python/mqt/core/plugins/qiskit/provider.py
+++ b/python/mqt/core/plugins/qiskit/provider.py
@@ -14,8 +14,18 @@ devices through Qiskit's BackendV2 interface.
 
 from __future__ import annotations
 
+import warnings
+from typing import TYPE_CHECKING
+
 from ...qdmi.driver import registered_device_ids
 from .backend import QDMIBackend
+from .exceptions import UnsupportedDeviceError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..._compat.typing import Unpack
+    from ...typing import QDMISessionParameters
 
 __all__ = ["QDMIProvider"]
 
@@ -27,9 +37,8 @@ def __dir__() -> list[str]:
 class QDMIProvider:
     """Provider for registered QDMI devices.
 
-    This provider discovers and manages registered QDMI devices. It provides a
-    Qiskit-idiomatic interface for device
-    discovery and backend instantiation.
+    This provider discovers registered QDMI devices lazily and adapts
+    Qiskit-compatible devices as backends.
 
     Examples:
         List all available backends:
@@ -47,15 +56,10 @@ class QDMIProvider:
         configuration or provider-specific environment.
     """
 
-    def __init__(self) -> None:
-        """Initialize a provider for the registered QDMI devices."""
-        self._backends: list[QDMIBackend] = []
-        for device_id in registered_device_ids():
-            try:
-                backend = QDMIBackend.from_device_id(device_id, provider=self)
-            except (IndexError, RuntimeError, ValueError):
-                continue
-            self._backends.append(backend)
+    @staticmethod
+    def device_ids() -> list[str]:
+        """Return the current registered QDMI device IDs without opening them."""
+        return registered_device_ids()
 
     def backends(self, name: str | None = None) -> list[QDMIBackend]:
         """Return all available backends, optionally filtered by name substring.
@@ -64,7 +68,7 @@ class QDMIProvider:
             name: If provided, return only backends whose name contains this substring.
 
         Returns:
-            List of QiskitBackend instances. Empty list if name specified but not found.
+            Compatible QDMI backends. The list is empty when no name matches.
 
         Examples:
             Get all backends:
@@ -74,14 +78,46 @@ class QDMIProvider:
 
             Filter backends by name substring:
 
-            >>> na_backends = provider.backends(name="NA")  # matches "MQT NA Default QDMI Device"
-            >>> qdmi_backends = provider.backends(name="QDMI")  # matches all devices with "QDMI" in name
+            >>> ddsim_backends = provider.backends(name="DDSIM")
+            >>> qdmi_backends = provider.backends(name="QDMI")
         """
-        # Filter by name substring if specified
-        if name is not None:
-            return [b for b in self._backends if b.name is not None and name in b.name]
+        return list(self._iter_backends(name))
 
-        return self._backends
+    def _iter_backends(self, name: str | None = None) -> Iterator[QDMIBackend]:
+        """Open available registered backends one at a time.
+
+        Args:
+            name: If provided, yield only backends whose name contains this substring.
+
+        Yields:
+            Each backend whose registered device can be opened.
+        """
+        for device_id in self.device_ids():
+            try:
+                backend = self.get_backend_by_device_id(device_id)
+            except UnsupportedDeviceError:
+                continue
+            except (IndexError, RuntimeError, ValueError):
+                warnings.warn(
+                    f"Could not open registered QDMI device '{device_id}'.",
+                    RuntimeWarning,
+                    stacklevel=3,
+                )
+                continue
+            if name is None or (backend.name is not None and name in backend.name):
+                yield backend
+
+    def get_backend_by_device_id(
+        self,
+        device_id: str,
+        **session_parameters: Unpack[QDMISessionParameters],
+    ) -> QDMIBackend:
+        """Open one fresh backend for an exact stable QDMI device ID.
+
+        Returns:
+            A backend for a fresh device session.
+        """
+        return QDMIBackend.from_device_id(device_id, provider=self, **session_parameters)
 
     def get_backend(self, name: str) -> QDMIBackend:
         """Get a single backend by name.
@@ -90,7 +126,7 @@ class QDMIProvider:
             name: Name of the backend to retrieve.
 
         Returns:
-            QiskitBackend instance.
+            The matching QDMI backend.
 
         Raises:
             ValueError: If no matching backend found.
@@ -101,7 +137,7 @@ class QDMIProvider:
             >>> provider = QDMIProvider()
             >>> backend = provider.get_backend("MQT Core DDSIM QDMI Device")
         """
-        for backend in self._backends:
+        for backend in self._iter_backends(name):
             if backend.name == name:
                 return backend
 
@@ -110,4 +146,4 @@ class QDMIProvider:
 
     def __repr__(self) -> str:
         """Return string representation of the provider."""
-        return f"<QDMIProvider(backends={len(self._backends)})>"
+        return f"<QDMIProvider(devices={len(self.device_ids())})>"

--- a/python/mqt/core/plugins/qiskit/sampler.py
+++ b/python/mqt/core/plugins/qiskit/sampler.py
@@ -10,7 +10,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 from qiskit.primitives import BaseSamplerV2, PrimitiveResult, SamplerPubResult
@@ -49,18 +49,15 @@ class QDMISampler(BaseSamplerV2):
         backend: QDMIBackend,
         *,
         default_shots: int = 1024,
-        options: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the QDMI Sampler.
 
         Args:
             backend: The QDMI backend to execute circuits on.
             default_shots: The default number of shots to use if not specified in run.
-            options: Default options for the sampler.
         """
         self._backend = backend
         self._default_shots = default_shots
-        self._options = options or {}
 
     @property
     def backend(self) -> QDMIBackend:

--- a/python/mqt/core/typing.py
+++ b/python/mqt/core/typing.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Shared public typing helpers for MQT Core."""
+
+import os  # ruff: ignore[typing-only-standard-library-import]
+from typing import TypedDict
+
+__all__ = ["QDMIJobParameters", "QDMISessionParameters"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+class QDMISessionParameters(TypedDict, total=False):
+    """Keyword arguments accepted when opening a QDMI device session."""
+
+    base_url: str | None
+    token: str | None
+    auth_file: str | os.PathLike[str] | None
+    auth_url: str | None
+    username: str | None
+    password: str | None
+    device_config: str | None
+    device_config_file: str | os.PathLike[str] | None
+    custom1: str | None
+    custom2: str | None
+    custom3: str | None
+    custom4: str | None
+    custom5: str | None
+
+
+class QDMIJobParameters(TypedDict, total=False):
+    """Custom keyword arguments accepted when submitting a QDMI job."""
+
+    custom1: str | bool | float | None
+    custom2: str | bool | float | None
+    custom3: str | bool | float | None
+    custom4: str | bool | float | None
+    custom5: str | bool | float | None

--- a/src/qdmi/driver/CMakeLists.txt
+++ b/src/qdmi/driver/CMakeLists.txt
@@ -16,8 +16,15 @@ if(NOT TARGET ${TARGET_NAME})
   target_sources(${TARGET_NAME} PRIVATE DeviceRegistry.cpp Driver.cpp)
 
   # Add headers using file sets
-  target_sources(${TARGET_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_CORE_INCLUDE_BUILD_DIR}
-                                       FILES ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/driver/Driver.hpp)
+  target_sources(
+    ${TARGET_NAME}
+    PUBLIC FILE_SET
+           HEADERS
+           BASE_DIRS
+           ${MQT_CORE_INCLUDE_BUILD_DIR}
+           FILES
+           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/driver/Driver.hpp
+           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/driver/SessionConfig.hpp)
 
   # Add link libraries
   target_link_libraries(

--- a/test/python/plugins/qdmi_pennylane/test_device.py
+++ b/test/python/plugins/qdmi_pennylane/test_device.py
@@ -201,7 +201,11 @@ def test_validates_configuration_and_width(monkeypatch: pytest.MonkeyPatch) -> N
     _patch_device(monkeypatch, qdmi)
 
     with pytest.raises(PennyLaneConfigurationError, match="unknown"):
-        QDMIDevice("fake.qdmi", wires=2, session_parameters={"unknown": "value"})
+        QDMIDevice(
+            "fake.qdmi",
+            wires=2,
+            session_parameters={"unknown": "value"},  # ty: ignore[invalid-argument-type, invalid-key]
+        )
     with pytest.raises(PennyLaneConfigurationError, match="3 wires"):
         QDMIDevice("fake.qdmi", wires=3)
 

--- a/test/python/plugins/qiskit/test_backend.py
+++ b/test/python/plugins/qiskit/test_backend.py
@@ -118,6 +118,19 @@ def test_backend_from_device_id_rejects_conflicting_device_configuration() -> No
 def test_backend_instantiation(ddsim_backend: QDMIBackend) -> None:
     """Backend exposes target qubit count."""
     assert ddsim_backend.target.num_qubits > 0
+    assert ddsim_backend.device_id == "mqt.ddsim.default"
+
+
+def test_direct_backend_has_no_stable_device_id() -> None:
+    """Direct construction remains valid when no registry ID is available."""
+    backend = QDMIBackend(open_device("mqt.ddsim.default"))
+    assert backend.device_id is None
+
+
+def test_direct_backend_accepts_explicit_stable_device_id() -> None:
+    """Specialized construction can retain the ID of an already-open device."""
+    backend = QDMIBackend(open_device("mqt.ddsim.default"), device_id="allocated.device")
+    assert backend.device_id == "allocated.device"
 
 
 def _single_qubit_circuit() -> QuantumCircuit:

--- a/test/python/plugins/qiskit/test_backend.py
+++ b/test/python/plugins/qiskit/test_backend.py
@@ -10,7 +10,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, get_type_hints
 
 import numpy as np
 import pytest
@@ -26,6 +28,7 @@ from mqt.core.plugins.qiskit import (
 )
 from mqt.core.plugins.qiskit.exceptions import UnsupportedDeviceError
 from mqt.core.qdmi.driver import open_device
+from mqt.core.typing import QDMISessionParameters
 
 if TYPE_CHECKING:
     from mqt.core.qdmi import Device as QDMIDevice
@@ -67,10 +70,49 @@ def test_backend_from_device_id_forwards_session_parameters(monkeypatch: pytest.
 
     monkeypatch.setattr("mqt.core.plugins.qiskit.backend.open_device", fake_open_device)
 
-    backend = QDMIBackend.from_device_id("test.device", session_parameters={"custom1": "value"})
+    auth_file = Path("auth.json")
+    config_file = Path("device.json")
+    session_parameters: QDMISessionParameters = {
+        "base_url": "https://device.example",
+        "token": "token",
+        "auth_file": auth_file,
+        "auth_url": "https://auth.example",
+        "username": "user",
+        "password": "password",
+        "device_config": "{}",
+        "device_config_file": config_file,
+        "custom1": "one",
+        "custom2": "two",
+        "custom3": "three",
+        "custom4": "four",
+        "custom5": "five",
+    }
+    backend = QDMIBackend.from_device_id("test.device", **session_parameters)
 
-    assert observed == ("test.device", {"custom1": "value"})
+    assert observed == ("test.device", session_parameters)
     assert backend.target.num_qubits > 0
+
+
+def test_backend_from_device_id_rejects_unknown_session_parameter() -> None:
+    """Reject unknown stable-ID factory keywords at runtime."""
+    with pytest.raises(TypeError, match="unknown"):
+        QDMIBackend.from_device_id("mqt.ddsim.default", unknown="value")
+
+
+def test_qdmi_session_parameter_annotations_are_runtime_resolvable() -> None:
+    """Expose the public TypedDict to runtime annotation consumers."""
+    annotations = get_type_hints(QDMISessionParameters)
+    assert annotations["auth_file"] == str | os.PathLike[str] | None
+
+
+def test_backend_from_device_id_rejects_conflicting_device_configuration() -> None:
+    """Retain native validation for mutually exclusive device configuration sources."""
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        QDMIBackend.from_device_id(
+            "mqt.ddsim.default",
+            device_config="{}",
+            device_config_file=Path("device.json"),
+        )
 
 
 def test_backend_instantiation(ddsim_backend: QDMIBackend) -> None:

--- a/test/python/plugins/qiskit/test_estimator.py
+++ b/test/python/plugins/qiskit/test_estimator.py
@@ -88,10 +88,9 @@ def test_estimator_precision_handling(estimator: QDMIEstimator) -> None:
     assert result[0].metadata["shots"] == other_expected_shots
 
 
-def test_estimator_options(estimator: QDMIEstimator) -> None:
-    """Test estimator options handling."""
-    # Test default_shots option
-    estimator2 = QDMIEstimator(estimator.backend, options={"default_shots": 500})
+def test_estimator_defaults(estimator: QDMIEstimator) -> None:
+    """Test explicit estimator shot and precision defaults."""
+    estimator2 = QDMIEstimator(estimator.backend, default_shots=500)
     qc = QuantumCircuit(1)
     op = SparsePauliOp("Z")
 
@@ -99,12 +98,24 @@ def test_estimator_options(estimator: QDMIEstimator) -> None:
     result = job.result()
     assert result[0].metadata["shots"] == 500
 
-    # Test default_precision option
+    # Test the default precision.
     estimator_prec = QDMIEstimator(estimator.backend, default_precision=0.1)
     job = estimator_prec.run([(qc, op)])
     result = job.result()
     # Should use default_precision -> 100 shots
     assert result[0].metadata["shots"] == 100
+
+
+def test_backend_constructs_estimator() -> None:
+    """A backend constructs an estimator that retains its identity and defaults."""
+    backend = QDMIBackend.from_device_id("mqt.ddsim.default")
+    estimator = backend.estimator(default_shots=73)
+    qc = QuantumCircuit(1)
+    op = SparsePauliOp("Z")
+
+    assert isinstance(estimator, QDMIEstimator)
+    assert estimator.backend is backend
+    assert estimator.run([(qc, op)]).result()[0].metadata["shots"] == 73
 
 
 def test_estimator_observable_bases(estimator: QDMIEstimator) -> None:

--- a/test/python/plugins/qiskit/test_provider.py
+++ b/test/python/plugins/qiskit/test_provider.py
@@ -10,9 +10,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
-from mqt.core.plugins.qiskit import QDMIProvider
+from mqt.core.plugins.qiskit import QDMIBackend, QDMIProvider
+from mqt.core.plugins.qiskit.exceptions import UnsupportedDeviceError
+from mqt.core.qdmi.driver import open_device
 
 
 def test_provider_backends_filter_by_name() -> None:
@@ -65,6 +69,34 @@ def test_provider_get_backend_by_name() -> None:
     assert backend.provider is provider
 
 
+def test_provider_get_backend_stops_after_exact_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exact-name lookup does not open devices after the matching backend."""
+    expected = QDMIBackend(open_device("mqt.ddsim.default"), device_id="matching.device")
+    opened_ids: list[str] = []
+    monkeypatch.setattr(
+        "mqt.core.plugins.qiskit.provider.registered_device_ids",
+        lambda: ["unavailable.device", "matching.device", "later.device"],
+    )
+
+    def lookup(device_id: str, **_session_parameters: object) -> QDMIBackend:
+        opened_ids.append(device_id)
+        if device_id == "unavailable.device":
+            msg = "credential=do-not-disclose"
+            raise RuntimeError(msg)
+        if device_id == "later.device":
+            pytest.fail("exact-name lookup continued after finding its backend")
+        return expected
+
+    provider = QDMIProvider()
+    monkeypatch.setattr(provider, "get_backend_by_device_id", lookup)
+
+    expected_name = expected.name
+    assert expected_name is not None
+    with pytest.warns(RuntimeWarning, match="unavailable.device"):
+        assert provider.get_backend(expected_name) is expected
+    assert opened_ids == ["unavailable.device", "matching.device"]
+
+
 def test_provider_get_backend_nonexistent() -> None:
     """Provider raises ValueError for non-existent backend."""
     provider = QDMIProvider()
@@ -86,7 +118,7 @@ def test_provider_repr() -> None:
     provider = QDMIProvider()
     repr_str = repr(provider)
     assert "QDMIProvider" in repr_str
-    assert "backends=" in repr_str
+    assert "devices=" in repr_str
 
 
 def test_backend_has_provider_reference() -> None:
@@ -104,3 +136,97 @@ def test_provider_default_constructor() -> None:
     assert len(backends) > 0
     backend = provider.get_backend("MQT Core DDSIM QDMI Device")
     assert backend.name == "MQT Core DDSIM QDMI Device"
+
+
+def test_provider_construction_opens_no_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Constructing a provider does not initialize any registered device."""
+    monkeypatch.setattr(
+        "mqt.core.plugins.qiskit.provider.QDMIBackend.from_device_id",
+        lambda *_args, **_kwargs: pytest.fail("provider construction opened a device"),
+    )
+    QDMIProvider()
+
+
+def test_provider_reads_registry_on_each_discovery_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A provider reflects registrations made after its construction."""
+    device_ids = ["first.device"]
+    monkeypatch.setattr("mqt.core.plugins.qiskit.provider.registered_device_ids", lambda: list(device_ids))
+    provider = QDMIProvider()
+
+    assert provider.device_ids() == ["first.device"]
+    device_ids.append("second.device")
+    assert provider.device_ids() == ["first.device", "second.device"]
+
+
+def test_provider_exact_id_lookup_forwards_session_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exact-ID lookup opens only that device with typed overrides."""
+    observed: tuple[str, QDMIProvider, dict[str, object]] | None = None
+    expected = QDMIBackend(open_device("mqt.ddsim.default"), device_id="test.device")
+
+    def fake_from_device_id(
+        device_id: str,
+        *,
+        provider: QDMIProvider,
+        **session_parameters: object,
+    ) -> QDMIBackend:
+        nonlocal observed
+        observed = device_id, provider, session_parameters
+        return expected
+
+    monkeypatch.setattr("mqt.core.plugins.qiskit.provider.QDMIBackend.from_device_id", fake_from_device_id)
+    provider = QDMIProvider()
+    token = str(123)
+
+    backend = provider.get_backend_by_device_id("test.device", token=token, custom1="queue")
+
+    assert backend is expected
+    assert observed == ("test.device", provider, {"token": token, "custom1": "queue"})
+
+
+def test_provider_warns_with_only_id_and_skips_unavailable_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enumeration reports an unavailable ID without leaking failure details."""
+    available = QDMIBackend(open_device("mqt.ddsim.default"), device_id="available.device")
+    monkeypatch.setattr(
+        "mqt.core.plugins.qiskit.provider.registered_device_ids",
+        lambda: ["available.device", "unavailable.device"],
+    )
+
+    def lookup(device_id: str, **_session_parameters: object) -> QDMIBackend:
+        if device_id == "unavailable.device":
+            msg = "credential=do-not-disclose"
+            raise RuntimeError(msg)
+        return available
+
+    provider = QDMIProvider()
+    monkeypatch.setattr(provider, "get_backend_by_device_id", lookup)
+
+    with pytest.warns(RuntimeWarning) as warnings:
+        assert provider.backends() == [available]
+
+    message = str(warnings[0].message)
+    assert warnings[0].filename == __file__
+    assert "unavailable.device" in message
+    assert "credential" not in message
+    assert "do-not-disclose" not in message
+
+
+def test_provider_silently_skips_incompatible_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enumeration silently omits devices that Qiskit cannot represent."""
+    available = QDMIBackend(open_device("mqt.ddsim.default"), device_id="available.device")
+    monkeypatch.setattr(
+        "mqt.core.plugins.qiskit.provider.registered_device_ids",
+        lambda: ["incompatible.device", "available.device"],
+    )
+
+    def lookup(device_id: str, **_session_parameters: object) -> QDMIBackend:
+        if device_id == "incompatible.device":
+            msg = "device cannot be represented by a Qiskit target"
+            raise UnsupportedDeviceError(msg)
+        return available
+
+    provider = QDMIProvider()
+    monkeypatch.setattr(provider, "get_backend_by_device_id", lookup)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert provider.backends() == [available]

--- a/test/python/plugins/qiskit/test_sampler.py
+++ b/test/python/plugins/qiskit/test_sampler.py
@@ -112,8 +112,8 @@ def test_sampler_run_multiple_cregs(sampler: QDMISampler) -> None:
     assert c1_bits.num_bits == 1
 
 
-def test_sampler_options(sampler: QDMISampler) -> None:
-    """Test sampler options mechanism."""
+def test_sampler_shot_defaults(sampler: QDMISampler) -> None:
+    """Test sampler shot defaults."""
     # 1. Use default shots from init
     sampler2 = QDMISampler(sampler.backend, default_shots=500)
     qc = QuantumCircuit(1)
@@ -127,6 +127,18 @@ def test_sampler_options(sampler: QDMISampler) -> None:
     job = sampler2.run([(qc,)], shots=200)
     result = job.result()
     assert result[0].metadata["shots"] == 200
+
+
+def test_backend_constructs_sampler() -> None:
+    """A backend constructs a sampler that retains its identity and defaults."""
+    backend = QDMIBackend.from_device_id("mqt.ddsim.default")
+    sampler = backend.sampler(default_shots=37)
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+
+    assert isinstance(sampler, QDMISampler)
+    assert sampler.backend is backend
+    assert sampler.run([(qc,)]).result()[0].metadata["shots"] == 37
 
 
 def test_sampler_no_circuits(sampler: QDMISampler) -> None:

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -373,7 +373,7 @@ def garnet_target() -> CompilerTarget:
     Returns:
         The detached compiler target.
     """
-    return CompilerTarget.from_device(open_device("mqt.sc.iqm.garnet"))
+    return CompilerTarget.from_device_id("mqt.sc.iqm.garnet")
 
 
 def test_compile_program_for_qdmi_target(garnet_target: CompilerTarget) -> None:
@@ -497,6 +497,59 @@ def test_compiler_target_snapshots_qdmi_device(garnet_target: CompilerTarget) ->
         site_tuple.fidelity is not None for operation in target.operations for site_tuple in operation.site_tuples
     )
     assert all(site_tuple.duration is None for operation in target.operations for site_tuple in operation.site_tuples)
+
+
+def _compiler_target_metadata(target: CompilerTarget) -> dict[str, object]:
+    """Return all metadata exposed by an immutable compiler target."""
+    duration_unit = target.duration_unit
+    synthesis_basis = target.synthesis_basis
+    return {
+        "name": target.name,
+        "duration_unit": None if duration_unit is None else (duration_unit.unit, duration_unit.scale_factor),
+        "num_qubits": target.num_qubits,
+        "sites": [(site.id, site.name, site.t1, site.t2) for site in target.sites],
+        "has_explicit_topology": target.has_explicit_topology,
+        "couplings": target.couplings,
+        "has_explicit_operations": target.has_explicit_operations,
+        "operations": [
+            (
+                operation.name,
+                operation.canonical_name,
+                operation.num_qubits,
+                operation.num_parameters,
+                operation.duration,
+                operation.fidelity,
+                [(site_tuple.sites, site_tuple.duration, site_tuple.fidelity) for site_tuple in operation.site_tuples],
+            )
+            for operation in target.operations
+        ],
+        "supported_gates": target.supported_gates,
+        "synthesis_basis": (
+            None if synthesis_basis is None else (synthesis_basis.single_qubit, synthesis_basis.entangler)
+        ),
+    }
+
+
+def test_compiler_target_from_device_id_matches_opened_device() -> None:
+    """Stable-ID construction produces the same detached DDSIM target."""
+    direct = CompilerTarget.from_device(open_device("mqt.ddsim.default"))
+    by_id = CompilerTarget.from_device_id("mqt.ddsim.default", custom1="value")
+
+    assert _compiler_target_metadata(by_id) == _compiler_target_metadata(direct)
+
+
+def test_compiler_target_from_device_id_preserves_open_and_conversion_errors() -> None:
+    """Stable-ID construction retains registry and target compatibility errors."""
+    with pytest.raises(IndexError, match="Unknown QDMI device ID"):
+        CompilerTarget.from_device_id("unknown.device")
+    with pytest.raises(ValueError, match="only circuit-model devices"):
+        CompilerTarget.from_device_id("mqt.na.default")
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        CompilerTarget.from_device_id(
+            "mqt.ddsim.default",
+            device_config="{}",
+            device_config_file=Path("device.json"),
+        )
 
 
 def test_compiler_target_rejects_qdmi_zone_model() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1769,6 +1769,9 @@ wheels = [
 [[package]]
 name = "mqt-core"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
 
 [package.optional-dependencies]
 pennylane = [
@@ -1847,6 +1850,7 @@ test-base = [
 requires-dist = [
     { name = "pennylane", marker = "python_full_version >= '3.11' and extra == 'pennylane'", specifier = ">=0.45.1,<0.46" },
     { name = "qiskit", extras = ["qasm3-import"], marker = "extra == 'qiskit'", specifier = ">=1.1.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.12" },
 ]
 provides-extras = ["pennylane", "qiskit"]
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Make stable QDMI device IDs the common construction path for Qiskit backends
and MLIR compiler targets.

This PR adds total-false `QDMISessionParameters` and `QDMIJobParameters`
`TypedDict`s in the public `mqt.core.typing` module. Stable-ID factories use
`Unpack[QDMISessionParameters]`, with the version-dependent import isolated in
the private `mqt.core._compat.typing` compatibility module and registered as a
typing module for Ruff. `typing-extensions` is required only on Python 3.10.

Qiskit backends retain their stable device ID and provide the canonical
`backend.sampler()` and `backend.estimator()` construction paths. Direct
primitive constructors remain available. Provider discovery is lazy and reads
the current registry for each call; name filtering happens during iteration,
exact-name lookup stops at its match, and exact-ID lookup opens one fresh
session. Enumeration silently skips devices that are incompatible with Qiskit,
while genuine availability warnings contain only the stable ID.

`CompilerTarget.from_device_id(...)` provides the equivalent MLIR entry point.
The native session-parameter conversion is shared through an installed QDMI
driver header, so neither binding target depends on the source tree.

The six commits are intentionally separated by contract:

1. Type QDMI adapter configuration.
2. Preserve stable IDs in Qiskit backends.
3. Make Qiskit provider discovery lazy.
4. Construct native primitives from backends.
5. Construct compiler targets from stable IDs.
6. Document the adapter conveniences.

The proposed Slurm framework shortcuts remain separate design work. The
existing `slurm.open_device_from_license()` API is unchanged.

## Validation

- Focused QDMI, Qiskit, PennyLane, MLIR, and Slurm tests
- Python 3.10–3.14 current-dependency and minimum-dependency suites
- Minimum Qiskit 1.1 suite
- Native Slurm selector and compiler-target tests
- Recursive stub generation and Python 3.10 type checking
- Strict AutoAPI and documentation verification
- Full repository lint
- Local ABI3 wheel build and `check-wheel-contents`
- Per-commit and aggregate `git diff --check`
- Independent adversarial review of the complete implementation and final
  exact-head confirmation at `c0d413ea6`

## AI assistance

GPT-5.6 via Codex assisted with implementation, tests, documentation, review,
validation, commit preparation, and this pull-request description. Publication
was explicitly authorized.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
