### PR TITLE
♻️ Prepare MQT Core for LLVM 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       files-changed-only: true
       setup-python: true
       install-pkgs: "nanobind==2.14.0"
-      cpp-linter-extra-args: "-std=c++20"
+      cpp-linter-extra-args: "-std=c++20 -Wunused-template"
       # Vendored third-party headers are checked upstream and are not maintained
       # according to MQT Core's clang-tidy configuration.
       cpp-linter-ignore-extra: "vendor/**"

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1477,6 +1477,9 @@ def IfOp
         /// for the else-block, or `nullptr` on failure.
         OpOperand* getTiedElseYieldedValue(BlockArgument bbArg);
 
+        /// Return the values populated when branching to the successor.
+        ValueRange getSuccessorInputs(RegionSuccessor successor);
+
         /// Append the specified additional "qubit" operands: replace this
         /// if-op with a new if-op that has the additional qubit operands.
         /// The operands can be of qubit or qtensor type.
@@ -1626,6 +1629,9 @@ def IndexSwitchOp
         /// Return the yielded value that corresponds to the given argument
         /// for the default case, or `nullptr` on failure.
         OpOperand* getTiedDefaultYieldedValue(BlockArgument bbArg);
+
+        /// Return the values populated when branching to the successor.
+        ValueRange getSuccessorInputs(RegionSuccessor successor);
 
         /// Append the specified additional linear operands: replace this
         /// index_switch with a new index_switch that has the additional linear operands.

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -250,20 +250,23 @@ Value QCOProgramBuilder::prepareInitArg(Value initArg,
 
   validateTensorValue(initArg);
   const auto regId = validTensors.find(initArg)->regId;
-  auto currentTensor = initArg;
-  for (auto it = validQubits.begin(); it != validQubits.end();) {
-    const auto& qubit = *it;
+
+  SmallVector<Qubit> qubitsToInsert;
+  for (const auto& qubit : validQubits) {
     if (qubit.regId == regId &&
         (initQubits == nullptr || !initQubits->contains(qubit))) {
-      auto newTensor =
-          qtensor::InsertOp::create(*this, qubit, currentTensor, qubit.regIndex)
-              .getResult();
-      updateTensorTracking(currentTensor, newTensor);
-      currentTensor = newTensor;
-      validQubits.erase(it++);
-    } else {
-      ++it;
+      qubitsToInsert.push_back(qubit);
     }
+  }
+
+  auto currentTensor = initArg;
+  for (const auto& qubit : qubitsToInsert) {
+    auto newTensor =
+        qtensor::InsertOp::create(*this, qubit, currentTensor, qubit.regIndex)
+            .getResult();
+    updateTensorTracking(currentTensor, newTensor);
+    currentTensor = newTensor;
+    validQubits.erase(qubit);
   }
   return currentTensor;
 }

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "RegionBranchCompat.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/QCOUtils.h"
 
@@ -96,20 +97,22 @@ void IfOp::getSuccessorRegions(RegionBranchPoint point,
   // The `then` and the `else` region branch back to the parent operation or
   // one of the recursive parent operations (early exit case).
   if (!point.isParent()) {
-    regions.push_back(RegionSuccessor(getOperation(), getResults()));
+    regions.push_back(
+        detail::makeRegionSuccessor(getOperation(), getResults()));
     return;
   }
 
-  regions.push_back(
-      RegionSuccessor(&getThenRegion(), getThenRegion().getArguments()));
+  regions.push_back(detail::makeRegionSuccessor(
+      &getThenRegion(), getThenRegion().getArguments()));
 
   // If the else region is empty, execution continues after the parent op.
   Region* elseRegion = &getElseRegion();
   if (elseRegion->empty()) {
-    regions.push_back(
-        RegionSuccessor(getOperation(), getOperation()->getResults()));
+    regions.push_back(detail::makeRegionSuccessor(
+        getOperation(), getOperation()->getResults()));
   } else {
-    regions.push_back(RegionSuccessor(elseRegion, elseRegion->getArguments()));
+    regions.push_back(
+        detail::makeRegionSuccessor(elseRegion, elseRegion->getArguments()));
   }
 }
 
@@ -118,17 +121,27 @@ void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
   FoldAdaptor adaptor(operands, *this);
   auto boolAttr = dyn_cast_or_null<BoolAttr>(adaptor.getCondition());
   if (!boolAttr || boolAttr.getValue()) {
-    regions.emplace_back(&getThenRegion(), getThenRegion().getArguments());
+    regions.push_back(detail::makeRegionSuccessor(
+        &getThenRegion(), getThenRegion().getArguments()));
   }
 
   // If the else region is empty, execution continues after the parent op.
   if (!boolAttr || !boolAttr.getValue()) {
     if (!getElseRegion().empty()) {
-      regions.emplace_back(&getElseRegion(), getElseRegion().getArguments());
+      regions.push_back(detail::makeRegionSuccessor(
+          &getElseRegion(), getElseRegion().getArguments()));
     } else {
-      regions.emplace_back(getOperation(), getResults());
+      regions.push_back(
+          detail::makeRegionSuccessor(getOperation(), getResults()));
     }
   }
+}
+
+ValueRange IfOp::getSuccessorInputs(RegionSuccessor successor) {
+  if (detail::isOperationSuccessor(successor)) {
+    return getResults();
+  }
+  return successor.getSuccessor()->getArguments();
 }
 
 OperandRange IfOp::getEntrySuccessorOperands(RegionSuccessor /*successor*/) {

--- a/mlir/lib/Dialect/QCO/IR/SCF/IndexSwitchOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IndexSwitchOp.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "RegionBranchCompat.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/QCOUtils.h"
 
@@ -68,12 +69,14 @@ void IndexSwitchOp::build(OpBuilder& odsBuilder, OperationState& odsState,
 void IndexSwitchOp::getSuccessorRegions(
     RegionBranchPoint point, SmallVectorImpl<RegionSuccessor>& regions) {
   if (!point.isParent()) {
-    regions.emplace_back(getOperation(), getResults());
+    regions.push_back(
+        detail::makeRegionSuccessor(getOperation(), getResults()));
     return;
   }
 
   for (Region* region : getRegions()) {
-    regions.emplace_back(region, region->getArguments());
+    regions.push_back(
+        detail::makeRegionSuccessor(region, region->getArguments()));
   }
 }
 
@@ -113,7 +116,8 @@ void IndexSwitchOp::getEntrySuccessorRegions(
   auto arg = dyn_cast_or_null<IntegerAttr>(adaptor.getArg());
   if (!arg) {
     for (Region* region : getRegions()) {
-      regions.emplace_back(region, region->getArguments());
+      regions.push_back(
+          detail::makeRegionSuccessor(region, region->getArguments()));
     }
     return;
   }
@@ -123,14 +127,22 @@ void IndexSwitchOp::getEntrySuccessorRegions(
 
   const auto* it = llvm::find(getCases(), arg.getInt());
   if (it == getCases().end()) {
-    regions.emplace_back(&getDefaultRegion(),
-                         getDefaultRegion().getArguments());
+    regions.push_back(detail::makeRegionSuccessor(
+        &getDefaultRegion(), getDefaultRegion().getArguments()));
     return;
   }
 
   const auto caseIndex = std::distance(getCases().begin(), it);
   auto& caseRegion = getCaseRegions()[caseIndex];
-  regions.emplace_back(&caseRegion, caseRegion.getArguments());
+  regions.push_back(
+      detail::makeRegionSuccessor(&caseRegion, caseRegion.getArguments()));
+}
+
+ValueRange IndexSwitchOp::getSuccessorInputs(RegionSuccessor successor) {
+  if (detail::isOperationSuccessor(successor)) {
+    return getResults();
+  }
+  return successor.getSuccessor()->getArguments();
 }
 
 OperandRange

--- a/mlir/lib/Dialect/QCO/IR/SCF/RegionBranchCompat.h
+++ b/mlir/lib/Dialect/QCO/IR/SCF/RegionBranchCompat.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include <llvm/Config/llvm-config.h>
+#include <mlir/Interfaces/ControlFlowInterfaces.h>
+
+namespace mlir::qco::detail {
+
+template <typename Target, typename Inputs>
+RegionSuccessor makeRegionSuccessor(Target* target,
+                                    [[maybe_unused]] Inputs inputs) {
+#if LLVM_VERSION_MAJOR >= 23
+  return RegionSuccessor(target);
+#else
+  return RegionSuccessor(target, inputs);
+#endif
+}
+
+[[nodiscard]] inline bool isOperationSuccessor(RegionSuccessor successor) {
+#if LLVM_VERSION_MAJOR >= 23
+  return successor.isOperation();
+#else
+  return successor.isParent();
+#endif
+}
+
+} // namespace mlir::qco::detail

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -497,7 +497,7 @@ private:
     newTypes.append(addons.getTypes().begin(), addons.getTypes().end());
 
     auto newWhileOp =
-        rewriter.create<scf::WhileOp>(whileOp.getLoc(), newTypes, newInits);
+        scf::WhileOp::create(rewriter, whileOp.getLoc(), newTypes, newInits);
 
     const SmallVector<Location> beforeLocs(newInits.size(), whileOp.getLoc());
     const SmallVector<Location> afterLocs(newTypes.size(), whileOp.getLoc());
@@ -522,8 +522,8 @@ private:
     llvm::append_range(newConditionArgs,
                        newBefBlock->getArguments().drop_front(oldBefNumArgs));
 
-    rewriter.create<scf::ConditionOp>(
-        conditionOp.getLoc(), conditionOp.getCondition(), newConditionArgs);
+    scf::ConditionOp::create(rewriter, conditionOp.getLoc(),
+                             conditionOp.getCondition(), newConditionArgs);
     rewriter.eraseOp(conditionOp);
 
     // Replace the old yield operation with one that includes the new "after"
@@ -536,7 +536,7 @@ private:
     llvm::append_range(newYieldArgs,
                        newAftBlock->getArguments().drop_front(oldAftNumArgs));
 
-    rewriter.create<scf::YieldOp>(yieldOp.getLoc(), newYieldArgs);
+    scf::YieldOp::create(rewriter, yieldOp.getLoc(), newYieldArgs);
     rewriter.eraseOp(yieldOp);
 
     // Finally, replace the old while operation with the new one.

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -688,6 +688,11 @@ TEST_F(QCOTest, IfOpWithClassicalResultRoundTripsAndPreservesTies) {
   EXPECT_EQ(ifOp.getTiedElseYieldedValue(ifOp.thenBlock()->getArgument(0)),
             nullptr);
 
+  SmallVector<RegionSuccessor> successors;
+  ifOp.getSuccessorRegions(RegionBranchPoint(ifOp.thenYield()), successors);
+  ASSERT_EQ(successors.size(), 1);
+  EXPECT_EQ(ifOp.getSuccessorInputs(successors.front()), ifOp.getResults());
+
   std::string printed;
   llvm::raw_string_ostream stream(printed);
   module->print(stream);
@@ -1007,10 +1012,17 @@ TEST_F(QCOTest, IndexSwitchWithClassicalResultRoundTripsAndPreservesTies) {
   switchOp.getEntrySuccessorRegions(operands, successors);
   ASSERT_EQ(successors.size(), 2);
   for (const RegionSuccessor successor : successors) {
-    ASSERT_EQ(successor.getSuccessorInputs().size(), 1);
+    ASSERT_EQ(switchOp.getSuccessorInputs(successor).size(), 1);
     EXPECT_EQ(switchOp.getEntrySuccessorOperands(successor).front(),
               switchOp.getTargets().front());
   }
+
+  successors.clear();
+  switchOp.getSuccessorRegions(RegionBranchPoint(switchOp.getCaseYield(0)),
+                               successors);
+  ASSERT_EQ(successors.size(), 1);
+  EXPECT_EQ(switchOp.getSuccessorInputs(successors.front()),
+            switchOp.getResults());
 
   std::string printed;
   llvm::raw_string_ostream stream(printed);

--- a/test/qir/jit/test_jit_session.cpp
+++ b/test/qir/jit/test_jit_session.cpp
@@ -193,8 +193,8 @@ define i64 @native_controls() #0 {
   call void @__quantum__rt__initialize(ptr null)
   call void @__quantum__qis__x__body(ptr null)
   call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-  call void @__quantum__qis__crx__body(double 0x400921FB54442D18, ptr null, ptr inttoptr (i64 2 to ptr))
-  call void @__quantum__qis__ccrx__body(double 0x400921FB54442D18, ptr null, ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 3 to ptr))
+  call void @__quantum__qis__crx__body(double 3.141592653589793, ptr null, ptr inttoptr (i64 2 to ptr))
+  call void @__quantum__qis__ccrx__body(double 3.141592653589793, ptr null, ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 3 to ptr))
   call void @__quantum__qis__mz__body(ptr inttoptr (i64 2 to ptr), ptr null)
   call void @__quantum__qis__mz__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
   call void @__quantum__rt__result_record_output(ptr null, ptr null)
@@ -250,7 +250,7 @@ define i64 @generic_controlled() #0 {
   %args = call ptr @__quantum__rt__tuple_create(i64 16)
   %angle_slot = getelementptr { double, ptr }, ptr %args, i32 0, i32 0
   %target_slot = getelementptr { double, ptr }, ptr %args, i32 0, i32 1
-  store double 0x400921FB54442D18, ptr %angle_slot
+  store double 3.141592653589793, ptr %angle_slot
   store ptr %target, ptr %target_slot
   call void @__quantum__qis__x__body(ptr %control0)
   call void @__quantum__qis__x__body(ptr %control1)
@@ -292,7 +292,7 @@ attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" }
 TEST_F(JitSessionTest, RejectsQirRunnerPauliRotationAbi) {
   constexpr std::string_view ir = R"(
 define i64 @pauli_rotation() #0 {
-  call void @__quantum__qis__r__body(i2 1, double 0x400921FB54442D18, ptr null)
+  call void @__quantum__qis__r__body(i2 1, double 3.141592653589793, ptr null)
   ret i64 0
 }
 declare void @__quantum__qis__r__body(i2, double, ptr)


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

Prepare the current LLVM/MLIR 22.1.8 code for known LLVM 23 changes:

- avoid iterator invalidation when erasing tracked qubits from a DenseSet
- support both the LLVM 22 and LLVM 23 RegionSuccessor APIs
- replace deprecated OpBuilder::create calls with operation create helpers
- use decimal LLVM IR floating-point literals accepted by LLVM 23
- enable -Wunused-template explicitly in the Clang 22 linter

Each item is an individual signed commit. The branch starts from the latest main, including #2125 and its stock LLVM no-exceptions/no-RTTI build policy.

## Validation

Validated with LLVM/MLIR 22.1.8:

- cmake --preset release
- cmake --build --preset release
- ctest --preset release: 4,164 configured tests; 2 job-query tests skipped, no failures
- uvx nox -s lint
- focused QCO region-branch, mapping, and QIR JIT tests

The LLVM 23 compatibility code follows the current release/23.x interfaces. An LLVM 23 build was not available locally, so the first LLVM 23 CI or package build should still confirm the transition.