### PR TITLE
🐛 Distinguish scalar OpenQASM qubits from registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,11 @@ releases may include breaking changes.
 - 📦 Build MLIR by default for C++ library builds ([#1356]) ([**@burgholzer**],
   [**@denialhaag**])
 
+### Fixed
+
+- 🐛 Distinguish scalar OpenQASM qubits from one-element qubit registers and
+  reject indexing scalar qubits ([#2157]) ([**@DRovara**], [**@burgholzer**])
+
 ### Removed
 
 - 💥 Remove batch job submission from the QDMI client. `Device::submitJob` now
@@ -807,6 +812,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2157]: https://github.com/munich-quantum-toolkit/core/pull/2157
 [#2154]: https://github.com/munich-quantum-toolkit/core/pull/2154
 [#2140]: https://github.com/munich-quantum-toolkit/core/pull/2140
 [#2138]: https://github.com/munich-quantum-toolkit/core/pull/2138

--- a/include/mqt-core/qasm3/NestedEnvironment.hpp
+++ b/include/mqt-core/qasm3/NestedEnvironment.hpp
@@ -30,7 +30,7 @@ public:
 
   void pop() { env.pop_back(); }
 
-  std::optional<T> find(std::string key) {
+  std::optional<T> find(std::string key) const {
     for (auto it = env.rbegin(); it != env.rend(); ++it) {
       auto found = it->find(key);
       if (found != it->end()) {

--- a/include/mqt-core/qasm3/Types.hpp
+++ b/include/mqt-core/qasm3/Types.hpp
@@ -154,7 +154,7 @@ public:
   std::string designatorToString();
 };
 
-enum UnsizedTy : uint8_t { Bool, Duration };
+enum UnsizedTy : uint8_t { Bool, Duration, SingleQubit };
 
 template <typename T> class UnsizedType final : public Type<T> {
 public:
@@ -178,6 +178,9 @@ public:
   static std::shared_ptr<Type<T>> getDurationTy() {
     return std::make_shared<UnsizedType>(Duration);
   }
+  static std::shared_ptr<Type<T>> getSingleQubitTy() {
+    return std::make_shared<UnsizedType>(SingleQubit);
+  }
 
   T getDesignator() override {
     throw std::runtime_error("Unsized types do not have designators");
@@ -195,6 +198,8 @@ public:
       return "bool";
     case Duration:
       return "duration";
+    case SingleQubit:
+      return "qubit";
     }
     throw std::runtime_error("Unhandled type");
   }

--- a/src/qasm3/Importer.cpp
+++ b/src/qasm3/Importer.cpp
@@ -145,6 +145,19 @@ void Importer::translateGateOperand(
   }
   const auto& qreg = qregIterator->second;
 
+  if (!indexedIdentifier->indices.empty()) {
+    if (const auto declaration =
+            declarations.find(indexedIdentifier->identifier);
+        declaration.has_value()) {
+      const auto type = std::get<1>(declaration.value()->type);
+      const auto unsizedType =
+          std::dynamic_pointer_cast<UnsizedType<uint64_t>>(type);
+      if (unsizedType && unsizedType->type == SingleQubit) {
+        throw CompilerError("Type 'qubit' cannot be indexed.", debugInfo);
+      }
+    }
+  }
+
   // full register
   if (indexedIdentifier->indices.empty()) {
     for (size_t i = 0; i < qreg.getSize(); ++i) {
@@ -372,8 +385,16 @@ void Importer::visitDeclarationStatement(
       throw CompilerError("Angle type is currently not supported.",
                           declarationStatement->debugInfo);
     }
+  } else if (const auto unsizedTy =
+                 std::dynamic_pointer_cast<UnsizedType<uint64_t>>(ty)) {
+    if (unsizedTy->type == SingleQubit) {
+      qc->addQubitRegister(1, identifier);
+    } else {
+      throw CompilerError("Only sized types or single qubits are supported.",
+                          declarationStatement->debugInfo);
+    }
   } else {
-    throw CompilerError("Only sized types are supported.",
+    throw CompilerError("Only sized types or single qubits are supported.",
                         declarationStatement->debugInfo);
   }
   declarations.emplace(identifier, declarationStatement);

--- a/src/qasm3/Parser.cpp
+++ b/src/qasm3/Parser.cpp
@@ -859,7 +859,8 @@ std::pair<std::shared_ptr<TypeExpr>, bool> Parser::parseType() {
   std::shared_ptr<TypeExpr> type;
   bool isOldStyleDeclaration = false;
 
-  switch (current().kind) {
+  const auto keyword = current().kind;
+  switch (keyword) {
   case Token::Kind::CReg:
     type = DesignatedType<std::shared_ptr<Expression>>::getBitTy(nullptr);
     isOldStyleDeclaration = true;
@@ -905,6 +906,11 @@ std::pair<std::shared_ptr<TypeExpr>, bool> Parser::parseType() {
     auto designator = parseTypeDesignator();
     type->setDesignator(std::move(designator));
     return std::pair{std::move(type), isOldStyleDeclaration};
+  }
+  if (keyword == Token::Kind::Qubit) {
+    return std::pair{
+        UnsizedType<std::shared_ptr<Expression>>::getSingleQubitTy(),
+        isOldStyleDeclaration};
   }
 
   return std::pair{std::move(type), isOldStyleDeclaration};

--- a/src/qasm3/passes/TypeCheckPass.cpp
+++ b/src/qasm3/passes/TypeCheckPass.cpp
@@ -57,9 +57,14 @@ void TypeCheckPass::checkIndexOperator(const IndexOperator& indexOperator) {
 }
 
 void TypeCheckPass::checkIndexedIdentifier(const IndexedIdentifier& id) {
-
-  if (const auto it = env.find(id.identifier); it == env.end()) {
+  const auto it = env.find(id.identifier);
+  if (it == env.end()) {
     error("Unknown identifier '" + id.identifier + "'.");
+    return;
+  }
+  if (!id.indices.empty() && !it->second.type->allowsDesignator()) {
+    error("Type '" + it->second.type->toString() + "' cannot be indexed.");
+    return;
   }
   for (const auto& index : id.indices) {
     checkIndexOperator(*index);
@@ -351,6 +356,12 @@ InferredType TypeCheckPass::visitIndexedIdentifier(
   if (indexedIdentifier->indices.empty()) {
     return type;
   }
+  if (type.isError) {
+    return type;
+  }
+  if (!type.type->allowsDesignator()) {
+    return error("Type '" + type.type->toString() + "' cannot be indexed.");
+  }
   // Assume that indexed access always results in a single element
   type.type->setDesignator(1);
   return type;
@@ -375,7 +386,18 @@ InferredType TypeCheckPass::visitMeasureExpression(
     error("Unknown identifier '" + indexedIdentifier->identifier + "'.");
     return InferredType::error();
   }
-  const auto width = it->second.type->getDesignator();
+  uint64_t width = 0;
+  const auto type = it->second.type;
+  if (type->allowsDesignator()) {
+    width = type->getDesignator();
+  } else {
+    const auto unsizedType =
+        std::dynamic_pointer_cast<UnsizedType<uint64_t>>(type);
+    if (!unsizedType || unsizedType->type != SingleQubit) {
+      return error("Cannot measure non-qubit type.");
+    }
+    width = 1;
+  }
   return InferredType{std::dynamic_pointer_cast<ResolvedType>(
       DesignatedType<uint64_t>::getBitTy(width))};
 }

--- a/test/ir/test_qasm3_parser.cpp
+++ b/test/ir/test_qasm3_parser.cpp
@@ -52,6 +52,59 @@ TEST_F(Qasm3ParserTest, ImportQasm3) {
   EXPECT_EQ(qc.getNcbits(), 3);
 }
 
+TEST_F(Qasm3ParserTest, ImportQasm3SingleQubit) {
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit q;\n"
+                               "x q;";
+  const auto qc = qasm3::Importer::imports(testfile);
+
+  EXPECT_EQ(qc.getNqubits(), 1);
+  ASSERT_EQ(qc.getNindividualOps(), 1);
+  EXPECT_EQ(qc.front()->getType(), qc::X);
+}
+
+TEST_F(Qasm3ParserTest, ImportQasm3MeasureSingleQubit) {
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "qubit q;\n"
+                               "bit c = measure q;";
+  const auto qc = qasm3::Importer::imports(testfile);
+
+  EXPECT_EQ(qc.getNqubits(), 1);
+  EXPECT_EQ(qc.getNcbits(), 1);
+  ASSERT_EQ(qc.getNindividualOps(), 1);
+  EXPECT_EQ(qc.front()->getType(), qc::Measure);
+}
+
+TEST_F(Qasm3ParserTest, ImportQasm3RejectsIndexingSingleQubit) {
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit q;\n"
+                               "x q[0];";
+  EXPECT_THROW(
+      {
+        try {
+          const auto qc = qasm3::Importer::imports(testfile);
+        } catch (const qasm3::CompilerError& e) {
+          EXPECT_EQ(e.message, "Type 'qubit' cannot be indexed.");
+          throw;
+        }
+      },
+      qasm3::CompilerError);
+}
+
+TEST_F(Qasm3ParserTest, ImportQasm3IndexesSizedQubitRegister) {
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[1] q;\n"
+                               "x q[0];";
+  const auto qc = qasm3::Importer::imports(testfile);
+
+  EXPECT_EQ(qc.getNqubits(), 1);
+  ASSERT_EQ(qc.getNindividualOps(), 1);
+  EXPECT_EQ(qc.front()->getType(), qc::X);
+}
+
 TEST_F(Qasm3ParserTest, ImportQasm3OldSyntax) {
   const std::string testfile = "OPENQASM 3.0;\n"
                                "include \"stdgates.inc\";\n"
@@ -737,7 +790,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3InvalidStatementInBlock) {
 }
 
 TEST_F(Qasm3ParserTest, ImportQasm3ImplicitInclude) {
-  const std::string testfile = "qubit q;\n"
+  const std::string testfile = "qubit[1] q;\n"
                                "h q[0];\n";
   const auto qc = qasm3::Importer::imports(testfile);
 
@@ -754,7 +807,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3ImplicitInclude) {
 TEST_F(Qasm3ParserTest, ImportQasm3Qelib1) {
   const std::string testfile = "OPENQASM 2.0;\n"
                                "include \"qelib1.inc\";\n"
-                               "qubit q;\n"
+                               "qubit[1] q;\n"
                                "h q[0];\n";
   const auto qc = qasm3::Importer::imports(testfile);
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Represent scalar OpenQASM declarations such as `qubit q;` separately from one-element registers. Scalar qubits remain valid gate and measurement operands, while `q[0]` is rejected. Existing `qubit[n]` declarations retain their register behavior.

This focused change was extracted from #1970 and supports the scalar syntax used by #1923. The implementation originated with @DRovara. This PR adds focused coverage for declarations, gates, measurements, invalid indexing, and sized-register compatibility.

The change does not need migration instructions. The parser already accepted the scalar syntax, but previously treated it as `qubit[1]`.

AI Notice: GPT-5 via Codex assisted with extraction, implementation, tests, validation, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
