### PR TITLE
:recycle: Integrate qubit-pair skipping into the getWindow function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,8 @@ releases may include breaking changes.
 - ✨ Add a compiler-target-aware `place-and-route` pass ([#1537], [#1547],
   [#1568], [#1581], [#1583], [#1588], [#1600], [#1664], [#1709], [#1716],
   [#1748], [#1805], [#1870], [#1904], [#1911], [#1951], [#1956], [#1997],
-  [#2016], [#2060], [#2184], [#2185]) ([**@MatthiasReumann**], [**@burgholzer**],
-  [**@rturrado**])
+  [#2016], [#2060], [#2184], [#2185]) ([**@MatthiasReumann**],
+  [**@burgholzer**], [**@rturrado**])
 - ✨ Add modifier and global-phase normalization passes ([#1986], [#1995],
   [#2015]) ([**@burgholzer**], [**@denialhaag**])
 - ✨ Add single-qubit optimization passes for unitary fusion, Hadamard lifting,
@@ -119,7 +119,8 @@ releases may include breaking changes.
   default, with one build option for source builds that omit both parts
   ([#1356], [#1549], [#1953], [#2284], [#2298]) ([**@burgholzer**],
   [**@denialhaag**], [**@simon1hofmann**])
-- ♻️ Improve the backward traversal logic for the `WireIterator` class ([#2184]) ([**@MatthiasReumann**])
+- ♻️ Improve the backward traversal logic for the `WireIterator` class ([#2184])
+  ([**@MatthiasReumann**])
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ releases may include breaking changes.
 - ✨ Add a compiler-target-aware `place-and-route` pass ([#1537], [#1547],
   [#1568], [#1581], [#1583], [#1588], [#1600], [#1664], [#1709], [#1716],
   [#1748], [#1805], [#1870], [#1904], [#1911], [#1951], [#1956], [#1997],
-  [#2016], [#2060], [#2184]) ([**@MatthiasReumann**], [**@burgholzer**],
+  [#2016], [#2060], [#2184], [#2185]) ([**@MatthiasReumann**], [**@burgholzer**],
   [**@rturrado**])
 - ✨ Add modifier and global-phase normalization passes ([#1986], [#1995],
   [#2015]) ([**@burgholzer**], [**@denialhaag**])
@@ -893,6 +893,7 @@ for previous changelogs._
 [#2214]: https://github.com/munich-quantum-toolkit/core/pull/2214
 [#2194]: https://github.com/munich-quantum-toolkit/core/pull/2194
 [#2193]: https://github.com/munich-quantum-toolkit/core/pull/2193
+[#2185]: https://github.com/munich-quantum-toolkit/core/pull/2185
 [#2184]: https://github.com/munich-quantum-toolkit/core/pull/2184
 [#2178]: https://github.com/munich-quantum-toolkit/core/pull/2178
 [#2176]: https://github.com/munich-quantum-toolkit/core/pull/2176

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ releases may include breaking changes.
   default, with one build option for source builds that omit both parts
   ([#1356], [#1549], [#1953], [#2284], [#2298]) ([**@burgholzer**],
   [**@denialhaag**], [**@simon1hofmann**])
+- ♻️ Improve the backward traversal logic for the `WireIterator` class ([#2184]) ([**@MatthiasReumann**])
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,8 +119,6 @@ releases may include breaking changes.
   default, with one build option for source builds that omit both parts
   ([#1356], [#1549], [#1953], [#2284], [#2298]) ([**@burgholzer**],
   [**@denialhaag**], [**@simon1hofmann**])
-- ♻️ Improve the backward traversal logic for the `WireIterator` class ([#2184])
-  ([**@MatthiasReumann**])
 
 ### Removed
 

--- a/mlir/include/mlir/Dialect/QCO/Utils/WireIterator.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/WireIterator.h
@@ -75,8 +75,8 @@ public:
         pos_(Position::PastTail) {}
 
   /// Construct a wire iterator pointing at the defining op of a qubit value.
-  explicit WireIterator(Value qubit)
-      : mapping_(nullptr), op_(qubit.getDefiningOp()), qubit_(qubit) {
+  explicit WireIterator(Value qubit, CallQubitMapping* mapping = nullptr)
+      : mapping_(mapping), op_(qubit.getDefiningOp()), qubit_(qubit) {
     if (op_ == nullptr || isHead(op_)) {
       pos_ = Position::Head;
     } else if (isTail(op_)) {
@@ -131,10 +131,6 @@ private:
 
   /// Labels the position on the wire.
   enum class Position : uint8_t { BeforeHead, Head, Between, Tail, PastTail };
-
-  WireIterator(Value qubit, CallQubitMapping* mapping) : WireIterator(qubit) {
-    mapping_ = mapping;
-  }
 
   /// Return true, if an op doesn't return, but only consumes, a qubit value.
   static bool isTail(Operation*);

--- a/mlir/include/mlir/Dialect/QCO/Utils/WireIterator.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/WireIterator.h
@@ -10,9 +10,6 @@
 
 #pragma once
 
-#include "mlir/Dialect/QCO/IR/QCOOps.h"
-#include "mlir/Dialect/QTensor/IR/QTensorOps.h"
-
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/DenseSet.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -73,11 +70,13 @@ public:
   using value_type = Operation*;
 
   /// Construct a dead-end sentinel wire-iterator.
-  WireIterator() : op_(nullptr), qubit_(nullptr), pos_(Position::PastTail) {}
+  WireIterator()
+      : mapping_(nullptr), op_(nullptr), qubit_(nullptr),
+        pos_(Position::PastTail) {}
 
   /// Construct a wire iterator pointing at the defining op of a qubit value.
   explicit WireIterator(Value qubit)
-      : op_(qubit.getDefiningOp()), qubit_(qubit) {
+      : mapping_(nullptr), op_(qubit.getDefiningOp()), qubit_(qubit) {
     if (op_ == nullptr || isHead(op_)) {
       pos_ = Position::Head;
     } else if (isTail(op_)) {
@@ -149,11 +148,6 @@ private:
   // Moves to the previous operation on the qubit wire.
   void backward();
 
-  Operation* op_;
-  Value qubit_;
-  Position pos_;
-  bool mappingFailed_ = false;
-
   // Resolves the call result continuing an operand's wire.
   FailureOr<Value> resultForOperand(func::CallOp callOp, Value operand) const;
 
@@ -161,7 +155,11 @@ private:
   [[nodiscard]] Value operandForResult(func::CallOp callOp, Value result) const;
 
   // Null means that each call query uses a fresh mapping.
-  CallQubitMapping* mapping_ = nullptr;
+  CallQubitMapping* mapping_;
+  Operation* op_;
+  Value qubit_;
+  Position pos_;
+  bool mappingFailed_ = false;
 };
 
 /// Categorizes the current traversal direction.

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1067,11 +1067,8 @@ private:
     return curr;
   }
 
-  /// Collect a routing lookahead window of up to `1 + nlookahead` ready
-  /// two-qubit gates.
-  /// In block-skipping mode, the function releases only gates belonging to the
-  /// current qubit-pair blocks and suppresses other ready gates until each
-  /// block is exhausted.
+  /// Return a window of layers with a maximum size of `1 + nlookahead`.
+  /// The function skips qubit-pair blocks.
   template <WireDirection Direction>
   Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT
     Window window;
@@ -1080,7 +1077,7 @@ private:
     SmallVector<IndexPairType> layer;
     layer.reserve(nlookahead);
 
-    enum class WalkMode : bool { Collect, BlockSkip };
+    enum class WalkMode : bool { Collect, SkipBlock };
     WalkMode mode = WalkMode::Collect;
 
     walkProgramGraph<Direction>(
@@ -1127,8 +1124,8 @@ private:
           }
 
           if (mode == WalkMode::Collect) {
-            mode = WalkMode::BlockSkip;
-          } else if (mode == WalkMode::BlockSkip && !skipped) {
+            mode = WalkMode::SkipBlock;
+          } else if (mode == WalkMode::SkipBlock && !skipped) {
             mode = WalkMode::Collect;
             layer.clear();
           }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1071,7 +1071,9 @@ private:
   /// Collect a routing lookahead window of up to `1 + nlookahead` ready
   /// two-qubit gates, while skipping qubit-pair blocks.
   template <WireDirection Direction>
-  Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT(performance-unnecessary-value-param)
+  Window getWindow(
+      Wires wires,
+      const WireInfos& infos) { // NOLINT(performance-unnecessary-value-param)
     Window window;
     window.reserve(1 + nlookahead);
 

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1096,7 +1096,7 @@ private:
               const auto i1 = indices[1];
               const auto prog0 = infos.lookupProgram(i0);
               const auto prog1 = infos.lookupProgram(i1);
-              const auto gate = std::minmax(prog0, prog1);
+              const IndexPairType gate = std::minmax(prog0, prog1);
 
               if (mode == WalkMode::Collect) {
 

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1081,13 +1081,13 @@ private:
 
     // Move past the initial two-qubit op.
     assert(it0.operation() == it1.operation());
-    std::advance(block[0], Traits::stride());
-    std::advance(block[1], Traits::stride());
+    std::ranges::advance(block[0], Traits::stride());
+    std::ranges::advance(block[1], Traits::stride());
 
     while (true) {
       for (auto& it : block) {
         for (; it != std::default_sentinel;
-             std::advance(it, Traits::stride())) {
+             std::ranges::advance(it, Traits::stride())) {
           if (it.operation() == nullptr) { // isa<Blockargument>
             return;
           }
@@ -1115,8 +1115,8 @@ private:
       it0 = block[0];
       it1 = block[1];
 
-      std::advance(block[0], Traits::stride());
-      std::advance(block[1], Traits::stride());
+      std::ranges::advance(block[0], Traits::stride());
+      std::ranges::advance(block[1], Traits::stride());
     }
   }
 

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1067,64 +1067,18 @@ private:
     return curr;
   }
 
-  /// Skip to the end of the two-qubit block for both wire iterators, where
-  /// initially both must point at the same two-qubit operation.
-  template <WireDirection Direction>
-  static void skipQubitPairBlock(WireIterator& it0, WireIterator& it1) {
-    using Traits = WireTraversalTraits<Direction>;
-
-    // Traverses the pair of wire iterators in tandem until a two-qubit
-    // operation is found. If the two-qubit operation is equivalent, continue.
-    // Otherwise, stop.
-
-    std::array block{it0, it1};
-
-    // Move past the initial two-qubit op.
-    assert(it0.operation() == it1.operation());
-    std::ranges::advance(block[0], Traits::stride());
-    std::ranges::advance(block[1], Traits::stride());
-
-    while (true) {
-      for (auto& it : block) {
-        for (; it != std::default_sentinel;
-             std::ranges::advance(it, Traits::stride())) {
-          if (it.operation() == nullptr) { // isa<Blockargument>
-            return;
-          }
-
-          if (auto u = dyn_cast<UnitaryOpInterface>(it.operation());
-              u && u.getNumQubits() > 1) {
-            // Handle two-qubit barrier edge case explicitly.
-            if (isa<BarrierOp>(u) && u.getNumQubits() != 2) {
-              return;
-            }
-            // Otherwise stop for subsequent two-qubit unitary comparison.
-            break;
-          }
-        }
-
-        if (it == std::default_sentinel) {
-          return;
-        }
-      }
-
-      if (block[0].operation() != block[1].operation()) {
-        return;
-      }
-
-      it0 = block[0];
-      it1 = block[1];
-
-      std::ranges::advance(block[0], Traits::stride());
-      std::ranges::advance(block[1], Traits::stride());
-    }
-  }
-
   /// Return a window of layers with a maximum size of `1 + nlookahead`.
+  /// The function skips qubit-pair blocks.
   template <WireDirection Direction>
-  Window getWindow(Wires wires, const WireInfos& infos) {
+  Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT
     Window window;
     window.reserve(1 + nlookahead);
+
+    SmallVector<IndexPairType> layer;
+    layer.reserve(nlookahead);
+
+    enum class WalkMode : bool { Collect, SkipBlock };
+    WalkMode mode = WalkMode::Collect;
 
     walkProgramGraph<Direction>(
         wires, [&](const ReadyMap& ready, ReleasedOps& released) {
@@ -1132,25 +1086,48 @@ private:
             return WalkResult::advance();
           }
 
+          bool skipped = false;
           for (const auto& [op, indices] : ready) {
-            if (isa<UnitaryOpInterface>(op)) {
+            if (!isa<BarrierOp>(op) && isa<UnitaryOpInterface>(op)) {
               const auto i0 = indices[0];
               const auto i1 = indices[1];
               const auto prog0 = infos.lookupProgram(i0);
               const auto prog1 = infos.lookupProgram(i1);
+              const auto gate = std::minmax(prog0, prog1);
 
-              window.emplace_back(prog0, prog1);
-              if (window.size() == 1 + nlookahead) {
-                return WalkResult::interrupt();
+              if (mode == WalkMode::Collect) {
+
+                // Collect gates in window and fill current layer vector.
+
+                window.emplace_back(gate);
+                if (window.size() == 1 + nlookahead) {
+                  return WalkResult::interrupt();
+                }
+
+                layer.emplace_back(gate);
+              } else {
+
+                // Skip qubit-pair block: If the gate is contained in the
+                // current layer release it. Otherwise, continue with the next
+                // ready operation.
+
+                if (is_contained(layer, gate)) {
+                  released.emplace_back(op);
+                  skipped = true;
+                }
+
+                continue;
               }
-
-              skipQubitPairBlock<Direction>(wires[i0], wires[i1]);
-              released.emplace_back(op);
-              return WalkResult::advance();
             }
 
             released.emplace_back(op);
-            return WalkResult::advance();
+          }
+
+          if (mode == WalkMode::Collect) {
+            mode = WalkMode::SkipBlock;
+          } else if (mode == WalkMode::SkipBlock && !skipped) {
+            mode = WalkMode::Collect;
+            layer.clear();
           }
 
           return WalkResult::advance();

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1068,10 +1068,7 @@ private:
   }
 
   /// Collect a routing lookahead window of up to `1 + nlookahead` ready
-  /// two-qubit gates.
-  /// In block-skipping mode, the function releases only gates belonging to the
-  /// current qubit-pair blocks and suppresses other ready gates until each
-  /// block is exhausted.
+  /// two-qubit gates, while skipping qubit-pair blocks.
   template <WireDirection Direction>
   Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT
     Window window;

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1071,7 +1071,7 @@ private:
   /// Collect a routing lookahead window of up to `1 + nlookahead` ready
   /// two-qubit gates, while skipping qubit-pair blocks.
   template <WireDirection Direction>
-  Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT
+  Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT(performance-unnecessary-value-param)
     Window window;
     window.reserve(1 + nlookahead);
 

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1067,8 +1067,11 @@ private:
     return curr;
   }
 
-  /// Return a window of layers with a maximum size of `1 + nlookahead`.
-  /// The function skips qubit-pair blocks.
+  /// Collect a routing lookahead window of up to `1 + nlookahead` ready
+  /// two-qubit gates.
+  /// In block-skipping mode, the function releases only gates belonging to the
+  /// current qubit-pair blocks and suppresses other ready gates until each
+  /// block is exhausted.
   template <WireDirection Direction>
   Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT
     Window window;
@@ -1077,7 +1080,7 @@ private:
     SmallVector<IndexPairType> layer;
     layer.reserve(nlookahead);
 
-    enum class WalkMode : bool { Collect, SkipBlock };
+    enum class WalkMode : bool { Collect, BlockSkip };
     WalkMode mode = WalkMode::Collect;
 
     walkProgramGraph<Direction>(
@@ -1124,8 +1127,8 @@ private:
           }
 
           if (mode == WalkMode::Collect) {
-            mode = WalkMode::SkipBlock;
-          } else if (mode == WalkMode::SkipBlock && !skipped) {
+            mode = WalkMode::BlockSkip;
+          } else if (mode == WalkMode::BlockSkip && !skipped) {
             mode = WalkMode::Collect;
             layer.clear();
           }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1074,11 +1074,8 @@ private:
     Window window;
     window.reserve(1 + nlookahead);
 
-    SmallVector<IndexPairType> layer;
-    layer.reserve(nlookahead);
-
-    enum class WalkMode : bool { Collect, BlockSkip };
-    WalkMode mode = WalkMode::Collect;
+    SmallVector<IndexPairType> prev;
+    SmallVector<IndexPairType> next;
 
     walkProgramGraph<Direction>(
         wires, [&](const ReadyMap& ready, ReleasedOps& released) {
@@ -1094,41 +1091,20 @@ private:
               const auto prog1 = infos.lookupProgram(i1);
               const IndexPairType gate = std::minmax(prog0, prog1);
 
-              if (mode == WalkMode::Collect) {
-
-                // Collect gates in window and fill current layer vector.
-
+              if (!llvm::is_contained(prev, gate)) {
                 window.emplace_back(gate);
                 if (window.size() == 1 + nlookahead) {
                   return WalkResult::interrupt();
                 }
-
-                layer.emplace_back(gate);
-              } else {
-
-                // Skip qubit-pair block: If the gate is contained in the
-                // current layer release it. Otherwise, continue with the next
-                // ready operation.
-
-                if (is_contained(layer, gate)) {
-                  released.emplace_back(op);
-                }
-
-                continue;
               }
+              next.emplace_back(gate);
             }
 
             released.emplace_back(op);
           }
 
-          if (mode == WalkMode::Collect && !layer.empty()) {
-            mode = WalkMode::BlockSkip;
-          } else if (mode == WalkMode::BlockSkip && released.empty()) {
-            mode = WalkMode::Collect;
-            layer.clear();
-          }
-
-          return WalkResult::advance();
+          prev.swap(next);
+          next.clear();
         });
 
     return window;

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -814,7 +814,7 @@ private:
           return it == std::default_sentinel;
         }));
 
-        for_each(t.bundle.wires, [](auto& it) { std::advance(it, -1); });
+        for_each(t.bundle.wires, [](auto& it) { std::ranges::advance(it, -1); });
 
         const auto bwRouteRes = route<WireDirection::Backward>(t.bundle);
         if (failed(bwRouteRes)) {
@@ -825,7 +825,7 @@ private:
           return it == std::default_sentinel;
         }));
 
-        for_each(t.bundle.wires, [](auto& it) { std::advance(it, 1); });
+        for_each(t.bundle.wires, [](auto& it) { std::ranges::advance(it, 1); });
 
         t.stats = *bwRouteRes;
       }
@@ -1192,8 +1192,8 @@ private:
 
         infos.swap(prog0, prog1);
 
-        std::advance(w0, 1); // Move to SWAP.
-        std::advance(w1, 1);
+        std::ranges::advance(w0, 1); // Move to SWAP.
+        std::ranges::advance(w1, 1);
       }
 
       layout.swap(hw0, hw1);
@@ -1471,7 +1471,7 @@ private:
       totalStats.merge(*stats);
 
       if constexpr (Mode == RoutingMode::Hot) {
-        for_each(child.wires, [](auto& it) { std::advance(it, -2); });
+        for_each(child.wires, [](auto& it) { std::ranges::advance(it, -2); });
       }
     }
 
@@ -1506,7 +1506,7 @@ private:
       totalStats.merge(*stats);
 
       if constexpr (Mode == RoutingMode::Hot) {
-        for_each(children[1].wires, [](auto& it) { std::advance(it, -2); });
+        for_each(children[1].wires, [](auto& it) { std::ranges::advance(it, -2); });
       }
     }
 
@@ -1643,7 +1643,7 @@ private:
           // respective wires.
 
           for_each(composite.indices, [&](size_t i) {
-            std::advance(wires[i], WireTraversalTraits<Direction>::stride());
+            std::ranges::advance(wires[i], WireTraversalTraits<Direction>::stride());
           });
         }
       }
@@ -1670,12 +1670,12 @@ private:
         bool comparable = true;
         for (WireIterator it : wires) {
           if (it == std::default_sentinel) {
-            std::advance(it, -2);
+            std::ranges::advance(it, -2);
             while (isa_and_nonnull<MeasureOp>(it.operation())) {
-              std::advance(it, -1);
+              std::ranges::advance(it, -1);
             }
           } else {
-            std::advance(it, -1);
+            std::ranges::advance(it, -1);
           }
 
           Operation* operation = it.operation();
@@ -1697,11 +1697,11 @@ private:
         // a classical use of its result.
         for (auto& it : wires) {
           if (it != std::default_sentinel) {
-            std::advance(it, -1);
+            std::ranges::advance(it, -1);
             continue;
           }
 
-          std::advance(it, -2);
+          std::ranges::advance(it, -2);
           if (!comparable) {
             continue;
           }
@@ -1718,7 +1718,7 @@ private:
                              })) {
               break;
             }
-            std::advance(it, -1);
+            std::ranges::advance(it, -1);
           }
         }
       }
@@ -1734,7 +1734,7 @@ private:
         // insertion. Otherwise, an increment will move the iterator to the
         // multi-qubit op of the current or subsequent layer or to a sink.
 
-        for_each(wires, [](auto& it) { std::advance(it, 1); });
+        for_each(wires, [](auto& it) { std::ranges::advance(it, 1); });
       }
     }
 

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1071,7 +1071,7 @@ private:
   /// Collect a routing lookahead window of up to `1 + nlookahead` ready
   /// two-qubit gates, while skipping qubit-pair blocks.
   template <WireDirection Direction>
-  Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT
+  Window getWindow(Wires wires, const WireInfos& infos) {
     Window window;
     window.reserve(1 + nlookahead);
 
@@ -1079,7 +1079,8 @@ private:
     SmallVector<IndexPairType> next;
 
     walkProgramGraph<Direction>(
-        wires, [&](const ReadyMap& ready, ReleasedOps& released) {
+        MutableArrayRef(wires.data(), wires.size()),
+        [&](const ReadyMap& ready, ReleasedOps& released) {
           if (ready.empty()) {
             return WalkResult::advance();
           }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1091,7 +1091,7 @@ private:
               const auto prog1 = infos.lookupProgram(i1);
               const IndexPairType gate = std::minmax(prog0, prog1);
 
-              if (!llvm::is_contained(prev, gate)) {
+              if (!is_contained(prev, gate)) {
                 window.emplace_back(gate);
                 if (window.size() == 1 + nlookahead) {
                   return WalkResult::interrupt();
@@ -1105,6 +1105,8 @@ private:
 
           prev.swap(next);
           next.clear();
+
+          return WalkResult::advance();
         });
 
     return window;

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1086,7 +1086,6 @@ private:
             return WalkResult::advance();
           }
 
-          bool skipped = false;
           for (const auto& [op, indices] : ready) {
             if (!isa<BarrierOp>(op) && isa<UnitaryOpInterface>(op)) {
               const auto i0 = indices[0];
@@ -1113,7 +1112,6 @@ private:
 
                 if (is_contained(layer, gate)) {
                   released.emplace_back(op);
-                  skipped = true;
                 }
 
                 continue;
@@ -1123,9 +1121,9 @@ private:
             released.emplace_back(op);
           }
 
-          if (mode == WalkMode::Collect) {
+          if (mode == WalkMode::Collect && !layer.empty()) {
             mode = WalkMode::BlockSkip;
-          } else if (mode == WalkMode::BlockSkip && !skipped) {
+          } else if (mode == WalkMode::BlockSkip && released.empty()) {
             mode = WalkMode::Collect;
             layer.clear();
           }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -814,7 +814,8 @@ private:
           return it == std::default_sentinel;
         }));
 
-        for_each(t.bundle.wires, [](auto& it) { std::ranges::advance(it, -1); });
+        for_each(t.bundle.wires,
+                 [](auto& it) { std::ranges::advance(it, -1); });
 
         const auto bwRouteRes = route<WireDirection::Backward>(t.bundle);
         if (failed(bwRouteRes)) {
@@ -1459,7 +1460,8 @@ private:
       totalStats.merge(*stats);
 
       if constexpr (Mode == RoutingMode::Hot) {
-        for_each(children[1].wires, [](auto& it) { std::ranges::advance(it, -2); });
+        for_each(children[1].wires,
+                 [](auto& it) { std::ranges::advance(it, -2); });
       }
     }
 
@@ -1596,7 +1598,8 @@ private:
           // respective wires.
 
           for_each(composite.indices, [&](size_t i) {
-            std::ranges::advance(wires[i], WireTraversalTraits<Direction>::stride());
+            std::ranges::advance(wires[i],
+                                 WireTraversalTraits<Direction>::stride());
           });
         }
       }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1071,7 +1071,7 @@ private:
   /// Collect a routing lookahead window of up to `1 + nlookahead` ready
   /// two-qubit gates, while skipping qubit-pair blocks.
   template <WireDirection Direction>
-  Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT(performance-unnecessary-value-param)
+  Window getWindow(Wires wires, const WireInfos& infos) { // NOLINT
     Window window;
     window.reserve(1 + nlookahead);
 

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -257,23 +257,6 @@ void WireIterator::forward() {
   // Find the output from the input qubit SSA value.
   pos_ = Position::Between;
 
-  // A call threads the qubit through to the matching result. When the callee
-  // keeps it, the wire ends here.
-  if (auto callOp = dyn_cast<func::CallOp>(op_)) {
-    auto result = resultForOperand(callOp, qubit_);
-    if (failed(result)) {
-      mappingFailed_ = true;
-      pos_ = Position::Tail;
-      return;
-    }
-    if (!*result) {
-      pos_ = Position::Tail;
-      return;
-    }
-    qubit_ = *result;
-    return;
-  }
-  
   TypeSwitch<Operation*>(op_)
       .Case<UnitaryOpInterface>(
           [&](UnitaryOpInterface op) { qubit_ = op.getOutputForInput(qubit_); })
@@ -294,6 +277,22 @@ void WireIterator::forward() {
           [&](IfOp op) { qubit_ = op.getTiedResult(&(*qubit_.use_begin())); })
       .Case<IndexSwitchOp>([&](IndexSwitchOp op) {
         qubit_ = op.getTiedResult(&(*qubit_.use_begin()));
+      })
+      .Case<func::CallOp>([&](func::CallOp op) {
+        // A call threads the qubit through to the matching result. When the
+        // callee keeps it, the wire ends here.
+
+        auto result = resultForOperand(op, qubit_);
+        if (failed(result)) {
+          mappingFailed_ = true;
+          pos_ = Position::Tail;
+          return;
+        }
+        if (!*result) {
+          pos_ = Position::Tail;
+          return;
+        }
+        qubit_ = *result;
       })
       .Default([&](Operation*) {
         mappingFailed_ = true;
@@ -329,14 +328,6 @@ void WireIterator::backward() {
     bool unknown = false;
     // Find the input from the output qubit SSA value.
     TypeSwitch<Operation*>(op_)
-        .Case<func::CallOp>([&](func::CallOp callOp) {
-          Value operand = operandForResult(callOp, qubit_);
-          if (!operand) {
-            unknown = true;
-            return;
-          }
-          qubit_ = operand;
-        })
         .Case<UnitaryOpInterface>([&](UnitaryOpInterface op) {
           qubit_ = op.getInputForOutput(qubit_);
         })
@@ -374,6 +365,14 @@ void WireIterator::backward() {
             return;
           }
           llvm::reportFatalInternalError("expected result lookup");
+        })
+        .Case<func::CallOp>([&](func::CallOp callOp) {
+          Value operand = operandForResult(callOp, qubit_);
+          if (!operand) {
+            unknown = true;
+            return;
+          }
+          qubit_ = operand;
         })
         .Default([&](Operation*) { unknown = true; });
 

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -18,6 +18,7 @@
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/ScopeExit.h>
 #include <llvm/ADT/TypeSwitch.h>
+#include <llvm/Support/Debug.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
@@ -273,6 +274,7 @@ void WireIterator::forward() {
     qubit_ = *result;
     return;
   }
+  
   TypeSwitch<Operation*>(op_)
       .Case<UnitaryOpInterface>(
           [&](UnitaryOpInterface op) { qubit_ = op.getOutputForInput(qubit_); })

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -18,7 +18,6 @@
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/ScopeExit.h>
 #include <llvm/ADT/TypeSwitch.h>
-#include <llvm/Support/Debug.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -273,7 +273,7 @@ void WireIterator::forward() {
     qubit_ = *result;
     return;
   }
-  
+
   TypeSwitch<Operation*>(op_)
       .Case<UnitaryOpInterface>(
           [&](UnitaryOpInterface op) { qubit_ = op.getOutputForInput(qubit_); })

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -1598,9 +1598,8 @@ TEST_P(MappingPassTest, MapSABRECircuit) {
   builder.qtensorDealloc(tensorDown);
 
   auto m = builder.finalize(bits);
-  ASSERT_TRUE(runPass(m.get(), target,
-                      MappingPassOptions{.ntrials = 1, .nlookahead = 15})
-                  .succeeded());
+  ASSERT_TRUE(
+      runPass(m.get(), target, MappingPassOptions{.ntrials = 1}).succeeded());
   ASSERT_TRUE(succeeded(verify(*m)));
   EXPECT_TRUE(isExecutable(getEntryPoint(m.get()), target));
 }

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -1861,7 +1861,7 @@ TEST_P(MappingPassTest, MapCircuitWithQubitPairBlock) {
 
   auto m = builder.finalize();
   ASSERT_TRUE(runPass(m.get(), target,
-                      MappingPassOptions{.ntrials = 1, .nlookahead = 15})
+                      MappingPassOptions{.nlookahead = 15, .ntrials = 1})
                   .succeeded());
   ASSERT_TRUE(succeeded(verify(*m)));
   EXPECT_TRUE(isExecutable(getEntryPoint(m.get()), target));

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -1810,48 +1810,6 @@ TEST_P(MappingPassTest, MapNestedForSwitch) {
   EXPECT_TRUE(isExecutable(getEntryPoint(m.get()), target));
 }
 
-TEST_P(MappingPassTest, MapIndexSwitchUsesVotedLayout) {
-  const auto target = llvm::cantFail(CompilerTarget::create(
-      3, std::vector<CompilerTarget::Coupling>{{0, 1}, {1, 2}}));
-
-  QCOProgramBuilder builder(context.get());
-  builder.initialize();
-
-  Value tensor = builder.qtensorAlloc(3);
-  SmallVector<Value> qubits(3);
-  for (int64_t i = 0; i < 3; ++i) {
-    std::tie(tensor, qubits[i]) = builder.qtensorExtract(tensor, i);
-  }
-
-  const auto routeTriangle = [&](ValueRange initArgs) {
-    SmallVector<Value> args(initArgs);
-    std::tie(args[0], args[1]) = builder.cx(args[0], args[1]);
-    std::tie(args[1], args[2]) = builder.cx(args[1], args[2]);
-    std::tie(args[0], args[2]) = builder.cx(args[0], args[2]);
-    return args;
-  };
-  const SmallVector<function_ref<SmallVector<Value>(ValueRange)>> caseBodies(
-      3, routeTriangle);
-  qubits = llvm::to_vector(builder.qcoIndexSwitch(
-      0, qubits, SmallVector<int64_t>{0, 1, 2}, caseBodies,
-      [](ValueRange args) { return llvm::to_vector(args); }));
-
-  for (int64_t i = 0; i < 3; ++i) {
-    tensor = builder.qtensorInsert(qubits[i], tensor, i);
-  }
-  builder.qtensorDealloc(tensor);
-
-  auto m = builder.finalize();
-  ASSERT_TRUE(
-      runPass(m.get(), target, MappingPassOptions{.ntrials = 1}).succeeded());
-
-  size_t numSwaps = 0;
-  m->walk([&](SWAPOp) { ++numSwaps; });
-  // The three routed cases agree on the voted exit layout; only the default
-  // case must be restored to it. Restoring every case to the parent needs 12.
-  EXPECT_EQ(numSwaps, 6UL);
-}
-
 TEST_P(MappingPassTest, MapPaddedCXCZGrid) {
   const auto& target = GetParam();
   const auto size = (target.numQubits() + 1) / 2;

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -1598,8 +1598,9 @@ TEST_P(MappingPassTest, MapSABRECircuit) {
   builder.qtensorDealloc(tensorDown);
 
   auto m = builder.finalize(bits);
-  ASSERT_TRUE(
-      runPass(m.get(), target, MappingPassOptions{.ntrials = 1}).succeeded());
+  ASSERT_TRUE(runPass(m.get(), target,
+                      MappingPassOptions{.ntrials = 1, .nlookahead = 15})
+                  .succeeded());
   ASSERT_TRUE(succeeded(verify(*m)));
   EXPECT_TRUE(isExecutable(getEntryPoint(m.get()), target));
 }
@@ -1832,6 +1833,36 @@ TEST_P(MappingPassTest, MapPaddedCXCZGrid) {
   auto m = builder.finalize(bits);
   ASSERT_TRUE(
       runPass(m.get(), target, MappingPassOptions{.ntrials = 1}).succeeded());
+  ASSERT_TRUE(succeeded(verify(*m)));
+  EXPECT_TRUE(isExecutable(getEntryPoint(m.get()), target));
+}
+
+TEST_P(MappingPassTest, MapCircuitWithQubitPairBlock) {
+  const auto& target = GetParam();
+
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  SmallVector<Value> qubits(5);
+  for (size_t i = 0; i < 5; ++i) {
+    qubits[i] = builder.allocQubit();
+  }
+
+  std::tie(qubits[1], qubits[2]) = builder.cx(qubits[1], qubits[2]);
+  std::tie(qubits[3], qubits[4]) = builder.cx(qubits[3], qubits[4]);
+  std::tie(qubits[1], qubits[2]) = builder.cx(qubits[1], qubits[2]);
+  std::tie(qubits[0], qubits[4]) = builder.cx(qubits[0], qubits[4]);
+  std::tie(qubits[1], qubits[2]) = builder.cx(qubits[1], qubits[2]);
+  std::tie(qubits[0], qubits[1]) = builder.cx(qubits[0], qubits[1]);
+
+  for (size_t i = 0; i < 5; ++i) {
+    builder.sink(qubits[i]);
+  }
+
+  auto m = builder.finalize();
+  ASSERT_TRUE(runPass(m.get(), target,
+                      MappingPassOptions{.ntrials = 1, .nlookahead = 15})
+                  .succeeded());
   ASSERT_TRUE(succeeded(verify(*m)));
   EXPECT_TRUE(isExecutable(getEntryPoint(m.get()), target));
 }

--- a/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
@@ -19,7 +19,6 @@
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Debug.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>

--- a/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_drivers.cpp
@@ -19,6 +19,7 @@
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Debug.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>

--- a/mlir/unittests/Dialect/QCO/Utils/test_wireiterator.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_wireiterator.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "gtest/gtest.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
@@ -15,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Debug.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
@@ -347,6 +349,7 @@ TEST_F(WireIteratorFixture, TraversalTerminatesAtUnknownCarrier) {
   --backward;
   EXPECT_EQ(backward, std::default_sentinel);
 }
+
 TEST_F(WireIteratorFixture, CallMappingFollowsNestedReordering) {
   auto module = parseModule(R"mlir(
 func.func private @swap(%flag: i1, %a: !qco.qubit, %b: !qco.qubit)

--- a/mlir/unittests/Dialect/QCO/Utils/test_wireiterator.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_wireiterator.cpp
@@ -8,7 +8,6 @@
  * Licensed under the MIT License
  */
 
-#include "gtest/gtest.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"

--- a/mlir/unittests/Dialect/QCO/Utils/test_wireiterator.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_wireiterator.cpp
@@ -15,7 +15,6 @@
 
 #include <gtest/gtest.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/Debug.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>


### PR DESCRIPTION
## Description

This pull request removes the `skipQubitPairBlock` function and implements block-skipping in the `walkProgramGraph` function. By doing so, we avoid an additional function call in the callback function while also improving the semantics of the callback (The callback isn't allowed to change / update / set the wire iterators). 

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>