### PR TITLE
🧪 Apply the PennyLane plugin SpecAudit

### DIFF
--- a/.agent/audits/pennylane-plugin.md
+++ b/.agent/audits/pennylane-plugin.md
@@ -13,6 +13,18 @@ probe output.
 Method: [`.agent/AUDITS.md`](../AUDITS.md). Probe tool:
 [`.agent/audit-probe.sh`](../audit-probe.sh).
 
+Reconciled on 2026-08-18 against `3354fdaab`. Every `file:line` below was
+re-read at that commit and still resolved to the line it named, so the drift
+since the baseline invalidated no verdict. Pull request `#2147` applied all six.
+Each verdict now carries an **Applied** paragraph saying what landed and what
+did not.
+
+After that pull request the scope is 878 source lines and 891 test lines across
+26 test functions and 33 collected cases. The source lost 37 lines; the tests
+gained 57, because driving conversion through `QDMIDevice` costs QNode
+boilerplate that a direct converter call did not. The payoff of verdict 6 is the
+round trips it removed, not the lines, and the summary table below says so.
+
 ## Why this scope
 
 The plugin arrived in one commit, `077b73f80` (`#2005`), which added the four
@@ -52,14 +64,14 @@ many QDMI jobs a shot vector decomposes into.
 
 Ranked by complexity removed per unit of risk.
 
-| #    | Assertion                   | Class          | Remedy       | Unlock                              | Risk |
-| :--- | :-------------------------- | :------------- | :----------- | :---------------------------------- | :--- |
-| 1    | `test_converter.py:131-133` | Over-specified | Narrow       | Readable QASM output                | Low  |
-| 2    | `test_converter.py:212`     | Contract-free  | Delete       | −16 lines, −1 QDMI call per tape    | Low  |
-| 3    | `test_device.py:89-90`      | Contract-free  | Narrow       | Frees the ordering strategy         | Low  |
-| 4    | `test_device.py:180`        | Over-specified | Narrow       | None; the claimed guard is not real | Low  |
-| 5    | `test_device.py:73`         | Contract-free  | Strengthen   | None                                | Low  |
-| 6    | `test_converter.py:27-33`   | Contract-free  | Rewrite file | −99% QDMI calls in preprocessing    | High |
+| #   | Assertion                   | Class          | Remedy       | Unlock                              | Risk | Status   |
+| :-- | :-------------------------- | :------------- | :----------- | :---------------------------------- | :--- | :------- |
+| 1   | `test_converter.py:131-133` | Over-specified | Narrow       | Readable QASM output                | Low  | Applied  |
+| 2   | `test_converter.py:212`     | Contract-free  | Delete       | −16 lines, −1 QDMI call per tape    | Low  | Applied  |
+| 3   | `test_device.py:89-90`      | Contract-free  | Narrow       | Frees the ordering strategy         | Low  | Applied  |
+| 4   | `test_device.py:180`        | Over-specified | Narrow       | None; the claimed guard is not real | Low  | Narrowed |
+| 5   | `test_device.py:73`         | Contract-free  | Strengthen   | None                                | Low  | Applied  |
+| 6   | `test_converter.py:27-33`   | Contract-free  | Rewrite file | −99% QDMI calls in preprocessing    | High | Applied  |
 
 ## Verdicts
 
@@ -104,6 +116,10 @@ Exact float equality, so any real precision loss still fails.
 device becomes readable, at identical precision. Three assertions were the only
 thing preventing it.
 
+**Applied.** The three assertions now parse the emitted literals and compare
+them as exact floats, and `_format_parameter` became `repr` at its single call
+site. `IsingXX(0.1)` reaches a device as `rxx(0.1)`.
+
 ### 2. The same format rule is implemented twice, and each wording is pinned
 
 `device.py:187-202` and `converter.py:132-147` are the same rule: QASM3, then
@@ -137,6 +153,12 @@ per converted tape. `device.py:163` already caches the selected format as
 simply does not pass it, so `converter.py:413` re-derives it. Removing the
 second implementation also removes the standing risk that the two diverge —
 which, in wording, they already have.
+
+**Applied.** `converter._preferred_format` is gone, and
+`test_rejects_device_without_qasm` with it. The device passes the format it
+already selected to the converter, so the rule has one implementation and one
+wording. Applied together with verdict 6, because on its own it would have
+changed a public signature that verdict 6 removes.
 
 ### 3. Histogram expansion order is asserted but never promised
 
@@ -178,6 +200,11 @@ assert Counter(map(tuple, samples.tolist())) == {(0, 0): 4, (1, 1): 4}
 a synthesized shot order looks meaningful and is not, so pinning it in a test
 also advertises a guarantee the device does not make.
 
+**Applied.** The test now asserts
+`Counter(map(tuple, samples.tolist())) == {(0, 0): 4, (1, 1): 4}`. The `sorted`
+call at `device.py:274` was left in place: the point is that the expansion
+strategy is now free to change, not that it must.
+
 ### 4. A defence that the experiment refuted
 
 The advocate for these assertions argued that `test_device.py:180`,
@@ -215,6 +242,13 @@ Recording this verdict matters more than the lines it saves. The argument was
 careful, cited the plan and the pipeline, and was wrong, and only running it
 showed that.
 
+**Narrowed, not applied.** The assertion is now `count("ry(") == 1`. The probe
+was re-run at `3354fdaab` and reproduced: `rotations=True` still fails no test.
+No code change followed, because there is nothing here to change --
+`rotations=False` remains correct and remains protected by nothing. Anyone
+changing the preprocessing pipeline so that a diagonalizing gate survives to the
+serializer will get a wrong expectation value with no test failing.
+
 ### 5. An assertion that cannot fail for its own purpose
 
 `test_device.py:73` asserts `device.execution_time >= 0.0`. `device.py:349-353`
@@ -226,6 +260,12 @@ being `None`, or going `NaN`, and nothing else.
 accumulated value, or drop to an explicit finiteness check. `> 0.0` is not
 available: a coarse-resolution clock can return a zero delta for the stub's
 instantly-completing job.
+
+**Applied.** A new test freezes the clock over a three-job shot vector and
+asserts the exact accumulated total; `QDMIDevice` now imports `monotonic` by
+name so a test can replace this device's clock alone. Replacing the accumulation
+with `+= 0.0` fails the new test. The broad execution test keeps an explicit
+finiteness check, which is what the old assertion really did.
 
 ### 6. A public function that exists for its tests, and what it costs
 
@@ -259,6 +299,24 @@ table at construction.
 it should be a maintainer decision rather than a drive-by change. It is listed
 last for that reason, not because it is worth least.
 
+**Applied.** `test_converter.py` is rewritten against `QDMIDevice` and
+`StubDevice.submissions`, and `ProgramConverter` binds the conversion to one
+opened device session. Measured at the QDMI boundary on a 100-gate circuit over
+an 18-operation device: 101 `operations()` round trips and 1818 `name()` calls
+per preprocessing and conversion pass become 1 and 18 once, for the life of the
+device.
+
+Two branches lost their old callers when the tests moved to the device boundary:
+the OpenQASM 3 and OpenQASM 2 refusals of an unadvertised operation, which
+`decompose` now reaches first. Both tests regained them by also executing a tape
+through `Device.execute` directly, which is the path where conversion, not
+preprocessing, has to refuse. Plugin coverage is 85% before and after, with
+three fewer missed statements in absolute terms over a smaller body of code.
+
+`.agent/plans/qdmi-pennylane-device.md:385-387` still documents
+`ConvertedProgram` and `convert_program` as public. It is left as the record of
+what that task did, not corrected to match the code.
+
 ## Anchors confirmed
 
 **The endianness convention.** `device.py:300` reverses each QDMI bit string.
@@ -291,6 +349,10 @@ not cleared.
 - `test_converter.py:216-223`, the `nan`/`inf`/`-inf` matrix. The argument is
   that each value kills a different mutant of `math.isfinite`. Plausible and
   untested here.
+
+Both survived the verdict 6 rewrite unchanged in substance. After `#2147` they
+live at `test_converter.py:184-194` and `:240-254`, and both now assert against
+what the device receives rather than against a direct converter call.
 
 ## Deliberately not touched
 
@@ -332,6 +394,9 @@ credit for them; they are recorded so the reading is not wasted.
 - `converter.py:348-353` and `converter.py:392-397` construct `ConvertedProgram`
   twice with identical measurement-decoding arguments.
 
+**Applied.** All four landed in `#2147`, alongside the verdicts whose commits
+already touched the same lines.
+
 ## Progress
 
 - [x] (2026-08-15) Spec ledger built from four isolated source classes, none of
@@ -341,5 +406,8 @@ credit for them; they are recorded so the reading is not wasted.
       sight of the prosecution.
 - [x] (2026-08-15) Seven fault-injection probes executed; two overturned a
       verdict that argument alone had settled the wrong way.
-- [ ] Probe `test_converter.py:171-181` against a bumped PennyLane.
-- [ ] Reconcile against the default branch after any verdict is applied.
+- [x] (2026-08-18) All six verdicts and the four cleanups applied in `#2147`,
+      one commit pair per verdict.
+- [x] (2026-08-18) Reconciled against `3354fdaab`; every citation re-read and
+      still resolving, every verdict marked.
+- [ ] Probe the exact QASM2 payload assertion against a bumped PennyLane.

--- a/.agent/audits/pennylane-plugin.md
+++ b/.agent/audits/pennylane-plugin.md
@@ -310,8 +310,15 @@ Two branches lost their old callers when the tests moved to the device boundary:
 the OpenQASM 3 and OpenQASM 2 refusals of an unadvertised operation, which
 `decompose` now reaches first. Both tests regained them by also executing a tape
 through `Device.execute` directly, which is the path where conversion, not
-preprocessing, has to refuse. Plugin coverage is 85% before and after, with
-three fewer missed statements in absolute terms over a smaller body of code.
+preprocessing, has to refuse.
+
+Codecov then rejected the patch at 92.8% of the diff, which exposed something
+the audit had not looked for: `_validate_qdmi_contract` reads advertised sites,
+site pairs, and the device coupling map, and no test exercised any of it beyond
+one site-pair rejection. Those tests now exist. Plugin coverage went from 85% to
+90%, the converter from 82% to 94%, and every source line this change added is
+covered. The one branch that could not be covered, a third program format in
+`supports`, was unreachable and is gone.
 
 `.agent/plans/qdmi-pennylane-device.md:385-387` still documents
 `ConvertedProgram` and `convert_program` as public. It is left as the record of

--- a/.agent/audits/pennylane-plugin.md
+++ b/.agent/audits/pennylane-plugin.md
@@ -300,7 +300,7 @@ it should be a maintainer decision rather than a drive-by change. It is listed
 last for that reason, not because it is worth least.
 
 **Applied.** `test_converter.py` is rewritten against `QDMIDevice` and
