### PR TITLE
✨ Let `QCOProgramBuilder` build additional functions and call them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ releases may include breaking changes.
   [#1807], [#1808], [#1815], [#1824], [#1869], [#1872], [#1914], [#1925],
   [#1927], [#1935], [#1936], [#1938], [#1975], [#1976], [#2006], [#2014],
   [#2015], [#2017], [#2026], [#2028], [#2054], [#2058], [#2125], [#2136],
-  [#2149], [#2150], [#2158], [#2194], [#2210], [#2211], [#2220])
+  [#2149], [#2150], [#2158], [#2194], [#2196], [#2210], [#2211], [#2220])
   ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**],
   [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
   [**@simon1hofmann**], [**@J4MMlE**])
@@ -890,6 +890,7 @@ for previous changelogs._
 [#2216]: https://github.com/munich-quantum-toolkit/core/pull/2216
 [#2203]: https://github.com/munich-quantum-toolkit/core/pull/2203
 [#2214]: https://github.com/munich-quantum-toolkit/core/pull/2214
+[#2196]: https://github.com/munich-quantum-toolkit/core/pull/2196
 [#2194]: https://github.com/munich-quantum-toolkit/core/pull/2194
 [#2193]: https://github.com/munich-quantum-toolkit/core/pull/2193
 [#2184]: https://github.com/munich-quantum-toolkit/core/pull/2184

--- a/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -1883,6 +1883,33 @@ public:
                                   ValueRange yieldedValues);
 
   //===--------------------------------------------------------------------===//
+  // Additional functions
+  //===--------------------------------------------------------------------===//
+
+  /// Starts a private function and returns its entry-block arguments.
+  ///
+  /// Functions must be defined before operations in `main` and cannot nest.
+  SmallVector<Value> startFunction(StringRef name, TypeRange argTypes,
+                                   TypeRange resultTypes);
+
+  /// Ends the active function and restores the surrounding builder scope.
+  ///
+  /// Every linear value in the function must be returned or consumed.
+  void endFunction(ValueRange returnValues);
+
+  /// Calls a completed function and returns its results.
+  ///
+  /// Linear operands and results are paired by following the callee body.
+  /// Mapping failure is a usage error.
+  SmallVector<Value> call(StringRef callee, ValueRange operands);
+
+  /// Returns the `!qco.qubit` type.
+  Type getQubitType();
+
+  /// Returns `tensor<size x !qco.qubit>`.
+  Type getQubitTensorType(int64_t size);
+
+  //===--------------------------------------------------------------------===//
   // Finalization
   //===--------------------------------------------------------------------===//
 
@@ -2070,6 +2097,9 @@ private:
 
   /// Ensure static and dynamic qubit allocation modes are not mixed.
   void ensureAllocationMode(AllocationMode requestedMode);
+
+  // Insertion point to restore after finishing an additional function.
+  OpBuilder::InsertPoint savedInsertionPoint;
 };
 } // namespace qco
 } // namespace mlir

--- a/mlir/lib/Dialect/QCO/Builder/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCO/Builder/CMakeLists.txt
@@ -17,7 +17,9 @@ add_mlir_library(
   MLIRMQTDialect
   MLIRSCFDialect
   MLIRQCODialect
+  MLIRQCOUtils
   MLIRQTensorDialect
+  MLIRQTensorUtils
   PRIVATE
   MLIRMQTUtils)
 

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -18,8 +18,10 @@
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/QCOUtils.h"
+#include "mlir/Dialect/QCO/Utils/WireIterator.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
+#include "mlir/Dialect/QTensor/Utils/TensorIterator.h"
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
@@ -37,6 +39,7 @@
 #include <mlir/IR/Location.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/SymbolTable.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
@@ -1407,6 +1410,215 @@ QCOProgramBuilder::scfCondition(Value reg,
   checkFinalized();
   auto condition = loadClassicalBit(reg, index);
   return scfCondition(condition, yieldedValues);
+}
+
+//===----------------------------------------------------------------------===//
+// Additional Functions
+//===----------------------------------------------------------------------===//
+
+Type QCOProgramBuilder::getQubitType() { return QubitType::get(ctx); }
+
+Type QCOProgramBuilder::getQubitTensorType(int64_t size) {
+  return RankedTensorType::get({size}, getQubitType());
+}
+
+static bool isQubitTensor(Type type) {
+  auto tensorType = dyn_cast<RankedTensorType>(type);
+  return tensorType && isa<QubitType>(tensorType.getElementType());
+}
+
+SmallVector<Value> QCOProgramBuilder::startFunction(StringRef name,
+                                                    TypeRange argTypes,
+                                                    TypeRange resultTypes) {
+  checkFinalized();
+
+  if (SymbolTable::lookupSymbolIn(module, name) != nullptr) {
+    llvm::reportFatalUsageError("Function with the same name already exists");
+  }
+
+  if (savedInsertionPoint.isSet()) {
+    llvm::reportFatalUsageError(
+        "Cannot start a function while another one is being built");
+  }
+
+  // Defining callees first prevents their bodies from capturing values from
+  // main and removes the need to preserve partially built main state.
+  if (!getInsertionBlock()->empty()) {
+    llvm::reportFatalUsageError(
+        "Functions must be defined before operations in main");
+  }
+  savedInsertionPoint = saveInsertionPoint();
+
+  setInsertionPointToEnd(cast<ModuleOp>(module).getBody());
+  func::FuncOp funcOp =
+      func::FuncOp::create(*this, name, getFunctionType(argTypes, resultTypes));
+  // The interprocedural passes only consider functions that are not externally
+  // visible, so additional functions are private by default.
+  funcOp.setPrivate();
+
+  Block& entryBlock = funcOp.getBody().emplaceBlock();
+  SmallVector<Location> locs(argTypes.size(), getLoc());
+  entryBlock.addArguments(argTypes, locs);
+  setInsertionPointToStart(&entryBlock);
+
+  SmallVector<Value> args;
+  for (BlockArgument arg : entryBlock.getArguments()) {
+    if (isa<QubitType>(arg.getType())) {
+      validQubits.insert(arg);
+    } else if (isQubitTensor(arg.getType())) {
+      // A tensor argument acts like a register the callee owns for the
+      // duration of the call, so give it its own register id.
+      validTensors.insert(Tensor{arg, tensorCounter++});
+    }
+    args.emplace_back(arg);
+  }
+
+  return args;
+}
+
+void QCOProgramBuilder::endFunction(ValueRange returnValues) {
+  checkFinalized();
+
+  if (!savedInsertionPoint.isSet()) {
+    llvm::reportFatalUsageError(
+        "endFunction() called without a matching startFunction()");
+  }
+
+  func::FuncOp funcOp = cast<func::FuncOp>(getInsertionBlock()->getParentOp());
+  if (!llvm::equal(returnValues.getTypes(), funcOp.getResultTypes())) {
+    llvm::reportFatalUsageError(
+        "Return values do not match the declared function result types");
+  }
+
+  for (Value value : returnValues) {
+    if (isa<QubitType>(value.getType())) {
+      validateQubitValue(value);
+      validQubits.erase(value);
+    } else if (isQubitTensor(value.getType())) {
+      validateTensorValue(value);
+      validTensors.erase(value);
+    }
+  }
+
+  // Only values created inside the function are tracked at this point, so
+  // anything left over has escaped.
+  if (!validQubits.empty()) {
+    llvm::reportFatalUsageError(
+        "Function body has qubit values that are neither returned nor "
+        "consumed");
+  }
+  if (!validTensors.empty()) {
+    llvm::reportFatalUsageError(
+        "Function body has tensor values that are neither returned nor "
+        "deallocated");
+  }
+
+  func::ReturnOp::create(*this, returnValues);
+
+  OpBuilder::InsertPoint insertionPoint = savedInsertionPoint;
+  savedInsertionPoint = {};
+  restoreInsertionPoint(insertionPoint);
+}
+
+SmallVector<Value> QCOProgramBuilder::call(StringRef callee,
+                                           ValueRange operands) {
+  checkFinalized();
+
+  func::FuncOp funcOp = dyn_cast_or_null<func::FuncOp>(
+      SymbolTable::lookupSymbolIn(module, getStringAttr(callee)));
+  if (!funcOp) {
+    llvm::reportFatalUsageError("Callee not found in module");
+  }
+
+  if (!llvm::equal(operands.getTypes(), funcOp.getArgumentTypes())) {
+    llvm::reportFatalUsageError(
+        "Call operands do not match the declared function argument types");
+  }
+
+  // Re-insert qubits that were extracted from a tensor operand, so the callee
+  // receives a complete register. Every other construct that hands a tensor to
+  // a nested region does the same before building it. Unlike those, a call may
+  // also carry classical operands, so `prepareInitArgs` cannot be used here;
+  // qubits passed alongside their tensor are excluded from the re-insertion.
+  DenseSet<Value> qubitOperandSet;
+  for (Value operand : operands) {
+    if (isa<QubitType>(operand.getType())) {
+      qubitOperandSet.insert(operand);
+    }
+  }
+  SmallVector<Value> preparedOperands;
+  preparedOperands.reserve(operands.size());
+  SmallVector<Value> qubitOperands;
+  SmallVector<Value> tensorOperands;
+  for (Value operand : operands) {
+    Value prepared = isQubitTensor(operand.getType())
+                         ? prepareInitArg(operand, &qubitOperandSet)
+                         : operand;
+    preparedOperands.emplace_back(prepared);
+    if (isa<QubitType>(prepared.getType())) {
+      validateQubitValue(prepared);
+      qubitOperands.emplace_back(prepared);
+    } else if (isQubitTensor(prepared.getType())) {
+      validateTensorValue(prepared);
+      tensorOperands.emplace_back(prepared);
+    }
+  }
+
+  func::CallOp callOp = func::CallOp::create(*this, funcOp, preparedOperands);
+
+  // Thread each qubit operand into the result that continues its wire. The
+  // correspondence is derived from the callee body instead of assumed to be
+  // positional, so a callee that hands its qubits back in a different order
+  // than it takes them is tracked the way it actually behaves.
+  CallQubitMapping qubitMapping;
+  DenseSet<Value> continuedResults;
+  for (Value operand : qubitOperands) {
+    auto resultOr = qubitMapping.getResultForOperand(callOp, operand);
+    if (failed(resultOr)) {
+      llvm::reportFatalUsageError(
+          "Cannot derive linear-value correspondence for callee");
+    }
+    Value result = *resultOr;
+    if (!result) {
+      // The callee keeps this qubit.
+      validQubits.erase(operand);
+      continue;
+    }
+    updateQubitTracking(operand, result);
+    continuedResults.insert(result);
+  }
+  // Qubit tensors are threaded the same way, using the tensor counterpart of
+  // the mapping above.
+  qtensor::CallTensorMapping tensorMapping;
+  for (Value operand : tensorOperands) {
+    auto resultOr = tensorMapping.getResultForOperand(callOp, operand);
+    if (failed(resultOr)) {
+      llvm::reportFatalUsageError(
+          "Cannot derive linear-value correspondence for callee");
+    }
+    Value result = *resultOr;
+    if (!result) {
+      // The callee keeps this tensor.
+      validTensors.erase(operand);
+      continue;
+    }
+    updateTensorTracking(operand, result);
+    continuedResults.insert(result);
+  }
+
+  // Results without a corresponding operand were created by the callee.
+  for (Value result : callOp.getResults()) {
+    if (continuedResults.contains(result)) {
+      continue;
+    }
+    if (isa<QubitType>(result.getType())) {
+      validQubits.insert(result);
+    } else if (isQubitTensor(result.getType())) {
+      validTensors.insert(Tensor{result, tensorCounter++});
+    }
+  }
+
+  return SmallVector<Value>(callOp.getResults());
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -323,6 +323,155 @@ TEST_F(QCOTest, BuilderSupportsIndependentClassicalRegisterInitialization) {
       "undefined");
 }
 
+TEST_F(QCOTest, BuilderSupportsAdditionalFunctions) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  Type qubitType = builder.getQubitType();
+
+  SmallVector<Value> args =
+      builder.startFunction("thread", {qubitType}, {qubitType});
+  builder.endFunction({builder.h(args[0])});
+
+  Value qubit = builder.allocQubit();
+  Value tensor = builder.qtensorAlloc(2);
+  SmallVector<Value> results = builder.call("thread", {qubit});
+  builder.sink(results[0]);
+  builder.qtensorDealloc(tensor);
+  EXPECT_TRUE(builder.finalize());
+}
+
+TEST_F(QCOTest, BuilderTracksKeptAndCreatedLinearValues) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  Type qubitType = builder.getQubitType();
+  Type tensorType = builder.getQubitTensorType(2);
+
+  SmallVector<Value> args = builder.startFunction(
+      "replace", {qubitType, tensorType}, {qubitType, tensorType});
+  builder.sink(args[0]);
+  builder.qtensorDealloc(args[1]);
+  builder.endFunction({builder.allocQubit(), builder.qtensorAlloc(2)});
+
+  Value qubit = builder.allocQubit();
+  Value tensor = builder.qtensorAlloc(2);
+  SmallVector<Value> results = builder.call("replace", {qubit, tensor});
+  builder.sink(results[0]);
+  builder.qtensorDealloc(results[1]);
+  EXPECT_TRUE(builder.finalize());
+}
+
+TEST_F(QCOTest, BuilderRejectsInvalidFunctionStateAndSymbols) {
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        Type qubitType = builder.getQubitType();
+        builder.startFunction("f", {qubitType}, {qubitType});
+        builder.startFunction("g", {qubitType}, {qubitType});
+      },
+      "Cannot start a function while another one is being built");
+
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        builder.endFunction({});
+      },
+      "endFunction\\(\\) called without a matching startFunction\\(\\)");
+
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        builder.call("does_not_exist", {});
+      },
+      "Callee not found in module");
+
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        Type qubitType = builder.getQubitType();
+        SmallVector<Value> args =
+            builder.startFunction("f", {qubitType}, {qubitType});
+        builder.call("f", {args[0]});
+      },
+      "Cannot derive linear-value correspondence for callee");
+
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        Type qubitType = builder.getQubitType();
+        SmallVector<Value> args =
+            builder.startFunction("f", {qubitType}, {qubitType});
+        builder.endFunction({args[0]});
+        builder.startFunction("f", {qubitType}, {qubitType});
+      },
+      "Function with the same name already exists");
+
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        builder.allocQubit();
+        Type qubitType = builder.getQubitType();
+        builder.startFunction("f", {qubitType}, {qubitType});
+      },
+      "Functions must be defined before operations in main");
+}
+
+TEST_F(QCOTest, BuilderRejectsInvalidFunctionValues) {
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        Type qubitType = builder.getQubitType();
+        SmallVector<Value> args =
+            builder.startFunction("f", {qubitType}, {qubitType});
+        auto measured = builder.measure(args[0]);
+        builder.sink(measured.first);
+        builder.endFunction({measured.second});
+      },
+      "Return values do not match the declared function result types");
+
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        Type qubitType = builder.getQubitType();
+        SmallVector<Value> args =
+            builder.startFunction("f", {qubitType}, {qubitType});
+        builder.endFunction({args[0]});
+        builder.call("f", {builder.floatConstant(0.5)});
+      },
+      "Call operands do not match the declared function argument types");
+
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        Type qubitType = builder.getQubitType();
+        SmallVector<Value> args =
+            builder.startFunction("f", {qubitType}, {qubitType});
+        builder.allocQubit();
+        builder.endFunction({args[0]});
+      },
+      "neither returned nor consumed");
+
+  EXPECT_DEATH(
+      {
+        QCOProgramBuilder builder(context.get());
+        builder.initialize();
+        Type qubitType = builder.getQubitType();
+        SmallVector<Value> args =
+            builder.startFunction("f", {qubitType}, {qubitType});
+        builder.qtensorAlloc(2);
+        builder.endFunction({args[0]});
+      },
+      "neither returned nor deallocated");
+}
+
 TEST_F(QCOTest, DirectSingleQubitPowBuilder) {
   QCOProgramBuilder builder(context.get());
   builder.initialize();


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Third of a stack replacing #1970. Builds on #2194.

`startFunction` and `endFunction` build private helper functions, while `call`
emits calls to them and transfers the builder's linear-value tracking across
the boundary.

Helper functions must be completed before operations are added to `main`. No
production consumer in this stack needs to suspend a partially built `main`, so
this ordering rule replaces copied caller tracking sets and a function-scope
abstraction with one saved insertion point. It also prevents helper bodies from
capturing values created in `main`.

At a call, qubit and qubit-tensor operands are paired with the results that
actually continue them using the mappings from #2194. Values kept by the callee
are consumed, results without a continuing operand are newly tracked, and
classical values pass through without linear tracking. Unsupported callee
shapes fail closed.

### Simplification audit

The Ponytail review combined operand preparation and validation, unified result
tracking, removed duplicated function-scope state, and deleted a tensor-swap
test that could not distinguish derived from positional pairing. The focused
tests retain each observable success and failure contract.

### Testing

- 9 builder-focused tests pass.
- All 492 QCO IR tests pass.
- The release build and all 3,923 configured tests pass on the final stack, with
  one expected skip.
- `uvx nox -s cpp-lint` and `uvx nox -s lint` pass.

### AI assistance

Code and this description were produced with Claude Code (Opus 5) and Codex,
acting on my instructions and within the scope I authorized.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
