### PR TITLE
📝 Update changelog and upgrade guide after release of `v3.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,33 +17,13 @@ releases may include breaking changes.
   ([**@marcelwa**])
 - ✨ Add `mqt.core.qdmi.is_binary_program_format`, which states whether a
   program format requires exact-byte submission ([#2114]) ([**@marcelwa**])
-- ✨ Add `Device::submitCalibrationJob` and
-  `mqt.core.qdmi.Device.submit_calibration_job` for triggering a calibration run
-  ([#2148]) ([**@marcelwa**])
-- ✨ Add SpecAudits, a method and probe script for auditing tests that pin
-  behavior the project never specified ([#2124]) ([**@marcelwa**])
 - ✨ Extract the existing QCO dead-gate elimination patterns from
   canonicalization into an explicit `remove-dead-gates` pass and use it in the
   qubit-reuse pipeline ([#2118]) ([**@simon1hofmann**])
-- 🚸 Add typed stable-ID construction for Qiskit backends and compiler targets,
-  fluent Qiskit primitives, and lazy provider discovery ([#2084])
-  ([**@burgholzer**])
-- 🧪 Test static Slurm license admission and QDMI execution with DDSIM and SC,
-  and document the cluster setup ([#2043]) ([**@burgholzer**])
-- ✨ Add C++ and Python adapters that open the QDMI device named by one local
-  Slurm license environment value ([#2025]) ([**@burgholzer**])
 - ✨ Add an `unroll-modifiers` pass for unrolling multi-operation modifiers
   ([#2015]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add Qiskit circuit import and export to the compiler collection ([#2031],
   [#2133], [#2136], [#2140]) ([**@burgholzer**], [**@simon1hofmann**])
-- ✨ Add generic C++ and Python FoMaC support for custom device properties that
-  contain operation handles ([#2042]) ([**@burgholzer**])
-- ✨ Support retrieving existing jobs by ID through the QDMI client API and C++
-  and Python FoMaC APIs, and expose optional device queue length and job queue
-  position ([#2008], [#2010]) ([**@burgholzer**])
-- 🐍 Start building CPython 3.15 wheels ([#2011]) ([**@denialhaag**])
-- ✨ Add PennyLane support for gate-based QDMI devices ([#2005], [#2147])
-  ([**@burgholzer**], [**@marcelwa**])
 - ✨ Integrate QDMI devices as MLIR compiler targets across C++, Python, and
   `mqt-cc` ([#1687]) ([**@MatthiasReumann**], [**@burgholzer**])
 - ✨ Add structured OpenQASM emission from the QC dialect to the C++ and Python
@@ -52,18 +32,8 @@ releases may include breaking changes.
   pipeline for decomposition, optimization, mapping, native synthesis, and
   conformance ([#1993], [#1999], [#2049]) ([**@simon1hofmann**],
   [**@burgholzer**])
-- ✨ Bundle reusable IQM Garnet and Emerald superconducting device models with
-  stable QDMI registry IDs ([#1992]) ([**@burgholzer**])
 - ✨ Add compiler-wide scoped global-phase normalization with exact modifier
   semantics and synthesis integration ([#1986], [#1995]) ([**@burgholzer**])
-- ✨ Expose compressed vector and matrix DD serialization through bytes-based
-  Python APIs ([#1983]) ([**@burgholzer**])
-- ✨ Make superconducting QDMI devices runtime configurable with session-owned
-  topology, operations, and calibration data ([#1980]) ([**@burgholzer**])
-- ✨ Expose registered QDMI device IDs without loading device libraries
-  ([#1972]) ([**@burgholzer**])
-- ✨ Add typed runtime configuration transport and relocatable assets for QDMI
-  device descriptions ([#1967]) ([**@burgholzer**])
 - ✨ Add and improve QIR generation support in the MQT Compiler Collection
   ([#1264], [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570],
   [#1572], [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751],
@@ -137,23 +107,9 @@ releases may include breaking changes.
 
 ### Changed
 
-- ⬆️ Update QDMI to version 1.3.3 ([#2168]) ([**@denialhaag**])
-- ⬆️ Update `nanobind` to version 2.15.0 ([#2141]) ([**@denialhaag**])
 - 💥 Prune dead and misleading CoreIR APIs, including renaming the non-garbage
   logical output count to `getNoutputQubits()` and `num_output_qubits` ([#2112])
   ([**@simon1hofmann**])
-- ♻️ Simplify Python optional-dependency checks while preserving the Qiskit and
-  PennyLane availability flags ([#2108]) ([**@simon1hofmann**])
-- 💥 Remove the unused `pybind11` CMake helper and rename
-  `add_mqt_python_binding_nanobind` to `add_mqt_python_binding` ([#2106])
-  ([**@denialhaag**])
-- 💥 Replace the MQT-specific QDMI primitive `options` mappings with explicit
-  shot and precision defaults ([#2084]) ([**@burgholzer**])
-- 💥 Move Python QDMI entities and the neutral-atom specialization to QDMI
-  namespaces, expose device registration and opening through
-  `mqt.core.qdmi.driver`, retain v3 FoMaC compatibility aliases, and let the
-  Qiskit adapter open stable device IDs directly ([#2074]) ([**@burgholzer**])
-- ⬆️ Update `nanobind` to version 2.14.0 ([#2073]) ([**@denialhaag**])
 - 🛡️ Isolate DDSIM QIR job execution and restrict statevector extraction to
   terminal `irreversible` regions of Base-profile programs ([#2036])
   ([**@burgholzer**])
@@ -167,17 +123,8 @@ releases may include breaking changes.
 - 📦 Build MLIR by default for C++ library builds ([#1356]) ([**@burgholzer**],
   [**@denialhaag**])
 
-### Fixed
-
-- 🐛 Distinguish scalar OpenQASM qubits from one-element qubit registers and
-  reject indexing scalar qubits ([#2157]) ([**@DRovara**], [**@burgholzer**])
-- 🐛 Preserve the original OpenQASM type error when an assignment's right-hand
-  expression cannot be typed ([#2156]) ([**@DRovara**], [**@burgholzer**])
-
 ### Removed
 
-- 💥 Remove batch job submission from the QDMI client. `Device::submitJob` now
-  states that MQT Core does not support batch jobs ([#2148]) ([**@marcelwa**])
 - 💥 Remove the IQM JSON converter `qiskit_to_iqm_json` and the `MoveGate` from
   the Qiskit plugin, which [QDMI-on-IQM] now owns ([#2114]) ([**@marcelwa**])
 - 💥 Remove the unused decision-diagram approximation algorithm, including the
@@ -195,8 +142,6 @@ releases may include breaking changes.
 - 💥 Remove the random-number generator, seed, and `getGenerator()` method from
   `QuantumComputation`; randomized algorithms now own generators initialized
   from their seed arguments ([#2111]) ([**@simon1hofmann**])
-- 💥 Remove QDMI device configuration through `[tool.qdmi]` in `pyproject.toml`
-  and the vendored toml++ header ([#2116]) ([**@denialhaag**])
 - 💥 Remove the FoMaC compatibility name from the C++ and Python QDMI APIs. Use
   the `qdmi` C++ namespace, headers, libraries, and CMake targets; the
   `mqt.core.qdmi` and `mqt.core.na.qdmi` Python modules; and the module-level
@@ -212,6 +157,81 @@ releases may include breaking changes.
   ([**@burgholzer**])
 - 🔥 Remove `datastructures` (`ds`) (sub)library from MQT Core ([#1458])
   ([**@burgholzer**])
+
+## [3.9.0] - 2026-08-19
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#390)._
+
+### Added
+
+- ✨ Add PennyLane support for gate-based QDMI devices ([#2005], [#2147])
+  ([**@burgholzer**], [**@marcelwa**])
+- ✨ Add `Device::submitCalibrationJob` and
+  `mqt.core.qdmi.Device.submit_calibration_job` for triggering a calibration run
+  ([#2148]) ([**@marcelwa**], [**@burgholzer**])
+- ✨ Add SpecAudits, a method and probe script for auditing tests that pin
+  behavior the project never specified ([#2124]) ([**@marcelwa**])
+- 🚸 Add typed stable-ID construction for Qiskit backends, lazy provider
+  discovery, and sampler and estimator factories with explicit shot and
+  precision defaults ([#2084]) ([**@burgholzer**])
+- 🧪 Test static Slurm license admission and QDMI execution with DDSIM and the
+  superconducting device, and document the cluster setup ([#2043])
+  ([**@burgholzer**])
+- ✨ Add C++ FoMaC and Python QDMI adapters that open the device named by one
+  local Slurm license environment value ([#2025]) ([**@burgholzer**])
+- ✨ Add generic C++ FoMaC and Python QDMI support for custom device properties
+  that contain operation handles ([#2042]) ([**@burgholzer**])
+- 📝 Generate `llms.txt` documentation indexes with Sphinx-LLM ([#1989],
+  [#2046]) ([**@denialhaag**], [**@burgholzer**])
+- ✨ Support retrieving existing jobs by ID through the QDMI client API, C++
+  FoMaC API, and Python QDMI API, and expose optional device queue length and
+  job queue position ([#2008], [#2010]) ([**@burgholzer**])
+- 🐍 Build CPython 3.15 wheels. Their post-build tests remain disabled until
+  test dependency wheels are available ([#2011]) ([**@denialhaag**])
+- ✨ Bundle reusable IQM Garnet and Emerald superconducting device models with
+  stable QDMI registry IDs ([#1992]) ([**@burgholzer**])
+- ✨ Expose compressed vector and matrix DD serialization through bytes-based
+  Python APIs ([#1983]) ([**@burgholzer**])
+- ✨ Make the neutral-atom and superconducting QDMI devices runtime configurable
+  with session-owned topology, operations, and calibration data ([#1974],
+  [#1980]) ([**@burgholzer**])
+- ✨ Expose registered QDMI device IDs without loading device libraries
+  ([#1972]) ([**@burgholzer**])
+- ✨ Add typed runtime configuration transport and relocatable assets for QDMI
+  device descriptions ([#1967]) ([**@burgholzer**])
+
+### Changed
+
+- ⬆️ Update QDMI to version 1.3.3 ([#2168]) ([**@denialhaag**])
+- ⬆️ Update `nanobind` to version 2.15.0 ([#2141]) ([**@denialhaag**])
+- 💥 Replace the MQT-specific QDMI primitive `options` mappings with explicit
+  shot and precision defaults ([#2084]) ([**@burgholzer**])
+- ♻️ Simplify Python optional-dependency checks while preserving the Qiskit and
+  PennyLane availability flags ([#2108]) ([**@simon1hofmann**])
+- 💥 Remove the unused `pybind11` CMake helper and rename
+  `add_mqt_python_binding_nanobind` to `add_mqt_python_binding` ([#2106])
+  ([**@denialhaag**])
+- 💥 Move Python QDMI entities and the neutral-atom specialization to QDMI
+  namespaces, expose device registration and opening through
+  `mqt.core.qdmi.driver`, retain v3 FoMaC compatibility aliases, and let the
+  Qiskit adapter open stable device IDs directly ([#2074]) ([**@burgholzer**])
+- 🚀 Reduce ZX diagram growth for multi-controlled X gates with an exact
+  ancilla-free quadratic decomposition ([#1984]) ([**@burgholzer**])
+
+### Fixed
+
+- 🐛 Distinguish scalar OpenQASM qubits from one-element qubit registers and
+  reject indexing scalar qubits ([#2157]) ([**@DRovara**], [**@burgholzer**])
+- 🐛 Preserve the original OpenQASM type error when an assignment's right-hand
+  expression cannot be typed ([#2156]) ([**@DRovara**], [**@burgholzer**])
+
+### Removed
+
+- 💥 Remove batch job submission from the QDMI client. `Device::submitJob` now
+  states that MQT Core does not support batch jobs ([#2148]) ([**@marcelwa**],
+  [**@burgholzer**])
+- 💥 Remove QDMI device configuration through `[tool.qdmi]` in `pyproject.toml`
+  and the vendored toml++ header ([#2116]) ([**@denialhaag**])
 
 ## [3.8.0] - 2026-07-30
 
@@ -793,7 +813,8 @@ for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.8.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.0...HEAD
+[3.9.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.9.0
 [3.8.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.8.0
 [3.7.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.7.0
 [3.6.1]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.6.1
@@ -842,12 +863,12 @@ for previous changelogs._
 [#2105]: https://github.com/munich-quantum-toolkit/core/pull/2105
 [#2084]: https://github.com/munich-quantum-toolkit/core/pull/2084
 [#2074]: https://github.com/munich-quantum-toolkit/core/pull/2074
-[#2073]: https://github.com/munich-quantum-toolkit/core/pull/2073
 [#2066]: https://github.com/munich-quantum-toolkit/core/pull/2066
 [#2060]: https://github.com/munich-quantum-toolkit/core/pull/2060
 [#2058]: https://github.com/munich-quantum-toolkit/core/pull/2058
 [#2054]: https://github.com/munich-quantum-toolkit/core/pull/2054
 [#2049]: https://github.com/munich-quantum-toolkit/core/pull/2049
+[#2046]: https://github.com/munich-quantum-toolkit/core/pull/2046
 [#2043]: https://github.com/munich-quantum-toolkit/core/pull/2043
 [#2042]: https://github.com/munich-quantum-toolkit/core/pull/2042
 [#2039]: https://github.com/munich-quantum-toolkit/core/pull/2039
@@ -882,14 +903,17 @@ for previous changelogs._
 [#1994]: https://github.com/munich-quantum-toolkit/core/pull/1994
 [#1993]: https://github.com/munich-quantum-toolkit/core/pull/1993
 [#1992]: https://github.com/munich-quantum-toolkit/core/pull/1992
+[#1989]: https://github.com/munich-quantum-toolkit/core/pull/1989
 [#1987]: https://github.com/munich-quantum-toolkit/core/pull/1987
 [#1986]: https://github.com/munich-quantum-toolkit/core/pull/1986
+[#1984]: https://github.com/munich-quantum-toolkit/core/pull/1984
 [#1983]: https://github.com/munich-quantum-toolkit/core/pull/1983
 [#1980]: https://github.com/munich-quantum-toolkit/core/pull/1980
 [#1979]: https://github.com/munich-quantum-toolkit/core/pull/1979
 [#1978]: https://github.com/munich-quantum-toolkit/core/pull/1978
 [#1976]: https://github.com/munich-quantum-toolkit/core/pull/1976
 [#1975]: https://github.com/munich-quantum-toolkit/core/pull/1975
+[#1974]: https://github.com/munich-quantum-toolkit/core/pull/1974
 [#1973]: https://github.com/munich-quantum-toolkit/core/pull/1973
 [#1972]: https://github.com/munich-quantum-toolkit/core/pull/1972
 [#1967]: https://github.com/munich-quantum-toolkit/core/pull/1967

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,148 +12,97 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Let a package register a program serializer for a program format through
-  the `mqt.core.qiskit.program_serializers` entry point group ([#2114])
-  ([**@marcelwa**])
-- ✨ Add `mqt.core.qdmi.is_binary_program_format`, which states whether a
-  program format requires exact-byte submission ([#2114]) ([**@marcelwa**])
-- ✨ Extract the existing QCO dead-gate elimination patterns from
-  canonicalization into an explicit `remove-dead-gates` pass and use it in the
-  qubit-reuse pipeline ([#2118]) ([**@simon1hofmann**])
-- ✨ Add an `unroll-modifiers` pass for unrolling multi-operation modifiers
-  ([#2015]) ([**@denialhaag**], [**@burgholzer**])
-- ✨ Add Qiskit circuit import and export to the compiler collection ([#2031],
-  [#2133], [#2136], [#2140]) ([**@burgholzer**], [**@simon1hofmann**])
-- ✨ Integrate QDMI devices as MLIR compiler targets across C++, Python, and
-  `mqt-cc` ([#1687]) ([**@MatthiasReumann**], [**@burgholzer**])
-- ✨ Add structured OpenQASM emission from the QC dialect to the C++ and Python
-  compiler APIs and `mqt-cc` ([#2003]) ([**@burgholzer**])
-- ✨ Add immutable MLIR compiler targets and a canonical target compilation
-  pipeline for decomposition, optimization, mapping, native synthesis, and
-  conformance ([#1993], [#1999], [#2049]) ([**@simon1hofmann**],
-  [**@burgholzer**])
-- ✨ Add compiler-wide scoped global-phase normalization with exact modifier
-  semantics and synthesis integration ([#1986], [#1995]) ([**@burgholzer**])
-- ✨ Add and improve QIR generation support in the MQT Compiler Collection
-  ([#1264], [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570],
-  [#1572], [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751],
-  [#1755], [#1787], [#1815], [#1823], [#1830], [#1886], [#1933], [#1978],
-  [#1979], [#2007], [#2026], [#2030], [#2066]) ([**@burgholzer**],
-  [**@denialhaag**], [**@simon1hofmann**], [**@li-mingbao**], [**@DRovara**],
-  [**@MatthiasReumann**])
-- ✨ Add decision diagram-based construction, simulation, and sampling of QCO
-  functions, including static unitaries, mid-circuit `measure`/`reset`, concrete
-  `if`/`index_switch`, initial classical SSA evaluation, dense `k>3` wire
-  embedding, and multi-shot `sample` ([#1915], [#1973]) ([**@simon1hofmann**])
-- ✨ Add target-independent two-qubit gate fusion, target-native post-routing
-  synthesis, and operation-capability and static-site conformance ([#1865],
-  [#1961], [#1998]) ([**@simon1hofmann**], [**@burgholzer**])
-- ✨ Add a `decompose-multi-controlled` pass for decomposing controlled X, Z,
-  SWAP, RCCX, and constant-angle phase gates with a configurable `min-qubits`
-  threshold (default 3: wider than two-qubit) ([#1810], [#1996], [#2001])
-  ([**@simon1hofmann**])
-- ✨ Add an LLVM-native staged OpenQASM frontend with typed semantic analysis
-  and direct QC emission, including lexical scope, assignment, inclusive ranges,
-  structured control flow, and alias-safe qubit-register access ([#1910],
-  [#1987], [#1994], [#2026]) ([**@burgholzer**], [**@denialhaag**])
-- ✨ Add Python bindings for the MQT Compiler Collection ([#1815])
-  ([**@burgholzer**], [**@denialhaag**])
-- ✨ Add support for IQM's `move` gate in the QDMI Qiskit backend converter
-  ([#1844], [#1848]) ([**@burgholzer**], [**@marcelwa**])
-- 🚸 Add `const` version of the `CompoundOperation`'s `getOps()` function
-  ([#1826]) ([**@ystade**])
-- 🐳 Add dev container configuration for consistent local development
-  environment ([#1786]) ([**@denialhaag**])
-- ✨ Add two-qubit Weyl (KAK) decomposition and native-gateset synthesis support
-  ([#1803], [#1832]) ([**@simon1hofmann**], [**@burgholzer**])
-- ✨ Extend the QCO unitary matrix library ([#1774], [#1802], [#1809], [#1814],
-  [#1850]) ([**@simon1hofmann**], [**@burgholzer**])
-- ✨ Add a `fuse-single-qubit-unitary-runs` pass for fusing compile-time
-  single-qubit unitary runs via Euler resynthesis ([#1672])
-  ([**@simon1hofmann**], [**@burgholzer**])
-- ✨ Add a `quantum-loop-unroll` pass for unrolling for-loop operations
-  containing quantum operations ([#1718]) ([**@MatthiasReumann**])
-- ✨ Add a `hadamard-lifting` pass for lifting Hadamard gates above Pauli gates
-  ([#1605]) ([**@lirem101**], [**@burgholzer**])
-- ✨ Add a `merge-single-qubit-rotation-gates` pass for merging consecutive
-  fixed and parameterized single-qubit gates using quaternions with global-phase
-  correction ([#1407], [#1674], [#2002], [#2038]) ([**@J4MMlE**],
-  [**@denialhaag**], [**@MatthiasReumann**], [**@simon1hofmann**])
+#### General MQT Compiler Collection infrastructure
+
+- ✨ Launch the MQT Compiler Collection with the QC and QCO dialects, its core
+  compiler infrastructure, and C++ and Python APIs ([#1264], [#1330], [#1402],
+  [#1428], [#1430], [#1436], [#1443], [#1446], [#1464], [#1465], [#1470],
+  [#1471], [#1472], [#1474], [#1475], [#1506], [#1510], [#1513], [#1521],
+  [#1542], [#1548], [#1550], [#1554], [#1567], [#1569], [#1570], [#1572],
+  [#1573], [#1580], [#1602], [#1603], [#1620], [#1623], [#1626], [#1627],
+  [#1635], [#1638], [#1673], [#1675], [#1700], [#1717], [#1728], [#1730],
+  [#1749], [#1751], [#1762], [#1765], [#1780], [#1781], [#1782], [#1806],
+  [#1807], [#1808], [#1815], [#1824], [#1869], [#1872], [#1914], [#1925],
+  [#1927], [#1935], [#1936], [#1938], [#1975], [#1976], [#2006], [#2014],
+  [#2015], [#2017], [#2026], [#2028], [#2054], [#2058], [#2125], [#2136],
+  [#2158]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
+  [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
+  [**@simon1hofmann**], [**@J4MMlE**])
+- ✨ Add decision diagram-based construction, simulation, and sampling for QCO
+  programs ([#1915], [#1973]) ([**@simon1hofmann**])
+- ✨ Add immutable MLIR compiler targets, QDMI device integration, and target
+  compilation through C++, Python, and `mqt-cc` ([#1687], [#1993], [#1999],
+  [#2049]) ([**@MatthiasReumann**], [**@simon1hofmann**], [**@burgholzer**])
+
+#### Import and export
+
+- ✨ Add Qiskit circuit import and target-aware export to the compiler
+  collection ([#2031], [#2133], [#2140]) ([**@burgholzer**],
+  [**@simon1hofmann**])
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637],
   [#1676], [#1706], [#1776], [#1836], [#1934], [#2000], [#2018], [#2105])
   ([**@denialhaag**], [**@burgholzer**])
-- ✨ Add a `place-and-route` pass for mapping scalar- and tensor-allocated
-  circuits to compiler-target topologies while preserving target site IDs and
-  materializing routing workspace on demand ([#1537], [#1547], [#1568], [#1581],
-  [#1583], [#1588], [#1600], [#1664], [#1709], [#1716], [#1748], [#1805],
-  [#1870], [#1904], [#1911], [#1951], [#1997], [#2016], [#2060])
-  ([**@MatthiasReumann**], [**@burgholzer**])
-- ✨ Add a pass for qubit reuse in quantum programs, as well as related
-  auxiliary passes and patterns ([#1705], [#1755], [#1756], [#1923], [#1924],
-  [#2039]) ([**@DRovara**], [**@burgholzer**], [**@simon1hofmann**])
-- ✨ Add initial infrastructure for new QC and QCO MLIR dialects ([#1264],
-  [#1330], [#1402], [#1428], [#1430], [#1436], [#1443], [#1446], [#1464],
-  [#1465], [#1470], [#1471], [#1472], [#1474], [#1475], [#1506], [#1510],
-  [#1513], [#1521], [#1542], [#1548], [#1550], [#1554], [#1567], [#1569],
-  [#1570], [#1572], [#1573], [#1580], [#1602], [#1603], [#1620], [#1623],
-  [#1626], [#1627], [#1635], [#1638], [#1673], [#1675], [#1700], [#1717],
-  [#1728], [#1730], [#1749], [#1751], [#1762], [#1765], [#1780], [#1781],
-  [#1782], [#1806], [#1807], [#1815], [#1808], [#1824], [#1869], [#1872],
-  [#1886], [#1914], [#1925], [#1927], [#1935], [#1936], [#1938], [#1975],
-  [#1976], [#2006], [#2014], [#2015], [#2017], [#2026], [#2028], [#2058],
-  [#2125], [#2158]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
-  [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
-  [**@simon1hofmann**], [**@J4MMlE**])
+- ✨ Add QIR generation support to the MQT Compiler Collection ([#1264],
+  [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570], [#1572],
+  [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751], [#1755],
+  [#1787], [#1815], [#1823], [#1933], [#1978], [#1979], [#2007], [#2026],
+  [#2030], [#2066]) ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
+  [**@li-mingbao**], [**@DRovara**], [**@MatthiasReumann**])
+- ✨ Add OpenQASM import and export to the MQT Compiler Collection ([#1910],
+  [#1987], [#1994], [#2003], [#2026]) ([**@burgholzer**], [**@denialhaag**])
+
+#### Passes and transformations
+
+- ✨ Add quantum loop unrolling and qubit reuse passes ([#1705], [#1718],
+  [#1755], [#1756], [#1923], [#1924], [#2039], [#2118]) ([**@MatthiasReumann**],
+  [**@DRovara**], [**@burgholzer**], [**@simon1hofmann**])
+- ✨ Add a compiler-target-aware `place-and-route` pass ([#1537], [#1547],
+  [#1568], [#1581], [#1583], [#1588], [#1600], [#1664], [#1709], [#1716],
+  [#1748], [#1805], [#1870], [#1904], [#1911], [#1951], [#1997], [#2016],
+  [#2060]) ([**@MatthiasReumann**], [**@burgholzer**])
+- ✨ Add modifier and global-phase normalization passes ([#1986], [#1995],
+  [#2015]) ([**@burgholzer**], [**@denialhaag**])
+- ✨ Add single-qubit optimization passes for unitary fusion, Hadamard lifting,
+  and rotation merging ([#1407], [#1605], [#1672], [#1674], [#2002], [#2038])
+  ([**@J4MMlE**], [**@lirem101**], [**@burgholzer**], [**@denialhaag**],
+  [**@MatthiasReumann**], [**@simon1hofmann**])
+- ✨ Add multi-qubit decomposition, fusion, and target-native synthesis passes
+  ([#1774], [#1802], [#1803], [#1809], [#1810], [#1814], [#1832], [#1850],
+  [#1865], [#1961], [#1996], [#1998], [#2001]) ([**@simon1hofmann**],
+  [**@burgholzer**])
+
+#### Other additions
+
+- ✨ Add extensible program serializers to QDMI Qiskit backends. [QDMI-on-IQM]
+  now provides the IQM JSON serializer and `MoveGate` integration ([#2114])
+  ([**@marcelwa**])
+- 🐳 Add dev container configuration for a consistent local development
+  environment ([#1786]) ([**@denialhaag**])
 
 ### Changed
 
-- 💥 Prune dead and misleading CoreIR APIs, including renaming the non-garbage
-  logical output count to `getNoutputQubits()` and `num_output_qubits` ([#2112])
-  ([**@simon1hofmann**])
-- 🛡️ Isolate DDSIM QIR job execution and restrict statevector extraction to
-  terminal `irreversible` regions of Base-profile programs ([#2036])
+- 💥 Prune dead and misleading CoreIR APIs and remove random-number generator
+  state from `QuantumComputation` ([#2111], [#2112]) ([**@simon1hofmann**])
+- 💥 Update QIR execution for QIR 2.1, isolated runtimes, reproducible
+  multi-shot execution, and safe statevector extraction ([#2035], [#2036])
   ([**@burgholzer**])
-- 💥 Update the QIR runner for QIR 2.1 entry points and resource management,
-  with entry-point selection and reproducible multi-shot execution ([#2035])
-  ([**@burgholzer**])
-- 💥 Require LLVM/MLIR and QIR support in every MQT Core build and remove the
-  corresponding build options ([#1953]) ([**@burgholzer**])
-- ⬆️ Require LLVM 22.1 for C++ library builds ([#1549]) ([**@burgholzer**],
-  [**@denialhaag**])
-- 📦 Build MLIR by default for C++ library builds ([#1356]) ([**@burgholzer**],
-  [**@denialhaag**])
+- 💥 Require LLVM/MLIR 22.1 and QIR support in every MQT Core source build,
+  build MLIR by default, and remove the corresponding build options ([#1356],
+  [#1549], [#1953]) ([**@burgholzer**], [**@denialhaag**])
 
 ### Removed
 
-- 💥 Remove the IQM JSON converter `qiskit_to_iqm_json` and the `MoveGate` from
-  the Qiskit plugin, which [QDMI-on-IQM] now owns ([#2114]) ([**@marcelwa**])
-- 💥 Remove the unused decision-diagram approximation algorithm, including the
-  `dd/Approximation.hpp` header, `dd::ApproximationMetadata`, and
-  `dd::approximate`. No replacement is provided ([#2154]) ([**@burgholzer**])
-- 💥 Remove `nlohmann_json` from the public package contract. MQT Core no longer
-  installs or exports the library, no installed header exposes a `nlohmann`
-  type, and the decision-diagram statistics report through strings and streams
-  ([#2138]) ([**@denialhaag**])
-- 💥 Remove the neutral-atom stack, which moves to MQT QMAP. This drops the
-  neutral-atom computation model, the neutral-atom FoMaC device session, the
-  neutral-atom QDMI device and its configuration, the `mqt.core.na` Python
-  module, `AodOperation`, and the `Move`, `Bridge`, `AodActivate`,
-  `AodDeactivate`, and `AodMove` operation kinds ([#2137]) ([**@denialhaag**])
-- 💥 Remove the random-number generator, seed, and `getGenerator()` method from
-  `QuantumComputation`; randomized algorithms now own generators initialized
-  from their seed arguments ([#2111]) ([**@simon1hofmann**])
-- 💥 Remove the FoMaC compatibility name from the C++ and Python QDMI APIs. Use
-  the `qdmi` C++ namespace, headers, libraries, and CMake targets; the
-  `mqt.core.qdmi` and `mqt.core.na.qdmi` Python modules; and the module-level
-  Python driver functions ([#2115]) ([**@burgholzer**])
-- 💥 Remove the legacy `QuantumComputation`-to-MLIR translator and its C++ and
-  Python compiler inputs. Use OpenQASM, Qiskit circuits, or typed MLIR programs
-  as compiler inputs ([#2054]) ([**@burgholzer**])
-- 💥 Remove the ZX-calculus library, including the `mqt-core-zx` target,
-  `MQT::CoreZX` alias, `zx` headers and namespace, and its Boost.Multiprecision
-  and GMP build support. Equivalence-checking users should use [MQT QCEC]; its
-  ZX implementation is internal and does not provide a replacement public API.
-- 🔥 Remove the density matrix support from the MQT Core DD package ([#1466])
+- 💥 Remove the unowned decision-diagram approximation algorithm and
+  density-matrix support from MQT Core ([#1466], [#2154]) ([**@burgholzer**])
+- 💥 Make `nlohmann_json` an implementation detail and replace JSON-typed
+  decision-diagram statistics APIs with strings and streams ([#2138])
+  ([**@denialhaag**])
+- 💥 Remove the neutral-atom stack from MQT Core and move it to [MQT QMAP]
+  ([#2137]) ([**@denialhaag**])
+- 💥 Remove the FoMaC compatibility names from the C++ and Python QDMI APIs
+  ([#2115]) ([**@burgholzer**])
+- 💥 Remove the ZX-calculus library and its Boost.Multiprecision and GMP
+  support. Equivalence-checking users should use [MQT QCEC] ([#2082])
   ([**@burgholzer**])
 - 🔥 Remove `datastructures` (`ds`) (sub)library from MQT Core ([#1458])
   ([**@burgholzer**])
@@ -862,6 +811,7 @@ for previous changelogs._
 [#2106]: https://github.com/munich-quantum-toolkit/core/pull/2106
 [#2105]: https://github.com/munich-quantum-toolkit/core/pull/2105
 [#2084]: https://github.com/munich-quantum-toolkit/core/pull/2084
+[#2082]: https://github.com/munich-quantum-toolkit/core/pull/2082
 [#2074]: https://github.com/munich-quantum-toolkit/core/pull/2074
 [#2066]: https://github.com/munich-quantum-toolkit/core/pull/2066
 [#2060]: https://github.com/munich-quantum-toolkit/core/pull/2060

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,7 +6,7 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
-### Program serializers for the Qiskit backend
+### Program serialization for QDMI Qiskit backends
 
 The Qiskit backend no longer decides in its own code how to turn a circuit into
 a program. It takes every program format from a registered _program serializer_,
@@ -58,8 +58,6 @@ class MyBackend(QDMIBackend):
     _EXTRA_GATES = {"move": MoveGate()}
 ```
 
