### PR TITLE
✨ Walk tensor chains across calls and compare untracked qubit tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ releases may include breaking changes.
 
 #### Passes and transformations
 
+- ✨ Add passes for quantum-specific interprocedural optimizations ([#2193])
+  ([**@DRovara**], [**@burgholzer**])
 - ✨ Add quantum loop unrolling and qubit reuse passes ([#1705], [#1718],
   [#1755], [#1756], [#1923], [#1924], [#2039], [#2118], [#2216])
   ([**@MatthiasReumann**], [**@DRovara**], [**@burgholzer**],
@@ -832,6 +834,7 @@ for previous changelogs._
 [#2216]: https://github.com/munich-quantum-toolkit/core/pull/2216
 [#2203]: https://github.com/munich-quantum-toolkit/core/pull/2203
 [#2214]: https://github.com/munich-quantum-toolkit/core/pull/2214
+[#2193]: https://github.com/munich-quantum-toolkit/core/pull/2193
 [#2175]: https://github.com/munich-quantum-toolkit/core/pull/2175
 [#2169]: https://github.com/munich-quantum-toolkit/core/pull/2169
 [#2168]: https://github.com/munich-quantum-toolkit/core/pull/2168

--- a/mlir/lib/Dialect/QTensor/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/QTensor/Utils/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(
   PUBLIC
   MLIRQCODialect
   PRIVATE
+  MLIRFuncDialect
   MLIRSCFDialect)
 
 mqt_mlir_target_use_project_options(MLIRQTensorUtils)

--- a/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
+++ b/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
@@ -16,6 +16,7 @@
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/ErrorHandling.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Value.h>
@@ -28,8 +29,9 @@
 namespace mlir::qtensor {
 TypedValue<RankedTensorType> TensorIterator::tensor() const {
   // The following operations don't have an OpResult.
-  if (op_ != nullptr &&
-      isa<DeallocOp, scf::YieldOp, scf::ConditionOp, qco::YieldOp>(op_)) {
+  // `func::CallOp` is deliberately absent: it does produce results.
+  if (op_ != nullptr && isa<DeallocOp, scf::YieldOp, scf::ConditionOp,
+                            qco::YieldOp, func::ReturnOp>(op_)) {
     return nullptr;
   }
 
@@ -97,8 +99,11 @@ void TensorIterator::forward() {
   assert(tensor_.hasOneUse() && "expected linear typing");
   op_ = *(tensor_.user_begin());
 
-  // The following operations define the end of the tensor's life-chain.
-  if (isa<DeallocOp, scf::YieldOp, scf::ConditionOp, qco::YieldOp>(op_)) {
+  // The following operations define the end of the tensor's life-chain. A
+  // `func.call` ends it because the tensor is handed to the callee; the tensor
+  // the call returns starts a life-chain of its own.
+  if (isa<DeallocOp, scf::YieldOp, scf::ConditionOp, qco::YieldOp,
+          func::ReturnOp, func::CallOp>(op_)) {
     isFinal_ = true;
     return;
   }
@@ -144,8 +149,16 @@ void TensorIterator::backward() {
     return;
   }
 
+  // A `func.call` sits on both sides of a life-chain: it consumes the caller's
+  // tensor and produces a fresh one. When the tensor is the call's result, it
+  // is the start of its chain, just like an allocation.
+  if (isa<func::CallOp>(op_) && tensor_.getDefiningOp() == op_) {
+    return;
+  }
+
   // For these operations, tensor_ is an OpOperand. Hence, only get the def-op.
-  if (isa<DeallocOp, scf::YieldOp, scf::ConditionOp, qco::YieldOp>(op_)) {
+  if (isa<DeallocOp, scf::YieldOp, scf::ConditionOp, qco::YieldOp,
+          func::ReturnOp, func::CallOp>(op_)) {
     op_ = tensor_.getDefiningOp();
     isFinal_ = false;
     return;

--- a/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
+++ b/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
@@ -38,6 +38,7 @@
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/Passes.h>
@@ -512,6 +513,126 @@ TEST_F(QTensorTest, ResetAfterExtractThroughSameIndexInsertIsNotEliminated) {
 
   EXPECT_FALSE(
       areModulesEquivalentWithPermutations(program.get(), reference.get()));
+}
+
+/**
+ * @brief Qubit tensors that do not descend from an allocation are compared
+ * through the regular SSA mapping.
+ *
+ * @details
+ * A tensor arriving as a function argument has no equivalence group, and the
+ * threaded tensor an extraction hands back is only covered once it is mapped
+ * explicitly. Both used to abort inside the comparison instead of reporting a
+ * result.
+ *
+ * The two equivalent programs are written differently and converge under the
+ * cleanup pipeline, so the comparison is reached from distinct sources. Note
+ * that it cannot be reached from distinct *results*: the permutation matching
+ * is keyed off the equivalence groups seeded by `qtensor.alloc`, which a
+ * function argument never joins, so on this path the comparison is structural.
+ * The negative cases below pin down how little it takes to break it.
+ */
+TEST_F(QTensorTest, ComparesQubitTensorsThatDoNotDescendFromAnAllocation) {
+  const auto parse = [&](const char* body) {
+    const std::string source = std::string(R"mlir(
+func.func @f(%t: tensor<2x!qco.qubit>) -> tensor<2x!qco.qubit> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+)mlir") + body + R"mlir(
+}
+)mlir";
+    auto module = parseSourceString<ModuleOp>(source, context.get());
+    if (module && runQCOCleanupPipeline(module.get()).failed()) {
+      return OwningOpRef<ModuleOp>{};
+    }
+    return module;
+  };
+
+  // Takes element 0 out, applies a gate, and puts it back.
+  auto program = parse(R"mlir(
+  %out, %q = qtensor.extract %t[%c0] : tensor<2x!qco.qubit>
+  %g = qco.h %q : !qco.qubit -> !qco.qubit
+  %r = qtensor.insert %g into %out[%c0] : tensor<2x!qco.qubit>
+  return %r : tensor<2x!qco.qubit>)mlir");
+
+  // The same, preceded by a round-trip on element 1 that folds away.
+  auto reference = parse(R"mlir(
+  %spare, %idle = qtensor.extract %t[%c1] : tensor<2x!qco.qubit>
+  %restored = qtensor.insert %idle into %spare[%c1] : tensor<2x!qco.qubit>
+  %out, %q = qtensor.extract %restored[%c0] : tensor<2x!qco.qubit>
+  %g = qco.h %q : !qco.qubit -> !qco.qubit
+  %r = qtensor.insert %g into %out[%c0] : tensor<2x!qco.qubit>
+  return %r : tensor<2x!qco.qubit>)mlir");
+
+  // A different gate on the same element.
+  auto otherGate = parse(R"mlir(
+  %out, %q = qtensor.extract %t[%c0] : tensor<2x!qco.qubit>
+  %g = qco.x %q : !qco.qubit -> !qco.qubit
+  %r = qtensor.insert %g into %out[%c0] : tensor<2x!qco.qubit>
+  return %r : tensor<2x!qco.qubit>)mlir");
+
+  // The same gate on the other element.
+  auto otherElement = parse(R"mlir(
+  %out, %q = qtensor.extract %t[%c1] : tensor<2x!qco.qubit>
+  %g = qco.h %q : !qco.qubit -> !qco.qubit
+  %r = qtensor.insert %g into %out[%c1] : tensor<2x!qco.qubit>
+  return %r : tensor<2x!qco.qubit>)mlir");
+
+  ASSERT_TRUE(program);
+  ASSERT_TRUE(reference);
+  ASSERT_TRUE(otherGate);
+  ASSERT_TRUE(otherElement);
+
+  EXPECT_TRUE(
+      areModulesEquivalentWithPermutations(program.get(), reference.get()));
+  EXPECT_FALSE(
+      areModulesEquivalentWithPermutations(program.get(), otherGate.get()));
+  EXPECT_FALSE(
+      areModulesEquivalentWithPermutations(program.get(), otherElement.get()));
+}
+
+/**
+ * @brief A tracked tensor is never matched against an untracked one.
+ *
+ * @details
+ * Only tensors descending from a `qtensor.alloc` join an equivalence group. The
+ * `rhs` guard is what stops a tracked left-hand tensor from being compared
+ * against a right-hand one that has no group, which would look the group up on
+ * a missing key. It is only reachable once the left-hand side is tracked, so it
+ * needs a case where the two sides disagree about that.
+ */
+TEST_F(QTensorTest, DoesNotMatchATrackedTensorAgainstAnUntrackedOne) {
+  const auto parse = [&](const char* worked, const char* released) {
+    const std::string source = std::string(R"mlir(
+func.func @f(%arg: tensor<2x!qco.qubit>) -> tensor<2x!qco.qubit> {
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %own = qtensor.alloc(%c2) : tensor<2x!qco.qubit>
+  %out, %q = qtensor.extract %)mlir") +
+                               worked + R"mlir([%c0] : tensor<2x!qco.qubit>
+  %g = qco.h %q : !qco.qubit -> !qco.qubit
+  %back = qtensor.insert %g into %out[%c0] : tensor<2x!qco.qubit>
+  qtensor.dealloc %)mlir" + released +
+                               R"mlir( : tensor<2x!qco.qubit>
+  return %back : tensor<2x!qco.qubit>
+}
+)mlir";
+    return parseSourceString<ModuleOp>(source, context.get());
+  };
+
+  // The same shape either way, with the two tensors swapping roles. The one
+  // that is worked on descends from the allocation in the first module and is
+  // the function argument in the second, so it is tracked in one and not in
+  // the other.
+  auto allocated = parse("own", "arg");
+  auto argument = parse("arg", "own");
+  ASSERT_TRUE(allocated);
+  ASSERT_TRUE(argument);
+
+  EXPECT_FALSE(
+      areModulesEquivalentWithPermutations(allocated.get(), argument.get()));
+  EXPECT_FALSE(
+      areModulesEquivalentWithPermutations(argument.get(), allocated.get()));
 }
 
 // ============================================================================

--- a/mlir/unittests/Dialect/QTensor/Utils/test_tensoriterator.cpp
+++ b/mlir/unittests/Dialect/QTensor/Utils/test_tensoriterator.cpp
@@ -261,6 +261,63 @@ TEST_F(TensorIteratorTest, Traversal) {
   ASSERT_EQ(recIt.tensor(), tensorElse0);
 }
 
+/**
+ * @brief A tensor returned by a call starts its own life-chain.
+ *
+ * @details
+ * A call sits on both sides of a chain: it consumes the caller's tensor and
+ * hands back a fresh one. Walking backward from the result therefore stops at
+ * the call, the same way it stops at an allocation, instead of continuing into
+ * the tensor that was passed in.
+ */
+TEST_F(TensorIteratorTest, CallResultStartsALifeChain) {
+  auto module = parseSourceString<ModuleOp>(R"mlir(
+func.func private @relabel(%t: tensor<2x!qco.qubit>) -> tensor<2x!qco.qubit> {
+  return %t : tensor<2x!qco.qubit>
+}
+func.func @main() {
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %in = qtensor.alloc(%c2) : tensor<2x!qco.qubit>
+  %out = func.call @relabel(%in) : (tensor<2x!qco.qubit>) -> tensor<2x!qco.qubit>
+  %rest, %q = qtensor.extract %out[%c0] : tensor<2x!qco.qubit>
+  %h = qco.h %q : !qco.qubit -> !qco.qubit
+  %back = qtensor.insert %h into %rest[%c0] : tensor<2x!qco.qubit>
+  qtensor.dealloc %back : tensor<2x!qco.qubit>
+  return
+}
+)mlir",
+                                            context.get());
+  ASSERT_TRUE(module);
+
+  func::CallOp call;
+  ExtractOp extract;
+  module->walk([&](Operation* op) {
+    if (auto c = dyn_cast<func::CallOp>(op)) {
+      call = c;
+    }
+    if (auto e = dyn_cast<ExtractOp>(op)) {
+      extract = e;
+    }
+  });
+  ASSERT_TRUE(call);
+  ASSERT_TRUE(extract);
+
+  const auto result = cast<TypedValue<RankedTensorType>>(call.getResult(0));
+  TensorIterator it(extract.getOutTensor());
+  ASSERT_EQ(it.operation(), extract.getOperation());
+
+  --it;
+  EXPECT_EQ(it.operation(), call.getOperation());
+  EXPECT_EQ(it.tensor(), result);
+
+  // The call produced this tensor, so the chain starts here: stepping back
+  // again must not walk into the tensor that was passed in.
+  --it;
+  EXPECT_EQ(it.operation(), call.getOperation());
+  EXPECT_EQ(it.tensor(), result);
+}
+
 TEST_F(TensorIteratorTest, TraversesMixedResultConditionals) {
   constexpr StringLiteral source = R"mlir(
     module {

--- a/mlir/unittests/Support/IRVerification.cpp
+++ b/mlir/unittests/Support/IRVerification.cpp
@@ -11,7 +11,6 @@
 #include "Support/IRVerification.h"
 
 #include "mlir/Dialect/QC/IR/QCOps.h"
-#include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QTensor/Utils/TensorIterator.h"
 
@@ -61,6 +60,19 @@ struct TensorMapping {
     const auto i = lhsEquivGroups.at(lhs);
     return equivGroupMapping.at(i) == rhsEquivGroups.at(rhs);
   }
+
+  /// Return true if the given lhs value takes part in the equivalence
+  /// tracking. Only tensors reachable from a `qtensor` allocation are tracked;
+  /// builtin tensors of qubits are compared through the regular SSA mapping.
+  [[nodiscard]] bool tracksLhs(Value lhs) const {
+    return lhsEquivGroups.contains(lhs);
+  }
+
+  /// Return true if the given rhs value takes part in the equivalence
+  /// tracking.
+  [[nodiscard]] bool tracksRhs(Value rhs) const {
+    return rhsEquivGroups.contains(rhs);
+  }
 };
 } // namespace
 
@@ -68,16 +80,6 @@ static bool compareRegions(Region& lhs, Region& rhs,
                            SetVector<Operation*>& lhsClosed,
                            SetVector<Operation*>& rhsClosed, IRMapping& m,
                            TensorMapping& tm);
-
-/// Return true, if the given value has the type `tensor<qco.qubit>`.
-static bool hasTypeQubitTensor(Value v) {
-  auto tensor = dyn_cast<RankedTensorType>(v.getType());
-  if (!tensor) {
-    return false;
-  }
-
-  return isa<qco::QubitType>(tensor.getElementType());
-}
 
 /// Recursively initialize the equivalence group for a tensor value.
 static void initEquivGroup(TypedValue<RankedTensorType> v, size_t id,
@@ -206,10 +208,10 @@ getPermutation(const LhsRange& lhs, const RhsRange& rhs, const IRMapping& m,
                const TensorMapping& tm) {
   SmallVector<size_t> permutation(lhs.size());
   for (const auto& [i, lhsValue] : llvm::enumerate(lhs)) {
-    const auto it = hasTypeQubitTensor(lhsValue)
+    const auto it = tm.tracksLhs(lhsValue)
                         ? llvm::find_if(rhs,
                                         [&](const auto rhsValue) {
-                                          if (!hasTypeQubitTensor(rhsValue)) {
+                                          if (!tm.tracksRhs(rhsValue)) {
                                             return false;
                                           }
                                           return tm.equals(lhsValue, rhsValue);
@@ -233,9 +235,9 @@ static bool compareValueLists(const LhsRange& lhs, const RhsRange& rhs,
 
   for (const auto lhsValue : lhs) {
     Value mapped;
-    if (hasTypeQubitTensor(lhsValue)) {
+    if (tm.tracksLhs(lhsValue)) {
       const auto it = llvm::find_if(rhs, [&](const auto rhsValue) {
-        return hasTypeQubitTensor(rhsValue) && tm.equals(lhsValue, rhsValue);
+        return tm.tracksRhs(rhsValue) && tm.equals(lhsValue, rhsValue);
       });
       if (it == rhs.end()) {
         return false;
@@ -478,8 +480,10 @@ static bool compareOperations(Operation* lhs, Operation* rhs,
   } else {
     for (const auto& [lhsOperand, rhsOperand] :
          llvm::zip_equal(lhs->getOperands(), rhs->getOperands())) {
-      if (hasTypeQubitTensor(lhsOperand)) {
-        assert(hasTypeQubitTensor(rhsOperand));
+      if (tm.tracksLhs(lhsOperand)) {
+        if (!tm.tracksRhs(rhsOperand)) {
+          return false;
+        }
 
         if (!tm.equals(lhsOperand, rhsOperand)) {
           return false;
@@ -745,6 +749,9 @@ static bool compareBlocks(Block& lhs, Block& rhs,
             auto lhsExtract = cast<qtensor::ExtractOp>(lhsOp);
             auto rhsExtract = cast<qtensor::ExtractOp>(rhsOp);
             m.map(lhsExtract.getResult(), rhsExtract.getResult());
+            // The threaded tensor is only covered by the equivalence groups
+            // when it descends from an allocation, so map it here as well.
+            m.map(lhsExtract.getOutTensor(), rhsExtract.getOutTensor());
           } else {
             SmallVector<size_t> permutation(lhsOp->getNumResults());
             std::iota(permutation.begin(), permutation.end(), 0);


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

First of a stack replacing #1970, which combined too many independently reviewable changes. This slice contains only shared infrastructure that later slices build on; no pass and no user-facing behaviour changes.

Two independent fixes:

**`TensorIterator` across call boundaries.** A tensor chain reaching a `func.call` or `func.return` aborted the process through the iterator's `report_fatal_error` default. Both now end the chain instead — the tensor a call returns starts a life-chain of its own.

**`areModulesEquivalentWithPermutations` with untracked qubit tensors.** The comparison assumed every qubit tensor belongs to an equivalence group, which only holds for tensors descending from a `qtensor` allocation. A tensor arriving as a function argument therefore hit `DenseMap::at` on a missing key, and the tensor threaded out of a `qtensor.extract` was never mapped, tripping `IRMapping::lookup`. Untracked tensors now fall back to the regular SSA mapping, and `getOutTensor()` is mapped alongside the qubit result.

### Testing

`ComparesQubitTensorsThatDoNotDescendFromAnAllocation` in `test_qtensor_ir.cpp` covers both paths and includes a negative case so it is not vacuous. Verified by mutation: removing the `getOutTensor()` mapping reproduces the original `IRMapping::lookup` assertion.

Every suite consuming `IRVerification` passes — jeff-round-trip 143, qco-to-qc 139, qc-to-qco 168, qc-to-qir-adaptive 146, qc-to-qir-base 124, qir-ir 116, qtensor-ir 30, optimizations 121.

### AI assistance

Code and this description were produced with Claude Code (Opus 5), acting on my instructions and within the scope I authorized.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
