### PR TITLE
🐛 Fix conversions of nested control flow between `jeff` and QCO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ releases may include breaking changes.
   correction ([#1407], [#1674], [#2002], [#2038]) ([**@J4MMlE**],
   [**@denialhaag**], [**@MatthiasReumann**], [**@simon1hofmann**])
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637],
-  [#1676], [#1706], [#1776], [#1836], [#1934], [#2000], [#2018])
+  [#1676], [#1706], [#1776], [#1836], [#1934], [#2000], [#2018], [#2105])
   ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add a `place-and-route` pass for mapping scalar- and tensor-allocated
   circuits to compiler-target topologies while preserving target site IDs and
@@ -751,6 +751,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2105]: https://github.com/munich-quantum-toolkit/core/pull/2105
 [#2074]: https://github.com/munich-quantum-toolkit/core/pull/2074
 [#2073]: https://github.com/munich-quantum-toolkit/core/pull/2073
 [#2066]: https://github.com/munich-quantum-toolkit/core/pull/2066

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -49,6 +49,7 @@
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/Location.h>
@@ -83,10 +84,11 @@ namespace mlir {
 
 [[nodiscard]] static std::shared_ptr<MLIRContext> createCompilerContext() {
   DialectRegistry registry;
-  registry.insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
-                  arith::ArithDialect, cf::ControlFlowDialect,
-                  func::FuncDialect, scf::SCFDialect, LLVM::LLVMDialect,
-                  memref::MemRefDialect, jeff::JeffDialect>();
+  registry
+      .insert<qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
+              arith::ArithDialect, cf::ControlFlowDialect, func::FuncDialect,
+              scf::SCFDialect, LLVM::LLVMDialect, memref::MemRefDialect,
+              tensor::TensorDialect, jeff::JeffDialect>();
   registerBuiltinDialectTranslation(registry);
   registerLLVMDialectTranslation(registry);
 

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -1039,9 +1039,12 @@ struct ConvertJeffSwitchOpToQCO final : OpConversionPattern<jeff::SwitchOp> {
 
     auto inValues = adaptor.getInValues();
 
+    // The operands may already carry converted types, which `isLinearType` does
+    // not recognize. The results still carry jeff types and correspond to the
+    // in-values positionally, so they decide which in-values are qubits.
     SmallVector<Value> qubits;
-    for (auto [value, adapted] : llvm::zip(op.getInValues(), inValues)) {
-      if (isLinearType(value.getType())) {
+    for (auto [type, adapted] : llvm::zip(op.getResultTypes(), inValues)) {
+      if (isLinearType(type)) {
         qubits.push_back(adapted);
       }
     }
@@ -1172,10 +1175,13 @@ struct ConvertJeffWhileOpToQCO final : OpConversionPattern<jeff::WhileOp> {
                   ConversionPatternRewriter& rewriter) const override {
     auto inValues = adaptor.getInValues();
 
+    // The operands may already carry converted types, which `isLinearType` does
+    // not recognize. The results still carry jeff types and correspond to the
+    // in-values positionally, so they decide which in-values are qubits.
     SmallVector<Value> qubits;
     SmallVector<Type> outTypes;
-    for (auto [value, adapted] : llvm::zip(op.getInValues(), inValues)) {
-      if (isLinearType(value.getType())) {
+    for (auto [type, adapted] : llvm::zip(op.getResultTypes(), inValues)) {
+      if (isLinearType(type)) {
         qubits.push_back(adapted);
         outTypes.push_back(adapted.getType());
       }

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -185,6 +185,28 @@ private:
   LoweringState* state_;
 };
 
+/**
+ * @brief Base class for patterns that move a region into a jeff operation
+ *
+ * @details
+ * `moveRegion` clones the operations of the source region, so a nested control
+ * flow operation reaches the driver as a new operation of the same kind as the
+ * one just matched. Without bounded rewrite recursion, the driver rejects it
+ * with "pattern was already applied" and the outer operation fails to legalize.
+ * The recursion terminates because each application moves one nesting level of
+ * the original program into its jeff counterpart.
+ */
+template <typename OpType>
+class RegionMovingConversionPattern
+    : public StatefulOpConversionPattern<OpType> {
+public:
+  RegionMovingConversionPattern(TypeConverter& typeConverter,
+                                MLIRContext* context, LoweringState* state)
+      : StatefulOpConversionPattern<OpType>(typeConverter, context, state) {
+    this->setHasBoundedRewriteRecursion();
+  }
+};
+
 } // namespace
 
 /**
@@ -1364,8 +1386,8 @@ struct ConvertQCOYieldOpToJeff final : StatefulOpConversionPattern<YieldOp> {
  * }
  * ```
  */
-struct ConvertQCOIfOpToJeff final : StatefulOpConversionPattern<IfOp> {
-  using StatefulOpConversionPattern::StatefulOpConversionPattern;
+struct ConvertQCOIfOpToJeff final : RegionMovingConversionPattern<IfOp> {
+  using RegionMovingConversionPattern::RegionMovingConversionPattern;
 
   LogicalResult
   matchAndRewrite(IfOp op, OpAdaptor adaptor,
@@ -1473,8 +1495,8 @@ struct ConvertQCOIfOpToJeff final : StatefulOpConversionPattern<IfOp> {
  * }
  * ```
  */
-struct ConvertSCFForOpToJeff final : StatefulOpConversionPattern<scf::ForOp> {
-  using StatefulOpConversionPattern::StatefulOpConversionPattern;
+struct ConvertSCFForOpToJeff final : RegionMovingConversionPattern<scf::ForOp> {
+  using RegionMovingConversionPattern::RegionMovingConversionPattern;
 
   LogicalResult
   matchAndRewrite(scf::ForOp op, OpAdaptor adaptor,
@@ -1556,8 +1578,8 @@ struct ConvertSCFForOpToJeff final : StatefulOpConversionPattern<scf::ForOp> {
  * ```
  */
 struct ConvertSCFWhileOpToJeff final
-    : StatefulOpConversionPattern<scf::WhileOp> {
-  using StatefulOpConversionPattern::StatefulOpConversionPattern;
+    : RegionMovingConversionPattern<scf::WhileOp> {
+  using RegionMovingConversionPattern::RegionMovingConversionPattern;
 
   LogicalResult
   matchAndRewrite(scf::WhileOp op, OpAdaptor adaptor,

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -468,7 +468,7 @@ static LogicalResult cleanUp(Operation* op, LoweringState& state) {
   module->setAttr("jeff.toolVersion", builder.getStringAttr(MQT_CORE_VERSION));
 
   module->setAttr("jeff.version", builder.getIntegerAttr(uint16Type, 0));
-  module->setAttr("jeff.versionMinor", builder.getIntegerAttr(uint16Type, 2));
+  module->setAttr("jeff.versionMinor", builder.getIntegerAttr(uint16Type, 3));
   module->setAttr("jeff.versionPatch", builder.getIntegerAttr(uint16Type, 0));
 
   return success();

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -50,6 +50,7 @@
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/IR/AsmState.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
@@ -451,7 +452,7 @@ static int runCompiler(int argc, char** argv) {
       .insert<arith::ArithDialect, cf::ControlFlowDialect, func::FuncDialect,
               LLVM::LLVMDialect, math::MathDialect, memref::MemRefDialect,
               qc::QCDialect, qco::QCODialect, qtensor::QTensorDialect,
-              scf::SCFDialect, jeff::JeffDialect>();
+              scf::SCFDialect, tensor::TensorDialect, jeff::JeffDialect>();
   registerBuiltinDialectTranslation(registry);
   registerLLVMDialectTranslation(registry);
 

--- a/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
+++ b/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
@@ -329,6 +329,26 @@ static Value whileWithRead(qco::QCOProgramBuilder& b) {
   return c;
 }
 
+static Value nestedWhileOpIfOp(qco::QCOProgramBuilder& b) {
+  auto q0 = b.allocQubit();
+  auto c = b.allocClassicalBitRegister(1);
+  auto q1 = b.h(q0);
+  auto res = b.scfWhile(
+      q1,
+      [&](ValueRange iterArgs) {
+        auto q2 = b.measure(iterArgs[0], c, 0).first;
+        b.scfCondition(c, 0, q2);
+        return SmallVector{q2};
+      },
+      [&](ValueRange iterArgs) {
+        auto inner = b.qcoIf(c, 0, iterArgs[0], [&](ValueRange innerArgs) {
+          return SmallVector{b.x(innerArgs[0])};
+        });
+        return SmallVector{inner[0]};
+      });
+  return b.measure(res[0]).second;
+}
+
 static LogicalResult convertQCOToJeff(ModuleOp module) {
   PassManager pm(module.getContext());
   pm.addPass(mlir::mqt::createUnrollModifiers());
@@ -1171,6 +1191,9 @@ INSTANTIATE_TEST_SUITE_P(
         JeffRoundTripTestCase{"SimpleDoWhile",
                               MQT_NAMED_BUILDER(qco::simpleDoWhileReset),
                               MQT_NAMED_BUILDER(qco::simpleDoWhileReset)},
+        JeffRoundTripTestCase{"NestedWhileOpIfOp",
+                              MQT_NAMED_BUILDER(nestedWhileOpIfOp),
+                              MQT_NAMED_BUILDER(nestedWhileOpIfOp)},
         JeffRoundTripTestCase{"WhileWithAngle",
                               MQT_NAMED_BUILDER(whileWithAngle),
                               MQT_NAMED_BUILDER(whileWithAngle)},

--- a/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
+++ b/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
@@ -274,6 +274,23 @@ static Value forLoopWithTwoMeasurements(qco::QCOProgramBuilder& b) {
   return c;
 }
 
+static Value nestedForLoopForOp(qco::QCOProgramBuilder& b) {
+  auto theta = b.floatConstant(0.123);
+  auto reg = b.qtensorAlloc(2);
+  auto res = b.scfFor(0, 2, 1, {reg}, [&](Value /*iv*/, ValueRange iterArgs) {
+    auto inner =
+        b.scfFor(0, 2, 1, iterArgs, [&](Value innerIv, ValueRange innerArgs) {
+          auto [t0, q0] = b.qtensorExtract(innerArgs[0], innerIv);
+          auto q1 = b.rx(theta, q0);
+          auto insert = b.qtensorInsert(q1, t0, innerIv);
+          return SmallVector{insert};
+        });
+    return SmallVector{inner[0]};
+  });
+  auto q = b.qtensorExtract(res[0], 0).second;
+  return b.measure(q).second;
+}
+
 static Value whileWithMeasurement(qco::QCOProgramBuilder& b) {
   auto q0 = b.allocQubit();
   auto c = b.allocClassicalBitRegister(1);
@@ -1130,6 +1147,9 @@ INSTANTIATE_TEST_SUITE_P(
         JeffRoundTripTestCase{"NestedForLoopWhileOp",
                               MQT_NAMED_BUILDER(qco::nestedForLoopWhileOp),
                               MQT_NAMED_BUILDER(qco::nestedForLoopWhileOp)},
+        JeffRoundTripTestCase{"NestedForLoopForOp",
+                              MQT_NAMED_BUILDER(nestedForLoopForOp),
+                              MQT_NAMED_BUILDER(nestedForLoopForOp)},
         JeffRoundTripTestCase{
             "NestedForLoopCtrlOpWithSeparateQubit",
             MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithSeparateQubit),


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This fixes two bugs that prevented nested control flow from surviving conversion between QCO and `jeff`.

An `scf.for` loop nested directly inside another `scf.for` loop failed to convert to `jeff`, and the outer loop was reported as not legalizable. `moveRegion` clones the operations of the source region, so a nested control flow operation reaches the conversion driver as a new operation of the same kind as the one just matched. The driver then rejects it with "pattern was already applied", and legalization of the outer operation fails with it. The patterns that move a region into a `jeff` operation now declare bounded rewrite recursion. The recursion terminates because each application moves one nesting level of the original program into its `jeff` counterpart. Directly nested `scf.while` loops were broken by the same mechanism and are fixed as well.

In the other direction, converting a `jeff.switch` nested in a `jeff.while` back to QCO crashed on an out-of-bounds access. `ConvertJeffSwitchOpToQCO` decided which in-values are qubits from the types of the operands, but by that point the operands may already carry converted types, which `isLinearType` does not recognize. It then read the results of the new `qco.if` using a count derived from the original `jeff` result types, and indexed past the end. Both loops now consult the result types, which still carry `jeff` types and correspond to the in-values positionally. `ConvertJeffWhileOpToQCO` had the same defect and is fixed as well.

This adds a `NestedForLoopForOp` round-trip test case, which covers the only nesting the `SCFForOpTest` suite was missing, and a `NestedWhileOpIfOp` case for the second fix.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