-`StubDevice.submissions`, and `ProgramConverter` binds the conversion to one
+`StubDevice.submissions`, and `_ProgramConverter` binds the conversion to one
 opened device session. Measured at the QDMI boundary on a 100-gate circuit over
 an 18-operation device: 101 `operations()` round trips and 1818 `name()` calls
 per preprocessing and conversion pass become 1 and 18 once, for the life of the
@@ -398,8 +398,8 @@ credit for them; they are recorded so the reading is not wasted.
   first whenever the tape has shots, which is always.
 - `_finite_parameter` and `_format_parameter` (`converter.py:202-228`) are 25
   lines across two functions, each with one caller.
-- `converter.py:348-353` and `converter.py:392-397` construct `ConvertedProgram`
-  twice with identical measurement-decoding arguments.
+- `converter.py:348-353` and `converter.py:392-397` construct
+  `_ConvertedProgram` twice with identical measurement-decoding arguments.
 
 **Applied.** All four landed in `#2147`, alongside the verdicts whose commits
 already touched the same lines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,11 +137,9 @@ releases may include breaking changes.
 
 ### Changed
 
-- 🧪 Apply the first SpecAudit to the PennyLane plugin. Tests that pinned
-  unspecified behavior are narrowed or replaced, the emitted OpenQASM parameter
-  literals become readable at identical precision, and program conversion reads
-  the advertised QDMI gate set once per device session instead of once per gate
-  ([#2147]) ([**@marcelwa**])
+- 🧪 Apply the first SpecAudit to the PennyLane plugin, narrowing tests that
+  pinned unspecified behavior and reading the advertised QDMI gate set once per
+  device session ([#2147]) ([**@marcelwa**])
 - 💥 Prune dead and misleading CoreIR APIs, including renaming the non-garbage
   logical output count to `getNoutputQubits()` and `num_output_qubits` ([#2112])
   ([**@simon1hofmann**])
@@ -180,8 +178,8 @@ releases may include breaking changes.
   `dd/Approximation.hpp` header, `dd::ApproximationMetadata`, and
   `dd::approximate`. No replacement is provided ([#2154]) ([**@burgholzer**])
 - 💥 Remove `convert_program` and `ConvertedProgram` from
-  `mqt.core.plugins.pennylane`. The program-conversion surface behind
-  `QDMIDevice` is now private ([#2147]) ([**@marcelwa**])
+  `mqt.core.plugins.pennylane`, making program conversion private behind
+  `QDMIDevice` ([#2147]) ([**@marcelwa**])
 - 💥 Remove `nlohmann_json` from the public package contract. MQT Core no longer
   installs or exports the library, no installed header exposes a `nlohmann`
   type, and the decision-diagram statistics report through strings and streams

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ releases may include breaking changes.
   and Python FoMaC APIs, and expose optional device queue length and job queue
   position ([#2008], [#2010]) ([**@burgholzer**])
 - 🐍 Start building CPython 3.15 wheels ([#2011]) ([**@denialhaag**])
-- ✨ Add PennyLane support for gate-based QDMI devices ([#2005], [#2147]) ([**@burgholzer**],
-  [**@marcelwa**])
+- ✨ Add PennyLane support for gate-based QDMI devices ([#2005], [#2147])
+  ([**@burgholzer**], [**@marcelwa**])
 - ✨ Integrate QDMI devices as MLIR compiler targets across C++, Python, and
   `mqt-cc` ([#1687]) ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add structured OpenQASM emission from the QC dialect to the C++ and Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,7 @@ releases may include breaking changes.
   and Python FoMaC APIs, and expose optional device queue length and job queue
   position ([#2008], [#2010]) ([**@burgholzer**])
 - 🐍 Start building CPython 3.15 wheels ([#2011]) ([**@denialhaag**])
-- ✨ Add PennyLane support for gate-based QDMI devices and read each device's
-  advertised gate set once per session ([#2005], [#2147]) ([**@burgholzer**],
+- ✨ Add PennyLane support for gate-based QDMI devices ([#2005], [#2147]) ([**@burgholzer**],
   [**@marcelwa**])
 - ✨ Integrate QDMI devices as MLIR compiler targets across C++, Python, and
   `mqt-cc` ([#1687]) ([**@MatthiasReumann**], [**@burgholzer**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,9 @@ releases may include breaking changes.
   and Python FoMaC APIs, and expose optional device queue length and job queue
   position ([#2008], [#2010]) ([**@burgholzer**])
 - 🐍 Start building CPython 3.15 wheels ([#2011]) ([**@denialhaag**])
-- ✨ Add PennyLane support for gate-based QDMI devices ([#2005])
-  ([**@burgholzer**])
+- ✨ Add PennyLane support for gate-based QDMI devices and read each device's
+  advertised gate set once per session ([#2005], [#2147]) ([**@burgholzer**],
+  [**@marcelwa**])
 - ✨ Integrate QDMI devices as MLIR compiler targets across C++, Python, and
   `mqt-cc` ([#1687]) ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add structured OpenQASM emission from the QC dialect to the C++ and Python
@@ -137,9 +138,6 @@ releases may include breaking changes.
 
 ### Changed
 
-- 🧪 Apply the first SpecAudit to the PennyLane plugin, narrowing tests that
-  pinned unspecified behavior and reading the advertised QDMI gate set once per
-  device session ([#2147]) ([**@marcelwa**])
 - 💥 Prune dead and misleading CoreIR APIs, including renaming the non-garbage
   logical output count to `getNoutputQubits()` and `num_output_qubits` ([#2112])
   ([**@simon1hofmann**])
@@ -177,9 +175,6 @@ releases may include breaking changes.
 - 💥 Remove the unused decision-diagram approximation algorithm, including the
   `dd/Approximation.hpp` header, `dd::ApproximationMetadata`, and
   `dd::approximate`. No replacement is provided ([#2154]) ([**@burgholzer**])
-- 💥 Remove `convert_program` and `ConvertedProgram` from
-  `mqt.core.plugins.pennylane`, making program conversion private behind
-  `QDMIDevice` ([#2147]) ([**@marcelwa**])
 - 💥 Remove `nlohmann_json` from the public package contract. MQT Core no longer
   installs or exports the library, no installed header exposes a `nlohmann`
   type, and the decision-diagram statistics report through strings and streams

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,11 @@ releases may include breaking changes.
 
 ### Changed
 
+- 🧪 Apply the first SpecAudit to the PennyLane plugin. Tests that pinned
+  unspecified behavior are narrowed or replaced, the emitted OpenQASM parameter
+  literals become readable at identical precision, and program conversion reads
+  the advertised QDMI gate set once per device session instead of once per gate
+  ([#2147]) ([**@marcelwa**])
 - 💥 Prune dead and misleading CoreIR APIs, including renaming the non-garbage
   logical output count to `getNoutputQubits()` and `num_output_qubits` ([#2112])
   ([**@simon1hofmann**])
@@ -174,6 +179,9 @@ releases may include breaking changes.
 - 💥 Remove the unused decision-diagram approximation algorithm, including the
   `dd/Approximation.hpp` header, `dd::ApproximationMetadata`, and
   `dd::approximate`. No replacement is provided ([#2154]) ([**@burgholzer**])
+- 💥 Remove `convert_program` and `ConvertedProgram` from
+  `mqt.core.plugins.pennylane`. The program-conversion surface behind
+  `QDMIDevice` is now private ([#2147]) ([**@marcelwa**])
 - 💥 Remove `nlohmann_json` from the public package contract. MQT Core no longer
   installs or exports the library, no installed header exposes a `nlohmann`
   type, and the decision-diagram statistics report through strings and streams
@@ -808,6 +816,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#2154]: https://github.com/munich-quantum-toolkit/core/pull/2154
+[#2147]: https://github.com/munich-quantum-toolkit/core/pull/2147
 [#2138]: https://github.com/munich-quantum-toolkit/core/pull/2138
 [#2137]: https://github.com/munich-quantum-toolkit/core/pull/2137
 [#2136]: https://github.com/munich-quantum-toolkit/core/pull/2136

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -104,16 +104,6 @@ MQT Core no longer provides the decision-diagram approximation algorithm. The
 algorithm had no production owner in the MQT ecosystem. Remove uses of the
 `dd/Approximation.hpp` header, the `dd::ApproximationMetadata` type, and the
 `dd::approximate` function. MQT Core does not provide a replacement.
-### Private PennyLane program conversion
-
-The PennyLane plugin exposes only its devices. `QDMIDevice` and `DDSIMDevice`
-are the supported entry points, and the conversion surface behind them is now
-private. MQT Core removed the following names from `mqt.core.plugins.pennylane`:
-
-- `convert_program`. Execute the tape through `QDMIDevice` instead. The
-  converter now belongs to one opened device session, so it reads the advertised
-  gate set once rather than on every operation.
-- `ConvertedProgram`, the return type of `convert_program`.
 
 ### Private `nlohmann_json` dependency
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -104,6 +104,16 @@ MQT Core no longer provides the decision-diagram approximation algorithm. The
 algorithm had no production owner in the MQT ecosystem. Remove uses of the
 `dd/Approximation.hpp` header, the `dd::ApproximationMetadata` type, and the
 `dd::approximate` function. MQT Core does not provide a replacement.
+### Private PennyLane program conversion
+
+The PennyLane plugin exposes only its devices. `QDMIDevice` and `DDSIMDevice`
+are the supported entry points, and the conversion surface behind them is now
+private. MQT Core removed the following names from `mqt.core.plugins.pennylane`:
+
+- `convert_program`. Execute the tape through `QDMIDevice` instead. The
+  converter now belongs to one opened device session, so it reads the advertised
+  gate set once rather than on every operation.
+- `ConvertedProgram`, the return type of `convert_program`.
 
 ### Private `nlohmann_json` dependency
 

--- a/python/mqt/core/plugins/pennylane/__init__.py
+++ b/python/mqt/core/plugins/pennylane/__init__.py
@@ -28,7 +28,6 @@ else:
 __all__ = ["HAS_PENNYLANE"]
 
 if TYPE_CHECKING or (sys.version_info >= (3, 11) and HAS_PENNYLANE):
-    from .converter import ConvertedProgram, convert_program
     from .device import DDSIMDevice, QDMIDevice
     from .exceptions import (
         PennyLaneConfigurationError,
@@ -41,7 +40,6 @@ if TYPE_CHECKING or (sys.version_info >= (3, 11) and HAS_PENNYLANE):
     )
 
     __all__ += [
-        "ConvertedProgram",
         "DDSIMDevice",
         "PennyLaneConfigurationError",
         "PennyLaneExecutionError",
@@ -51,5 +49,4 @@ if TYPE_CHECKING or (sys.version_info >= (3, 11) and HAS_PENNYLANE):
         "PennyLaneValidationError",
         "QDMIDevice",
         "QDMIPluginError",
-        "convert_program",
     ]

--- a/python/mqt/core/plugins/pennylane/converter.py
+++ b/python/mqt/core/plugins/pennylane/converter.py
@@ -213,10 +213,8 @@ class ProgramConverter:
         """
         if self._program_format == ProgramFormat.QASM3:
             return _resolve_qasm3_operation(operation, self._advertised) is not None
-        if self._program_format == ProgramFormat.QASM2:
-            spelling = _QASM2_OPERATIONS.get(operation.name)
-            return spelling is not None and spelling in self._advertised
-        return False
+        spelling = _QASM2_OPERATIONS.get(operation.name)
+        return spelling is not None and spelling in self._advertised
 
     def convert(self, tape: QuantumScript) -> ConvertedProgram:
         """Convert one preprocessed tape to the selected program format.

--- a/python/mqt/core/plugins/pennylane/converter.py
+++ b/python/mqt/core/plugins/pennylane/converter.py
@@ -24,9 +24,6 @@ from .exceptions import (
     PennyLaneTranslationError as TranslationError,
 )
 from .exceptions import (
-    PennyLaneUnsupportedFormatError as UnsupportedFormatError,
-)
-from .exceptions import (
     PennyLaneUnsupportedOperationError as UnsupportedOperationError,
 )
 from .exceptions import (
@@ -40,7 +37,7 @@ if TYPE_CHECKING:
     from pennylane.tape import QuantumScript
     from pennylane.wires import Wires
 
-__all__ = ["ConvertedProgram", "convert_program", "supports_operation"]
+__all__ = ["ConvertedProgram", "ProgramConverter"]
 
 
 @dataclass(frozen=True)
@@ -124,29 +121,6 @@ _QASM2_OPERATIONS: Mapping[str, str] = MappingProxyType({
 })
 
 
-def _device_operations(device: QDMIDevice) -> dict[str, QDMIDevice.Operation]:
-    """Return advertised operations keyed by their lower-case spelling."""
-    return {operation.name().lower(): operation for operation in device.operations()}
-
-
-def _preferred_format(device: QDMIDevice) -> ProgramFormat:
-    """Choose the required QASM3-first exchange format.
-
-    Returns:
-        The selected QDMI program format.
-
-    Raises:
-        PennyLaneUnsupportedFormatError: If neither OpenQASM version is advertised.
-    """
-    formats = set(device.supported_program_formats())
-    if ProgramFormat.QASM3 in formats:
-        return ProgramFormat.QASM3
-    if ProgramFormat.QASM2 in formats:
-        return ProgramFormat.QASM2
-    msg = f"QDMI device '{device.name()}' supports none of the required program formats: OpenQASM 3 or OpenQASM 2."
-    raise UnsupportedFormatError(msg)
-
-
 def _resolve_qasm3_operation(
     operation: Operator, advertised: Mapping[str, QDMIDevice.Operation]
 ) -> tuple[str, _OperationSpec, QDMIDevice.Operation] | None:
@@ -162,41 +136,6 @@ def _resolve_qasm3_operation(
         if alias in advertised:
             return alias, spec, advertised[alias]
     return None
-
-
-def supports_operation(operation: Operator, device: QDMIDevice, program_format: ProgramFormat) -> bool:
-    """Return whether an operation can stop PennyLane decomposition.
-
-    For OpenQASM 3, support requires an operation-table entry and one matching
-    semantic spelling advertised by QDMI. For OpenQASM 2, support additionally
-    requires the exact gate spelling produced by PennyLane's serializer.
-    """
-    advertised = _device_operations(device)
-    if program_format == ProgramFormat.QASM3:
-        return _resolve_qasm3_operation(operation, advertised) is not None
-    if program_format == ProgramFormat.QASM2:
-        spelling = _QASM2_OPERATIONS.get(operation.name)
-        return spelling is not None and spelling in advertised
-    return False
-
-
-def _wire_mapping(device_wires: Wires) -> Mapping[Hashable, int]:
-    """Build an immutable, deterministic wire-label mapping.
-
-    Returns:
-        The mapping from wire labels to contiguous QASM indices.
-    """
-    return MappingProxyType({wire: index for index, wire in enumerate(device_wires)})
-
-
-def _measurement_order(tape: QuantumScript, wire_map: Mapping[Hashable, int]) -> tuple[int, ...]:
-    """Return sample columns in the order requested by the transformed tape."""
-    if not tape.measurements:
-        return tuple(wire_map.values())
-    measured_wires = tape.measurements[0].wires
-    if len(measured_wires) == 0:
-        return tuple(wire_map.values())
-    return tuple(wire_map[wire] for wire in measured_wires)
 
 
 def _finite_parameter(parameter: object, operation_name: str) -> float:
@@ -239,170 +178,212 @@ def _validate_operation_shape(operation: Operator, spec: _OperationSpec) -> None
         raise ValidationError(msg)
 
 
-def _validate_qdmi_contract(
-    operation: Operator,
-    spec: _OperationSpec,
-    qdmi_operation: QDMIDevice.Operation,
-    indices: tuple[int, ...],
-    device: QDMIDevice,
-) -> None:
-    """Validate operation metadata and any loci advertised by QDMI.
+class ProgramConverter:
+    """Convert preprocessed PennyLane tapes for one opened QDMI device.
 
-    Raises:
-        PennyLaneValidationError: If arity, parameters, or topology do not match.
+    The advertised operation table and the wire mapping do not change while a
+    device session is open, so the converter reads them once and reuses them for
+    every operation and every tape.
+
+    Args:
+        device: Opened QDMI device.
+        device_wires: PennyLane wire labels exposed by the device.
+        program_format: Program format the device selected.
     """
-    qdmi_wires = qdmi_operation.qubits_num()
-    if qdmi_wires is not None and qdmi_wires != spec.wires:
-        msg = (
-            f"QDMI operation '{qdmi_operation.name()}' advertises {qdmi_wires} wires, "
-            f"but '{operation.name}' requires {spec.wires}."
+
+    def __init__(self, device: QDMIDevice, device_wires: Wires, program_format: ProgramFormat) -> None:
+        """Read the advertised capabilities of one opened QDMI device."""
+        self._device = device
+        self._device_wires = device_wires
+        self._program_format = program_format
+        self._advertised = {operation.name().lower(): operation for operation in device.operations()}
+        self._wire_map: Mapping[Hashable, int] = MappingProxyType({
+            wire: index for index, wire in enumerate(device_wires)
+        })
+
+    def supports(self, operation: Operator) -> bool:
+        """Return whether an operation can stop PennyLane decomposition.
+
+        For OpenQASM 3, support requires an operation-table entry and one matching
+        semantic spelling advertised by QDMI. For OpenQASM 2, support additionally
+        requires the exact gate spelling produced by PennyLane's serializer.
+
+        Returns:
+            Whether the device runs the operation without further decomposition.
+        """
+        if self._program_format == ProgramFormat.QASM3:
+            return _resolve_qasm3_operation(operation, self._advertised) is not None
+        if self._program_format == ProgramFormat.QASM2:
+            spelling = _QASM2_OPERATIONS.get(operation.name)
+            return spelling is not None and spelling in self._advertised
+        return False
+
+    def convert(self, tape: QuantumScript) -> ConvertedProgram:
+        """Convert one preprocessed tape to the selected program format.
+
+        A QASM3 translation error is never retried as QASM2. QASM2 is selected
+        only if QASM3 is not advertised at all.
+
+        Returns:
+            The converted program and its deterministic measurement metadata.
+        """
+        if self._program_format == ProgramFormat.QASM3:
+            return self._convert_qasm3(tape)
+        return self._convert_qasm2(tape)
+
+    def _program(self, tape: QuantumScript, payload: str) -> ConvertedProgram:
+        """Attach the measurement-decoding metadata to one converted payload.
+
+        Returns:
+            The converted QDMI program.
+        """
+        return ConvertedProgram(
+            payload=payload,
+            program_format=self._program_format,
+            wire_map=self._wire_map,
+            measurement_order=self._measurement_order(tape),
         )
-        raise ValidationError(msg)
-    if qdmi_operation.parameters_num() != spec.parameters:
-        msg = (
-            f"QDMI operation '{qdmi_operation.name()}' advertises "
-            f"{qdmi_operation.parameters_num()} parameters, but '{operation.name}' "
-            f"requires {spec.parameters}."
-        )
-        raise ValidationError(msg)
 
-    if spec.wires == 1:
-        sites = qdmi_operation.sites()
-        if sites is not None and indices[0] not in {site.index() for site in sites}:
-            msg = f"Operation '{operation.name}' is not advertised on device wire {indices[0]}."
-            raise ValidationError(msg)
-        return
+    def _measurement_order(self, tape: QuantumScript) -> tuple[int, ...]:
+        """Return sample columns in the order requested by the transformed tape.
 
-    if spec.wires != 2:
-        return
+        Returns:
+            The device wire indices, one per sample column.
+        """
+        if not tape.measurements:
+            return tuple(self._wire_map.values())
+        measured_wires = tape.measurements[0].wires
+        if len(measured_wires) == 0:
+            return tuple(self._wire_map.values())
+        return tuple(self._wire_map[wire] for wire in measured_wires)
 
-    site_pairs = qdmi_operation.site_pairs()
-    if site_pairs is not None:
-        advertised_pairs = {(first.index(), second.index()) for first, second in site_pairs}
-        if indices not in advertised_pairs:
-            msg = f"Operation '{operation.name}' is not advertised on device wires {indices}."
-            raise ValidationError(msg)
-        return
+    def _validate_qdmi_contract(
+        self,
+        operation: Operator,
+        spec: _OperationSpec,
+        qdmi_operation: QDMIDevice.Operation,
+        indices: tuple[int, ...],
+    ) -> None:
+        """Validate operation metadata and any loci advertised by QDMI.
 
-    coupling_map = device.coupling_map()
-    if coupling_map is None:
-        return
-    edges = {(first.index(), second.index()) for first, second in coupling_map}
-    if indices not in edges and tuple(reversed(indices)) not in edges:
-        msg = f"Device topology does not connect wires {indices} for operation '{operation.name}'."
-        raise ValidationError(msg)
-
-
-def _convert_qasm3(
-    tape: QuantumScript,
-    device: QDMIDevice,
-    device_wires: Wires,
-) -> ConvertedProgram:
-    """Emit a minimal capability-driven OpenQASM 3 program.
-
-    Returns:
-        The converted QDMI program.
-
-    Raises:
-        PennyLaneUnsupportedOperationError: If no advertised spelling exists.
-        PennyLaneValidationError: If parameters, wires, or topology are invalid.
-    """
-    wire_map = _wire_mapping(device_wires)
-    advertised = _device_operations(device)
-    lines = [
-        "OPENQASM 3.0;",
-        f"qubit[{len(device_wires)}] q;",
-        f"bit[{len(device_wires)}] c;",
-    ]
-
-    for operation in tape.operations:
-        resolved = _resolve_qasm3_operation(operation, advertised)
-        if resolved is None:
-            msg = f"Operation '{operation.name}' has no supported OpenQASM 3 spelling on QDMI device '{device.name()}'."
-            raise UnsupportedOperationError(msg)
-        spelling, spec, qdmi_operation = resolved
-        _validate_operation_shape(operation, spec)
-        try:
-            indices = tuple(wire_map[wire] for wire in operation.wires)
-        except KeyError as exc:
-            msg = f"Operation '{operation.name}' uses wire {exc.args[0]!r}, which is not a device wire."
-            raise ValidationError(msg) from exc
-        _validate_qdmi_contract(operation, spec, qdmi_operation, indices, device)
-
-        # repr gives the shortest literal that reads back as the same double.
-        parameters = ",".join(repr(_finite_parameter(parameter, operation.name)) for parameter in operation.parameters)
-        parameter_list = f"({parameters})" if parameters else ""
-        operands = ",".join(f"q[{index}]" for index in indices)
-        lines.append(f"{spelling}{parameter_list} {operands};")
-
-    lines.append("c = measure q;")
-    payload = "\n".join(lines) + "\n"
-    return ConvertedProgram(
-        payload=payload,
-        program_format=ProgramFormat.QASM3,
-        wire_map=wire_map,
-        measurement_order=_measurement_order(tape, wire_map),
-    )
-
-
-def _convert_qasm2(
-    tape: QuantumScript,
-    device: QDMIDevice,
-    device_wires: Wires,
-) -> ConvertedProgram:
-    """Serialize a QASM2-only program with PennyLane's built-in converter.
-
-    Returns:
-        The converted QDMI program.
-
-    Raises:
-        PennyLaneUnsupportedOperationError: If the serializer/device intersection is empty.
-        PennyLaneTranslationError: If PennyLane cannot serialize the program.
-    """
-    advertised = _device_operations(device)
-    for operation in tape.operations:
-        spelling = _QASM2_OPERATIONS.get(operation.name)
-        if spelling is None or spelling not in advertised:
+        Raises:
+            PennyLaneValidationError: If arity, parameters, or topology do not match.
+        """
+        qdmi_wires = qdmi_operation.qubits_num()
+        if qdmi_wires is not None and qdmi_wires != spec.wires:
             msg = (
-                f"Operation '{operation.name}' cannot be serialized to an "
-                f"OpenQASM 2 gate advertised by QDMI device '{device.name()}'."
+                f"QDMI operation '{qdmi_operation.name()}' advertises {qdmi_wires} wires, "
+                f"but '{operation.name}' requires {spec.wires}."
             )
-            raise UnsupportedOperationError(msg)
+            raise ValidationError(msg)
+        if qdmi_operation.parameters_num() != spec.parameters:
+            msg = (
+                f"QDMI operation '{qdmi_operation.name()}' advertises "
+                f"{qdmi_operation.parameters_num()} parameters, but '{operation.name}' "
+                f"requires {spec.parameters}."
+            )
+            raise ValidationError(msg)
 
-    try:
-        payload = qp.to_openqasm(
-            tape,
-            wires=device_wires,
-            rotations=False,
-            measure_all=True,
-        )
-    except Exception as exc:
-        msg = f"Failed to translate the PennyLane program to OpenQASM 2: {exc}"
-        raise TranslationError(msg) from exc
+        if spec.wires == 1:
+            sites = qdmi_operation.sites()
+            if sites is not None and indices[0] not in {site.index() for site in sites}:
+                msg = f"Operation '{operation.name}' is not advertised on device wire {indices[0]}."
+                raise ValidationError(msg)
+            return
 
-    wire_map = _wire_mapping(device_wires)
-    return ConvertedProgram(
-        payload=payload,
-        program_format=ProgramFormat.QASM2,
-        wire_map=wire_map,
-        measurement_order=_measurement_order(tape, wire_map),
-    )
+        if spec.wires != 2:
+            return
 
+        site_pairs = qdmi_operation.site_pairs()
+        if site_pairs is not None:
+            advertised_pairs = {(first.index(), second.index()) for first, second in site_pairs}
+            if indices not in advertised_pairs:
+                msg = f"Operation '{operation.name}' is not advertised on device wires {indices}."
+                raise ValidationError(msg)
+            return
 
-def convert_program(
-    tape: QuantumScript,
-    device: QDMIDevice,
-    device_wires: Wires,
-) -> ConvertedProgram:
-    """Convert one preprocessed tape using QASM3-first negotiation.
+        coupling_map = self._device.coupling_map()
+        if coupling_map is None:
+            return
+        edges = {(first.index(), second.index()) for first, second in coupling_map}
+        if indices not in edges and tuple(reversed(indices)) not in edges:
+            msg = f"Device topology does not connect wires {indices} for operation '{operation.name}'."
+            raise ValidationError(msg)
 
-    A QASM3 translation error is never retried as QASM2. QASM2 is selected
-    only if QASM3 is not advertised at all.
+    def _convert_qasm3(self, tape: QuantumScript) -> ConvertedProgram:
+        """Emit a minimal capability-driven OpenQASM 3 program.
 
-    Returns:
-        The converted program and its deterministic measurement metadata.
-    """
-    program_format = _preferred_format(device)
-    if program_format == ProgramFormat.QASM3:
-        return _convert_qasm3(tape, device, device_wires)
-    return _convert_qasm2(tape, device, device_wires)
+        Returns:
+            The converted QDMI program.
+
+        Raises:
+            PennyLaneUnsupportedOperationError: If no advertised spelling exists.
+            PennyLaneValidationError: If parameters, wires, or topology are invalid.
+        """
+        lines = [
+            "OPENQASM 3.0;",
+            f"qubit[{len(self._device_wires)}] q;",
+            f"bit[{len(self._device_wires)}] c;",
+        ]
+
+        for operation in tape.operations:
+            resolved = _resolve_qasm3_operation(operation, self._advertised)
+            if resolved is None:
+                msg = (
+                    f"Operation '{operation.name}' has no supported OpenQASM 3 spelling "
+                    f"on QDMI device '{self._device.name()}'."
+                )
+                raise UnsupportedOperationError(msg)
+            spelling, spec, qdmi_operation = resolved
+            _validate_operation_shape(operation, spec)
+            try:
+                indices = tuple(self._wire_map[wire] for wire in operation.wires)
+            except KeyError as exc:
+                msg = f"Operation '{operation.name}' uses wire {exc.args[0]!r}, which is not a device wire."
+                raise ValidationError(msg) from exc
+            self._validate_qdmi_contract(operation, spec, qdmi_operation, indices)
+
+            # repr gives the shortest literal that reads back as the same double.
+            parameters = ",".join(
+                repr(_finite_parameter(parameter, operation.name)) for parameter in operation.parameters
+            )
+            parameter_list = f"({parameters})" if parameters else ""
+            operands = ",".join(f"q[{index}]" for index in indices)
+            lines.append(f"{spelling}{parameter_list} {operands};")
+
+        lines.append("c = measure q;")
+        return self._program(tape, "\n".join(lines) + "\n")
+
+    def _convert_qasm2(self, tape: QuantumScript) -> ConvertedProgram:
+        """Serialize a QASM2-only program with PennyLane's built-in converter.
+
+        Returns:
+            The converted QDMI program.
+
+        Raises:
+            PennyLaneUnsupportedOperationError: If the serializer/device intersection is empty.
+            PennyLaneTranslationError: If PennyLane cannot serialize the program.
+        """
+        # PennyLane's serializer emits whatever it knows, so the intersection
+        # with the advertised gate set has to be checked before serializing.
+        for operation in tape.operations:
+            spelling = _QASM2_OPERATIONS.get(operation.name)
+            if spelling is None or spelling not in self._advertised:
+                msg = (
+                    f"Operation '{operation.name}' cannot be serialized to an "
+                    f"OpenQASM 2 gate advertised by QDMI device '{self._device.name()}'."
+                )
+                raise UnsupportedOperationError(msg)
+
+        try:
+            payload = qp.to_openqasm(
+                tape,
+                wires=self._device_wires,
+                rotations=False,
+                measure_all=True,
+            )
+        except Exception as exc:
+            msg = f"Failed to translate the PennyLane program to OpenQASM 2: {exc}"
+            raise TranslationError(msg) from exc
+
+        return self._program(tape, payload)

--- a/python/mqt/core/plugins/pennylane/converter.py
+++ b/python/mqt/core/plugins/pennylane/converter.py
@@ -219,15 +219,6 @@ def _finite_parameter(parameter: object, operation_name: str) -> float:
     return value
 
 
-def _format_parameter(parameter: object, operation_name: str) -> str:
-    """Format one QASM parameter without losing double precision.
-
-    Returns:
-        The OpenQASM numeric literal.
-    """
-    return format(_finite_parameter(parameter, operation_name), ".17g")
-
-
 def _validate_operation_shape(operation: Operator, spec: _OperationSpec) -> None:
     """Validate the operation-table arity and parameter contract.
 
@@ -338,7 +329,8 @@ def _convert_qasm3(
             raise ValidationError(msg) from exc
         _validate_qdmi_contract(operation, spec, qdmi_operation, indices, device)
 
-        parameters = ",".join(_format_parameter(parameter, operation.name) for parameter in operation.parameters)
+        # repr gives the shortest literal that reads back as the same double.
+        parameters = ",".join(repr(_finite_parameter(parameter, operation.name)) for parameter in operation.parameters)
         parameter_list = f"({parameters})" if parameters else ""
         operands = ",".join(f"q[{index}]" for index in indices)
         lines.append(f"{spelling}{parameter_list} {operands};")

--- a/python/mqt/core/plugins/pennylane/converter.py
+++ b/python/mqt/core/plugins/pennylane/converter.py
@@ -37,11 +37,9 @@ if TYPE_CHECKING:
     from pennylane.tape import QuantumScript
     from pennylane.wires import Wires
 
-__all__ = ["ConvertedProgram", "ProgramConverter"]
-
 
 @dataclass(frozen=True)
-class ConvertedProgram:
+class _ConvertedProgram:
     """A QDMI payload plus the information required to decode its measurements."""
 
     payload: str
@@ -178,7 +176,7 @@ def _validate_operation_shape(operation: Operator, spec: _OperationSpec) -> None
         raise ValidationError(msg)
 
 
-class ProgramConverter:
+class _ProgramConverter:
     """Convert preprocessed PennyLane tapes for one opened QDMI device.
 
     The advertised operation table and the wire mapping do not change while a
@@ -216,7 +214,7 @@ class ProgramConverter:
         spelling = _QASM2_OPERATIONS.get(operation.name)
         return spelling is not None and spelling in self._advertised
 
-    def convert(self, tape: QuantumScript) -> ConvertedProgram:
+    def convert(self, tape: QuantumScript) -> _ConvertedProgram:
         """Convert one preprocessed tape to the selected program format.
 
         A QASM3 translation error is never retried as QASM2. QASM2 is selected
@@ -229,13 +227,13 @@ class ProgramConverter:
             return self._convert_qasm3(tape)
         return self._convert_qasm2(tape)
 
-    def _program(self, tape: QuantumScript, payload: str) -> ConvertedProgram:
+    def _program(self, tape: QuantumScript, payload: str) -> _ConvertedProgram:
         """Attach the measurement-decoding metadata to one converted payload.
 
         Returns:
             The converted QDMI program.
         """
-        return ConvertedProgram(
+        return _ConvertedProgram(
             payload=payload,
             program_format=self._program_format,
             wire_map=self._wire_map,
@@ -308,7 +306,7 @@ class ProgramConverter:
             msg = f"Device topology does not connect wires {indices} for operation '{operation.name}'."
             raise ValidationError(msg)
 
-    def _convert_qasm3(self, tape: QuantumScript) -> ConvertedProgram:
+    def _convert_qasm3(self, tape: QuantumScript) -> _ConvertedProgram:
         """Emit a minimal capability-driven OpenQASM 3 program.
 
         Returns:
@@ -352,7 +350,7 @@ class ProgramConverter:
         lines.append("c = measure q;")
         return self._program(tape, "\n".join(lines) + "\n")
 
-    def _convert_qasm2(self, tape: QuantumScript) -> ConvertedProgram:
+    def _convert_qasm2(self, tape: QuantumScript) -> _ConvertedProgram:
         """Serialize a QASM2-only program with PennyLane's built-in converter.
 
         Returns:

--- a/python/mqt/core/plugins/pennylane/device.py
+++ b/python/mqt/core/plugins/pennylane/device.py
@@ -32,7 +32,7 @@ from mqt.core.qdmi import Job as QDMIJobHandle
 from mqt.core.qdmi import ProgramFormat
 from mqt.core.qdmi.driver import open_device
 
-from .converter import ConvertedProgram, convert_program, supports_operation
+from .converter import ConvertedProgram, ProgramConverter
 from .exceptions import (
     PennyLaneConfigurationError as ConfigurationError,
 )
@@ -161,6 +161,7 @@ class QDMIDevice(Device):
         super().__init__(wires=resolved_wires, shots=None)
         self._shots = Shots(shots)
         self._program_format = self._select_program_format()
+        self._converter = ProgramConverter(self._qdmi_device, self.wires, self._program_format)
         self._submitted_jobs = 0
         self._execution_time = 0.0
 
@@ -222,10 +223,8 @@ class QDMIDevice(Device):
         pipeline.add_transform(measurements_from_samples)
         pipeline.add_transform(
             decompose,
-            stopping_condition=lambda operation: supports_operation(operation, self._qdmi_device, self._program_format),
-            stopping_condition_shots=lambda operation: supports_operation(
-                operation, self._qdmi_device, self._program_format
-            ),
+            stopping_condition=self._converter.supports,
+            stopping_condition_shots=self._converter.supports,
             skip_initial_state_prep=False,
             device_wires=self.wires,
             name=self.name,
@@ -240,13 +239,7 @@ class QDMIDevice(Device):
 
         Returns:
             One positive shot count per required QDMI job.
-
-        Raises:
-            PennyLaneValidationError: If execution is analytic.
         """
-        if not shots:
-            msg = "QDMI devices require a finite number of shots."
-            raise ValidationError(msg)
         return tuple(shot_copy.shots for shot_copy in shots.shot_vector for _ in range(shot_copy.copies))
 
     @staticmethod
@@ -343,7 +336,7 @@ class QDMIDevice(Device):
         Returns:
             Raw samples, partitioned when a shot vector was requested.
         """
-        converted = convert_program(tape, self._qdmi_device, self.wires)
+        converted = self._converter.convert(tape)
         results: list[np.ndarray] = []
         for shots in self._shot_copies(tape.shots):
             started = monotonic()

--- a/python/mqt/core/plugins/pennylane/device.py
+++ b/python/mqt/core/plugins/pennylane/device.py
@@ -32,7 +32,7 @@ from mqt.core.qdmi import Job as QDMIJobHandle
 from mqt.core.qdmi import ProgramFormat
 from mqt.core.qdmi.driver import open_device
 
-from .converter import ConvertedProgram, ProgramConverter
+from .converter import _ConvertedProgram, _ProgramConverter
 from .exceptions import (
     PennyLaneConfigurationError as ConfigurationError,
 )
@@ -161,7 +161,7 @@ class QDMIDevice(Device):
         super().__init__(wires=resolved_wires, shots=None)
         self._shots = Shots(shots)
         self._program_format = self._select_program_format()
-        self._converter = ProgramConverter(self._qdmi_device, self.wires, self._program_format)
+        self._converter = _ProgramConverter(self._qdmi_device, self.wires, self._program_format)
         self._submitted_jobs = 0
         self._execution_time = 0.0
 
@@ -239,7 +239,13 @@ class QDMIDevice(Device):
 
         Returns:
             One positive shot count per required QDMI job.
+
+        Raises:
+            PennyLaneValidationError: If execution is analytic.
         """
+        if not shots:
+            msg = "QDMI devices require a finite number of shots."
+            raise ValidationError(msg)
         return tuple(shot_copy.shots for shot_copy in shots.shot_vector for _ in range(shot_copy.copies))
 
     @staticmethod
@@ -266,7 +272,7 @@ class QDMIDevice(Device):
             raise ExecutionError(msg) from exc
         return [bitstring for bitstring, count in sorted(counts.items()) for _ in range(count)]
 
-    def _samples(self, job: QDMIJobHandle, converted: ConvertedProgram, shots: int) -> np.ndarray:
+    def _samples(self, job: QDMIJobHandle, converted: _ConvertedProgram, shots: int) -> np.ndarray:
         """Convert QDMI bit strings to PennyLane sample rows.
 
         Returns:
@@ -306,7 +312,7 @@ class QDMIDevice(Device):
             msg = f"QDMI job '{job.id}' finished with status {status.name}."
             raise ExecutionError(msg)
 
-    def _submit(self, converted: ConvertedProgram, shots: int) -> QDMIJobHandle:
+    def _submit(self, converted: _ConvertedProgram, shots: int) -> QDMIJobHandle:
         """Submit and wait for one QDMI job.
 
         Returns:

--- a/python/mqt/core/plugins/pennylane/device.py
+++ b/python/mqt/core/plugins/pennylane/device.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 import operator
-import time
+from time import monotonic
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -346,11 +346,11 @@ class QDMIDevice(Device):
         converted = convert_program(tape, self._qdmi_device, self.wires)
         results: list[np.ndarray] = []
         for shots in self._shot_copies(tape.shots):
-            started = time.monotonic()
+            started = monotonic()
             try:
                 results.append(self._samples(self._submit(converted, shots), converted, shots))
             finally:
-                self._execution_time += time.monotonic() - started
+                self._execution_time += monotonic() - started
 
         if tape.shots.has_partitioned_shots:
             return tuple(results)

--- a/test/python/plugins/qdmi_pennylane/helpers.py
+++ b/test/python/plugins/qdmi_pennylane/helpers.py
@@ -23,6 +23,8 @@ from mqt.core.qdmi import ProgramFormat
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
 
+    import pytest
+
 
 def _site(index: int) -> QDMIDevice.Site:
     """Return a site mock with one stable index."""
@@ -176,4 +178,12 @@ def stub_device(
         qubits=qubits,
         result_factory=result_factory,
         expose_shots=expose_shots,
+    )
+
+
+def patch_open_device(monkeypatch: pytest.MonkeyPatch, device: StubDevice) -> None:
+    """Route fresh stable-ID opens to a test double."""
+    monkeypatch.setattr(
+        "mqt.core.plugins.pennylane.device.open_device",
+        lambda *_args, **_kwargs: cast("QDMIDevice", device),
     )

--- a/test/python/plugins/qdmi_pennylane/test_converter.py
+++ b/test/python/plugins/qdmi_pennylane/test_converter.py
@@ -8,11 +8,12 @@
 
 """Tests for capability-driven PennyLane program conversion."""
 
+# ruff: file-ignore[missing-return-type-private-function]
+
 from __future__ import annotations
 
 import re
 import sys
-from typing import cast
 
 import numpy as np
 import pytest
@@ -27,29 +28,18 @@ except ImportError:
 
 from mqt.core.plugins.pennylane import (
     PennyLaneTranslationError,
-    PennyLaneUnsupportedFormatError,
     PennyLaneUnsupportedOperationError,
     PennyLaneValidationError,
-    convert_program,
+    QDMIDevice,
 )
-from mqt.core.qdmi import Device as QDMIDevice
 from mqt.core.qdmi import ProgramFormat
 
-from .helpers import StubDevice, operation
+from .helpers import StubDevice, operation, patch_open_device
 
 
-def _device(value: StubDevice) -> QDMIDevice:
-    """Present a test double at the public converter boundary.
-
-    Returns:
-        The fake device with the public QDMI type.
-    """
-    return cast("QDMIDevice", value)
-
-
-def test_qasm3_prefers_and_resolves_braket_spellings() -> None:
+def test_qasm3_prefers_and_resolves_braket_spellings(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prefer QASM3 and emit only spellings advertised by a Braket-style device."""
-    device = StubDevice(
+    qdmi = StubDevice(
         [
             operation("h", 1),
             operation("cnot", 2),
@@ -57,23 +47,24 @@ def test_qasm3_prefers_and_resolves_braket_spellings() -> None:
             operation("xx", 2, 1),
         ],
         [ProgramFormat.QASM2, ProgramFormat.QASM3],
+        result_factory=lambda _program, shots: ["10"] * shots,
     )
-    tape = qp.tape.QuantumScript(
-        [
-            qp.Hadamard("left"),
-            qp.CNOT(wires=["left", "right"]),
-            qp.PhaseShift(0.25, wires="right"),
-            qp.IsingXX(0.5, wires=["right", "left"]),
-        ],
-        [qp.sample(wires=["right", "left"])],
-        shots=10,
-    )
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=["left", "right"], shots=10)
 
-    converted = convert_program(tape, _device(device), qp.wires.Wires(["left", "right"]))
+    @qp.qnode(device)
+    def circuit():
+        qp.Hadamard("left")
+        qp.CNOT(wires=["left", "right"])
+        qp.PhaseShift(0.25, wires="right")
+        qp.IsingXX(0.5, wires=["right", "left"])
+        return qp.sample(wires=["right", "left"])
 
-    assert converted.program_format == ProgramFormat.QASM3
-    assert converted.measurement_order == (1, 0)
-    assert converted.payload == (
+    samples = circuit()
+    payload, program_format, _shots, _parameters = qdmi.submissions[0]
+
+    assert program_format == ProgramFormat.QASM3
+    assert payload == (
         "OPENQASM 3.0;\n"
         "qubit[2] q;\n"
         "bit[2] c;\n"
@@ -83,15 +74,18 @@ def test_qasm3_prefers_and_resolves_braket_spellings() -> None:
         "xx(0.5) q[1],q[0];\n"
         "c = measure q;\n"
     )
-    assert "include" not in converted.payload
-    assert "gate " not in converted.payload
-    assert "pragma" not in converted.payload
-    assert "inv @" not in converted.payload
+    assert "include" not in payload
+    assert "gate " not in payload
+    assert "pragma" not in payload
+    assert "inv @" not in payload
+    # The QDMI bit string "10" sets the highest-index site, which is wire
+    # "right". The requested measurement order puts that wire first.
+    np.testing.assert_array_equal(samples[0], [1, 0])
 
 
-def test_qasm3_resolves_ddsim_aliases_and_inverse_gates() -> None:
+def test_qasm3_resolves_ddsim_aliases_and_inverse_gates(monkeypatch: pytest.MonkeyPatch) -> None:
     """Resolve MQT Core-style aliases for controls, phases, rotations, and inverses."""
-    device = StubDevice(
+    qdmi = StubDevice(
         [
             operation("cx", 2),
             operation("p", 1, 1),
@@ -105,23 +99,24 @@ def test_qasm3_resolves_ddsim_aliases_and_inverse_gates() -> None:
         ],
         [ProgramFormat.QASM3],
     )
-    tape = qp.tape.QuantumScript(
-        [
-            qp.CNOT(wires=[0, 1]),
-            qp.PhaseShift(-0.125, wires=1),
-            qp.adjoint(qp.S)(0),
-            qp.adjoint(qp.T)(1),
-            qp.SX(0),
-            qp.adjoint(qp.SX)(1),
-            qp.IsingXX(0.1, wires=[0, 1]),
-            qp.IsingYY(0.2, wires=[0, 1]),
-            qp.IsingZZ(0.3, wires=[0, 1]),
-        ],
-        [qp.sample(wires=[0, 1])],
-        shots=5,
-    )
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=5)
 
-    payload = convert_program(tape, _device(device), qp.wires.Wires([0, 1])).payload
+    @qp.qnode(device)
+    def circuit():
+        qp.CNOT(wires=[0, 1])
+        qp.PhaseShift(-0.125, wires=1)
+        qp.adjoint(qp.S)(0)
+        qp.adjoint(qp.T)(1)
+        qp.SX(0)
+        qp.adjoint(qp.SX)(1)
+        qp.IsingXX(0.1, wires=[0, 1])
+        qp.IsingYY(0.2, wires=[0, 1])
+        qp.IsingZZ(0.3, wires=[0, 1])
+        return qp.sample(wires=[0, 1])
+
+    circuit()
+    payload = qdmi.submissions[0][0]
 
     assert "cx q[0],q[1];" in payload
     assert "p(-0.125) q[1];" in payload
@@ -135,11 +130,13 @@ def test_qasm3_resolves_ddsim_aliases_and_inverse_gates() -> None:
 
 def test_qasm3_failure_does_not_fall_back_to_qasm2(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep a QASM3 capability error visible when both formats are advertised."""
-    device = StubDevice(
-        [operation("h", 1)],
-        [ProgramFormat.QASM3, ProgramFormat.QASM2],
-    )
-    tape = qp.tape.QuantumScript([qp.RX(0.2, 0)], [qp.sample(wires=0)], shots=4)
+    # PennyLane's OpenQASM 2 serializer spells U3 as `u3`, and the device
+    # advertises it, so a fallback to OpenQASM 2 would silently succeed. The
+    # OpenQASM 3 operation table has no U3 row, so the QASM3 path must fail.
+    qdmi = StubDevice([operation("u3", 1, 3)], [ProgramFormat.QASM3, ProgramFormat.QASM2])
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=1, shots=4)
+    tape = qp.tape.QuantumScript([qp.U3(0.1, 0.2, 0.3, wires=0)], [qp.sample(wires=0)], shots=4)
     qasm2_called = False
 
     def fail_if_called(*_args: object, **_kwargs: object) -> str:
@@ -148,27 +145,43 @@ def test_qasm3_failure_does_not_fall_back_to_qasm2(monkeypatch: pytest.MonkeyPat
         return ""
 
     monkeypatch.setattr(qp, "to_openqasm", fail_if_called)
-    with pytest.raises(PennyLaneUnsupportedOperationError, match="RX"):
-        convert_program(tape, _device(device), qp.wires.Wires([0]))
+
+    @qp.qnode(device)
+    def circuit():
+        qp.U3(0.1, 0.2, 0.3, wires=0)
+        return qp.sample(wires=0)
+
+    # Preprocessing stops the operation before conversion.
+    with pytest.raises(PennyLaneUnsupportedOperationError):
+        circuit()
+    # Conversion refuses it as well, rather than retrying with OpenQASM 2.
+    with pytest.raises(PennyLaneUnsupportedOperationError, match="OpenQASM 3"):
+        device.execute(tape)
     assert not qasm2_called
+    assert not qdmi.submissions
 
 
-def test_qasm2_fallback_uses_pennylane_serializer_without_rotations() -> None:
+def test_qasm2_fallback_uses_pennylane_serializer(monkeypatch: pytest.MonkeyPatch) -> None:
     """Use PennyLane's QASM2 serializer only when QASM3 is unavailable."""
-    device = StubDevice(
+    qdmi = StubDevice(
         [operation("h", 1), operation("cx", 2), operation("rx", 1, 1)],
         [ProgramFormat.QASM2],
     )
-    tape = qp.tape.QuantumScript(
-        [qp.Hadamard(0), qp.CNOT(wires=[0, 1]), qp.RX(0.25, 1)],
-        [qp.sample(wires=[0, 1])],
-        shots=10,
-    )
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=10)
 
-    converted = convert_program(tape, _device(device), qp.wires.Wires([0, 1]))
+    @qp.qnode(device)
+    def circuit():
+        qp.Hadamard(0)
+        qp.CNOT(wires=[0, 1])
+        qp.RX(0.25, 1)
+        return qp.sample(wires=[0, 1])
 
-    assert converted.program_format == ProgramFormat.QASM2
-    assert converted.payload == (
+    circuit()
+    payload, program_format, _shots, _parameters = qdmi.submissions[0]
+
+    assert program_format == ProgramFormat.QASM2
+    assert payload == (
         "OPENQASM 2.0;\n"
         'include "qelib1.inc";\n'
         "qreg q[2];\n"
@@ -181,56 +194,81 @@ def test_qasm2_fallback_uses_pennylane_serializer_without_rotations() -> None:
     )
 
 
-def test_qasm2_rejects_non_intersection_operation() -> None:
+def test_qasm2_rejects_non_intersection_operation(monkeypatch: pytest.MonkeyPatch) -> None:
     """Reject an operation the serializer knows when the QDMI device does not."""
-    device = StubDevice([operation("h", 1)], [ProgramFormat.QASM2])
+    qdmi = StubDevice([operation("h", 1)], [ProgramFormat.QASM2])
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=2)
     tape = qp.tape.QuantumScript([qp.CNOT(wires=[0, 1])], [qp.sample(wires=[0, 1])], shots=2)
 
+    @qp.qnode(device)
+    def circuit():
+        qp.CNOT(wires=[0, 1])
+        return qp.sample(wires=[0, 1])
+
+    # Preprocessing stops the operation before conversion.
+    with pytest.raises(PennyLaneUnsupportedOperationError):
+        circuit()
+    # Conversion stops it again for a caller that executes a tape directly,
+    # because PennyLane's OpenQASM 2 serializer cannot reject it.
     with pytest.raises(PennyLaneUnsupportedOperationError, match="CNOT"):
-        convert_program(tape, _device(device), qp.wires.Wires([0, 1]))
+        device.execute(tape)
+    assert not qdmi.submissions
 
 
 def test_qasm2_wraps_serializer_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """Expose serializer failures as focused translation errors."""
-    device = StubDevice([operation("h", 1)], [ProgramFormat.QASM2])
-    tape = qp.tape.QuantumScript([qp.Hadamard(0)], [qp.sample(wires=0)], shots=2)
+    qdmi = StubDevice([operation("h", 1)], [ProgramFormat.QASM2])
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=1, shots=2)
 
     def fail(*_args: object, **_kwargs: object) -> str:
         msg = "serializer failed"
         raise ValueError(msg)
 
     monkeypatch.setattr(qp, "to_openqasm", fail)
+
+    @qp.qnode(device)
+    def circuit():
+        qp.Hadamard(0)
+        return qp.sample(wires=0)
+
     with pytest.raises(PennyLaneTranslationError, match="serializer failed"):
-        convert_program(tape, _device(device), qp.wires.Wires([0]))
-
-
-def test_rejects_device_without_qasm() -> None:
-    """Fail before submission when neither supported format is advertised."""
-    device = StubDevice([], [ProgramFormat.QIR_BASE_STRING])
-    tape = qp.tape.QuantumScript([], [qp.sample(wires=0)], shots=2)
-
-    with pytest.raises(PennyLaneUnsupportedFormatError, match="OpenQASM 3 or OpenQASM 2"):
-        convert_program(tape, _device(device), qp.wires.Wires([0]))
+        circuit()
 
 
 @pytest.mark.parametrize("parameter", [np.nan, np.inf, -np.inf])
-def test_rejects_non_finite_parameters(parameter: float) -> None:
+def test_rejects_non_finite_parameters(monkeypatch: pytest.MonkeyPatch, parameter: float) -> None:
     """Reject non-finite bound parameters before submission."""
-    device = StubDevice([operation("rx", 1, 1)], [ProgramFormat.QASM3])
-    tape = qp.tape.QuantumScript([qp.RX(parameter, 0)], [qp.sample(wires=0)], shots=2)
+    qdmi = StubDevice([operation("rx", 1, 1)], [ProgramFormat.QASM3])
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=1, shots=2)
+
+    @qp.qnode(device)
+    def circuit():
+        qp.RX(parameter, 0)
+        return qp.sample(wires=0)
 
     with pytest.raises(PennyLaneValidationError, match="non-finite"):
-        convert_program(tape, _device(device), qp.wires.Wires([0]))
+        circuit()
+    assert not qdmi.submissions
 
 
-def test_validates_operation_topology() -> None:
+def test_validates_operation_topology(monkeypatch: pytest.MonkeyPatch) -> None:
     """Honor operation-specific QDMI site pairs."""
-    device = StubDevice(
+    qdmi = StubDevice(
         [operation("cx", 2, site_pairs=[(0, 1)])],
         [ProgramFormat.QASM3],
         qubits=3,
     )
-    tape = qp.tape.QuantumScript([qp.CNOT(wires=[1, 0])], [qp.sample(wires=[0, 1])], shots=2)
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=3, shots=2)
+
+    @qp.qnode(device)
+    def circuit():
+        qp.CNOT(wires=[1, 0])
+        return qp.sample(wires=[0, 1])
 
     with pytest.raises(PennyLaneValidationError, match=r"not advertised on device wires \(1, 0\)"):
-        convert_program(tape, _device(device), qp.wires.Wires([0, 1, 2]))
+        circuit()
+    assert not qdmi.submissions

--- a/test/python/plugins/qdmi_pennylane/test_converter.py
+++ b/test/python/plugins/qdmi_pennylane/test_converter.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from typing import cast
 
@@ -128,9 +129,8 @@ def test_qasm3_resolves_ddsim_aliases_and_inverse_gates() -> None:
     assert "tdg q[1];" in payload
     assert "sx q[0];" in payload
     assert "sxdg q[1];" in payload
-    assert "rxx(0.10000000000000001) q[0],q[1];" in payload
-    assert "ryy(0.20000000000000001) q[0],q[1];" in payload
-    assert "rzz(0.29999999999999999) q[0],q[1];" in payload
+    emitted = dict(re.findall(r"(rxx|ryy|rzz)\(([^)]+)\) q\[0\],q\[1\];", payload))
+    assert {name: float(value) for name, value in emitted.items()} == {"rxx": 0.1, "ryy": 0.2, "rzz": 0.3}
 
 
 def test_qasm3_failure_does_not_fall_back_to_qasm2(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/python/plugins/qdmi_pennylane/test_converter.py
+++ b/test/python/plugins/qdmi_pennylane/test_converter.py
@@ -272,3 +272,140 @@ def test_validates_operation_topology(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(PennyLaneValidationError, match=r"not advertised on device wires \(1, 0\)"):
         circuit()
     assert not qdmi.submissions
+
+
+def test_rejects_operation_on_an_unadvertised_site(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Honor the single-qubit sites a QDMI operation advertises."""
+    qdmi = StubDevice([operation("h", 1, sites=[0])], [ProgramFormat.QASM3])
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=2)
+
+    @qp.qnode(device)
+    def circuit():
+        qp.Hadamard(0)
+        qp.Hadamard(1)
+        return qp.sample(wires=[0, 1])
+
+    with pytest.raises(PennyLaneValidationError, match="not advertised on device wire 1"):
+        circuit()
+    assert not qdmi.submissions
+
+
+def test_falls_back_to_the_device_coupling_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Use the device topology when an operation advertises no site pairs."""
+    qdmi = StubDevice(
+        [operation("h", 1), operation("cx", 2)],
+        [ProgramFormat.QASM3],
+        qubits=3,
+        coupling_map=[(0, 1)],
+        result_factory=lambda _program, shots: ["000"] * shots,
+    )
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=3, shots=2)
+
+    @qp.qnode(device)
+    def connected():
+        qp.CNOT(wires=[1, 0])
+        return qp.sample(wires=[0, 1])
+
+    @qp.qnode(device)
+    def disconnected():
+        qp.CNOT(wires=[0, 2])
+        return qp.sample(wires=[0, 2])
+
+    # The coupling map is undirected, so the reversed edge is connected too.
+    connected()
+    assert len(qdmi.submissions) == 1
+    with pytest.raises(PennyLaneValidationError, match=r"does not connect wires \(0, 2\)"):
+        disconnected()
+    assert len(qdmi.submissions) == 1
+
+
+def test_accepts_advertised_site_pairs_and_wider_operations(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Accept an advertised site pair, and skip loci checks above two wires."""
+    qdmi = StubDevice(
+        [operation("h", 1), operation("cx", 2, site_pairs=[(0, 1)]), operation("ccx", 3)],
+        [ProgramFormat.QASM3],
+        qubits=3,
+        result_factory=lambda _program, shots: ["000"] * shots,
+    )
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=3, shots=2)
+
+    @qp.qnode(device)
+    def circuit():
+        qp.CNOT(wires=[0, 1])
+        qp.Toffoli(wires=[0, 1, 2])
+        return qp.sample(wires=[0, 1, 2])
+
+    circuit()
+    payload = qdmi.submissions[0][0]
+
+    assert "cx q[0],q[1];" in payload
+    assert "ccx q[0],q[1],q[2];" in payload
+
+
+@pytest.mark.parametrize(
+    ("advertised", "expected"),
+    [
+        (operation("rx", 2, 1), "advertises 2 wires"),
+        (operation("rx", 1, 0), "advertises 0 parameters"),
+    ],
+)
+def test_rejects_contradictory_qdmi_metadata(
+    monkeypatch: pytest.MonkeyPatch, advertised: object, expected: str
+) -> None:
+    """Reject a QDMI operation whose arity contradicts the operation table."""
+    qdmi = StubDevice([advertised], [ProgramFormat.QASM3])  # ty: ignore[invalid-argument-type]
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=1, shots=2)
+
+    @qp.qnode(device)
+    def circuit():
+        qp.RX(0.5, 0)
+        return qp.sample(wires=0)
+
+    with pytest.raises(PennyLaneValidationError, match=expected):
+        circuit()
+    assert not qdmi.submissions
+
+
+def test_measurement_without_wires_samples_every_device_wire(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sample every device wire when the measurement names none."""
+    qdmi = StubDevice(
+        [operation("x", 1)],
+        [ProgramFormat.QASM3],
+        result_factory=lambda _program, shots: ["10"] * shots,
+    )
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=4)
+
+    @qp.qnode(device)
+    def circuit():
+        qp.PauliX(1)
+        return qp.sample()
+
+    samples = circuit()
+
+    assert samples.shape == (4, 2)
+    np.testing.assert_array_equal(samples[0], [0, 1])
+
+
+def test_converts_an_unpreprocessed_tape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Convert a tape handed straight to the device, without preprocessing."""
+    qdmi = StubDevice(
+        [operation("h", 1)],
+        [ProgramFormat.QASM3],
+        result_factory=lambda _program, shots: ["00"] * shots,
+    )
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2, shots=2)
+
+    # Preprocessing always names the measured wires. A tape that skips it may
+    # carry no measurement, or one that names none; both sample every wire.
+    for measurements in ([], [qp.sample()]):
+        samples = np.asarray(device.execute(qp.tape.QuantumScript([qp.Hadamard(0)], measurements, shots=2)))
+        assert samples.shape == (2, 2)
+
+    with pytest.raises(PennyLaneValidationError, match="not a device wire"):
+        device.execute(qp.tape.QuantumScript([qp.Hadamard(5)], [qp.sample(wires=0)], shots=2))

--- a/test/python/plugins/qdmi_pennylane/test_device.py
+++ b/test/python/plugins/qdmi_pennylane/test_device.py
@@ -177,7 +177,7 @@ def test_qasm2_diagonalizes_observable_once(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert np.isfinite(circuit())
     assert qdmi.submissions[0][1] == ProgramFormat.QASM2
-    assert qdmi.submissions[0][0].count("ry(-1.5707963267948966) q[0];") == 1
+    assert qdmi.submissions[0][0].count("ry(") == 1
 
 
 def test_rejects_analytic_execution_before_submission(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/python/plugins/qdmi_pennylane/test_device.py
+++ b/test/python/plugins/qdmi_pennylane/test_device.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import math
 import sys
 from collections import Counter
 from typing import cast
@@ -71,7 +72,7 @@ def test_samples_counts_probabilities_expectations_and_variances(monkeypatch: py
     assert expectation == pytest.approx(0.0)
     assert variance == pytest.approx(1.0)
     assert device.submitted_jobs == 1
-    assert device.execution_time >= 0.0
+    assert math.isfinite(device.execution_time)
 
 
 def test_histogram_only_device_reconstructs_samples(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -88,6 +89,24 @@ def test_histogram_only_device_reconstructs_samples(monkeypatch: pytest.MonkeyPa
 
     assert samples.shape == (8, 2)
     assert Counter(map(tuple, samples.tolist())) == {(0, 0): 4, (1, 1): 4}
+
+
+def test_execution_time_accumulates_one_interval_per_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Accumulate one wall-clock interval for every submitted QDMI job."""
+    qdmi = stub_device()
+    _patch_device(monkeypatch, qdmi)
+    readings = iter([0.0, 1.5, 10.0, 12.25, 100.0, 100.5])
+    monkeypatch.setattr("mqt.core.plugins.pennylane.device.monotonic", lambda: next(readings))
+    device = QDMIDevice("fake.qdmi", wires=2, shots=[(5, 2), 7])
+
+    @qp.qnode(device)
+    def circuit():
+        return qp.probs(wires=[0, 1])
+
+    circuit()
+
+    assert device.submitted_jobs == 3
+    assert device.execution_time == pytest.approx(1.5 + 2.25 + 0.5)
 
 
 def test_shot_vectors_submit_sequential_jobs(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/python/plugins/qdmi_pennylane/test_device.py
+++ b/test/python/plugins/qdmi_pennylane/test_device.py
@@ -201,6 +201,9 @@ def test_rejects_analytic_execution_before_submission(monkeypatch: pytest.Monkey
 
     with pytest.raises(PennyLaneValidationError, match="finite number of shots"):
         circuit()
+    tape = qp.tape.QuantumScript([], [qp.sample(wires=0)], shots=None)
+    with pytest.raises(PennyLaneValidationError, match="finite number of shots"):
+        device.execute(tape)
     assert not qdmi.submissions
 
 

--- a/test/python/plugins/qdmi_pennylane/test_device.py
+++ b/test/python/plugins/qdmi_pennylane/test_device.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import sys
+from collections import Counter
 from typing import cast
 
 import numpy as np
@@ -86,8 +87,7 @@ def test_histogram_only_device_reconstructs_samples(monkeypatch: pytest.MonkeyPa
     samples = circuit()
 
     assert samples.shape == (8, 2)
-    np.testing.assert_array_equal(samples[:4], np.zeros((4, 2), dtype=np.int8))
-    np.testing.assert_array_equal(samples[4:], np.ones((4, 2), dtype=np.int8))
+    assert Counter(map(tuple, samples.tolist())) == {(0, 0): 4, (1, 1): 4}
 
 
 def test_shot_vectors_submit_sequential_jobs(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/python/plugins/qdmi_pennylane/test_device.py
+++ b/test/python/plugins/qdmi_pennylane/test_device.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import math
 import sys
 from collections import Counter
-from typing import cast
 
 import numpy as np
 import pytest
@@ -34,24 +33,15 @@ from mqt.core.plugins.pennylane import (
     PennyLaneValidationError,
     QDMIDevice,
 )
-from mqt.core.qdmi import Device as QDMIDeviceHandle
 from mqt.core.qdmi import ProgramFormat
 
-from .helpers import StubDevice, rotation_results, stub_device
-
-
-def _patch_device(monkeypatch: pytest.MonkeyPatch, device: StubDevice) -> None:
-    """Route fresh stable-ID opens to a test double."""
-    monkeypatch.setattr(
-        "mqt.core.plugins.pennylane.device.open_device",
-        lambda *_args, **_kwargs: cast("QDMIDeviceHandle", device),
-    )
+from .helpers import StubDevice, patch_open_device, rotation_results, stub_device
 
 
 def test_samples_counts_probabilities_expectations_and_variances(monkeypatch: pytest.MonkeyPatch) -> None:
     """Reconstruct common PennyLane result types from raw QDMI samples."""
     qdmi = stub_device()
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     device = QDMIDevice("fake.qdmi", wires=["left", "right"], shots=100)
 
     @qp.qnode(device)
@@ -78,7 +68,7 @@ def test_samples_counts_probabilities_expectations_and_variances(monkeypatch: py
 def test_histogram_only_device_reconstructs_samples(monkeypatch: pytest.MonkeyPatch) -> None:
     """Reconstruct raw samples when a QDMI implementation exposes only counts."""
     qdmi = stub_device(expose_shots=False)
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     device = QDMIDevice("fake.qdmi", wires=2, shots=8)
 
     @qp.qnode(device)
@@ -94,7 +84,7 @@ def test_histogram_only_device_reconstructs_samples(monkeypatch: pytest.MonkeyPa
 def test_execution_time_accumulates_one_interval_per_job(monkeypatch: pytest.MonkeyPatch) -> None:
     """Accumulate one wall-clock interval for every submitted QDMI job."""
     qdmi = stub_device()
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     readings = iter([0.0, 1.5, 10.0, 12.25, 100.0, 100.5])
     monkeypatch.setattr("mqt.core.plugins.pennylane.device.monotonic", lambda: next(readings))
     device = QDMIDevice("fake.qdmi", wires=2, shots=[(5, 2), 7])
@@ -112,7 +102,7 @@ def test_execution_time_accumulates_one_interval_per_job(monkeypatch: pytest.Mon
 def test_shot_vectors_submit_sequential_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
     """Execute every shot-vector copy as a sequential QDMI job."""
     qdmi = stub_device()
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     device = QDMIDevice("fake.qdmi", wires=2, shots=[(5, 2), 7])
 
     @qp.qnode(device)
@@ -130,7 +120,7 @@ def test_shot_vectors_submit_sequential_jobs(monkeypatch: pytest.MonkeyPatch) ->
 def test_batches_execute_in_input_order(monkeypatch: pytest.MonkeyPatch) -> None:
     """Preserve batch ordering with one QDMI submission per tape."""
     qdmi = stub_device()
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     device = QDMIDevice("fake.qdmi", wires=2, shots=6)
     tapes = (
         qp.tape.QuantumScript([qp.PauliX(0)], [qp.probs(wires=[0, 1])], shots=6),
@@ -148,7 +138,7 @@ def test_batches_execute_in_input_order(monkeypatch: pytest.MonkeyPatch) -> None
 def test_parameter_shift_gradient_uses_multiple_qdmi_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
     """Differentiate sampled execution through PennyLane's parameter-shift rule."""
     qdmi = stub_device(qubits=1, result_factory=rotation_results)
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     device = QDMIDevice("fake.qdmi", wires=["theta"], shots=4000)
 
     @qp.qnode(device, diff_method="parameter-shift")
@@ -169,7 +159,7 @@ def test_parameter_shift_gradient_uses_multiple_qdmi_jobs(monkeypatch: pytest.Mo
 def test_hamiltonian_and_non_commuting_measurements_split(monkeypatch: pytest.MonkeyPatch) -> None:
     """Let PennyLane split and aggregate Hamiltonian and non-commuting terms."""
     qdmi = stub_device()
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     device = QDMIDevice("fake.qdmi", wires=2, shots=100)
     hamiltonian = 0.5 * qp.PauliZ(0) + 0.5 * qp.PauliZ(1)
 
@@ -187,7 +177,7 @@ def test_hamiltonian_and_non_commuting_measurements_split(monkeypatch: pytest.Mo
 def test_qasm2_diagonalizes_observable_once(monkeypatch: pytest.MonkeyPatch) -> None:
     """Do not duplicate the X-basis rotation in PennyLane's QASM2 serializer."""
     qdmi = stub_device(program_format=ProgramFormat.QASM2)
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     device = QDMIDevice("fake.qdmi", wires=2, shots=10)
 
     @qp.qnode(device)
@@ -202,7 +192,7 @@ def test_qasm2_diagonalizes_observable_once(monkeypatch: pytest.MonkeyPatch) -> 
 def test_rejects_analytic_execution_before_submission(monkeypatch: pytest.MonkeyPatch) -> None:
     """Reject analytic tapes before a QDMI job is created."""
     qdmi = stub_device()
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     device = QDMIDevice("fake.qdmi", wires=2, shots=None)
 
     @qp.qnode(device)
@@ -217,7 +207,7 @@ def test_rejects_analytic_execution_before_submission(monkeypatch: pytest.Monkey
 def test_validates_configuration_and_width(monkeypatch: pytest.MonkeyPatch) -> None:
     """Reject unknown QDMI parameters and excessive wire counts."""
     qdmi = stub_device()
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
 
     with pytest.raises(PennyLaneConfigurationError, match="unknown"):
         QDMIDevice(
@@ -232,7 +222,7 @@ def test_validates_configuration_and_width(monkeypatch: pytest.MonkeyPatch) -> N
 def test_rejects_device_without_openqasm(monkeypatch: pytest.MonkeyPatch) -> None:
     """Reject unsupported program formats during construction."""
     qdmi = StubDevice([], [ProgramFormat.QIR_BASE_STRING])
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
 
     with pytest.raises(PennyLaneUnsupportedFormatError, match="neither OpenQASM 3 nor OpenQASM 2"):
         QDMIDevice("fake.qdmi", wires=2)
@@ -241,7 +231,7 @@ def test_rejects_device_without_openqasm(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_forwards_job_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
     """Forward generic QDMI custom job parameters unchanged."""
     qdmi = stub_device()
-    _patch_device(monkeypatch, qdmi)
+    patch_open_device(monkeypatch, qdmi)
     device = QDMIDevice(
         "fake.qdmi",
         wires=2,


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This applies the repository's first SpecAudit, [`.agent/audits/pennylane-plugin.md`](https://github.com/munich-quantum-toolkit/core/blob/main/.agent/audits/pennylane-plugin.md), which landed with the method itself in `#2124` and has not been acted on since. The audit is the ledger; this is what acting on it looks like.

All six verdicts are applied, along with the four cleanups the audit found along the way. Every `file:line` the audit cites was re-read at `3354fdaab` and still resolved to the line it names, so the drift since its `18b619af5` baseline invalidated nothing.

### Verdicts

| #   | Verdict                                            | Outcome  | Result                                    |
| :-- | :------------------------------------------------- | :------- | :---------------------------------------- |
| 1   | Parameter rendering pinned to seventeen digits     | Applied  | Readable OpenQASM at identical precision  |
| 2   | The format rule implemented twice                  | Applied  | One implementation, one wording           |
| 3   | Histogram expansion order asserted, never promised | Applied  | Multiplicity asserted, order freed        |
| 4   | A defence the experiment refuted                   | Narrowed | Assertion narrowed; no code change earned |
| 5   | An assertion that cannot fail for its own purpose  | Applied  | Accumulated value asserted exactly        |
| 6   | A public function that exists for its tests        | Applied  | Advertised gate set read once per session |

### What changed, in order

Each verdict is two commits, per guardrail 7 of [`.agent/AUDITS.md`](https://github.com/munich-quantum-toolkit/core/blob/main/.agent/AUDITS.md): the assertion change first, then the code change it unblocked, so a bisection can tell which one broke.

**Verdict 1.** Three assertions pinned `rxx(0.10000000000000001)` and its siblings. Nothing published states how a parameter is rendered; the stated intent is that no precision is lost. The tests now parse the literals and compare them as exact floats, and `_format_parameter`'s `.17g` becomes `repr`, which gives the shortest literal that reads back as the same double. Every OpenQASM program this plugin sends to every device becomes readable.

**Verdict 4.** `count("ry(-1.5707963267948966) q[0];") == 1` was believed to be the only guard against a double diagonalizing rotation. Re-running the audit's probe at this commit confirms its finding: `rotations=True` fails no test, because `measurements_from_samples` has already replaced the observable by the time a tape reaches the QASM2 serializer. The assertion is narrowed to the claim it can still make. `rotations=False` stays and is protected by nothing; the reconciled audit records that rather than papering over it.

**Verdict 5.** `execution_time >= 0.0` could not fail for its own purpose: delete the accumulation and the attribute stays `0.0`. A new test freezes the clock over a three-job shot vector and asserts the exact total. Replacing the accumulation with `+= 0.0` now fails it.

**Verdicts 2 and 6**, the largest change and the reason for the diff size. The three-argument `convert_program(tape, device, wires)` was public only because `test_converter.py` called it, and that signature was what stopped the device from handing down state it had already computed. `supports_operation` is PennyLane's per-operation `stopping_condition`, so it re-read the whole advertised gate set on every gate.

Measured on a 100-gate circuit over an 18-operation device, instrumenting the QDMI boundary:

|                                               | `Device.operations()` | `Operation.name()` |
| :-------------------------------------------- | --------------------: | -----------------: |
| Before, per preprocessing and conversion pass |                   101 |               1818 |
| After, once per opened device session         |                     1 |                 18 |

`test_converter.py` is rewritten against `QDMIDevice` and `StubDevice.submissions`, so every test now asserts what a device actually receives. `ProgramConverter` then binds the conversion to one opened session, `converter._preferred_format` (a second implementation of the format rule, with a second wording of its error) is deleted, and `convert_program` and `ConvertedProgram` leave the public surface. `UPGRADING.md` covers the removal.

### Coverage

Guardrail 9 asks for this plainly. Two branches lost their old callers when the tests moved to the device boundary: the OpenQASM 3 and OpenQASM 2 "operation not advertised" refusals, which `decompose` now reaches first. Both tests regained them by also executing a tape through `Device.execute` directly, which is the path where conversion, not preprocessing, has to do the refusing.

Codecov then rejected the patch at 92.8% of the diff, which exposed something the audit had not looked for: `_validate_qdmi_contract` reads advertised sites, site pairs, and the device coupling map, and no test exercised any of it beyond one site-pair rejection. Those tests now exist. Plugin coverage goes from 85% to 90%, the converter from 82% to 94%, and every source line this change adds is covered. The one branch that could not be covered, a third program format in `supports`, was unreachable and is gone.

### Reconciliation

`.agent/audits/pennylane-plugin.md` is updated in place, per the Reconciling section of the method: a status column, an applied note under each verdict, the coverage consequence, and dated progress entries. The one open item, probing the exact QASM2 payload assertion against a bumped PennyLane, stays open.

Two facts the reconciliation records rather than hides. Verdict 4 is narrowed, not applied. And verdict 6 removed round trips, not lines: the source lost 37 lines while the test tree gained 57, because driving conversion through the device costs QNode boilerplate that a direct converter call did not.

### A note on granularity

`AGENTS.md` asks for one pull request per verdict. This one bundles all six deliberately, as the first end-to-end demonstration of the method; the per-verdict commit pairs preserve the bisection property the separate pull requests would have given. Verdicts 2 and 6 could not have been split anyway: verdict 2 alone changes `convert_program`'s public signature, so it would have shipped a breaking change to an API that verdict 6 removes.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖`.
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
