### PR TITLE
♻️ Remove RNG state from QuantumComputation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,9 @@ releases may include breaking changes.
 
 ### Removed
 
+- 💥 Remove the random-number generator, seed, and `getGenerator()` method from
+  `QuantumComputation`; randomized algorithms now own generators initialized
+  from their seed arguments ([#2111]) ([**@simon1hofmann**])
 - 💥 Remove QDMI device configuration through `[tool.qdmi]` in `pyproject.toml`
   and the vendored toml++ header ([#2116]) ([**@denialhaag**])
 - 💥 Remove the FoMaC compatibility name from the C++ and Python QDMI APIs. Use
@@ -779,6 +782,7 @@ for previous changelogs._
 [#2108]: https://github.com/munich-quantum-toolkit/core/pull/2108
 [#2115]: https://github.com/munich-quantum-toolkit/core/pull/2115
 [#2106]: https://github.com/munich-quantum-toolkit/core/pull/2106
+[#2111]: https://github.com/munich-quantum-toolkit/core/pull/2111
 [#2105]: https://github.com/munich-quantum-toolkit/core/pull/2105
 [#2084]: https://github.com/munich-quantum-toolkit/core/pull/2084
 [#2074]: https://github.com/munich-quantum-toolkit/core/pull/2074

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -95,6 +95,14 @@ Python code can convert a legacy circuit to OpenQASM 3 before compilation:
 program = compile_program(computation.qasm3_str())
 ```
 
+### QuantumComputation random-number generator
+
+`QuantumComputation` no longer stores a random-number generator or seed. Remove
+the third `seed` argument from C++ and Python constructor calls. C++ callers
+that used `QuantumComputation::getGenerator()` must create and own a
+random-number generator instead. Randomized circuit generators continue to
+accept a seed and now own a separate generator for each call.
+
 ### Removal of the ZX-calculus library
 
 MQT Core no longer provides the `mqt-core-zx` library, the `MQT::CoreZX` CMake

--- a/bindings/ir/register_quantum_computation.cpp
+++ b/bindings/ir/register_quantum_computation.cpp
@@ -68,14 +68,12 @@ Acts as mutable sequence of :class:`~mqt.core.ir.operations.Operation` objects, 
 
 Args:
     nq: The number of qubits in the quantum computation.
-    nc: The number of classical bits in the quantum computation.
-    seed: The seed to use for the internal random number generator.)pb");
+    nc: The number of classical bits in the quantum computation.)pb");
 
   ///---------------------------------------------------------------------------
   ///                           \n Constructors \n
   ///---------------------------------------------------------------------------
-  qc.def(nb::init<std::size_t, std::size_t, std::size_t>(), "nq"_a = 0U,
-         "nc"_a = 0U, "seed"_a = 0U);
+  qc.def(nb::init<std::size_t, std::size_t>(), "nq"_a = 0U, "nc"_a = 0U);
 
   // expose the static constructor from qasm strings or files
   qc.def_static("from_qasm_str", &qasm3::Importer::imports, "qasm"_a,

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -30,7 +30,6 @@
 #include <memory>
 #include <optional>
 #include <ostream>
-#include <random>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -65,16 +64,12 @@ protected:
   std::vector<bool> ancillary;
   std::vector<bool> garbage;
 
-  std::mt19937_64 mt;
-  std::size_t seed = 0;
-
   fp globalPhase = 0.;
 
   std::unordered_set<sym::Variable> occurringVariables;
 
 public:
-  explicit QuantumComputation(std::size_t nq = 0, std::size_t nc = 0U,
-                              std::size_t s = 0);
+  explicit QuantumComputation(std::size_t nq = 0, std::size_t nc = 0U);
   QuantumComputation(QuantumComputation&& qc) noexcept = default;
   QuantumComputation& operator=(QuantumComputation&& qc) noexcept = default;
   QuantumComputation(const QuantumComputation& qc);
@@ -126,8 +121,6 @@ public:
   [[nodiscard]] const auto& getAncillaRegisters() const noexcept {
     return ancillaRegisters;
   }
-  [[nodiscard]] decltype(mt)& getGenerator() noexcept { return mt; }
-
   [[nodiscard]] fp getGlobalPhase() const noexcept { return globalPhase; }
   [[nodiscard]] bool hasGlobalPhase() const noexcept {
     return std::abs(getGlobalPhase()) > 0;

--- a/python/mqt/core/ir/__init__.pyi
+++ b/python/mqt/core/ir/__init__.pyi
@@ -96,10 +96,9 @@ class QuantumComputation(MutableSequence[operations.Operation]):
     Args:
         nq: The number of qubits in the quantum computation.
         nc: The number of classical bits in the quantum computation.
-        seed: The seed to use for the internal random number generator.
     """
 
-    def __init__(self, nq: int = 0, nc: int = 0, seed: int = 0) -> None: ...
+    def __init__(self, nq: int = 0, nc: int = 0) -> None: ...
     @staticmethod
     def from_qasm_str(qasm: str) -> QuantumComputation:
         """Create a QuantumComputation object from an OpenQASM string.

--- a/src/algorithms/BernsteinVazirani.cpp
+++ b/src/algorithms/BernsteinVazirani.cpp
@@ -105,8 +105,9 @@ auto createBernsteinVazirani(const BVBitString& hiddenString)
 
 auto createBernsteinVazirani(const Qubit nq, const std::size_t seed)
     -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto hiddenString = generateBitstring(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto hiddenString = generateBitstring(nq, generator);
+  auto qc = QuantumComputation();
   constructBernsteinVaziraniCircuit(qc, hiddenString, nq);
   return qc;
 }
@@ -169,8 +170,9 @@ auto createIterativeBernsteinVazirani(const BVBitString& hiddenString)
 
 auto createIterativeBernsteinVazirani(const Qubit nq, const std::size_t seed)
     -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto hiddenString = generateBitstring(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto hiddenString = generateBitstring(nq, generator);
+  auto qc = QuantumComputation();
   constructIterativeBernsteinVaziraniCircuit(qc, hiddenString, nq);
   return qc;
 }

--- a/src/algorithms/Grover.cpp
+++ b/src/algorithms/Grover.cpp
@@ -128,8 +128,9 @@ auto constructGroverCircuit(QuantumComputation& qc, const Qubit nq,
 
 auto createGrover(const Qubit nq, const std::size_t seed)
     -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto targetValue = generateTargetValue(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto targetValue = generateTargetValue(nq, generator);
+  auto qc = QuantumComputation();
   constructGroverCircuit(qc, nq, targetValue);
   return qc;
 }

--- a/src/algorithms/QPE.cpp
+++ b/src/algorithms/QPE.cpp
@@ -129,9 +129,10 @@ auto constructQPECircuit(QuantumComputation& qc, const fp lambda,
 
 auto createQPE(const Qubit nq, const bool exact, const std::size_t seed)
     -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto lambda = exact ? createExactPhase(nq, qc.getGenerator())
-                            : createInexactPhase(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto lambda = exact ? createExactPhase(nq, generator)
+                            : createInexactPhase(nq, generator);
+  auto qc = QuantumComputation();
   constructQPECircuit(qc, lambda, nq);
   return qc;
 }
@@ -194,9 +195,10 @@ auto constructIterativeQPECircuit(QuantumComputation& qc, const fp lambda,
 
 auto createIterativeQPE(const Qubit nq, const bool exact,
                         const std::size_t seed) -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto lambda = exact ? createExactPhase(nq, qc.getGenerator())
-                            : createInexactPhase(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto lambda = exact ? createExactPhase(nq, generator)
+                            : createInexactPhase(nq, generator);
+  auto qc = QuantumComputation();
   constructIterativeQPECircuit(qc, lambda, nq);
   return qc;
 }

--- a/src/algorithms/RandomCliffordCircuit.cpp
+++ b/src/algorithms/RandomCliffordCircuit.cpp
@@ -206,12 +206,13 @@ auto append2QClifford(QuantumComputation& circ, const std::uint16_t idx,
 
 auto createRandomCliffordCircuit(const Qubit nq, const std::size_t depth,
                                  const std::size_t seed) -> QuantumComputation {
-  auto qc = QuantumComputation(nq, nq, seed);
+  auto qc = QuantumComputation(nq, nq);
   qc.setName("random_clifford_" + std::to_string(nq) + "_" +
              std::to_string(depth) + "_" + std::to_string(seed));
 
   std::uniform_int_distribution<std::uint16_t> distribution(0, 11520);
-  auto cliffordGenerator = [&]() { return distribution(qc.getGenerator()); };
+  auto generator = std::mt19937_64(seed);
+  auto cliffordGenerator = [&]() { return distribution(generator); };
 
   for (std::size_t l = 0; l < depth; ++l) {
     if (nq == 1) {

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -22,7 +22,6 @@
 #include "ir/operations/SymbolicOperation.hpp"
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
@@ -37,7 +36,6 @@
 #include <numeric>
 #include <optional>
 #include <ostream>
-#include <random>
 #include <ranges>
 #include <set>
 #include <sstream>
@@ -569,7 +567,7 @@ bool QuantumComputation::operator==(const QuantumComputation& rhs) const {
       initialLayout != rhs.initialLayout ||
       outputPermutation != rhs.outputPermutation ||
       ancillary != rhs.ancillary || garbage != rhs.garbage ||
-      seed != rhs.seed || globalPhase != rhs.globalPhase ||
+      globalPhase != rhs.globalPhase ||
       occurringVariables != rhs.occurringVariables) {
     return false;
   }
@@ -950,25 +948,12 @@ void QuantumComputation::checkClassicalRegister(
 void QuantumComputation::reverse() { std::ranges::reverse(ops); }
 
 QuantumComputation::QuantumComputation(const std::size_t nq,
-                                       const std::size_t nc,
-                                       const std::size_t s)
-    : seed(s) {
+                                       const std::size_t nc) {
   if (nq > 0) {
     addQubitRegister(nq);
   }
   if (nc > 0) {
     addClassicalRegister(nc);
-  }
-  if (seed != 0) {
-    mt.seed(seed);
-  } else {
-    // create and properly seed rng
-    std::array<std::mt19937_64::result_type, std::mt19937_64::state_size>
-        randomData{};
-    std::random_device rd;
-    std::ranges::generate(randomData, [&rd]() { return rd(); });
-    std::seed_seq seeds(std::begin(randomData), std::end(randomData));
-    mt.seed(seeds);
   }
 }
 
@@ -977,8 +962,8 @@ QuantumComputation::QuantumComputation(const QuantumComputation& qc)
       name(qc.name), quantumRegisters(qc.quantumRegisters),
       classicalRegisters(qc.classicalRegisters),
       ancillaRegisters(qc.ancillaRegisters), ancillary(qc.ancillary),
-      garbage(qc.garbage), mt(qc.mt), seed(qc.seed),
-      globalPhase(qc.globalPhase), occurringVariables(qc.occurringVariables),
+      garbage(qc.garbage), globalPhase(qc.globalPhase),
+      occurringVariables(qc.occurringVariables),
       initialLayout(qc.initialLayout), outputPermutation(qc.outputPermutation) {
   ops.reserve(qc.ops.size());
   for (const auto& op : qc.ops) {
@@ -995,8 +980,6 @@ QuantumComputation::operator=(const QuantumComputation& qc) {
     quantumRegisters = qc.quantumRegisters;
     classicalRegisters = qc.classicalRegisters;
     ancillaRegisters = qc.ancillaRegisters;
-    mt = qc.mt;
-    seed = qc.seed;
     globalPhase = qc.globalPhase;
     occurringVariables = qc.occurringVariables;
     initialLayout = qc.initialLayout;

--- a/test/algorithms/test_randomized_algorithms.cpp
+++ b/test/algorithms/test_randomized_algorithms.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2026 Munich Quantum Software Company GmbH
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
  * All rights reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/algorithms/test_randomized_algorithms.cpp
+++ b/test/algorithms/test_randomized_algorithms.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "algorithms/BernsteinVazirani.hpp"
+#include "algorithms/Grover.hpp"
+#include "algorithms/QPE.hpp"
+#include "algorithms/RandomCliffordCircuit.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+
+TEST(RandomizedAlgorithms, ReproducibleWithExplicitSeed) {
+  constexpr std::size_t seed = 17;
+
+  EXPECT_EQ(qc::createBernsteinVazirani(64, seed),
+            qc::createBernsteinVazirani(64, seed));
+  EXPECT_EQ(qc::createIterativeBernsteinVazirani(64, seed),
+            qc::createIterativeBernsteinVazirani(64, seed));
+  EXPECT_EQ(qc::createGrover(5, seed), qc::createGrover(5, seed));
+  EXPECT_EQ(qc::createQPE(8, true, seed), qc::createQPE(8, true, seed));
+  EXPECT_EQ(qc::createIterativeQPE(8, false, seed),
+            qc::createIterativeQPE(8, false, seed));
+  EXPECT_EQ(qc::createRandomCliffordCircuit(4, 8, seed),
+            qc::createRandomCliffordCircuit(4, 8, seed));
+}
+
+TEST(RandomizedAlgorithms, SeedsAreIndependentBetweenCalls) {
+  constexpr std::size_t seed = 23;
+  const auto expected = qc::createBernsteinVazirani(64, seed);
+
+  static_cast<void>(qc::createGrover(5, seed + 1));
+  static_cast<void>(qc::createQPE(8, true, seed + 2));
+  static_cast<void>(qc::createRandomCliffordCircuit(4, 8, seed + 3));
+
+  EXPECT_EQ(qc::createBernsteinVazirani(64, seed), expected);
+  EXPECT_NE(qc::createBernsteinVazirani(64, seed + 1), expected);
+}

--- a/test/algorithms/test_randomized_algorithms.cpp
+++ b/test/algorithms/test_randomized_algorithms.cpp
@@ -35,7 +35,7 @@ TEST(RandomizedAlgorithms, ReproducibleWithExplicitSeed) {
 
 TEST(RandomizedAlgorithms, SeedsAreIndependentBetweenCalls) {
   constexpr std::size_t seed = 23;
-  const auto expected = qc::createBernsteinVazirani(64, seed);
+  const qc::QuantumComputation expected = qc::createBernsteinVazirani(64, seed);
 
   static_cast<void>(qc::createGrover(5, seed + 1));
   static_cast<void>(qc::createQPE(8, true, seed + 2));

--- a/test/algorithms/test_randomized_algorithms.cpp
+++ b/test/algorithms/test_randomized_algorithms.cpp
@@ -12,6 +12,7 @@
 #include "algorithms/Grover.hpp"
 #include "algorithms/QPE.hpp"
 #include "algorithms/RandomCliffordCircuit.hpp"
+#include "ir/QuantumComputation.hpp"
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- remove the random-number generator and seed from QuantumComputation
- give each randomized circuit generator a local generator initialized from its seed argument
- remove the third C++ and Python constructor argument and regenerate the Python stub
- add reproducibility and seed-separation coverage
- document the breaking API change in the upgrade guide

Closes #2100.

Also removed in downstream repositories: https://github.com/munich-quantum-toolkit/qcec/pull/1020 and https://github.com/munich-quantum-toolkit/ddsim/pull/954.

## Validation

- all 280 CoreAlgorithms tests pass
- focused Python IR tests pass
- full lint suite passes
- git diff --check passes

## AI assistance

Codex materially assisted with implementation, tests, validation, and this pull-request description. The human contributor remains responsible for reviewing and accepting the changes.