### PR TITLE
💥 Remove dead `pybind11` CMake support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,9 @@ releases may include breaking changes.
 
 ### Changed
 
+- 💥 Remove the unused `pybind11` CMake helper and rename
+  `add_mqt_python_binding_nanobind` to `add_mqt_python_binding` ([#2106])
+  ([**@denialhaag**])
 - 💥 Move Python QDMI entities and the neutral-atom specialization to QDMI
   namespaces, expose device registration and opening through
   `mqt.core.qdmi.driver`, retain v3 FoMaC compatibility aliases, and let the
@@ -751,6 +754,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2106]: https://github.com/munich-quantum-toolkit/core/pull/2106
 [#2074]: https://github.com/munich-quantum-toolkit/core/pull/2074
 [#2073]: https://github.com/munich-quantum-toolkit/core/pull/2073
 [#2066]: https://github.com/munich-quantum-toolkit/core/pull/2066

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,28 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Python binding CMake helper
+
+The `add_mqt_python_binding_nanobind` function is now called
+`add_mqt_python_binding`. Rename the calls in downstream `CMakeLists.txt` files:
+
+```cmake
+add_mqt_python_binding(
+  MYPACKAGE
+  py_mypackage
+  ${SOURCES}
+  MODULE_NAME
+  _core
+  INSTALL_DIR
+  .
+  LINK_LIBS
+  MQT::Core)
+```
+
+The former `add_mqt_python_binding` function built modules with `pybind11`. All
+MQT projects have switched from `pybind11` to `nanobind`, so no build used that
+function. MQT Core no longer provides it.
+
 ### Removal of the ZX-calculus library
 
 MQT Core no longer provides the `mqt-core-zx` library, the `MQT::CoreZX` CMake

--- a/bindings/dd/CMakeLists.txt
+++ b/bindings/dd/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-dd-bindings)
   file(GLOB_RECURSE DD_SOURCES **.cpp)
 
   # declare the Python module
-  add_mqt_python_binding_nanobind(
+  add_mqt_python_binding(
     CORE
     ${MQT_CORE_TARGET_NAME}-dd-bindings
     ${DD_SOURCES}

--- a/bindings/ir/CMakeLists.txt
+++ b/bindings/ir/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-ir-bindings)
   file(GLOB_RECURSE IR_SOURCES **.cpp)
 
   # declare the Python module
-  add_mqt_python_binding_nanobind(
+  add_mqt_python_binding(
     CORE
     ${MQT_CORE_TARGET_NAME}-ir-bindings
     ${IR_SOURCES}

--- a/bindings/mlir/CMakeLists.txt
+++ b/bindings/mlir/CMakeLists.txt
@@ -71,7 +71,7 @@ if(NOT TARGET ${TARGET_NAME})
   endif()
 
   # declare the Python module
-  add_mqt_python_binding_nanobind(
+  add_mqt_python_binding(
     CORE
     ${TARGET_NAME}
     ${SOURCES}

--- a/bindings/na/CMakeLists.txt
+++ b/bindings/na/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT TARGET ${TARGET_NAME})
   file(GLOB_RECURSE SOURCES *.cpp)
 
   # declare the Python module
-  add_mqt_python_binding_nanobind(
+  add_mqt_python_binding(
     CORE
     ${TARGET_NAME}
     ${SOURCES}

--- a/bindings/qdmi/CMakeLists.txt
+++ b/bindings/qdmi/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT TARGET ${TARGET_NAME})
   file(GLOB_RECURSE SOURCES **.cpp)
 
   # declare the Python module
-  add_mqt_python_binding_nanobind(
+  add_mqt_python_binding(
     CORE
     ${TARGET_NAME}
     ${SOURCES}

--- a/cmake/AddMQTPythonBinding.cmake
+++ b/cmake/AddMQTPythonBinding.cmake
@@ -7,54 +7,6 @@
 # Licensed under the MIT License
 
 function(add_mqt_python_binding package_name target_name)
-  # parse the arguments
-  cmake_parse_arguments(ARG "" "MODULE_NAME;INSTALL_DIR" "LINK_LIBS" ${ARGN})
-  set(SOURCES ${ARG_UNPARSED_ARGUMENTS})
-
-  # declare the Python module
-  pybind11_add_module(
-    # name of the extension
-    ${target_name}
-    # prefer thin LTO if available
-    THIN_LTO
-    # optimize the bindings for size
-    OPT_SIZE
-    # source code goes here
-    ${SOURCES})
-
-  # set default "." for INSTALL_DIR
-  if(NOT ARG_INSTALL_DIR)
-    set(ARG_INSTALL_DIR ".")
-  endif()
-
-  if(ARG_MODULE_NAME)
-    # the library name must be the same as the module name
-    set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${ARG_MODULE_NAME})
-    target_compile_definitions(${target_name}
-                               PRIVATE MQT_${package_name}_MODULE_NAME=${ARG_MODULE_NAME})
-  else()
-    # use the target name as the module name
-    target_compile_definitions(${target_name}
-                               PRIVATE MQT_${package_name}_MODULE_NAME=${target_name})
-  endif()
-
-  # add project libraries to the link libraries
-  list(APPEND ARG_LINK_LIBS MQT::ProjectOptions MQT::ProjectWarnings)
-
-  # Set c++ standard
-  target_compile_features(${target_name} PRIVATE cxx_std_20)
-
-  # link the required libraries
-  target_link_libraries(${target_name} PRIVATE ${ARG_LINK_LIBS})
-
-  # install directive for scikit-build-core
-  install(
-    TARGETS ${target_name}
-    DESTINATION ${ARG_INSTALL_DIR}
-    COMPONENT ${MQT_${package_name}_TARGET_NAME}_Python)
-endfunction()
-
-function(add_mqt_python_binding_nanobind package_name target_name)
   cmake_parse_arguments(ARG "" "MODULE_NAME;INSTALL_DIR" "LINK_LIBS" ${ARGN})
   set(SOURCES ${ARG_UNPARSED_ARGUMENTS})
 


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

`cmake/AddMQTPythonBinding.cmake` still held `add_mqt_python_binding`, which called `pybind11_add_module`. All MQT projects have switched from `pybind11` to `nanobind`, so that function no longer worked and nothing used it.

This removes the dead function and renames the remaining helper from `add_mqt_python_binding_nanobind` to `add_mqt_python_binding`. The file keeps its name, so the install rules in `src/CMakeLists.txt` and the include in `cmake/mqt-core-config.cmake.in` do not change.

The rename breaks the installed CMake API. Downstream repositories that call `add_mqt_python_binding_nanobind` need a follow-up pull request each: `ddsim`, `qmap` (four call sites), `qcec`, `qudits`, `syrec`, `qusat`, and `debugger`. `CHANGELOG.md` and `UPGRADING.md` document the rename.

Fixes #2089

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
