### PR TITLE
🐛 Fix unused sparse target-site indexing

### DIFF
--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -716,8 +716,7 @@ private:
     rewriter.setInsertionPoint(body.back().getTerminator());
     for (size_t prog = wires.size(); prog < layout.nqubits(); ++prog) {
       const auto hw = layout.getHardwareIndex(prog);
-      const auto site = target->siteForVertex(hw);
-      const auto qubit = staticQubits[site];
+      const auto qubit = staticQubits[hw];
 
       wires.emplace_back(qubit);
       infos.insertOrUpdate(prog, prog);

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -408,6 +408,42 @@ TEST_F(MappingPassFixture, PreserveNoncontiguousTargetSiteIds) {
   EXPECT_EQ(numStatics, 3);
 }
 
+TEST_F(MappingPassFixture, MapNoncontiguousTargetWithUnusedSites) {
+  std::vector<CompilerTarget::Site> sites;
+  sites.emplace_back(llvm::cantFail(CompilerTarget::Site::create(7)));
+  sites.emplace_back(llvm::cantFail(CompilerTarget::Site::create(19)));
+  sites.emplace_back(llvm::cantFail(CompilerTarget::Site::create(42)));
+  const auto target = llvm::cantFail(CompilerTarget::create(std::move(sites)));
+
+  QCOProgramBuilder builder(context.get());
+  builder.initialize({builder.getI1Type()});
+  auto qubit = builder.h(builder.allocQubit());
+  Value bit;
+  std::tie(qubit, bit) = builder.measure(qubit);
+  builder.sink(qubit);
+  auto module = builder.finalize(bit);
+
+  PassManager pm(module->getContext());
+  pm.addPass(createMappingPass(target, MappingPassOptions{.ntrials = 1}));
+  ASSERT_TRUE(pm.run(module.get()).succeeded());
+  ASSERT_TRUE(succeeded(verify(*module)));
+  EXPECT_TRUE(isExecutable(getEntryPoint(module.get()), target));
+
+  const DenseSet<CompilerTarget::SiteId> expectedSites{7, 19, 42};
+  size_t numAllocations = 0;
+  size_t numStatics = 0;
+  size_t numSinks = 0;
+  module->walk([&](AllocOp) { ++numAllocations; });
+  module->walk([&](StaticOp op) {
+    ++numStatics;
+    EXPECT_TRUE(expectedSites.contains(op.getIndex()));
+  });
+  module->walk([&](SinkOp) { ++numSinks; });
+  EXPECT_EQ(numAllocations, 0);
+  EXPECT_EQ(numStatics, 3);
+  EXPECT_EQ(numSinks, 3);
+}
+
 TEST_F(MappingPassFixture, KeepWorkspaceSparseOnLargeTarget) {
   constexpr size_t numTargetQubits = 64;
   std::vector<CompilerTarget::Coupling> couplings;


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Fix mapping programs onto targets with noncontiguous site IDs when some target
sites are unused.

The mapper stores materialized static qubits in dense hardware-vertex order,
but the unused-site path indexed that vector with the external target site ID.
For sparse IDs, this could access the vector out of bounds. The path now uses
the dense hardware vertex consistently with the active-site paths.

The regression maps a one-qubit program to target sites `{7, 19, 42}` and
verifies that mapping succeeds, produces all three static qubits and sinks, and
remains executable for the target.

This PR was implemented and submitted with OpenAI Codex assistance after the
author explicitly authorized the branch and PR work. Human maintainer review is
still required before merge.

## Validation

- 82/82 mapping unit tests passed.
- The complete repository lint passed.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes (not needed; this is an internal correctness fix).
- [x] A changelog entry is not needed for this internal correctness fix.
- [x] I have added migration instructions to the upgrade guide (not needed; there is no API change).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
