### PR TITLE
🔧 Indicate support for CMake 4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Licensed under the MIT License
 
 # set required cmake version
-cmake_minimum_required(VERSION 3.24...4.2)
+cmake_minimum_required(VERSION 3.24...4.4)
 
 project(
   mqt-core


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This raises the CMake policy maximum in the top-level `CMakeLists.txt` from `4.2` to `4.4`. The minimum required version stays at `3.24`.

The upper bound of the version range only selects which policies default to `NEW`. The policies added in CMake 4.3 and 4.4 (`CMP0205` through `CMP0219`) cover Swift, file sets, archives, link flags, and macro arguments, so none of them affect how MQT Core builds.

CMake 4.4 is also the first release whose `FindPython` module handles the free-threaded stable ABI (`abi3t`). That support comes with the CMake version itself and does not depend on the policy range. `wheel.py-api = "cp312"` in `pyproject.toml` still decides the wheel tags, so free-threaded builds continue to produce ordinary `cp3XXt` wheels. Emitting combined `abi3.abi3t` wheels would be a separate change.

The two standalone consumer projects under `test/qdmi/driver/` keep their bare `cmake_minimum_required(VERSION 3.24)`. They stand in for downstream consumers, and a bare minimum is both the realistic case and one fewer place to drift on future bumps.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
