### PR TITLE
💥 Depend on `nlohmann_json` privately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,10 @@ releases may include breaking changes.
 
 ### Removed
 
+- 💥 Remove `nlohmann_json` from the public package contract. MQT Core no longer
+  installs or exports the library, no installed header exposes a `nlohmann`
+  type, and the decision-diagram statistics report through strings and streams
+  ([#2138]) ([**@denialhaag**])
 - 💥 Remove the neutral-atom stack, which moves to MQT QMAP. This drops the
   neutral-atom computation model, the neutral-atom FoMaC device session, the
   neutral-atom QDMI device and its configuration, the `mqt.core.na` Python
@@ -786,6 +790,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2138]: https://github.com/munich-quantum-toolkit/core/pull/2138
 [#2137]: https://github.com/munich-quantum-toolkit/core/pull/2137
 [#2133]: https://github.com/munich-quantum-toolkit/core/pull/2133
 [#2124]: https://github.com/munich-quantum-toolkit/core/pull/2124

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,28 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Private `nlohmann_json` dependency
+
+MQT Core uses `nlohmann_json` only inside its implementation. It no longer
+installs the library, exports it, or looks for it in its package configuration.
+Depend on `nlohmann_json` directly if your project uses it.
+
+No installed header includes a `nlohmann` header any more. The decision-diagram
+statistics report through strings and streams instead. MQT Core removed the
+following names:
+
+- `dd::Statistics::json`, `dd::MemoryManagerStatistics::json`,
+  `dd::TableStatistics::json`, and `dd::UniqueTableStatistics::json`. Use
+  `toString`, the stream operator, or the individual counters.
+- `dd::UniqueTable::getStatsJson`. Use `dd::getStatisticsString`.
+- `dd::getStatistics` and `dd::getDataStructureStatistics`. Use
+  `dd::getStatisticsString` and `dd::getDataStructureStatisticsString`, which
+  return the same report as a JSON-formatted string.
+- The `MQT_CORE_JSON_INSTALL` CMake option.
+
+`dd::getStatisticsString` takes the `includeIndividualTables` flag that
+`dd::getStatistics` used to take.
+
 ### Removal of the neutral-atom stack
 
 MQT Core no longer contains any neutral-atom functionality. The complete stack

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -46,12 +46,10 @@ set(JSON_URL https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}
 set(JSON_SystemInclude
     ON
     CACHE INTERNAL "Treat the library headers like system headers")
-cmake_dependent_option(MQT_CORE_JSON_INSTALL "Install nlohmann_json library" ON "MQT_CORE_INSTALL"
-                       OFF)
-# Disable upstream nlohmann_json install rules and install with explicit MQT components below.
+# nlohmann_json is a private build-time dependency, so it is never installed.
 set(JSON_Install
     OFF
-    CACHE BOOL "Disable upstream nlohmann_json install rules; handled by mqt-core" FORCE)
+    CACHE BOOL "Do not install nlohmann_json; mqt-core uses it privately" FORCE)
 FetchContent_Declare(nlohmann_json URL ${JSON_URL} FIND_PACKAGE_ARGS ${JSON_VERSION})
 list(APPEND FETCH_PACKAGES nlohmann_json)
 
@@ -114,64 +112,6 @@ endif()
 
 # Make all declared dependencies available.
 FetchContent_MakeAvailable(${FETCH_PACKAGES})
-
-# Install nlohmann_json with explicit MQT components.
-if(MQT_CORE_JSON_INSTALL AND TARGET nlohmann_json)
-  set(MQT_CORE_JSON_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/nlohmann_json")
-  set(MQT_CORE_JSON_TARGETS_EXPORT_NAME "nlohmann_jsonTargets")
-  set(MQT_CORE_JSON_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/nlohmann_jsonConfig.cmake")
-  set(MQT_CORE_JSON_VERSION_CONFIG_FILE
-      "${CMAKE_CURRENT_BINARY_DIR}/nlohmann_jsonConfigVersion.cmake")
-
-  # nlohmann_json's upstream templates expect these names.
-  set(_mqt_core_saved_project_name "${PROJECT_NAME}")
-  set(_mqt_core_saved_project_version "${PROJECT_VERSION}")
-  set(_mqt_core_saved_project_version_major "${PROJECT_VERSION_MAJOR}")
-  set(PROJECT_NAME "nlohmann_json")
-  set(PROJECT_VERSION "${JSON_VERSION}")
-  string(REGEX MATCH "^[0-9]+" PROJECT_VERSION_MAJOR "${JSON_VERSION}")
-  set(NLOHMANN_JSON_TARGET_NAME "nlohmann_json")
-  set(NLOHMANN_JSON_TARGETS_EXPORT_NAME "${MQT_CORE_JSON_TARGETS_EXPORT_NAME}")
-
-  configure_file(${nlohmann_json_SOURCE_DIR}/cmake/config.cmake.in ${MQT_CORE_JSON_CONFIG_FILE}
-                 @ONLY)
-  configure_file(${nlohmann_json_SOURCE_DIR}/cmake/nlohmann_jsonConfigVersion.cmake.in
-                 ${MQT_CORE_JSON_VERSION_CONFIG_FILE} @ONLY)
-
-  set(PROJECT_NAME "${_mqt_core_saved_project_name}")
-  set(PROJECT_VERSION "${_mqt_core_saved_project_version}")
-  set(PROJECT_VERSION_MAJOR "${_mqt_core_saved_project_version_major}")
-  unset(_mqt_core_saved_project_name)
-  unset(_mqt_core_saved_project_version)
-  unset(_mqt_core_saved_project_version_major)
-  unset(NLOHMANN_JSON_TARGET_NAME)
-  unset(NLOHMANN_JSON_TARGETS_EXPORT_NAME)
-
-  install(
-    DIRECTORY ${nlohmann_json_SOURCE_DIR}/include/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-
-  if(MSVC)
-    install(
-      FILES ${nlohmann_json_SOURCE_DIR}/nlohmann_json.natvis
-      DESTINATION .
-      COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-  endif()
-
-  install(TARGETS nlohmann_json EXPORT ${MQT_CORE_JSON_TARGETS_EXPORT_NAME})
-
-  install(
-    EXPORT ${MQT_CORE_JSON_TARGETS_EXPORT_NAME}
-    NAMESPACE nlohmann_json::
-    DESTINATION ${MQT_CORE_JSON_CONFIG_INSTALL_DIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-
-  install(
-    FILES ${MQT_CORE_JSON_CONFIG_FILE} ${MQT_CORE_JSON_VERSION_CONFIG_FILE}
-    DESTINATION ${MQT_CORE_JSON_CONFIG_INSTALL_DIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-endif()
 
 # Ensure external shared libraries end up in a common lib layout used by our RUNPATH
 if(MQT_CORE_MANAGES_SPDLOG AND TARGET spdlog)

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -46,10 +46,6 @@ set(JSON_URL https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}
 set(JSON_SystemInclude
     ON
     CACHE INTERNAL "Treat the library headers like system headers")
-# nlohmann_json is a private build-time dependency, so it is never installed.
-set(JSON_Install
-    OFF
-    CACHE BOOL "Do not install nlohmann_json; mqt-core uses it privately" FORCE)
 FetchContent_Declare(nlohmann_json URL ${JSON_URL} FIND_PACKAGE_ARGS ${JSON_VERSION})
 list(APPEND FETCH_PACKAGES nlohmann_json)
 

--- a/cmake/mqt-core-config.cmake.in
+++ b/cmake/mqt-core-config.cmake.in
@@ -13,7 +13,6 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 include(CMakeFindDependencyMacro)
-find_dependency(nlohmann_json)
 find_dependency(spdlog)
 find_dependency(qdmi)
 

--- a/eval/CMakeLists.txt
+++ b/eval/CMakeLists.txt
@@ -9,4 +9,4 @@
 add_executable(mqt-core-dd-eval eval_dd_package.cpp)
 target_link_libraries(
   mqt-core-dd-eval PRIVATE MQT::CoreDD MQT::CoreAlgorithms MQT::CoreCircuitOptimizer
-                           MQT::ProjectOptions MQT::ProjectWarnings)
+                           nlohmann_json::nlohmann_json MQT::ProjectOptions MQT::ProjectWarnings)

--- a/eval/eval_dd_package.cpp
+++ b/eval/eval_dd_package.cpp
@@ -87,7 +87,7 @@ benchmarkSimulate(const qc::QuantumComputation& qc) {
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
       std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-  exp->stats = getStatistics(*exp->dd);
+  exp->stats = nlohmann::basic_json<>::parse(getStatisticsString(*exp->dd));
   return exp;
 }
 
@@ -101,7 +101,7 @@ benchmarkFunctionalityConstruction(const qc::QuantumComputation& qc) {
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
       std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-  exp->stats = getStatistics(*exp->dd);
+  exp->stats = nlohmann::basic_json<>::parse(getStatisticsString(*exp->dd));
   return exp;
 }
 
@@ -142,7 +142,7 @@ benchmarkSimulateGrover(const qc::Qubit nq,
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
       std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-  exp->stats = getStatistics(*exp->dd);
+  exp->stats = nlohmann::basic_json<>::parse(getStatisticsString(*exp->dd));
   return exp;
 }
 
@@ -190,7 +190,7 @@ benchmarkFunctionalityConstructionGrover(
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
       std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-  exp->stats = getStatistics(*exp->dd);
+  exp->stats = nlohmann::basic_json<>::parse(getStatisticsString(*exp->dd));
   return exp;
 }
 

--- a/include/mqt-core/dd/UniqueTable.hpp
+++ b/include/mqt-core/dd/UniqueTable.hpp
@@ -21,8 +21,6 @@
 #include "dd/statistics/UniqueTableStatistics.hpp"
 #include "ir/Definitions.hpp"
 
-#include <nlohmann/json_fwd.hpp>
-
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -132,10 +130,6 @@ public:
   /// Get a reference to individual statistics
   [[nodiscard]] const UniqueTableStatistics&
   getStats(std::size_t idx) const noexcept;
-
-  /// Get a JSON object with the statistics
-  [[nodiscard]] nlohmann::basic_json<>
-  getStatsJson(bool includeIndividualTables = false) const;
 
   /// Get the total number of entries
   [[nodiscard]] std::size_t getNumEntries() const noexcept;

--- a/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
+++ b/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
@@ -15,9 +15,9 @@
 #pragma once
 
 #include "dd/statistics/Statistics.hpp"
-#include "nlohmann/json_fwd.hpp"
 
 #include <cstddef>
+#include <string>
 
 namespace dd {
 
@@ -81,8 +81,8 @@ struct MemoryManagerStatistics final : Statistics {
   /// Reset all statistics (except for the peak values)
   void reset() noexcept override;
 
-  /// Get a JSON representation of the statistics
-  [[nodiscard]] nlohmann::json json() const override;
+  /// Get a JSON-formatted string representation of the statistics
+  [[nodiscard]] std::string toString() const override;
 };
 
 } // namespace dd

--- a/include/mqt-core/dd/statistics/PackageStatistics.hpp
+++ b/include/mqt-core/dd/statistics/PackageStatistics.hpp
@@ -16,8 +16,6 @@
 
 #include "dd/Package.hpp"
 
-#include <nlohmann/json_fwd.hpp>
-
 #include <iostream>
 #include <string>
 
@@ -44,16 +42,20 @@ namespace dd {
  */
 [[nodiscard]] double computePeakMemoryMiB(const Package& package);
 
-[[nodiscard]] nlohmann::json
-getStatistics(Package& package, bool includeIndividualTables = false);
-
 /**
  * @brief Get some key statistics about data structures used by the DD package
- * @return A JSON representation of the statistics
+ * @return A JSON-formatted string representation of the statistics
  */
-[[nodiscard]] nlohmann::json getDataStructureStatistics();
+[[nodiscard]] std::string getDataStructureStatisticsString();
 
-[[nodiscard]] std::string getStatisticsString(Package& package);
+/**
+ * @brief Get key statistics about the data structures held by a package
+ * @param package The package instance
+ * @param includeIndividualTables Whether to report every unique table
+ * @return A JSON-formatted string representation of the statistics
+ */
+[[nodiscard]] std::string
+getStatisticsString(Package& package, bool includeIndividualTables = false);
 
 void printStatistics(Package& package, std::ostream& os = std::cout);
 

--- a/include/mqt-core/dd/statistics/PackageStatistics.hpp
+++ b/include/mqt-core/dd/statistics/PackageStatistics.hpp
@@ -43,13 +43,13 @@ namespace dd {
 [[nodiscard]] double computePeakMemoryMiB(const Package& package);
 
 /**
- * @brief Get some key statistics about data structures used by the DD package
+ * @brief Get key statistics about the data structures used by the DD package.
  * @return A JSON-formatted string representation of the statistics
  */
 [[nodiscard]] std::string getDataStructureStatisticsString();
 
 /**
- * @brief Get key statistics about the data structures held by a package
+ * @brief Get key statistics about the data structures held by @p package.
  * @param package The package instance
  * @param includeIndividualTables Whether to report every unique table
  * @return A JSON-formatted string representation of the statistics

--- a/include/mqt-core/dd/statistics/Statistics.hpp
+++ b/include/mqt-core/dd/statistics/Statistics.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include "nlohmann/json_fwd.hpp"
-
 #include <ostream>
 #include <string>
 
@@ -32,10 +30,7 @@ struct Statistics {
   /// Reset all statistics (except for peak values)
   virtual void reset() noexcept {};
 
-  /// Get a JSON representation of the statistics
-  [[nodiscard]] virtual nlohmann::json json() const;
-
-  /// Get a pretty-printed string representation of the statistics
+  /// Get a JSON-formatted string representation of the statistics
   [[nodiscard]] virtual std::string toString() const;
 
   /**

--- a/include/mqt-core/dd/statistics/TableStatistics.hpp
+++ b/include/mqt-core/dd/statistics/TableStatistics.hpp
@@ -16,9 +16,8 @@
 
 #include "dd/statistics/Statistics.hpp"
 
-#include <nlohmann/json_fwd.hpp>
-
 #include <cstddef>
+#include <string>
 
 namespace dd {
 
@@ -77,8 +76,8 @@ struct TableStatistics : Statistics {
   /// Get the amount of memory required for the table in MiB
   [[nodiscard]] double getMemoryMiB() const noexcept;
 
-  /// Get a JSON representation of the statistics
-  [[nodiscard]] nlohmann::json json() const override;
+  /// Get a JSON-formatted string representation of the statistics
+  [[nodiscard]] std::string toString() const override;
 };
 
 } // namespace dd

--- a/include/mqt-core/dd/statistics/UniqueTableStatistics.hpp
+++ b/include/mqt-core/dd/statistics/UniqueTableStatistics.hpp
@@ -16,9 +16,8 @@
 
 #include "dd/statistics/TableStatistics.hpp"
 
-#include <nlohmann/json_fwd.hpp>
-
 #include <cstddef>
+#include <string>
 
 namespace dd {
 /// \brief A class for storing statistics of a unique table
@@ -29,8 +28,8 @@ struct UniqueTableStatistics : TableStatistics {
   /// Reset all statistics (except for the peak values)
   void reset() noexcept override;
 
-  /// Get a JSON representation of the statistics
-  [[nodiscard]] nlohmann::json json() const override;
+  /// Get a JSON-formatted string representation of the statistics
+  [[nodiscard]] std::string toString() const override;
 };
 
 } // namespace dd

--- a/src/dd/CMakeLists.txt
+++ b/src/dd/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-dd)
                                       FILES ${DD_HEADERS})
 
   # add link libraries
-  target_link_libraries(${MQT_CORE_TARGET_NAME}-dd PUBLIC MQT::CoreIR)
+  target_link_libraries(${MQT_CORE_TARGET_NAME}-dd PUBLIC MQT::CoreIR
                         PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 
   # generate export header

--- a/src/dd/CMakeLists.txt
+++ b/src/dd/CMakeLists.txt
@@ -23,8 +23,10 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-dd)
                                       FILES ${DD_HEADERS})
 
   # add link libraries
-  target_link_libraries(${MQT_CORE_TARGET_NAME}-dd PUBLIC MQT::CoreIR
-                        PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
+  target_link_libraries(
+    ${MQT_CORE_TARGET_NAME}-dd
+    PUBLIC MQT::CoreIR
+    PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 
   # generate export header
   include(GenerateExportHeader)

--- a/src/dd/CMakeLists.txt
+++ b/src/dd/CMakeLists.txt
@@ -23,7 +23,9 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-dd)
                                       FILES ${DD_HEADERS})
 
   # add link libraries
-  target_link_libraries(${MQT_CORE_TARGET_NAME}-dd PUBLIC MQT::CoreIR nlohmann_json::nlohmann_json)
+  target_link_libraries(${MQT_CORE_TARGET_NAME}-dd PUBLIC MQT::CoreIR)
+  target_link_libraries(${MQT_CORE_TARGET_NAME}-dd
+                        PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 
   # generate export header
   include(GenerateExportHeader)

--- a/src/dd/CMakeLists.txt
+++ b/src/dd/CMakeLists.txt
@@ -24,7 +24,6 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-dd)
 
   # add link libraries
   target_link_libraries(${MQT_CORE_TARGET_NAME}-dd PUBLIC MQT::CoreIR)
-  target_link_libraries(${MQT_CORE_TARGET_NAME}-dd
                         PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 
   # generate export header

--- a/src/dd/UniqueTable.cpp
+++ b/src/dd/UniqueTable.cpp
@@ -12,6 +12,7 @@
 
 #include "dd/MemoryManager.hpp"
 #include "dd/Node.hpp"
+#include "statistics/StatisticsJson.hpp"
 
 #include <nlohmann/json.hpp>
 
@@ -113,8 +114,9 @@ UniqueTable::getStats(const std::size_t idx) const noexcept {
   return stats.at(idx);
 }
 
-nlohmann::basic_json<>
-UniqueTable::getStatsJson(const bool includeIndividualTables) const {
+nlohmann::basic_json<> toJson(const UniqueTable& table,
+                              const bool includeIndividualTables) {
+  const auto& stats = table.getStats();
   if (std::ranges::all_of(stats, [](const UniqueTableStatistics& stat) {
         return stat.peakNumEntries == 0U;
       })) {
@@ -135,11 +137,11 @@ UniqueTable::getStatsJson(const bool includeIndividualTables) const {
   }
 
   nlohmann::basic_json<> j;
-  j["total"] = totalStats.json();
+  j["total"] = toJson(totalStats);
   if (includeIndividualTables) {
     std::size_t v = 0U;
     for (const auto& stat : stats) {
-      j[std::to_string(v)] = stat.json();
+      j[std::to_string(v)] = toJson(stat);
       ++v;
     }
   }

--- a/src/dd/statistics/MemoryManagerStatistics.cpp
+++ b/src/dd/statistics/MemoryManagerStatistics.cpp
@@ -10,12 +10,13 @@
 
 #include "dd/statistics/MemoryManagerStatistics.hpp"
 
-#include "dd/statistics/Statistics.hpp"
+#include "StatisticsJson.hpp"
 
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
 #include <cstddef>
+#include <string>
 
 namespace dd {
 
@@ -74,24 +75,28 @@ void MemoryManagerStatistics::reset() noexcept {
   numAvailableForReuse = 0U;
 }
 
-nlohmann::basic_json<> MemoryManagerStatistics::json() const {
-  if (peakNumUsed == 0) {
+std::string MemoryManagerStatistics::toString() const {
+  return toJson(*this).dump(2U);
+}
+
+nlohmann::basic_json<> toJson(const MemoryManagerStatistics& s) {
+  if (s.peakNumUsed == 0) {
     return "unused";
   }
 
-  auto j = Statistics::json();
-  j["memory_allocated_MiB"] = getAllocatedMemoryMiB();
-  j["memory_used_MiB"] = getUsedMemoryMiB();
-  j["memory_used_MiB_peak"] = getPeakUsedMemoryMiB();
-  j["num_allocated"] = numAllocated;
-  j["num_allocations"] = numAllocations;
-  j["num_available_for_reuse"] = numAvailableForReuse;
-  j["num_available_for_reuse_peak"] = peakNumAvailableForReuse;
-  j["num_available_from_chunks"] = getNumAvailableFromChunks();
-  j["num_available_total"] = getTotalNumAvailable();
-  j["num_used"] = numUsed;
-  j["num_used_peak"] = peakNumUsed;
-  j["usage_ratio"] = getUsageRatio();
+  nlohmann::basic_json<> j;
+  j["memory_allocated_MiB"] = s.getAllocatedMemoryMiB();
+  j["memory_used_MiB"] = s.getUsedMemoryMiB();
+  j["memory_used_MiB_peak"] = s.getPeakUsedMemoryMiB();
+  j["num_allocated"] = s.numAllocated;
+  j["num_allocations"] = s.numAllocations;
+  j["num_available_for_reuse"] = s.numAvailableForReuse;
+  j["num_available_for_reuse_peak"] = s.peakNumAvailableForReuse;
+  j["num_available_from_chunks"] = s.getNumAvailableFromChunks();
+  j["num_available_total"] = s.getTotalNumAvailable();
+  j["num_used"] = s.numUsed;
+  j["num_used_peak"] = s.peakNumUsed;
+  j["usage_ratio"] = s.getUsageRatio();
   return j;
 }
 

--- a/src/dd/statistics/PackageStatistics.cpp
+++ b/src/dd/statistics/PackageStatistics.cpp
@@ -10,6 +10,7 @@
 
 #include "dd/statistics/PackageStatistics.hpp"
 
+#include "StatisticsJson.hpp"
 #include "dd/Complex.hpp"
 #include "dd/ComplexNumbers.hpp"
 #include "dd/ComplexValue.hpp"
@@ -78,8 +79,11 @@ double computePeakMemoryMiB(const Package& package) {
   return memoryForNodes + memoryForEdges + memoryForRealNumbers;
 }
 
-nlohmann::basic_json<> getStatistics(Package& package,
-                                     const bool includeIndividualTables) {
+namespace {
+[[nodiscard]] nlohmann::basic_json<> getDataStructureStatistics();
+
+[[nodiscard]] nlohmann::basic_json<>
+getStatistics(Package& package, const bool includeIndividualTables) {
   nlohmann::basic_json<> j;
 
   j["data_structure"] = getDataStructureStatistics();
@@ -89,43 +93,43 @@ nlohmann::basic_json<> getStatistics(Package& package,
 
   auto& vector = j["vector"];
   auto& vectorUniqueTable = vector["unique_table"];
-  vectorUniqueTable =
-      package.vUniqueTable.getStatsJson(includeIndividualTables);
+  vectorUniqueTable = toJson(package.vUniqueTable, includeIndividualTables);
   if (vectorUniqueTable != "unused") {
     vectorUniqueTable["total"]["num_active_entries"] = activeVectorNodes;
   }
-  vector["memory_manager"] = package.vMemoryManager.getStats().json();
+  vector["memory_manager"] = toJson(package.vMemoryManager.getStats());
 
   auto& matrix = j["matrix"];
   auto& matrixUniqueTable = matrix["unique_table"];
-  matrixUniqueTable =
-      package.mUniqueTable.getStatsJson(includeIndividualTables);
+  matrixUniqueTable = toJson(package.mUniqueTable, includeIndividualTables);
   if (matrixUniqueTable != "unused") {
     matrixUniqueTable["total"]["num_active_entries"] = activeMatrixNodes;
   }
-  matrix["memory_manager"] = package.mMemoryManager.getStats().json();
+  matrix["memory_manager"] = toJson(package.mMemoryManager.getStats());
 
   auto& realNumbers = j["real_numbers"];
   auto& realNumbersUniqueTable = realNumbers["unique_table"];
-  realNumbersUniqueTable = package.cUniqueTable.getStats().json();
+  realNumbersUniqueTable = toJson(package.cUniqueTable.getStats());
   if (realNumbersUniqueTable != "unused") {
     realNumbersUniqueTable["num_active_entries"] = activeRealNumbers;
   }
-  realNumbers["memory_manager"] = package.cMemoryManager.getStats().json();
+  realNumbers["memory_manager"] = toJson(package.cMemoryManager.getStats());
 
   auto& computeTables = j["compute_tables"];
-  computeTables["vector_add"] = package.vectorAdd.getStats().json();
-  computeTables["matrix_add"] = package.matrixAdd.getStats().json();
+  computeTables["vector_add"] = toJson(package.vectorAdd.getStats());
+  computeTables["matrix_add"] = toJson(package.matrixAdd.getStats());
   computeTables["matrix_conjugate_transpose"] =
-      package.conjugateMatrixTranspose.getStats().json();
+      toJson(package.conjugateMatrixTranspose.getStats());
   computeTables["matrix_vector_mult"] =
-      package.matrixVectorMultiplication.getStats().json();
+      toJson(package.matrixVectorMultiplication.getStats());
   computeTables["matrix_matrix_mult"] =
-      package.matrixMatrixMultiplication.getStats().json();
-  computeTables["vector_kronecker"] = package.vectorKronecker.getStats().json();
-  computeTables["matrix_kronecker"] = package.matrixKronecker.getStats().json();
+      toJson(package.matrixMatrixMultiplication.getStats());
+  computeTables["vector_kronecker"] =
+      toJson(package.vectorKronecker.getStats());
+  computeTables["matrix_kronecker"] =
+      toJson(package.matrixKronecker.getStats());
   computeTables["vector_inner_product"] =
-      package.vectorInnerProduct.getStats().json();
+      toJson(package.vectorInnerProduct.getStats());
 
   j["active_memory_mib"] = computeActiveMemoryMiB(package);
   j["peak_memory_mib"] = computePeakMemoryMiB(package);
@@ -133,7 +137,7 @@ nlohmann::basic_json<> getStatistics(Package& package,
   return j;
 }
 
-nlohmann::basic_json<> getDataStructureStatistics() {
+[[nodiscard]] nlohmann::basic_json<> getDataStructureStatistics() {
   nlohmann::basic_json<> j;
 
   // Information about key data structures
@@ -222,8 +226,15 @@ nlohmann::basic_json<> getDataStructureStatistics() {
   return j;
 }
 
-std::string getStatisticsString(Package& package) {
-  return getStatistics(package).dump(2U);
+} // namespace
+
+std::string getDataStructureStatisticsString() {
+  return getDataStructureStatistics().dump(2U);
+}
+
+std::string getStatisticsString(Package& package,
+                                const bool includeIndividualTables) {
+  return getStatistics(package, includeIndividualTables).dump(2U);
 }
 
 void printStatistics(Package& package, std::ostream& os) {

--- a/src/dd/statistics/Statistics.cpp
+++ b/src/dd/statistics/Statistics.cpp
@@ -16,8 +16,6 @@
 
 namespace dd {
 
-nlohmann::basic_json<> Statistics::json() const { return nlohmann::json{}; }
-
-std::string Statistics::toString() const { return json().dump(2U); }
+std::string Statistics::toString() const { return nlohmann::json{}.dump(2U); }
 
 } // namespace dd

--- a/src/dd/statistics/Statistics.cpp
+++ b/src/dd/statistics/Statistics.cpp
@@ -10,12 +10,11 @@
 
 #include "dd/statistics/Statistics.hpp"
 
-#include <nlohmann/json.hpp>
-
 #include <string>
 
 namespace dd {
 
-std::string Statistics::toString() const { return nlohmann::json{}.dump(2U); }
+/// The base class carries no statistics, which JSON renders as a null value.
+std::string Statistics::toString() const { return "null"; }
 
 } // namespace dd

--- a/src/dd/statistics/StatisticsJson.hpp
+++ b/src/dd/statistics/StatisticsJson.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/** @file StatisticsJson.hpp
+ * @brief Internal JSON rendering for decision-diagram statistics.
+ * @details This header is not installed. It keeps nlohmann_json out of the
+ * public headers while the statistics reports stay JSON-formatted.
+ */
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace dd {
+
+class UniqueTable;
+struct MemoryManagerStatistics;
+struct TableStatistics;
+struct UniqueTableStatistics;
+
+/// Render the memory-manager statistics, or "unused" if nothing was used.
+[[nodiscard]] nlohmann::basic_json<> toJson(const MemoryManagerStatistics& s);
+
+/// Render the table statistics, or "unused" if the table was never queried.
+[[nodiscard]] nlohmann::basic_json<> toJson(const TableStatistics& s);
+
+/// Render the unique-table statistics, or "unused" if it was never queried.
+[[nodiscard]] nlohmann::basic_json<> toJson(const UniqueTableStatistics& s);
+
+/**
+ * @brief Render the statistics of every table in a unique table.
+ * @param table The unique table
+ * @param includeIndividualTables Whether to add an entry per variable
+ * @return The rendered statistics, or "unused" if no table holds entries
+ */
+[[nodiscard]] nlohmann::basic_json<> toJson(const UniqueTable& table,
+                                            bool includeIndividualTables);
+
+} // namespace dd

--- a/src/dd/statistics/TableStatistics.cpp
+++ b/src/dd/statistics/TableStatistics.cpp
@@ -10,11 +10,12 @@
 
 #include "dd/statistics/TableStatistics.hpp"
 
-#include "dd/statistics/Statistics.hpp"
+#include "StatisticsJson.hpp"
 
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <string>
 
 namespace dd {
 
@@ -55,23 +56,25 @@ double TableStatistics::getMemoryMiB() const noexcept {
   return static_cast<double>(numBuckets) * getEntrySizeMiB();
 }
 
-nlohmann::basic_json<> TableStatistics::json() const {
-  if (lookups == 0) {
+std::string TableStatistics::toString() const { return toJson(*this).dump(2U); }
+
+nlohmann::basic_json<> toJson(const TableStatistics& s) {
+  if (s.lookups == 0) {
     return "unused";
   }
 
-  auto j = Statistics::json();
-  j["num_buckets"] = numBuckets;
-  j["memory_MiB"] = getMemoryMiB();
-  j["num_entries"] = numEntries;
-  j["peak_num_entries"] = peakNumEntries;
-  j["collisions"] = collisions;
-  j["hits"] = hits;
-  j["lookups"] = lookups;
-  j["inserts"] = inserts;
-  j["hit_ratio"] = hitRatio();
-  j["col_ratio"] = colRatio();
-  j["load_factor"] = loadFactor();
+  nlohmann::basic_json<> j;
+  j["num_buckets"] = s.numBuckets;
+  j["memory_MiB"] = s.getMemoryMiB();
+  j["num_entries"] = s.numEntries;
+  j["peak_num_entries"] = s.peakNumEntries;
+  j["collisions"] = s.collisions;
+  j["hits"] = s.hits;
+  j["lookups"] = s.lookups;
+  j["inserts"] = s.inserts;
+  j["hit_ratio"] = s.hitRatio();
+  j["col_ratio"] = s.colRatio();
+  j["load_factor"] = s.loadFactor();
   return j;
 }
 

--- a/src/dd/statistics/UniqueTableStatistics.cpp
+++ b/src/dd/statistics/UniqueTableStatistics.cpp
@@ -10,21 +10,28 @@
 
 #include "dd/statistics/UniqueTableStatistics.hpp"
 
+#include "StatisticsJson.hpp"
 #include "dd/statistics/TableStatistics.hpp"
 
 #include <nlohmann/json.hpp>
+
+#include <string>
 
 namespace dd {
 
 void UniqueTableStatistics::reset() noexcept { TableStatistics::reset(); }
 
-nlohmann::basic_json<> UniqueTableStatistics::json() const {
-  if (lookups == 0) {
+std::string UniqueTableStatistics::toString() const {
+  return toJson(*this).dump(2U);
+}
+
+nlohmann::basic_json<> toJson(const UniqueTableStatistics& s) {
+  if (s.lookups == 0) {
     return "unused";
   }
 
-  auto j = TableStatistics::json();
-  j["gc_runs"] = gcRuns;
+  auto j = toJson(static_cast<const TableStatistics&>(s));
+  j["gc_runs"] = s.gcRuns;
   return j;
 }
 } // namespace dd

--- a/src/qdmi/devices/sc/CMakeLists.txt
+++ b/src/qdmi/devices/sc/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT TARGET ${TARGET_NAME})
     ${TARGET_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_CORE_INCLUDE_BUILD_DIR} FILES
                           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/devices/sc/Configuration.hpp)
 
-  target_link_libraries(${TARGET_NAME} PUBLIC nlohmann_json::nlohmann_json)
+  target_link_libraries(${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 
   list(APPEND MQT_CORE_TARGETS ${TARGET_NAME})
 

--- a/src/qdmi/driver/CMakeLists.txt
+++ b/src/qdmi/driver/CMakeLists.txt
@@ -30,8 +30,8 @@ if(NOT TARGET ${TARGET_NAME})
   target_link_libraries(
     ${TARGET_NAME}
     PUBLIC qdmi::qdmi MQT::CoreQDMICommon
-    PRIVATE qdmi::qdmi_project_warnings nlohmann_json::nlohmann_json spdlog::spdlog
-            ${CMAKE_DL_LIBS})
+    PRIVATE qdmi::qdmi_project_warnings $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>
+            spdlog::spdlog ${CMAKE_DL_LIBS})
 
   mqt_get_qdmi_device_targets(QDMI_DEVICE_TARGETS)
 

--- a/test/dd/CMakeLists.txt
+++ b/test/dd/CMakeLists.txt
@@ -9,5 +9,6 @@
 if(TARGET MQT::CoreDD)
   file(GLOB_RECURSE DD_TEST_SOURCES *.cpp)
   package_add_test(mqt-core-dd-test MQT::CoreDD ${DD_TEST_SOURCES})
-  target_link_libraries(mqt-core-dd-test PRIVATE MQT::CoreCircuitOptimizer MQT::CoreQASM)
+  target_link_libraries(mqt-core-dd-test PRIVATE MQT::CoreCircuitOptimizer MQT::CoreQASM
+                                                 nlohmann_json::nlohmann_json)
 endif()

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -2488,7 +2488,7 @@ TEST(DDPackageTest, CTPerformanceRegressionTest) {
 TEST(DDPackageTest, DataStructureStatistics) {
   constexpr auto nqubits = 1U;
   const auto dd = std::make_unique<Package>(nqubits);
-  const auto stats = getDataStructureStatistics();
+  const auto stats = nlohmann::json::parse(getDataStructureStatisticsString());
 
   EXPECT_EQ(stats["vNode"]["size_B"], 64U);
   EXPECT_EQ(stats["vNode"]["alignment_B"], 8U);
@@ -2507,9 +2507,10 @@ TEST(DDPackageTest, DDStatistics) {
   const auto dd = std::make_unique<Package>(nqubits);
   const auto dummyGate = getDD(qc::StandardOperation(0U, qc::X), *dd);
   EXPECT_NE(dummyGate.p, nullptr);
-  const auto stats = getStatistics(*dd, true);
+  const auto statsString = getStatisticsString(*dd, true);
+  const auto stats = nlohmann::json::parse(statsString);
 
-  std::cout << stats.dump(2) << "\n";
+  std::cout << statsString << "\n";
   EXPECT_TRUE(stats.contains("vector"));
   ASSERT_TRUE(stats.contains("matrix"));
   EXPECT_TRUE(stats.contains("real_numbers"));

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include <array>
 #include <cmath>


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

MQT Core no longer exposes `nlohmann_json` as part of its public package contract. It uses the library only inside its implementation, for QDMI device discovery and superconducting device configuration, and stops installing it, exporting it, and looking for it in its package configuration.

The decision-diagram statistics drove most of the public exposure. They now report through strings and streams: `json()` on `Statistics`, `MemoryManagerStatistics`, `TableStatistics`, and `UniqueTableStatistics`, as well as `UniqueTable::getStatsJson`, `getStatistics`, and `getDataStructureStatistics`, are removed. The primitive counters, `toString()`, and the stream operator remain, and `getStatisticsString` and the new `getDataStructureStatisticsString` return the same report as a JSON-formatted string. Rendering moved to a header that is not installed, so the reports keep their format while no installed header includes a `nlohmann` header.

The remaining users link the library through `$<BUILD_INTERFACE:>`. Without the generator expression, a private dependency of a static library still appears as a `$<LINK_ONLY:>` entry in the installed interface, which would leave consumers resolving a target that MQT Core no longer provides.

This also removes the `MQT_CORE_JSON_INSTALL` option together with the machinery that installed the library's headers, package configuration, and natvis file.

Consumers that use `nlohmann_json` themselves have to depend on it directly. MQT QCEC, MQT DDSIM, and MQT QuSAT already do; MQT QMAP always did.

This pull request forms a stack with #2137 and targets that pull request's branch rather than `main`.

Fixes #2099

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
