### PR TITLE
✨ Support compile-time fixed-width OpenQASM angles

### DIFF
--- a/.agent/plans/openqasm-compile-time-fixed-angles.md
+++ b/.agent/plans/openqasm-compile-time-fixed-angles.md
@@ -41,6 +41,9 @@ OpenQASM-specific metadata to MLIR.
       including a non-overlapping workflow update that landed during
       publication. Opened draft pull request #2169 and folded its reference into
       the existing unreleased OpenQASM changelog entry.
+- [x] (2026-08-19 13:23Z) Resolved all four Clang-Tidy 22.1.8 findings from the
+      first CI run. The exact checks, release and non-unity builds, and both
+      affected test suites pass locally.
 
 ## Surprises & Discoveries
 
@@ -118,6 +121,13 @@ cached tag file from another current MQT Core worktree through Sphinx's normal
 configuration override. The existing unreleased staged-OpenQASM changelog entry
 now references pull request #2169. The entry already credits the contributing
 authors.
+
+The first CI lint run found four warnings in the new code: one signed/unsigned
+comparison, two nested conditional expressions, and one redundant cast. The
+follow-up uses `std::cmp_greater`, explicit branches, and the literal exponent
+type. These changes preserve behavior. The four exact checks pass with
+Clang-Tidy 22.1.8, and both affected test binaries pass in release and non-unity
+builds.
 
 ## Context and Orientation
 

--- a/.agent/plans/openqasm-compile-time-fixed-angles.md
+++ b/.agent/plans/openqasm-compile-time-fixed-angles.md
@@ -1,0 +1,211 @@
+# Add compile-time fixed-width OpenQASM angles
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+MQT Core currently recognizes the OpenQASM `angle` keyword but rejects angle
+declarations. After this change, users can declare initialized fixed-width
+angles, cast finite constant float expressions to them, use the supported
+compile-time angle arithmetic, and pass the results to quantum gates. MQT Core
+honors the fixed-width modulo arithmetic before it lowers the result to the
+existing binary64 radians gate interface.
+
+A user can observe the feature by importing `angle[8] theta = pi / 2;` followed
+by `rx(theta) q;`. The QC program contains the binary64 value of pi divided by
+two. Exporting that QC program produces valid OpenQASM 3.1 with a floating-point
+gate argument. The export does not reproduce the source declaration or attach
+OpenQASM-specific metadata to MLIR.
+
+## Progress
+
+- [x] (2026-08-19 11:59Z) Rechecked current `origin/main`, repository policy,
+      the old pull-request stack, the live OpenQASM 3.1 rules, and the angle
+      representations used by common quantum frameworks.
+- [x] (2026-08-19 11:59Z) Added private parser syntax for angle declarations,
+      width designators, and angle casts.
+- [x] (2026-08-19 11:59Z) Added exact compile-time quantization, resizing,
+      modular arithmetic, comparisons, and the binary64 lowering boundary.
+- [x] (2026-08-19 11:59Z) Added focused frontend and canonical export tests; the
+      new tests pass.
+- [x] (2026-08-19 12:17Z) Updated the OpenQASM support documentation and
+      completed release, non-unity, test, documentation, and lint validation.
+- [x] (2026-08-19 12:17Z) Reviewed the final nine-file change and recorded the
+      outcome. No remote state was changed.
+
+## Surprises & Discoveries
+
+- Observation: The typed OpenQASM frontend and QC emitter already represent gate
+  parameters as binary64 radians. An angle constant can therefore become an
+  ordinary `ScalarType::Angle` constant at the end of semantic analysis without
+  changing the public frontend types or the QC dialect. Evidence: the focused
+  export test emits `rx(1.5707963267948966)` and reparses it in strict mode.
+- Observation: The source width is needed only while constant expressions are
+  evaluated. Keeping a private pair of residue and width removes the need for
+  source-format attributes, integer angle operations in QC, and pattern
+  reconstruction in the exporter.
+- Observation: Binary64 cannot distinguish every adjacent fixed-angle residue at
+  width 53 near two pi. Width 52 has a step larger than the largest binary64
+  spacing in the represented interval. The supported range is therefore 1
+  through 52, and an omitted width resolves to 52.
+- Observation: OpenQASM defines `pi`, `tau`, and `euler` as 64-bit floats, and
+  inverse trigonometric functions return floats. The previous frontend treated
+  some of these values as angles. The fixed-angle work exposes and corrects that
+  mismatch.
+- Observation: The live specification first describes binary angle operations on
+  equal-width operands, then states that mixed-width angles use unsigned integer
+  promotion. The implementation widens both fixed values before it applies the
+  operation.
+- Observation: The normal documentation build needs a QDMI 1.3.2 tag file from
+  GitHub Pages. The first build failed during a temporary DNS outage. Reusing
+  the identical cached 1.3.2 tag file made the warnings-as-errors build pass.
+
+## Decision Log
+
+- Decision: Support fixed-width angles only as compile-time values. Rationale:
+  the requested use case does not require runtime angle storage, and the
+  existing backend interfaces use binary64 gate parameters. Date/Author:
+  2026-08-19 / Codex.
+- Decision: Keep fixed-angle state private to
+  `mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp`. Rationale: no other format
+  or dialect needs the OpenQASM storage width when the selected output contract
+  is canonical semantic output rather than source round-trip. Date/Author:
+  2026-08-19 / Codex.
+- Decision: Accept widths 1 through 52 and use 52 for unsized angles. Rationale:
+  every supported residue remains distinguishable after conversion to the
+  existing binary64 radians boundary. Date/Author: 2026-08-19 / Codex.
+- Decision: Use round-to-nearest, ties-to-even for float conversion and angle
+  narrowing. Widening appends zero low bits. Rationale: this is one of the
+  OpenQASM-defined narrowing policies and is the required float-to-angle rule.
+  Date/Author: 2026-08-19 / Codex.
+- Decision: Treat initialized declarations with or without `const` as write-once
+  compile-time bindings. Rationale: this accepts common source while avoiding
+  runtime storage and assignment. Reassignment and missing or dynamic
+  initializers receive diagnostics. Date/Author: 2026-08-19 / Codex.
+- Decision: Leave bare gate parameters as binary64 and defer global gate-angle
+  quantization. Rationale: other quantum formats use continuous floating-point
+  parameters, and unconditional modulo reduction is unsafe for phase-sensitive
+  or controlled operations. Date/Author: 2026-08-19 / Codex.
+
+## Outcomes & Retrospective
+
+The implementation is complete in the local worktree. The product, test, and
+documentation diff changes eight files with 577 insertions and 65 deletions. The
+ExecPlan is the ninth file. The old pull-request stack changed 30 files with
+about 6,000 insertions. The smaller design needs no public frontend change, no
+MLIR dialect or operation, no format-specific attribute, no exporter
+reconstruction, and no Python or generated-file change.
+
+The release build passed. CTest passed all 4,104 tests; one device query test
+was skipped by its fixture. The complete OpenQASM target and QC translation
+binaries passed 168 and 173 tests. The same two targets built without unity and
+their test binaries passed. The repository lint session and the warnings-as-
+errors documentation build passed. `git diff --check` passed.
+
+The first ordinary documentation run failed only because DNS resolution could
+not download the QDMI 1.3.2 tag file. The successful retry used the identical
+cached tag file from another current MQT Core worktree through Sphinx's normal
+configuration override. A changelog entry still needs the number and author
+metadata of the pull request that will carry this replacement; adding a guessed
+reference now would violate the repository's changelog format.
+
+## Context and Orientation
+
+The parser in `mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMParser.h`
+creates a private syntax tree declared in `OpenQASMSyntax.h` and copied by
+`mlir/lib/Target/OpenQASM/OpenQASMSyntax.cpp`. Semantic analysis in
+`mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp` converts that syntax into the
+public typed frontend. The QC emitter already maps typed angle expressions to
+binary64 MLIR values. The reverse exporter maps binary64 values to OpenQASM
+`float`, which is valid as a gate argument because gate arguments can promote to
+the language's unknown-width angle type.
+
+An OpenQASM fixed angle of width N is an unsigned N-bit residue k whose value is
+two pi times k divided by 2 to the power N. Float conversion first reduces the
+value modulo the binary64 representation of two pi and then selects the nearest
+residue, with ties selecting an even low bit. Mixed-width angle operands widen
+to the larger width before arithmetic or comparison. Multiplication and division
+use an integer literal that can be represented at the angle width. These
+operations and unary negation use unsigned modular arithmetic. Comparisons use
+the unsigned residue order.
+
+This task supports initialized declarations, casts from finite constant floats,
+angle-to-angle resizing, unary negation, angle addition and subtraction,
+nonnegative integer-literal multiplication, positive integer-literal division,
+comparisons, `sin`, `cos`, `tan`, and gate arguments. It does not support angle
+inputs or outputs, mutable or runtime angles, bit casts, bitwise operations,
+shifts, rotations, population count, angle divided by angle, or a global
+quantization pass.
+
+## Plan of Work
+
+Extend the private parse vocabulary with an angle scalar kind and an angle-cast
+expression. Preserve an optional width expression on declarations and casts so
+semantic analysis can evaluate named constant widths.
+
+Inside semantic analysis, store fixed constants as a private `FixedAngle` value
+containing an unsigned residue and a width. Use integer arithmetic to quantize
+every finite binary64 input exactly relative to the binary64 value of two pi.
+Keep every operation in the residue domain. Convert to radians only when a
+folded constant enters the existing typed frontend.
+
+Do not change `mlir/include/mlir/Target/OpenQASM/Frontend.h`, QC, QCO, QIR,
+Python bindings, generated stubs, or the QC-to-OpenQASM exporter. Document the
+compile-time input subset and the canonical floating-point output boundary in
+`docs/mlir/OpenQASM.md`.
+
+Add parser and semantic tests under `mlir/unittests/Target/OpenQASM/`. Add one
+end-to-end import/export test under `mlir/unittests/Dialect/QC/Translation/`.
+The tests must cover the specification halfway example, negative and multi-turn
+conversion, widths 1 and 52, omitted width, widening and narrowing, large and
+subnormal binary64 inputs, modular arithmetic, comparisons, trigonometric use,
+unsupported runtime behavior, and strict reparsing of canonical output.
+
+## Concrete Steps
+
+Run all commands from the repository root. Build and run the focused frontend
+tests first:
+
+    cmake --build --preset release --target mqt-core-mlir-unittest-openqasm-target
+    ./build/release/mlir/unittests/Target/OpenQASM/mqt-core-mlir-unittest-openqasm-target
+
+Build and run the QC translation tests:
+
+    cmake --build --preset release --target mqt-core-mlir-unittest-qc-translation
+    ./build/release/mlir/unittests/Dialect/QC/Translation/mqt-core-mlir-unittest-qc-translation
+
+Then complete release, documentation, and repository validation:
+
+    cmake --build --preset release
+    ctest --preset release
+    uvx nox --non-interactive -s docs
+    uvx nox -s lint
+    git diff --check
+
+## Validation and Acceptance
+
+The OpenQASM target tests must pass and show that a width-8 halfway input rounds
+to the even residue, negative and multi-turn inputs reduce modulo two pi, mixed
+widths widen correctly, narrowing uses ties-to-even, and omitted width retains
+the width-52 low step. Width 0, width 53, missing initializers, dynamic values,
+reassignment, angle division, and oversized integer literals must fail with a
+diagnostic.
+
+The QC translation test must import a fixed angle, export the QC program, find
+no `angle` declaration or `mqt.openqasm` attribute in the output, observe the
+expected binary64 gate argument, and reparse the emitted OpenQASM 3.1 in strict
+mode. Existing OpenQASM, compiler, and repository tests must remain green.
+
+## Idempotence and Recovery
+
+Builds and tests write only under existing build and cache directories and are
+safe to repeat. The implementation changes no generated files and performs no
+remote action. If a focused test fails, rerun its GoogleTest filter after the
+source fix, then rerun the complete binary so shared frontend behavior is not
+missed. Preserve unrelated worktree changes when inspecting or revising the
+diff.

