### PR TITLE
✨ Export OpenQASM measurements to Qiskit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ releases may include breaking changes.
 - ✨ Add an `unroll-modifiers` pass for unrolling multi-operation modifiers
   ([#2015]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add Qiskit circuit import and export to the compiler collection ([#2031],
-  [#2133], [#2136]) ([**@burgholzer**], [**@simon1hofmann**])
+  [#2133], [#2136], [#2140]) ([**@burgholzer**], [**@simon1hofmann**])
 - ✨ Add generic C++ and Python FoMaC support for custom device properties that
   contain operation handles ([#2042]) ([**@burgholzer**])
 - ✨ Support retrieving existing jobs by ID through the QDMI client API and C++
@@ -808,6 +808,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#2154]: https://github.com/munich-quantum-toolkit/core/pull/2154
+[#2140]: https://github.com/munich-quantum-toolkit/core/pull/2140
 [#2138]: https://github.com/munich-quantum-toolkit/core/pull/2138
 [#2137]: https://github.com/munich-quantum-toolkit/core/pull/2137
 [#2136]: https://github.com/munich-quantum-toolkit/core/pull/2136

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -28,6 +28,7 @@
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/Matchers.h>
@@ -537,6 +538,16 @@ void collectFlatInstructions(mlir::func::FuncOp function, ExportState& state) {
       }
       throw std::runtime_error(
           "QC to Qiskit export encountered an unsupported memory deallocation");
+    }
+    if (auto poison = llvm::dyn_cast<mlir::ub::PoisonOp>(operation)) {
+      initializationRegister = {};
+      if (llvm::all_of(poison->getResults(), [](const mlir::Value result) {
+            return result.use_empty();
+          })) {
+        continue;
+      }
+      throw std::runtime_error(
+          "QC to Qiskit export does not support used poison values");
     }
     if (auto store = llvm::dyn_cast<mlir::memref::StoreOp>(operation)) {
       if (llvm::isa_and_nonnull<mlir::qc::MeasureOp>(

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -490,7 +490,7 @@ void collectResources(mlir::func::FuncOp function, ExportState& state,
 
 [[nodiscard]] std::optional<uint32_t>
 initialClassicalZeroStoreIndex(mlir::memref::StoreOp store,
-                               const mlir::Value registerValue,
+                               mlir::Value registerValue,
                                const ExportState& state) {
   if (store.getMemref() != registerValue || store.getIndices().size() != 1U ||
       !mlir::matchPattern(store.getValueToStore(), mlir::m_Zero())) {

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -30,6 +30,7 @@
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Region.h>
 #include <mlir/IR/Value.h>
@@ -44,6 +45,7 @@
 #include <cstdint>
 #include <limits>
 #include <numeric>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -485,14 +487,41 @@ void collectResources(mlir::func::FuncOp function, ExportState& state,
   }
 }
 
+[[nodiscard]] std::optional<uint32_t>
+initialClassicalZeroStoreIndex(mlir::memref::StoreOp store,
+                               const mlir::Value registerValue,
+                               const ExportState& state) {
+  if (store.getMemref() != registerValue || store.getIndices().size() != 1U ||
+      !mlir::matchPattern(store.getValueToStore(), mlir::m_Zero())) {
+    return std::nullopt;
+  }
+
+  const auto size = state.classicalSizes.find(registerValue);
+  const auto index = mlir::getConstantIntValue(store.getIndices().front());
+  if (size == state.classicalSizes.end() || !index || *index < 0 ||
+      std::cmp_greater_equal(*index, size->second)) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(*index);
+}
+
 void collectFlatInstructions(mlir::func::FuncOp function, ExportState& state) {
+  mlir::Value initializationRegister;
+  llvm::DenseSet<uint32_t> initializedClassicalBits;
   for (auto& operation : function.getBody().front()) {
-    if (llvm::isa<mlir::arith::ConstantOp, mlir::memref::AllocOp,
-                  mlir::qc::AllocOp, mlir::qc::DeallocOp, mlir::qc::StaticOp,
-                  mlir::func::ReturnOp>(operation)) {
+    if (auto alloc = llvm::dyn_cast<mlir::memref::AllocOp>(operation)) {
+      initializationRegister = {};
+      initializedClassicalBits.clear();
+      if (state.classicalBases.contains(alloc.getResult())) {
+        initializationRegister = alloc.getResult();
+      }
+      continue;
+    }
+    if (llvm::isa<mlir::arith::ConstantOp>(operation)) {
       continue;
     }
     if (auto load = llvm::dyn_cast<mlir::memref::LoadOp>(operation)) {
+      initializationRegister = {};
       if (state.qubits.contains(load.getResult())) {
         continue;
       }
@@ -501,6 +530,7 @@ void collectFlatInstructions(mlir::func::FuncOp function, ExportState& state) {
           "loads");
     }
     if (auto dealloc = llvm::dyn_cast<mlir::memref::DeallocOp>(operation)) {
+      initializationRegister = {};
       if (state.quantumBases.contains(dealloc.getMemref()) ||
           state.classicalBases.contains(dealloc.getMemref())) {
         continue;
@@ -511,10 +541,24 @@ void collectFlatInstructions(mlir::func::FuncOp function, ExportState& state) {
     if (auto store = llvm::dyn_cast<mlir::memref::StoreOp>(operation)) {
       if (llvm::isa_and_nonnull<mlir::qc::MeasureOp>(
               store.getValueToStore().getDefiningOp())) {
+        initializationRegister = {};
         continue;
       }
+      if (initializationRegister) {
+        const auto index = initialClassicalZeroStoreIndex(
+            store, initializationRegister, state);
+        if (index && initializedClassicalBits.insert(*index).second) {
+          continue;
+        }
+      }
+      initializationRegister = {};
       throw std::runtime_error(
           "QC to Qiskit export does not support classical execution");
+    }
+    initializationRegister = {};
+    if (llvm::isa<mlir::qc::AllocOp, mlir::qc::DeallocOp, mlir::qc::StaticOp,
+                  mlir::func::ReturnOp>(operation)) {
+      continue;
     }
     if (auto phase = llvm::dyn_cast<mlir::qc::GPhaseOp>(operation)) {
       state.globalPhase += exportParameter(phase.getTheta());

--- a/bindings/mlir/qiskit/QiskitImport.cpp
+++ b/bindings/mlir/qiskit/QiskitImport.cpp
@@ -1554,7 +1554,9 @@ mlir::QCProgram importCircuit(const nb::handle circuit) {
       classicalRegisters, view->numClbits(), "classical");
 
   auto context = createContext();
-  mlir::qc::QCProgramBuilder builder(context.get());
+  mlir::qc::QCProgramBuilder builder(
+      context.get(),
+      mlir::qc::QCProgramBuilder::ClassicalRegisterInitialization::Zero);
   llvm::SmallVector<mlir::Type> resultTypes;
   if (view->numClbits() == 0U) {
     resultTypes.push_back(builder.getI64Type());

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -454,6 +454,82 @@ def test_flat_circuit_round_trip_preserves_supported_metadata() -> None:
     ]
 
 
+def test_openqasm2_measurements_export_with_zero_initialized_register() -> None:
+    """Ignore only the implicit classical zero initialization from OpenQASM 2."""
+    program = QCProgram.from_qasm_str(
+        """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+x q[1];
+measure q[1] -> c[0];
+measure q[0] -> c[1];
+"""
+    )
+
+    restored = program.to_qiskit()
+
+    assert program.ir.count("memref.store") == 4
+    assert [(register.name, len(register)) for register in restored.qregs] == [("q", 2)]
+    assert [(register.name, len(register)) for register in restored.cregs] == [("c", 2)]
+    assert [item.operation.name for item in restored.data] == ["x", "measure", "measure"]
+    measurements = [item for item in restored.data if item.operation.name == "measure"]
+    assert [
+        (restored.find_bit(item.qubits[0]).index, restored.find_bit(item.clbits[0]).index) for item in measurements
+    ] == [(1, 0), (0, 1)]
+
+
+@pytest.mark.parametrize("late_value", ["false", "true"])
+def test_flat_export_rejects_classical_store_after_quantum_work(late_value: str) -> None:
+    """Do not mistake a later constant assignment for register initialization."""
+    program = QCProgram.from_mlir_str(
+        f"""module {{
+  func.func @main() attributes {{passthrough = ["entry_point"]}} {{
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %initial = arith.constant false
+    %late = arith.constant {late_value}
+    %q = qc.alloc : !qc.qubit
+    %c = memref.alloc() : memref<2xi1>
+    memref.store %initial, %c[%c0] : memref<2xi1>
+    qc.x %q : !qc.qubit
+    memref.store %late, %c[%c1] : memref<2xi1>
+    qc.dealloc %q : !qc.qubit
+    return
+  }}
+}}
+"""
+    )
+
+    with pytest.raises(RuntimeError, match="does not support classical execution"):
+        program.to_qiskit()
+
+
+def test_target_compiled_openqasm2_measurements_export() -> None:
+    """Export initialized result registers after target compilation."""
+    target = CompilerTarget(5)
+    program = QCProgram.from_qasm_str(
+        """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+x q[1];
+measure q[1] -> c[0];
+measure q[0] -> c[1];
+"""
+    )
+    mapped = program.to_qco(copy=True)
+    mapped.compile_for_target(target)
+
+    restored = mapped.to_qc(copy=True).to_qiskit(target=target)
+
+    assert restored.num_qubits == 5
+    assert [(register.name, len(register)) for register in restored.qregs] == [("q", 5)]
+    assert [(register.name, len(register)) for register in restored.cregs] == [("c", 2)]
+    assert restored.layout is None
+    assert restored.count_ops() == {"measure": 2, "x": 1}
+
+
 def test_layout_is_accepted_and_ignored() -> None:
     """Import laid-out operations without retaining transpiler metadata."""
     circuit = QuantumCircuit(2)

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -530,6 +530,50 @@ measure q[0] -> c[1];
     assert restored.count_ops() == {"measure": 2, "x": 1}
 
 
+def test_openqasm3_measurement_export_ignores_unused_poison() -> None:
+    """Ignore the unused poison value that initializes an OpenQASM 3 output."""
+    program = QCProgram.from_qasm_str(
+        """OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q;
+bit[1] c;
+h q[1];
+c[0] = measure q[1];
+"""
+    )
+
+    restored = program.to_qiskit()
+
+    assert "ub.poison" in program.ir
+    assert [(register.name, len(register)) for register in restored.qregs] == [("q", 2)]
+    assert [(register.name, len(register)) for register in restored.cregs] == [("c", 1)]
+    assert [item.operation.name for item in restored.data] == ["h", "measure"]
+    measurement = restored.data[-1]
+    assert restored.find_bit(measurement.qubits[0]).index == 1
+    assert restored.find_bit(measurement.clbits[0]).index == 0
+
+
+def test_flat_export_rejects_used_poison() -> None:
+    """Reject poison when it participates in classical execution."""
+    program = QCProgram.from_mlir_str(
+        """module {
+  func.func @main() attributes {passthrough = ["entry_point"]} {
+    %c0 = arith.constant 0 : index
+    %poison = ub.poison : i1
+    %q = qc.alloc : !qc.qubit
+    %c = memref.alloc() : memref<1xi1>
+    memref.store %poison, %c[%c0] : memref<1xi1>
+    qc.dealloc %q : !qc.qubit
+    return
+  }
+}
+"""
+    )
+
+    with pytest.raises(RuntimeError, match="does not support used poison values"):
+        program.to_qiskit()
+
+
 def test_layout_is_accepted_and_ignored() -> None:
     """Import laid-out operations without retaining transpiler metadata."""
     circuit = QuantumCircuit(2)

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -469,7 +469,6 @@ measure q[0] -> c[1];
 
     restored = program.to_qiskit()
 
-    assert program.ir.count("memref.store") == 4
     assert [(register.name, len(register)) for register in restored.qregs] == [("q", 2)]
     assert [(register.name, len(register)) for register in restored.cregs] == [("c", 2)]
     assert [item.operation.name for item in restored.data] == ["x", "measure", "measure"]

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -815,6 +815,20 @@ def test_nested_structured_control_and_bound_loop_parameter() -> None:
         program.to_qiskit()
 
 
+def test_qiskit_import_zero_initializes_clbits_before_control_flow() -> None:
+    """Initialize Qiskit clbits before a condition reads them."""
+    circuit = QuantumCircuit(1, 1)
+    with circuit.if_test((circuit.clbits[0], False)):
+        circuit.x(0)
+
+    ir = QCProgram.from_qiskit(circuit).ir
+
+    false_constant = ir.index("arith.constant false")
+    initialization = ir.index("memref.store", false_constant)
+    condition_load = ir.index("memref.load", initialization)
+    assert false_constant < initialization < condition_load
+
+
 @pytest.mark.parametrize(
     ("condition", "operation"),
     [


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This pull request enables Qiskit export for measurement results produced by the OpenQASM frontends. It skips only the implicit leading zero initialization emitted for OpenQASM 2 result registers and ignores unused OpenQASM 3 poison placeholders. It still rejects later classical stores, used poison values, and other unsupported classical execution.

The Qiskit importer now initializes its classical registers to zero. This preserves Qiskit conditions that read a classical bit before its first measurement.

This compatibility logic is intentionally narrow. A follow-up design issue will track the replacement of implicit `memref<i1>` conventions with first-class classical registers.

AI assistance: CodeRabbit suggested the MLIR value-parameter cleanup. Codex assisted with the signed rebase, the Qiskit import correction, its regression test, validation, and this description.

Validation:

- `uv run --no-sync pytest test/python/test_mlir_qiskit_translation.py` (114 passed)
- `uvx nox -s stubs`
- `uvx nox -s lint`

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
