### PR TITLE
⬆️ Update QDMI to version 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ⬆️ Update QDMI to version 1.3.3 ([#2168]) ([**@denialhaag**])
+- ⬆️ Update `nanobind` to version 2.15.0 ([#2141]) ([**@denialhaag**])
 - 💥 Prune dead and misleading CoreIR APIs, including renaming the non-garbage
   logical output count to `getNoutputQubits()` and `num_output_qubits` ([#2112])
   ([**@simon1hofmann**])
@@ -814,11 +816,13 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2168]: https://github.com/munich-quantum-toolkit/core/pull/2168
 [#2157]: https://github.com/munich-quantum-toolkit/core/pull/2157
 [#2156]: https://github.com/munich-quantum-toolkit/core/pull/2156
 [#2154]: https://github.com/munich-quantum-toolkit/core/pull/2154
 [#2148]: https://github.com/munich-quantum-toolkit/core/pull/2148
 [#2147]: https://github.com/munich-quantum-toolkit/core/pull/2147
+[#2141]: https://github.com/munich-quantum-toolkit/core/pull/2141
 [#2140]: https://github.com/munich-quantum-toolkit/core/pull/2140
 [#2138]: https://github.com/munich-quantum-toolkit/core/pull/2138
 [#2137]: https://github.com/munich-quantum-toolkit/core/pull/2137

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,17 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### QDMI updated to version 1.3.3
+
+While not a breaking change, this release updates the QDMI dependency to version
+1.3.3.
+
+### `nanobind` updated to version 2.15.0
+
+This release updates the `nanobind` dependency to version 2.15.0, which includes
+an ABI bump. Any existing code that uses the `mqt-core` Python bindings will
+need to be recompiled with the new `nanobind` version.
+
 ### Calibration runs and batch jobs
 
 `Device::submitJob` used to reject `CALIBRATION` and `BATCH_JOB` together, which

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -70,7 +70,7 @@ set(QDMI_MINIMUM_VERSION 1.3.3
         CACHE STRING "Minimum QDMI version")
 set(QDMI_VERSION 1.3.3
         CACHE STRING "QDMI version")
-set(QDMI_REV "e80020f7ace5c0a716142378c812f30f86263c4e" # QDMI develop
+set(QDMI_REV "18cfb67fd9042761d3005c2f8655751c1758f9c5" # v1.3.3
         CACHE STRING "QDMI identifier (tag, branch or commit hash)")
 set(QDMI_REPO_OWNER "Munich-Quantum-Software-Stack"
         CACHE STRING "QDMI repository owner (change when using a fork)")

--- a/docs/_ext/cpp_api.py
+++ b/docs/_ext/cpp_api.py
@@ -332,10 +332,10 @@ def setup(app: Sphinx) -> ExtensionMetadata:
         Metadata declaring that the extension supports parallel builds.
     """
     app.add_config_value("cpp_api_tagfile", ("_build/doxygen/mqt-core.tag", "cpp/", "_build/doxygen/xml"), "env")
-    app.add_config_value("qdmi_api_tagfile", ("_tagfiles/qdmi-1.3.2.tag", ""), "env")
+    app.add_config_value("qdmi_api_tagfile", ("_tagfiles/qdmi-1.3.3.tag", ""), "env")
     app.add_config_value(
         "qdmi_api_tagfile_url",
-        "https://munich-quantum-software-stack.github.io/QDMI/v1.3.2/qdmi.tag",
+        "https://munich-quantum-software-stack.github.io/QDMI/v1.3.3/qdmi.tag",
         "env",
     )
     app.add_domain(CppApiDomain)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,7 +179,7 @@ linkcheck_anchors_ignore_for_url = [
 cpp_api_tagfile = ("_build/doxygen/mqt-core.tag", "cpp/", "_build/doxygen/xml")
 qdmi_api_tagfile = (
     "_build/qdmi.tag",
-    "https://munich-quantum-software-stack.github.io/QDMI/v1.3.2/",
+    "https://munich-quantum-software-stack.github.io/QDMI/v1.3.3/",
 )
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This PR updates QDMI to version 1.3.3. The dependency now points at the released tag instead of a `develop` commit, and the QDMI API cross-references in the documentation point at the matching version.

It also adds the changelog and upgrade guide entries for the `nanobind` update to version 2.15.0 from #2141, which were missing.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