--- a/.agent/plans/openqasm-compile-time-fixed-angles.md
+++ b/.agent/plans/openqasm-compile-time-fixed-angles.md
@@ -44,6 +44,14 @@ OpenQASM-specific metadata to MLIR.
 - [x] (2026-08-19 13:23Z) Resolved all four Clang-Tidy 22.1.8 findings from the
       first CI run. The exact checks, release and non-unity builds, and both
       affected test suites pass locally.
+- [x] (2026-08-19 20:24Z) Rebased the branch on `cb5cf0103`, retained the CBit
+      representation from #2158 while resolving adjacent conflicts, and kept
+      #2169 in the current unreleased OpenQASM changelog entry.
+- [x] (2026-08-19 20:24Z) Added small coverage cases for direct angle casts,
+      both comparison orderings, runtime casts, unsupported outputs, and mixed
+      angle arithmetic. The focused OpenQASM and QC translation suites pass.
+- [x] (2026-08-19 20:24Z) Created #2174 for the format-independent runtime and
+      target-aware work that remains after #2169 closes #1128.
 
 ## Surprises & Discoveries
 
@@ -71,6 +79,10 @@ OpenQASM-specific metadata to MLIR.
 - Observation: The normal documentation build needs a QDMI 1.3.2 tag file from
   GitHub Pages. The first build failed during a temporary DNS outage. Reusing
   the identical cached 1.3.2 tag file made the warnings-as-errors build pass.
+- Observation: Current `main` replaces implicit classical-register memrefs with
+  CBit IR. The rebase conflicts were adjacent rather than semantic. The resolved
+  documentation and end-to-end test retain CBit and the compile-time angle
+  boundary.
 
 ## Decision Log
 
@@ -98,6 +110,11 @@ OpenQASM-specific metadata to MLIR.
   quantization. Rationale: other quantum formats use continuous floating-point
   parameters, and unconditional modulo reduction is unsafe for phase-sensitive
   or controlled operations. Date/Author: 2026-08-19 / Codex.
+- Decision: Let #2169 close #1128 and track the remaining runtime storage and
+  target-aware quantization work in #2174. Rationale: #2169 satisfies the
+  issue's stated design and parser or lowering acceptance criterion. The
+  remaining work needs a format-independent compiler contract and is not part of
+  compile-time OpenQASM input support. Date/Author: 2026-08-19 / Codex.
 
 ## Outcomes & Retrospective
 
@@ -109,11 +126,12 @@ design needs no public frontend change, no MLIR dialect or operation, no
 format-specific attribute, no exporter reconstruction, and no Python or
 generated-file change.
 
-The release build passed. CTest passed all 4,104 tests; one device query test
-was skipped by its fixture. The complete OpenQASM target and QC translation
-binaries passed 168 and 173 tests. The same two targets built without unity and
-their test binaries passed. The repository lint session and the warnings-as-
-errors documentation build passed. `git diff --check` passed.
+The release build passed after the latest rebase. CTest passed all 4,295 tests;
+one device query test was skipped by its fixture. The complete OpenQASM target
+and QC translation binaries passed 168 and 175 tests. The same two targets also
+built without unity before the rebase and their test binaries passed. The
+repository lint session, diff-scoped Clang-Tidy with warnings as errors, and the
+warnings-as-errors documentation build passed. `git diff --check` passed.
 
 The first ordinary documentation run failed only because DNS resolution could
 not download the QDMI 1.3.2 tag file. The successful retry used the identical
@@ -128,6 +146,11 @@ follow-up uses `std::cmp_greater`, explicit branches, and the literal exponent
 type. These changes preserve behavior. The four exact checks pass with
 Clang-Tidy 22.1.8, and both affected test binaries pass in release and non-unity
 builds.
+
+The branch was later rebased on `cb5cf0103`, after the v3.9.0 release and the
+CBit migration. The conflict resolution retains the current unreleased changelog
+structure and CBit semantics. Follow-up issue #2174 owns the separate,
+format-independent runtime fixed-angle and target-aware quantization contract.
 
 ## Context and Orientation
 

--- a/.agent/plans/openqasm-compile-time-fixed-angles.md
+++ b/.agent/plans/openqasm-compile-time-fixed-angles.md
@@ -37,6 +37,10 @@ OpenQASM-specific metadata to MLIR.
       completed release, non-unity, test, documentation, and lint validation.
 - [x] (2026-08-19 12:17Z) Reviewed the final nine-file change and recorded the
       outcome. No remote state was changed.
+- [x] (2026-08-19 12:37Z) Rebased the signed implementation on current `main`,
+      including a non-overlapping workflow update that landed during
+      publication. Opened draft pull request #2169 and folded its reference into
+      the existing unreleased OpenQASM changelog entry.
 
 ## Surprises & Discoveries
 
@@ -94,12 +98,13 @@ OpenQASM-specific metadata to MLIR.
 
 ## Outcomes & Retrospective
 
-The implementation is complete in the local worktree. The product, test, and
-documentation diff changes eight files with 577 insertions and 65 deletions. The
-ExecPlan is the ninth file. The old pull-request stack changed 30 files with
-about 6,000 insertions. The smaller design needs no public frontend change, no
-MLIR dialect or operation, no format-specific attribute, no exporter
-reconstruction, and no Python or generated-file change.
+The implementation is published as draft pull request #2169. The source, test,
+and feature-documentation diff changes eight files with 577 insertions and 65
+deletions. The changelog and ExecPlan bring the pull request to ten files. The
+old pull-request stack changed 30 files with about 6,000 insertions. The smaller
+design needs no public frontend change, no MLIR dialect or operation, no
+format-specific attribute, no exporter reconstruction, and no Python or
+generated-file change.
 
 The release build passed. CTest passed all 4,104 tests; one device query test
 was skipped by its fixture. The complete OpenQASM target and QC translation
