### PR TITLE
📝 Fix documentation link checks

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -663,7 +663,7 @@ access to QDMI devices.
 Install with Qiskit support: `uv pip install "mqt-core[qiskit]"`
 
 See the
-[Qiskit Backend documentation](https://mqt.readthedocs.io/projects/core/en/latest/qdmi/qiskit_backend.html)
+[Qiskit Backend documentation](https://mqt.readthedocs.io/projects/core/en/latest/qdmi/qdmi_backend.html)
 for details.
 
 ### Argument name changes in `QuantumComputation` and `CompoundOperation` dunder methods

--- a/docs/_ext/cpp_api.py
+++ b/docs/_ext/cpp_api.py
@@ -302,6 +302,21 @@ def build_doxygen(app: Sphinx) -> None:
         raise ExtensionError(msg) from error
 
 
+def rewrite_doxygen_linkcheck_uri(app: Sphinx, uri: str) -> str | None:
+    """Map a C++ API URI to the generated file that linkcheck can inspect.
+
+    Returns:
+        The generated file path, or ``None`` for other URIs.
+    """
+    tagfile, base_uri = app.config.cpp_api_tagfile[:2]
+    if not uri.startswith(base_uri):
+        return None
+
+    target_uri, _, _ = uri.removeprefix(base_uri).partition("#")
+    html_dir = _path_from_config(app, tagfile).parent / "html"
+    return str(html_dir / target_uri)
+
+
 def publish_doxygen_html(app: Sphinx, exception: Exception | None) -> None:
     """Publish native Doxygen HTML alongside an HTML Sphinx build."""
     if exception is not None or app.builder.format != "html":
@@ -326,5 +341,6 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_domain(CppApiDomain)
     app.add_domain(QdmiApiDomain)
     app.connect("builder-inited", build_doxygen)
+    app.connect("linkcheck-process-uri", rewrite_doxygen_linkcheck_uri)
     app.connect("build-finished", publish_doxygen_html)
     return {"parallel_read_safe": False, "parallel_write_safe": True}

--- a/docs/ai_usage.md
+++ b/docs/ai_usage.md
@@ -174,7 +174,7 @@ of
 with the help of Gemini 3 Pro (Preview). The links above serve as attribution.
 
 [Astral]: https://github.com/astral-sh/uv/blob/c89a78ec085077f6344b0439ddf07fdad7336310/CONTRIBUTING.md
-[Qiskit]: https://github.com/Qiskit/qiskit/blob/cd8701690723d3d9602fac63fe0bd7ea618799be/CONTRIBUTING.md
+[Qiskit]: https://github.com/Qiskit/qiskit/blob/cd8701690723d3d9602fac63fe0bd7ea618799be/CONTRIBUTING.md#use-of-ai-tools
 [LLVM]: https://github.com/llvm/llvm-project/blob/9b6391f9c439c9926e8587b7b940e9a1e98a7819/llvm/docs/AIToolPolicy.md
 [fedora]: https://communityblog.fedoraproject.org/council-policy-proposal-policy-on-ai-assisted-contributions/
 [cca]: https://creativecommons.org/licenses/by/4.0/

--- a/docs/ai_usage.md
+++ b/docs/ai_usage.md
@@ -174,7 +174,7 @@ of
 with the help of Gemini 3 Pro (Preview). The links above serve as attribution.
 
 [Astral]: https://github.com/astral-sh/uv/blob/c89a78ec085077f6344b0439ddf07fdad7336310/CONTRIBUTING.md
-[Qiskit]: https://github.com/Qiskit/qiskit/blob/cd8701690723d3d9602fac63fe0bd7ea618799be/CONTRIBUTING.md#use-of-ai-tools
+[Qiskit]: https://github.com/Qiskit/qiskit/blob/cd8701690723d3d9602fac63fe0bd7ea618799be/CONTRIBUTING.md
 [LLVM]: https://github.com/llvm/llvm-project/blob/9b6391f9c439c9926e8587b7b940e9a1e98a7819/llvm/docs/AIToolPolicy.md
 [fedora]: https://communityblog.fedoraproject.org/council-policy-proposal-policy-on-ai-assisted-contributions/
 [cca]: https://creativecommons.org/licenses/by/4.0/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,6 +167,9 @@ nitpick_ignore_regex = [
     ("py:class", r"qiskit\.primitives\.containers\.(Estimator|Sampler)PubLike"),
 ]
 
+# ACM and SIAM reject automated requests after resolving their valid DOI links.
+linkcheck_ignore = [r"https://doi\.org/10\.(?:1137|1145)/.*"]
+
 
 cpp_api_tagfile = ("_build/doxygen/mqt-core.tag", "cpp/", "_build/doxygen/xml")
 qdmi_api_tagfile = (

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,6 +170,11 @@ nitpick_ignore_regex = [
 # ACM and SIAM reject automated requests after resolving their valid DOI links.
 linkcheck_ignore = [r"https://doi\.org/10\.(?:1137|1145)/.*"]
 
+# GitHub renders this valid source-document anchor outside the fetched HTML.
+linkcheck_anchors_ignore_for_url = [
+    r"https://github\.com/Qiskit/qiskit/blob/cd8701690723d3d9602fac63fe0bd7ea618799be/CONTRIBUTING\.md"
+]
+
 
 cpp_api_tagfile = ("_build/doxygen/mqt-core.tag", "cpp/", "_build/doxygen/xml")
 qdmi_api_tagfile = (

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -11,7 +11,7 @@
   author              = {Adarsh, Smaran and Burgholzer, Lukas and Manjunath, Tanmay and Wille, Robert},
   year                = {2022},
   journal             = {Software Impacts},
-  doi                 = {10.1016/j.simpa.2022.10045},
+  doi                 = {10.1016/j.simpa.2022.100451},
 }
 
 @inproceedings{baharAlgebraicDecisionDiagrams1993,


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Fix the documentation link checker by:

- validating generated Doxygen API targets against their generated files;
- correcting the SyReC paper DOI and stale QDMI documentation link;
- preserving the Qiskit AI-policy anchor while skipping only its unreliable anchor check; and
- ignoring valid ACM and SIAM DOI redirects because the publishers reject automated requests.

No dependencies are required. A changelog entry and migration instructions are not needed because this change only repairs documentation links and link-check behavior.

Validation:

- `uvx nox -s docs -- -b linkcheck`
- `uvx nox --non-interactive -s docs`
- `uvx nox -s lint`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
