### PR TITLE
✨ Add dense unitary operations to the compiler collection

### DIFF
--- a/.agent/plans/dense-unitary-operations.md
+++ b/.agent/plans/dense-unitary-operations.md
@@ -1,0 +1,110 @@
+# Preserve dense unitary operations across the compiler collection
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+MQT Core must represent a numeric unitary matrix as one frontend-neutral
+operation instead of asking Qiskit to synthesize that matrix during import.
+After this change, users can import and export Qiskit `UnitaryGate` operations
+without losing the dense matrix. QC and QCO programs can also verify, convert,
+serialize, simulate, modify, and synthesize the same operation through their
+existing unitary interfaces.
+
+## Progress
+
+- [x] (2026-08-17 18:00Z) Audited the existing matrix, unitary-interface,
+  decision-diagram, native-synthesis, and Qiskit bridge support.
+- [x] (2026-08-17 21:20Z) Added verified `qc.unitary` and `qco.unitary`
+  operations and builders.
+- [x] (2026-08-17 21:25Z) Preserved dense unitaries during QC-to-QCO and
+  QCO-to-QC conversion.
+- [x] (2026-08-17 21:35Z) Imported and exported Qiskit dense unitaries with
+      explicit qubit-order conversion.
+- [x] (2026-08-17 21:45Z) Added dialect, conversion, synthesis, simulation,
+  modifier, serialization, and Qiskit regressions.
+- [x] (2026-08-17 21:55Z) Built the affected C++ and Python targets, ran the
+  focused and full affected tests, confirmed that no stub signature changed,
+  and ran the repository lint session.
+
+## Surprises & Discoveries
+
+- Observation: QC and QCO interpret operation operand zero as the most
+  significant matrix bit. Qiskit interprets the first `UnitaryGate` qubit as the
+  least significant matrix bit. Import and export must therefore apply the same
+  row-and-column bit permutation at both boundaries.
+- Observation: existing native synthesis accepts compile-time one- and two-qubit
+  matrices through `qco::UnitaryOpInterface`. Mapping does not accept operations
+  wider than two qubits. Wider matrices remain representable and exportable but
+  cannot yet pass target compilation.
+- Observation: deterministic unitarity checking is cubic in the matrix side
+  length. The verifier therefore rejects operations wider than eight qubits
+  before materializing or scanning matrix entries.
+- Observation: Qiskit 2.5's native instruction accessor aborts on wrapped dense
+  unitaries because their Python matrix parameter is not scalar. The importer
+  must identify and reject those wrappers before calling the native accessor.
+
+## Decision Log
+
+- Decision: Store matrices as rank-two dense `complex<f64>` tensor attributes in
+  row-major order. Verify shape, finite entries, dimension, and unitarity at the
+  operation boundary. Rationale: this is the native MLIR representation used by
+  the existing matrix and synthesis infrastructure.
+- Decision: Preserve dense operations instead of expanding Qiskit's circuit
+  definition. Rationale: definition expansion is frontend-specific, increases IR
+  size, and becomes redundant once QC and QCO can represent the matrix.
+- Decision: Canonicalize only exact identity matrices. Rationale: tolerance-
+  based rewriting can change program semantics.
+- Decision: Accept dense operations on one to eight qubits and verify
+  `U^dagger U` entry-wise with absolute tolerance `1e-10`. Rationale: eight
+  qubits bounds the deterministic cubic check while covering the required Qiskit
+  and Quantum Volume workloads.
+
+## Milestones
+
+### Add dialect operations and conversions
+
+Define `qc.unitary` and `qco.unitary` in the QC and QCO operation tables. Add
+shared verification for a nonempty square matrix whose dimension is `2^n`, whose
+entries are finite, and whose conjugate transpose times the matrix is the
+identity within the documented verifier tolerance. Implement builders and
+preserve the matrix and operand order in both QC/QCO conversion directions.
+Focused QC, QCO, and conversion tests must parse valid operations and reject
+wrong shapes, nonfinite values, and nonunitary matrices.
+
+### Connect Qiskit and the existing unitary infrastructure
+
+Read and write Qiskit's native matrix through its C API. Convert the matrix bit
+order at the boundary so Qiskit and QC/QCO apply the same operator to the same
+qubits. Keep one-, two-, and three-qubit matrices dense during a Qiskit
+round-trip. Prove one- and two-qubit target synthesis, modifier handling, and
+decision-diagram semantics with focused tests. A seeded Quantum Volume circuit
+must import without expanding its two-qubit matrices.
+
+### Validate the complete change
+
+From the repository root, build the affected MLIR and Python binding targets.
+Run the focused QC, QCO, conversion, native-synthesis, decision-diagram, and
+Python Qiskit tests. Run `uvx nox -s stubs` when binding signatures change, then
+run `uvx nox -s lint` and `git diff --check`. Record concise pass or failure
+evidence below.
+
+## Outcomes & Retrospective
+
+MQT Core now preserves verified dense numeric unitaries on one to eight qubits
+as frontend-neutral QC/QCO operations. Qiskit import and export retain one-,
+two-, and three-qubit matrices and explicitly convert the Qiskit/QC bit-order
+convention. Existing target synthesis handles one- and two-qubit operations;
+wider operations remain representable, serializable, and exportable but are not
+yet accepted by mapping.
+
+Validation passed with 334 QC IR tests, 485 QCO IR tests, 3 QC/QCO round-trip
+tests, 23 target-synthesis tests, and 102 Qiskit translation tests. A QV100
+smoke test preserved all 5,000 dense operations and compiled for FakeTorino in
+20.431 seconds with target validation succeeding. The full repository lint
+session and `git diff --check` also passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ releases may include breaking changes.
 - ✨ Add an `unroll-modifiers` pass for unrolling multi-operation modifiers
   ([#2015]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add Qiskit circuit import and export to the compiler collection ([#2031],
-  [#2133]) ([**@burgholzer**], [**@simon1hofmann**])
+  [#2133], [#2136]) ([**@burgholzer**], [**@simon1hofmann**])
 - ✨ Add generic C++ and Python FoMaC support for custom device properties that
   contain operation handles ([#2042]) ([**@burgholzer**])
 - ✨ Support retrieving existing jobs by ID through the QDMI client API and C++
@@ -792,6 +792,7 @@ for previous changelogs._
 
 [#2138]: https://github.com/munich-quantum-toolkit/core/pull/2138
 [#2137]: https://github.com/munich-quantum-toolkit/core/pull/2137
+[#2136]: https://github.com/munich-quantum-toolkit/core/pull/2136
 [#2133]: https://github.com/munich-quantum-toolkit/core/pull/2133
 [#2124]: https://github.com/munich-quantum-toolkit/core/pull/2124
 [#2125]: https://github.com/munich-quantum-toolkit/core/pull/2125

--- a/bindings/mlir/qiskit/Qiskit2_5.cpp
+++ b/bindings/mlir/qiskit/Qiskit2_5.cpp
@@ -15,12 +15,14 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h> // NOLINT(misc-include-cleaner): enables the std::string caster.
 #include <qiskit.h>
+#include <qiskit/complex.h>
 #include <qiskit/funcs_py.h>
 #include <qiskit/version.h>
 
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -223,6 +225,34 @@ void appendControlModifier(const nb::handle object,
   }
   modifiers.push_back({.kind = GateModifierKind::Control,
                        .numControls = static_cast<uint32_t>(controls)});
+}
+
+[[nodiscard]] nb::object terminalPythonGate(const nb::handle operation,
+                                            const size_t depth = 0U) {
+  if (depth >= MAX_ANNOTATED_OPERATION_DEPTH) {
+    throw std::runtime_error(
+        "Qiskit annotated operations exceed the nesting limit of 64");
+  }
+  if (nb::hasattr(operation, "base_op")) {
+    return terminalPythonGate(
+        pythonAttribute(operation, "base_op",
+                        "Qiskit annotated operation has no base"),
+        depth + 1U);
+  }
+  if (nb::hasattr(operation, "base_gate")) {
+    return terminalPythonGate(
+        pythonAttribute(operation, "base_gate",
+                        "Qiskit controlled gate has no base"),
+        depth + 1U);
+  }
+  return nb::borrow<nb::object>(operation);
+}
+
+[[nodiscard]] bool isPythonUnitaryGate(const nb::handle operation) {
+  const auto terminal = terminalPythonGate(operation);
+  const auto unitaryGate =
+      nb::module_::import_("qiskit.circuit.library").attr("UnitaryGate");
+  return nb::isinstance(terminal, unitaryGate);
 }
 
 void normalizePythonModifier(const nb::handle modifier,
@@ -690,6 +720,17 @@ public:
     if (kind == OperationKind::ControlFlow) {
       return {.kind = kind, .name = "control_flow"};
     }
+    std::optional<Instruction> normalizedUnknown;
+    if (kind == OperationKind::Unknown) {
+      const auto operation = pythonOperation(index);
+      if (isPythonUnitaryGate(operation)) {
+        throw std::runtime_error(
+            "Qiskit circuit import supports only native, unwrapped "
+            "UnitaryGate instructions");
+      }
+      normalizedUnknown.emplace();
+      normalizePythonGate(operation, *normalizedUnknown);
+    }
     QkCircuitInstruction native{};
     qk_circuit_get_instruction(circuit_, index, &native);
     struct InstructionGuard {
@@ -714,13 +755,39 @@ public:
       result.parameters.emplace_back(normalizeParameter(parameter));
     }
     if (result.kind == OperationKind::Unknown) {
-      const auto operation = pythonOperation(index);
-      normalizePythonGate(operation, result);
+      result.name = std::move(normalizedUnknown->name);
+      result.modifiers = std::move(normalizedUnknown->modifiers);
       if (!result.modifiers.empty()) {
         result.kind = OperationKind::Gate;
       }
     }
     result.standardGate = standardGateMapping(result.name);
+    return result;
+  }
+
+  [[nodiscard]] std::vector<std::complex<double>>
+  unitary(const size_t index) const override {
+    const auto instructionData = instruction(index);
+    if (instructionData.kind != OperationKind::Unitary) {
+      throw std::runtime_error(
+          "requested unitary data for a non-unitary instruction");
+    }
+    if (instructionData.qubits.size() >=
+        std::numeric_limits<size_t>::digits / 2U) {
+      throw std::runtime_error(
+          "Qiskit unitary is too large to represent safely");
+    }
+    const auto entries = size_t{1} << (2U * instructionData.qubits.size());
+    std::vector<QkComplex64> native(entries);
+    qk_circuit_inst_unitary(
+        // Qiskit's read-only accessor is not const-correct in version 2.5.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        const_cast<QkCircuit*>(circuit_), index, native.data());
+    std::vector<std::complex<double>> result;
+    result.reserve(entries);
+    for (const auto value : native) {
+      result.emplace_back(value.re, value.im);
+    }
     return result;
   }
 
@@ -1094,6 +1161,19 @@ public:
     checkExitCode(qk_circuit_barrier(circuit_, qubits.data(),
                                      static_cast<uint32_t>(qubits.size())),
                   "adding barrier");
+  }
+
+  void addUnitary(const std::vector<std::complex<double>>& matrix,
+                  const std::vector<uint32_t>& qubits) override {
+    std::vector<QkComplex64> native;
+    native.reserve(matrix.size());
+    for (const auto value : matrix) {
+      native.push_back({.re = value.real(), .im = value.imag()});
+    }
+    checkExitCode(qk_circuit_unitary(circuit_, native.data(), qubits.data(),
+                                     static_cast<uint32_t>(qubits.size()),
+                                     true),
+                  "adding unitary");
   }
 
   [[nodiscard]] nb::object finish() override {

--- a/bindings/mlir/qiskit/Qiskit2_5.cpp
+++ b/bindings/mlir/qiskit/Qiskit2_5.cpp
@@ -1259,6 +1259,8 @@ public:
                                      true),
                   "adding unitary");
     if (numControls != 0U) {
+      // The Qiskit C API can append only a bare unitary. Defer its control
+      // wrapper until finish() exposes the Python operation.
       pendingControlledUnitaries_.push_back(
           {.instructionIndex = instructionIndex,
            .numControls = numControls,
@@ -1278,37 +1280,7 @@ public:
     }
     auto pythonCircuit = nb::steal<nb::object>(result);
     try {
-      auto data = pythonAttribute(pythonCircuit, "data",
-                                  "Qiskit circuit has no instruction data");
-      const auto circuitQubits = pythonAttribute(
-          pythonCircuit, "qubits", "Qiskit circuit has no qubits");
-      const auto append = pythonAttribute(
-          pythonCircuit, "append", "Qiskit circuit cannot append operations");
-      for (const auto& pending : pendingControlledUnitaries_) {
-        if (pending.instructionIndex >= nb::len(data)) {
-          throw std::runtime_error(
-              "Qiskit controlled-unitary placeholder is missing");
-        }
-        const auto operation =
-            pythonAttribute(data[pending.instructionIndex], "operation",
-                            "Qiskit unitary placeholder has no operation");
-        const auto controlled =
-            pythonAttribute(operation, "control",
-                            "Qiskit unitary operation cannot be controlled")(
-                pending.numControls, nb::arg("annotated") = true);
-        nb::list qargs;
-        for (const auto qubit : pending.qubits) {
-          if (qubit >= nb::len(circuitQubits)) {
-            throw std::runtime_error(
-                "Qiskit controlled unitary references an invalid qubit");
-          }
-          qargs.append(circuitQubits[qubit]);
-        }
-        append(controlled, qargs);
-        const auto replacement = pythonAttribute(
-            data, "pop", "Qiskit circuit data cannot remove instructions")();
-        data[pending.instructionIndex] = replacement;
-      }
+      replacePendingControlledUnitaries(pythonCircuit);
     } catch (const nb::python_error& error) {
       throwPythonError("Qiskit failed to construct a controlled unitary",
                        error);
@@ -1322,6 +1294,41 @@ private:
     uint32_t numControls = 0U;
     std::vector<uint32_t> qubits;
   };
+
+  void replacePendingControlledUnitaries(const nb::handle pythonCircuit) const {
+    auto data = pythonAttribute(pythonCircuit, "data",
+                                "Qiskit circuit has no instruction data");
+    const auto circuitQubits = pythonAttribute(pythonCircuit, "qubits",
+                                               "Qiskit circuit has no qubits");
+    for (const auto& pending : pendingControlledUnitaries_) {
+      if (pending.instructionIndex >= nb::len(data)) {
+        throw std::runtime_error(
+            "Qiskit controlled-unitary placeholder is missing");
+      }
+      const auto placeholder =
+          nb::borrow<nb::object>(data[pending.instructionIndex]);
+      const auto operation =
+          pythonAttribute(placeholder, "operation",
+                          "Qiskit unitary placeholder has no operation");
+      const auto controlled =
+          pythonAttribute(operation, "control",
+                          "Qiskit unitary operation cannot be controlled")(
+              pending.numControls, nb::arg("annotated") = true);
+      nb::list qargs;
+      for (const auto qubit : pending.qubits) {
+        if (qubit >= nb::len(circuitQubits)) {
+          throw std::runtime_error(
+              "Qiskit controlled unitary references an invalid qubit");
+        }
+        qargs.append(circuitQubits[qubit]);
+      }
+      const auto replacement =
+          pythonAttribute(placeholder, "replace",
+                          "Qiskit unitary placeholder cannot be replaced")(
+              nb::arg("operation") = controlled, nb::arg("qubits") = qargs);
+      data[pending.instructionIndex] = replacement;
+    }
+  }
 
   QkCircuit* circuit_ = nullptr;
   std::vector<PendingControlledUnitary> pendingControlledUnitaries_;

--- a/bindings/mlir/qiskit/Qiskit2_5.cpp
+++ b/bindings/mlir/qiskit/Qiskit2_5.cpp
@@ -13,6 +13,7 @@
 
 // Qiskit requires its umbrella header before the extension function table.
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 #include <nanobind/stl/string.h> // NOLINT(misc-include-cleaner): enables the std::string caster.
 #include <qiskit.h>
 #include <qiskit/complex.h>
@@ -724,9 +725,11 @@ public:
     if (kind == OperationKind::Unknown) {
       const auto operation = pythonOperation(index);
       if (isPythonUnitaryGate(operation)) {
-        throw std::runtime_error(
-            "Qiskit circuit import supports only native, unwrapped "
-            "UnitaryGate instructions");
+        Instruction result{.kind = OperationKind::Unitary, .name = "unitary"};
+        normalizePythonGate(operation, result);
+        result.name = "unitary";
+        result.qubits = pythonInstructionQubits(index);
+        return result;
       }
       normalizedUnknown.emplace();
       normalizePythonGate(operation, *normalizedUnknown);
@@ -771,6 +774,55 @@ public:
     if (instructionData.kind != OperationKind::Unitary) {
       throw std::runtime_error(
           "requested unitary data for a non-unitary instruction");
+    }
+    const auto nativeKind =
+        normalizeKind(qk_circuit_instruction_kind(circuit_, index));
+    if (nativeKind == OperationKind::Unknown) {
+      size_t numControls = 0U;
+      for (const auto& modifier : instructionData.modifiers) {
+        if (modifier.kind == GateModifierKind::Control) {
+          if (modifier.numControls >
+              std::numeric_limits<size_t>::max() - numControls) {
+            throw std::runtime_error("Qiskit control count is too large");
+          }
+          numControls += modifier.numControls;
+        }
+      }
+      if (numControls >= instructionData.qubits.size()) {
+        throw std::runtime_error(
+            "Qiskit unitary instruction has an unsupported operand arity");
+      }
+      const auto numTargets = instructionData.qubits.size() - numControls;
+      if (numTargets >= std::numeric_limits<size_t>::digits / 2U) {
+        throw std::runtime_error(
+            "Qiskit unitary is too large to represent safely");
+      }
+      const auto expectedDimension = size_t{1} << numTargets;
+      using Matrix =
+          nb::ndarray<nb::numpy, const std::complex<double>, nb::ndim<2>>;
+      try {
+        const auto terminal = terminalPythonGate(pythonOperation(index));
+        const auto matrixObject =
+            pythonAttribute(terminal, "to_matrix",
+                            "Qiskit unitary does not expose its matrix")();
+        const auto matrix = nb::cast<Matrix>(matrixObject);
+        if (matrix.shape(0) != expectedDimension ||
+            matrix.shape(1) != expectedDimension) {
+          throw std::runtime_error(
+              "Qiskit unitary matrix has an invalid dimension");
+        }
+        std::vector<std::complex<double>> result;
+        result.reserve(expectedDimension * expectedDimension);
+        for (size_t row = 0U; row < expectedDimension; ++row) {
+          for (size_t column = 0U; column < expectedDimension; ++column) {
+            result.push_back(matrix(row, column));
+          }
+        }
+        return result;
+      } catch (const nb::python_error& error) {
+        throwPythonError("Qiskit failed to read a wrapped unitary matrix",
+                         error);
+      }
     }
     if (instructionData.qubits.size() >=
         std::numeric_limits<size_t>::digits / 2U) {
@@ -831,6 +883,32 @@ public:
   }
 
 private:
+  [[nodiscard]] std::vector<uint32_t>
+  pythonInstructionQubits(const size_t index) const {
+    std::vector<uint32_t> result;
+    try {
+      const auto qubits =
+          pythonAttribute(data_[index], "qubits",
+                          "Qiskit circuit instruction has no qubit operands");
+      result.reserve(nb::len(qubits));
+      const auto findBit =
+          pythonAttribute(pythonCircuit_, "find_bit",
+                          "Qiskit circuit cannot resolve instruction qubits");
+      for (const nb::handle qubit : nb::iter(qubits)) {
+        const auto location = findBit(qubit);
+        const auto position = pythonUnsignedAttribute(
+            location, "index", "Qiskit qubit has an invalid circuit index");
+        if (position > std::numeric_limits<uint32_t>::max()) {
+          throw std::runtime_error("Qiskit qubit index cannot be represented");
+        }
+        result.push_back(static_cast<uint32_t>(position));
+      }
+    } catch (const nb::python_error& error) {
+      throwPythonError("Qiskit failed to resolve unitary qubits", error);
+    }
+    return result;
+  }
+
   [[nodiscard]] nb::object pythonOperation(const size_t index) const {
     if (index >= nb::len(data_)) {
       throw std::runtime_error("Qiskit instruction index is out of bounds");
@@ -1164,16 +1242,28 @@ public:
   }
 
   void addUnitary(const std::vector<std::complex<double>>& matrix,
-                  const std::vector<uint32_t>& qubits) override {
+                  const std::vector<uint32_t>& qubits,
+                  const uint32_t numControls) override {
+    if (numControls >= qubits.size()) {
+      throw std::runtime_error("Qiskit unitary has an invalid control count");
+    }
+    const std::vector targets(qubits.begin() + numControls, qubits.end());
     std::vector<QkComplex64> native;
     native.reserve(matrix.size());
     for (const auto value : matrix) {
       native.push_back({.re = value.real(), .im = value.imag()});
     }
-    checkExitCode(qk_circuit_unitary(circuit_, native.data(), qubits.data(),
-                                     static_cast<uint32_t>(qubits.size()),
+    const auto instructionIndex = qk_circuit_num_instructions(circuit_);
+    checkExitCode(qk_circuit_unitary(circuit_, native.data(), targets.data(),
+                                     static_cast<uint32_t>(targets.size()),
                                      true),
                   "adding unitary");
+    if (numControls != 0U) {
+      pendingControlledUnitaries_.push_back(
+          {.instructionIndex = instructionIndex,
+           .numControls = numControls,
+           .qubits = qubits});
+    }
   }
 
   [[nodiscard]] nb::object finish() override {
@@ -1186,11 +1276,55 @@ public:
     if (result == nullptr) {
       throwPythonError("Qiskit failed to create a QuantumCircuit");
     }
-    return nb::steal<nb::object>(result);
+    auto pythonCircuit = nb::steal<nb::object>(result);
+    try {
+      auto data = pythonAttribute(pythonCircuit, "data",
+                                  "Qiskit circuit has no instruction data");
+      const auto circuitQubits = pythonAttribute(
+          pythonCircuit, "qubits", "Qiskit circuit has no qubits");
+      const auto append = pythonAttribute(
+          pythonCircuit, "append", "Qiskit circuit cannot append operations");
+      for (const auto& pending : pendingControlledUnitaries_) {
+        if (pending.instructionIndex >= nb::len(data)) {
+          throw std::runtime_error(
+              "Qiskit controlled-unitary placeholder is missing");
+        }
+        const auto operation =
+            pythonAttribute(data[pending.instructionIndex], "operation",
+                            "Qiskit unitary placeholder has no operation");
+        const auto controlled =
+            pythonAttribute(operation, "control",
+                            "Qiskit unitary operation cannot be controlled")(
+                pending.numControls, nb::arg("annotated") = true);
+        nb::list qargs;
+        for (const auto qubit : pending.qubits) {
+          if (qubit >= nb::len(circuitQubits)) {
+            throw std::runtime_error(
+                "Qiskit controlled unitary references an invalid qubit");
+          }
+          qargs.append(circuitQubits[qubit]);
+        }
+        append(controlled, qargs);
+        const auto replacement = pythonAttribute(
+            data, "pop", "Qiskit circuit data cannot remove instructions")();
+        data[pending.instructionIndex] = replacement;
+      }
+    } catch (const nb::python_error& error) {
+      throwPythonError("Qiskit failed to construct a controlled unitary",
+                       error);
+    }
+    return pythonCircuit;
   }
 
 private:
+  struct PendingControlledUnitary {
+    size_t instructionIndex = 0U;
+    uint32_t numControls = 0U;
+    std::vector<uint32_t> qubits;
+  };
+
   QkCircuit* circuit_ = nullptr;
+  std::vector<PendingControlledUnitary> pendingControlledUnitaries_;
 };
 
 class NativeTranslation final : public VersionedTranslation {

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -67,6 +67,7 @@ struct ExportedInstruction {
   std::vector<uint32_t> clbits;
   std::vector<double> parameters;
   std::vector<std::complex<double>> matrix;
+  uint32_t unitaryControls = 0;
 };
 
 [[nodiscard]] double exportParameter(const mlir::Value value) {
@@ -190,10 +191,15 @@ modifierQubitMap(const llvm::DenseMap<mlir::Value, uint32_t>& outer,
 
 void invertGate(ExportedInstruction& instruction) {
   if (instruction.kind == ExportedInstruction::Kind::Unitary) {
-    if (instruction.qubits.size() >= std::numeric_limits<size_t>::digits / 2U) {
+    if (instruction.unitaryControls > instruction.qubits.size()) {
+      throw std::runtime_error("QC unitary has an invalid control count");
+    }
+    const auto numTargets =
+        instruction.qubits.size() - instruction.unitaryControls;
+    if (numTargets >= std::numeric_limits<size_t>::digits / 2U) {
       throw std::runtime_error("QC unitary matrix is too large to represent");
     }
-    const auto dimension = size_t{1} << instruction.qubits.size();
+    const auto dimension = size_t{1} << numTargets;
     if (dimension * dimension != instruction.matrix.size()) {
       throw std::runtime_error("QC unitary matrix has an invalid dimension");
     }
@@ -293,15 +299,14 @@ collectUnitaryInstruction(mlir::Operation& operation,
           "QC control export requires one standard gate in the modifier body");
     }
     auto result = collectUnitaryInstruction(*bodyOperations.front(), nestedMap);
-    if (result.kind == ExportedInstruction::Kind::Unitary) {
-      throw std::runtime_error(
-          "QC control export does not support dense unitary matrices");
-    }
-    if (controls.size() >
-        std::numeric_limits<uint32_t>::max() - result.gate.controls) {
+    auto& numControls = result.kind == ExportedInstruction::Kind::Unitary
+                            ? result.unitaryControls
+                            : result.gate.controls;
+    if (std::cmp_greater(controls.size(),
+                         std::numeric_limits<uint32_t>::max() - numControls)) {
       throw std::runtime_error("QC control count cannot be represented");
     }
-    result.gate.controls += static_cast<uint32_t>(controls.size());
+    numControls += static_cast<uint32_t>(controls.size());
     result.qubits.insert(result.qubits.begin(), controls.begin(),
                          controls.end());
     return result;
@@ -663,7 +668,8 @@ nb::object exportCircuit(const mlir::QCProgram& program,
       writer->addBarrier(instruction.qubits);
       break;
     case ExportedInstruction::Kind::Unitary:
-      writer->addUnitary(instruction.matrix, instruction.qubits);
+      writer->addUnitary(instruction.matrix, instruction.qubits,
+                         instruction.unitaryControls);
       break;
     }
   }

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -39,6 +39,8 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <complex>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <numeric>
@@ -57,12 +59,14 @@ struct ExportedInstruction {
     Measure,
     Reset,
     Barrier,
+    Unitary,
   };
   Kind kind = Kind::Gate;
   StandardGateMapping gate;
   std::vector<uint32_t> qubits;
   std::vector<uint32_t> clbits;
   std::vector<double> parameters;
+  std::vector<std::complex<double>> matrix;
 };
 
 [[nodiscard]] double exportParameter(const mlir::Value value) {
@@ -185,6 +189,23 @@ modifierQubitMap(const llvm::DenseMap<mlir::Value, uint32_t>& outer,
 }
 
 void invertGate(ExportedInstruction& instruction) {
+  if (instruction.kind == ExportedInstruction::Kind::Unitary) {
+    if (instruction.qubits.size() >= std::numeric_limits<size_t>::digits / 2U) {
+      throw std::runtime_error("QC unitary matrix is too large to represent");
+    }
+    const auto dimension = size_t{1} << instruction.qubits.size();
+    if (dimension * dimension != instruction.matrix.size()) {
+      throw std::runtime_error("QC unitary matrix has an invalid dimension");
+    }
+    auto source = instruction.matrix;
+    for (size_t row = 0U; row < dimension; ++row) {
+      for (size_t column = 0U; column < dimension; ++column) {
+        instruction.matrix[(row * dimension) + column] =
+            std::conj(source[(column * dimension) + row]);
+      }
+    }
+    return;
+  }
   using Gate = mlir::qc::StandardGate;
   switch (instruction.gate.gate) {
   case Gate::Id:
@@ -272,6 +293,10 @@ collectUnitaryInstruction(mlir::Operation& operation,
           "QC control export requires one standard gate in the modifier body");
     }
     auto result = collectUnitaryInstruction(*bodyOperations.front(), nestedMap);
+    if (result.kind == ExportedInstruction::Kind::Unitary) {
+      throw std::runtime_error(
+          "QC control export does not support dense unitary matrices");
+    }
     if (controls.size() >
         std::numeric_limits<uint32_t>::max() - result.gate.controls) {
       throw std::runtime_error("QC control count cannot be represented");
@@ -311,6 +336,16 @@ collectUnitaryInstruction(mlir::Operation& operation,
       invertGate(result);
     }
     return result;
+  }
+  if (auto unitary = llvm::dyn_cast<mlir::qc::UnitaryOp>(operation)) {
+    const auto matrix =
+        llvm::cast<mlir::DenseElementsAttr>(unitary.getMatrix());
+    std::vector<std::complex<double>> values;
+    values.reserve(matrix.size());
+    llvm::append_range(values, matrix.getValues<std::complex<double>>());
+    return {.kind = ExportedInstruction::Kind::Unitary,
+            .qubits = mapQubits(unitary.getQubits(), qubits),
+            .matrix = reverseQubitOrder(values, unitary.getNumQubits())};
   }
   auto gate = llvm::dyn_cast<mlir::qc::UnitaryOpInterface>(operation);
   if (!gate || llvm::isa<mlir::qc::GPhaseOp, mlir::qc::BarrierOp>(operation)) {
@@ -529,6 +564,11 @@ void collectFlatInstructions(mlir::func::FuncOp function, ExportState& state) {
            .qubits = mapQubits(barrier.getQubits(), state.qubits)});
       continue;
     }
+    if (llvm::isa<mlir::qc::UnitaryOp>(operation)) {
+      state.instructions.push_back(
+          collectUnitaryInstruction(operation, state.qubits));
+      continue;
+    }
     if (llvm::isa<mlir::scf::IfOp, mlir::scf::WhileOp, mlir::scf::ForOp,
                   mlir::scf::IndexSwitchOp>(operation)) {
       throw std::runtime_error(
@@ -621,6 +661,9 @@ nb::object exportCircuit(const mlir::QCProgram& program,
       break;
     case ExportedInstruction::Kind::Barrier:
       writer->addBarrier(instruction.qubits);
+      break;
+    case ExportedInstruction::Kind::Unitary:
+      writer->addUnitary(instruction.matrix, instruction.qubits);
       break;
     }
   }

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -348,9 +348,11 @@ collectUnitaryInstruction(mlir::Operation& operation,
     std::vector<std::complex<double>> values;
     values.reserve(matrix.size());
     llvm::append_range(values, matrix.getValues<std::complex<double>>());
+    auto targetQubits = mapQubits(unitary.getQubits(), qubits);
+    std::ranges::reverse(targetQubits);
     return {.kind = ExportedInstruction::Kind::Unitary,
-            .qubits = mapQubits(unitary.getQubits(), qubits),
-            .matrix = reverseQubitOrder(values, unitary.getNumQubits())};
+            .qubits = std::move(targetQubits),
+            .matrix = std::move(values)};
   }
   auto gate = llvm::dyn_cast<mlir::qc::UnitaryOpInterface>(operation);
   if (!gate || llvm::isa<mlir::qc::GPhaseOp, mlir::qc::BarrierOp>(operation)) {

--- a/bindings/mlir/qiskit/QiskitImport.cpp
+++ b/bindings/mlir/qiskit/QiskitImport.cpp
@@ -60,6 +60,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -1072,11 +1073,12 @@ void translateCircuit(mlir::qc::QCProgramBuilder& builder,
         operands.push_back(getQubit(qubit));
       }
       const auto arity = denseUnitaryArity(instruction);
+      auto targets = std::span{operands}.subspan(arity.controls);
+      std::ranges::reverse(targets);
       const auto dimension = int64_t{1} << arity.targets;
       const auto type = mlir::RankedTensorType::get(
           {dimension, dimension}, mlir::ComplexType::get(builder.getF64Type()));
-      const auto values =
-          reverseQubitOrder(circuit.unitary(index), arity.targets);
+      const auto values = circuit.unitary(index);
       const auto matrix = mlir::DenseElementsAttr::get(
           type, llvm::ArrayRef<std::complex<double>>(values));
       emitModifiedOperation(builder, instruction, operands, arity,

--- a/bindings/mlir/qiskit/QiskitImport.cpp
+++ b/bindings/mlir/qiskit/QiskitImport.cpp
@@ -250,13 +250,11 @@ void emitStandardGate(mlir::qc::QCProgramBuilder& builder,
                       const Instruction& instruction, mlir::ValueRange qubits,
                       llvm::ArrayRef<ParameterValue> parameters);
 
-template <typename EmitBase>
-void emitModifiedOperation(mlir::qc::QCProgramBuilder& builder,
-                           const Instruction& instruction,
-                           const mlir::ValueRange qubits,
-                           const ModifiedQubitArity arity,
-                           const LocalParameters& localParameters,
-                           EmitBase&& emitBase) {
+void emitModifiedOperation(
+    mlir::qc::QCProgramBuilder& builder, const Instruction& instruction,
+    const mlir::ValueRange qubits, const ModifiedQubitArity arity,
+    const LocalParameters& localParameters,
+    llvm::function_ref<void(mlir::ValueRange)> emitBase) {
   const auto targets = qubits.drop_front(arity.controls);
   const auto emitModifiers =
       [&](auto&& self, const size_t count,

--- a/bindings/mlir/qiskit/QiskitImport.cpp
+++ b/bindings/mlir/qiskit/QiskitImport.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/QC/Translation/StandardGate.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
+#include "mlir/Dialect/Utils/DenseUnitary.h"
 
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/DenseMap.h>
@@ -51,6 +52,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -1012,9 +1014,25 @@ void translateCircuit(mlir::qc::QCProgramBuilder& builder,
       requireArity(instruction, 1, 0);
       builder.reset(getQubit(instruction.qubits[0]));
       break;
-    case OperationKind::Unitary:
-      translateDefinition(index, instruction);
-      break;
+    case OperationKind::Unitary: {
+      llvm::SmallVector<mlir::Value> operands;
+      operands.reserve(instruction.qubits.size());
+      for (const auto qubit : instruction.qubits) {
+        operands.push_back(getQubit(qubit));
+      }
+      if (operands.size() > mlir::utils::MAX_DENSE_UNITARY_QUBITS) {
+        throw std::runtime_error(
+            "Qiskit unitary exceeds the supported eight-qubit limit");
+      }
+      const auto dimension = int64_t{1} << operands.size();
+      const auto type = mlir::RankedTensorType::get(
+          {dimension, dimension}, mlir::ComplexType::get(builder.getF64Type()));
+      const auto values =
+          reverseQubitOrder(circuit.unitary(index), operands.size());
+      builder.unitary(operands,
+                      mlir::DenseElementsAttr::get(
+                          type, llvm::ArrayRef<std::complex<double>>(values)));
+    } break;
     case OperationKind::ControlFlow: {
       const auto controlFlow = circuit.controlFlow(index);
       translateControlFlow(builder, *controlFlow, allQubits, classicalBits,
@@ -1069,7 +1087,6 @@ expansionSummary(const CircuitReader& circuit, ExpansionCountState& state,
     const auto instruction = circuit.instruction(index);
     if ((instruction.kind == OperationKind::Gate &&
          !instruction.standardGate) ||
-        instruction.kind == OperationKind::Unitary ||
         instruction.kind == OperationKind::Unknown) {
       if (!instruction.modifiers.empty()) {
         throw std::runtime_error(
@@ -1452,8 +1469,15 @@ void validateCircuit(const CircuitReader& circuit,
       }
       break;
     case OperationKind::Unitary:
-      validateDefinition(circuit, index, localParameters, definitionDepth,
-                         controlFlowDepth);
+      if (!instruction.parameters.empty() || !instruction.clbits.empty() ||
+          !instruction.modifiers.empty() || instruction.qubits.empty()) {
+        throw std::runtime_error(
+            "Qiskit unitary instruction has an unsupported operand arity");
+      }
+      if (instruction.qubits.size() > mlir::utils::MAX_DENSE_UNITARY_QUBITS) {
+        throw std::runtime_error(
+            "Qiskit unitary exceeds the supported eight-qubit limit");
+      }
       break;
     case OperationKind::ControlFlow: {
       const auto controlFlow = circuit.controlFlow(index);

--- a/bindings/mlir/qiskit/QiskitImport.cpp
+++ b/bindings/mlir/qiskit/QiskitImport.cpp
@@ -143,6 +143,56 @@ void requireArity(const Instruction& instruction, const size_t qubits,
 
 using GateArity = std::pair<size_t, size_t>;
 
+struct ModifiedQubitArity {
+  size_t controls;
+  size_t targets;
+};
+
+[[nodiscard]] size_t modifierControlCount(const Instruction& instruction) {
+  size_t controls = 0U;
+  for (const auto& modifier : instruction.modifiers) {
+    if (modifier.kind != GateModifierKind::Control) {
+      continue;
+    }
+    if (modifier.numControls > std::numeric_limits<size_t>::max() - controls) {
+      throw std::runtime_error("Qiskit control count is too large");
+    }
+    controls += modifier.numControls;
+  }
+  return controls;
+}
+
+[[nodiscard]] ModifiedQubitArity
+modifiedQubitArity(const Instruction& instruction, const size_t targets) {
+  const auto controls = modifierControlCount(instruction);
+  if (targets > std::numeric_limits<size_t>::max() - controls ||
+      instruction.qubits.size() != controls + targets) {
+    throw std::runtime_error("Qiskit instruction '" + instruction.name +
+                             "' has an unsupported modified operand arity");
+  }
+  return {.controls = controls, .targets = targets};
+}
+
+[[nodiscard]] ModifiedQubitArity
+denseUnitaryArity(const Instruction& instruction) {
+  if (!instruction.parameters.empty() || !instruction.clbits.empty()) {
+    throw std::runtime_error(
+        "Qiskit unitary instruction has an unsupported operand arity");
+  }
+  const auto controls = modifierControlCount(instruction);
+  if (instruction.qubits.size() <= controls) {
+    throw std::runtime_error(
+        "Qiskit unitary instruction has an unsupported operand arity");
+  }
+  const auto targets = instruction.qubits.size() - controls;
+  if (targets > mlir::utils::MAX_DENSE_UNITARY_QUBITS) {
+    throw std::runtime_error(
+        "Qiskit unitary supports at most " +
+        std::to_string(mlir::utils::MAX_DENSE_UNITARY_QUBITS) + " qubits");
+  }
+  return {.controls = controls, .targets = targets};
+}
+
 [[nodiscard]] std::optional<GateArity>
 gateArity(const Instruction& instruction) {
   if (!instruction.standardGate) {
@@ -200,38 +250,19 @@ void emitStandardGate(mlir::qc::QCProgramBuilder& builder,
                       const Instruction& instruction, mlir::ValueRange qubits,
                       llvm::ArrayRef<ParameterValue> parameters);
 
-void emitModifiedGate(mlir::qc::QCProgramBuilder& builder,
-                      const Instruction& instruction,
-                      const mlir::ValueRange qubits,
-                      const llvm::ArrayRef<ParameterValue> parameters,
-                      const LocalParameters& localParameters) {
-  const auto arity = gateArity(instruction);
-  if (!arity) {
-    throw std::runtime_error("unsupported modified Qiskit standard gate '" +
-                             instruction.name + "'");
-  }
-  size_t numControls = 0;
-  for (const auto& modifier : instruction.modifiers) {
-    if (modifier.kind == GateModifierKind::Control) {
-      if (modifier.numControls >
-          std::numeric_limits<size_t>::max() - numControls) {
-        throw std::runtime_error("Qiskit control count is too large");
-      }
-      numControls += modifier.numControls;
-    }
-  }
-  if (instruction.qubits.size() != numControls + arity->first ||
-      instruction.parameters.size() != arity->second) {
-    throw std::runtime_error("Qiskit instruction '" + instruction.name +
-                             "' has an unsupported modified operand arity");
-  }
-
-  const auto targets = qubits.drop_front(numControls);
+template <typename EmitBase>
+void emitModifiedOperation(mlir::qc::QCProgramBuilder& builder,
+                           const Instruction& instruction,
+                           const mlir::ValueRange qubits,
+                           const ModifiedQubitArity arity,
+                           const LocalParameters& localParameters,
+                           EmitBase&& emitBase) {
+  const auto targets = qubits.drop_front(arity.controls);
   const auto emitModifiers =
       [&](auto&& self, const size_t count,
           const mlir::ValueRange targetArguments) -> void {
     if (count == 0U) {
-      emitStandardGate(builder, instruction, targetArguments, parameters);
+      emitBase(targetArguments);
       return;
     }
     const auto& modifier = instruction.modifiers[count - 1U];
@@ -258,15 +289,37 @@ void emitModifiedGate(mlir::qc::QCProgramBuilder& builder,
     throw std::runtime_error("unknown normalized Qiskit gate modifier");
   };
 
-  if (numControls == 0U) {
+  if (arity.controls == 0U) {
     emitModifiers(emitModifiers, instruction.modifiers.size(), targets);
     return;
   }
-  builder.ctrl(qubits.take_front(numControls), targets,
+  builder.ctrl(qubits.take_front(arity.controls), targets,
                [&](const mlir::ValueRange targetArguments) {
                  emitModifiers(emitModifiers, instruction.modifiers.size(),
                                targetArguments);
                });
+}
+
+void emitModifiedGate(mlir::qc::QCProgramBuilder& builder,
+                      const Instruction& instruction,
+                      const mlir::ValueRange qubits,
+                      const llvm::ArrayRef<ParameterValue> parameters,
+                      const LocalParameters& localParameters) {
+  const auto arity = gateArity(instruction);
+  if (!arity) {
+    throw std::runtime_error("unsupported modified Qiskit standard gate '" +
+                             instruction.name + "'");
+  }
+  if (instruction.parameters.size() != arity->second) {
+    throw std::runtime_error("Qiskit instruction '" + instruction.name +
+                             "' has an unsupported modified operand arity");
+  }
+  emitModifiedOperation(
+      builder, instruction, qubits,
+      modifiedQubitArity(instruction, arity->first), localParameters,
+      [&](const mlir::ValueRange targetArguments) {
+        emitStandardGate(builder, instruction, targetArguments, parameters);
+      });
 }
 
 void emitStandardGate(mlir::qc::QCProgramBuilder& builder,
@@ -1020,18 +1073,19 @@ void translateCircuit(mlir::qc::QCProgramBuilder& builder,
       for (const auto qubit : instruction.qubits) {
         operands.push_back(getQubit(qubit));
       }
-      if (operands.size() > mlir::utils::MAX_DENSE_UNITARY_QUBITS) {
-        throw std::runtime_error(
-            "Qiskit unitary exceeds the supported eight-qubit limit");
-      }
-      const auto dimension = int64_t{1} << operands.size();
+      const auto arity = denseUnitaryArity(instruction);
+      const auto dimension = int64_t{1} << arity.targets;
       const auto type = mlir::RankedTensorType::get(
           {dimension, dimension}, mlir::ComplexType::get(builder.getF64Type()));
       const auto values =
-          reverseQubitOrder(circuit.unitary(index), operands.size());
-      builder.unitary(operands,
-                      mlir::DenseElementsAttr::get(
-                          type, llvm::ArrayRef<std::complex<double>>(values)));
+          reverseQubitOrder(circuit.unitary(index), arity.targets);
+      const auto matrix = mlir::DenseElementsAttr::get(
+          type, llvm::ArrayRef<std::complex<double>>(values));
+      emitModifiedOperation(builder, instruction, operands, arity,
+                            localParameters,
+                            [&](const mlir::ValueRange targetArguments) {
+                              builder.unitary(targetArguments, matrix);
+                            });
     } break;
     case OperationKind::ControlFlow: {
       const auto controlFlow = circuit.controlFlow(index);
@@ -1469,15 +1523,7 @@ void validateCircuit(const CircuitReader& circuit,
       }
       break;
     case OperationKind::Unitary:
-      if (!instruction.parameters.empty() || !instruction.clbits.empty() ||
-          !instruction.modifiers.empty() || instruction.qubits.empty()) {
-        throw std::runtime_error(
-            "Qiskit unitary instruction has an unsupported operand arity");
-      }
-      if (instruction.qubits.size() > mlir::utils::MAX_DENSE_UNITARY_QUBITS) {
-        throw std::runtime_error(
-            "Qiskit unitary exceeds the supported eight-qubit limit");
-      }
+      static_cast<void>(denseUnitaryArity(instruction));
       break;
     case OperationKind::ControlFlow: {
       const auto controlFlow = circuit.controlFlow(index);

--- a/bindings/mlir/qiskit/QiskitImport.cpp
+++ b/bindings/mlir/qiskit/QiskitImport.cpp
@@ -1013,8 +1013,8 @@ void translateCircuit(mlir::qc::QCProgramBuilder& builder,
       builder.reset(getQubit(instruction.qubits[0]));
       break;
     case OperationKind::Unitary:
-      throw std::runtime_error(
-          "Qiskit circuit import does not support arbitrary unitaries");
+      translateDefinition(index, instruction);
+      break;
     case OperationKind::ControlFlow: {
       const auto controlFlow = circuit.controlFlow(index);
       translateControlFlow(builder, *controlFlow, allQubits, classicalBits,
@@ -1069,6 +1069,7 @@ expansionSummary(const CircuitReader& circuit, ExpansionCountState& state,
     const auto instruction = circuit.instruction(index);
     if ((instruction.kind == OperationKind::Gate &&
          !instruction.standardGate) ||
+        instruction.kind == OperationKind::Unitary ||
         instruction.kind == OperationKind::Unknown) {
       if (!instruction.modifiers.empty()) {
         throw std::runtime_error(
@@ -1451,8 +1452,9 @@ void validateCircuit(const CircuitReader& circuit,
       }
       break;
     case OperationKind::Unitary:
-      throw std::runtime_error(
-          "Qiskit circuit import does not support arbitrary unitaries");
+      validateDefinition(circuit, index, localParameters, definitionDepth,
+                         controlFlowDepth);
+      break;
     case OperationKind::ControlFlow: {
       const auto controlFlow = circuit.controlFlow(index);
       validateControlFlow(*controlFlow, localParameters, rootQubits, rootClbits,

--- a/bindings/mlir/qiskit/QiskitTranslation.cpp
+++ b/bindings/mlir/qiskit/QiskitTranslation.cpp
@@ -13,11 +13,7 @@
 #include <llvm/ADT/StringSet.h>
 
 #include <algorithm>
-#include <complex>
-#include <cstddef>
 #include <cstdint>
-#include <limits>
-#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -68,34 +64,6 @@ uint32_t validateRegisterLayout(const std::vector<Register>& registers,
                              " bits before contiguous registers");
   }
   return loose;
-}
-
-std::vector<std::complex<double>>
-reverseQubitOrder(const std::span<const std::complex<double>> matrix,
-                  const size_t numQubits) {
-  if (numQubits >= std::numeric_limits<size_t>::digits / 2U) {
-    throw std::runtime_error("unitary matrix is too large to represent safely");
-  }
-  const auto dimension = size_t{1} << numQubits;
-  if (matrix.size() != dimension * dimension) {
-    throw std::runtime_error(
-        "unitary matrix size does not match its qubit count");
-  }
-  const auto reverseIndex = [numQubits](const size_t index) {
-    size_t reversed = 0U;
-    for (size_t bit = 0U; bit < numQubits; ++bit) {
-      reversed = (reversed << 1U) | ((index >> bit) & 1U);
-    }
-    return reversed;
-  };
-  std::vector<std::complex<double>> result(matrix.size());
-  for (size_t row = 0U; row < dimension; ++row) {
-    for (size_t column = 0U; column < dimension; ++column) {
-      result[(row * dimension) + column] =
-          matrix[(reverseIndex(row) * dimension) + reverseIndex(column)];
-    }
-  }
-  return result;
 }
 
 } // namespace mqt::bindings::qiskit

--- a/bindings/mlir/qiskit/QiskitTranslation.cpp
+++ b/bindings/mlir/qiskit/QiskitTranslation.cpp
@@ -13,7 +13,11 @@
 #include <llvm/ADT/StringSet.h>
 
 #include <algorithm>
+#include <complex>
+#include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -64,6 +68,34 @@ uint32_t validateRegisterLayout(const std::vector<Register>& registers,
                              " bits before contiguous registers");
   }
   return loose;
+}
+
+std::vector<std::complex<double>>
+reverseQubitOrder(const std::span<const std::complex<double>> matrix,
+                  const size_t numQubits) {
+  if (numQubits >= std::numeric_limits<size_t>::digits / 2U) {
+    throw std::runtime_error("unitary matrix is too large to represent safely");
+  }
+  const auto dimension = size_t{1} << numQubits;
+  if (matrix.size() != dimension * dimension) {
+    throw std::runtime_error(
+        "unitary matrix size does not match its qubit count");
+  }
+  const auto reverseIndex = [numQubits](const size_t index) {
+    size_t reversed = 0U;
+    for (size_t bit = 0U; bit < numQubits; ++bit) {
+      reversed = (reversed << 1U) | ((index >> bit) & 1U);
+    }
+    return reversed;
+  };
+  std::vector<std::complex<double>> result(matrix.size());
+  for (size_t row = 0U; row < dimension; ++row) {
+    for (size_t column = 0U; column < dimension; ++column) {
+      result[(row * dimension) + column] =
+          matrix[(reverseIndex(row) * dimension) + reverseIndex(column)];
+    }
+  }
+  return result;
 }
 
 } // namespace mqt::bindings::qiskit

--- a/bindings/mlir/qiskit/QiskitTranslation.h
+++ b/bindings/mlir/qiskit/QiskitTranslation.h
@@ -19,7 +19,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -48,16 +47,6 @@ struct Register {
 [[nodiscard]] uint32_t
 validateRegisterLayout(const std::vector<Register>& registers, uint32_t total,
                        std::string_view kind);
-
-/**
- * Convert between Qiskit's LSB-first and QC/QCO's MSB-first operand convention.
- *
- * The permutation reverses the low @p numQubits bits of both matrix indices
- * and is therefore its own inverse.
- */
-[[nodiscard]] std::vector<std::complex<double>>
-reverseQubitOrder(std::span<const std::complex<double>> matrix,
-                  size_t numQubits);
 
 struct Parameter {
   std::optional<double> number = 0.0;

--- a/bindings/mlir/qiskit/QiskitTranslation.h
+++ b/bindings/mlir/qiskit/QiskitTranslation.h
@@ -258,7 +258,8 @@ public:
   virtual void addReset(uint32_t qubit) = 0;
   virtual void addBarrier(const std::vector<uint32_t>& qubits) = 0;
   virtual void addUnitary(const std::vector<std::complex<double>>& matrix,
-                          const std::vector<uint32_t>& qubits) = 0;
+                          const std::vector<uint32_t>& qubits,
+                          uint32_t numControls) = 0;
   /** Transfer the native circuit to a new owned Python QuantumCircuit. */
   [[nodiscard]] virtual nb::object finish() = 0;
 };

--- a/bindings/mlir/qiskit/QiskitTranslation.h
+++ b/bindings/mlir/qiskit/QiskitTranslation.h
@@ -14,10 +14,12 @@
 
 #include <nanobind/nanobind.h>
 
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -46,6 +48,16 @@ struct Register {
 [[nodiscard]] uint32_t
 validateRegisterLayout(const std::vector<Register>& registers, uint32_t total,
                        std::string_view kind);
+
+/**
+ * Convert between Qiskit's LSB-first and QC/QCO's MSB-first operand convention.
+ *
+ * The permutation reverses the low @p numQubits bits of both matrix indices
+ * and is therefore its own inverse.
+ */
+[[nodiscard]] std::vector<std::complex<double>>
+reverseQubitOrder(std::span<const std::complex<double>> matrix,
+                  size_t numQubits);
 
 struct Parameter {
   std::optional<double> number = 0.0;
@@ -197,6 +209,8 @@ public:
   [[nodiscard]] virtual Register classicalRegister(size_t index) const = 0;
   [[nodiscard]] virtual Parameter globalPhase() const = 0;
   [[nodiscard]] virtual Instruction instruction(size_t index) const = 0;
+  [[nodiscard]] virtual std::vector<std::complex<double>>
+  unitary(size_t index) const = 0;
   [[nodiscard]] virtual std::unique_ptr<ControlFlowReader>
   controlFlow(size_t index) const = 0;
   [[nodiscard]] virtual std::unique_ptr<CircuitReader>
@@ -243,6 +257,8 @@ public:
   virtual void addMeasure(uint32_t qubit, uint32_t clbit) = 0;
   virtual void addReset(uint32_t qubit) = 0;
   virtual void addBarrier(const std::vector<uint32_t>& qubits) = 0;
+  virtual void addUnitary(const std::vector<std::complex<double>>& matrix,
+                          const std::vector<uint32_t>& qubits) = 0;
   /** Transfer the native circuit to a new owned Python QuantumCircuit. */
   [[nodiscard]] virtual nb::object finish() = 0;
 };

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -187,8 +187,9 @@ operations.
 Dense numeric unitaries remain explicit matrix operations during import and
 export. Target compilation synthesizes supported one- and two-qubit matrices to
 the target gate set. Dense unitary operations support at most eight qubits.
-Qiskit import rejects annotated or controlled dense-unitary wrappers. Export
-supports inverse and constant powers of `1` or `-1`, but rejects controls.
+Qiskit import preserves inverse, numeric power, and closed-control modifiers on
+dense-unitary operations. Export preserves inverse and closed-control modifiers.
+Other powers require canonicalization or synthesis.
 
 A circuit remains valid when {code}`circ.layout` is present. The importer
 translates the circuit operations and deliberately does not preserve physical or

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -174,7 +174,7 @@ program structures than its C API can construct.
 | Constant Boolean, `Uint` up to 64 bits, and `Float` expressions   | Supported            | Rejected       |
 | Standalone classical variables or variable expressions            | Rejected             | Rejected       |
 | Free symbolic parameters                                          | Rejected             | Rejected       |
-| Arbitrary unitaries                                               | Rejected             | Rejected       |
+| Numerically bound Qiskit unitaries                                | Recursively expanded | Not preserved  |
 | Register aliases or interleaved membership                        | Rejected             | Rejected       |
 | Transpiler layout metadata                                        | Accepted and ignored | Not emitted    |
 
@@ -183,6 +183,11 @@ parameters passed to a custom instruction are bound before its definition is
 expanded. Definition expansion rejects missing definitions, cycles, operand
 arity mismatches, nesting beyond 64 levels, and more than 10 million expanded
 operations.
+
+The importer also expands the numeric circuit definition that Qiskit provides
+for each {py:class}`~qiskit.circuit.library.UnitaryGate`. This conversion lowers
+the synthesized definition to standard operations. It does not retain a dense
+matrix operation for later export.
 
 A circuit remains valid when {code}`circ.layout` is present. The importer
 translates the circuit operations and deliberately does not preserve physical or

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -174,7 +174,7 @@ program structures than its C API can construct.
 | Constant Boolean, `Uint` up to 64 bits, and `Float` expressions   | Supported            | Rejected       |
 | Standalone classical variables or variable expressions            | Rejected             | Rejected       |
 | Free symbolic parameters                                          | Rejected             | Rejected       |
-| Numerically bound Qiskit unitaries                                | Recursively expanded | Not preserved  |
+| Dense numeric unitaries up to eight qubits                        | Supported            | Supported      |
 | Register aliases or interleaved membership                        | Rejected             | Rejected       |
 | Transpiler layout metadata                                        | Accepted and ignored | Not emitted    |
 
@@ -184,10 +184,11 @@ expanded. Definition expansion rejects missing definitions, cycles, operand
 arity mismatches, nesting beyond 64 levels, and more than 10 million expanded
 operations.
 
-The importer also expands the numeric circuit definition that Qiskit provides
-for each {py:class}`~qiskit.circuit.library.UnitaryGate`. This conversion lowers
-the synthesized definition to standard operations. It does not retain a dense
-matrix operation for later export.
+Dense numeric unitaries remain explicit matrix operations during import and
+export. Target compilation synthesizes supported one- and two-qubit matrices to
+the target gate set. Dense unitary operations support at most eight qubits.
+Qiskit import rejects annotated or controlled dense-unitary wrappers. Export
+supports inverse and constant powers of `1` or `-1`, but rejects controls.
 
 A circuit remains valid when {code}`circ.layout` is present. The importer
 translates the circuit operations and deliberately does not preserve physical or

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -12,6 +12,7 @@
 
 #include <llvm/ADT/StringSet.h>
 #include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Support/LLVM.h>
@@ -991,6 +992,15 @@ public:
    * ```
    */
   QCProgramBuilder& barrier(ValueRange qubits);
+
+  /**
+   * @brief Apply an explicitly represented dense unitary matrix
+   *
+   * @param qubits Target qubits
+   * @param matrix Square row-major `complex<f64>` matrix
+   * @return Reference to this builder for method chaining
+   */
+  QCProgramBuilder& unitary(ValueRange qubits, DenseElementsAttr matrix);
 
   //===--------------------------------------------------------------------===//
   // Modifiers

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -996,7 +996,8 @@ public:
   /**
    * @brief Apply an explicitly represented dense unitary matrix
    *
-   * @param qubits Target qubits
+   * @param qubits Target qubits, ordered from the most-significant basis bit
+   * to the least-significant basis bit
    * @param matrix Square row-major `complex<f64>` matrix
    * @return Reference to this builder for method chaining
    */

--- a/mlir/include/mlir/Dialect/QC/IR/QCOps.td
+++ b/mlir/include/mlir/Dialect/QC/IR/QCOps.td
@@ -881,6 +881,49 @@ def RCCXOp
     }];
 }
 
+def UnitaryOp : QCOp<"unitary", traits = [UnitaryOpInterface]> {
+  let summary = "Apply an explicitly represented unitary matrix";
+  let description = [{
+        Applies a dense unitary matrix to a variadic list of target qubits.
+        The matrix is stored in row-major order as a square rank-two tensor of
+        `complex<f64>` values. Its side length must be `2^n`, where `n` is the
+        number of target qubits. Operand 0 labels the most-significant basis
+        bit; the last operand labels the least-significant bit. The
+        deterministic matrix verifier supports one to eight qubits and checks
+        `U^dagger U` entry-wise with absolute tolerance `1e-10`.
+
+        Example:
+        ```mlir
+        qc.unitary dense<[[(0.0,0.0), (1.0,0.0)],
+                          [(1.0,0.0), (0.0,0.0)]]>
+            : tensor<2x2xcomplex<f64>> %q : !qc.qubit
+        ```
+    }];
+
+  let arguments = (ins ElementsAttr:$matrix,
+      Arg<Variadic<QubitType>,
+          "the target qubits", [MemRead, MemWrite]>:$qubits);
+  let assemblyFormat = "$matrix $qubits attr-dict `:` type($qubits)";
+
+  let extraClassDeclaration = [{
+        size_t getNumQubits() { return getNumTargets(); }
+        size_t getNumTargets() { return getQubits().size(); }
+        static size_t getNumControls() { return 0; }
+        static OperandRange getControls() { return {nullptr, 0}; }
+        Value getQubit(size_t i) { return getTarget(i); }
+        Value getTarget(size_t i) { return getQubits()[i]; }
+        OperandRange getTargets() { return getQubits(); }
+        static Value getControl(size_t i) { llvm::reportFatalUsageError("UnitaryOp cannot be controlled directly"); }
+        static size_t getNumParams() { return 0; }
+        static Value getParameter(size_t i) { llvm::reportFatalUsageError("UnitaryOp does not have parameters"); }
+        static OperandRange getParameters() { return {nullptr, 0}; }
+        static StringRef getBaseSymbol() { return "unitary"; }
+    }];
+
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+}
+
 def BarrierOp : QCOp<"barrier", traits = [UnitaryOpInterface]> {
   let summary = "Apply a barrier gate to a set of qubits";
   let description = [{

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -14,6 +14,7 @@
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/StringSet.h>
 #include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Support/LLVM.h>
@@ -1370,6 +1371,15 @@ public:
    * ```
    */
   ValueRange barrier(ValueRange qubits);
+
+  /**
+   * @brief Apply an explicitly represented dense unitary matrix
+   *
+   * @param qubits Input qubits (must be valid/unconsumed)
+   * @param matrix Square row-major `complex<f64>` matrix
+   * @return Output qubits
+   */
+  ValueRange unitary(ValueRange qubits, DenseElementsAttr matrix);
 
   //===--------------------------------------------------------------------===//
   // Modifiers

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -1375,7 +1375,8 @@ public:
   /**
    * @brief Apply an explicitly represented dense unitary matrix
    *
-   * @param qubits Input qubits (must be valid/unconsumed)
+   * @param qubits Input qubits (must be valid/unconsumed), ordered from the
+   * most-significant basis bit to the least-significant basis bit
    * @param matrix Square row-major `complex<f64>` matrix
    * @return Output qubits
    */

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOInterfaces.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOInterfaces.td
@@ -52,6 +52,8 @@ def UnitaryOpInterface : OpInterface<"UnitaryOpInterface"> {
         if constexpr (std::is_same_v<ValueT, Matrix1x1>) {
           out = $_op.getUnitaryMatrix();
           return true;
+        } else if constexpr (std::is_same_v<ValueT, DynamicMatrix>) {
+          return out.assignFrom($_op.getUnitaryMatrix());
         }
         return false;
       } else {
@@ -81,6 +83,8 @@ def UnitaryOpInterface : OpInterface<"UnitaryOpInterface"> {
         if constexpr (std::is_same_v<ValueT, Matrix2x2>) {
           out = $_op.getUnitaryMatrix();
           return true;
+        } else if constexpr (std::is_same_v<ValueT, DynamicMatrix>) {
+          return out.assignFrom($_op.getUnitaryMatrix());
         }
         return false;
       } else {
@@ -110,6 +114,8 @@ def UnitaryOpInterface : OpInterface<"UnitaryOpInterface"> {
         if constexpr (std::is_same_v<ValueT, Matrix4x4>) {
           out = $_op.getUnitaryMatrix();
           return true;
+        } else if constexpr (std::is_same_v<ValueT, DynamicMatrix>) {
+          return out.assignFrom($_op.getUnitaryMatrix());
         }
         return false;
       } else {

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1027,6 +1027,65 @@ def RCCXOp : QCOOp<"rccx", traits = [UnitaryOpInterface,
   let hasCanonicalizer = 1;
 }
 
+def UnitaryOp : QCOOp<"unitary", traits = [UnitaryOpInterface, Pure]> {
+  let summary = "Apply an explicitly represented unitary matrix";
+  let description = [{
+        Applies a dense unitary matrix and returns the transformed qubits. The
+        matrix is stored in row-major order as a square rank-two tensor of
+        `complex<f64>` values. Its side length must be `2^n`, where `n` is the
+        number of input qubits. Operand 0 labels the most-significant basis bit;
+        the last operand labels the least-significant bit. The deterministic
+        matrix verifier supports one to eight qubits and checks `U^dagger U`
+        entry-wise with absolute tolerance `1e-10`.
+
+        Example:
+        ```mlir
+        %q_out = qco.unitary dense<[[(0.0,0.0), (1.0,0.0)],
+                                    [(1.0,0.0), (0.0,0.0)]]>
+            : tensor<2x2xcomplex<f64>> %q_in
+            : !qco.qubit -> !qco.qubit
+        ```
+    }];
+
+  let arguments = (ins ElementsAttr:$matrix,
+      Arg<Variadic<QubitType>, "the input qubits">:$qubits_in);
+  let results = (outs Variadic<QubitType>:$qubits_out);
+  let assemblyFormat = "$matrix $qubits_in attr-dict `:` type($qubits_in)"
+                       " `->` type($qubits_out)";
+
+  let extraClassDeclaration = [{
+        size_t getNumQubits() { return getNumTargets(); }
+        size_t getNumTargets() { return getQubitsIn().size(); }
+        static size_t getNumControls() { return 0; }
+        Value getInputQubit(size_t i) { return getInputTarget(i); }
+        OperandRange getInputQubits() { return getQubitsIn(); }
+        OperandRange getInputTargets() { return getInputQubits(); }
+        Value getOutputQubit(size_t i) { return getOutputTarget(i); }
+        ResultRange getOutputQubits() { return getQubitsOut(); }
+        Value getInputTarget(size_t i) { return getQubitsIn()[i]; }
+        Value getOutputTarget(size_t i) { return getQubitsOut()[i]; }
+        static Value getInputControl(size_t i) { llvm::reportFatalUsageError("UnitaryOp cannot be controlled directly"); }
+        static OperandRange getInputControls() { return {nullptr, 0}; }
+        static Value getOutputControl(size_t i) { llvm::reportFatalUsageError("UnitaryOp cannot be controlled directly"); }
+        static ResultRange getOutputControls() { return {nullptr, 0}; }
+        ResultRange getOutputTargets() { return getOutputQubits(); }
+        Value getInputForOutput(Value output);
+        Value getOutputForInput(Value input);
+        static size_t getNumParams() { return 0; }
+        static Value getParameter(size_t i) { llvm::reportFatalUsageError("UnitaryOp has no parameters"); }
+        static OperandRange getParameters() { return {nullptr, 0}; }
+        [[nodiscard]] static StringRef getBaseSymbol() { return "unitary"; }
+        [[nodiscard]] static bool hasCompileTimeKnownUnitaryMatrix() { return true; }
+        [[nodiscard]] DynamicMatrix getUnitaryMatrix();
+    }];
+
+  let builders = [OpBuilder<(ins "ValueRange":$qubits,
+      "ElementsAttr":$matrix)>];
+
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+}
+
 def BarrierOp : QCOOp<"barrier", traits = [UnitaryOpInterface, Pure]> {
   let summary = "Apply a barrier gate to a set of qubits";
   let description = [{

--- a/mlir/include/mlir/Dialect/Utils/DenseUnitary.h
+++ b/mlir/include/mlir/Dialect/Utils/DenseUnitary.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Casting.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LogicalResult.h>
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+
+namespace mlir::utils {
+
+/**
+ * Maximum absolute entry-wise deviation of U^dagger U from the identity.
+ *
+ * This tolerance accounts for binary64 accumulation error while remaining
+ * substantially below the precision at which dense input matrices are
+ * normally specified.
+ */
+inline constexpr double DENSE_UNITARY_TOLERANCE = 1e-10;
+
+/** Maximum matrix arity accepted by the deterministic unitarity verifier. */
+inline constexpr size_t MAX_DENSE_UNITARY_QUBITS = 8;
+
+/** Verify the common dense-matrix contract of QC and QCO unitary operations. */
+[[nodiscard]] inline LogicalResult
+verifyDenseUnitaryMatrix(Operation* operation, const ElementsAttr matrixAttr,
+                         const ValueRange qubits) {
+  const auto numQubits = qubits.size();
+  if (numQubits == 0U) {
+    return operation->emitOpError("requires at least one qubit");
+  }
+  if (numQubits > MAX_DENSE_UNITARY_QUBITS) {
+    return operation->emitOpError()
+           << "supports at most " << MAX_DENSE_UNITARY_QUBITS << " qubits";
+  }
+  llvm::SmallDenseSet<Value, 8> uniqueQubits;
+  for (const auto qubit : qubits) {
+    if (!uniqueQubits.insert(qubit).second) {
+      return operation->emitOpError("duplicate qubit operand");
+    }
+  }
+  const auto matrix = dyn_cast<DenseElementsAttr>(matrixAttr);
+  if (!matrix) {
+    return operation->emitOpError("matrix must use dense element storage");
+  }
+  const auto type = dyn_cast<RankedTensorType>(matrix.getType());
+  if (!type || type.getRank() != 2 ||
+      type.getShape()[0] != type.getShape()[1]) {
+    return operation->emitOpError("matrix must be a square rank-two tensor");
+  }
+  const auto complexType = dyn_cast<ComplexType>(type.getElementType());
+  if (!complexType || !complexType.getElementType().isF64()) {
+    return operation->emitOpError(
+        "matrix elements must have type complex<f64>");
+  }
+  const auto expectedDimension = static_cast<int64_t>(uint64_t{1} << numQubits);
+  if (type.getShape()[0] != expectedDimension) {
+    return operation->emitOpError()
+           << "matrix dimension must be 2^n = " << expectedDimension << " for "
+           << numQubits << " qubits";
+  }
+
+  llvm::SmallVector<std::complex<double>, 16> values;
+  values.reserve(static_cast<size_t>(matrix.size()));
+  for (const auto value : matrix.getValues<std::complex<double>>()) {
+    if (!std::isfinite(value.real()) || !std::isfinite(value.imag())) {
+      return operation->emitOpError("matrix entries must be finite");
+    }
+    values.push_back(value);
+  }
+
+  const auto dimension = static_cast<size_t>(expectedDimension);
+  for (size_t lhsColumn = 0; lhsColumn < dimension; ++lhsColumn) {
+    for (size_t rhsColumn = 0; rhsColumn < dimension; ++rhsColumn) {
+      std::complex<long double> innerProduct{};
+      for (size_t row = 0; row < dimension; ++row) {
+        const auto lhs = values[(row * dimension) + lhsColumn];
+        const auto rhs = values[(row * dimension) + rhsColumn];
+        innerProduct +=
+            std::conj(std::complex<long double>{lhs.real(), lhs.imag()}) *
+            std::complex<long double>{rhs.real(), rhs.imag()};
+      }
+      const std::complex<long double> expected =
+          lhsColumn == rhsColumn ? 1.0L : 0.0L;
+      if (std::abs(innerProduct - expected) > DENSE_UNITARY_TOLERANCE) {
+        return operation->emitOpError()
+               << "matrix must be unitary within absolute tolerance "
+               << DENSE_UNITARY_TOLERANCE;
+      }
+    }
+  }
+  return success();
+}
+
+/** Return whether a dense square matrix is exactly the identity. */
+[[nodiscard]] inline bool isExactIdentityMatrix(const ElementsAttr matrixAttr) {
+  const auto matrix = dyn_cast<DenseElementsAttr>(matrixAttr);
+  if (!matrix) {
+    return false;
+  }
+  const auto type = dyn_cast<RankedTensorType>(matrix.getType());
+  if (!type || type.getRank() != 2 ||
+      type.getShape()[0] != type.getShape()[1] || type.getShape()[0] <= 0) {
+    return false;
+  }
+  const auto complexType = dyn_cast<ComplexType>(type.getElementType());
+  if (!complexType || !complexType.getElementType().isF64()) {
+    return false;
+  }
+  const auto dimension = static_cast<size_t>(type.getShape()[0]);
+  size_t index = 0U;
+  for (const auto value : matrix.getValues<std::complex<double>>()) {
+    const auto row = index / dimension;
+    const auto column = index % dimension;
+    const std::complex<double> expected = row == column ? 1.0 : 0.0;
+    if (value != expected) {
+      return false;
+    }
+    ++index;
+  }
+  return true;
+}
+
+} // namespace mlir::utils

--- a/mlir/include/mlir/Dialect/Utils/DenseUnitary.h
+++ b/mlir/include/mlir/Dialect/Utils/DenseUnitary.h
@@ -89,18 +89,17 @@ verifyDenseUnitaryMatrix(Operation* operation, const ElementsAttr matrixAttr,
 
   const auto dimension = static_cast<size_t>(expectedDimension);
   for (size_t lhsColumn = 0; lhsColumn < dimension; ++lhsColumn) {
-    for (size_t rhsColumn = 0; rhsColumn < dimension; ++rhsColumn) {
-      std::complex<long double> innerProduct{};
+    for (size_t rhsColumn = lhsColumn; rhsColumn < dimension; ++rhsColumn) {
+      std::complex<double> innerProduct{};
       for (size_t row = 0; row < dimension; ++row) {
         const auto lhs = values[(row * dimension) + lhsColumn];
         const auto rhs = values[(row * dimension) + rhsColumn];
-        innerProduct +=
-            std::conj(std::complex<long double>{lhs.real(), lhs.imag()}) *
-            std::complex<long double>{rhs.real(), rhs.imag()};
+        innerProduct += std::conj(lhs) * rhs;
       }
-      const std::complex<long double> expected =
-          lhsColumn == rhsColumn ? 1.0L : 0.0L;
-      if (std::abs(innerProduct - expected) > DENSE_UNITARY_TOLERANCE) {
+      const std::complex<double> expected = lhsColumn == rhsColumn ? 1.0 : 0.0;
+      if (!std::isfinite(innerProduct.real()) ||
+          !std::isfinite(innerProduct.imag()) ||
+          std::abs(innerProduct - expected) > DENSE_UNITARY_TOLERANCE) {
         return operation->emitOpError()
                << "matrix must be unitary within absolute tolerance "
                << DENSE_UNITARY_TOLERANCE;

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -433,6 +433,20 @@ struct ConvertQCOGateToQC final : OpConversionPattern<QCOOpType> {
   }
 };
 
+/** Converts a variadic dense qco.unitary to its reference-semantics form. */
+struct ConvertQCOUnitaryOp final : OpConversionPattern<qco::UnitaryOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(qco::UnitaryOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter& rewriter) const override {
+    const auto qcQubits = adaptor.getQubitsIn();
+    qc::UnitaryOp::create(rewriter, op.getLoc(), op.getMatrix(), qcQubits);
+    rewriter.replaceOp(op, qcQubits);
+    return success();
+  }
+};
+
 } // namespace
 
 template <typename QCOOp, typename QCOp, std::size_t Targets,
@@ -1195,7 +1209,7 @@ protected:
     // Register operation conversion patterns that do not need state tracking
     patterns
         .add<ConvertQTensorInsertOp, ConvertQTensorDeallocOp,
-             ConvertQCOMeasureOp, ConvertQCOResetOp,
+             ConvertQCOMeasureOp, ConvertQCOResetOp, ConvertQCOUnitaryOp,
              ConvertQCOZeroTargetOneParameterToQC<qco::GPhaseOp, qc::GPhaseOp>>(
             typeConverter, context);
 

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -1165,6 +1165,27 @@ struct ConvertQCGateToQCO final : StatefulOpConversionPattern<QCOpType> {
   }
 };
 
+/** Converts a variadic dense qc.unitary to its value-semantics form. */
+struct ConvertQCUnitaryOp final : StatefulOpConversionPattern<qc::UnitaryOp> {
+  using StatefulOpConversionPattern::StatefulOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(qc::UnitaryOp op, OpAdaptor /*adaptor*/,
+                  ConversionPatternRewriter& rewriter) const override {
+    auto& state = getState();
+    auto* operation = op.getOperation();
+    const auto qcQubits = op.getQubits();
+    auto materialized = materializeQubits(state, operation, qcQubits, rewriter);
+    auto qcoOp = qco::UnitaryOp::create(rewriter, op.getLoc(),
+                                        materialized.values, op.getMatrix());
+
+    commitQubits(state, operation, qcQubits, qcoOp.getQubitsOut(), materialized,
+                 rewriter);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 /**
  * @brief Converts qc.barrier to qco.barrier
  *
@@ -1889,13 +1910,14 @@ protected:
     target.addLegalOp<scf::YieldOp, scf::ConditionOp>();
 
     // Register operation conversion patterns with state tracking.
-    patterns.add<ConvertSCFForOp, ConvertSCFWhileOp, ConvertSCFIfOp,
-                 ConvertSCFIndexSwitchOp, ConvertMemRefAllocOp,
-                 ConvertMemRefLoadOp, ConvertMemRefDeallocOp, ConvertQCAllocOp,
-                 ConvertQCDeallocOp, ConvertQCStaticOp, ConvertQCMeasureOp,
-                 ConvertQCResetOp, ConvertQCBarrierOp, ConvertQCCtrlOp,
-                 ConvertQCInvOp, ConvertQCPowOp, ConvertQCYieldOp>(
-        typeConverter, context, &state);
+    patterns
+        .add<ConvertSCFForOp, ConvertSCFWhileOp, ConvertSCFIfOp,
+             ConvertSCFIndexSwitchOp, ConvertMemRefAllocOp, ConvertMemRefLoadOp,
+             ConvertMemRefDeallocOp, ConvertQCAllocOp, ConvertQCDeallocOp,
+             ConvertQCStaticOp, ConvertQCMeasureOp, ConvertQCResetOp,
+             ConvertQCUnitaryOp, ConvertQCBarrierOp, ConvertQCCtrlOp,
+             ConvertQCInvOp, ConvertQCPowOp, ConvertQCYieldOp>(typeConverter,
+                                                               context, &state);
 
     // Not part of the central gate table.
     patterns.add<ConvertQCGateToQCO<qc::GPhaseOp, qco::GPhaseOp, 0, 1>>(

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -504,6 +504,13 @@ QCProgramBuilder& QCProgramBuilder::barrier(ValueRange qubits) {
   return *this;
 }
 
+QCProgramBuilder& QCProgramBuilder::unitary(ValueRange qubits,
+                                            DenseElementsAttr matrix) {
+  checkFinalized();
+  UnitaryOp::create(*this, matrix, qubits);
+  return *this;
+}
+
 //===----------------------------------------------------------------------===//
 // Modifiers
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/QC/IR/Operations/UnitaryOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Operations/UnitaryOp.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/Dialect/Utils/DenseUnitary.h"
+
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Support/LogicalResult.h>
+
+using namespace mlir;
+using namespace mlir::qc;
+
+namespace {
+
+struct EraseIdentityUnitary final : OpRewritePattern<UnitaryOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(UnitaryOp op,
+                                PatternRewriter& rewriter) const override {
+    if (!utils::isExactIdentityMatrix(op.getMatrix())) {
+      return failure();
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+LogicalResult UnitaryOp::verify() {
+  return utils::verifyDenseUnitaryMatrix(getOperation(), getMatrix(),
+                                         getQubits());
+}
+
+void UnitaryOp::getCanonicalizationPatterns(RewritePatternSet& results,
+                                            MLIRContext* context) {
+  results.add<EraseIdentityUnitary>(context);
+}

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -875,6 +875,19 @@ ValueRange QCOProgramBuilder::barrier(ValueRange qubits) {
   return qubitsOut;
 }
 
+ValueRange QCOProgramBuilder::unitary(ValueRange qubits,
+                                      DenseElementsAttr matrix) {
+  checkFinalized();
+
+  auto op = UnitaryOp::create(*this, qubits, matrix);
+  auto qubitsOut = op.getQubitsOut();
+  for (const auto [inputQubit, outputQubit] :
+       llvm::zip_equal(qubits, qubitsOut)) {
+    updateQubitTracking(inputQubit, outputQubit);
+  }
+  return qubitsOut;
+}
+
 //===----------------------------------------------------------------------===//
 // Modifiers
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/QCO/IR/Operations/UnitaryOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/UnitaryOp.cpp
@@ -50,7 +50,7 @@ void UnitaryOp::build(OpBuilder& /*builder*/, OperationState& state,
                       const ValueRange qubits, const ElementsAttr matrix) {
   state.addOperands(qubits);
   state.addTypes(qubits.getTypes());
-  state.addAttribute("matrix", matrix);
+  state.addAttribute(getMatrixAttrName(state.name), matrix);
 }
 
 LogicalResult UnitaryOp::verify() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/UnitaryOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/UnitaryOp.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/Utils/Matrix.h"
+#include "mlir/Dialect/Utils/DenseUnitary.h"
+
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/ErrorHandling.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OperationSupport.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+
+#include <complex>
+#include <cstdint>
+
+using namespace mlir;
+using namespace mlir::qco;
+
+namespace {
+
+struct FoldIdentityUnitary final : OpRewritePattern<UnitaryOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(UnitaryOp op,
+                                PatternRewriter& rewriter) const override {
+    if (!utils::isExactIdentityMatrix(op.getMatrix())) {
+      return failure();
+    }
+    rewriter.replaceOp(op, op.getQubitsIn());
+    return success();
+  }
+};
+
+} // namespace
+
+void UnitaryOp::build(OpBuilder& /*builder*/, OperationState& state,
+                      const ValueRange qubits, const ElementsAttr matrix) {
+  state.addOperands(qubits);
+  state.addTypes(qubits.getTypes());
+  state.addAttribute("matrix", matrix);
+}
+
+LogicalResult UnitaryOp::verify() {
+  if (getQubitsOut().size() != getQubitsIn().size()) {
+    return emitOpError("must return one qubit for every input qubit");
+  }
+  return utils::verifyDenseUnitaryMatrix(getOperation(), getMatrix(),
+                                         getQubitsIn());
+}
+
+Value UnitaryOp::getInputForOutput(const Value output) {
+  for (const auto [input, candidate] :
+       llvm::zip_equal(getQubitsIn(), getQubitsOut())) {
+    if (candidate == output) {
+      return input;
+    }
+  }
+  llvm::reportFatalUsageError("Given qubit is not an output of UnitaryOp");
+}
+
+Value UnitaryOp::getOutputForInput(const Value input) {
+  for (const auto [candidate, output] :
+       llvm::zip_equal(getQubitsIn(), getQubitsOut())) {
+    if (candidate == input) {
+      return output;
+    }
+  }
+  llvm::reportFatalUsageError("Given qubit is not an input of UnitaryOp");
+}
+
+DynamicMatrix UnitaryOp::getUnitaryMatrix() {
+  const auto matrix = cast<DenseElementsAttr>(getMatrix());
+  const auto dimension = matrix.getType().getShape()[0];
+  DynamicMatrix result(dimension);
+  auto values = matrix.getValues<std::complex<double>>();
+  auto iterator = values.begin();
+  for (int64_t row = 0; row < dimension; ++row) {
+    for (int64_t column = 0; column < dimension; ++column) {
+      result(row, column) = *iterator;
+      ++iterator;
+    }
+  }
+  return result;
+}
+
+void UnitaryOp::getCanonicalizationPatterns(RewritePatternSet& results,
+                                            MLIRContext* context) {
+  results.add<FoldIdentityUnitary>(context);
+}

--- a/mlir/unittests/Conversion/QCQCORoundTrip/test_qc_qco_round_trip.cpp
+++ b/mlir/unittests/Conversion/QCQCORoundTrip/test_qc_qco_round_trip.cpp
@@ -11,13 +11,16 @@
 #include "mlir/Conversion/QCOToQC/QCOToQC.h"
 #include "mlir/Conversion/QCToQCO/QCToQCO.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 
 #include <gtest/gtest.h>
+#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
@@ -26,6 +29,8 @@
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
+
+#include <string>
 
 using namespace mlir;
 
@@ -141,4 +146,53 @@ module {
   auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
   EXPECT_EQ(returnOp.getOperand(0), switchOp.getResult(0));
   expectNoScratchStorage(*module);
+}
+
+TEST_F(QCQCORoundTripTest, PreservesDenseUnitaryMatrixAndQubitArity) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %q0 = qc.alloc : !qc.qubit
+    %q1 = qc.alloc : !qc.qubit
+    qc.unitary dense<[
+        [(1.0,0.0), (0.0,0.0), (0.0,0.0), (0.0,0.0)],
+        [(0.0,0.0), (0.0,0.0), (1.0,0.0), (0.0,0.0)],
+        [(0.0,0.0), (1.0,0.0), (0.0,0.0), (0.0,0.0)],
+        [(0.0,0.0), (0.0,0.0), (0.0,0.0), (1.0,0.0)]]>
+        : tensor<4x4xcomplex<f64>> %q0, %q1 : !qc.qubit, !qc.qubit
+    qc.dealloc %q0 : !qc.qubit
+    qc.dealloc %q1 : !qc.qubit
+    return
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  ElementsAttr originalMatrix;
+  module->walk(
+      [&](qc::UnitaryOp unitary) { originalMatrix = unitary.getMatrix(); });
+  ASSERT_TRUE(originalMatrix);
+
+  std::string serialized;
+  llvm::raw_string_ostream stream(serialized);
+  module->print(stream);
+  stream.flush();
+  auto reparsed = parseSourceString<ModuleOp>(serialized, &context);
+  ASSERT_TRUE(reparsed);
+  qc::UnitaryOp reparsedUnitary;
+  reparsed->walk([&](qc::UnitaryOp candidate) { reparsedUnitary = candidate; });
+  ASSERT_TRUE(reparsedUnitary);
+  EXPECT_EQ(reparsedUnitary.getMatrix(), originalMatrix);
+
+  ASSERT_TRUE(succeeded(runRoundTrip(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  qc::UnitaryOp unitary;
+  module->walk([&](qc::UnitaryOp candidate) { unitary = candidate; });
+  ASSERT_TRUE(unitary);
+  EXPECT_EQ(unitary.getQubits().size(), 2U);
+  EXPECT_EQ(unitary.getMatrix(), originalMatrix);
 }

--- a/mlir/unittests/Conversion/QCQCORoundTrip/test_qc_qco_round_trip.cpp
+++ b/mlir/unittests/Conversion/QCQCORoundTrip/test_qc_qco_round_trip.cpp
@@ -20,7 +20,7 @@
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
-#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/BuiltinAttributeInterfaces.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>

--- a/mlir/unittests/Conversion/QCQCORoundTrip/test_qc_qco_round_trip.cpp
+++ b/mlir/unittests/Conversion/QCQCORoundTrip/test_qc_qco_round_trip.cpp
@@ -182,9 +182,11 @@ module {
   stream.flush();
   auto reparsed = parseSourceString<ModuleOp>(serialized, &context);
   ASSERT_TRUE(reparsed);
+  ASSERT_TRUE(succeeded(verify(*reparsed)));
   qc::UnitaryOp reparsedUnitary;
   reparsed->walk([&](qc::UnitaryOp candidate) { reparsedUnitary = candidate; });
   ASSERT_TRUE(reparsedUnitary);
+  EXPECT_EQ(reparsedUnitary.getQubits().size(), 2U);
   EXPECT_EQ(reparsedUnitary.getMatrix(), originalMatrix);
 
   ASSERT_TRUE(succeeded(runRoundTrip(*module)));

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/Dialect/Utils/DenseUnitary.h"
 #include "mlir/Dialect/Utils/Transforms/Passes.h"
 #include "mlir/Support/IRVerification.h"
 #include "mlir/Support/Passes.h"
@@ -314,6 +315,11 @@ TEST_F(QCTest, DenseUnitaryBuilderVerifiesAndCanonicalizesIdentity) {
   ASSERT_EQ(unitaries.size(), 1U);
   EXPECT_EQ(unitaries.front().getMatrix(), xMatrix);
 
+  ASSERT_TRUE(succeeded(runQCCleanupPipeline(*module)));
+  unitaries = llvm::to_vector(function.getBody().getOps<UnitaryOp>());
+  ASSERT_EQ(unitaries.size(), 1U);
+  EXPECT_EQ(unitaries.front().getMatrix(), xMatrix);
+
   const std::array<std::complex<double>, 4> identityValues{
       {{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}}};
   unitaries.front()->setAttr(
@@ -362,6 +368,50 @@ TEST_F(QCTest, DenseUnitaryVerifierRejectsMalformedShapeAndDimension) {
 
   expectRejected({2});
   expectRejected({3, 3});
+}
+
+TEST_F(QCTest, DenseUnitaryVerifierRejectsUnsupportedArityAndAttributes) {
+  QCProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  const auto complexType = ComplexType::get(builder.getF64Type());
+
+  const auto scalarMatrix =
+      DenseElementsAttr::get(RankedTensorType::get({1, 1}, complexType),
+                             std::complex<double>{1.0, 0.0});
+  auto zeroQubitUnitary =
+      UnitaryOp::create(builder, scalarMatrix, ValueRange{});
+
+  const auto matrixType = RankedTensorType::get({2, 2}, complexType);
+  const auto indices = DenseElementsAttr::get(
+      RankedTensorType::get({1, 2}, builder.getI64Type()),
+      ArrayRef<int64_t>{0, 0});
+  const auto values = DenseElementsAttr::get(
+      RankedTensorType::get({1}, complexType), std::complex<double>{1.0, 0.0});
+  const auto sparseMatrix =
+      SparseElementsAttr::get(matrixType, indices, values);
+  auto sparseUnitary =
+      UnitaryOp::create(builder, sparseMatrix, ValueRange{qubit});
+
+  const auto realMatrix = DenseElementsAttr::get(
+      RankedTensorType::get({2, 2}, builder.getF64Type()), 0.0);
+  auto realUnitary = UnitaryOp::create(builder, realMatrix, ValueRange{qubit});
+
+  ScopedDiagnosticHandler handler(context.get(),
+                                  [](Diagnostic&) { return success(); });
+  EXPECT_TRUE(failed(zeroQubitUnitary.verify()));
+  EXPECT_TRUE(failed(sparseUnitary.verify()));
+  EXPECT_TRUE(failed(realUnitary.verify()));
+
+  EXPECT_FALSE(utils::isExactIdentityMatrix(sparseMatrix));
+  const auto rankOneMatrix = DenseElementsAttr::get(
+      RankedTensorType::get({2}, complexType), std::complex<double>{0.0, 0.0});
+  EXPECT_FALSE(utils::isExactIdentityMatrix(rankOneMatrix));
+  EXPECT_FALSE(utils::isExactIdentityMatrix(realMatrix));
+
+  zeroQubitUnitary.erase();
+  sparseUnitary.erase();
+  realUnitary.erase();
 }
 
 TEST_F(QCTest, DenseUnitaryVerifierRejectsRepeatedQubit) {

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -47,6 +47,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iosfwd>
+#include <limits>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -336,18 +337,27 @@ TEST_F(QCTest, DenseUnitaryVerifierRejectsNonUnitaryMatrix) {
   const auto qubit = builder.allocQubit();
   const auto matrixType =
       RankedTensorType::get({2, 2}, ComplexType::get(builder.getF64Type()));
-  const std::array<std::complex<double>, 4> values{
-      {{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.5, 0.0}}};
-  auto unitary = UnitaryOp::create(
-      builder,
-      DenseElementsAttr::get(matrixType,
-                             llvm::ArrayRef<std::complex<double>>(values)),
-      ValueRange{qubit});
-
   ScopedDiagnosticHandler handler(context.get(),
                                   [](Diagnostic&) { return success(); });
-  EXPECT_TRUE(failed(unitary.verify()));
-  unitary.erase();
+  const auto expectRejected = [&](const ArrayRef<std::complex<double>> values) {
+    auto unitary = UnitaryOp::create(
+        builder, DenseElementsAttr::get(matrixType, values), ValueRange{qubit});
+    EXPECT_TRUE(failed(unitary.verify()));
+    unitary.erase();
+  };
+
+  const std::array<std::complex<double>, 4> nonUnitaryValues{
+      {{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.5, 0.0}}};
+  expectRejected(nonUnitaryValues);
+
+  const std::array<std::complex<double>, 4> nonOrthogonalValues{
+      {{1.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}}};
+  expectRejected(nonOrthogonalValues);
+
+  const auto maximum = std::numeric_limits<double>::max();
+  const std::array<std::complex<double>, 4> overflowingValues{
+      {{maximum, maximum}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}}};
+  expectRejected(overflowingValues);
 }
 
 TEST_F(QCTest, DenseUnitaryVerifierRejectsMalformedShapeAndDimension) {

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -28,6 +29,7 @@
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
@@ -40,6 +42,7 @@
 #include <mlir/Support/LLVM.h>
 
 #include <array>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <iosfwd>
@@ -288,6 +291,130 @@ TEST_F(QCTest, DirectSingleQubitPowBuilder) {
   EXPECT_EQ(pow.getQubits().front(), qubit);
   EXPECT_EQ(pow.getBody()->getArgument(0), bodyQubit);
   EXPECT_TRUE(pow.verify().succeeded());
+}
+
+TEST_F(QCTest, DenseUnitaryBuilderVerifiesAndCanonicalizesIdentity) {
+  const auto matrixType = RankedTensorType::get(
+      {2, 2}, ComplexType::get(Float64Type::get(context.get())));
+  const std::array<std::complex<double>, 4> xValues{
+      {{0.0, 0.0}, {1.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}}};
+  const auto xMatrix = DenseElementsAttr::get(
+      matrixType, llvm::ArrayRef<std::complex<double>>(xValues));
+
+  QCProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  builder.unitary(ValueRange{qubit}, xMatrix);
+  auto module = builder.finalize();
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  auto function = *module->getOps<func::FuncOp>().begin();
+  auto unitaries = llvm::to_vector(function.getBody().getOps<UnitaryOp>());
+  ASSERT_EQ(unitaries.size(), 1U);
+  EXPECT_EQ(unitaries.front().getMatrix(), xMatrix);
+
+  const std::array<std::complex<double>, 4> identityValues{
+      {{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}}};
+  unitaries.front()->setAttr(
+      "matrix",
+      DenseElementsAttr::get(
+          matrixType, llvm::ArrayRef<std::complex<double>>(identityValues)));
+  ASSERT_TRUE(succeeded(runQCCleanupPipeline(*module)));
+  EXPECT_TRUE(function.getBody().getOps<UnitaryOp>().empty());
+}
+
+TEST_F(QCTest, DenseUnitaryVerifierRejectsNonUnitaryMatrix) {
+  QCProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  const auto matrixType =
+      RankedTensorType::get({2, 2}, ComplexType::get(builder.getF64Type()));
+  const std::array<std::complex<double>, 4> values{
+      {{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.5, 0.0}}};
+  auto unitary = UnitaryOp::create(
+      builder,
+      DenseElementsAttr::get(matrixType,
+                             llvm::ArrayRef<std::complex<double>>(values)),
+      ValueRange{qubit});
+
+  ScopedDiagnosticHandler handler(context.get(),
+                                  [](Diagnostic&) { return success(); });
+  EXPECT_TRUE(failed(unitary.verify()));
+  unitary.erase();
+}
+
+TEST_F(QCTest, DenseUnitaryVerifierRejectsMalformedShapeAndDimension) {
+  QCProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  const auto complexType = ComplexType::get(builder.getF64Type());
+  const auto expectRejected = [&](const ArrayRef<int64_t> shape) {
+    const auto matrix =
+        DenseElementsAttr::get(RankedTensorType::get(shape, complexType),
+                               std::complex<double>{0.0, 0.0});
+    auto unitary = UnitaryOp::create(builder, matrix, ValueRange{qubit});
+    EXPECT_TRUE(failed(unitary.verify()));
+    unitary.erase();
+  };
+  ScopedDiagnosticHandler handler(context.get(),
+                                  [](Diagnostic&) { return success(); });
+
+  expectRejected({2});
+  expectRejected({3, 3});
+}
+
+TEST_F(QCTest, DenseUnitaryVerifierRejectsRepeatedQubit) {
+  QCProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  const auto matrixType =
+      RankedTensorType::get({4, 4}, ComplexType::get(builder.getF64Type()));
+  const std::array<std::complex<double>, 16> identityValues{{
+      {1.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {1.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {1.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {1.0, 0.0},
+  }};
+  const auto identity = DenseElementsAttr::get(
+      matrixType, llvm::ArrayRef<std::complex<double>>(identityValues));
+  auto unitary = UnitaryOp::create(builder, identity, ValueRange{qubit, qubit});
+
+  ScopedDiagnosticHandler handler(context.get(),
+                                  [](Diagnostic&) { return success(); });
+  EXPECT_TRUE(failed(unitary.verify()));
+  unitary.erase();
+}
+
+TEST_F(QCTest, DenseUnitaryVerifierRejectsMoreThanEightQubits) {
+  QCProgramBuilder builder(context.get());
+  builder.initialize();
+  llvm::SmallVector<Value, 9> qubits;
+  for (size_t index = 0; index < 9U; ++index) {
+    qubits.push_back(builder.allocQubit());
+  }
+  const auto matrixType =
+      RankedTensorType::get({512, 512}, ComplexType::get(builder.getF64Type()));
+  const auto matrix =
+      DenseElementsAttr::get(matrixType, std::complex<double>{0.0, 0.0});
+  auto unitary = UnitaryOp::create(builder, matrix, ValueRange{qubits});
+
+  ScopedDiagnosticHandler handler(context.get(),
+                                  [](Diagnostic&) { return success(); });
+  EXPECT_TRUE(failed(unitary.verify()));
+  unitary.erase();
 }
 
 namespace {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
@@ -238,6 +238,18 @@ TEST_F(QCOMatrixTest, DenseUnitaryBuilderExposesMatrixAndFoldsIdentity) {
                 unitaries.front().getQubitsIn().front()),
             unitaries.front().getQubitsOut().front());
 
+  ASSERT_TRUE(succeeded(runQCOCleanupPipeline(*module)));
+  unitaries = llvm::to_vector(function.getBody().getOps<UnitaryOp>());
+  ASSERT_EQ(unitaries.size(), 1U);
+  EXPECT_TRUE(
+      unitaries.front().getUnitaryMatrix().isApprox(XOp::getUnitaryMatrix()));
+  EXPECT_DEATH_IF_SUPPORTED((void)unitaries.front().getInputForOutput(
+                                unitaries.front().getQubitsIn().front()),
+                            "Given qubit is not an output of UnitaryOp");
+  EXPECT_DEATH_IF_SUPPORTED((void)unitaries.front().getOutputForInput(
+                                unitaries.front().getQubitsOut().front()),
+                            "Given qubit is not an input of UnitaryOp");
+
   const std::array<std::complex<double>, 4> identityValues{
       {{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}}};
   unitaries.front()->setAttr(

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
@@ -33,19 +33,24 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Support/LLVM.h>
 
+#include <array>
 #include <cmath>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <numbers>
 #include <optional>
@@ -202,6 +207,175 @@ protected:
 };
 
 } // namespace
+
+/// \name QCO/Operations/UnitaryOp.cpp
+/// @{
+TEST_F(QCOMatrixTest, DenseUnitaryBuilderExposesMatrixAndFoldsIdentity) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  const auto matrixType =
+      RankedTensorType::get({2, 2}, ComplexType::get(builder.getF64Type()));
+  const std::array<std::complex<double>, 4> xValues{
+      {{0.0, 0.0}, {1.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}}};
+  builder.unitary(
+      ValueRange{qubit},
+      DenseElementsAttr::get(matrixType,
+                             llvm::ArrayRef<std::complex<double>>(xValues)));
+  auto module = builder.finalize();
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  auto function = *module->getOps<func::FuncOp>().begin();
+  auto unitaries = llvm::to_vector(function.getBody().getOps<UnitaryOp>());
+  ASSERT_EQ(unitaries.size(), 1U);
+  EXPECT_TRUE(
+      unitaries.front().getUnitaryMatrix().isApprox(XOp::getUnitaryMatrix()));
+  EXPECT_EQ(unitaries.front().getInputForOutput(
+                unitaries.front().getQubitsOut().front()),
+            unitaries.front().getQubitsIn().front());
+  EXPECT_EQ(unitaries.front().getOutputForInput(
+                unitaries.front().getQubitsIn().front()),
+            unitaries.front().getQubitsOut().front());
+
+  const std::array<std::complex<double>, 4> identityValues{
+      {{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}}};
+  unitaries.front()->setAttr(
+      "matrix",
+      DenseElementsAttr::get(
+          matrixType, llvm::ArrayRef<std::complex<double>>(identityValues)));
+  ASSERT_TRUE(succeeded(runQCOCleanupPipeline(*module)));
+  EXPECT_TRUE(function.getBody().getOps<UnitaryOp>().empty());
+}
+
+TEST_F(QCOMatrixTest, DenseUnitaryVerifierRejectsRepeatedQubit) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  const auto matrixType =
+      RankedTensorType::get({4, 4}, ComplexType::get(builder.getF64Type()));
+  const std::array<std::complex<double>, 16> identityValues{{
+      {1.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {1.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {1.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {0.0, 0.0},
+      {1.0, 0.0},
+  }};
+  const auto identity = DenseElementsAttr::get(
+      matrixType, llvm::ArrayRef<std::complex<double>>(identityValues));
+  auto unitary = UnitaryOp::create(builder, ValueRange{qubit, qubit}, identity);
+
+  ScopedDiagnosticHandler handler(context.get(),
+                                  [](Diagnostic&) { return success(); });
+  EXPECT_TRUE(failed(unitary.verify()));
+  unitary.erase();
+}
+
+TEST_F(QCOMatrixTest, DenseUnitaryVerifierRejectsNonFiniteMatrices) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  const auto matrixType =
+      RankedTensorType::get({2, 2}, ComplexType::get(builder.getF64Type()));
+  const auto expectRejected = [&](const double value) {
+    const auto matrix =
+        DenseElementsAttr::get(matrixType, std::complex<double>{value, 0.0});
+    auto unitary = UnitaryOp::create(builder, ValueRange{qubit}, matrix);
+    EXPECT_TRUE(failed(unitary.verify()));
+    unitary.erase();
+  };
+  ScopedDiagnosticHandler handler(context.get(),
+                                  [](Diagnostic&) { return success(); });
+
+  expectRejected(std::numeric_limits<double>::infinity());
+  expectRejected(std::numeric_limits<double>::quiet_NaN());
+}
+
+TEST_F(QCOMatrixTest, DenseUnitaryVerifierRejectsOutputArityMismatch) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto qubit = builder.allocQubit();
+  const auto matrixType =
+      RankedTensorType::get({2, 2}, ComplexType::get(builder.getF64Type()));
+  const std::array<std::complex<double>, 4> identityValues{
+      {{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {1.0, 0.0}}};
+  const auto identity = DenseElementsAttr::get(
+      matrixType, llvm::ArrayRef<std::complex<double>>(identityValues));
+  OperationState state(builder.getLoc(), UnitaryOp::getOperationName());
+  UnitaryOp::build(builder, state, ValueRange{qubit}, identity);
+  state.addTypes(QubitType::get(context.get()));
+  auto unitary = cast<UnitaryOp>(builder.create(state));
+
+  ScopedDiagnosticHandler handler(context.get(),
+                                  [](Diagnostic&) { return success(); });
+  EXPECT_TRUE(failed(unitary.verify()));
+  unitary.erase();
+}
+
+TEST_F(QCOMatrixTest, DenseUnitaryComposesThroughModifiers) {
+  const auto matrixType = RankedTensorType::get(
+      {2, 2}, ComplexType::get(Float64Type::get(context.get())));
+  const std::array<std::complex<double>, 4> sValues{
+      {{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 1.0}}};
+  const auto sMatrix = DenseElementsAttr::get(
+      matrixType, llvm::ArrayRef<std::complex<double>>(sValues));
+
+  auto inverse =
+      QCOProgramBuilder::build(context.get(), [&](QCOProgramBuilder& builder) {
+        auto qubit = builder.allocQubit();
+        qubit = builder.inv(qubit, [&](const Value argument) {
+          return builder.unitary(ValueRange{argument}, sMatrix).front();
+        });
+        return builder.measure(qubit).second;
+      });
+  ASSERT_TRUE(inverse);
+  const auto inverseMatrix = firstInvOp(*inverse).getUnitaryMatrix();
+  ASSERT_TRUE(inverseMatrix);
+  EXPECT_TRUE(inverseMatrix->isApprox(
+      DynamicMatrix(SOp::getUnitaryMatrix().adjoint())));
+
+  auto controlled =
+      QCOProgramBuilder::build(context.get(), [&](QCOProgramBuilder& builder) {
+        auto qubits = builder.allocQubitRegister(2);
+        const auto outputs =
+            builder.ctrl(qubits[0], qubits[1], [&](const Value argument) {
+              return builder.unitary(ValueRange{argument}, sMatrix).front();
+            });
+        return builder.measure(outputs.second).second;
+      });
+  ASSERT_TRUE(controlled);
+  const auto controlledMatrix = firstCtrlOp(*controlled).getUnitaryMatrix();
+  ASSERT_TRUE(controlledMatrix);
+  DynamicMatrix expected = DynamicMatrix::identity(4);
+  expected.setBottomRightCorner(SOp::getUnitaryMatrix());
+  EXPECT_TRUE(controlledMatrix->isApprox(expected));
+
+  auto powered =
+      QCOProgramBuilder::build(context.get(), [&](QCOProgramBuilder& builder) {
+        auto qubit = builder.allocQubit();
+        qubit = builder.pow(-1.0, qubit, [&](const Value argument) {
+          return builder.unitary(ValueRange{argument}, sMatrix).front();
+        });
+        return builder.measure(qubit).second;
+      });
+  ASSERT_TRUE(powered);
+  const auto poweredMatrix = firstPowOp(*powered).getUnitaryMatrix();
+  ASSERT_TRUE(poweredMatrix);
+  EXPECT_TRUE(poweredMatrix->isApprox(
+      DynamicMatrix(SOp::getUnitaryMatrix().adjoint())));
+}
+/// @}
 
 /// \name QCO/Modifiers/CtrlOp.cpp
 /// @{

--- a/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
@@ -24,11 +24,15 @@
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/Pass.h>
@@ -37,6 +41,8 @@
 #include <mlir/Support/LogicalResult.h>
 
 #include <algorithm>
+#include <array>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -54,11 +60,13 @@ using Site = Target::Site;
 using mlir::ModuleOp;
 using mlir::OwningOpRef;
 using mlir::Value;
+using mlir::ValueRange;
 using mlir::qco::CtrlOp;
 using mlir::qco::HOp;
 using mlir::qco::QCOProgramBuilder;
 using mlir::qco::RXXOp;
 using mlir::qco::SWAPOp;
+using mlir::qco::UnitaryOp;
 using mlir::qco::XOp;
 using mlir::qco::ZOp;
 
@@ -146,6 +154,41 @@ makeUCxTarget(std::optional<std::vector<Site>> sites = std::nullopt) {
   return valid(
       Target::create(std::move(*sites), std::nullopt, std::move(operations)));
 }
+
+[[nodiscard]] static mlir::DenseElementsAttr
+denseMatrix(QCOProgramBuilder& builder, const int64_t dimension,
+            const llvm::ArrayRef<std::complex<double>> values) {
+  const auto type = mlir::RankedTensorType::get(
+      {dimension, dimension}, mlir::ComplexType::get(builder.getF64Type()));
+  return mlir::DenseElementsAttr::get(type, values);
+}
+
+constexpr std::array<std::complex<double>, 4> X_MATRIX{{
+    {0.0, 0.0},
+    {1.0, 0.0},
+    {1.0, 0.0},
+    {0.0, 0.0},
+}};
+
+// CX with operand 0 as the most-significant (control) qubit.
+constexpr std::array<std::complex<double>, 16> CX_MATRIX{{
+    {1.0, 0.0},
+    {0.0, 0.0},
+    {0.0, 0.0},
+    {0.0, 0.0},
+    {0.0, 0.0},
+    {1.0, 0.0},
+    {0.0, 0.0},
+    {0.0, 0.0},
+    {0.0, 0.0},
+    {0.0, 0.0},
+    {0.0, 0.0},
+    {1.0, 0.0},
+    {0.0, 0.0},
+    {0.0, 0.0},
+    {1.0, 0.0},
+    {0.0, 0.0},
+}};
 
 namespace {
 
@@ -347,6 +390,72 @@ TEST_F(TargetSynthesisTest,
   ASSERT_TRUE(mlir::succeeded(
       runPass(*synthesized, mlir::qco::createVerifyTargetConformance(target))));
   expectEquivalent(expected, synthesized);
+}
+
+TEST_F(TargetSynthesisTest, DenseUnitaryHasAsymmetricTwoQubitDDSemantics) {
+  const auto denseCx = [](QCOProgramBuilder& builder) {
+    auto q0 = builder.staticQubit(0);
+    auto q1 = builder.staticQubit(1);
+    builder.unitary(ValueRange{q0, q1}, denseMatrix(builder, 4, CX_MATRIX));
+    return builder.intConstant(0);
+  };
+  const auto cxReference = [](QCOProgramBuilder& builder) {
+    auto q0 = builder.staticQubit(0);
+    auto q1 = builder.staticQubit(1);
+    std::tie(q0, q1) = builder.cx(q0, q1);
+    return builder.intConstant(0);
+  };
+  auto expected = build(cxReference);
+  auto actual = build(denseCx);
+
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*actual)));
+  expectEquivalent(expected, actual);
+}
+
+TEST_F(TargetSynthesisTest,
+       TargetNativeSynthesisLowersDenseOneAndTwoQubitMatrices) {
+  const auto denseX = [](QCOProgramBuilder& builder) {
+    const auto qubit = builder.staticQubit(0);
+    builder.unitary(ValueRange{qubit}, denseMatrix(builder, 2, X_MATRIX));
+    return builder.intConstant(0);
+  };
+  const auto xReference = [](QCOProgramBuilder& builder) {
+    auto qubit = builder.staticQubit(0);
+    qubit = builder.x(qubit);
+    return builder.intConstant(0);
+  };
+  auto expectedX = build(xReference);
+  auto synthesizedX = build(denseX);
+  const auto target = makeUCxTarget();
+
+  ASSERT_TRUE(mlir::succeeded(
+      runPass(*synthesizedX, mlir::qco::createTargetNativeSynthesis(target))));
+  EXPECT_EQ(countOps<UnitaryOp>(*synthesizedX), 0U);
+  ASSERT_TRUE(mlir::succeeded(runPass(
+      *synthesizedX, mlir::qco::createVerifyTargetConformance(target))));
+  expectEquivalent(expectedX, synthesizedX);
+
+  const auto denseCx = [](QCOProgramBuilder& builder) {
+    auto q0 = builder.staticQubit(0);
+    auto q1 = builder.staticQubit(1);
+    builder.unitary(ValueRange{q0, q1}, denseMatrix(builder, 4, CX_MATRIX));
+    return builder.intConstant(0);
+  };
+  const auto cxReference = [](QCOProgramBuilder& builder) {
+    auto q0 = builder.staticQubit(0);
+    auto q1 = builder.staticQubit(1);
+    std::tie(q0, q1) = builder.cx(q0, q1);
+    return builder.intConstant(0);
+  };
+  auto expectedCx = build(cxReference);
+  auto synthesizedCx = build(denseCx);
+
+  ASSERT_TRUE(mlir::succeeded(
+      runPass(*synthesizedCx, mlir::qco::createTargetNativeSynthesis(target))));
+  EXPECT_EQ(countOps<UnitaryOp>(*synthesizedCx), 0U);
+  ASSERT_TRUE(mlir::succeeded(runPass(
+      *synthesizedCx, mlir::qco::createVerifyTargetConformance(target))));
+  expectEquivalent(expectedCx, synthesizedCx);
 }
 
 TEST_F(TargetSynthesisTest, TargetNativeSynthesisPreservesNativeSwap) {

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -139,7 +139,7 @@ def test_dense_unitary_round_trip_preserves_qarg_mapping_and_source_data() -> No
 
 
 def test_dense_unitary_import_converts_qiskit_qubit_order() -> None:
-    """Convert Qiskit's least-significant-first matrix to QC's convention."""
+    """Convert Qiskit's qubit order by reversing the operation targets."""
     matrix = np.array([
         [0.0, 1.0, 0.0, 0.0],
         [0.0, 0.0, 1.0j, 0.0],
@@ -155,9 +155,8 @@ def test_dense_unitary_import_converts_qiskit_qubit_order() -> None:
     matches = re.findall(r"\(([-+0-9.eE]+),([-+0-9.eE]+)\)", dense_text)
     entries = [complex(float(real), float(imaginary)) for real, imaginary in matches]
     imported = np.asarray(entries).reshape((4, 4))
-    bit_reversal = [0, 2, 1, 3]
-    expected = matrix[np.ix_(bit_reversal, bit_reversal)]
-    assert np.allclose(imported, expected)
+    assert np.allclose(imported, matrix)
+    assert "%1, %0 : !qc.qubit, !qc.qubit" in ir
 
 
 @pytest.mark.parametrize("num_qubits", [1, 2, 3])

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -183,7 +183,7 @@ def test_dense_unitary_import_rejects_more_than_eight_qubits() -> None:
         range(9),
     )
 
-    with pytest.raises(RuntimeError, match="eight-qubit limit"):
+    with pytest.raises(RuntimeError, match=r"supports at most \d+ qubits"):
         QCProgram.from_qiskit(circuit)
 
 
@@ -221,19 +221,21 @@ def test_two_qubit_dense_unitary_compiles_to_target_basis() -> None:
     assert set(restored.count_ops()) <= {"u", "cx"}
 
 
-def test_controlled_dense_unitary_export_is_rejected() -> None:
-    """Reject a controlled dense matrix until Qiskit export can preserve it."""
+def test_controlled_dense_unitary_export_preserves_operation_order() -> None:
+    """Export a controlled dense matrix with a Qiskit control annotation."""
     program = QCProgram.from_mlir_str(
         """module {
   func.func @main() attributes {passthrough = ["entry_point"]} {
     %control = qc.alloc : !qc.qubit
     %target = qc.alloc : !qc.qubit
+    qc.x %control : !qc.qubit
     qc.ctrl(%control) targets (%argument = %target) {
       qc.unitary dense<[[(0.0,0.0), (1.0,0.0)],
                         [(1.0,0.0), (0.0,0.0)]]>
           : tensor<2x2xcomplex<f64>> %argument : !qc.qubit
       qc.yield
     } : {!qc.qubit}, {!qc.qubit}
+    qc.z %target : !qc.qubit
     qc.dealloc %control : !qc.qubit
     qc.dealloc %target : !qc.qubit
     return
@@ -242,35 +244,121 @@ def test_controlled_dense_unitary_export_is_rejected() -> None:
 """
     )
 
-    with pytest.raises(RuntimeError, match="does not support dense unitary matrices"):
-        program.to_qiskit()
+    restored = program.to_qiskit()
+
+    assert [item.operation.name for item in restored.data[:1]] == ["x"]
+    assert [item.operation.name for item in restored.data[2:]] == ["z"]
+    controlled = restored.data[1]
+    assert isinstance(controlled.operation, AnnotatedOperation)
+    assert len(controlled.operation.modifiers) == 1
+    modifier = controlled.operation.modifiers[0]
+    assert isinstance(modifier, ControlModifier)
+    assert modifier.num_ctrl_qubits == 1
+    assert modifier.ctrl_state == 1
+    assert [restored.find_bit(qubit).index for qubit in controlled.qubits] == [0, 1]
+    expected = QuantumCircuit(2)
+    expected.x(0)
+    expected.cx(0, 1)
+    expected.z(1)
+    assert np.allclose(Operator(restored).data, Operator(expected).data)
 
 
-def test_wrapped_dense_unitary_import_is_rejected_without_abort() -> None:
-    """Reject wrapped dense matrices before entering Qiskit's C accessor."""
+def test_wrapped_dense_unitary_import_avoids_unsafe_c_accessor() -> None:
+    """Import wrapped dense matrices without entering Qiskit's C accessor."""
     script = """
 import numpy as np
 from qiskit import QuantumCircuit
-from qiskit.circuit import AnnotatedOperation
+from qiskit.circuit import (
+    AnnotatedOperation,
+    ControlModifier,
+    InverseModifier,
+    PowerModifier,
+)
 from qiskit.circuit.library import UnitaryGate
 from mqt.core.mlir import QCProgram
 
 unitary = UnitaryGate(np.array([[0.0, 1.0], [1.0, 0.0]]))
 renamed = UnitaryGate(np.array([[0.0, 1.0], [1.0, 0.0]]))
 renamed.name = "renamed_unitary"
-operations = [unitary.control(1), AnnotatedOperation(unitary, []), renamed]
+operations = [
+    unitary.control(1),
+    AnnotatedOperation(unitary, []),
+    AnnotatedOperation(unitary, InverseModifier()),
+    AnnotatedOperation(unitary, PowerModifier(0.5)),
+    AnnotatedOperation(unitary, ControlModifier(1)),
+    renamed,
+]
 for operation in operations:
     circuit = QuantumCircuit(operation.num_qubits)
     circuit.append(operation, circuit.qubits)
-    try:
-        QCProgram.from_qiskit(circuit)
-    except RuntimeError as error:
-        assert "native, unwrapped UnitaryGate instructions" in str(error)
-    else:
-        raise AssertionError("wrapped dense unitary import unexpectedly succeeded")
+    program = QCProgram.from_qiskit(circuit)
+    assert "qc.unitary" in program.ir
 """
 
     subprocess.run([sys.executable, "-c", script], check=True)  # ruff: ignore[subprocess-without-shell-equals-true]
+
+
+@pytest.mark.parametrize(
+    ("modifier", "expected"),
+    [
+        (InverseModifier(), "qc.inv"),
+        (PowerModifier(0.5), "qc.pow"),
+        (ControlModifier(2), "qc.ctrl"),
+    ],
+    ids=["inverse", "power", "control"],
+)
+def test_dense_unitary_modifiers_are_imported(
+    modifier: InverseModifier | PowerModifier | ControlModifier, expected: str
+) -> None:
+    """Preserve supported Qiskit modifiers around dense unitary operations."""
+    operation = AnnotatedOperation(
+        library.UnitaryGate(np.asarray([[1.0, 0.0], [0.0, 1.0j]])),
+        modifier,
+    )
+    circuit = QuantumCircuit(operation.num_qubits)
+    circuit.append(operation, circuit.qubits)
+
+    program = QCProgram.from_qiskit(circuit)
+
+    assert "qc.unitary" in program.ir
+    assert expected in program.ir
+    if not isinstance(modifier, PowerModifier):
+        restored = program.to_qiskit()
+        assert np.allclose(Operator(restored).data, Operator(circuit).data)
+
+
+def test_controlled_dense_unitary_round_trip_preserves_qarg_order() -> None:
+    """Preserve controls and target ordering around an asymmetric matrix."""
+    operation = library.UnitaryGate(random_unitary(4, seed=2136)).control(1)
+    circuit = QuantumCircuit(4)
+    circuit.append(operation, [3, 0, 2])
+
+    program = QCProgram.from_qiskit(circuit)
+    restored = program.to_qiskit()
+
+    assert "qc.ctrl" in program.ir
+    assert "qc.unitary" in program.ir
+    controlled = restored.data[0]
+    assert [restored.find_bit(qubit).index for qubit in controlled.qubits] == [3, 0, 2]
+    assert np.allclose(Operator(restored).data, Operator(circuit).data)
+
+
+def test_inverse_controlled_dense_unitary_round_trip() -> None:
+    """Preserve inverse and control modifiers around one dense unitary."""
+    unitary = library.UnitaryGate(np.asarray([[1.0, 0.0], [0.0, 1.0j]]))
+    operation = AnnotatedOperation(
+        AnnotatedOperation(unitary, ControlModifier(1)),
+        InverseModifier(),
+    )
+    circuit = QuantumCircuit(2)
+    circuit.append(operation, circuit.qubits)
+
+    program = QCProgram.from_qiskit(circuit)
+    restored = program.to_qiskit()
+
+    assert "qc.ctrl" in program.ir
+    assert "qc.inv" in program.ir
+    assert np.allclose(Operator(restored).data, Operator(circuit).data)
 
 
 @pytest.mark.parametrize(

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 
@@ -108,8 +109,8 @@ def test_standard_gates_round_trip(gate: Gate) -> None:
     assert np.allclose(Operator(restored).data, Operator(circuit).data)
 
 
-def test_unitary_definition_expansion_preserves_qarg_mapping_and_source_data() -> None:
-    """Expand a numeric unitary definition without changing the source circuit data."""
+def test_dense_unitary_round_trip_preserves_qarg_mapping_and_source_data() -> None:
+    """Preserve a dense unitary and its qubit mapping without changing source data."""
     local = QuantumCircuit(2)
     local.global_phase = 0.23
     local.h(0)
@@ -118,40 +119,158 @@ def test_unitary_definition_expansion_preserves_qarg_mapping_and_source_data() -
 
     circuit = QuantumCircuit(3)
     circuit.x(1)
-    circuit.append(library.UnitaryGate(Operator(local)), [2, 0])
+    local_operator = Operator(local)
+    circuit.append(library.UnitaryGate(local_operator), [2, 0])
     source_data = list(circuit.data)
     source_operator = Operator(circuit)
 
-    restored = QCProgram.from_qiskit(circuit).to_qiskit()
+    program = QCProgram.from_qiskit(circuit)
+    restored = program.to_qiskit()
 
+    assert "qc.unitary" in program.ir
     assert np.allclose(Operator(restored).data, source_operator.data)
     assert np.allclose(Operator(circuit).data, source_operator.data)
     assert list(circuit.data) == source_data
     assert circuit.count_ops() == {"x": 1, "unitary": 1}
-    assert "unitary" not in restored.count_ops()
+    assert restored.count_ops() == {"x": 1, "unitary": 1}
+    restored_unitary = next(item for item in restored.data if item.operation.name == "unitary")
+    assert [restored.find_bit(qubit).index for qubit in restored_unitary.qubits] == [2, 0]
+    assert np.allclose(Operator(restored_unitary.operation).data, local_operator.data)
+
+
+def test_dense_unitary_import_converts_qiskit_qubit_order() -> None:
+    """Convert Qiskit's least-significant-first matrix to QC's convention."""
+    matrix = np.array([
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0j, 0.0],
+        [0.0, 0.0, 0.0, -1.0],
+        [-1.0j, 0.0, 0.0, 0.0],
+    ])
+    circuit = QuantumCircuit(2)
+    circuit.append(library.UnitaryGate(matrix), [0, 1])
+
+    ir = QCProgram.from_qiskit(circuit).ir
+
+    dense_text = ir.split("qc.unitary dense<[", 1)[1].split("]>", 1)[0]
+    matches = re.findall(r"\(([-+0-9.eE]+),([-+0-9.eE]+)\)", dense_text)
+    entries = [complex(float(real), float(imaginary)) for real, imaginary in matches]
+    imported = np.asarray(entries).reshape((4, 4))
+    bit_reversal = [0, 2, 1, 3]
+    expected = matrix[np.ix_(bit_reversal, bit_reversal)]
+    assert np.allclose(imported, expected)
 
 
 @pytest.mark.parametrize("num_qubits", [1, 2, 3])
-def test_unitary_definition_synthesis_paths(num_qubits: int) -> None:
-    """Import Qiskit's one-, two-, and three-qubit synthesis paths."""
+def test_dense_unitary_round_trip(num_qubits: int) -> None:
+    """Preserve one-, two-, and three-qubit dense unitaries."""
     circuit = QuantumCircuit(num_qubits)
     matrix = random_unitary(2**num_qubits, seed=100 + num_qubits)
     circuit.append(library.UnitaryGate(matrix), range(num_qubits))
 
-    restored = QCProgram.from_qiskit(circuit).to_qiskit()
+    program = QCProgram.from_qiskit(circuit)
+    restored = program.to_qiskit()
 
+    assert "qc.unitary" in program.ir
     assert np.allclose(Operator(restored).data, Operator(circuit).data)
+    assert restored.count_ops() == {"unitary": 1}
 
 
-def test_quantum_volume_unitaries_import_through_definitions() -> None:
-    """Import the definition-backed unitaries used by Quantum Volume."""
+def test_dense_unitary_import_rejects_more_than_eight_qubits() -> None:
+    """Reject oversized matrices before constructing a compiler program."""
+    circuit = QuantumCircuit(9)
+    circuit.append(
+        library.UnitaryGate(np.eye(2**9), check_input=False),
+        range(9),
+    )
+
+    with pytest.raises(RuntimeError, match="eight-qubit limit"):
+        QCProgram.from_qiskit(circuit)
+
+
+def test_quantum_volume_unitaries_remain_dense() -> None:
+    """Preserve the dense two-qubit unitaries used by Quantum Volume."""
     circuit = library.quantum_volume(4, depth=3, seed=12345)
     assert circuit.count_ops().get("unitary") == 6
 
-    restored = QCProgram.from_qiskit(circuit).to_qiskit()
+    program = QCProgram.from_qiskit(circuit)
+    restored = program.to_qiskit()
 
+    assert program.ir.count("qc.unitary") == 6
     assert np.allclose(Operator(restored).data, Operator(circuit).data)
-    assert "unitary" not in restored.count_ops()
+    assert restored.count_ops().get("unitary") == 6
+
+
+def test_two_qubit_dense_unitary_compiles_to_target_basis() -> None:
+    """Synthesize a dense two-qubit unitary to the target basis."""
+    circuit = QuantumCircuit(2)
+    circuit.append(library.UnitaryGate(random_unitary(4, seed=2136)), [0, 1])
+    target = CompilerTarget(
+        2,
+        operations=[
+            CompilerTarget.Operation("u", 1, 3),
+            CompilerTarget.Operation("cx", 2, 0),
+        ],
+    )
+    program = QCProgram.from_qiskit(circuit).to_qco(copy=True)
+
+    program.compile_for_target(target)
+    restored = program.to_qc(copy=True).to_qiskit(target=target)
+
+    assert "qco.unitary" not in program.ir
+    assert restored.size() > 0
+    assert set(restored.count_ops()) <= {"u", "cx"}
+
+
+def test_controlled_dense_unitary_export_is_rejected() -> None:
+    """Reject a controlled dense matrix until Qiskit export can preserve it."""
+    program = QCProgram.from_mlir_str(
+        """module {
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %control = qc.alloc : !qc.qubit
+    %target = qc.alloc : !qc.qubit
+    qc.ctrl(%control) targets (%argument = %target) {
+      qc.unitary dense<[[(0.0,0.0), (1.0,0.0)],
+                        [(1.0,0.0), (0.0,0.0)]]>
+          : tensor<2x2xcomplex<f64>> %argument : !qc.qubit
+      qc.yield
+    } : {!qc.qubit}, {!qc.qubit}
+    qc.dealloc %control : !qc.qubit
+    qc.dealloc %target : !qc.qubit
+    return
+  }
+}
+"""
+    )
+
+    with pytest.raises(RuntimeError, match="does not support dense unitary matrices"):
+        program.to_qiskit()
+
+
+def test_wrapped_dense_unitary_import_is_rejected_without_abort() -> None:
+    """Reject wrapped dense matrices before entering Qiskit's C accessor."""
+    script = """
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.circuit import AnnotatedOperation
+from qiskit.circuit.library import UnitaryGate
+from mqt.core.mlir import QCProgram
+
+unitary = UnitaryGate(np.array([[0.0, 1.0], [1.0, 0.0]]))
+renamed = UnitaryGate(np.array([[0.0, 1.0], [1.0, 0.0]]))
+renamed.name = "renamed_unitary"
+operations = [unitary.control(1), AnnotatedOperation(unitary, []), renamed]
+for operation in operations:
+    circuit = QuantumCircuit(operation.num_qubits)
+    circuit.append(operation, circuit.qubits)
+    try:
+        QCProgram.from_qiskit(circuit)
+    except RuntimeError as error:
+        assert "native, unwrapped UnitaryGate instructions" in str(error)
+    else:
+        raise AssertionError("wrapped dense unitary import unexpectedly succeeded")
+"""
+
+    subprocess.run([sys.executable, "-c", script], check=True)  # ruff: ignore[subprocess-without-shell-equals-true]
 
 
 @pytest.mark.parametrize(
@@ -378,8 +497,7 @@ def test_cyclic_and_excessively_nested_definitions_are_rejected() -> None:
         QCProgram.from_qiskit(too_deep)
 
 
-@pytest.mark.parametrize("root_kind", ["custom", "unitary"])
-def test_exponential_definition_expansion_is_rejected_by_budget(root_kind: str) -> None:
+def test_exponential_definition_expansion_is_rejected_by_budget() -> None:
     """Count repeated definitions without materializing their full expansion."""
     leaf_definition = QuantumCircuit(1)
     leaf_definition.h(0)
@@ -391,14 +509,8 @@ def test_exponential_definition_expansion_is_rejected_by_budget(root_kind: str) 
         definition.append(nested, [0])
         nested = Gate(f"branch_{level}", 1, [])
         nested.definition = definition
-    root: Gate = nested
-    if root_kind == "unitary":
-        definition = QuantumCircuit(1)
-        definition.append(nested, [0])
-        root = library.UnitaryGate(np.eye(2))
-        root.definition = definition
     circuit = QuantumCircuit(1)
-    circuit.append(root, [0])
+    circuit.append(nested, [0])
 
     with pytest.raises(RuntimeError, match="expansion exceeds 10000000 operations"):
         QCProgram.from_qiskit(circuit)

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -31,7 +31,7 @@ from qiskit.circuit import (
     library,
 )
 from qiskit.circuit.classical import expr, types
-from qiskit.quantum_info import Operator
+from qiskit.quantum_info import Operator, random_unitary
 
 from mqt.core.mlir import CompilerTarget, QCProgram, compile_program
 from mqt.core.plugins.qiskit import qiskit_to_mqt
@@ -106,6 +106,52 @@ def test_standard_gates_round_trip(gate: Gate) -> None:
     restored = QCProgram.from_qiskit(circuit).to_qiskit()
 
     assert np.allclose(Operator(restored).data, Operator(circuit).data)
+
+
+def test_unitary_definition_expansion_preserves_qarg_mapping_and_source_data() -> None:
+    """Expand a numeric unitary definition without changing the source circuit data."""
+    local = QuantumCircuit(2)
+    local.global_phase = 0.23
+    local.h(0)
+    local.cx(0, 1)
+    local.rz(0.37, 1)
+
+    circuit = QuantumCircuit(3)
+    circuit.x(1)
+    circuit.append(library.UnitaryGate(Operator(local)), [2, 0])
+    source_data = list(circuit.data)
+    source_operator = Operator(circuit)
+
+    restored = QCProgram.from_qiskit(circuit).to_qiskit()
+
+    assert np.allclose(Operator(restored).data, source_operator.data)
+    assert np.allclose(Operator(circuit).data, source_operator.data)
+    assert list(circuit.data) == source_data
+    assert circuit.count_ops() == {"x": 1, "unitary": 1}
+    assert "unitary" not in restored.count_ops()
+
+
+@pytest.mark.parametrize("num_qubits", [1, 2, 3])
+def test_unitary_definition_synthesis_paths(num_qubits: int) -> None:
+    """Import Qiskit's one-, two-, and three-qubit synthesis paths."""
+    circuit = QuantumCircuit(num_qubits)
+    matrix = random_unitary(2**num_qubits, seed=100 + num_qubits)
+    circuit.append(library.UnitaryGate(matrix), range(num_qubits))
+
+    restored = QCProgram.from_qiskit(circuit).to_qiskit()
+
+    assert np.allclose(Operator(restored).data, Operator(circuit).data)
+
+
+def test_quantum_volume_unitaries_import_through_definitions() -> None:
+    """Import the definition-backed unitaries used by Quantum Volume."""
+    circuit = library.quantum_volume(4, depth=3, seed=12345)
+    assert circuit.count_ops().get("unitary") == 6
+
+    restored = QCProgram.from_qiskit(circuit).to_qiskit()
+
+    assert np.allclose(Operator(restored).data, Operator(circuit).data)
+    assert "unitary" not in restored.count_ops()
 
 
 @pytest.mark.parametrize(
@@ -332,7 +378,8 @@ def test_cyclic_and_excessively_nested_definitions_are_rejected() -> None:
         QCProgram.from_qiskit(too_deep)
 
 
-def test_exponential_definition_expansion_is_rejected_by_budget() -> None:
+@pytest.mark.parametrize("root_kind", ["custom", "unitary"])
+def test_exponential_definition_expansion_is_rejected_by_budget(root_kind: str) -> None:
     """Count repeated definitions without materializing their full expansion."""
     leaf_definition = QuantumCircuit(1)
     leaf_definition.h(0)
@@ -344,8 +391,14 @@ def test_exponential_definition_expansion_is_rejected_by_budget() -> None:
         definition.append(nested, [0])
         nested = Gate(f"branch_{level}", 1, [])
         nested.definition = definition
+    root: Gate = nested
+    if root_kind == "unitary":
+        definition = QuantumCircuit(1)
+        definition.append(nested, [0])
+        root = library.UnitaryGate(np.eye(2))
+        root.definition = definition
     circuit = QuantumCircuit(1)
-    circuit.append(nested, [0])
+    circuit.append(root, [0])
 
     with pytest.raises(RuntimeError, match="expansion exceeds 10000000 operations"):
         QCProgram.from_qiskit(circuit)
@@ -372,7 +425,7 @@ def test_value_list_loop_expansion_counts_each_iteration() -> None:
 
 
 def test_rejections_do_not_modify_source_circuits() -> None:
-    """Reject unsupported parameters, inputs, and unitaries without mutation."""
+    """Reject unsupported parameters and inputs without mutation."""
     theta = Parameter("theta")
     symbolic = QuantumCircuit(1)
     symbolic.rx(theta, 0)
@@ -390,13 +443,6 @@ def test_rejections_do_not_modify_source_circuits() -> None:
     with pytest.raises(RuntimeError, match="standalone classical variables"):
         QCProgram.from_qiskit(runtime_input)
     assert list(runtime_input.data) == input_data
-
-    unitary = QuantumCircuit(1)
-    unitary.unitary(np.eye(2), [0])
-    unitary_data = list(unitary.data)
-    with pytest.raises(RuntimeError, match="does not support arbitrary unitaries"):
-        QCProgram.from_qiskit(unitary)
-    assert list(unitary.data) == unitary_data
 
 
 @pytest.mark.parametrize("resource", ["quantum", "classical"])


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

- Add verified `qc.unitary` and `qco.unitary` operations for dense complex matrices on one to eight qubits.
- Preserve bare Qiskit `UnitaryGate` instructions across compiler import and export, including explicit conversion between Qiskit's LSB-first and QC/QCO's MSB-first matrix conventions.
- Integrate dense matrices with the QC/QCO builders and conversion, MLIR serialization, decision-diagram semantics, modifiers, and one- and two-qubit target synthesis.
- Preserve inverse, numeric-power, and closed-control modifiers around Qiskit dense unitaries without materializing controlled matrices; reject unsupported open controls before mutating compiler state.

Target-native synthesis remains limited to one- and two-qubit matrices; wider matrices remain representable, verifiable, serializable, and round-trippable through Qiskit.

Closes #2068.

## Testing

- 334 QC IR tests
- 485 QCO IR tests
- 3 QC/QCO round-trip tests
- 23 target-synthesis tests
- 107 Qiskit translation tests
- QV100/FakeTorino smoke: all 5,000 dense operations were preserved, target compilation completed, and validation passed
- Full repository lint session

AI assistance: Codex assisted with the implementation, tests, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
