### PR TITLE
🐛 Let the QDMI client trigger a calibration run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ releases may include breaking changes.
   ([**@marcelwa**])
 - ✨ Add `mqt.core.qdmi.is_binary_program_format`, which states whether a
   program format requires exact-byte submission ([#2114]) ([**@marcelwa**])
+- ✨ Add `Device::submitCalibrationJob` and
+  `mqt.core.qdmi.Device.submit_calibration_job` for triggering a calibration run
+  ([#2140]) ([**@marcelwa**])
 - ✨ Add SpecAudits, a method and probe script for auditing tests that pin
   behavior the project never specified ([#2124]) ([**@marcelwa**])
 - ✨ Extract the existing QCO dead-gate elimination patterns from
@@ -164,6 +167,8 @@ releases may include breaking changes.
 
 ### Removed
 
+- 💥 Remove batch job submission from the QDMI client. `Device::submitJob` now
+  states that MQT Core does not support batch jobs ([#2140]) ([**@marcelwa**])
 - 💥 Remove the IQM JSON converter `qiskit_to_iqm_json` and the `MoveGate` from
   the Qiskit plugin, which [QDMI-on-IQM] now owns ([#2114]) ([**@marcelwa**])
 - 💥 Remove the unused decision-diagram approximation algorithm, including the
@@ -814,6 +819,7 @@ for previous changelogs._
 [#2112]: https://github.com/munich-quantum-toolkit/core/pull/2112
 [#2108]: https://github.com/munich-quantum-toolkit/core/pull/2108
 [#2115]: https://github.com/munich-quantum-toolkit/core/pull/2115
+[#2140]: https://github.com/munich-quantum-toolkit/core/pull/2140
 [#2114]: https://github.com/munich-quantum-toolkit/core/pull/2114
 [#2106]: https://github.com/munich-quantum-toolkit/core/pull/2106
 [#2111]: https://github.com/munich-quantum-toolkit/core/pull/2111

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ releases may include breaking changes.
   program format requires exact-byte submission ([#2114]) ([**@marcelwa**])
 - ✨ Add `Device::submitCalibrationJob` and
   `mqt.core.qdmi.Device.submit_calibration_job` for triggering a calibration run
-  ([#2140]) ([**@marcelwa**])
+  ([#2148]) ([**@marcelwa**])
 - ✨ Add SpecAudits, a method and probe script for auditing tests that pin
   behavior the project never specified ([#2124]) ([**@marcelwa**])
 - ✨ Extract the existing QCO dead-gate elimination patterns from
@@ -168,7 +168,7 @@ releases may include breaking changes.
 ### Removed
 
 - 💥 Remove batch job submission from the QDMI client. `Device::submitJob` now
-  states that MQT Core does not support batch jobs ([#2140]) ([**@marcelwa**])
+  states that MQT Core does not support batch jobs ([#2148]) ([**@marcelwa**])
 - 💥 Remove the IQM JSON converter `qiskit_to_iqm_json` and the `MoveGate` from
   the Qiskit plugin, which [QDMI-on-IQM] now owns ([#2114]) ([**@marcelwa**])
 - 💥 Remove the unused decision-diagram approximation algorithm, including the
@@ -819,7 +819,7 @@ for previous changelogs._
 [#2112]: https://github.com/munich-quantum-toolkit/core/pull/2112
 [#2108]: https://github.com/munich-quantum-toolkit/core/pull/2108
 [#2115]: https://github.com/munich-quantum-toolkit/core/pull/2115
-[#2140]: https://github.com/munich-quantum-toolkit/core/pull/2140
+[#2148]: https://github.com/munich-quantum-toolkit/core/pull/2148
 [#2114]: https://github.com/munich-quantum-toolkit/core/pull/2114
 [#2106]: https://github.com/munich-quantum-toolkit/core/pull/2106
 [#2111]: https://github.com/munich-quantum-toolkit/core/pull/2111

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,31 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Calibration runs and batch jobs
+
+`Device::submitJob` used to reject `CALIBRATION` and `BATCH_JOB` together, which
+left MQT Core reporting that a device needs calibration through
+`needs_calibration()` without any way to trigger one. The two formats are
+different cases and are now treated as such.
+
+A calibration run has its own entry point. QDMI does not require a program for
+one, so the payload is optional; when it is present, the device defines what it
+means:
+
+```python
+device.submit_calibration_job()
+device.submit_calibration_job("configuration")
+```
+
+In C++, use `Device::submitCalibrationJob`. A calibration run executes no
+circuit, so neither form takes a shot count.
+
+Batch jobs are explicitly unsupported. A batch job's program is a list of job
+handles rather than a byte payload, which `submitJob` cannot express, so MQT
+Core says so rather than describing it as a missing payload. Passing
+`ProgramFormat.BATCH_JOB` to `submit_job` raises a `ValueError` that names the
+limitation. Support can return once a device implements the feature.
+
 ### Program serializers for the Qiskit backend
 
 The Qiskit backend no longer decides in its own code how to turn a circuit into

--- a/bindings/qdmi/qdmi.cpp
+++ b/bindings/qdmi/qdmi.cpp
@@ -30,6 +30,7 @@
 #include <span>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace mqt {
@@ -388,6 +389,41 @@ when the custom slot is unsupported.)pb");
       "custom3"_a = nb::none(), "custom4"_a = nb::none(),
       "custom5"_a = nb::none(), nb::rv_policy::reference_internal,
       "Submits an exact byte payload to the device.");
+
+  device.def(
+      "submit_calibration_job",
+      [](const qdmi::Device& self,
+         const std::optional<std::variant<std::string, nb::bytes>>& program,
+         const std::optional<qdmi::CustomJobParameter>& custom1,
+         const std::optional<qdmi::CustomJobParameter>& custom2,
+         const std::optional<qdmi::CustomJobParameter>& custom3,
+         const std::optional<qdmi::CustomJobParameter>& custom4,
+         const std::optional<qdmi::CustomJobParameter>& custom5) {
+        if (!program.has_value()) {
+          return self.submitCalibrationJob(std::nullopt, custom1, custom2,
+                                           custom3, custom4, custom5);
+        }
+        if (const auto* text = std::get_if<std::string>(&*program);
+            text != nullptr) {
+          return self.submitCalibrationJob(*text, custom1, custom2, custom3,
+                                           custom4, custom5);
+        }
+        const auto& payload = std::get<nb::bytes>(*program);
+        const auto bytes = std::span{
+            static_cast<const std::byte*>(payload.data()), payload.size()};
+        return self.submitCalibrationJob(bytes, custom1, custom2, custom3,
+                                         custom4, custom5);
+      },
+      "program"_a = nb::none(), nb::kw_only(), "custom1"_a = nb::none(),
+      "custom2"_a = nb::none(), "custom3"_a = nb::none(),
+      "custom4"_a = nb::none(), "custom5"_a = nb::none(),
+      nb::rv_policy::reference_internal,
+      R"pb(Triggers a calibration run on the device.
+
+QDMI does not require a program for a calibration run, so ``program`` is
+optional and may be a string or bytes. When it is given, the device defines
+what it means, which is usually a configuration for the run. A calibration run
+executes no circuit, so it takes no shot count.)pb");
 
   device.def(
       "retrieve_job_by_id",

--- a/include/mqt-core/qdmi/Client.hpp
+++ b/include/mqt-core/qdmi/Client.hpp
@@ -587,8 +587,8 @@ public:
    * @brief Submits a textual program.
    * @details The terminating null byte required by QDMI text formats is
    * included in the submitted payload.
-   * @throws std::invalid_argument If the format requires binary submission or
-   * does not carry a generic program payload.
+   * @throws std::invalid_argument If the format requires binary submission,
+   * names a batch job, or names a calibration run.
    * @see QDMI_job_submit
    */
   [[nodiscard]] Job submitJob(
@@ -603,13 +603,48 @@ public:
    * @brief Submits a binary program.
    * @details The bytes are submitted exactly as provided without appending a
    * null byte.
-   * @throws std::invalid_argument If the format does not carry a generic
-   * program payload.
+   * @throws std::invalid_argument If the format names a batch job or a
+   * calibration run.
    * @see QDMI_job_submit
    */
   [[nodiscard]] Job submitJob(
       std::span<const std::byte> program, QDMI_Program_Format format,
       size_t numShots,
+      const std::optional<CustomJobParameter>& custom1 = std::nullopt,
+      const std::optional<CustomJobParameter>& custom2 = std::nullopt,
+      const std::optional<CustomJobParameter>& custom3 = std::nullopt,
+      const std::optional<CustomJobParameter>& custom4 = std::nullopt,
+      const std::optional<CustomJobParameter>& custom5 = std::nullopt) const;
+
+  /**
+   * @brief Triggers a calibration run.
+   * @details A device that reports a nonzero
+   * `QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION` is asked to calibrate by submitting
+   * a job in the `QDMI_PROGRAM_FORMAT_CALIBRATION` format. QDMI does not
+   * require a program for such a job, so the payload is optional; when it is
+   * present, the device defines what it means, which is usually a
+   * configuration for the run. A calibration run executes no circuit, so no
+   * shot count is set.
+   * @param program The calibration payload, or `std::nullopt` for none.
+   * @see QDMI_job_submit
+   */
+  [[nodiscard]] Job submitCalibrationJob(
+      std::optional<std::span<const std::byte>> program = std::nullopt,
+      const std::optional<CustomJobParameter>& custom1 = std::nullopt,
+      const std::optional<CustomJobParameter>& custom2 = std::nullopt,
+      const std::optional<CustomJobParameter>& custom3 = std::nullopt,
+      const std::optional<CustomJobParameter>& custom4 = std::nullopt,
+      const std::optional<CustomJobParameter>& custom5 = std::nullopt) const;
+
+  /**
+   * @brief Triggers a calibration run with a text payload.
+   * @details The terminating null byte required by QDMI text formats is
+   * included in the submitted payload.
+   * @param program The calibration payload.
+   * @see QDMI_job_submit
+   */
+  [[nodiscard]] Job submitCalibrationJob(
+      const std::string& program,
       const std::optional<CustomJobParameter>& custom1 = std::nullopt,
       const std::optional<CustomJobParameter>& custom2 = std::nullopt,
       const std::optional<CustomJobParameter>& custom3 = std::nullopt,

--- a/include/mqt-core/qdmi/Client.hpp
+++ b/include/mqt-core/qdmi/Client.hpp
@@ -625,7 +625,8 @@ public:
    * present, the device defines what it means, which is usually a
    * configuration for the run. A calibration run executes no circuit, so no
    * shot count is set.
-   * @param program The calibration payload, or `std::nullopt` for none.
+   * @param program The calibration payload. An empty span or `std::nullopt`
+   * means that the job has no payload.
    * @see QDMI_job_submit
    */
   [[nodiscard]] Job submitCalibrationJob(
@@ -739,6 +740,16 @@ private:
       return value;
     }
   }
+
+  [[nodiscard]] Job
+  submitJobImpl(QDMI_Program_Format format,
+                std::optional<std::span<const std::byte>> program,
+                std::optional<size_t> numShots,
+                const std::optional<CustomJobParameter>& custom1,
+                const std::optional<CustomJobParameter>& custom2,
+                const std::optional<CustomJobParameter>& custom3,
+                const std::optional<CustomJobParameter>& custom4,
+                const std::optional<CustomJobParameter>& custom5) const;
 
   static void setCustomJobParam(QDMI_Job job, QDMI_Job_Parameter param,
                                 const CustomJobParameter& value);

--- a/python/mqt/core/qdmi/__init__.pyi
+++ b/python/mqt/core/qdmi/__init__.pyi
@@ -332,6 +332,24 @@ class Device:
     ) -> Job:
         """Submits an exact byte payload to the device."""
 
+    def submit_calibration_job(
+        self,
+        program: str | bytes | None = None,
+        *,
+        custom1: str | bool | float | None = None,
+        custom2: str | bool | float | None = None,
+        custom3: str | bool | float | None = None,
+        custom4: str | bool | float | None = None,
+        custom5: str | bool | float | None = None,
+    ) -> Job:
+        """Triggers a calibration run on the device.
+
+        QDMI does not require a program for a calibration run, so ``program`` is
+        optional and may be a string or bytes. When it is given, the device defines
+        what it means, which is usually a configuration for the run. A calibration run
+        executes no circuit, so it takes no shot count.
+        """
+
     def retrieve_job_by_id(self, job_id: str) -> Job:
         """Retrieves an existing job by its device-provided ID."""
 

--- a/src/qdmi/Client.cpp
+++ b/src/qdmi/Client.cpp
@@ -392,6 +392,19 @@ Job Device::submitJob(const std::span<const std::byte> program,
                       const std::optional<CustomJobParameter>& custom5) const {
   rejectUnsupportedProgramFormat(format);
 
+  return submitJobImpl(format, program, numShots, custom1, custom2, custom3,
+                       custom4, custom5);
+}
+
+Job Device::submitJobImpl(
+    const QDMI_Program_Format format,
+    const std::optional<std::span<const std::byte>> program,
+    const std::optional<size_t> numShots,
+    const std::optional<CustomJobParameter>& custom1,
+    const std::optional<CustomJobParameter>& custom2,
+    const std::optional<CustomJobParameter>& custom3,
+    const std::optional<CustomJobParameter>& custom4,
+    const std::optional<CustomJobParameter>& custom5) const {
   QDMI_Job job = nullptr;
   qdmi::throwIfError(QDMI_device_create_job(device_.get(), &job),
                      "Creating job");
@@ -401,14 +414,18 @@ Job Device::submitJob(const std::span<const std::byte> program,
                                             QDMI_JOB_PARAMETER_PROGRAMFORMAT,
                                             sizeof(format), &format),
                      "Setting program format");
-  qdmi::throwIfError(QDMI_job_set_parameter(jobWrapper,
-                                            QDMI_JOB_PARAMETER_PROGRAM,
-                                            program.size(), program.data()),
-                     "Setting program");
-  qdmi::throwIfError(QDMI_job_set_parameter(jobWrapper,
-                                            QDMI_JOB_PARAMETER_SHOTSNUM,
-                                            sizeof(numShots), &numShots),
-                     "Setting number of shots");
+  if (program.has_value()) {
+    qdmi::throwIfError(QDMI_job_set_parameter(jobWrapper,
+                                              QDMI_JOB_PARAMETER_PROGRAM,
+                                              program->size(), program->data()),
+                       "Setting program");
+  }
+  if (numShots.has_value()) {
+    qdmi::throwIfError(QDMI_job_set_parameter(jobWrapper,
+                                              QDMI_JOB_PARAMETER_SHOTSNUM,
+                                              sizeof(*numShots), &*numShots),
+                       "Setting number of shots");
+  }
 
   if (custom1.has_value()) {
     setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM1, *custom1);
@@ -437,44 +454,10 @@ Job Device::submitCalibrationJob(
     const std::optional<CustomJobParameter>& custom3,
     const std::optional<CustomJobParameter>& custom4,
     const std::optional<CustomJobParameter>& custom5) const {
-  QDMI_Job job = nullptr;
-  qdmi::throwIfError(QDMI_device_create_job(device_.get(), &job),
-                     "Creating job");
-  Job jobWrapper{job, device_};
-
-  constexpr auto format = QDMI_PROGRAM_FORMAT_CALIBRATION;
-  qdmi::throwIfError(QDMI_job_set_parameter(jobWrapper,
-                                            QDMI_JOB_PARAMETER_PROGRAMFORMAT,
-                                            sizeof(format), &format),
-                     "Setting program format");
-  // QDMI does not require a program for a calibration run, so the parameter is
-  // set only when the caller supplies one. The device defines what it means.
-  if (program.has_value()) {
-    qdmi::throwIfError(QDMI_job_set_parameter(jobWrapper,
-                                              QDMI_JOB_PARAMETER_PROGRAM,
-                                              program->size(), program->data()),
-                       "Setting program");
-  }
-  // A calibration run executes no circuit, so it takes no shot count.
-
-  if (custom1.has_value()) {
-    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM1, *custom1);
-  }
-  if (custom2.has_value()) {
-    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM2, *custom2);
-  }
-  if (custom3.has_value()) {
-    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM3, *custom3);
-  }
-  if (custom4.has_value()) {
-    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM4, *custom4);
-  }
-  if (custom5.has_value()) {
-    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM5, *custom5);
-  }
-
-  qdmi::throwIfError(QDMI_job_submit(jobWrapper), "Submitting job");
-  return jobWrapper;
+  const auto payload =
+      program.has_value() && !program->empty() ? program : std::nullopt;
+  return submitJobImpl(QDMI_PROGRAM_FORMAT_CALIBRATION, payload, std::nullopt,
+                       custom1, custom2, custom3, custom4, custom5);
 }
 
 Job Device::submitCalibrationJob(

--- a/src/qdmi/Client.cpp
+++ b/src/qdmi/Client.cpp
@@ -38,12 +38,21 @@
 
 namespace qdmi {
 namespace {
-/// The generic program payload is a byte blob. A batch job's program is a list
-/// of job handles instead, which `submitJob` cannot express.
-[[nodiscard]] constexpr bool
-hasNoGenericProgramPayload(const QDMI_Program_Format format) noexcept {
-  return format == QDMI_PROGRAM_FORMAT_CALIBRATION ||
-         format == QDMI_PROGRAM_FORMAT_BATCHJOB;
+/// Rejects the formats that `submitJob` cannot carry.
+/// A batch job's program is a list of job handles rather than a byte blob, so
+/// this API cannot express it at all. A calibration run has its own entry
+/// point, because its payload is optional and it takes no shot count.
+void rejectUnsupportedProgramFormat(const QDMI_Program_Format format) {
+  if (format == QDMI_PROGRAM_FORMAT_BATCHJOB) {
+    throw std::invalid_argument(
+        "MQT Core does not support batch jobs. A batch job's program is a list "
+        "of job handles, which this API cannot express");
+  }
+  if (format == QDMI_PROGRAM_FORMAT_CALIBRATION) {
+    throw std::invalid_argument(
+        "Use submitCalibrationJob (submit_calibration_job in Python) to "
+        "trigger a calibration run");
+  }
 }
 } // namespace
 
@@ -366,10 +375,7 @@ Job Device::submitJob(const std::string& program,
     throw std::invalid_argument(
         "Binary program formats require exact-byte submission");
   }
-  if (hasNoGenericProgramPayload(format)) {
-    throw std::invalid_argument(
-        "Calibration and batch jobs do not use a generic program payload");
-  }
+  rejectUnsupportedProgramFormat(format);
 
   const auto bytes = std::as_bytes(
       std::span(program.c_str(), static_cast<size_t>(program.size() + 1)));
@@ -384,10 +390,7 @@ Job Device::submitJob(const std::span<const std::byte> program,
                       const std::optional<CustomJobParameter>& custom3,
                       const std::optional<CustomJobParameter>& custom4,
                       const std::optional<CustomJobParameter>& custom5) const {
-  if (hasNoGenericProgramPayload(format)) {
-    throw std::invalid_argument(
-        "Calibration and batch jobs do not use a generic program payload");
-  }
+  rejectUnsupportedProgramFormat(format);
 
   QDMI_Job job = nullptr;
   qdmi::throwIfError(QDMI_device_create_job(device_.get(), &job),
@@ -425,6 +428,66 @@ Job Device::submitJob(const std::span<const std::byte> program,
 
   qdmi::throwIfError(QDMI_job_submit(jobWrapper), "Submitting job");
   return jobWrapper;
+}
+
+Job Device::submitCalibrationJob(
+    const std::optional<std::span<const std::byte>> program,
+    const std::optional<CustomJobParameter>& custom1,
+    const std::optional<CustomJobParameter>& custom2,
+    const std::optional<CustomJobParameter>& custom3,
+    const std::optional<CustomJobParameter>& custom4,
+    const std::optional<CustomJobParameter>& custom5) const {
+  QDMI_Job job = nullptr;
+  qdmi::throwIfError(QDMI_device_create_job(device_.get(), &job),
+                     "Creating job");
+  Job jobWrapper{job, device_};
+
+  constexpr auto format = QDMI_PROGRAM_FORMAT_CALIBRATION;
+  qdmi::throwIfError(QDMI_job_set_parameter(jobWrapper,
+                                            QDMI_JOB_PARAMETER_PROGRAMFORMAT,
+                                            sizeof(format), &format),
+                     "Setting program format");
+  // QDMI does not require a program for a calibration run, so the parameter is
+  // set only when the caller supplies one. The device defines what it means.
+  if (program.has_value()) {
+    qdmi::throwIfError(QDMI_job_set_parameter(jobWrapper,
+                                              QDMI_JOB_PARAMETER_PROGRAM,
+                                              program->size(), program->data()),
+                       "Setting program");
+  }
+  // A calibration run executes no circuit, so it takes no shot count.
+
+  if (custom1.has_value()) {
+    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM1, *custom1);
+  }
+  if (custom2.has_value()) {
+    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM2, *custom2);
+  }
+  if (custom3.has_value()) {
+    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM3, *custom3);
+  }
+  if (custom4.has_value()) {
+    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM4, *custom4);
+  }
+  if (custom5.has_value()) {
+    setCustomJobParam(jobWrapper, QDMI_JOB_PARAMETER_CUSTOM5, *custom5);
+  }
+
+  qdmi::throwIfError(QDMI_job_submit(jobWrapper), "Submitting job");
+  return jobWrapper;
+}
+
+Job Device::submitCalibrationJob(
+    const std::string& program,
+    const std::optional<CustomJobParameter>& custom1,
+    const std::optional<CustomJobParameter>& custom2,
+    const std::optional<CustomJobParameter>& custom3,
+    const std::optional<CustomJobParameter>& custom4,
+    const std::optional<CustomJobParameter>& custom5) const {
+  const auto bytes = std::as_bytes(
+      std::span(program.c_str(), static_cast<size_t>(program.size() + 1)));
+  return submitCalibrationJob(bytes, custom1, custom2, custom3, custom4,
+                              custom5);
 }
 
 Job Device::retrieveJobById(const std::string_view jobId) const {

--- a/test/python/qdmi/test_qdmi.py
+++ b/test/python/qdmi/test_qdmi.py
@@ -529,7 +529,7 @@ def test_device_sends_calibration_runs_elsewhere(ddsim_device: Device) -> None:
         ddsim_device.submit_job(b"", ProgramFormat.CALIBRATION, num_shots=1)
 
 
-@pytest.mark.parametrize("program", [None, "configuration", b"\x01\x02"])
+@pytest.mark.parametrize("program", [None, "configuration", b"", b"\x01\x02"])
 def test_calibration_job_reaches_the_device(ddsim_device: Device, program: str | bytes | None) -> None:
     """Let the device decide about a calibration run, with or without a payload.
 

--- a/test/python/qdmi/test_qdmi.py
+++ b/test/python/qdmi/test_qdmi.py
@@ -517,11 +517,28 @@ def test_device_rejects_text_for_binary_format(ddsim_device: Device) -> None:
         ddsim_device.submit_job("not bitcode", ProgramFormat.QIR_BASE_MODULE, num_shots=1)
 
 
-@pytest.mark.parametrize("program_format", [ProgramFormat.CALIBRATION, ProgramFormat.BATCH_JOB])
-def test_device_rejects_formats_without_generic_payload(ddsim_device: Device, program_format: ProgramFormat) -> None:
-    """Keep specialized QDMI formats out of the generic program API."""
-    with pytest.raises(ValueError, match="do not use a generic program payload"):
-        ddsim_device.submit_job(b"", program_format, num_shots=1)
+def test_device_rejects_batch_jobs(ddsim_device: Device) -> None:
+    """State that MQT Core does not support batch jobs."""
+    with pytest.raises(ValueError, match="does not support batch jobs"):
+        ddsim_device.submit_job(b"", ProgramFormat.BATCH_JOB, num_shots=1)
+
+
+def test_device_sends_calibration_runs_elsewhere(ddsim_device: Device) -> None:
+    """Point a calibration run at its own entry point."""
+    with pytest.raises(ValueError, match="submit_calibration_job"):
+        ddsim_device.submit_job(b"", ProgramFormat.CALIBRATION, num_shots=1)
+
+
+@pytest.mark.parametrize("program", [None, "configuration", b"\x01\x02"])
+def test_calibration_job_reaches_the_device(ddsim_device: Device, program: str | bytes | None) -> None:
+    """Let the device decide about a calibration run, with or without a payload.
+
+    The DD simulator needs no calibration and declines the format itself. What
+    matters is that the client no longer refuses before asking, so the failure
+    is a device error rather than a `ValueError` about the argument.
+    """
+    with pytest.raises(RuntimeError, match="Setting program format"):
+        ddsim_device.submit_calibration_job(program)
 
 
 def test_device_executes_qir_program(ddsim_device: Device) -> None:

--- a/test/qdmi/test_client.cpp
+++ b/test/qdmi/test_client.cpp
@@ -815,17 +815,55 @@ c = measure q;)";
 
 TEST_F(DDSimulatorDeviceTest, SubmitJobRejectsIncompatiblePayloadKinds) {
   const std::string textProgram = "OPENQASM 3.0;";
-  constexpr std::array bytes{std::byte{0}};
 
   EXPECT_THROW(std::ignore = device.submitJob(
                    textProgram, QDMI_PROGRAM_FORMAT_QIRBASEMODULE, 0),
                std::invalid_argument);
-  EXPECT_THROW(std::ignore = device.submitJob(
-                   textProgram, QDMI_PROGRAM_FORMAT_CALIBRATION, 0),
-               std::invalid_argument);
+}
+
+TEST_F(DDSimulatorDeviceTest, SubmitJobRejectsBatchJobs) {
+  // A batch job's program is a list of job handles, which the byte-span API
+  // cannot express, so MQT Core states that it does not support them.
+  constexpr std::array bytes{std::byte{0}};
+
   EXPECT_THROW(std::ignore =
                    device.submitJob(bytes, QDMI_PROGRAM_FORMAT_BATCHJOB, 0),
                std::invalid_argument);
+  EXPECT_THROW(std::ignore = device.submitJob(std::string{},
+                                              QDMI_PROGRAM_FORMAT_BATCHJOB, 0),
+               std::invalid_argument);
+}
+
+TEST_F(DDSimulatorDeviceTest, SubmitJobSendsCalibrationRunsElsewhere) {
+  // A calibration run takes no shot count and an optional payload, so it has
+  // its own entry point rather than a special case in `submitJob`.
+  EXPECT_THROW(std::ignore = device.submitJob(
+                   std::string{}, QDMI_PROGRAM_FORMAT_CALIBRATION, 0),
+               std::invalid_argument);
+}
+
+TEST_F(DDSimulatorDeviceTest, CalibrationJobReachesTheDevice) {
+  // The DD simulator needs no calibration and rejects the format itself. What
+  // matters is that the client no longer refuses before asking: the failure
+  // comes from the device, as a runtime error rather than an argument error.
+  EXPECT_THROW(std::ignore = device.submitCalibrationJob(), std::runtime_error);
+  EXPECT_THROW(std::ignore = device.submitCalibrationJob("configuration"),
+               std::runtime_error);
+
+  constexpr std::array payload{std::byte{1}, std::byte{2}};
+  EXPECT_THROW(std::ignore = device.submitCalibrationJob(payload),
+               std::runtime_error);
+
+  EXPECT_NO_THROW({
+    try {
+      std::ignore = device.submitCalibrationJob();
+    } catch (const std::invalid_argument&) {
+      FAIL() << "the client rejected the calibration run before the device saw "
+                "it";
+    } catch (const std::runtime_error&) { // NOLINT(bugprone-empty-catch)
+      // The device declined, which is its decision to make.
+    }
+  });
 }
 
 TEST_F(DDSimulatorDeviceTest, SubmitJobCustomSupportedTypes) {

--- a/test/qdmi/test_client.cpp
+++ b/test/qdmi/test_client.cpp
@@ -854,6 +854,11 @@ TEST_F(DDSimulatorDeviceTest, CalibrationJobReachesTheDevice) {
   EXPECT_THROW(std::ignore = device.submitCalibrationJob(payload),
                std::runtime_error);
 
+  constexpr std::byte emptyPayloadStorage{};
+  const std::span emptyPayload{&emptyPayloadStorage, size_t{0}};
+  EXPECT_THROW(std::ignore = device.submitCalibrationJob(emptyPayload),
+               std::runtime_error);
+
   EXPECT_NO_THROW({
     try {
       std::ignore = device.submitCalibrationJob();


### PR DESCRIPTION
🤖 *AI text below* 🤖

> **Stacked on #2114.** The base of this PR is `agent/2094-move-iqm-conversion`, so the diff shown here is only this change. Merge #2114 first.

## Description

Follow-up to the discussion in #2114, where reviewing the program-format classification turned up a bug behind it.

`Device::submitJob` rejected `CALIBRATION` and `BATCH_JOB` together, under one predicate that read as "carries no program payload":

```cpp
if (hasNoGenericProgramPayload(format)) {
  throw std::invalid_argument(
      "Calibration and batch jobs do not use a generic program payload");
}
```

They are not the same case, and the calibration half was wrong.

### Calibration

QDMI declares the format as `` `void*` A calibration program `` and says of it:

> Triggering a calibration run **does not require** a program to be set via `QDMI_DEVICE_JOB_PARAMETER_PROGRAM`.

That is the explicit exception to `QDMI_DEVICE_JOB_PARAMETER_PROGRAM` being "required" — the payload is *optional*, not absent, and QDMI-on-IQM sends one. MQT Core rejected the format before any device call, so a calibration run could not be started at all, with or without a payload. Meanwhile `QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION` is exposed as `Device::getNeedsCalibration()` and `needs_calibration()`: we told a caller a device needs calibration and gave them no way to act on it, even though the spec says exactly how.

This adds a dedicated entry point:

```python
device.submit_calibration_job()                 # no payload
device.submit_calibration_job("configuration")  # text payload
device.submit_calibration_job(b"\x01\x02")      # exact bytes
```

`Device::submitCalibrationJob` in C++, with `std::optional<std::span<const std::byte>>` and a `std::string` convenience overload. It sets no shot count, because a calibration run executes no circuit. Its own entry point rather than a special case in `submitJob`, since the payload is optional and the shot count does not apply — `submitJob` now points there instead of failing silently on intent.

### Batch jobs

A different problem. The spec requires the program for a batch job, but types it as a `QDMI_Job*` list — an array of live job handles. `submitJob` takes `std::span<const std::byte>`, so it structurally cannot express one, whatever the check says. MQT Core has no support for batch jobs and no device currently implements the feature; per the discussion, it was added for the multi-chip neutral-atom demonstrator, whose stack left MQT Core in #2137.

So this states the limitation instead of describing it as a missing payload, and leaves the door open:

```text
MQT Core does not support batch jobs. A batch job's program is a list of job
handles, which this API cannot express
```

## Validation

- `./build/release/test/qdmi/mqt-core-qdmi-test` — 277 passed
- `uv run --no-sync pytest test/python` — 626 passed, 4 skipped
- `uvx nox -s stubs` — the stub diff contains only `submit_calibration_job`
- `uvx nox -s lint` — passes, full `prek` hook set

The bundled DD simulator and SC device both report `NEEDSCALIBRATION = 0` and decline the format themselves, so the new tests assert what is actually verifiable here: the client no longer refuses before asking, and the failure arrives as a device error rather than an argument error. A device that supports calibration is needed to exercise the happy path.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

AI assistance: written by Claude Opus 5 via Claude Code, under my direction. The last checkbox is left for me to tick after my own review.
