### PR TITLE
🤖 Improve prose, terminology, and test guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,8 @@ MQT Core. The project-wide policy for AI-assisted contributions is
 - Follow the patterns in neighboring files and prefer the smallest change that
   fully solves the problem.
 - Write code comments, documentation, tests, changelog entries, and public text
-  for the final design. Do not preserve prompts, review chronology, former
-  names, or abandoned approaches unless they remain necessary user-facing
-  context.
+  for the final design. Never preserve prompts, review chronology, former names,
+  or abandoned approaches unless they remain necessary user-facing context.
 - Apply
   [Orwell's six rules for writing](https://www.orwellfoundation.com/the-orwell-foundation/orwell/essays-and-other-works/politics-and-the-english-language/)
   to every category of prose, including reasoning, descriptions, commit
@@ -47,28 +46,25 @@ MQT Core. The project-wide policy for AI-assisted contributions is
   6. Break a rule before it makes the text unclear, incorrect, or needlessly
      difficult to read.
 
-  Also apply the relevant principles of
+- Apply the relevant principles of
   [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/): use
   short, direct sentences; give each sentence one main idea; use one term for
-  one meaning; and use explicit nouns instead of vague pronouns. Treat these as
-  mandatory style rules, not as a claim of formal ASD-STE100 compliance.
+  one meaning; and use explicit nouns instead of vague pronouns. These are
+  mandatory style rules, not a claim of formal ASD-STE100 compliance.
 - Base terminology and phrasing on repository usage and established precedents
   in the quantum computing, LLVM/MLIR and compiler, high-performance computing,
   and general computer science communities. Use the established term that most
   precisely matches the concept. If communities use different terms, explain the
-  mapping once. Do not invent synonyms for variety.
+  mapping once. Never invent synonyms for variety.
 - Preserve the established capitalization of project and dependency names in
   prose. For example, write `jeff` for the exchange format and `jeff-mlir` for
   the related MLIR project.
-- Add tests that protect intended behavior or reproduce a concrete regression.
-  Do not test provisional implementation choices that are not part of the
-  supported contract.
-- Remove obsolete scaffolding and diagnostic suppressions before handoff. Keep a
-  workaround or suppression only when it is still necessary, scope it as
-  narrowly as possible, and document the technical reason.
 - Add or update automated tests for every behavioral code change. During
   development, run the narrowest relevant test first, then the required lint
   checks before handoff.
+- Add tests that protect intended behavior or reproduce a concrete regression.
+  Never test provisional implementation choices that are not part of the
+  supported contract.
 - Place tests in the corresponding test tree, organized by the subsystem that
   owns the behavior. Within MLIR, keep tests under `mlir/unittests/` or another
   established test root; never place them under `mlir/tools/` or another
@@ -77,6 +73,9 @@ MQT Core. The project-wide policy for AI-assisted contributions is
   CLI behavior. Normal test targets and dependencies belong in the test build;
   avoid promoting an otherwise optional production tool into the default build
   solely for subprocess testing.
+- Remove obsolete scaffolding and diagnostic suppressions before handoff. Keep a
+  workaround or suppression only when it is still necessary, scope it as
+  narrowly as possible, and document the technical reason.
 - Update `CHANGELOG.md` and `UPGRADING.md` for user-facing, breaking, or
   otherwise noteworthy changes.
 - Format changelog entries with the pull request reference and every


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This feeds the wording of [munich-quantum-toolkit/templates#399](https://github.com/munich-quantum-toolkit/templates/pull/399) back into MQT Core, as suggested in the review of that pull request. That pull request replicated #2072 in the shared `AGENTS.md` template and tightened it along the way.

- Promote the ASD-STE100 principles to their own rule. They previously trailed the numbered Orwell rules and read as a footnote to them.
- Group the three rules on tests, which stood apart from each other, and move the rule on obsolete scaffolding to the end of the set.
- Use "Never" for the prohibitions on provisional tests, on preserved prompts and abandoned approaches, and on invented synonyms, matching the other strong rules in the file.
- Drop two hedges: "Treat these as mandatory style rules" becomes "These are mandatory style rules".

The rules keep their meaning. The terminology rule keeps the communities it names, and the rule on the capitalization of `jeff` and `jeff-mlir` stays as it is, since both are specific to this repository.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