@@ -110,9 +115,9 @@ errors documentation build passed. `git diff --check` passed.
 The first ordinary documentation run failed only because DNS resolution could
 not download the QDMI 1.3.2 tag file. The successful retry used the identical
 cached tag file from another current MQT Core worktree through Sphinx's normal
-configuration override. A changelog entry still needs the number and author
-metadata of the pull request that will carry this replacement; adding a guessed
-reference now would violate the repository's changelog format.
+configuration override. The existing unreleased staged-OpenQASM changelog entry
+now references pull request #2169. The entry already credits the contributing
+authors.
 
 ## Context and Orientation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ releases may include breaking changes.
   [#2030], [#2066]) ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
   [**@li-mingbao**], [**@DRovara**], [**@MatthiasReumann**])
 - ✨ Add OpenQASM import and export to the MQT Compiler Collection ([#1910],
-  [#1987], [#1994], [#2003], [#2026]) ([**@burgholzer**], [**@denialhaag**])
+  [#1987], [#1994], [#2003], [#2026], [#2169]) ([**@burgholzer**],
+  [**@denialhaag**])
 
 #### Passes and transformations
 
@@ -786,6 +787,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2169]: https://github.com/munich-quantum-toolkit/core/pull/2169
 [#2168]: https://github.com/munich-quantum-toolkit/core/pull/2168
 [#2158]: https://github.com/munich-quantum-toolkit/core/pull/2158
 [#2157]: https://github.com/munich-quantum-toolkit/core/pull/2157

--- a/docs/mlir/OpenQASM.md
+++ b/docs/mlir/OpenQASM.md
@@ -35,22 +35,33 @@ mqt-cc --input-format=qasm program.txt
 
 ### Input support
 
-| OpenQASM concept           | Support and restrictions                                                                                                                                                                        |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Versions and includes      | Versionless input and versions 3.0 and 3.1 use the maintained OpenQASM profile. `stdgates.inc`, `qelib1.inc`, and nested textual includes are supported.                                        |
-| Classical types            | Unsized `bit`, `bool`, `int`, `uint`, and `float` declarations are supported. Width-qualified numeric types, arrays, complex values, and aliases are not yet supported.                         |
-| Outputs                    | Explicit `output` declarations are preserved in source order. Without any explicit output, global classical variables become outputs.                                                           |
-| Gates                      | Language gates, the standard libraries, custom gates, broadcasting, and `inv`, `ctrl`, `negctrl`, and `pow` modifiers are supported. Recursive custom gates are rejected.                       |
-| Quantum statements         | Measurement, reset, barrier, logical qubits, and physical qubits are supported. The QC target rejects programs that mix logical allocation with physical qubits.                                |
-| Expressions                | Scalar arithmetic, comparisons, Boolean expressions, and the supported math functions are type checked before translation. `popcount`, `rotl`, and `rotr` operate on initialized bit registers. |
-| Structured control         | `if`, inclusive `for`, `while`, and `switch` lower to SCF operations. Switch controls and case labels must be integers; labels must be unique constant expressions.                             |
-| Dynamic indexing           | Dynamic qubit and bit indices are supported on input. The generated QC includes bounds checks and structured dispatch where needed.                                                             |
-| Unsupported language areas | Subroutines, `extern`, calibration and timing constructs, input declarations, arbitrary arrays, `break`, and `continue` are diagnosed.                                                          |
+| OpenQASM concept           | Support and restrictions                                                                                                                                                                                                                              |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Versions and includes      | Versionless input and versions 3.0 and 3.1 use the maintained OpenQASM profile. `stdgates.inc`, `qelib1.inc`, and nested textual includes are supported.                                                                                              |
+| Classical types            | Unsized `bit`, `bool`, `int`, `uint`, and `float` declarations are supported. Initialized compile-time `angle[N]` values support widths 1 through 52. Other width-qualified numeric types, arrays, complex values, and aliases are not yet supported. |
+| Outputs                    | Explicit `output` declarations are preserved in source order. Without any explicit output, global classical variables become outputs.                                                                                                                 |
+| Gates                      | Language gates, the standard libraries, custom gates, broadcasting, and `inv`, `ctrl`, `negctrl`, and `pow` modifiers are supported. Recursive custom gates are rejected.                                                                             |
+| Quantum statements         | Measurement, reset, barrier, logical qubits, and physical qubits are supported. The QC target rejects programs that mix logical allocation with physical qubits.                                                                                      |
+| Expressions                | Scalar arithmetic, comparisons, Boolean expressions, and the supported math functions are type checked before translation. `popcount`, `rotl`, and `rotr` operate on initialized bit registers.                                                       |
+| Structured control         | `if`, inclusive `for`, `while`, and `switch` lower to SCF operations. Switch controls and case labels must be integers; labels must be unique constant expressions.                                                                                   |
+| Dynamic indexing           | Dynamic qubit and bit indices are supported on input. The generated QC includes bounds checks and structured dispatch where needed.                                                                                                                   |
+| Unsupported language areas | Subroutines, `extern`, calibration and timing constructs, input declarations, arbitrary arrays, `break`, and `continue` are diagnosed.                                                                                                                |
 
 Syntax and semantic diagnostics retain source locations and include stacks.
 Runtime integer preconditions and dynamic-index bounds are represented
 explicitly in QC. This safety machinery is supported by the normal compiler and
 QIR paths, but it is intentionally outside the export subset described below.
+
+Fixed-width angles are a compile-time input feature. An omitted angle width
+resolves to 52 bits. Both `const angle[N]` and initialized `angle[N]`
+declarations are accepted as write-once values. Initializers and angle casts
+must be compile-time expressions. MQT Core supports float-to-angle conversion,
+angle resizing, unary negation, addition and subtraction, multiplication and
+division by nonnegative integer literals that fit the angle width, comparisons,
+and `sin`, `cos`, and `tan`. Mixed-width angle operands promote to the wider
+width. It uses round-to-nearest, ties-to-even for float conversion and
+narrowing. Runtime angle state, reassignment, bit-level angle operations, and
+angle inputs or outputs are not supported.
 
 Bit registers use `!cbit.reg<N>` in QC. OpenQASM 2 initializes each register to
 zero. OpenQASM 3 leaves each register undefined until a statement writes it.
@@ -152,10 +163,10 @@ Output types follow a deliberately small canonical mapping:
 | `f64`                             | `float`         |
 
 A lone constant-zero `i64` result is treated as the frontend's status return and
-is not emitted. Import and export do not preserve `uint`, angle spelling,
-scalar-versus-one-element bit spelling, or scalar output names. Unsigned
-constants therefore normalize to `int`. Operations whose signedness affects
-their meaning, such as unsigned division, comparison, or conversion, are
+is not emitted. Import and export do not preserve `uint`, fixed-angle spelling
+or width, scalar-versus-one-element bit spelling, or scalar output names.
+Unsigned constants therefore normalize to `int`. Operations whose signedness
+affects their meaning, such as unsigned division, comparison, or conversion, are
 rejected instead of being approximated. Integer sign extension and truncation
 are also rejected because OpenQASM scalar casts have different value semantics.
 

--- a/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMParser.h
+++ b/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMParser.h
@@ -40,7 +40,7 @@ struct Version {
   uint32_t minor = 0;
 };
 
-enum class ScalarKind : uint8_t { Bool, Int, Uint, Float };
+enum class ScalarKind : uint8_t { Bool, Int, Uint, Float, Angle };
 
 /**
  * @defgroup ParseVocabulary Transient parse vocabulary
@@ -66,6 +66,7 @@ struct Expr {
     Float,
     Bool,
     Identifier,
+    AngleCast,
     Index,
     Neg,
     Not,
@@ -211,7 +212,7 @@ concept QASMSink =
       s.error(loc, str);
       s.version(loc, version);
       s.include(loc, str);
-      s.scalarDecl(loc, ScalarKind::Int, str, &expr, flag, flag);
+      s.scalarDecl(loc, ScalarKind::Int, str, &expr, &expr, flag, flag);
       s.assignment(loc, reference, expr);
       s.qubitRegister(loc, str, &expr);
       s.classicalRegister(loc, str, &expr, &expr, flag);
@@ -333,12 +334,11 @@ private:
     case TokenKind::Int:
     case TokenKind::Uint:
     case TokenKind::Float:
-      return parseScalarDeclaration(/*isOutput=*/false);
     case TokenKind::Angle:
+      return parseScalarDeclaration(/*isOutput=*/false);
     case TokenKind::Duration:
       return sink.error(current().loc,
-                        "'angle' and 'duration' declarations are not supported "
-                        "yet");
+                        "'duration' declarations are not supported yet");
     case TokenKind::Qubit:
       return parseQuantumDecl();
     case TokenKind::Qreg:
@@ -508,7 +508,7 @@ private:
 
   //===--- Declarations -------------------------------------------------===//
 
-  /// Parse `[const] (int|uint|float|bool) <id> [= <initializer>];`.
+  /// Parse `[const] (int|uint|float|bool|angle) <id> [= <initializer>];`.
   [[nodiscard]] LogicalResult parseScalarDeclaration(const bool isOutput) {
     const auto loc = current().loc;
 
@@ -524,12 +524,11 @@ private:
     case TokenKind::Int:
     case TokenKind::Uint:
     case TokenKind::Float:
-      break;
     case TokenKind::Angle:
+      break;
     case TokenKind::Duration:
       return sink.error(current().loc,
-                        "'angle' and 'duration' declarations are not supported "
-                        "yet");
+                        "'duration' declarations are not supported yet");
     case TokenKind::UnsupportedKeyword:
       return unsupportedKeyword();
     default:
@@ -537,6 +536,14 @@ private:
     }
     advance(); // type
 
+    const Expr* size = nullptr;
+    if (kind == TokenKind::Angle && current().kind == TokenKind::LBracket) {
+      auto designator = parseDesignator();
+      if (failed(designator)) {
+        return failure();
+      }
+      size = *designator;
+    }
     if ((kind == TokenKind::Int || kind == TokenKind::Uint) &&
         current().kind == TokenKind::LBracket) {
       return sink.error(current().loc,
@@ -592,8 +599,10 @@ private:
       scalarKind = ScalarKind::Int;
     } else if (kind == TokenKind::Uint) {
       scalarKind = ScalarKind::Uint;
+    } else if (kind == TokenKind::Angle) {
+      scalarKind = ScalarKind::Angle;
     }
-    if (failed(sink.scalarDecl(loc, scalarKind, id, initializer, isConst,
+    if (failed(sink.scalarDecl(loc, scalarKind, id, size, initializer, isConst,
                                isOutput))) {
       return failure();
     }
@@ -1595,6 +1604,28 @@ private:
       }
       advance();
       return expr;
+    case TokenKind::Angle: {
+      advance(); // angle
+      const Expr* size = nullptr;
+      if (current().kind == TokenKind::LBracket) {
+        auto designator = parseDesignator();
+        if (failed(designator)) {
+          return failure();
+        }
+        size = *designator;
+      }
+      if (failed(expect(TokenKind::LParen))) {
+        return failure();
+      }
+      auto operand = parseExpression();
+      if (failed(operand) || failed(expect(TokenKind::RParen))) {
+        return failure();
+      }
+      expr->kind = Expr::Kind::AngleCast;
+      expr->lhs = size;
+      expr->rhs = *operand;
+      return expr;
+    }
     case TokenKind::Identifier: {
       if (peek().kind == TokenKind::LParen) {
         const auto kind = getMathFunctionKind(current().identifier);

--- a/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMParser.h
+++ b/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMParser.h
@@ -1605,7 +1605,7 @@ private:
       advance();
       return expr;
     case TokenKind::Angle: {
-      advance(); // angle
+      advance();
       const Expr* size = nullptr;
       if (current().kind == TokenKind::LBracket) {
         auto designator = parseDesignator();

--- a/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMSyntax.h
+++ b/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMSyntax.h
@@ -73,6 +73,7 @@ struct SyntaxGateCall {
 struct SyntaxScalarDeclaration {
   ScalarKind kind = ScalarKind::Int;
   StringRef identifier;
+  std::optional<SyntaxExpressionId> size;
   std::optional<SyntaxExpressionId> initializer;
   bool isConst = false;
   bool output = false;
@@ -203,7 +204,7 @@ public:
   [[nodiscard]] SyntaxStatementId
   standardLibraryInclude(SMLoc location, StandardLibraryKind kind);
   [[nodiscard]] LogicalResult scalarDecl(SMLoc location, ScalarKind kind,
-                                         StringRef identifier,
+                                         StringRef identifier, const Expr* size,
                                          const Expr* initializer, bool isConst,
                                          bool output);
   [[nodiscard]] LogicalResult

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -31,6 +31,7 @@
 #include <mlir/Support/LogicalResult.h>
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
@@ -54,10 +55,24 @@ constexpr uint64_t TOTAL_REGISTER_ELEMENT_LIMIT = 100'000;
 constexpr size_t EXPRESSION_DEPTH_LIMIT = 256;
 constexpr size_t GATE_DEPENDENCY_DEPTH_LIMIT = 64;
 constexpr size_t TYPED_STATEMENT_LIMIT = 1'000'000;
+constexpr uint32_t DEFAULT_ANGLE_WIDTH = 52;
+constexpr uint32_t MAX_ANGLE_WIDTH = 52;
+constexpr double TWO_PI = 2.0 * std::numbers::pi;
+constexpr uint64_t TWO_PI_BITS = 0x401921FB54442D18ULL;
+constexpr uint64_t TWO_PI_ODD_SIGNIFICAND = 0x3243F6A8885A3ULL;
+constexpr uint64_t DOUBLE_FRACTION_MASK = (uint64_t{1} << 52U) - 1U;
+constexpr uint64_t DOUBLE_EXPONENT_MASK = 0x7FFU;
+
+static_assert(std::bit_cast<uint64_t>(TWO_PI) == TWO_PI_BITS);
+
+struct FixedAngle {
+  uint64_t bits = 0;
+  uint32_t bitWidth = DEFAULT_ANGLE_WIDTH;
+};
 
 struct Constant {
   ScalarType type = ScalarType::Int;
-  std::variant<bool, int64_t, uint64_t, double> value = int64_t{0};
+  std::variant<bool, int64_t, uint64_t, double, FixedAngle> value = int64_t{0};
 };
 
 struct GateSignature {
@@ -84,6 +99,115 @@ struct Symbol {
 
 } // namespace
 
+[[nodiscard]] static uint64_t angleMask(const uint32_t bitWidth) {
+  assert(bitWidth >= 1 && bitWidth <= MAX_ANGLE_WIDTH);
+  return (uint64_t{1} << bitWidth) - 1U;
+}
+
+[[nodiscard]] static llvm::APInt
+roundUnsignedQuotient(const llvm::APInt& numerator,
+                      const llvm::APInt& denominator) {
+  const auto quotient = numerator.udiv(denominator);
+  const auto remainder = numerator.urem(denominator);
+  const auto twiceRemainder = remainder.shl(1U);
+  const auto roundUp = twiceRemainder.ugt(denominator) ||
+                       (twiceRemainder == denominator && quotient[0]);
+  return roundUp ? quotient + 1U : quotient;
+}
+
+[[nodiscard]] static uint64_t
+quantizeAngleMagnitude(const uint64_t significand, const int32_t binaryExponent,
+                       const uint32_t bitWidth) {
+  constexpr unsigned workingWidth = 128;
+  const llvm::APInt modulus(workingWidth, TWO_PI_ODD_SIGNIFICAND);
+  const llvm::APInt magnitude(workingWidth, significand);
+  llvm::APInt rounded(workingWidth, 0);
+
+  if (binaryExponent >= 0) {
+    auto power = llvm::APInt(workingWidth, 2);
+    auto factor = llvm::APInt(workingWidth, 1);
+    auto exponent = static_cast<uint32_t>(binaryExponent);
+    while (exponent != 0) {
+      if ((exponent & 1U) != 0) {
+        factor = (factor * power).urem(modulus);
+      }
+      power = (power * power).urem(modulus);
+      exponent >>= 1U;
+    }
+    const auto remainder = (magnitude.urem(modulus) * factor).urem(modulus);
+    rounded = roundUnsignedQuotient(remainder.shl(bitWidth), modulus);
+  } else {
+    const auto scaledExponent = binaryExponent + static_cast<int32_t>(bitWidth);
+    if (scaledExponent >= 0) {
+      rounded = roundUnsignedQuotient(
+          magnitude.shl(static_cast<unsigned>(scaledExponent)), modulus);
+    } else {
+      const auto denominatorShift = static_cast<unsigned>(-scaledExponent);
+      // The numerator has at most 53 bits and the odd denominator has 50.
+      // Five more denominator bits put even the largest numerator below half.
+      if (denominatorShift >= 5U) {
+        return 0;
+      }
+      rounded = roundUnsignedQuotient(magnitude, modulus.shl(denominatorShift));
+    }
+  }
+
+  return rounded.trunc(bitWidth).getZExtValue();
+}
+
+[[nodiscard]] static std::optional<uint64_t>
+quantizeAngle(const double radians, const uint32_t bitWidth) {
+  if (bitWidth < 1 || bitWidth > MAX_ANGLE_WIDTH || !std::isfinite(radians)) {
+    return std::nullopt;
+  }
+
+  const auto representation = std::bit_cast<uint64_t>(radians);
+  const auto exponent =
+      static_cast<uint32_t>((representation >> 52U) & DOUBLE_EXPONENT_MASK);
+  const auto fraction = representation & DOUBLE_FRACTION_MASK;
+  if (exponent == 0 && fraction == 0) {
+    return 0;
+  }
+
+  const auto significand =
+      exponent == 0 ? fraction : fraction | (uint64_t{1} << 52U);
+  // The binary64 value of 2*pi is TWO_PI_ODD_SIGNIFICAND * 2^-47.
+  const auto binaryExponent =
+      exponent == 0 ? -1027 : static_cast<int32_t>(exponent) - 1028;
+  auto result = quantizeAngleMagnitude(significand, binaryExponent, bitWidth);
+  if ((representation >> 63U) != 0) {
+    result = (uint64_t{0} - result) & angleMask(bitWidth);
+  }
+  return result;
+}
+
+[[nodiscard]] static double angleToRadians(const FixedAngle angle) {
+  assert(angle.bitWidth >= 1 && angle.bitWidth <= MAX_ANGLE_WIDTH);
+  return static_cast<double>(angle.bits) *
+         std::ldexp(TWO_PI, -static_cast<int>(angle.bitWidth));
+}
+
+[[nodiscard]] static FixedAngle resizeAngle(const FixedAngle angle,
+                                            const uint32_t targetWidth) {
+  assert(targetWidth >= 1 && targetWidth <= MAX_ANGLE_WIDTH);
+  if (angle.bitWidth == targetWidth) {
+    return angle;
+  }
+  if (angle.bitWidth < targetWidth) {
+    return {.bits = angle.bits << (targetWidth - angle.bitWidth),
+            .bitWidth = targetWidth};
+  }
+
+  const auto discardedWidth = angle.bitWidth - targetWidth;
+  auto retained = angle.bits >> discardedWidth;
+  const auto discarded = angle.bits & ((uint64_t{1} << discardedWidth) - 1U);
+  const auto halfway = uint64_t{1} << (discardedWidth - 1U);
+  if (discarded > halfway || (discarded == halfway && (retained & 1U) != 0)) {
+    ++retained;
+  }
+  return {.bits = retained & angleMask(targetWidth), .bitWidth = targetWidth};
+}
+
 [[nodiscard]] static ScalarType scalarType(const ScalarKind kind) {
   switch (kind) {
   case ScalarKind::Bool:
@@ -94,6 +218,8 @@ struct Symbol {
     return ScalarType::Uint;
   case ScalarKind::Float:
     return ScalarType::Float;
+  case ScalarKind::Angle:
+    return ScalarType::Angle;
   }
   llvm_unreachable("unknown syntax scalar kind");
 }
@@ -130,8 +256,16 @@ belongsToStdGates(const GateAvailability availability) {
 }
 
 [[nodiscard]] static double asDouble(const Constant& constant) {
-  return std::visit([](const auto value) { return static_cast<double>(value); },
-                    constant.value);
+  return std::visit(
+      [](const auto value) {
+        using T = std::remove_cvref_t<decltype(value)>;
+        if constexpr (std::is_same_v<T, FixedAngle>) {
+          return angleToRadians(value);
+        } else {
+          return static_cast<double>(value);
+        }
+      },
+      constant.value);
 }
 
 [[nodiscard]] static std::optional<int64_t> asSigned(const Constant& constant) {
@@ -156,19 +290,17 @@ belongsToStdGates(const GateAvailability availability) {
            destination == ScalarType::Float;
   case ScalarType::Int:
     return destination == ScalarType::Float ||
-           destination == ScalarType::Angle ||
            (destination == ScalarType::Uint &&
             std::get<int64_t>(initializer.value) >= 0);
   case ScalarType::Uint:
     return destination == ScalarType::Float ||
-           destination == ScalarType::Angle ||
            (destination == ScalarType::Int &&
             std::get<uint64_t>(initializer.value) <=
                 static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
   case ScalarType::Float:
     return destination == ScalarType::Angle;
   case ScalarType::Angle:
-    return destination == ScalarType::Float;
+    return false;
   }
   llvm_unreachable("unknown scalar type");
 }
@@ -663,9 +795,24 @@ private:
   }
 
   [[nodiscard]] ExpressionId addConstant(const Constant& constant) {
-    return addExpression({.kind = ExpressionKind::Constant,
-                          .type = constant.type,
-                          .constant = constant.value});
+    if (constant.type == ScalarType::Angle) {
+      return addExpression(
+          {.kind = ExpressionKind::Constant,
+           .type = ScalarType::Angle,
+           .constant = angleToRadians(std::get<FixedAngle>(constant.value))});
+    }
+    return std::visit(
+        [&](const auto value) -> ExpressionId {
+          using T = std::remove_cvref_t<decltype(value)>;
+          if constexpr (std::is_same_v<T, FixedAngle>) {
+            llvm_unreachable("fixed angles require angle type");
+          } else {
+            return addExpression({.kind = ExpressionKind::Constant,
+                                  .type = constant.type,
+                                  .constant = value});
+          }
+        },
+        constant.value);
   }
 
   [[nodiscard]] static bool canImplicitlyConvert(const ScalarType source,
@@ -744,10 +891,65 @@ private:
       return Constant{.type = ScalarType::Float,
                       .value = asDouble(initializer)};
     case ScalarType::Angle:
-      return Constant{.type = ScalarType::Angle,
-                      .value = asDouble(initializer)};
+      llvm_unreachable("fixed angle initializers require an explicit width");
     }
     llvm_unreachable("unknown scalar type");
+  }
+
+  [[nodiscard]] FailureOr<uint32_t>
+  angleWidth(const std::optional<SyntaxExpressionId> size,
+             const SMLoc location) const {
+    if (!size) {
+      return DEFAULT_ANGLE_WIDTH;
+    }
+    if (!isConstantExpression(*size)) {
+      return fail(location,
+                  "angle width must be a constant integer expression");
+    }
+    MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(*size));
+    if (!isInteger(constant.type)) {
+      return fail(location, "angle width must be an integer expression");
+    }
+    const auto width = asSigned(constant);
+    if (!width || *width < 1 ||
+        *width > static_cast<int64_t>(MAX_ANGLE_WIDTH)) {
+      return fail(location, Twine("angle width must be between 1 and ") +
+                                Twine(MAX_ANGLE_WIDTH));
+    }
+    return static_cast<uint32_t>(*width);
+  }
+
+  [[nodiscard]] FailureOr<Constant>
+  convertToFixedAngle(const Constant& source, const uint32_t bitWidth,
+                      const SMLoc location) const {
+    if (source.type == ScalarType::Angle) {
+      return Constant{
+          .type = ScalarType::Angle,
+          .value = resizeAngle(std::get<FixedAngle>(source.value), bitWidth)};
+    }
+    if (source.type != ScalarType::Float) {
+      return fail(location,
+                  "angle conversion requires a float or angle operand");
+    }
+    const auto bits = quantizeAngle(std::get<double>(source.value), bitWidth);
+    if (!bits) {
+      return fail(location, "angle conversion requires a finite float value");
+    }
+    return Constant{.type = ScalarType::Angle,
+                    .value = FixedAngle{.bits = *bits, .bitWidth = bitWidth}};
+  }
+
+  [[nodiscard]] FailureOr<uint64_t>
+  angleIntegerLiteral(const SyntaxExpressionId id,
+                      const uint32_t bitWidth) const {
+    const auto& expression = syntax.expressions[id];
+    if (expression.kind != Expr::Kind::Int || !expression.wideInteger.empty() ||
+        expression.integer > angleMask(bitWidth)) {
+      return fail(expression.location,
+                  "angle multiplication and division require a nonnegative "
+                  "integer literal that fits the angle width");
+    }
+    return expression.integer;
   }
 
   [[nodiscard]] bool expressionProducesBool(const SyntaxExpressionId id) const {
@@ -813,10 +1015,10 @@ private:
   [[nodiscard]] static std::optional<Constant>
   builtinConstant(StringRef identifier) {
     if (identifier == "pi" || identifier == "π") {
-      return Constant{.type = ScalarType::Angle, .value = std::numbers::pi};
+      return Constant{.type = ScalarType::Float, .value = std::numbers::pi};
     }
     if (identifier == "tau" || identifier == "τ") {
-      return Constant{.type = ScalarType::Angle,
+      return Constant{.type = ScalarType::Float,
                       .value = 2.0 * std::numbers::pi};
     }
     if (identifier == "euler" || identifier == "ℇ") {
@@ -861,15 +1063,29 @@ private:
         }
         return *symbol->constant;
       }
+      case Expr::Kind::AngleCast: {
+        MQT_OQ3_TRY_ASSIGN(width,
+                           angleWidth(expression.lhs, expression.location));
+        MQT_OQ3_TRY_ASSIGN(operand, evaluateConstant(*expression.rhs));
+        return convertToFixedAngle(operand, width, expression.location);
+      }
       case Expr::Kind::Neg: {
         MQT_OQ3_TRY_ASSIGN(operand, evaluateConstant(*expression.lhs));
         if (operand.type == ScalarType::Bool) {
           return fail(expression.location,
                       "numeric negation requires a numeric operand");
         }
-        if (operand.type == ScalarType::Float ||
-            operand.type == ScalarType::Angle) {
-          return Constant{.type = operand.type, .value = -asDouble(operand)};
+        if (operand.type == ScalarType::Angle) {
+          const auto angle = std::get<FixedAngle>(operand.value);
+          return Constant{.type = ScalarType::Angle,
+                          .value =
+                              FixedAngle{.bits = (uint64_t{0} - angle.bits) &
+                                                 angleMask(angle.bitWidth),
+                                         .bitWidth = angle.bitWidth}};
+        }
+        if (operand.type == ScalarType::Float) {
+          return Constant{.type = ScalarType::Float,
+                          .value = -std::get<double>(operand.value)};
         }
         if (operand.type == ScalarType::Uint) {
           const auto value = std::get<uint64_t>(operand.value);
@@ -955,7 +1171,38 @@ private:
               std::get<bool>(lhs.value) == std::get<bool>(rhs.value);
           result = expression.kind == Expr::Kind::Equal ? equal : !equal;
         } else {
-          const auto ordering = compareNumericConstants(lhs, rhs);
+          auto ordering = 0;
+          if (lhs.type == ScalarType::Angle || rhs.type == ScalarType::Angle) {
+            if ((lhs.type != ScalarType::Angle &&
+                 lhs.type != ScalarType::Float) ||
+                (rhs.type != ScalarType::Angle &&
+                 rhs.type != ScalarType::Float)) {
+              return fail(expression.location,
+                          "angles can only be compared with angles or finite "
+                          "float constants");
+            }
+            const auto commonWidth =
+                lhs.type == ScalarType::Angle && rhs.type == ScalarType::Angle
+                    ? std::max(std::get<FixedAngle>(lhs.value).bitWidth,
+                               std::get<FixedAngle>(rhs.value).bitWidth)
+                    : (lhs.type == ScalarType::Angle
+                           ? std::get<FixedAngle>(lhs.value).bitWidth
+                           : std::get<FixedAngle>(rhs.value).bitWidth);
+            MQT_OQ3_TRY_ASSIGN(
+                leftAngle,
+                convertToFixedAngle(lhs, commonWidth, expression.location));
+            MQT_OQ3_TRY_ASSIGN(
+                rightAngle,
+                convertToFixedAngle(rhs, commonWidth, expression.location));
+            const auto left =
+                resizeAngle(std::get<FixedAngle>(leftAngle.value), commonWidth);
+            const auto right = resizeAngle(
+                std::get<FixedAngle>(rightAngle.value), commonWidth);
+            ordering =
+                left.bits < right.bits ? -1 : (left.bits > right.bits ? 1 : 0);
+          } else {
+            ordering = compareNumericConstants(lhs, rhs);
+          }
           switch (expression.kind) {
           case Expr::Kind::Equal:
             result = ordering == 0;
@@ -1053,9 +1300,7 @@ private:
           return fail(expression.location,
                       "constant math expression has a non-finite result");
         }
-        return Constant{.type =
-                            inverseTrig ? ScalarType::Angle : ScalarType::Float,
-                        .value = result};
+        return Constant{.type = ScalarType::Float, .value = result};
       }
       case Expr::Kind::Add:
       case Expr::Kind::Sub:
@@ -1126,6 +1371,10 @@ private:
         }
         return symbol->constant->type;
       }
+      case Expr::Kind::AngleCast: {
+        MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(id));
+        return constant.type;
+      }
       case Expr::Kind::Neg: {
         MQT_OQ3_TRY_ASSIGN(type, constantExpressionType(*expression.lhs));
         if (type == ScalarType::Bool) {
@@ -1185,7 +1434,7 @@ private:
           return fail(expression.location,
                       "math functions require numeric operands");
         }
-        return ScalarType::Angle;
+        return ScalarType::Float;
       }
       case Expr::Kind::Ceiling:
       case Expr::Kind::Exp:
@@ -1308,30 +1557,50 @@ private:
                                    rhs.type == ScalarType::Int &&
                                    std::get<int64_t>(rhs.value) < 0;
     if (lhs.type == ScalarType::Angle || rhs.type == ScalarType::Angle) {
-      const auto left = asDouble(lhs);
-      const auto right = asDouble(rhs);
       if (expression.kind == Expr::Kind::Add ||
           expression.kind == Expr::Kind::Sub) {
+        if (lhs.type != ScalarType::Angle || rhs.type != ScalarType::Angle) {
+          return fail(expression.location,
+                      "angle addition and subtraction require angle operands");
+        }
+        const auto lhsAngle = std::get<FixedAngle>(lhs.value);
+        const auto rhsAngle = std::get<FixedAngle>(rhs.value);
+        const auto bitWidth = std::max(lhsAngle.bitWidth, rhsAngle.bitWidth);
+        const auto left = resizeAngle(lhsAngle, bitWidth).bits;
+        const auto right = resizeAngle(rhsAngle, bitWidth).bits;
+        const auto bits =
+            expression.kind == Expr::Kind::Add ? left + right : left - right;
         return Constant{.type = ScalarType::Angle,
-                        .value = expression.kind == Expr::Kind::Add
-                                     ? left + right
-                                     : left - right};
+                        .value = FixedAngle{.bits = bits & angleMask(bitWidth),
+                                            .bitWidth = bitWidth}};
       }
       if (expression.kind == Expr::Kind::Mul &&
           (lhs.type == ScalarType::Angle) != (rhs.type == ScalarType::Angle)) {
-        return Constant{.type = ScalarType::Angle, .value = left * right};
+        const auto angle = std::get<FixedAngle>(
+            lhs.type == ScalarType::Angle ? lhs.value : rhs.value);
+        const auto literalId =
+            lhs.type == ScalarType::Angle ? *expression.rhs : *expression.lhs;
+        MQT_OQ3_TRY_ASSIGN(factor,
+                           angleIntegerLiteral(literalId, angle.bitWidth));
+        return Constant{.type = ScalarType::Angle,
+                        .value = FixedAngle{.bits = (angle.bits * factor) &
+                                                    angleMask(angle.bitWidth),
+                                            .bitWidth = angle.bitWidth}};
       }
-      if (expression.kind == Expr::Kind::Div && lhs.type == ScalarType::Angle) {
-        if (right == 0.0) {
+      if (expression.kind == Expr::Kind::Div && lhs.type == ScalarType::Angle &&
+          rhs.type != ScalarType::Angle) {
+        const auto angle = std::get<FixedAngle>(lhs.value);
+        MQT_OQ3_TRY_ASSIGN(
+            divisor, angleIntegerLiteral(*expression.rhs, angle.bitWidth));
+        if (divisor == 0) {
           return fail(expression.location, "division by zero");
         }
-        return Constant{.type = rhs.type == ScalarType::Angle
-                                    ? ScalarType::Float
-                                    : ScalarType::Angle,
-                        .value = left / right};
+        return Constant{.type = ScalarType::Angle,
+                        .value = FixedAngle{.bits = angle.bits / divisor,
+                                            .bitWidth = angle.bitWidth}};
       }
       return fail(expression.location,
-                  "unsupported arithmetic operation on angle operands");
+                  "unsupported compile-time arithmetic on angle operands");
     }
     if (lhs.type == ScalarType::Float || rhs.type == ScalarType::Float ||
         builtinFloatPower) {
@@ -1657,6 +1926,9 @@ private:
 
     auto kind = ExpressionKind::Constant;
     switch (expression.kind) {
+    case Expr::Kind::AngleCast:
+      return fail(expression.location,
+                  "runtime angle conversions are not supported");
     case Expr::Kind::Neg:
       kind = ExpressionKind::Negate;
       break;
@@ -1791,9 +2063,7 @@ private:
                          expression.location));
       lhs = convertedLhs;
       return addExpression(
-          {.kind = kind,
-           .type = inverseTrig ? ScalarType::Angle : ScalarType::Float,
-           .lhs = lhs});
+          {.kind = kind, .type = ScalarType::Float, .lhs = lhs});
     }
     if (!rhs) {
       return addExpression({.kind = kind, .type = lhsType, .lhs = lhs});
@@ -2089,6 +2359,28 @@ private:
       return fail(location, "outputs must be declared at global scope");
     }
     const auto type = scalarType(declaration.kind);
+    if (type == ScalarType::Angle) {
+      if (declaration.output) {
+        return fail(location, "angle outputs are not supported");
+      }
+      if (!declaration.initializer) {
+        return fail(location,
+                    "angle declarations require a compile-time initializer");
+      }
+      if (!isConstantExpression(*declaration.initializer)) {
+        return fail(location,
+                    "angle declarations require a compile-time initializer");
+      }
+      MQT_OQ3_TRY_ASSIGN(width, angleWidth(declaration.size, location));
+      MQT_OQ3_TRY_ASSIGN(initializer,
+                         evaluateConstant(*declaration.initializer));
+      MQT_OQ3_TRY_ASSIGN(constant,
+                         convertToFixedAngle(initializer, width, location));
+      return declare(location, declaration.identifier,
+                     {.kind = SymbolKind::Constant,
+                      .type = ScalarType::Angle,
+                      .constant = constant});
+    }
     if (declaration.isConst) {
       if (!declaration.initializer ||
           !isConstantExpression(*declaration.initializer)) {
@@ -3083,6 +3375,7 @@ private:
     case Expr::Kind::Int:
     case Expr::Kind::Float:
     case Expr::Kind::Bool:
+    case Expr::Kind::AngleCast:
     case Expr::Kind::Neg:
     case Expr::Kind::BitNot:
     case Expr::Kind::Add:

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -143,8 +143,8 @@ quantizeAngleMagnitude(const uint64_t significand, const int32_t binaryExponent,
           magnitude.shl(static_cast<unsigned>(scaledExponent)), modulus);
     } else {
       const auto denominatorShift = static_cast<unsigned>(-scaledExponent);
-      // The numerator has at most 53 bits and the odd denominator has 50.
-      // Five more denominator bits put even the largest numerator below half.
+      /// The numerator has at most 53 bits and the odd denominator has 50.
+      /// Five more denominator bits put even the largest numerator below half.
       if (denominatorShift >= 5U) {
         return 0;
       }
@@ -171,7 +171,7 @@ quantizeAngle(const double radians, const uint32_t bitWidth) {
 
   const auto significand =
       exponent == 0 ? fraction : fraction | (uint64_t{1} << 52U);
-  // The binary64 value of 2*pi is TWO_PI_ODD_SIGNIFICAND * 2^-47.
+  /// The binary64 value of 2*pi is TWO_PI_ODD_SIGNIFICAND * 2^-47.
   const auto binaryExponent =
       exponent == 0 ? -1027 : static_cast<int32_t>(exponent) - 1028;
   auto result = quantizeAngleMagnitude(significand, binaryExponent, bitWidth);

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -911,8 +911,7 @@ private:
       return fail(location, "angle width must be an integer expression");
     }
     const auto width = asSigned(constant);
-    if (!width || *width < 1 ||
-        *width > static_cast<int64_t>(MAX_ANGLE_WIDTH)) {
+    if (!width || *width < 1 || std::cmp_greater(*width, MAX_ANGLE_WIDTH)) {
       return fail(location, Twine("angle width must be between 1 and ") +
                                 Twine(MAX_ANGLE_WIDTH));
     }
@@ -1181,13 +1180,14 @@ private:
                           "angles can only be compared with angles or finite "
                           "float constants");
             }
-            const auto commonWidth =
-                lhs.type == ScalarType::Angle && rhs.type == ScalarType::Angle
-                    ? std::max(std::get<FixedAngle>(lhs.value).bitWidth,
-                               std::get<FixedAngle>(rhs.value).bitWidth)
-                    : (lhs.type == ScalarType::Angle
-                           ? std::get<FixedAngle>(lhs.value).bitWidth
-                           : std::get<FixedAngle>(rhs.value).bitWidth);
+            uint32_t commonWidth = 0;
+            if (lhs.type == ScalarType::Angle) {
+              commonWidth = std::get<FixedAngle>(lhs.value).bitWidth;
+            }
+            if (rhs.type == ScalarType::Angle) {
+              commonWidth = std::max(commonWidth,
+                                     std::get<FixedAngle>(rhs.value).bitWidth);
+            }
             MQT_OQ3_TRY_ASSIGN(
                 leftAngle,
                 convertToFixedAngle(lhs, commonWidth, expression.location));
@@ -1198,8 +1198,11 @@ private:
                 resizeAngle(std::get<FixedAngle>(leftAngle.value), commonWidth);
             const auto right = resizeAngle(
                 std::get<FixedAngle>(rightAngle.value), commonWidth);
-            ordering =
-                left.bits < right.bits ? -1 : (left.bits > right.bits ? 1 : 0);
+            if (left.bits < right.bits) {
+              ordering = -1;
+            } else if (left.bits > right.bits) {
+              ordering = 1;
+            }
           } else {
             ordering = compareNumericConstants(lhs, rhs);
           }

--- a/mlir/lib/Target/OpenQASM/OpenQASMSyntax.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSyntax.cpp
@@ -156,13 +156,16 @@ SyntaxGateCall SyntaxBuilder::copyGateCall(const GateCall& call) {
 }
 
 LogicalResult SyntaxBuilder::scalarDecl(SMLoc location, const ScalarKind kind,
-                                        StringRef identifier,
+                                        StringRef identifier, const Expr* size,
                                         const Expr* initializer,
                                         const bool isConst, const bool output) {
   SyntaxScalarDeclaration declaration{.kind = kind,
                                       .identifier = identifier,
                                       .isConst = isConst,
                                       .output = output};
+  if (size != nullptr) {
+    declaration.size = copyExpression(*size);
+  }
   if (initializer != nullptr) {
     declaration.initializer = copyExpression(*initializer);
   }

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -118,6 +118,31 @@ TEST(OpenQASM3EmissionTest, PreservesMeasurementOrderBeforeDelayedStore) {
       << *emitted;
 }
 
+TEST(OpenQASM3EmissionTest, CanonicalizesFixedAnglesToPortableFloats) {
+  constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
+include "stdgates.inc";
+angle[8] theta = angle[8](pi / 2);
+qubit q;
+rx(theta) q;
+output bit result;
+result = measure q;
+)qasm";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_EQ(emitted->find("angle"), std::string::npos);
+  EXPECT_EQ(emitted->find("mqt.openqasm"), std::string::npos);
+  EXPECT_NE(emitted->find("rx(1.5707963267948966)"), std::string::npos)
+      << *emitted;
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+      << *emitted;
+}
+
 TEST(OpenQASM3EmissionTest, UsesCanonicalOutputTypesWithoutResultMetadata) {
   constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
 include "stdgates.inc";

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_parser.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_parser.cpp
@@ -519,7 +519,6 @@ TEST(OpenQASMFrontendTest, DiagnosesMalformedLexicalAndGrammarFamilies) {
        .source = "OPENQASM 3.1; qubit q; x $;"},
       {.name = "float-overflow",
        .source = "OPENQASM 3.1; float value = 1e99999;"},
-      {.name = "unsupported-angle", .source = "OPENQASM 3.1; angle theta;"},
       {.name = "unsupported-duration",
        .source = "OPENQASM 3.1; duration delay;"},
       {.name = "unsupported-opaque",
@@ -554,6 +553,18 @@ TEST(OpenQASMFrontendTest, DiagnosesMalformedLexicalAndGrammarFamilies) {
     ASSERT_FALSE(parsed.diagnostics.empty());
     EXPECT_FALSE(parsed.diagnostics.front().message.empty());
   }
+}
+
+TEST(OpenQASMFrontendTest, ParsesFixedAngleDeclarationsAndCasts) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+const uint WIDTH = 8;
+const angle[WIDTH] fixed = angle[WIDTH](pi / 2);
+angle machine = angle(tau / 4);
+)qasm";
+
+  auto parsed = oq3::frontend::parseOpenQASM(source);
+  ASSERT_TRUE(parsed) << parsed.diagnostics.front().message;
 }
 
 TEST(OpenQASMFrontendTest, RejectsUnsupportedReservedWordsAsIdentifiers) {

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -816,8 +816,7 @@ if (a > b && a == 7.0 * pi / 8.0) { x q; }
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 
-  const auto defaultStep =
-      std::ldexp(2.0 * std::numbers::pi, -static_cast<int>(52));
+  const auto defaultStep = std::ldexp(2.0 * std::numbers::pi, -52);
   const std::array expectedParameters{
       std::numbers::pi / 2.0,
       15.0 * std::numbers::pi / 8.0,

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -810,7 +810,8 @@ rx(smallest_default) q;
 rx(huge) q;
 rx(subnormal) q;
 rx(sin(a)) q;
-if (a > b && a == 7.0 * pi / 8.0) { x q; }
+rx(sin(angle[4](pi / 8.0))) q;
+if (a > b && b < a && a == 7.0 * pi / 8.0) { x q; }
 )qasm";
 
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
@@ -835,6 +836,7 @@ if (a > b && a == 7.0 * pi / 8.0) { x q; }
       3985068968215732.0 * defaultStep,
       0.0,
       std::sin(7.0 * std::numbers::pi / 8.0),
+      std::sin(std::numbers::pi / 8.0),
   };
   size_t parameterIndex = 0;
   bool sawTrueCondition = false;
@@ -882,6 +884,11 @@ TEST(OpenQASMFrontendTest, RejectsUnsupportedFixedAnglePrograms) {
       "a;",
       "OPENQASM 3.1; const angle[8] a = angle[8](pi); const angle[8] b = a * "
       "256;",
+      "OPENQASM 3.1; output angle[8] result;",
+      "OPENQASM 3.1; float theta = pi; qubit q; rx(angle[8](theta)) q;",
+      "OPENQASM 3.1; const angle[8] a = angle[8](pi); const bool bad = a == 1;",
+      "OPENQASM 3.1; const angle[8] a = angle[8](pi); const angle[8] bad = a + "
+      "pi;",
   });
 
   for (const auto source : sources) {

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -20,8 +20,10 @@
 #include <llvm/Support/SourceMgr.h>
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <numbers>
 #include <string>
 #include <utility>
 #include <variant>
@@ -762,6 +764,141 @@ const int integer_arithmetic =
     (1 + 2) - (3 * 1) + (8 / 2) + (5 % 2) + pow(2, 3);
 )qasm";
 
+  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+  EXPECT_TRUE(analyzed.program->body.empty());
+}
+
+TEST(OpenQASMFrontendTest, FoldsFixedAngleConversionsAndArithmetic) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+const float two_pi = 6.283185307179586;
+angle[8] halfway = angle[8](two_pi * (127.0 / 512.0));
+const angle[4] negative = angle[4](-pi / 8.0);
+const angle[4] multi_turn = angle[4](tau + pi / 2.0);
+const angle[1] width_one = angle[1](pi);
+const angle[4] a = angle[4](7.0 * pi / 8.0);
+const angle[4] b = angle[4](pi / 8.0);
+const angle[8] widened = angle[8](b);
+const angle[8] mixed_width = widened + b;
+const angle[3] tie_even_down = angle[3](b);
+const angle[3] tie_even_up = angle[3](angle[4](3.0 * pi / 8.0));
+const angle[4] sum = a + b;
+const angle[4] difference = b - a;
+const angle[4] product = 2 * b;
+const angle[4] quotient = a / 2;
+const angle[4] negated = -b;
+angle smallest_default = angle(tau / 4503599627370496.0);
+const angle[52] huge = angle[52](1e300);
+const angle[52] subnormal = angle[52](5e-324);
+qubit q;
+rx(halfway) q;
+rx(negative) q;
+rx(multi_turn) q;
+rx(width_one) q;
+rx(widened) q;
+rx(mixed_width) q;
+rx(tie_even_down) q;
+rx(tie_even_up) q;
+rx(sum) q;
+rx(difference) q;
+rx(product) q;
+rx(quotient) q;
+rx(negated) q;
+rx(smallest_default) q;
+rx(huge) q;
+rx(subnormal) q;
+rx(sin(a)) q;
+if (a > b && a == 7.0 * pi / 8.0) { x q; }
+)qasm";
+
+  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+
+  const auto defaultStep =
+      std::ldexp(2.0 * std::numbers::pi, -static_cast<int>(52));
+  const std::array expectedParameters{
+      std::numbers::pi / 2.0,
+      15.0 * std::numbers::pi / 8.0,
+      std::numbers::pi / 2.0,
+      std::numbers::pi,
+      std::numbers::pi / 8.0,
+      std::numbers::pi / 4.0,
+      0.0,
+      std::numbers::pi / 2.0,
+      std::numbers::pi,
+      5.0 * std::numbers::pi / 4.0,
+      std::numbers::pi / 4.0,
+      3.0 * std::numbers::pi / 8.0,
+      15.0 * std::numbers::pi / 8.0,
+      defaultStep,
+      3985068968215732.0 * defaultStep,
+      0.0,
+      std::sin(7.0 * std::numbers::pi / 8.0),
+  };
+  size_t parameterIndex = 0;
+  bool sawTrueCondition = false;
+  for (const auto statement : analyzed.program->body) {
+    const auto& data = analyzed.program->statements[statement].data;
+    if (const auto* application =
+            std::get_if<oq3::frontend::GateApplication>(&data);
+        application != nullptr && application->callee == "rx") {
+      ASSERT_LT(parameterIndex, expectedParameters.size());
+      const auto& parameter =
+          analyzed.program->expressions.at(application->parameters.front());
+      ASSERT_EQ(parameter.type, oq3::frontend::ScalarType::Angle);
+      const auto& value = parameter.kind == oq3::frontend::ExpressionKind::Cast
+                              ? analyzed.program->expressions.at(parameter.lhs)
+                              : parameter;
+      ASSERT_EQ(value.kind, oq3::frontend::ExpressionKind::Constant);
+      EXPECT_DOUBLE_EQ(std::get<double>(value.constant),
+                       expectedParameters[parameterIndex]);
+      ++parameterIndex;
+    }
+    if (const auto* conditional =
+            std::get_if<oq3::frontend::IfStatement>(&data)) {
+      const auto& condition =
+          analyzed.program->conditions.at(conditional->condition);
+      sawTrueCondition =
+          condition.kind == oq3::frontend::ConditionKind::Literal &&
+          condition.literal;
+    }
+  }
+  EXPECT_EQ(parameterIndex, expectedParameters.size());
+  EXPECT_TRUE(sawTrueCondition);
+  EXPECT_TRUE(analyzed.program->scalars.empty());
+  EXPECT_TRUE(analyzed.program->outputs.empty());
+}
+
+TEST(OpenQASMFrontendTest, RejectsUnsupportedFixedAnglePrograms) {
+  constexpr auto sources = std::to_array<llvm::StringLiteral>({
+      "OPENQASM 3.1; angle[0] a = pi;",
+      "OPENQASM 3.1; angle[53] a = pi;",
+      "OPENQASM 3.1; angle a;",
+      "OPENQASM 3.1; float f = 0.5; angle[8] a = f;",
+      "OPENQASM 3.1; angle[8] a = pi; a = pi / 2;",
+      "OPENQASM 3.1; float f = 0.5; const angle[8] a = angle[8](f);",
+      "OPENQASM 3.1; const angle[8] a = angle[8](pi); const angle[8] b = a / "
+      "a;",
+      "OPENQASM 3.1; const angle[8] a = angle[8](pi); const angle[8] b = a * "
+      "256;",
+  });
+
+  for (const auto source : sources) {
+    SCOPED_TRACE(source.str());
+    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    ASSERT_FALSE(analyzed);
+    ASSERT_FALSE(analyzed.diagnostics.empty());
+  }
+}
+
+TEST(OpenQASMFrontendTest, UsesSpecificationTypesForRealConstantsAndArcTrig) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+const float circle = pi + tau;
+const float inverse = arccos(0.5) + arcsin(0.5) + arctan(0.5);
+)qasm";
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   EXPECT_TRUE(analyzed.program->body.empty());


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This PR replaces #2040 and #2061 with a current-`main` implementation of compile-time fixed-width OpenQASM angles.

The frontend keeps the source residue and width only while it evaluates constant expressions. It lowers each result to the existing binary64 gate-parameter representation before QC emission. This design adds no OpenQASM-specific MLIR attributes, MLIR types, public frontend API, exporter reconstruction, Python code, or generated files.

The focused subset supports initialized `angle[N]` declarations for widths 1 through 52, unsized compile-time angles at width 52, exact binary64 conversion with ties-to-even, resizing, modular negation and addition or subtraction, multiplication and division by fitting integer literals, mixed-width promotion, comparisons, and `sin`, `cos`, and `tan`. Runtime angle state, reassignment, angle inputs or outputs, bit-level angle operations, and angle-by-angle division remain outside this subset.

The QC-to-OpenQASM path emits canonical floating-point gate arguments. An end-to-end test verifies that the result contains no source-format metadata and reparses in strict OpenQASM 3.1 mode.

Fixes #1128. Runtime fixed-angle state and target-aware quantization are tracked in #2174. Supersedes #2040 and #2061.

### Validation

- The complete release CTest suite passed all 4,295 configured tests; one device-query test was skipped by design.
- The affected OpenQASM target and QC translation suites pass on the rebased current `main` branch: 168 and 175 tests.
- Non-unity release builds of both affected targets pass.
- The MLIR documentation warnings-as-errors build passes with the cached QDMI 1.3.2 tag file.
- Diff-scoped Clang-Tidy passes with all warnings as errors.
- `uvx nox -s lint` and `git diff --check` pass.

GPT-5 via Codex materially assisted with design analysis, implementation, tests, documentation, validation, and this PR text.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.


