### PR TITLE
⚡ Avoid redundant target-compilation liveness analysis

### DIFF
--- a/mlir/lib/Compiler/TargetCompilation.cpp
+++ b/mlir/lib/Compiler/TargetCompilation.cpp
@@ -34,7 +34,6 @@ void populateTargetCompilationPipeline(OpPassManager& pm,
   populateQCOCleanupPipeline(pm);
   pm.addPass(qco::createTargetNativeSynthesis(target));
   pm.addPass(createCSEPass());
-  pm.addPass(createRemoveDeadValuesPass());
   pm.addPass(qco::createVerifyTargetConformance(target));
 }
 

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -57,6 +57,7 @@
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Transforms/Passes.h>
 
 #include <cctype>
 #include <cstddef>
@@ -1380,6 +1381,67 @@ TEST_F(CompilerPipelineTest, QCOProgramCompilesForTarget) {
   auto unsupportedQCO = std::move(*unsupportedQC).intoQCO();
   ASSERT_TRUE(unsupportedQCO);
   EXPECT_FALSE(unsupportedQCO->compileForTarget(makeSparseUCZTarget(false)));
+}
+
+/// Test that target compilation leaves dead-value cleanup at a fixed point.
+TEST_F(CompilerPipelineTest,
+       TargetCompilationLeavesDeadValueCleanupAtFixedPoint) {
+  constexpr llvm::StringLiteral source = R"mlir(
+    module {
+      func.func private @forward(%condition: i1) -> i1 {
+        return %condition : i1
+      }
+      func.func @main(%condition: i1)
+          attributes {mqt.entry_point} {
+        %q0 = qco.alloc : !qco.qubit
+        %q1 = qco.alloc : !qco.qubit
+        %forwarded = func.call @forward(%condition) : (i1) -> i1
+        %q2, %q3 = qco.if %forwarded
+            args(%control = %q0, %target = %q1)
+            -> (!qco.qubit, !qco.qubit) {
+          %controlOut, %targetOut = qco.ctrl(%control)
+              targets(%targetArg = %target) {
+            %x = qco.x %targetArg : !qco.qubit -> !qco.qubit
+            qco.yield %x : !qco.qubit
+          } : ({!qco.qubit}, {!qco.qubit})
+              -> ({!qco.qubit}, {!qco.qubit})
+          %h = qco.h %controlOut : !qco.qubit -> !qco.qubit
+          qco.yield %h, %targetOut : !qco.qubit, !qco.qubit
+        } else args(%control = %q0, %target = %q1) {
+          %x0 = qco.x %control : !qco.qubit -> !qco.qubit
+          %x1 = qco.x %target : !qco.qubit -> !qco.qubit
+          qco.yield %x0, %x1 : !qco.qubit, !qco.qubit
+        }
+        qco.sink %q2 : !qco.qubit
+        qco.sink %q3 : !qco.qubit
+        return
+      }
+    }
+  )mlir";
+
+  auto program = QCOProgram::fromMLIRString(source.str());
+  ASSERT_TRUE(program);
+  using TargetOperation = CompilerTarget::Operation;
+  std::vector operations{llvm::cantFail(TargetOperation::create("u", 1, 3)),
+                         llvm::cantFail(TargetOperation::create("cz", 2, 0))};
+  auto target = llvm::cantFail(CompilerTarget::create(
+      2, std::vector<CompilerTarget::Coupling>{{0, 1}}, std::move(operations)));
+
+  ASSERT_TRUE(program->compileForTarget(target));
+  const std::string before = program->str();
+  EXPECT_NE(before.find("func.func private @forward"), std::string::npos);
+  EXPECT_NE(before.find("call @forward"), std::string::npos);
+  EXPECT_NE(before.find("qco.if"), std::string::npos);
+  EXPECT_NE(before.find("qco.u"), std::string::npos);
+  EXPECT_NE(before.find("qco.ctrl"), std::string::npos);
+  EXPECT_NE(before.find("qco.z"), std::string::npos);
+  EXPECT_EQ(before.find("qco.h"), std::string::npos);
+  EXPECT_EQ(before.find("qco.x"), std::string::npos);
+
+  PassManager pm(program->module().getContext());
+  pm.addPass(createRemoveDeadValuesPass());
+  ASSERT_TRUE(pm.run(program->module()).succeeded());
+  EXPECT_EQ(program->str(), before);
 }
 
 TEST_F(CompilerPipelineTest, QCOProgramCompilesDynamicRunForSupportedTargets) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

Remove the final module-wide `remove-dead-values` pass from target compilation. The second QCO cleanup immediately before native synthesis already establishes global liveness, while native synthesis replaces one- and two-qubit unitary operations with native equivalents and reconnects their results.

Post-synthesis CSE and final target-conformance verification remain unchanged.

## Motivation

The production-shaped profile in #2134 measured the final `RemoveDeadValues` pass at 7.77 seconds of a 29.93-second target-compilation run (about 26%), including 4.09 seconds in liveness analysis, for `hwb10` targeting `FakeTorino`.

This PR removes that measured cleanup stage without changing placement, routing, native-synthesis choices, or target-conformance checks. It addresses the cleanup portion of #2134.

## Safety and testing

The added end-to-end regression compiles a program containing a private helper call, dynamic `qco.if`, and one- and two-qubit synthesis. It then reruns `RemoveDeadValues` and requires the IR to remain byte-for-byte unchanged, protecting the intended fixed point.

- `mqt-core-mlir-unittests-compiler`: 140/140 passed.
- `uvx nox -s lint`: passed.
- `uvx nox -s cpp-lint` with LLVM/Clang 22: 0 findings.
- `git diff --check`: passed.

## Stack

- Base: `main` (includes #2179)
- Follow-ups: #2181 → #2297

AI assistance: Codex assisted with diagnosis, implementation, review, testing, stack maintenance, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.