-### IQM JSON serialization moved to QDMI-on-IQM
-
 MQT Core no longer provides `qiskit_to_iqm_json` or `MoveGate`.
 [QDMI-on-IQM](https://github.com/iqm-finland/QDMI-on-IQM) owns both. Import them
 from `iqm.qdmi` instead:
@@ -73,12 +71,16 @@ Installing `iqm-qdmi` is enough to keep submitting IQM JSON. The package
 advertises its serializer through the entry point group described above, so a
 backend over an IQM device needs no code change.
 
-### Removal of DD approximation support
+### Removal of DD approximation and density-matrix support
 
 MQT Core no longer provides the decision-diagram approximation algorithm. The
 algorithm had no production owner in the MQT ecosystem. Remove uses of the
 `dd/Approximation.hpp` header, the `dd::ApproximationMetadata` type, and the
 `dd::approximate` function. MQT Core does not provide a replacement.
+
+MQT Core also no longer provides density-matrix decision diagrams or the noise
+operations that depended on them. Consumers must provide this functionality or
+use another implementation.
 
 ### Private `nlohmann_json` dependency
 
@@ -124,6 +126,35 @@ MQT Core removed the following names:
   `aod_activate`, `aod_deactivate`, and `aod_move`.
 - The bundled `mqt.na.default` QDMI device.
 
+### Removal of FoMaC compatibility APIs
+
+MQT Core 4 removes the deprecated FoMaC names that MQT Core 3.9 kept as
+compatibility aliases. Replace Python imports of QDMI entities from
+`mqt.core.fomac` with imports from `mqt.core.qdmi`. Import registry functions
+and `DeviceDefinition` from `mqt.core.qdmi.driver`.
+
+MQT Core 4 also removes `mqt.core.qdmi.driver.Session`. Use
+`registered_device_ids()` to discover devices and `open_device()` to open a
+fresh device session. Pass provider configuration overrides to `open_device()`
+when a device needs per-open configuration.
+
+Apply these replacements to C++ and MLIR code:
+
+- `fomac::` becomes `qdmi::`.
+- `fomac/FoMaC.hpp` becomes `qdmi/Client.hpp`.
+- `fomac/Slurm.hpp` becomes `qdmi/Slurm.hpp`.
+- `MQT::CoreFoMaC` becomes `MQT::CoreQDMI`.
+- `mlir/Compiler/FoMaCAdapter.h` and `MQTCompilerFoMaCAdapter` become
+  `mlir/Compiler/QDMIAdapter.h` and `MQTCompilerQDMIAdapter`.
+
+The class and function names do not change. For example:
+
+```cpp
+#include "qdmi/Client.hpp"
+
+auto device = qdmi::Session::openDevice("mqt.ddsim.default");
+```
+
 ### CoreIR API cleanup
 
 The CoreIR API cleanup requires the following migrations:
@@ -141,6 +172,12 @@ The CoreIR API cleanup requires the following migrations:
 The register lookup helpers `getQubitRegister()`, `getPhysicalQubitIndex()`, and
 `physicalQubitIsAncillary()` are now private implementation details.
 
+`QuantumComputation` no longer stores a random-number generator or seed. Remove
+the third `seed` argument from C++ and Python constructor calls. C++ callers
+that used `QuantumComputation::getGenerator()` must create and own a
+random-number generator instead. Randomized circuit generators continue to
+accept a seed and now own a separate generator for each call.
+
 ### Removal of the legacy circuit-to-MLIR translator
 
 The compiler no longer accepts `qc::QuantumComputation` or
@@ -153,14 +190,6 @@ Python code can convert a legacy circuit to OpenQASM 3 before compilation:
 ```python
 program = compile_program(computation.qasm3_str())
 ```
-
-### QuantumComputation random-number generator
-
-`QuantumComputation` no longer stores a random-number generator or seed. Remove
-the third `seed` argument from C++ and Python constructor calls. C++ callers
-that used `QuantumComputation::getGenerator()` must create and own a
-random-number generator instead. Randomized circuit generators continue to
-accept a seed and now own a separate generator for each call.
 
 ### Removal of the ZX-calculus library
 
@@ -175,21 +204,19 @@ The `MQT::Multiprecision` target and the `USE_SYSTEM_BOOST`,
 removed. MQT Core no longer discovers, fetches, or exports configuration for
 Boost.Multiprecision or GMP.
 
-### QIR runner
+### QIR execution
 
-The QIR runner now invokes a selected QIR entry point as a parameterless `i64`
-function instead of assuming an `int main(int, char**)`. Use `--entry-point` to
-select among multiple entry points, `--shots` for repeated execution, and
-`--seed` for deterministic sampling.
+The standalone QIR runner now invokes a selected QIR entry point as a
+parameterless `i64` function instead of assuming an `int main(int, char**)`. Use
+`--entry-point` to select among multiple entry points, `--shots` for repeated
+execution, and `--seed` for deterministic sampling.
 
 Dynamic QIR inputs must use the current QIR 2.1 resource-management interface.
 Legacy qir-runner allocator and output overloads are no longer accepted.
 
-### DDSIM QDMI device
-
-DDSIM now isolates the runtime, simulator state, random-number generator, and
-output sink of every QIR job, so concurrently submitted jobs no longer share
-execution state or write QIR records to process stdout.
+The DDSIM QDMI device now isolates the runtime, simulator state, random-number
+generator, and output sink of every QIR job. Concurrently submitted jobs no
+longer share execution state or write QIR records to process stdout.
 
 QIR statevector extraction is supported only for Base-format jobs. The input
 must mark its first measurement boundary as `irreversible`, and no quantum work
@@ -226,30 +253,11 @@ Known limitations:
 - AppleClang 17+ is required to build MQT Core due to some C++20 features that
   are not yet properly supported by older versions.
 
-### Removal of the density matrix support from the DD package
-
-The density matrix support within the DD package has been removed. This change
-was made to reduce the maintenance burden of the package. Any libraries that
-depend on the density matrix functionality, such as [MQT DDSIM], need to
-implement it on their own or use an alternative solution. In a related fashion,
-this PR also removes the noise operations from the MQT Core IR as they no longer
-serve a purpose.
-
 ### Removal of the `datastructures` (sub)library
 
-The `datastructures` (sub)library has been removed from the MQT Core repository.
-Its functionality has only ever been used in [MQT QMAP] since its inception. As
-a consequence, the code shall be moved to [MQT QMAP] once QMAP adopts an MQT
-Core version that includes this change.
-
-### Dev container
-
-A [dev container](https://containers.dev/) configuration is available to provide
-a consistent local development environment. Common IDEs like
-[CLion](https://www.jetbrains.com/help/clion/dev-containers-starting-page.html)
-and [VS Code](https://code.visualstudio.com/docs/devcontainers/containers) can
-open the repository directly inside the container. If you are on Windows, we
-recommend using Docker Desktop with the WSL 2 backend.
+MQT Core no longer provides the `datastructures` (`ds`) sublibrary. MQT QMAP was
+its only consumer. Downstream users must depend on MQT QMAP or provide the
+required data structures directly.
 
 ## [3.9.0]
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,42 +6,6 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
-### QDMI updated to version 1.3.3
-
-While not a breaking change, this release updates the QDMI dependency to version
-1.3.3.
-
-### `nanobind` updated to version 2.15.0
-
-This release updates the `nanobind` dependency to version 2.15.0, which includes
-an ABI bump. Any existing code that uses the `mqt-core` Python bindings will
-need to be recompiled with the new `nanobind` version.
-
-### Calibration runs and batch jobs
-
-`Device::submitJob` used to reject `CALIBRATION` and `BATCH_JOB` together, which
-left MQT Core reporting that a device needs calibration through
-`needs_calibration()` without any way to trigger one. The two formats are
-different cases and are now treated as such.
-
-A calibration run has its own entry point. QDMI does not require a program for
-one, so the payload is optional; when it is present, the device defines what it
-means:
-
-```python
-device.submit_calibration_job()
-device.submit_calibration_job("configuration")
-```
-
-In C++, use `Device::submitCalibrationJob`. A calibration run executes no
-circuit, so neither form takes a shot count.
-
-Batch jobs are explicitly unsupported. A batch job's program is a list of job
-handles rather than a byte payload, which `submitJob` cannot express, so MQT
-Core says so rather than describing it as a missing payload. Passing
-`ProgramFormat.BATCH_JOB` to `submit_job` raises a `ValueError` that names the
-limitation. Support can return once a device implements the feature.
-
 ### Program serializers for the Qiskit backend
 
 The Qiskit backend no longer decides in its own code how to turn a circuit into
@@ -160,65 +124,6 @@ MQT Core removed the following names:
   `aod_activate`, `aod_deactivate`, and `aod_move`.
 - The bundled `mqt.na.default` QDMI device.
 
-### Removal of QDMI configuration through `pyproject.toml`
-
-MQT Core no longer reads QDMI device definitions from a `[tool.qdmi]` table in
-`pyproject.toml`. Project discovery now looks only for `qdmi.json`. Move an
-existing table into a `qdmi.json` file beside the `pyproject.toml`. For example,
-replace this `pyproject.toml` table:
-
-```toml
-[tool.qdmi]
-devices = [
-  { id = "example.device", library = "libexample-device.so", prefix = "EXAMPLE" },
-]
-```
-
-with this `qdmi.json`:
-
-```json
-{
-  "schema-version": 1,
-  "qdmi": {
-    "devices": [
-      {
-        "id": "example.device",
-        "library": "libexample-device.so",
-        "prefix": "EXAMPLE"
-      }
-    ]
-  }
-}
-```
-
-The JSON document adds the `"schema-version": 1` key and nests the device array
-under `qdmi`. Every other key keeps its name and meaning. Relative paths still
-resolve against the file that declares them. `MQT_CORE_QDMI_CONFIG_FILE`,
-`MQT_CORE_QDMI_CONFIG_JSON`, the system and user files, and the packaged
-`*.qdmi.json` fragments do not change.
-
-### Python binding CMake helper
-
-The `add_mqt_python_binding_nanobind` function is now called
-`add_mqt_python_binding`. Rename the calls in downstream `CMakeLists.txt` files:
-
-```cmake
-add_mqt_python_binding(
-  MYPACKAGE
-  py_mypackage
-  ${SOURCES}
-  MODULE_NAME
-  _core
-  INSTALL_DIR
-  .
-  LINK_LIBS
-  MQT::Core)
-```
-
-The former `add_mqt_python_binding` function built modules with `pybind11`. All
-MQT projects have switched from `pybind11` to `nanobind`, so no build used that
-function. MQT Core no longer provides it.
-
 ### CoreIR API cleanup
 
 The CoreIR API cleanup requires the following migrations:
@@ -270,66 +175,6 @@ The `MQT::Multiprecision` target and the `USE_SYSTEM_BOOST`,
 removed. MQT Core no longer discovers, fetches, or exports configuration for
 Boost.Multiprecision or GMP.
 
-### QDMI Python namespace
-
-The Python QDMI API is available only in the QDMI namespace. Import QDMI
-entities such as `Device`, `Job`, and `ProgramFormat` from `mqt.core.qdmi`.
-Import functions and classes for device discovery, registration, and opening
-from `mqt.core.qdmi.driver`:
-
-```python
-from mqt.core.qdmi.driver import open_device
-
-device = open_device("mqt.ddsim.default")
-```
-
-MQT Core 4 removes `mqt.core.fomac`. Replace imports of QDMI entities with
-`mqt.core.qdmi`. Replace imports of registry functions and `DeviceDefinition`
-with `mqt.core.qdmi.driver`.
-
-MQT Core 4 also removes `mqt.core.qdmi.driver.Session`. Use
-`registered_device_ids()` to discover devices and `open_device()` to open a
-fresh device session. Pass provider configuration overrides to `open_device()`
-when a device needs per-open configuration.
-
-MQT Core 4 removes `mqt.core.na.fomac`. Import the neutral-atom specialization
-from `mqt.core.na.qdmi`.
-
-MQT Core 4 also removes the FoMaC name from its C++ API. Apply these
-replacements:
-
-- `fomac::` becomes `qdmi::`.
-- `fomac/FoMaC.hpp` becomes `qdmi/Client.hpp`.
-- `fomac/Slurm.hpp` becomes `qdmi/Slurm.hpp`.
-- `na/fomac/Device.hpp` becomes `na/qdmi/Device.hpp`.
-- `MQT::CoreFoMaC` becomes `MQT::CoreQDMI`.
-- `MQT::CoreNAFoMaC` becomes `MQT::CoreNAQDMI`.
-- `mlir/Compiler/FoMaCAdapter.h` and `MQTCompilerFoMaCAdapter` become
-  `mlir/Compiler/QDMIAdapter.h` and `MQTCompilerQDMIAdapter`.
-
-The class and function names do not change. For example:
-
-```cpp
-#include "qdmi/Client.hpp"
-
-auto device = qdmi::Session::openDevice("mqt.ddsim.default");
-```
-
-### QDMI Qiskit primitive options
-
-`QDMISampler` and `QDMIEstimator` no longer accept the MQT-specific `options`
-mapping. Pass shot and precision defaults directly, preferably through the
-backend factories:
-
-```python
-sampler = backend.sampler(default_shots=2048)
-estimator = backend.estimator(default_precision=0.01, default_shots=2048)
-```
-
-Replace `QDMIEstimator(..., options={"default_shots": shots})` with
-`QDMIEstimator(..., default_shots=shots)`. The sampler ignored its former
-`options` mapping, so remove that argument without replacement.
-
 ### QIR runner
 
 The QIR runner now invokes a selected QIR entry point as a parameterless `i64`
@@ -350,38 +195,6 @@ QIR statevector extraction is supported only for Base-format jobs. The input
 must mark its first measurement boundary as `irreversible`, and no quantum work
 may follow that boundary. Adaptive-format statevector requests continue to
 return `QDMI_ERROR_NOTSUPPORTED`.
-
-### Runtime-configurable SC QDMI device
-
-The built-in superconducting QDMI provider now parses its device description
-when each session is initialized. The `mqt-core-qdmi-sc-device-gen` target,
-SC-specific generator executable, `sc::writeHeader`, `sc::writeJSONSchema`, and
-generated `DeviceMemberInitializers.hpp` file have been removed. Replace
-generator API use with `sc::Device` and the `sc::readJSON` functions declared in
-`qdmi/devices/sc/Configuration.hpp`.
-
-### Runtime-configurable neutral-atom QDMI device
-
-The built-in neutral-atom QDMI provider now parses its device description when
-each session is initialized. The `mqt-core-qdmi-na-device-gen` target,
-`mqt-core-qdmi-na-device-generator` executable, `na::writeHeader`, and generated
-`DeviceMemberInitializers.hpp` file have been removed. Replace generator API use
-with the `na::Device` configuration type and the `na::readJSON` functions in
-`qdmi/devices/na/Configuration.hpp`.
-
-At runtime, use the registry `session.device-config` field or Python
-`device_config` and `device_config_file` arguments. Direct QDMI v1 clients pass
-inline JSON through CUSTOM1 or a file path through CUSTOM2.
-
-### Bundled QDMI devices in embedded builds
-
-The bundled QDMI devices now have individual CMake options:
-`BUILD_MQT_CORE_QDMI_DDSIM_DEVICE`, `BUILD_MQT_CORE_QDMI_NA_DEVICE`, and
-`BUILD_MQT_CORE_QDMI_SC_DEVICE`. All three remain enabled by default in a
-standalone MQT Core build. They default to disabled when MQT Core is consumed
-through CMake's `FetchContent` or `add_subdirectory`; embedded consumers can
-enable only the devices they need before making MQT Core available. The QDMI
-driver and FoMaC libraries remain available independently.
 
 ### LLVM/MLIR required for all source builds
 
@@ -437,6 +250,175 @@ a consistent local development environment. Common IDEs like
 and [VS Code](https://code.visualstudio.com/docs/devcontainers/containers) can
 open the repository directly inside the container. If you are on Windows, we
 recommend using Docker Desktop with the WSL 2 backend.
+
+## [3.9.0]
+
+### Shared-library ABI version
+
+The shared-library ABI version (`SOVERSION`) changes from `3.8` to `3.9`.
+Rebuild downstream C++ libraries against MQT Core 3.9.0. In `cibuildwheel`
+configurations that exclude bundled MQT Core libraries from wheel repair,
+replace each `libmqt-core-*.so.3.8` entry with the corresponding
+`libmqt-core-*.so.3.9` entry.
+
+### `nanobind` updated to version 2.15.0
+
+`nanobind` 2.15.0 changes the `nanobind` ABI. Rebuild downstream native Python
+extensions that use MQT Core's `nanobind`-bound C++ types. Pure Python consumers
+do not need to recompile anything.
+
+### QDMI updated to version 1.3.3
+
+The minimum supported QDMI version changes from 1.3.2 to 1.3.3. CMake builds
+that use a system installation of QDMI must provide version 1.3.3 or newer.
+Builds that let MQT Core fetch QDMI need no change.
+
+### QDMI calibration runs and batch jobs
+
+`Device::submitJob` used to reject `CALIBRATION` and `BATCH_JOB` together, which
+left MQT Core reporting that a device needs calibration through
+`needs_calibration()` without any way to trigger one. The two formats are
+different cases and are now treated as such.
+
+A calibration run has its own entry point. QDMI does not require a program for
+one, so the payload is optional; when it is present, the device defines what it
+means:
+
+```python
+device.submit_calibration_job()
+device.submit_calibration_job("configuration")
+```
+
+In C++, use `Device::submitCalibrationJob`. A calibration run executes no
+circuit, so neither form takes a shot count.
+
+Batch jobs are explicitly unsupported. A batch job's program is a list of job
+handles rather than a byte payload, which `submitJob` cannot express. Passing
+`ProgramFormat.BATCH_JOB` to `submit_job` raises `ValueError` in Python and
+`std::invalid_argument` in C++.
+
+### Removal of QDMI configuration through `pyproject.toml`
+
+MQT Core no longer reads QDMI device definitions from a `[tool.qdmi]` table in
+`pyproject.toml`. Project discovery now looks only for `qdmi.json`. Move an
+existing table into a `qdmi.json` file beside the `pyproject.toml`. For example,
+replace this `pyproject.toml` table:
+
+```toml
+[tool.qdmi]
+devices = [
+  { id = "example.device", library = "libexample-device.so", prefix = "EXAMPLE" },
+]
+```
+
+with this `qdmi.json`:
+
+```json
+{
+  "schema-version": 1,
+  "qdmi": {
+    "devices": [
+      {
+        "id": "example.device",
+        "library": "libexample-device.so",
+        "prefix": "EXAMPLE"
+      }
+    ]
+  }
+}
+```
+
+The JSON document adds the `"schema-version": 1` key and nests the device array
+under `qdmi`. Every other key keeps its name and meaning. Relative paths still
+resolve against the file that declares them. `MQT_CORE_QDMI_CONFIG_FILE`,
+`MQT_CORE_QDMI_CONFIG_JSON`, the system and user files, and the packaged
+`*.qdmi.json` fragments do not change.
+
+### QDMI Qiskit primitive options
+
+`QDMISampler` and `QDMIEstimator` no longer accept the MQT-specific `options`
+mapping. Pass shot and precision defaults directly, preferably through the
+backend factories:
+
+```python
+sampler = backend.sampler(default_shots=2048)
+estimator = backend.estimator(default_precision=0.01, default_shots=2048)
+```
+
+Replace `QDMIEstimator(..., options={"default_shots": shots})` with
+`QDMIEstimator(..., default_shots=shots)`. The sampler ignored its former
+`options` mapping, so remove that argument without replacement.
+
+### Runtime-configurable SC QDMI device
+
+The built-in superconducting QDMI provider now parses its device description
+when each session is initialized. The `mqt-core-qdmi-sc-device-gen` target,
+SC-specific generator executable, `sc::writeHeader`, `sc::writeJSONSchema`, and
+generated `DeviceMemberInitializers.hpp` file have been removed. Replace
+generator API use with `sc::Device` and the `sc::readJSON` functions declared in
+`qdmi/devices/sc/Configuration.hpp`.
+
+### Runtime-configurable neutral-atom QDMI device
+
+The built-in neutral-atom QDMI provider now parses its device description when
+each session is initialized. The `mqt-core-qdmi-na-device-gen` target,
+`mqt-core-qdmi-na-device-generator` executable, `na::writeHeader`, and generated
+`DeviceMemberInitializers.hpp` file have been removed. Replace generator API use
+with the `na::Device` configuration type and the `na::readJSON` functions in
+`qdmi/devices/na/Configuration.hpp`.
+
+At runtime, use the registry `session.device-config` field or Python
+`device_config` and `device_config_file` arguments. Direct low-level QDMI
+clients pass inline JSON through CUSTOM1 or a file path through CUSTOM2.
+
+### QDMI Python namespace
+
+The native Python module has moved from `mqt.core.fomac` to `mqt.core.qdmi`.
+QDMI entities such as `Device`, `Job`, and `ProgramFormat` are in
+`mqt.core.qdmi`. Import functions and classes from `mqt.core.qdmi.driver` for
+device discovery, registration, and opening:
+
+```python
+from mqt.core.qdmi.driver import open_device
+
+device = open_device("mqt.ddsim.default")
+```
+
+`mqt.core.fomac` remains available in MQT Core v3 and re-exports the same
+objects. Importing that module emits a `DeprecationWarning`. It will be removed
+in MQT Core 4.0. The legacy `driver.Session` class also emits a
+`DeprecationWarning` when constructed and will be removed in 4.0. Replace
+session-based discovery with `registered_device_ids()` and `open_device()` from
+`mqt.core.qdmi.driver`.
+
+The neutral-atom specialization has moved from `mqt.core.na.fomac` to
+`mqt.core.na.qdmi`. The former submodule remains a v3 compatibility alias and
+will be removed in MQT Core 4.0.
+
+The C++ FoMaC namespace, headers, library, and `MQT::CoreFoMaC` target do not
+change.
+
+### Python binding CMake helper
+
+The `add_mqt_python_binding_nanobind` function is now called
+`add_mqt_python_binding`. Rename the calls in downstream `CMakeLists.txt` files:
+
+```cmake
+add_mqt_python_binding(
+  MYPACKAGE
+  py_mypackage
+  ${SOURCES}
+  MODULE_NAME
+  _core
+  INSTALL_DIR
+  .
+  LINK_LIBS
+  MQT::Core)
+```
+
+The old `add_mqt_python_binding` function built modules with `pybind11` and has
+been removed. MQT Core now uses that name for its `nanobind` helper. The
+arguments to the renamed helper do not change.
 
 ## [3.8.0]
 
@@ -857,7 +839,8 @@ It also requires the `uv` library version 0.5.20 or higher.
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.8.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.0...HEAD
+[3.9.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.5.1...v3.6.0


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This PR moves the changes released in `v3.9.0` from the unreleased sections of the changelog and the upgrade guide into dedicated `3.9.0` sections, and updates the comparison links. The main-only v4 entries stay under `Unreleased`. Both new sections match the released `v3.9.0` tag exactly.

It also drops the "Bundled QDMI devices in embedded builds" upgrade note from `Unreleased`, which the `3.8.0` section already carries verbatim.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
