### PR TITLE
🐛 Guard assignment type checking after expression errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,11 @@ releases may include breaking changes.
 - 📦 Build MLIR by default for C++ library builds ([#1356]) ([**@burgholzer**],
   [**@denialhaag**])
 
+### Fixed
+
+- 🐛 Preserve the original OpenQASM type error when an assignment's right-hand
+  expression cannot be typed ([#2156]) ([**@DRovara**], [**@burgholzer**])
+
 ### Removed
 
 - 💥 Remove batch job submission from the QDMI client. `Device::submitJob` now
@@ -807,6 +812,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2156]: https://github.com/munich-quantum-toolkit/core/pull/2156
 [#2154]: https://github.com/munich-quantum-toolkit/core/pull/2154
 [#2140]: https://github.com/munich-quantum-toolkit/core/pull/2140
 [#2138]: https://github.com/munich-quantum-toolkit/core/pull/2138

--- a/src/qasm3/passes/TypeCheckPass.cpp
+++ b/src/qasm3/passes/TypeCheckPass.cpp
@@ -166,6 +166,10 @@ void TypeCheckPass::visitAssignmentStatement(
     return;
   }
 
+  if (exprTy.isError) {
+    return;
+  }
+
   if (!idTy->second.type->fits(*exprTy.type)) {
     std::stringstream ss;
     ss << "Type mismatch in assignment. Expected '";

--- a/test/ir/test_qasm3_parser.cpp
+++ b/test/ir/test_qasm3_parser.cpp
@@ -1727,6 +1727,22 @@ TEST_F(Qasm3ParserTest, ImportQasmTypeMismatchAssignment) {
       qasm3::CompilerError);
 }
 
+TEST_F(Qasm3ParserTest, ImportQasmAssignmentUnknownRightHandSide) {
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "bit x;\n"
+                               "x = y;";
+  EXPECT_THROW(
+      {
+        try {
+          const auto qc = qasm3::Importer::imports(testfile);
+        } catch (const qasm3::CompilerError& e) {
+          EXPECT_EQ(e.message, "Type Check Error: Unknown identifier 'y'.");
+          throw;
+        }
+      },
+      qasm3::CompilerError);
+}
+
 TEST_F(Qasm3ParserTest, ImportQasmTypeMismatchBinaryExpr) {
   const std::string testfile = "OPENQASM 3.0;\n"
                                "const bit x = 0;\n"


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Stop OpenQASM assignment type checking after the right-hand expression has already failed to type. This prevents dereferencing a missing inferred type and preserves the original diagnostic.

This focused fix was extracted from #1970. The implementation originated with @DRovara. This PR adds a regression test and rebases the fix onto current `main`.

The change does not need documentation or migration instructions.

AI Notice: GPT-5 via Codex assisted with extraction, tests, validation, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
