### PR TITLE
✨ Prove affine OpenQASM quantum indices

### DIFF
--- a/.agent/plans/openqasm-affine-quantum-indices.md
+++ b/.agent/plans/openqasm-affine-quantum-indices.md
@@ -45,6 +45,12 @@ index before MLIR emission. A user can compile the loop from issue #2188 to
   test skipped under its own condition.
 - [x] (2026-08-20 23:15Z) Published draft pull request #2203 from the signed
   rebased branch and linked the changelog entry to the pull request.
+- [x] (2026-08-21 22:13Z) Restored compile-time normalization of constant
+  negative indices, restricted aliases to `const` values, and charged the
+  distinctness budget only for Presburger queries.
+- [x] (2026-08-21 22:27Z) Passed the 169 OpenQASM and 126 compiler tests in
+      debug and release builds, the reported Clang-Tidy check, repository lint,
+      and a second Ponytail review with no further findings.
 
 ## Surprises & Discoveries
 
@@ -73,6 +79,16 @@ index before MLIR emission. A user can compile the loop from issue #2188 to
 - Observation: Pairwise Presburger checks run before emitter resource checks.
   Wide affine barriers and broadcast gate calls therefore need their own
   semantic comparison limit.
+- Observation: Mutable scalar aliases can retain runtime `i64` arithmetic after
+  the semantic analyzer accepts the captured affine initializer. Evidence: the
+  source `int x = i + 1; h q[x];` failed `jeff` emission because
+  `jeff.int_binary_op` requires the same operand and result types.
+- Observation: The distinctness counter charged constant differences before the
+  no-solver fast path. A broadcast of one proven operand pair could exhaust the
+  budget even though each comparison was constant.
+- Observation: OpenQASM defines constant negative indices relative to the end of
+  a register. Compile-time normalization preserves that source behavior without
+  runtime guards.
 
 ## Decision Log
 
@@ -97,18 +113,19 @@ index before MLIR emission. A user can compile the loop from issue #2188 to
   loop. Rationale: generation checks alone see only the first source-order
   iteration and could accept an index that is unsafe after the back edge.
   Date/Author: 2026-08-20, Codex.
-- Decision: Store each scalar alias as the affine value captured by its
-  initializer, guarded by the alias's generation. Rationale: later changes to an
-  initializer dependency do not change the already assigned scalar value.
-  Date/Author: 2026-08-20, Codex.
+- Decision: Admit direct affine expressions and `const` aliases, but reject
+  mutable scalar aliases in quantum indices. Rationale: the emitter cannot
+  recover a mutable alias's affine initializer without more typed state, while a
+  direct expression or `const` declaration has the required compile-time form.
+  Date/Author: 2026-08-21, Codex.
 - Decision: Use direct positive-range lowering for mixed signed and unsigned
   endpoints only when every signed endpoint is proven nonnegative. Rationale:
   this condition makes unsigned promotion value-preserving; otherwise generic
   lowering retains the source semantics. Date/Author: 2026-08-20, Codex.
-- Decision: Limit each barrier or gate call to 1,024 affine distinctness
-  comparisons and resolve constant differences without a solver call. Rationale:
-  source limits permit wide operand lists, and semantic proof runs before
-  emitter budgeting. Date/Author: 2026-08-20, Codex.
+- Decision: Limit each barrier or gate call to 1,024 affine distinctness solver
+  queries and resolve constant differences without charging the limit.
+  Rationale: source limits permit wide operand lists, but repeated constant
+  proofs do not consume Presburger resources. Date/Author: 2026-08-21, Codex.
 
 ## Outcomes & Retrospective
 
@@ -117,7 +134,7 @@ domains and rejects unproved bounds or operand distinctness. The emitter is four
 lines smaller than before this work: it directly emits proven `index` arithmetic
 and no longer emits quantum bounds, wrapping, or distinctness guards. The
 semantic analyzer is larger because it owns the source-level proof, including
-exact relational domains, overflow checks, captured aliases, and loop-back-edge
+exact relational domains, overflow checks, `const` aliases, and loop-back-edge
 mutation safety. Interval bounds or source-order generation checks would not
 cover the required triangular and `j - step` benchmark shapes.
 
@@ -150,16 +167,16 @@ The semantic analyzer will prove a quantum index by showing that adding either
 `index < 0` or `index >= width` makes the active domain empty. It will prove
 same-register operands distinct by showing that adding `left == right` makes the
 domain empty. It will also prove every supported arithmetic node fits the signed
-64-bit representation emitted by this frontend. Scalar aliases remain usable
-only while their own generation matches the value captured at initialization. A
-pre-scan excludes scalars assigned anywhere in a repeating loop so that the
-proof remains valid after the loop back edge.
+64-bit representation emitted by this frontend. The analyzer folds `const`
+aliases before it builds an affine form. A pre-scan excludes scalars assigned
+anywhere in a repeating loop so that the proof remains valid after the loop back
+edge.
 
 ## Plan of Work
 
 Add a small private affine-expression representation and active-domain state to
 `OpenQASMSemantics.cpp`. Build forms for integer constants, active induction
-variables, valid immutable aliases, negation, addition, subtraction, constant
+variables, folded `const` aliases, negation, addition, subtraction, constant
 multiplication, and value-preserving integer casts. Use arbitrary-precision
 coefficients while constructing constraints. Reject unsupported forms only when
 they reach a quantum index or are needed to mark a loop as a proven range.
@@ -168,9 +185,7 @@ During `analyzeFor`, recognize positive constant steps and affine start and stop
 expressions whose direct lowering arithmetic fits signed 64-bit. Append the
 induction variable and its inclusive bounds to the active domain while analyzing
 the body, then restore the outer domain. Mark the resulting typed `ForStatement`
-as a proven positive range. Track scalar initializer expressions as captured
-affine values; assignments invalidate the corresponding fact by advancing the
-existing generation counter. Find loop-body assignments before body analysis so
+as a proven positive range. Find loop-body assignments before body analysis so
 an outer scalar cannot supply a proof that fails on a later iteration.
 
 Rename the optional expression in `QubitReference` from `dynamicIndex` to
@@ -218,12 +233,18 @@ pipeline to `jeff`. Its emitted QC must contain direct qubit loads inside
 `arith.select`. A nested QFT-shaped loop with `j` ranging from `i + 1` through
 the final register index must prove both bounds and operand distinctness. A
 QFT-adder-shaped `j - step` index and reverse `N - 1 - i` index must also pass.
+Constant negative indices must normalize relative to the register width.
 
 Programs with possibly out-of-range, possibly aliased, measurement-derived,
 mutated, nonlinear, or unsupported-step quantum indices must fail semantic
 analysis with a precise diagnostic. Dynamic classical indexing and generic
 runtime loops that do not supply quantum indices must retain their current
 behavior. All existing test suites and lint checks must pass.
+
+Revision note (2026-08-21): The review follow-up removed mutable affine aliases,
+restored constant negative-index normalization, and limited the resource counter
+to actual solver queries. Focused debug and release tests, Clang-Tidy, lint, and
+the follow-up simplicity review passed.
 
 ## Idempotence and Recovery
 

--- a/.agent/plans/openqasm-affine-quantum-indices.md
+++ b/.agent/plans/openqasm-affine-quantum-indices.md
@@ -51,6 +51,12 @@ index before MLIR emission. A user can compile the loop from issue #2188 to
 - [x] (2026-08-21 22:27Z) Passed the 169 OpenQASM and 126 compiler tests in
       debug and release builds, the reported Clang-Tidy check, repository lint,
       and a second Ponytail review with no further findings.
+- [x] (2026-08-22 01:10Z) Replaced mutable-alias rejection with affine scalar
+  data-flow facts, restored the original scalar-index tests, and passed 174
+  OpenQASM tests plus focused standard, adaptive, and `jeff` pipeline tests.
+- [x] (2026-08-22 01:35Z) Passed the 174 OpenQASM and 131 compiler tests,
+      Clang-Tidy for the changed production code, repository lint, and final
+      diff checks.
 
 ## Surprises & Discoveries
 
@@ -79,10 +85,10 @@ index before MLIR emission. A user can compile the loop from issue #2188 to
 - Observation: Pairwise Presburger checks run before emitter resource checks.
   Wide affine barriers and broadcast gate calls therefore need their own
   semantic comparison limit.
-- Observation: Mutable scalar aliases can retain runtime `i64` arithmetic after
-  the semantic analyzer accepts the captured affine initializer. Evidence: the
-  source `int x = i + 1; h q[x];` failed `jeff` emission because
-  `jeff.int_binary_op` requires the same operand and result types.
+- Observation: Rejecting all mutable scalar aliases forced simple constant
+  indices into artificial one-iteration loops. Expanding each proven alias in
+  the typed qubit reference lets dead scalar arithmetic disappear before `jeff`
+  conversion while retaining the original OpenQASM program.
 - Observation: The distinctness counter charged constant differences before the
   no-solver fast path. A broadcast of one proven operand pair could exhaust the
   budget even though each comparison was constant.
@@ -100,10 +106,10 @@ index before MLIR emission. A user can compile the loop from issue #2188 to
   domains. Rationale: bounds and same-register distinctness in triangular loops
   require relational reasoning, while this existing dependency provides exact
   integer checks. Date/Author: 2026-08-20, Codex.
-- Decision: Admit only compile-time positive loop steps into the proven range
-  path and ignore step congruence in the proof domain. Rationale: this is a safe
-  over-approximation that covers the benchmark patterns and keeps lowering to a
-  direct positive-step `scf.for`. Date/Author: 2026-08-20, Codex.
+- Decision: Admit only steps with a known positive integer value into the proven
+  range path and ignore step congruence in the proof domain. Rationale: this is
+  a safe over-approximation that covers the benchmark patterns and keeps
+  lowering to a direct positive-step `scf.for`. Date/Author: 2026-08-22, Codex.
 - Decision: Preserve generic loop and dynamic classical-index behavior.
   Rationale: only quantum-register indexing is optional in the base OpenQASM
   contract, and unrelated runtime behavior is outside issue #2188. Date/Author:
@@ -113,11 +119,11 @@ index before MLIR emission. A user can compile the loop from issue #2188 to
   loop. Rationale: generation checks alone see only the first source-order
   iteration and could accept an index that is unsafe after the back edge.
   Date/Author: 2026-08-20, Codex.
-- Decision: Admit direct affine expressions and `const` aliases, but reject
-  mutable scalar aliases in quantum indices. Rationale: the emitter cannot
-  recover a mutable alias's affine initializer without more typed state, while a
-  direct expression or `const` declaration has the required compile-time form.
-  Date/Author: 2026-08-21, Codex.
+- Decision: Track the current canonical affine expression for each scalar and
+  invalidate that fact on unequal control-flow joins or possible loop mutation.
+  Rationale: this admits known mutable values without treating mutability as
+  runtime uncertainty. Canonical expressions also keep scalar aliases out of the
+  emitter's proven-index path. Date/Author: 2026-08-22, Codex.
 - Decision: Use direct positive-range lowering for mixed signed and unsigned
   endpoints only when every signed endpoint is proven nonnegative. Rationale:
   this condition makes unsigned promotion value-preserving; otherwise generic
@@ -134,9 +140,9 @@ domains and rejects unproved bounds or operand distinctness. The emitter is four
 lines smaller than before this work: it directly emits proven `index` arithmetic
 and no longer emits quantum bounds, wrapping, or distinctness guards. The
 semantic analyzer is larger because it owns the source-level proof, including
-exact relational domains, overflow checks, `const` aliases, and loop-back-edge
-mutation safety. Interval bounds or source-order generation checks would not
-cover the required triangular and `j - step` benchmark shapes.
+exact relational domains, overflow checks, known scalar values, and
+loop-back-edge mutation safety. Interval bounds or source-order generation
+checks would not cover the required triangular and `j - step` benchmark shapes.
 
 The exact issue #2188 program reaches `jeff` without `i128`, `arith.select`, or
 `cf.assert`. PR #2135 remained at the audited head and no benchmark source was
@@ -144,7 +150,8 @@ changed. After the rebase, the full release build, 169 OpenQASM tests, all 2,804
 MLIR tests, all 4,301 configured release CTests, and `uvx nox -s lint` passed.
 One QDMI test skipped under its own condition. The first lint run formatted
 changed files; the second run passed without edits. Draft pull request #2203
-contains the signed result.
+contains the signed result. The later scalar-fact revision passed 174 OpenQASM
+tests and all 131 compiler tests, including an affine alias through `jeff`.
 
 ## Context and Orientation
 
@@ -160,23 +167,23 @@ An affine expression is a constant plus integer coefficients multiplied by
 active loop induction variables. A Presburger domain is a set of integer
 solutions to linear equalities and inequalities. For an inclusive OpenQASM range
 `[lower:step:upper]`, this work records `lower <= induction <= upper` when
-`step` is a positive compile-time integer. Omitting the step's congruence class
+`step` has a known positive integer value. Omitting the step's congruence class
 adds possible values, so a property proved over this larger set is still safe.
 
 The semantic analyzer will prove a quantum index by showing that adding either
 `index < 0` or `index >= width` makes the active domain empty. It will prove
 same-register operands distinct by showing that adding `left == right` makes the
 domain empty. It will also prove every supported arithmetic node fits the signed
-64-bit representation emitted by this frontend. The analyzer folds `const`
-aliases before it builds an affine form. A pre-scan excludes scalars assigned
-anywhere in a repeating loop so that the proof remains valid after the loop back
-edge.
+64-bit representation emitted by this frontend. The analyzer tracks canonical
+affine expressions for scalar values and merges only equal facts across control
+flow. A pre-scan excludes scalars assigned anywhere in a repeating loop so that
+the proof remains valid after the loop back edge.
 
 ## Plan of Work
 
 Add a small private affine-expression representation and active-domain state to
 `OpenQASMSemantics.cpp`. Build forms for integer constants, active induction
-variables, folded `const` aliases, negation, addition, subtraction, constant
+variables, known scalar values, negation, addition, subtraction, constant
 multiplication, and value-preserving integer casts. Use arbitrary-precision
 coefficients while constructing constraints. Reject unsupported forms only when
 they reach a quantum index or are needed to mark a loop as a proven range.
@@ -204,8 +211,8 @@ index path for classical bits and the existing generic loop path intact.
 Add semantic tests for accepted and rejected expressions, emitter tests for the
 shape of issue #2188 and nested benchmark patterns, and an in-process compiler
 pipeline regression that produces a `JeffProgram`. Update the documented
-OpenQASM subset, `UPGRADING.md`, and `CHANGELOG.md` without editing generated or
-template-managed files.
+OpenQASM subset and the existing OpenQASM `CHANGELOG.md` entry without editing
+generated or template-managed files.
 
 ## Concrete Steps
 
@@ -235,16 +242,22 @@ the final register index must prove both bounds and operand distinctness. A
 QFT-adder-shaped `j - step` index and reverse `N - 1 - i` index must also pass.
 Constant negative indices must normalize relative to the register width.
 
-Programs with possibly out-of-range, possibly aliased, measurement-derived,
-mutated, nonlinear, or unsupported-step quantum indices must fail semantic
-analysis with a precise diagnostic. Dynamic classical indexing and generic
-runtime loops that do not supply quantum indices must retain their current
-behavior. All existing test suites and lint checks must pass.
+Programs with possibly out-of-range, measurement-derived, nonlinear, mutated
+loop-carried, unequally merged, or unsupported-step quantum indices must fail
+semantic analysis with a precise diagnostic. Dynamic classical indexing and
+generic runtime loops that do not supply quantum indices must retain their
+current behavior. All existing test suites and lint checks must pass.
 
 Revision note (2026-08-21): The review follow-up removed mutable affine aliases,
 restored constant negative-index normalization, and limited the resource counter
 to actual solver queries. Focused debug and release tests, Clang-Tidy, lint, and
 the follow-up simplicity review passed.
+
+Revision note (2026-08-22): The scalar-fact follow-up restored the original
+mutable scalar programs without runtime quantum guards. It canonicalizes proven
+aliases before emission and invalidates facts at uncertain joins and loop back
+edges. The upgrade-guide fragment was removed, and the changelog text was folded
+into the existing OpenQASM entry.
 
 ## Idempotence and Recovery
 

--- a/.agent/plans/openqasm-affine-quantum-indices.md
+++ b/.agent/plans/openqasm-affine-quantum-indices.md
@@ -1,0 +1,235 @@
+# Prove affine OpenQASM quantum indices
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+OpenQASM 3 permits an implementation to reject quantum-register indices that are
+not compile-time constants. MQT Core currently accepts arbitrary runtime indices
+and emits bounds, negative-index, overflow, and operand-distinctness guards.
+Those guards prevent simple structured programs from lowering to `jeff`. After
+this change, MQT Core accepts a larger-than-required but precisely defined
+subset: constants and integer affine expressions whose safety follows from
+enclosing positive-step `for` ranges. The frontend rejects every other quantum
+index before MLIR emission. A user can compile the loop from issue #2188 to
+`jeff`, and benchmark-shaped triangular loops such as QFT retain direct
+`scf.for` structure without runtime guard scaffolding.
+
+## Progress
+
+- [x] (2026-08-20 15:44Z) Refreshed PR #2135 and confirmed its head remains
+  `5d8eb8f26ba8c99ef94d1dace9d47429d27b8a16`.
+- [x] (2026-08-20 15:44Z) Inspected the semantic analyzer, emitter, tests, and
+  installed MLIR Presburger API.
+- [x] (2026-08-20 16:27Z) Added the affine proof context and typed-frontend
+  invariants.
+- [x] (2026-08-20 16:41Z) Removed quantum runtime guards and directly lowered
+  proven positive ranges.
+- [x] (2026-08-20 17:06Z) Added acceptance, rejection, structural, and
+  end-to-end regressions.
+- [x] (2026-08-20 17:13Z) Updated user-facing documentation and migration notes.
+- [x] (2026-08-20 17:48Z) Passed focused tests, all 2,789 MLIR tests, the full
+  release build, lint, and final diff checks.
+- [x] (2026-08-20 22:59Z) Audited merged PRs #2150, #2189, and #2202, then
+  rebased the work onto `0c50dd30815638517aa159d20e78290cd449323e`.
+- [x] (2026-08-20 23:05Z) Completed a read-only review-agent pass and fixed its
+  mixed-range correctness and affine-proof resource findings.
+- [x] (2026-08-20 23:12Z) Passed the full release build, all 2,804 MLIR tests,
+  169 OpenQASM tests, the issue-to-`jeff` regression, lint, and diff checks.
+- [x] (2026-08-20 23:13Z) Passed all 4,301 configured release CTests; one QDMI
+  test skipped under its own condition.
+- [x] (2026-08-20 23:15Z) Published draft pull request #2203 from the signed
+  rebased branch and linked the changelog entry to the pull request.
+
+## Surprises & Discoveries
+
+- Observation: The existing constant-range `scf.for` path still reconstructs its
+  source induction value with `i128` multiply and add operations. Evidence:
+  `OpenQASMToQCEmitter.cpp` creates `counterWide`, `offset`, and `inductionWide`
+  in `emitFor`. The direct positive-range path must replace this code as well as
+  the quantum-index guards.
+- Observation: PR #2135 constructs QC modules directly, but QFT-shaped source
+  requires relational constraints such as `j >= i + 1`. Independent intervals
+  cannot prove that `q[j]` and `q[i]` differ.
+- Observation: An access before an assignment in a repeating loop is not safe on
+  later iterations. The semantic analyzer must find loop mutations before it
+  analyzes the first iteration.
+- Observation: Emitting proven loop arithmetic as `i64` still left index
+  materialization that the `jeff` pipeline could not accept. Emitting the affine
+  expression in MLIR's `index` type removes that conversion while an `i64` view
+  remains available to ordinary scalar consumers.
+- Observation: Existing compiler fixtures classified arbitrary runtime quantum
+  indices as accepted input. The new frontend contract makes those fixtures
+  semantic-rejection cases and moves the induction-index fixture into the
+  `jeff`-compatible set.
+- Observation: Mixed signed and unsigned range endpoints use unsigned comparison
+  semantics. A direct signed-index loop is valid only when signed endpoints are
+  proven nonnegative.
+- Observation: Pairwise Presburger checks run before emitter resource checks.
+  Wide affine barriers and broadcast gate calls therefore need their own
+  semantic comparison limit.
+
+## Decision Log
+
+- Decision: Place all proof state in `OpenQASMSemantics.cpp` and expose only
+  proof results through the typed OpenQASM frontend data. Rationale: OpenQASM
+  owns the optional quantum-index extension; QC and QCO must remain independent
+  of source-language policy. Date/Author: 2026-08-20, Codex.
+- Decision: Use `MLIRPresburger` integer emptiness checks over affine loop
+  domains. Rationale: bounds and same-register distinctness in triangular loops
+  require relational reasoning, while this existing dependency provides exact
+  integer checks. Date/Author: 2026-08-20, Codex.
+- Decision: Admit only compile-time positive loop steps into the proven range
+  path and ignore step congruence in the proof domain. Rationale: this is a safe
+  over-approximation that covers the benchmark patterns and keeps lowering to a
+  direct positive-step `scf.for`. Date/Author: 2026-08-20, Codex.
+- Decision: Preserve generic loop and dynamic classical-index behavior.
+  Rationale: only quantum-register indexing is optional in the base OpenQASM
+  contract, and unrelated runtime behavior is outside issue #2188. Date/Author:
+  2026-08-20, Codex.
+- Decision: Scan each repeating loop body for assignments before semantic
+  analysis and exclude those scalar symbols from affine facts throughout that
+  loop. Rationale: generation checks alone see only the first source-order
+  iteration and could accept an index that is unsafe after the back edge.
+  Date/Author: 2026-08-20, Codex.
+- Decision: Store each scalar alias as the affine value captured by its
+  initializer, guarded by the alias's generation. Rationale: later changes to an
+  initializer dependency do not change the already assigned scalar value.
+  Date/Author: 2026-08-20, Codex.
+- Decision: Use direct positive-range lowering for mixed signed and unsigned
+  endpoints only when every signed endpoint is proven nonnegative. Rationale:
+  this condition makes unsigned promotion value-preserving; otherwise generic
+  lowering retains the source semantics. Date/Author: 2026-08-20, Codex.
+- Decision: Limit each barrier or gate call to 1,024 affine distinctness
+  comparisons and resolve constant differences without a solver call. Rationale:
+  source limits permit wide operand lists, and semantic proof runs before
+  emitter budgeting. Date/Author: 2026-08-20, Codex.
+
+## Outcomes & Retrospective
+
+The frontend now proves affine quantum indices against nested Presburger loop
+domains and rejects unproved bounds or operand distinctness. The emitter is four
+lines smaller than before this work: it directly emits proven `index` arithmetic
+and no longer emits quantum bounds, wrapping, or distinctness guards. The
+semantic analyzer is larger because it owns the source-level proof, including
+exact relational domains, overflow checks, captured aliases, and loop-back-edge
+mutation safety. Interval bounds or source-order generation checks would not
+cover the required triangular and `j - step` benchmark shapes.
+
+The exact issue #2188 program reaches `jeff` without `i128`, `arith.select`, or
+`cf.assert`. PR #2135 remained at the audited head and no benchmark source was
+changed. After the rebase, the full release build, 169 OpenQASM tests, all 2,804
+MLIR tests, all 4,301 configured release CTests, and `uvx nox -s lint` passed.
+One QDMI test skipped under its own condition. The first lint run formatted
+changed files; the second run passed without edits. Draft pull request #2203
+contains the signed result.
+
+## Context and Orientation
+
+`mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp` converts parsed syntax into the
+typed structures declared in `mlir/include/mlir/Target/OpenQASM/Frontend.h`.
+Before this change, quantum-register references carried an optional
+`dynamicIndex` with no static-safety invariant.
+`mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp` then emits runtime
+checks for such references and lowers only fully constant source ranges through
+`scf.for`; other ranges become `scf.while`.
+
+An affine expression is a constant plus integer coefficients multiplied by
+active loop induction variables. A Presburger domain is a set of integer
+solutions to linear equalities and inequalities. For an inclusive OpenQASM range
+`[lower:step:upper]`, this work records `lower <= induction <= upper` when
+`step` is a positive compile-time integer. Omitting the step's congruence class
+adds possible values, so a property proved over this larger set is still safe.
+
+The semantic analyzer will prove a quantum index by showing that adding either
+`index < 0` or `index >= width` makes the active domain empty. It will prove
+same-register operands distinct by showing that adding `left == right` makes the
+domain empty. It will also prove every supported arithmetic node fits the signed
+64-bit representation emitted by this frontend. Scalar aliases remain usable
+only while their own generation matches the value captured at initialization. A
+pre-scan excludes scalars assigned anywhere in a repeating loop so that the
+proof remains valid after the loop back edge.
+
+## Plan of Work
+
+Add a small private affine-expression representation and active-domain state to
+`OpenQASMSemantics.cpp`. Build forms for integer constants, active induction
+variables, valid immutable aliases, negation, addition, subtraction, constant
+multiplication, and value-preserving integer casts. Use arbitrary-precision
+coefficients while constructing constraints. Reject unsupported forms only when
+they reach a quantum index or are needed to mark a loop as a proven range.
+
+During `analyzeFor`, recognize positive constant steps and affine start and stop
+expressions whose direct lowering arithmetic fits signed 64-bit. Append the
+induction variable and its inclusive bounds to the active domain while analyzing
+the body, then restore the outer domain. Mark the resulting typed `ForStatement`
+as a proven positive range. Track scalar initializer expressions as captured
+affine values; assignments invalidate the corresponding fact by advancing the
+existing generation counter. Find loop-body assignments before body analysis so
+an outer scalar cannot supply a proof that fails on a later iteration.
+
+Rename the optional expression in `QubitReference` from `dynamicIndex` to
+`provenIndex`. Resolve every nonconstant quantum index through the affine proof
+before constructing this reference. Check pairwise same-register gate and
+explicit barrier operands during semantic analysis. Unprovable accesses report
+clear source diagnostics and never enter the typed program.
+
+In `OpenQASMToQCEmitter.cpp`, emit a proven affine integer expression without
+the generic signed-overflow checks. Use this path for proven quantum indices and
+proven positive loop endpoints. Lower such source loops directly to `scf.for`
+with an exclusive upper bound of `stop + 1`. Remove quantum bounds and
+distinctness assertions and revise preflight emission costs. Leave the checked
+index path for classical bits and the existing generic loop path intact.
+
+Add semantic tests for accepted and rejected expressions, emitter tests for the
+shape of issue #2188 and nested benchmark patterns, and an in-process compiler
+pipeline regression that produces a `JeffProgram`. Update the documented
+OpenQASM subset, `UPGRADING.md`, and `CHANGELOG.md` without editing generated or
+template-managed files.
+
+## Concrete Steps
+
+From the repository root, edit the frontend header, semantic analyzer, emitter,
+their CMake dependency lists, and the matching OpenQASM and compiler tests. Run
+the narrow test binaries after building them:
+
+    cmake --build --preset release --target mqt-core-mlir-unittest-openqasm-target
+    ./build/release/mlir/unittests/Target/OpenQASM/mqt-core-mlir-unittest-openqasm-target
+    cmake --build --preset release --target mqt-core-mlir-unittests-compiler
+    ./build/release/mlir/unittests/Compiler/mqt-core-mlir-unittests-compiler
+
+After focused tests pass, run:
+
+    cmake --build --preset release
+    ctest --test-dir build/release/mlir --output-on-failure
+    uvx nox -s lint
+    git diff --check
+
+## Validation and Acceptance
+
+The issue #2188 source must analyze, verify as QC, and pass the default compiler
+pipeline to `jeff`. Its emitted QC must contain direct qubit loads inside
+`scf.for` and no `i128`, quantum-index `cf.assert`, or negative-index
+`arith.select`. A nested QFT-shaped loop with `j` ranging from `i + 1` through
+the final register index must prove both bounds and operand distinctness. A
+QFT-adder-shaped `j - step` index and reverse `N - 1 - i` index must also pass.
+
+Programs with possibly out-of-range, possibly aliased, measurement-derived,
+mutated, nonlinear, or unsupported-step quantum indices must fail semantic
+analysis with a precise diagnostic. Dynamic classical indexing and generic
+runtime loops that do not supply quantum indices must retain their current
+behavior. All existing test suites and lint checks must pass.
+
+## Idempotence and Recovery
+
+All edits and tests are local and repeatable. Build output stays under `build/`.
+No remote state is changed. If a proof rule proves too little, add a focused
+failing test before extending that rule; do not restore runtime quantum guards.
+If Presburger integration proves unsuitable, keep the typed-interface and test
+changes isolated until the proof implementation is replaced, and record the
+reason in this plan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,9 @@ releases may include breaking changes.
   [#1787], [#1815], [#1823], [#1933], [#1978], [#1979], [#2007], [#2026],
   [#2030], [#2066]) ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
   [**@li-mingbao**], [**@DRovara**], [**@MatthiasReumann**])
-- ✨ Add OpenQASM import and export to the MQT Compiler Collection ([#1910],
-  [#1987], [#1994], [#2003], [#2026], [#2169]) ([**@burgholzer**],
+- ✨ Add OpenQASM import and export to the MQT Compiler Collection, including
+  fixed-angle constants and proven affine quantum-register indices ([#1910],
+  [#1987], [#1994], [#2003], [#2026], [#2169], [#2203]) ([**@burgholzer**],
   [**@denialhaag**])
 
 #### Passes and transformations
@@ -82,9 +83,6 @@ releases may include breaking changes.
 
 ### Changed
 
-- 💥 Require semantic proof for nonconstant OpenQASM quantum-register indices
-  and lower proven affine loops without runtime quantum-index guards ([#2203])
-  ([**@burgholzer**], [**@denialhaag**])
 - 💥 Prune dead and misleading CoreIR APIs and remove random-number generator
   state from `QuantumComputation` ([#2111], [#2112]) ([**@simon1hofmann**])
 - 💥 Update QIR execution for QIR 2.1, isolated runtimes, reproducible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ releases may include breaking changes.
 
 ### Changed
 
+- 💥 Require semantic proof for nonconstant OpenQASM quantum-register indices
+  and lower proven affine loops without runtime quantum-index guards ([#2203])
+  ([**@burgholzer**], [**@denialhaag**])
 - 💥 Prune dead and misleading CoreIR APIs and remove random-number generator
   state from `QuantumComputation` ([#2111], [#2112]) ([**@simon1hofmann**])
 - 💥 Update QIR execution for QIR 2.1, isolated runtimes, reproducible
@@ -787,6 +790,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2203]: https://github.com/munich-quantum-toolkit/core/pull/2203
 [#2175]: https://github.com/munich-quantum-toolkit/core/pull/2175
 [#2169]: https://github.com/munich-quantum-toolkit/core/pull/2169
 [#2168]: https://github.com/munich-quantum-toolkit/core/pull/2168

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,19 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### OpenQASM quantum-register indices
+
+The OpenQASM importer no longer wraps negative qubit indices or emits runtime
+bounds and distinctness assertions for nonconstant qubit indices. It accepts a
+nonconstant qubit index only when semantic analysis proves its bounds and, for
+multi-qubit gates and explicit barriers, proves that all operands are distinct.
+
+Use positive constant-step `for` loops and affine index expressions over their
+induction variables. Constants and unmodified scalar aliases are also supported.
+Move data-dependent indexing to classical bit registers or rewrite the program
+if a qubit index depends on a measurement, mutation, branch fact, nonlinear
+expression, or unsupported range step.
+
 ### Program serialization for QDMI Qiskit backends
 
 The Qiskit backend no longer decides in its own code how to turn a circuit into

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,15 +8,16 @@ of changes including minor and patch releases, please refer to the
 
 ### OpenQASM quantum-register indices
 
-The OpenQASM importer no longer wraps negative qubit indices or emits runtime
+The OpenQASM importer still normalizes constant negative qubit indices at
+compile time. It no longer wraps nonconstant negative indices or emits runtime
 bounds and distinctness assertions for nonconstant qubit indices. It accepts a
 nonconstant qubit index only when semantic analysis proves its bounds and, for
 multi-qubit gates and explicit barriers, proves that all operands are distinct.
 
 Use positive constant-step `for` loops and affine index expressions over their
-induction variables. Constants and unmodified scalar aliases are also supported.
-Move data-dependent indexing to classical bit registers or rewrite the program
-if a qubit index depends on a measurement, mutation, branch fact, nonlinear
+induction variables. Constants and `const` aliases are also supported. Move
+data-dependent indexing to classical bit registers or rewrite the program if a
+qubit index depends on a measurement, mutation, branch fact, nonlinear
 expression, or unsupported range step.
 
 ### Program serialization for QDMI Qiskit backends

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,20 +6,6 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
-### OpenQASM quantum-register indices
-
-The OpenQASM importer still normalizes constant negative qubit indices at
-compile time. It no longer wraps nonconstant negative indices or emits runtime
-bounds and distinctness assertions for nonconstant qubit indices. It accepts a
-nonconstant qubit index only when semantic analysis proves its bounds and, for
-multi-qubit gates and explicit barriers, proves that all operands are distinct.
-
-Use positive constant-step `for` loops and affine index expressions over their
-induction variables. Constants and `const` aliases are also supported. Move
-data-dependent indexing to classical bit registers or rewrite the program if a
-qubit index depends on a measurement, mutation, branch fact, nonlinear
-expression, or unsupported range step.
-
 ### Program serialization for QDMI Qiskit backends
 
 The Qiskit backend no longer decides in its own code how to turn a circuit into

--- a/docs/mlir/OpenQASM.md
+++ b/docs/mlir/OpenQASM.md
@@ -66,18 +66,20 @@ angle inputs or outputs are not supported.
 The frontend accepts a nonconstant qubit index only when it proves that every
 value is in the register and that operands of one gate or explicit barrier are
 distinct. Proven expressions can contain constants, positive constant-step `for`
-induction variables, `const` aliases, negation, addition, subtraction,
+induction variables, known scalar values, negation, addition, subtraction,
 multiplication by an integer constant, and value-preserving `int`/`uint` casts.
-A nested loop bound can use proven induction variables from enclosing loops. The
-proof treats an inclusive range as its full interval and does not use the step's
-congruence.
+Assignments and control-flow joins preserve a scalar value only while its affine
+form remains known. A nested loop bound can use proven induction variables from
+enclosing loops. The proof treats an inclusive range as its full interval and
+does not use the step's congruence.
 
 The frontend normalizes constant negative indices relative to the register
-width. It rejects mutable or measurement-derived indices, nonconstant negative
-indices, nonlinear expressions, unsupported integer operators, and ranges with a
-nonconstant or nonpositive step when their induction variable reaches a qubit
-index. Branch conditions do not add proof facts. Classical bit indexing and
-loops that do not index qubits keep their runtime behavior.
+width. It rejects measurement-derived values, nonconstant negative indices,
+nonlinear expressions, unsupported integer operators, and ranges whose step is
+not known to be positive when their induction variable reaches a qubit index.
+Mutations in repeating loops and unequal branch values invalidate scalar facts.
+Branch conditions do not add proof facts. Classical bit indexing and loops that
+do not index qubits keep their runtime behavior.
 
 Bit registers use `!cbit.reg<N>` in QC. OpenQASM 2 initializes each register to
 zero. OpenQASM 3 leaves each register undefined until a statement writes it.

--- a/docs/mlir/OpenQASM.md
+++ b/docs/mlir/OpenQASM.md
@@ -44,11 +44,11 @@ mqt-cc --input-format=qasm program.txt
 | Quantum statements         | Measurement, reset, barrier, logical qubits, and physical qubits are supported. The QC target rejects programs that mix logical allocation with physical qubits.                                                                                      |
 | Expressions                | Scalar arithmetic, comparisons, Boolean expressions, and the supported math functions are type checked before translation. `popcount`, `rotl`, and `rotr` operate on initialized bit registers.                                                       |
 | Structured control         | `if`, inclusive `for`, `while`, and `switch` lower to SCF operations. Switch controls and case labels must be integers; labels must be unique constant expressions.                                                                                   |
-| Dynamic indexing           | Dynamic qubit and bit indices are supported on input. The generated QC includes bounds checks and structured dispatch where needed.                                                                                                                   |
+| Dynamic indexing           | Classical bit indices can be dynamic and receive runtime bounds checks. A nonconstant qubit index must be a proven affine expression as described below.                                                                                              |
 | Unsupported language areas | Subroutines, `extern`, calibration and timing constructs, input declarations, arbitrary arrays, `break`, and `continue` are diagnosed.                                                                                                                |
 
 Syntax and semantic diagnostics retain source locations and include stacks.
-Runtime integer preconditions and dynamic-index bounds are represented
+Runtime integer preconditions and classical-index bounds are represented
 explicitly in QC. This safety machinery is supported by the normal compiler and
 QIR paths, but it is intentionally outside the export subset described below.
 
@@ -62,6 +62,21 @@ and `sin`, `cos`, and `tan`. Mixed-width angle operands promote to the wider
 width. It uses round-to-nearest, ties-to-even for float conversion and
 narrowing. Runtime angle state, reassignment, bit-level angle operations, and
 angle inputs or outputs are not supported.
+
+The frontend accepts a nonconstant qubit index only when it proves that every
+value is in the register and that operands of one gate or explicit barrier are
+distinct. Proven expressions can contain constants, positive constant-step `for`
+induction variables, unmodified scalar aliases, negation, addition, subtraction,
+multiplication by an integer constant, and value-preserving `int`/`uint` casts.
+A nested loop bound can use proven induction variables from enclosing loops. The
+proof treats an inclusive range as its full interval and does not use the step's
+congruence.
+
+The frontend rejects mutable or measurement-derived indices, negative indices,
+nonlinear expressions, unsupported integer operators, and ranges with a
+nonconstant or nonpositive step when their induction variable reaches a qubit
+index. Branch conditions do not add proof facts. Classical bit indexing and
+loops that do not index qubits keep their runtime behavior.
 
 Bit registers use `!cbit.reg<N>` in QC. OpenQASM 2 initializes each register to
 zero. OpenQASM 3 leaves each register undefined until a statement writes it.

--- a/docs/mlir/OpenQASM.md
+++ b/docs/mlir/OpenQASM.md
@@ -66,14 +66,15 @@ angle inputs or outputs are not supported.
 The frontend accepts a nonconstant qubit index only when it proves that every
 value is in the register and that operands of one gate or explicit barrier are
 distinct. Proven expressions can contain constants, positive constant-step `for`
-induction variables, unmodified scalar aliases, negation, addition, subtraction,
+induction variables, `const` aliases, negation, addition, subtraction,
 multiplication by an integer constant, and value-preserving `int`/`uint` casts.
 A nested loop bound can use proven induction variables from enclosing loops. The
 proof treats an inclusive range as its full interval and does not use the step's
 congruence.
 
-The frontend rejects mutable or measurement-derived indices, negative indices,
-nonlinear expressions, unsupported integer operators, and ranges with a
+The frontend normalizes constant negative indices relative to the register
+width. It rejects mutable or measurement-derived indices, nonconstant negative
+indices, nonlinear expressions, unsupported integer operators, and ranges with a
 nonconstant or nonpositive step when their induction variable reaches a qubit
 index. Branch conditions do not add proof facts. Classical bit indexing and
 loops that do not index qubits keep their runtime behavior.

--- a/mlir/include/mlir/Target/OpenQASM/Frontend.h
+++ b/mlir/include/mlir/Target/OpenQASM/Frontend.h
@@ -179,7 +179,8 @@ struct QubitReference {
   QubitReferenceKind kind = QubitReferenceKind::Register;
   uint32_t symbol = 0;
   uint64_t index = 0;
-  std::optional<ExpressionId> dynamicIndex;
+  /// A nonconstant register index proven safe by semantic analysis.
+  std::optional<ExpressionId> provenIndex;
 
   bool operator==(const QubitReference&) const = default;
 };
@@ -301,6 +302,9 @@ struct ForStatement {
   ExpressionId start = 0;
   ExpressionId step = 0;
   ExpressionId stop = 0;
+  /// Whether the inclusive range has a positive constant step and all range
+  /// arithmetic is proven to fit the frontend's signed 64-bit index model.
+  bool provenPositiveRange = false;
   std::vector<StatementId> body;
 };
 

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -411,15 +411,13 @@ private:
               : std::get<int64_t>(expression.constant);
       return arith::ConstantIndexOp::create(opBuilder, loc, value);
     }
-    case frontend::ExpressionKind::Variable:
-      if (const auto induction =
-              provenInductionValues.find(expression.variable);
-          induction != provenInductionValues.end()) {
-        return induction->second;
+    case frontend::ExpressionKind::Variable: {
+      const auto induction = provenInductionValues.find(expression.variable);
+      if (induction == provenInductionValues.end()) {
+        llvm_unreachable("proven index refers to an inactive induction");
       }
-      return arith::IndexCastOp::create(opBuilder, loc,
-                                        opBuilder.getIndexType(),
-                                        scalarValues.at(expression.variable));
+      return induction->second;
+    }
     case frontend::ExpressionKind::Cast:
       return emitProvenIndexExpression(opBuilder, expression.lhs);
     case frontend::ExpressionKind::Negate: {
@@ -2365,7 +2363,6 @@ private:
     const auto slots = mutatedState(loop.body);
     const auto initialValues = stateValues(slots);
     const auto savedScalars = scalarValues;
-    const auto savedProvenInductions = provenInductionValues;
 
     if (loop.provenPositiveRange) {
       auto start = emitProvenIndexExpression(builder, loop.start);
@@ -2393,7 +2390,7 @@ private:
         scf::YieldOp::create(builder, stateValues(slots));
       }
       scalarValues = savedScalars;
-      provenInductionValues = savedProvenInductions;
+      provenInductionValues.erase(loop.inductionVariable);
       assignState(slots, forOp.getResults());
       return;
     }

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -191,6 +191,7 @@ private:
   std::vector<Value> qubitValues;
   std::vector<Value> classicalRegisters;
   std::vector<Value> scalarValues;
+  llvm::DenseMap<frontend::ScalarId, Value> provenInductionValues;
   mutable std::vector<std::optional<size_t>> expressionEmissionCosts;
   mutable std::vector<std::optional<size_t>> bitVectorExpressionEmissionCosts;
   DenseMap<const oq3::frontend::GateDefinition*, bool>
@@ -396,6 +397,57 @@ private:
     llvm_unreachable("unknown scalar expression kind");
   }
 
+  Value emitProvenIndexExpression(OpBuilder& opBuilder,
+                                  const frontend::ExpressionId id) {
+    const auto& expression = program.expressions.at(id);
+    auto loc = opBuilder.getInsertionPoint() == opBuilder.getBlock()->end()
+                   ? opBuilder.getUnknownLoc()
+                   : opBuilder.getInsertionPoint()->getLoc();
+    switch (expression.kind) {
+    case frontend::ExpressionKind::Constant: {
+      const auto value =
+          expression.type == frontend::ScalarType::Uint
+              ? static_cast<int64_t>(std::get<uint64_t>(expression.constant))
+              : std::get<int64_t>(expression.constant);
+      return arith::ConstantIndexOp::create(opBuilder, loc, value);
+    }
+    case frontend::ExpressionKind::Variable:
+      if (const auto induction =
+              provenInductionValues.find(expression.variable);
+          induction != provenInductionValues.end()) {
+        return induction->second;
+      }
+      return arith::IndexCastOp::create(opBuilder, loc,
+                                        opBuilder.getIndexType(),
+                                        scalarValues.at(expression.variable));
+    case frontend::ExpressionKind::Cast:
+      return emitProvenIndexExpression(opBuilder, expression.lhs);
+    case frontend::ExpressionKind::Negate: {
+      auto zero = arith::ConstantIndexOp::create(opBuilder, loc, 0);
+      auto operand = emitProvenIndexExpression(opBuilder, expression.lhs);
+      return arith::SubIOp::create(opBuilder, loc, zero, operand);
+    }
+    case frontend::ExpressionKind::Add:
+    case frontend::ExpressionKind::Subtract:
+    case frontend::ExpressionKind::Multiply: {
+      auto lhs = emitProvenIndexExpression(opBuilder, expression.lhs);
+      auto rhs = emitProvenIndexExpression(opBuilder, expression.rhs);
+      switch (expression.kind) {
+      case frontend::ExpressionKind::Add:
+        return arith::AddIOp::create(opBuilder, loc, lhs, rhs);
+      case frontend::ExpressionKind::Subtract:
+        return arith::SubIOp::create(opBuilder, loc, lhs, rhs);
+      case frontend::ExpressionKind::Multiply:
+        return arith::MulIOp::create(opBuilder, loc, lhs, rhs);
+      default:
+        llvm_unreachable("not a proven affine binary expression");
+      }
+    }
+    default:
+      llvm_unreachable("semantic analysis produced a non-affine expression");
+    }
+  }
+
   [[nodiscard]] size_t bitVectorExpressionEmissionCost(
       const frontend::BitVectorExpressionId id) const {
     if (bitVectorExpressionEmissionCosts[id]) {
@@ -451,67 +503,25 @@ private:
            chargeScaledEmission(11, multiplicity, projectedEmission, source);
   }
 
-  [[nodiscard]] static llvm::SmallDenseSet<frontend::RegisterId, 4>
-  collectDynamicallyIndexedRegisters(
-      const ArrayRef<frontend::QubitReference> references) {
-    llvm::SmallDenseSet<frontend::RegisterId, 4> registers;
-    for (const auto& reference : references) {
-      if (reference.kind == frontend::QubitReferenceKind::Register &&
-          reference.dynamicIndex) {
-        registers.insert(reference.symbol);
-      }
-    }
-    return registers;
-  }
-
   [[nodiscard]] bool
   chargeQubitAccesses(const ArrayRef<frontend::QubitReference> references,
                       const size_t multiplicity, size_t& projectedEmission,
                       const oq3::frontend::SourceLocation& source) const {
-    struct RegisterAccessCounts {
-      size_t total = 0;
-      size_t dynamic = 0;
-    };
-    const auto dynamicallyIndexedRegisters =
-        collectDynamicallyIndexedRegisters(references);
-    llvm::DenseMap<frontend::RegisterId, RegisterAccessCounts> priorAccesses;
-
     for (const auto& reference : references) {
       if (reference.kind != frontend::QubitReferenceKind::Register ||
           program.registers.at(reference.symbol).isScalar) {
         continue;
       }
 
-      if (reference.dynamicIndex &&
-          !chargeExpressionEmission(*reference.dynamicIndex, multiplicity,
+      if (reference.provenIndex &&
+          !chargeExpressionEmission(*reference.provenIndex, multiplicity,
                                     projectedEmission, source)) {
         return false;
       }
-      // A static access emits a constant index and a load. A checked dynamic
-      // access additionally normalizes signed negative indices, verifies the
-      // bounds, and casts to the MLIR index type.
-      const size_t accessCost = reference.dynamicIndex ? 12 : 2;
-      if (!chargeScaledEmission(accessCost, multiplicity, projectedEmission,
-                                source)) {
+      /// Each access emits an index value and a load. Semantic analysis has
+      /// already proved a nonconstant index's bounds and uniqueness.
+      if (!chargeScaledEmission(2, multiplicity, projectedEmission, source)) {
         return false;
-      }
-
-      if (!dynamicallyIndexedRegisters.contains(reference.symbol)) {
-        continue;
-      }
-      auto& accesses = priorAccesses[reference.symbol];
-      const auto comparisons =
-          reference.dynamicIndex ? accesses.total : accesses.dynamic;
-      if (comparisons > PROJECTED_EMISSION_LIMIT / 2) {
-        return reportProjectedEmissionLimit(source);
-      }
-      if (!chargeScaledEmission(2 * comparisons, multiplicity,
-                                projectedEmission, source)) {
-        return false;
-      }
-      ++accesses.total;
-      if (reference.dynamicIndex) {
-        ++accesses.dynamic;
       }
     }
     return true;
@@ -624,7 +634,8 @@ private:
           }
         } else if (const auto* loop = std::get_if<oq3::frontend::ForStatement>(
                        &statement.data)) {
-          if (!chargeScaledEmission(16, multiplicity, projectedEmission,
+          const size_t localCost = loop->provenPositiveRange ? 7 : 16;
+          if (!chargeScaledEmission(localCost, multiplicity, projectedEmission,
                                     statement.location) ||
               !chargeExpressionEmission(loop->start, multiplicity,
                                         projectedEmission,
@@ -1484,56 +1495,15 @@ private:
           program.registers.at(reference.symbol).isScalar) {
         continue;
       }
-      if (!reference.dynamicIndex) {
+      if (!reference.provenIndex) {
         indices[position] = arith::ConstantIndexOp::create(
             builder, static_cast<int64_t>(reference.index));
         continue;
       }
-      const auto width =
-          static_cast<int64_t>(program.registers.at(reference.symbol).width);
-      auto checked = emitCheckedIndex(*reference.dynamicIndex, width,
-                                      "dynamic qubit index out of bounds");
       indices[position] =
-          arith::IndexCastOp::create(builder, builder.getIndexType(), checked);
+          emitProvenIndexExpression(builder, *reference.provenIndex);
     }
     return indices;
-  }
-
-  void
-  emitDistinctQubitAssertions(ArrayRef<frontend::QubitReference> references,
-                              ValueRange indices, const StringRef message) {
-    const auto dynamicallyIndexedRegisters =
-        collectDynamicallyIndexedRegisters(references);
-    if (dynamicallyIndexedRegisters.empty()) {
-      return;
-    }
-
-    struct PriorRegisterAccesses {
-      SmallVector<size_t> all;
-      SmallVector<size_t> dynamic;
-    };
-    llvm::DenseMap<frontend::RegisterId, PriorRegisterAccesses> priorAccesses;
-
-    for (const auto [position, reference] : llvm::enumerate(references)) {
-      if (reference.kind != frontend::QubitReferenceKind::Register ||
-          program.registers.at(reference.symbol).isScalar ||
-          !dynamicallyIndexedRegisters.contains(reference.symbol)) {
-        continue;
-      }
-      auto& accesses = priorAccesses[reference.symbol];
-      const ArrayRef<size_t> possibleAliases =
-          reference.dynamicIndex ? accesses.all : accesses.dynamic;
-      for (const auto previousPosition : possibleAliases) {
-        auto distinct =
-            arith::CmpIOp::create(builder, arith::CmpIPredicate::ne,
-                                  indices[previousPosition], indices[position]);
-        cf::AssertOp::create(builder, distinct, message);
-      }
-      accesses.all.push_back(position);
-      if (reference.dynamicIndex) {
-        accesses.dynamic.push_back(position);
-      }
-    }
   }
 
   [[nodiscard]] SmallVector<Value>
@@ -1748,9 +1718,6 @@ private:
       parameters.push_back(parameter);
     }
     const auto qubitIndices = emitQubitIndices(application.qubits);
-    emitDistinctQubitAssertions(
-        application.qubits, qubitIndices,
-        "gate operands must not reference the same qubit");
     SmallVector<int64_t> controlCounts(application.modifiers.size(), 0);
     SmallVector<std::variant<double, Value>> modifierOperands(
         application.modifiers.size());
@@ -2147,9 +2114,6 @@ private:
             }
           } else if constexpr (std::is_same_v<T, frontend::BarrierStatement>) {
             const auto indices = emitQubitIndices(data.qubits);
-            emitDistinctQubitAssertions(
-                data.qubits, indices,
-                "barrier operands must not reference the same qubit");
             builder.barrier(resolveQubits(data.qubits, gateQubits, indices));
           } else if constexpr (std::is_same_v<T, frontend::IfStatement>) {
             emitIf(data, gateParameters, gateQubits);
@@ -2401,6 +2365,38 @@ private:
     const auto slots = mutatedState(loop.body);
     const auto initialValues = stateValues(slots);
     const auto savedScalars = scalarValues;
+    const auto savedProvenInductions = provenInductionValues;
+
+    if (loop.provenPositiveRange) {
+      auto start = emitProvenIndexExpression(builder, loop.start);
+      auto step = emitProvenIndexExpression(builder, loop.step);
+      auto stop = emitProvenIndexExpression(builder, loop.stop);
+      auto exclusiveStop = arith::AddIOp::create(
+          builder, stop, arith::ConstantIndexOp::create(builder, 1));
+      auto forOp = scf::ForOp::create(builder, start, exclusiveStop, step,
+                                      initialValues);
+      {
+        OpBuilder::InsertionGuard guard(builder);
+        auto* body = forOp.getBody();
+        if (!body->empty()) {
+          body->back().erase();
+        }
+        builder.setInsertionPointToEnd(body);
+        scalarValues = savedScalars;
+        assignState(slots, forOp.getRegionIterArgs());
+        provenInductionValues[loop.inductionVariable] = forOp.getInductionVar();
+        scalarValues.at(loop.inductionVariable) = arith::IndexCastOp::create(
+            builder, builder.getI64Type(), forOp.getInductionVar());
+        for (const auto statement : loop.body) {
+          emitStatement(statement, gateParameters, gateQubits);
+        }
+        scf::YieldOp::create(builder, stateValues(slots));
+      }
+      scalarValues = savedScalars;
+      provenInductionValues = savedProvenInductions;
+      assignState(slots, forOp.getResults());
+      return;
+    }
 
     auto start = emitExpression(builder, loop.start, {});
     auto step = emitExpression(builder, loop.step, {});

--- a/mlir/lib/Target/OpenQASM/CMakeLists.txt
+++ b/mlir/lib/Target/OpenQASM/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_library(
   OpenQASMSyntax.cpp
   LINK_LIBS
   LLVMSupport
+  MLIRPresburger
   MLIRQCTranslationSupport)
 
 mqt_mlir_target_use_project_options(MLIROpenQASMFrontend)

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -19,6 +19,7 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/DynamicAPInt.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/StringMap.h>
@@ -27,6 +28,8 @@
 #include <llvm/Support/MathExtras.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
+#include <mlir/Analysis/Presburger/IntegerRelation.h>
+#include <mlir/Analysis/Presburger/PresburgerSpace.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
@@ -55,6 +58,7 @@ constexpr uint64_t TOTAL_REGISTER_ELEMENT_LIMIT = 100'000;
 constexpr size_t EXPRESSION_DEPTH_LIMIT = 256;
 constexpr size_t GATE_DEPENDENCY_DEPTH_LIMIT = 64;
 constexpr size_t TYPED_STATEMENT_LIMIT = 1'000'000;
+constexpr size_t AFFINE_DISTINCTNESS_COMPARISON_LIMIT = 1'024;
 constexpr uint32_t DEFAULT_ANGLE_WIDTH = 52;
 constexpr uint32_t MAX_ANGLE_WIDTH = 52;
 constexpr double TWO_PI = 2.0 * std::numbers::pi;
@@ -371,6 +375,20 @@ public:
   }
 
 private:
+  struct AffineForm {
+    SmallVector<llvm::DynamicAPInt, 4> coefficients;
+    llvm::DynamicAPInt constant{0};
+  };
+
+  struct AffineAlias {
+    AffineForm form;
+    uint64_t generation = 0;
+  };
+
+  struct ActiveInduction {
+    unsigned position = 0;
+  };
+
   struct DynamicBitFact {
     ExpressionId expression = 0;
     std::vector<std::pair<uint64_t, uint64_t>> dependencies;
@@ -391,6 +409,11 @@ private:
   std::vector<std::shared_ptr<DynamicBitFactSet>> dynamicBitFacts;
   std::vector<bool> initializedScalars;
   std::vector<uint64_t> scalarGenerations;
+  std::vector<std::optional<AffineAlias>> affineAliases;
+  llvm::DenseMap<ScalarId, ActiveInduction> activeInductions;
+  llvm::DenseSet<ScalarId> loopVariantScalars;
+  presburger::IntegerPolyhedron affineDomain{
+      presburger::PresburgerSpace::getSetSpace()};
   std::vector<uint64_t> bitGenerations;
   std::vector<ProgramOutput> implicitOutputs;
   std::vector<ProgramOutput> explicitOutputs;
@@ -432,6 +455,279 @@ private:
   [[nodiscard]] LogicalResult fail(const SMLoc location,
                                    const Twine& message) const {
     return fail(getSourceLocation(location), message);
+  }
+
+  [[nodiscard]] static llvm::DynamicAPInt
+  unsignedCoefficient(const uint64_t value) {
+    return llvm::DynamicAPInt(llvm::APInt(65, value));
+  }
+
+  [[nodiscard]] static llvm::DynamicAPInt signedMinimum() {
+    return llvm::DynamicAPInt(llvm::APInt::getSignedMinValue(64));
+  }
+
+  [[nodiscard]] static llvm::DynamicAPInt signedMaximum() {
+    return llvm::DynamicAPInt(llvm::APInt::getSignedMaxValue(64));
+  }
+
+  [[nodiscard]] AffineForm
+  constantAffineForm(const llvm::DynamicAPInt& value) const {
+    return {.coefficients = SmallVector<llvm::DynamicAPInt, 4>(
+                affineDomain.getNumDimVars(), llvm::DynamicAPInt(0)),
+            .constant = value};
+  }
+
+  [[nodiscard]] static bool isAffineConstant(const AffineForm& form) {
+    return llvm::all_of(form.coefficients,
+                        [](const auto& value) { return value == 0; });
+  }
+
+  [[nodiscard]] static AffineForm addAffineForms(const AffineForm& lhs,
+                                                 const AffineForm& rhs) {
+    assert(lhs.coefficients.size() == rhs.coefficients.size());
+    auto result = lhs;
+    for (const auto [index, value] : llvm::enumerate(rhs.coefficients)) {
+      result.coefficients[index] += value;
+    }
+    result.constant += rhs.constant;
+    return result;
+  }
+
+  [[nodiscard]] static AffineForm negateAffineForm(const AffineForm& form) {
+    auto result = form;
+    for (auto& coefficient : result.coefficients) {
+      coefficient = -coefficient;
+    }
+    result.constant = -result.constant;
+    return result;
+  }
+
+  [[nodiscard]] static AffineForm
+  scaleAffineForm(const AffineForm& form, const llvm::DynamicAPInt& scale) {
+    auto result = form;
+    for (auto& coefficient : result.coefficients) {
+      coefficient *= scale;
+    }
+    result.constant *= scale;
+    return result;
+  }
+
+  [[nodiscard]] static SmallVector<llvm::DynamicAPInt, 4>
+  affineConstraint(const AffineForm& form) {
+    SmallVector<llvm::DynamicAPInt, 4> result(form.coefficients);
+    result.push_back(form.constant);
+    return result;
+  }
+
+  [[nodiscard]] bool
+  domainIsEmptyWithInequality(const AffineForm& inequality) const {
+    presburger::IntegerPolyhedron candidate(affineDomain);
+    candidate.addInequality(affineConstraint(inequality));
+    return candidate.isIntegerEmpty();
+  }
+
+  [[nodiscard]] bool
+  domainIsEmptyWithEquality(const AffineForm& equality) const {
+    presburger::IntegerPolyhedron candidate(affineDomain);
+    candidate.addEquality(affineConstraint(equality));
+    return candidate.isIntegerEmpty();
+  }
+
+  [[nodiscard]] bool provesLowerBound(const AffineForm& form,
+                                      const llvm::DynamicAPInt& lower) const {
+    auto counterexample = negateAffineForm(form);
+    counterexample.constant += lower - 1;
+    return domainIsEmptyWithInequality(counterexample);
+  }
+
+  [[nodiscard]] bool provesUpperBound(const AffineForm& form,
+                                      const llvm::DynamicAPInt& upper) const {
+    auto counterexample = form;
+    counterexample.constant -= upper + 1;
+    return domainIsEmptyWithInequality(counterexample);
+  }
+
+  [[nodiscard]] bool affineFormFitsType(const AffineForm& form,
+                                        const ScalarType type) const {
+    if (type != ScalarType::Int && type != ScalarType::Uint) {
+      return false;
+    }
+    return provesLowerBound(form, type == ScalarType::Int
+                                      ? signedMinimum()
+                                      : llvm::DynamicAPInt(0)) &&
+           provesUpperBound(form, signedMaximum());
+  }
+
+  [[nodiscard]] std::optional<AffineForm>
+  buildAffineForm(const ExpressionId expression) const {
+    const auto& value = program.expressions.at(expression);
+    std::optional<AffineForm> result;
+    switch (value.kind) {
+    case ExpressionKind::Constant:
+      if (value.type == ScalarType::Int) {
+        result = constantAffineForm(
+            llvm::DynamicAPInt(std::get<int64_t>(value.constant)));
+      } else if (value.type == ScalarType::Uint) {
+        result = constantAffineForm(
+            unsignedCoefficient(std::get<uint64_t>(value.constant)));
+      }
+      break;
+    case ExpressionKind::Variable: {
+      if (loopVariantScalars.contains(value.variable)) {
+        break;
+      }
+      const auto induction = activeInductions.find(value.variable);
+      if (induction != activeInductions.end()) {
+        result = constantAffineForm(llvm::DynamicAPInt(0));
+        result->coefficients[induction->second.position] =
+            llvm::DynamicAPInt(1);
+        break;
+      }
+      if (value.variable >= affineAliases.size() ||
+          !affineAliases[value.variable] ||
+          affineAliases[value.variable]->generation !=
+              scalarGenerations[value.variable]) {
+        break;
+      }
+      result = affineAliases[value.variable]->form;
+      result->coefficients.resize(affineDomain.getNumDimVars(),
+                                  llvm::DynamicAPInt(0));
+      break;
+    }
+    case ExpressionKind::Cast:
+      if (isInteger(value.type) &&
+          isInteger(program.expressions.at(value.lhs).type)) {
+        result = buildAffineForm(value.lhs);
+      }
+      break;
+    case ExpressionKind::Negate:
+      if (auto operand = buildAffineForm(value.lhs)) {
+        result = negateAffineForm(*operand);
+      }
+      break;
+    case ExpressionKind::Add:
+    case ExpressionKind::Subtract: {
+      auto lhs = buildAffineForm(value.lhs);
+      auto rhs = buildAffineForm(value.rhs);
+      if (lhs && rhs) {
+        result = addAffineForms(*lhs, value.kind == ExpressionKind::Add
+                                          ? *rhs
+                                          : negateAffineForm(*rhs));
+      }
+      break;
+    }
+    case ExpressionKind::Multiply: {
+      auto lhs = buildAffineForm(value.lhs);
+      auto rhs = buildAffineForm(value.rhs);
+      if (!lhs || !rhs) {
+        break;
+      }
+      if (isAffineConstant(*lhs)) {
+        result = scaleAffineForm(*rhs, lhs->constant);
+      } else if (isAffineConstant(*rhs)) {
+        result = scaleAffineForm(*lhs, rhs->constant);
+      }
+      break;
+    }
+    default:
+      break;
+    }
+    if (!result || !affineFormFitsType(*result, value.type)) {
+      return std::nullopt;
+    }
+    return result;
+  }
+
+  void
+  collectLoopMutations(const ArrayRef<SyntaxStatementId> statements,
+                       llvm::DenseSet<ScalarId>& mutations,
+                       llvm::DenseSet<StringRef>& blockLocalScalars) const {
+    const auto collectNested = [&](const ArrayRef<SyntaxStatementId> body,
+                                   llvm::DenseSet<StringRef> locals) {
+      collectLoopMutations(body, mutations, locals);
+    };
+    for (const auto statement : statements) {
+      const auto& data = syntax.statements[statement].data;
+      if (const auto* assignment = std::get_if<SyntaxAssignment>(&data)) {
+        if (!assignment->target.index &&
+            !blockLocalScalars.contains(assignment->target.identifier)) {
+          const auto* symbol = lookup(assignment->target.identifier);
+          if (symbol != nullptr && symbol->kind == SymbolKind::Scalar) {
+            mutations.insert(symbol->id);
+          }
+        }
+        continue;
+      }
+      if (const auto* declaration =
+              std::get_if<SyntaxScalarDeclaration>(&data)) {
+        if (!declaration->isConst) {
+          blockLocalScalars.insert(declaration->identifier);
+        }
+        continue;
+      }
+      if (const auto* conditional = std::get_if<SyntaxIf>(&data)) {
+        collectNested(conditional->thenStatements, blockLocalScalars);
+        collectNested(conditional->elseStatements, blockLocalScalars);
+        continue;
+      }
+      if (const auto* loop = std::get_if<SyntaxFor>(&data)) {
+        auto locals = blockLocalScalars;
+        locals.insert(loop->inductionVariable);
+        collectNested(loop->body, std::move(locals));
+        continue;
+      }
+      if (const auto* loop = std::get_if<SyntaxWhile>(&data)) {
+        collectNested(loop->body, blockLocalScalars);
+        continue;
+      }
+      if (const auto* switchStatement = std::get_if<SyntaxSwitch>(&data)) {
+        for (const auto& switchCase : switchStatement->cases) {
+          collectNested(switchCase.body, blockLocalScalars);
+        }
+        collectNested(switchStatement->defaultStatements, blockLocalScalars);
+      }
+    }
+  }
+
+  [[nodiscard]] bool proveDistinct(const QubitReference& lhs,
+                                   const QubitReference& rhs,
+                                   size_t& affineComparisons) const {
+    if (lhs.kind != rhs.kind) {
+      return true;
+    }
+    if (lhs.kind == QubitReferenceKind::GateArgument) {
+      return lhs.symbol != rhs.symbol;
+    }
+    if (lhs.kind == QubitReferenceKind::Hardware) {
+      return lhs.index != rhs.index;
+    }
+    if (lhs.symbol != rhs.symbol) {
+      return true;
+    }
+    if (!lhs.provenIndex && !rhs.provenIndex) {
+      return lhs.index != rhs.index;
+    }
+    if (affineComparisons >= AFFINE_DISTINCTNESS_COMPARISON_LIMIT) {
+      return false;
+    }
+    ++affineComparisons;
+    const auto indexForm =
+        [&](const QubitReference& reference) -> std::optional<AffineForm> {
+      if (reference.provenIndex) {
+        return buildAffineForm(*reference.provenIndex);
+      }
+      return constantAffineForm(unsignedCoefficient(reference.index));
+    };
+    auto left = indexForm(lhs);
+    auto right = indexForm(rhs);
+    if (!left || !right) {
+      return false;
+    }
+    const auto difference = addAffineForms(*left, negateAffineForm(*right));
+    if (isAffineConstant(difference)) {
+      return difference.constant != 0;
+    }
+    return domainIsEmptyWithEquality(difference);
   }
 
   [[nodiscard]] LogicalResult validateExpressionDepth() const {
@@ -2200,7 +2496,7 @@ private:
 
   [[nodiscard]] FailureOr<std::optional<uint64_t>>
   constantIndex(const SyntaxExpressionId id, const uint64_t width,
-                SMLoc location) const {
+                SMLoc location, const bool wrapNegative) const {
     if (!isConstantExpression(id)) {
       return std::optional<uint64_t>{};
     }
@@ -2213,6 +2509,9 @@ private:
       return fail(location, "unsigned value does not fit in signed i64");
     }
     if (*value < 0) {
+      if (!wrapNegative) {
+        return fail(location, "cannot prove that qubit index is in bounds");
+      }
       *value += static_cast<int64_t>(width);
     }
     if (*value < 0) {
@@ -2405,6 +2704,7 @@ private:
                                .location = getSourceLocation(location)});
     initializedScalars.push_back(false);
     scalarGenerations.push_back(0);
+    affineAliases.emplace_back();
     if (failed(declare(location, declaration.identifier,
                        {.kind = SymbolKind::Scalar, .type = type, .id = id}))) {
       return failure();
@@ -2431,6 +2731,10 @@ private:
                 initializer, type,
                 syntax.expressions[*declaration.initializer].location));
         typed.initializer = convertedInitializer;
+        if (auto form = buildAffineForm(convertedInitializer)) {
+          affineAliases[id] =
+              AffineAlias{.form = std::move(*form), .generation = 0};
+        }
       }
       initializedScalars[id] = true;
     }
@@ -2749,7 +3053,7 @@ private:
 
     if (barrier.operands.size() > 1) {
       llvm::DenseSet<std::pair<RegisterId, uint64_t>> staticRegisterQubits;
-      llvm::DenseSet<std::pair<RegisterId, ExpressionId>> dynamicRegisterQubits;
+      llvm::DenseSet<std::pair<RegisterId, ExpressionId>> provenRegisterQubits;
       llvm::DenseSet<uint32_t> gateArguments;
       llvm::DenseSet<uint64_t> hardwareQubitOperands;
       llvm::DenseMap<RegisterId, size_t> staticRegisterQubitCounts;
@@ -2758,10 +3062,10 @@ private:
         bool inserted = false;
         switch (qubit.kind) {
         case QubitReferenceKind::Register:
-          if (qubit.dynamicIndex) {
-            inserted = dynamicRegisterQubits
-                           .insert({qubit.symbol, *qubit.dynamicIndex})
-                           .second;
+          if (qubit.provenIndex) {
+            inserted =
+                provenRegisterQubits.insert({qubit.symbol, *qubit.provenIndex})
+                    .second;
           } else {
             inserted =
                 staticRegisterQubits.insert({qubit.symbol, qubit.index}).second;
@@ -2785,14 +3089,34 @@ private:
         }
       }
 
-      for (const auto& dynamicRegisterQubit : dynamicRegisterQubits) {
-        const auto reg = dynamicRegisterQubit.first;
+      for (const auto& provenRegisterQubit : provenRegisterQubits) {
+        const auto reg = provenRegisterQubit.first;
         if (staticRegisterQubitCounts.lookup(reg) ==
             program.registers.at(reg).width) {
           return fail(
               location,
               "barrier operands must not reference the same qubit more than "
               "once");
+        }
+      }
+
+      if (!provenRegisterQubits.empty()) {
+        size_t affineComparisons = 0;
+        for (const auto [position, qubit] : llvm::enumerate(qubits)) {
+          for (const auto& previous : ArrayRef(qubits).take_front(position)) {
+            if (qubit.kind != QubitReferenceKind::Register ||
+                previous.kind != QubitReferenceKind::Register ||
+                qubit.symbol != previous.symbol ||
+                (!qubit.provenIndex && !previous.provenIndex)) {
+              continue;
+            }
+            if (!proveDistinct(previous, qubit, affineComparisons)) {
+              return fail(
+                  location,
+                  "cannot prove that barrier operands reference distinct "
+                  "qubits");
+            }
+          }
         }
       }
     }
@@ -2922,6 +3246,37 @@ private:
       }
     }
 
+    const auto startForm = buildAffineForm(result.start);
+    const auto stopForm = buildAffineForm(result.stop);
+    const bool unsignedEndpoints =
+        program.expressions[result.start].type == ScalarType::Uint ||
+        program.expressions[result.stop].type == ScalarType::Uint;
+    const bool endpointValuesPreserved =
+        !unsignedEndpoints ||
+        (startForm && stopForm &&
+         provesLowerBound(*startForm, llvm::DynamicAPInt(0)) &&
+         provesLowerBound(*stopForm, llvm::DynamicAPInt(0)));
+    std::optional<llvm::DynamicAPInt> positiveStep;
+    const auto& stepExpression = program.expressions[result.step];
+    if (stepExpression.kind == ExpressionKind::Constant) {
+      if (stepExpression.type == ScalarType::Int) {
+        const auto value = std::get<int64_t>(stepExpression.constant);
+        if (value > 0) {
+          positiveStep = llvm::DynamicAPInt(value);
+        }
+      } else if (stepExpression.type == ScalarType::Uint) {
+        const auto value =
+            unsignedCoefficient(std::get<uint64_t>(stepExpression.constant));
+        if (value > 0) {
+          positiveStep = value;
+        }
+      }
+    }
+    result.provenPositiveRange =
+        startForm && stopForm && endpointValuesPreserved && positiveStep &&
+        *positiveStep <= signedMaximum() &&
+        provesUpperBound(*stopForm, signedMaximum() - 1);
+
     const auto beforeBitsInitialized = initializedBits;
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
@@ -2934,6 +3289,7 @@ private:
         {.type = type, .name = loop.inductionVariable.str()});
     initializedScalars.push_back(true);
     scalarGenerations.push_back(0);
+    affineAliases.emplace_back();
     if (failed(declare(location, loop.inductionVariable,
                        {.kind = insideGate ? SymbolKind::GateLocalScalar
                                            : SymbolKind::Scalar,
@@ -2943,9 +3299,31 @@ private:
       return failure();
     }
     result.inductionVariable = scalar;
+    const auto outerDomain = affineDomain;
+    const auto outerLoopVariantScalars = loopVariantScalars;
+    llvm::DenseSet<StringRef> blockLocalScalars;
+    collectLoopMutations(loop.body, loopVariantScalars, blockLocalScalars);
+    if (result.provenPositiveRange) {
+      affineDomain.appendVar(presburger::VarKind::SetDim);
+      auto lower = *startForm;
+      auto upper = *stopForm;
+      lower.coefficients.push_back(llvm::DynamicAPInt(0));
+      upper.coefficients.push_back(llvm::DynamicAPInt(0));
+      auto induction = constantAffineForm(llvm::DynamicAPInt(0));
+      induction.coefficients.back() = llvm::DynamicAPInt(1);
+      affineDomain.addInequality(
+          affineConstraint(addAffineForms(induction, negateAffineForm(lower))));
+      affineDomain.addInequality(
+          affineConstraint(addAffineForms(upper, negateAffineForm(induction))));
+      activeInductions.insert(
+          {scalar, {.position = affineDomain.getNumDimVars() - 1}});
+    }
     const auto bodyResult =
         analyzeBody(loop.body, result.body, /*global=*/false);
     if (failed(bodyResult)) {
+      activeInductions.erase(scalar);
+      affineDomain = outerDomain;
+      loopVariantScalars = outerLoopVariantScalars;
       scopes.pop_back();
       return failure();
     }
@@ -2954,6 +3332,9 @@ private:
     const auto afterBodyGenerations = scalarGenerations;
     const auto afterBodyBitGenerations = bitGenerations;
     const auto afterBodyDynamicBitFacts = dynamicBitFacts;
+    activeInductions.erase(scalar);
+    affineDomain = outerDomain;
+    loopVariantScalars = outerLoopVariantScalars;
     scopes.pop_back();
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                        beforeGenerations, beforeBitGenerations);
@@ -3023,8 +3404,12 @@ private:
     const auto beforeBitGenerations = bitGenerations;
     const auto beforeDynamicBitFacts = dynamicBitFacts;
     scopes.emplace_back();
+    const auto outerLoopVariantScalars = loopVariantScalars;
+    llvm::DenseSet<StringRef> blockLocalScalars;
+    collectLoopMutations(loop.body, loopVariantScalars, blockLocalScalars);
     const auto bodyResult =
         analyzeBody(loop.body, result.body, /*global=*/false);
+    loopVariantScalars = outerLoopVariantScalars;
     scopes.pop_back();
     if (failed(bodyResult)) {
       return failure();
@@ -3584,6 +3969,7 @@ private:
 
     std::vector<GateApplication> applications;
     applications.reserve(broadcastWidth);
+    size_t affineComparisons = 0;
     for (size_t index = 0; index < broadcastWidth; ++index) {
       GateApplication application{
           .callee = callee, .parameters = parameters, .modifiers = modifiers};
@@ -3593,11 +3979,13 @@ private:
             selection[selection.size() == 1 ? 0 : index]);
       }
       for (const auto [position, qubit] : llvm::enumerate(application.qubits)) {
-        if (llvm::is_contained(
-                ArrayRef(application.qubits).take_front(position), qubit)) {
-          return fail(call.location,
-                      "gate operands must not reference the same qubit more "
-                      "than once");
+        for (const auto& previous :
+             ArrayRef(application.qubits).take_front(position)) {
+          if (!proveDistinct(previous, qubit, affineComparisons)) {
+            return fail(call.location,
+                        "cannot prove that gate operands reference distinct "
+                        "qubits");
+          }
         }
       }
       applications.push_back(std::move(application));
@@ -3645,24 +4033,36 @@ private:
       }
       return selection;
     }
-    MQT_OQ3_TRY_ASSIGN(constant,
-                       constantIndex(*operand.index, width, operand.location));
+    MQT_OQ3_TRY_ASSIGN(constant, constantIndex(*operand.index, width,
+                                               operand.location, false));
     if (constant) {
       if (*constant >= width) {
-        return fail(operand.location, "qubit index is out of bounds");
+        return fail(operand.location,
+                    "cannot prove that qubit index is in bounds");
       }
       return std::vector<QubitReference>{{.kind = QubitReferenceKind::Register,
                                           .symbol = reg,
                                           .index = *constant}};
     }
-    MQT_OQ3_TRY_ASSIGN(dynamic, analyzeExpression(*operand.index));
-    if (!isInteger(program.expressions[dynamic].type)) {
+    MQT_OQ3_TRY_ASSIGN(index, analyzeExpression(*operand.index));
+    if (!isInteger(program.expressions[index].type)) {
       return fail(operand.location,
                   "qubit index must be an integer expression");
     }
+    const auto form = buildAffineForm(index);
+    if (!form) {
+      return fail(operand.location,
+                  "cannot prove that qubit index is in bounds");
+    }
+    if (!provesLowerBound(*form, llvm::DynamicAPInt(0)) ||
+        !provesUpperBound(
+            *form, unsignedCoefficient(static_cast<uint64_t>(width - 1)))) {
+      return fail(operand.location,
+                  "cannot prove that qubit index is in bounds");
+    }
     return std::vector<QubitReference>{{.kind = QubitReferenceKind::Register,
                                         .symbol = reg,
-                                        .dynamicIndex = dynamic}};
+                                        .provenIndex = index}};
   }
 
   [[nodiscard]] FailureOr<std::vector<frontend::BitReference>>
@@ -3683,8 +4083,8 @@ private:
       }
       return result;
     }
-    MQT_OQ3_TRY_ASSIGN(
-        constant, constantIndex(*reference.index, width, reference.location));
+    MQT_OQ3_TRY_ASSIGN(constant, constantIndex(*reference.index, width,
+                                               reference.location, true));
     if (constant) {
       if (*constant >= width) {
         return fail(reference.location, "classical bit index is out of bounds");

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -400,6 +400,7 @@ private:
   std::vector<std::shared_ptr<DynamicBitFactSet>> dynamicBitFacts;
   std::vector<bool> initializedScalars;
   std::vector<uint64_t> scalarGenerations;
+  std::vector<std::optional<ExpressionId>> affineScalarValues;
   llvm::DenseMap<ScalarId, unsigned> activeInductions;
   llvm::DenseSet<ScalarId> loopVariantScalars;
   presburger::IntegerPolyhedron affineDomain{
@@ -572,6 +573,10 @@ private:
         result->coefficients[induction->second] = llvm::DynamicAPInt(1);
         break;
       }
+      if (value.variable < affineScalarValues.size() &&
+          affineScalarValues[value.variable]) {
+        result = buildAffineForm(*affineScalarValues[value.variable]);
+      }
       break;
     }
     case ExpressionKind::Cast:
@@ -616,6 +621,62 @@ private:
       return std::nullopt;
     }
     return result;
+  }
+
+  [[nodiscard]] std::optional<ExpressionId>
+  expandAffineScalarValues(const ExpressionId expression) {
+    const auto value = program.expressions.at(expression);
+    switch (value.kind) {
+    case ExpressionKind::Constant:
+      return expression;
+    case ExpressionKind::Variable:
+      if (activeInductions.contains(value.variable)) {
+        return expression;
+      }
+      if (value.variable < affineScalarValues.size()) {
+        return affineScalarValues[value.variable];
+      }
+      return std::nullopt;
+    case ExpressionKind::Cast:
+    case ExpressionKind::Negate: {
+      auto operand = expandAffineScalarValues(value.lhs);
+      if (!operand) {
+        return std::nullopt;
+      }
+      if (*operand == value.lhs) {
+        return expression;
+      }
+      auto expanded = value;
+      expanded.lhs = *operand;
+      return addExpression(expanded);
+    }
+    case ExpressionKind::Add:
+    case ExpressionKind::Subtract:
+    case ExpressionKind::Multiply: {
+      auto lhs = expandAffineScalarValues(value.lhs);
+      auto rhs = expandAffineScalarValues(value.rhs);
+      if (!lhs || !rhs) {
+        return std::nullopt;
+      }
+      if (*lhs == value.lhs && *rhs == value.rhs) {
+        return expression;
+      }
+      auto expanded = value;
+      expanded.lhs = *lhs;
+      expanded.rhs = *rhs;
+      return addExpression(expanded);
+    }
+    default:
+      return std::nullopt;
+    }
+  }
+
+  [[nodiscard]] bool sameAffineValue(const ExpressionId lhs,
+                                     const ExpressionId rhs) const {
+    const auto left = buildAffineForm(lhs);
+    const auto right = buildAffineForm(rhs);
+    return left && right && left->coefficients == right->coefficients &&
+           left->constant == right->constant;
   }
 
   void
@@ -755,6 +816,13 @@ private:
     for (size_t reg = facts.size(); reg < dynamicBitFacts.size(); ++reg) {
       dynamicBitFacts[reg] = std::make_shared<DynamicBitFactSet>();
     }
+  }
+
+  void restoreAffineScalarValuesPrefix(
+      const std::vector<std::optional<ExpressionId>>& values) {
+    const auto size = affineScalarValues.size();
+    affineScalarValues = values;
+    affineScalarValues.resize(size);
   }
 
   [[nodiscard]] BitInitialization&
@@ -2681,6 +2749,7 @@ private:
                                .location = getSourceLocation(location)});
     initializedScalars.push_back(false);
     scalarGenerations.push_back(0);
+    affineScalarValues.emplace_back();
     if (failed(declare(location, declaration.identifier,
                        {.kind = SymbolKind::Scalar, .type = type, .id = id}))) {
       return failure();
@@ -2707,6 +2776,10 @@ private:
                 initializer, type,
                 syntax.expressions[*declaration.initializer].location));
         typed.initializer = convertedInitializer;
+        if (buildAffineForm(convertedInitializer)) {
+          affineScalarValues[id] =
+              expandAffineScalarValues(convertedInitializer);
+        }
       }
       initializedScalars[id] = true;
     }
@@ -2744,6 +2817,7 @@ private:
       if (symbol->type == ScalarType::Bool) {
         MQT_OQ3_TRY_ASSIGN(condition, analyzeBoolValue(assignment.value));
         typed.condition = condition;
+        affineScalarValues[symbol->id].reset();
       } else {
         MQT_OQ3_TRY_ASSIGN(value, analyzeExpression(assignment.value));
         MQT_OQ3_TRY_ASSIGN(
@@ -2751,6 +2825,10 @@ private:
             castExpression(value, symbol->type,
                            syntax.expressions[assignment.value].location));
         typed.value = convertedValue;
+        affineScalarValues[symbol->id] =
+            buildAffineForm(convertedValue)
+                ? expandAffineScalarValues(convertedValue)
+                : std::nullopt;
       }
       initializedScalars[symbol->id] = true;
       ++scalarGenerations[symbol->id];
@@ -3104,6 +3182,7 @@ private:
     const auto beforeBitsInitialized = initializedBits;
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
+    const auto beforeAffineScalarValues = affineScalarValues;
     const auto beforeBitGenerations = bitGenerations;
     const auto beforeDynamicBitFacts = dynamicBitFacts;
     scopes.emplace_back();
@@ -3117,12 +3196,14 @@ private:
     const auto afterThenBitsInitialized = initializedBits;
     const auto afterThenInitialized = initializedScalars;
     const auto afterThenGenerations = scalarGenerations;
+    const auto afterThenAffineScalarValues = affineScalarValues;
     const auto afterThenBitGenerations = bitGenerations;
     const auto afterThenDynamicBitFacts = dynamicBitFacts;
     scopes.pop_back();
 
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                        beforeGenerations, beforeBitGenerations);
+    restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
     restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     scopes.emplace_back();
     const auto elseResult =
@@ -3135,6 +3216,7 @@ private:
     const auto afterElseBitsInitialized = initializedBits;
     const auto afterElseInitialized = initializedScalars;
     const auto afterElseGenerations = scalarGenerations;
+    const auto afterElseAffineScalarValues = affineScalarValues;
     const auto afterElseBitGenerations = bitGenerations;
     const auto afterElseDynamicBitFacts = dynamicBitFacts;
     scopes.pop_back();
@@ -3148,18 +3230,23 @@ private:
           *knownCondition ? afterThenInitialized : afterElseInitialized;
       const auto& knownGenerations =
           *knownCondition ? afterThenGenerations : afterElseGenerations;
+      const auto& knownAffineScalarValues = *knownCondition
+                                                ? afterThenAffineScalarValues
+                                                : afterElseAffineScalarValues;
       const auto& knownBitGenerations =
           *knownCondition ? afterThenBitGenerations : afterElseBitGenerations;
       const auto& knownDynamicBitFacts =
           *knownCondition ? afterThenDynamicBitFacts : afterElseDynamicBitFacts;
       restoreStatePrefix(knownBitsInitialized, knownInitialized,
                          knownGenerations, knownBitGenerations);
+      restoreAffineScalarValuesPrefix(knownAffineScalarValues);
       restoreDynamicFactsPrefix(knownDynamicBitFacts);
       return addStatement(location, std::move(result));
     }
 
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                        beforeGenerations, beforeBitGenerations);
+    restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
     restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     for (size_t reg = 0; reg < beforeBitsInitialized.size(); ++reg) {
       auto& merged = mutableBitInitialization(static_cast<RegisterId>(reg));
@@ -3187,6 +3274,14 @@ private:
           afterThenInitialized[scalar] && afterElseInitialized[scalar];
       scalarGenerations[scalar] =
           std::max(afterThenGenerations[scalar], afterElseGenerations[scalar]);
+      if (afterThenAffineScalarValues[scalar] &&
+          afterElseAffineScalarValues[scalar] &&
+          sameAffineValue(*afterThenAffineScalarValues[scalar],
+                          *afterElseAffineScalarValues[scalar])) {
+        affineScalarValues[scalar] = afterThenAffineScalarValues[scalar];
+      } else {
+        affineScalarValues[scalar].reset();
+      }
     }
     for (size_t reg = 0; reg < beforeBitGenerations.size(); ++reg) {
       bitGenerations[reg] =
@@ -3206,20 +3301,12 @@ private:
         return fail(location, "for-loop ranges require integer expressions");
       }
     }
-    const auto constantIsZero = [](const Constant& value) {
-      return value.type == ScalarType::Uint
-                 ? std::get<uint64_t>(value.value) == 0
-                 : std::get<int64_t>(value.value) == 0;
-    };
-    if (isConstantExpression(loop.step)) {
-      MQT_OQ3_TRY_ASSIGN(stepConstant, evaluateConstant(loop.step));
-      if (constantIsZero(stepConstant)) {
-        return fail(location, "for-loop range step must not be zero");
-      }
-    }
-
     const auto startForm = buildAffineForm(result.start);
+    const auto stepForm = buildAffineForm(result.step);
     const auto stopForm = buildAffineForm(result.stop);
+    if (stepForm && isAffineConstant(*stepForm) && stepForm->constant == 0) {
+      return fail(location, "for-loop range step must not be zero");
+    }
     const bool unsignedEndpoints =
         program.expressions[result.start].type == ScalarType::Uint ||
         program.expressions[result.stop].type == ScalarType::Uint;
@@ -3229,29 +3316,28 @@ private:
          provesLowerBound(*startForm, llvm::DynamicAPInt(0)) &&
          provesLowerBound(*stopForm, llvm::DynamicAPInt(0)));
     std::optional<llvm::DynamicAPInt> positiveStep;
-    const auto& stepExpression = program.expressions[result.step];
-    if (stepExpression.kind == ExpressionKind::Constant) {
-      if (stepExpression.type == ScalarType::Int) {
-        const auto value = std::get<int64_t>(stepExpression.constant);
-        if (value > 0) {
-          positiveStep = llvm::DynamicAPInt(value);
-        }
-      } else if (stepExpression.type == ScalarType::Uint) {
-        const auto value =
-            unsignedCoefficient(std::get<uint64_t>(stepExpression.constant));
-        if (value > 0) {
-          positiveStep = value;
-        }
-      }
+    if (stepForm && isAffineConstant(*stepForm) && stepForm->constant > 0) {
+      positiveStep = stepForm->constant;
     }
     result.provenPositiveRange =
         startForm && stopForm && endpointValuesPreserved && positiveStep &&
         *positiveStep <= signedMaximum() &&
         provesUpperBound(*stopForm, signedMaximum() - 1);
+    if (result.provenPositiveRange) {
+      const auto expandedStart = expandAffineScalarValues(result.start);
+      const auto expandedStep = expandAffineScalarValues(result.step);
+      const auto expandedStop = expandAffineScalarValues(result.stop);
+      assert(expandedStart && expandedStep && expandedStop &&
+             "proven affine ranges must have expandable expressions");
+      result.start = *expandedStart;
+      result.step = *expandedStep;
+      result.stop = *expandedStop;
+    }
 
     const auto beforeBitsInitialized = initializedBits;
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
+    const auto beforeAffineScalarValues = affineScalarValues;
     const auto beforeBitGenerations = bitGenerations;
     const auto beforeDynamicBitFacts = dynamicBitFacts;
     scopes.emplace_back();
@@ -3261,6 +3347,7 @@ private:
         {.type = type, .name = loop.inductionVariable.str()});
     initializedScalars.push_back(true);
     scalarGenerations.push_back(0);
+    affineScalarValues.emplace_back();
     if (failed(declare(location, loop.inductionVariable,
                        {.kind = insideGate ? SymbolKind::GateLocalScalar
                                            : SymbolKind::Scalar,
@@ -3308,7 +3395,9 @@ private:
     scopes.pop_back();
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                        beforeGenerations, beforeBitGenerations);
+    restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
     restoreDynamicFactsPrefix(beforeDynamicBitFacts);
+    bool rangeMayExecute = true;
     if (isConstantExpression(loop.start) && isConstantExpression(loop.step) &&
         isConstantExpression(loop.stop)) {
       MQT_OQ3_TRY_ASSIGN(startConstant, evaluateConstant(loop.start));
@@ -3345,6 +3434,7 @@ private:
           compareRangeValues(startConstant, stopConstant);
       const bool nonempty =
           positiveStep ? endpointOrder <= 0 : endpointOrder >= 0;
+      rangeMayExecute = nonempty;
       if (nonempty) {
         for (size_t reg = 0; reg < beforeBitsInitialized.size(); ++reg) {
           initializedBits[reg] = afterBodyBitsInitialized[reg];
@@ -3361,6 +3451,13 @@ private:
         }
       }
     }
+    if (rangeMayExecute) {
+      for (size_t scalar = 0; scalar < beforeGenerations.size(); ++scalar) {
+        if (afterBodyGenerations[scalar] != beforeGenerations[scalar]) {
+          affineScalarValues[scalar].reset();
+        }
+      }
+    }
     return addStatement(location, std::move(result));
   }
 
@@ -3371,6 +3468,7 @@ private:
     const auto beforeBitsInitialized = initializedBits;
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
+    const auto beforeAffineScalarValues = affineScalarValues;
     const auto beforeBitGenerations = bitGenerations;
     const auto beforeDynamicBitFacts = dynamicBitFacts;
     scopes.emplace_back();
@@ -3388,10 +3486,14 @@ private:
     const auto afterBodyBitGenerations = bitGenerations;
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                        beforeGenerations, beforeBitGenerations);
+    restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
     restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     for (size_t scalar = 0; scalar < beforeGenerations.size(); ++scalar) {
       scalarGenerations[scalar] =
           std::max(beforeGenerations[scalar], afterBodyGenerations[scalar]);
+      if (afterBodyGenerations[scalar] != beforeGenerations[scalar]) {
+        affineScalarValues[scalar].reset();
+      }
     }
     for (size_t reg = 0; reg < beforeBitGenerations.size(); ++reg) {
       bitGenerations[reg] =
@@ -3412,6 +3514,7 @@ private:
     const auto beforeBitsInitialized = initializedBits;
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
+    const auto beforeAffineScalarValues = affineScalarValues;
     const auto beforeBitGenerations = bitGenerations;
     const auto beforeDynamicBitFacts = dynamicBitFacts;
     auto mergedScalarGenerations = beforeGenerations;
@@ -3419,11 +3522,14 @@ private:
     std::vector<std::vector<std::shared_ptr<BitInitialization>>>
         branchBitsInitialized;
     std::vector<std::vector<bool>> branchScalarsInitialized;
+    std::vector<std::vector<std::optional<ExpressionId>>>
+        branchAffineScalarValues;
     const auto analyzeBranch =
         [&](const ArrayRef<SyntaxStatementId> syntaxStatements,
             std::vector<StatementId>& statements) -> LogicalResult {
       restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                          beforeGenerations, beforeBitGenerations);
+      restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
       restoreDynamicFactsPrefix(beforeDynamicBitFacts);
       scopes.emplace_back();
       const auto branchResult =
@@ -3434,6 +3540,7 @@ private:
       }
       branchBitsInitialized.push_back(initializedBits);
       branchScalarsInitialized.push_back(initializedScalars);
+      branchAffineScalarValues.push_back(affineScalarValues);
       for (size_t index = 0; index < beforeGenerations.size(); ++index) {
         mergedScalarGenerations[index] =
             std::max(mergedScalarGenerations[index], scalarGenerations[index]);
@@ -3486,6 +3593,7 @@ private:
 
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                        mergedScalarGenerations, mergedBitGenerations);
+    restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
     restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     for (size_t reg = 0; reg < beforeBitsInitialized.size(); ++reg) {
       auto& initialized =
@@ -3501,6 +3609,15 @@ private:
       initializedScalars[scalar] =
           llvm::all_of(branchScalarsInitialized,
                        [&](const auto& branch) { return branch[scalar]; });
+      const auto& first = branchAffineScalarValues.front()[scalar];
+      if (first &&
+          llvm::all_of(branchAffineScalarValues, [&](const auto& branch) {
+            return branch[scalar] && sameAffineValue(*first, *branch[scalar]);
+          })) {
+        affineScalarValues[scalar] = first;
+      } else {
+        affineScalarValues[scalar].reset();
+      }
     }
     return addStatement(location, std::move(result));
   }
@@ -4024,15 +4141,32 @@ private:
       return fail(operand.location,
                   "cannot prove that qubit index is in bounds");
     }
+    if (isAffineConstant(*form)) {
+      auto value = static_cast<int64_t>(form->constant);
+      if (value < 0) {
+        value += static_cast<int64_t>(width);
+      }
+      if (value < 0 || std::cmp_greater_equal(value, width)) {
+        return fail(operand.location,
+                    "cannot prove that qubit index is in bounds");
+      }
+      return std::vector<QubitReference>{
+          {.kind = QubitReferenceKind::Register,
+           .symbol = reg,
+           .index = static_cast<uint64_t>(value)}};
+    }
     if (!provesLowerBound(*form, llvm::DynamicAPInt(0)) ||
         !provesUpperBound(
             *form, unsignedCoefficient(static_cast<uint64_t>(width - 1)))) {
       return fail(operand.location,
                   "cannot prove that qubit index is in bounds");
     }
+    const auto expandedIndex = expandAffineScalarValues(index);
+    assert(expandedIndex &&
+           "proven affine indices must have expandable expressions");
     return std::vector<QubitReference>{{.kind = QubitReferenceKind::Register,
                                         .symbol = reg,
-                                        .provenIndex = index}};
+                                        .provenIndex = expandedIndex}};
   }
 
   [[nodiscard]] FailureOr<std::vector<frontend::BitReference>>

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -380,15 +380,6 @@ private:
     llvm::DynamicAPInt constant{0};
   };
 
-  struct AffineAlias {
-    AffineForm form;
-    uint64_t generation = 0;
-  };
-
-  struct ActiveInduction {
-    unsigned position = 0;
-  };
-
   struct DynamicBitFact {
     ExpressionId expression = 0;
     std::vector<std::pair<uint64_t, uint64_t>> dependencies;
@@ -409,8 +400,7 @@ private:
   std::vector<std::shared_ptr<DynamicBitFactSet>> dynamicBitFacts;
   std::vector<bool> initializedScalars;
   std::vector<uint64_t> scalarGenerations;
-  std::vector<std::optional<AffineAlias>> affineAliases;
-  llvm::DenseMap<ScalarId, ActiveInduction> activeInductions;
+  llvm::DenseMap<ScalarId, unsigned> activeInductions;
   llvm::DenseSet<ScalarId> loopVariantScalars;
   presburger::IntegerPolyhedron affineDomain{
       presburger::PresburgerSpace::getSetSpace()};
@@ -579,19 +569,9 @@ private:
       const auto induction = activeInductions.find(value.variable);
       if (induction != activeInductions.end()) {
         result = constantAffineForm(llvm::DynamicAPInt(0));
-        result->coefficients[induction->second.position] =
-            llvm::DynamicAPInt(1);
+        result->coefficients[induction->second] = llvm::DynamicAPInt(1);
         break;
       }
-      if (value.variable >= affineAliases.size() ||
-          !affineAliases[value.variable] ||
-          affineAliases[value.variable]->generation !=
-              scalarGenerations[value.variable]) {
-        break;
-      }
-      result = affineAliases[value.variable]->form;
-      result->coefficients.resize(affineDomain.getNumDimVars(),
-                                  llvm::DynamicAPInt(0));
       break;
     }
     case ExpressionKind::Cast:
@@ -707,10 +687,6 @@ private:
     if (!lhs.provenIndex && !rhs.provenIndex) {
       return lhs.index != rhs.index;
     }
-    if (affineComparisons >= AFFINE_DISTINCTNESS_COMPARISON_LIMIT) {
-      return false;
-    }
-    ++affineComparisons;
     const auto indexForm =
         [&](const QubitReference& reference) -> std::optional<AffineForm> {
       if (reference.provenIndex) {
@@ -727,6 +703,10 @@ private:
     if (isAffineConstant(difference)) {
       return difference.constant != 0;
     }
+    if (affineComparisons >= AFFINE_DISTINCTNESS_COMPARISON_LIMIT) {
+      return false;
+    }
+    ++affineComparisons;
     return domainIsEmptyWithEquality(difference);
   }
 
@@ -2496,7 +2476,7 @@ private:
 
   [[nodiscard]] FailureOr<std::optional<uint64_t>>
   constantIndex(const SyntaxExpressionId id, const uint64_t width,
-                SMLoc location, const bool wrapNegative) const {
+                SMLoc location) const {
     if (!isConstantExpression(id)) {
       return std::optional<uint64_t>{};
     }
@@ -2509,9 +2489,6 @@ private:
       return fail(location, "unsigned value does not fit in signed i64");
     }
     if (*value < 0) {
-      if (!wrapNegative) {
-        return fail(location, "cannot prove that qubit index is in bounds");
-      }
       *value += static_cast<int64_t>(width);
     }
     if (*value < 0) {
@@ -2704,7 +2681,6 @@ private:
                                .location = getSourceLocation(location)});
     initializedScalars.push_back(false);
     scalarGenerations.push_back(0);
-    affineAliases.emplace_back();
     if (failed(declare(location, declaration.identifier,
                        {.kind = SymbolKind::Scalar, .type = type, .id = id}))) {
       return failure();
@@ -2731,10 +2707,6 @@ private:
                 initializer, type,
                 syntax.expressions[*declaration.initializer].location));
         typed.initializer = convertedInitializer;
-        if (auto form = buildAffineForm(convertedInitializer)) {
-          affineAliases[id] =
-              AffineAlias{.form = std::move(*form), .generation = 0};
-        }
       }
       initializedScalars[id] = true;
     }
@@ -3289,7 +3261,6 @@ private:
         {.type = type, .name = loop.inductionVariable.str()});
     initializedScalars.push_back(true);
     scalarGenerations.push_back(0);
-    affineAliases.emplace_back();
     if (failed(declare(location, loop.inductionVariable,
                        {.kind = insideGate ? SymbolKind::GateLocalScalar
                                            : SymbolKind::Scalar,
@@ -3315,8 +3286,7 @@ private:
           affineConstraint(addAffineForms(induction, negateAffineForm(lower))));
       affineDomain.addInequality(
           affineConstraint(addAffineForms(upper, negateAffineForm(induction))));
-      activeInductions.insert(
-          {scalar, {.position = affineDomain.getNumDimVars() - 1}});
+      activeInductions.insert({scalar, affineDomain.getNumDimVars() - 1});
     }
     const auto bodyResult =
         analyzeBody(loop.body, result.body, /*global=*/false);
@@ -4033,8 +4003,8 @@ private:
       }
       return selection;
     }
-    MQT_OQ3_TRY_ASSIGN(constant, constantIndex(*operand.index, width,
-                                               operand.location, false));
+    MQT_OQ3_TRY_ASSIGN(constant,
+                       constantIndex(*operand.index, width, operand.location));
     if (constant) {
       if (*constant >= width) {
         return fail(operand.location,
@@ -4083,8 +4053,8 @@ private:
       }
       return result;
     }
-    MQT_OQ3_TRY_ASSIGN(constant, constantIndex(*reference.index, width,
-                                               reference.location, true));
+    MQT_OQ3_TRY_ASSIGN(
+        constant, constantIndex(*reference.index, width, reference.location));
     if (constant) {
       if (*constant >= width) {
         return fail(reference.location, "classical bit index is out of bounds");

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -560,6 +560,39 @@ roundTripThroughOptimizedJeff(const qasm::OpenQASMProgram& source,
 
 namespace {
 
+TEST(OpenQASMCompilerOutputTest, LowersAffineQuantumLoopsToJeff) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[4] q;
+bit[4] c;
+for int i in [0:3] {
+  h q[i];
+}
+for int i in [0:2] {
+  cx q[i], q[i + 1];
+}
+c = measure q;
+)qasm";
+
+  auto qc = QCProgram::fromQASMString(source.str());
+  ASSERT_TRUE(qc);
+  const auto imported = qc->str();
+  EXPECT_EQ(imported.find("i128"), std::string::npos);
+  EXPECT_EQ(imported.find("arith.select"), std::string::npos);
+  EXPECT_EQ(imported.find("cf.assert"), std::string::npos);
+
+  auto qco = std::move(*qc).intoQCO();
+  ASSERT_TRUE(qco);
+  ASSERT_TRUE(qco->cleanup());
+  ASSERT_TRUE(qco->runPassPipeline("mqt-qco-default"));
+  ASSERT_TRUE(qco->cleanup());
+  const auto optimized = qco->str();
+  auto jeff = std::move(*qco).intoJeff();
+  ASSERT_TRUE(jeff) << optimized;
+  EXPECT_TRUE(jeff->cleanup());
+}
+
 TEST(OpenQASMCompilerOutputTest,
      CanonicalizesMixedScalarAndRegisterResultsThroughQCO) {
   constexpr llvm::StringLiteral source = R"qasm(

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -706,7 +706,9 @@ OPENQASM 3.1;
 include "stdgates.inc";
 qubit[3163] q;
 qubit[3163] aux;
-for int i in [0:0] { cx q[i], aux[i + 1]; }
+int i = 0;
+int j = 1;
+cx q[i], aux[j];
 )qasm";
 
   MLIRContext context;
@@ -788,8 +790,8 @@ TEST(OpenQASMTargetTest, DoesNotMultiplyCustomGatesByRegisterWidth) {
   source += "}\n"
             "qubit[640] q;\n"
             "qubit[640] aux;\n"
-            "const int i = 0;\n"
-            "const int j = 1;\n"
+            "int i = 0;\n"
+            "int j = 1;\n"
             "expanded q[i], aux[j];\n";
 
   MLIRContext context;
@@ -1449,30 +1451,25 @@ TEST(OpenQASMTargetTest, EmitsStructuredDiagnosticsWithIncludeStacks) {
   EXPECT_EQ(nestedLocation.getLine(), 2);
 }
 
-TEST(OpenQASMTargetTest, NormalizesStaticAndRejectsDynamicQuantumIndices) {
-  constexpr llvm::StringLiteral staticIndexSource = R"qasm(
+TEST(OpenQASMTargetTest,
+     NormalizesKnownScalarIndicesAndRejectsDuplicateQubits) {
+  constexpr llvm::StringLiteral indexSource = R"qasm(
 OPENQASM 3.1;
 qubit[3] q;
 x q[-1];
 bit[3] c = measure q;
 if (c[-1]) { h q[-1]; }
-)qasm";
-  MLIRContext staticIndexContext;
-  auto staticIndex =
-      qc::translateQASM3ToQC(staticIndexSource, &staticIndexContext);
-  ASSERT_TRUE(staticIndex);
-  EXPECT_TRUE(succeeded(verify(*staticIndex)));
-
-  constexpr llvm::StringLiteral dynamicIndexSource = R"qasm(
-OPENQASM 3.1;
-qubit[3] q;
 int i = -1;
 x q[i];
+c[i] = measure q[i];
+if (c[i]) { x q[0]; }
+output bit[3] result;
+result = measure q;
 )qasm";
-  MLIRContext dynamicIndexContext;
-  auto dynamicIndex =
-      qc::translateQASM3ToQC(dynamicIndexSource, &dynamicIndexContext);
-  EXPECT_FALSE(dynamicIndex);
+  MLIRContext indexContext;
+  auto indexed = qc::translateQASM3ToQC(indexSource, &indexContext);
+  ASSERT_TRUE(indexed);
+  EXPECT_TRUE(succeeded(verify(*indexed)));
 
   constexpr llvm::StringLiteral aliasSource = R"qasm(
 OPENQASM 3.1;
@@ -1491,7 +1488,8 @@ TEST(OpenQASMTargetTest, LoadsDynamicQubitGatesDirectly) {
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[2] q;
-for int i in [0:0] { x q[i]; }
+int i = 0;
+x q[i];
 )qasm";
 
   MLIRContext context;
@@ -1553,7 +1551,8 @@ TEST(OpenQASMTargetTest, LoadsDynamicQubitMeasurementsDirectly) {
 OPENQASM 3.1;
 qubit[2] q;
 bit c;
-for int i in [0:0] { c = measure q[i]; }
+int i = 0;
+c = measure q[i];
 )qasm";
 
   MLIRContext context;
@@ -1578,7 +1577,8 @@ TEST(OpenQASMTargetTest, HandlesWidthOneAndMultipleDynamicQubitLoads) {
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[1] q;
-for int i in [0:0] { x q[i]; }
+int i = 0;
+x q[i];
 )qasm";
   MLIRContext widthOneContext;
   auto widthOneModule =
@@ -1598,7 +1598,9 @@ OPENQASM 3.1;
 include "stdgates.inc";
 qubit[2] left;
 qubit[2] right;
-for int i in [0:0] { cx left[i], right[i + 1]; }
+int i = 0;
+int j = 1;
+cx left[i], right[j];
 )qasm";
   MLIRContext nestedContext;
   auto nestedModule = qc::translateQASM3ToQC(nestedSource, &nestedContext);
@@ -1622,13 +1624,12 @@ TEST(OpenQASMTargetTest, LoadsEveryDynamicQuantumStatementDirectly) {
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[4] q;
-bit measured;
-for int i in [0:0] {
-  negctrl @ x q[i], q[i + 1];
-  measured = measure q[i];
-  reset q[i + 1];
-  barrier q[i], q[i + 1];
-}
+int i = 0;
+int j = 1;
+negctrl @ x q[i], q[j];
+bit measured = measure q[i];
+reset q[j];
+barrier q[i], q[j];
 )qasm";
 
   MLIRContext context;
@@ -1664,8 +1665,7 @@ for int i in [0:0] {
 TEST(OpenQASMTargetTest, QuantumEmissionDoesNotScaleWithRegisterWidth) {
   const auto operationCount = [](const int64_t width) {
     const auto source = "OPENQASM 3.1;\ninclude \"stdgates.inc\";\nqubit[" +
-                        std::to_string(width) +
-                        "] q;\nfor int i in [0:0] { h q[i]; }\n";
+                        std::to_string(width) + "] q;\nint i = 0;\nh q[i];\n";
     MLIRContext context;
     auto moduleOp = qc::translateQASM3ToQC(source, &context);
     EXPECT_TRUE(moduleOp);
@@ -1958,7 +1958,7 @@ TEST(OpenQASMTargetTest, LowersMultiIterationInductionIndicesAtQCTarget) {
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[4] q;
-for uint i in [0:2] { h q[i + 1]; }
+for uint i in [0:2] { int x = i + 1; h q[x]; }
 )qasm";
 
   MLIRContext context;
@@ -1974,7 +1974,7 @@ include "stdgates.inc";
 qubit[8] q;
 qubit[8] left;
 qubit[8] right;
-const int last = 7;
+int last = 7;
 for int i in [0:6] {
   cx q[i], q[i + 1];
   h q[last - i];
@@ -1985,7 +1985,8 @@ for int i in [0:6] {
     }
   }
 }
-for int i in [0:2:6] { x q[i]; }
+int stride = 2;
+for int i in [0:stride:6] { x q[i]; }
 )qasm";
 
   MLIRContext context;
@@ -2131,13 +2132,14 @@ for int i in [start:step:stop] { x q; }
   EXPECT_GE(assertions, 1);
 }
 
-TEST(OpenQASMTargetTest, ElidesStaticallyFalseQuantumBranch) {
+TEST(OpenQASMTargetTest, PreservesStaticallySelectedIndexState) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
-qubit[1] q;
-if (false) { pow(2) @ x q[0]; }
-x q[0];
+qubit[2] q;
+int i = 0;
+if (false) { i = 1; pow(2) @ x q[1]; }
+x q[i];
 )qasm";
 
   MLIRContext context;
@@ -2163,7 +2165,7 @@ x q[0];
   EXPECT_EQ(powers, 0);
 }
 
-TEST(OpenQASMTargetTest, RejectsAssignedIndexFactsAfterControlFlow) {
+TEST(OpenQASMTargetTest, PreservesEqualConstantIndexJoins) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
@@ -2176,7 +2178,8 @@ x q[i];
 
   MLIRContext context;
   auto moduleOp = qc::translateQASM3ToQC(source, &context);
-  EXPECT_FALSE(moduleOp);
+  ASSERT_TRUE(moduleOp);
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
 }
 
 TEST(OpenQASMTargetTest, LowersShortCircuitBooleanEvaluation) {

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -23,6 +23,7 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -1450,7 +1451,7 @@ TEST(OpenQASMTargetTest, EmitsStructuredDiagnosticsWithIncludeStacks) {
   EXPECT_EQ(nestedLocation.getLine(), 2);
 }
 
-TEST(OpenQASMTargetTest, NormalizesNegativeIndicesAndChecksDynamicAliases) {
+TEST(OpenQASMTargetTest, RejectsNegativeAndAliasingQuantumIndices) {
   constexpr llvm::StringLiteral indexSource = R"qasm(
 OPENQASM 3.1;
 qubit[3] q;
@@ -1466,11 +1467,7 @@ result = measure q;
 )qasm";
   MLIRContext indexContext;
   auto indexed = qc::translateQASM3ToQC(indexSource, &indexContext);
-  ASSERT_TRUE(indexed);
-  ASSERT_TRUE(succeeded(verify(*indexed)));
-  size_t indexSelections = 0;
-  indexed->walk([&](arith::SelectOp) { ++indexSelections; });
-  EXPECT_GE(indexSelections, 3);
+  EXPECT_FALSE(indexed);
 
   constexpr llvm::StringLiteral aliasSource = R"qasm(
 OPENQASM 3.1;
@@ -1481,11 +1478,7 @@ bit[2] result = measure q;
 )qasm";
   MLIRContext aliasContext;
   auto aliased = qc::translateQASM3ToQC(aliasSource, &aliasContext);
-  ASSERT_TRUE(aliased);
-  ASSERT_TRUE(succeeded(verify(*aliased)));
-  size_t aliasAssertions = 0;
-  aliased->walk([&](cf::AssertOp) { ++aliasAssertions; });
-  EXPECT_GE(aliasAssertions, 3);
+  EXPECT_FALSE(aliased);
 }
 
 TEST(OpenQASMTargetTest, LoadsDynamicQubitGatesDirectly) {
@@ -1647,7 +1640,6 @@ barrier q[i], q[j];
   size_t measurements = 0;
   size_t resets = 0;
   size_t barriers = 0;
-  size_t distinctnessAssertions = 0;
   moduleOp->walk([&](scf::IndexSwitchOp) { ++switches; });
   moduleOp->walk([&](memref::LoadOp load) {
     if (isa<qc::QubitType>(load.getType())) {
@@ -1658,16 +1650,14 @@ barrier q[i], q[j];
   moduleOp->walk([&](qc::MeasureOp) { ++measurements; });
   moduleOp->walk([&](qc::ResetOp) { ++resets; });
   moduleOp->walk([&](qc::BarrierOp) { ++barriers; });
-  moduleOp->walk([&](cf::AssertOp assertion) {
-    distinctnessAssertions += assertion.getMsg().ends_with(
-        "operands must not reference the same qubit");
-  });
   EXPECT_EQ(switches, 0);
   EXPECT_EQ(loads, 6);
   EXPECT_EQ(measurements, 1);
   EXPECT_EQ(resets, 1);
   EXPECT_EQ(barriers, 1);
-  EXPECT_EQ(distinctnessAssertions, 2);
+  size_t assertions = 0;
+  moduleOp->walk([&](cf::AssertOp) { ++assertions; });
+  EXPECT_EQ(assertions, 0);
 }
 
 TEST(OpenQASMTargetTest, QuantumEmissionDoesNotScaleWithRegisterWidth) {
@@ -1778,6 +1768,32 @@ for uint i in [start:-1:stop] { x q; }
   EXPECT_EQ(xGates, 0);
 }
 
+TEST(OpenQASMTargetTest, PreservesMixedPositiveRangeEndpointPromotion) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+const uint stop = 1;
+qubit q;
+for int i in [-1:stop] { x q; }
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  PassManager canonicalizer(&context);
+  canonicalizer.addPass(createCanonicalizerPass());
+  ASSERT_TRUE(succeeded(canonicalizer.run(*moduleOp)));
+  size_t loops = 0;
+  size_t xGates = 0;
+  moduleOp->walk([&](Operation* operation) {
+    loops += isa<scf::ForOp>(operation);
+    xGates += isa<qc::XOp>(operation);
+  });
+  EXPECT_EQ(loops, 0);
+  EXPECT_EQ(xGates, 0);
+}
+
 TEST(OpenQASMTargetTest, ThreadsGateParametersIntoWhileConditions) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
@@ -1865,7 +1881,7 @@ x q;
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
 }
 
-TEST(OpenQASMTargetTest, LowersRuntimeDynamicIndicesWithBoundsChecks) {
+TEST(OpenQASMTargetTest, RejectsMutableRuntimeQuantumIndices) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
@@ -1878,11 +1894,7 @@ x q[i];
 
   MLIRContext context;
   auto moduleOp = qc::translateQASM3ToQC(source, &context);
-  ASSERT_TRUE(moduleOp);
-  ASSERT_TRUE(succeeded(verify(*moduleOp)));
-  size_t assertions = 0;
-  moduleOp->walk([&](cf::AssertOp) { ++assertions; });
-  EXPECT_GE(assertions, 1);
+  EXPECT_FALSE(moduleOp);
 }
 
 TEST(OpenQASMTargetTest, LowersRuntimeIndicesAcrossStatementKinds) {
@@ -1901,10 +1913,6 @@ if (c[i]) { x q[0]; })qasm",
       "OPENQASM 3.1; qubit[2] q; bit[2] c = measure q; int i = 0; "
       "bit choose = measure q[0]; if (choose) { i = 1; } "
       "c[i] = measure q[0];",
-      "OPENQASM 3.1; qubit[2] q; int i = 0; "
-      "bit choose = measure q[0]; if (choose) { i = 1; } reset q[i];",
-      "OPENQASM 3.1; qubit[2] q; int i = 0; "
-      "bit choose = measure q[0]; if (choose) { i = 1; } barrier q[i];",
   });
 
   for (const auto source : sources) {
@@ -1914,9 +1922,21 @@ if (c[i]) { x q[0]; })qasm",
     ASSERT_TRUE(moduleOp);
     EXPECT_TRUE(succeeded(verify(*moduleOp)));
   }
+
+  constexpr auto rejectedQuantumSources = std::to_array<llvm::StringLiteral>({
+      "OPENQASM 3.1; qubit[2] q; int i = 0; "
+      "bit choose = measure q[0]; if (choose) { i = 1; } reset q[i];",
+      "OPENQASM 3.1; qubit[2] q; int i = 0; "
+      "bit choose = measure q[0]; if (choose) { i = 1; } barrier q[i];",
+  });
+  for (const auto source : rejectedQuantumSources) {
+    SCOPED_TRACE(source.str());
+    MLIRContext context;
+    EXPECT_FALSE(qc::translateQASM3ToQC(source, &context));
+  }
 }
 
-TEST(OpenQASMTargetTest, LowersLoopVariantDynamicIndicesAtQCTarget) {
+TEST(OpenQASMTargetTest, RejectsLoopVariantQuantumIndicesAtQCTarget) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
@@ -1928,8 +1948,7 @@ while (repeat) { x q[i]; i = 1; repeat = measure q[0]; }
 
   MLIRContext context;
   auto moduleOp = qc::translateQASM3ToQC(source, &context);
-  ASSERT_TRUE(moduleOp);
-  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_FALSE(moduleOp);
 }
 
 TEST(OpenQASMTargetTest, LowersMultiIterationInductionIndicesAtQCTarget) {
@@ -1944,6 +1963,49 @@ for uint i in [0:2] { int x = i + 1; h q[x]; }
   auto moduleOp = qc::translateQASM3ToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
+}
+
+TEST(OpenQASMTargetTest, LowersProvenAffineIndicesWithoutRuntimeGuards) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+qubit[8] q;
+qubit[8] left;
+qubit[8] right;
+int last = 7;
+for int i in [0:6] {
+  cx q[i], q[i + 1];
+  h q[last - i];
+  for int j in [i + 1:last] {
+    cx q[j], q[i];
+    for int step in [0:j] {
+      cx left[j - step], right[j];
+    }
+  }
+}
+for int i in [0:2:6] { x q[i]; }
+)qasm";
+
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  size_t forLoops = 0;
+  size_t whileLoops = 0;
+  size_t assertions = 0;
+  size_t selections = 0;
+  moduleOp->walk([&](scf::ForOp) { ++forLoops; });
+  moduleOp->walk([&](scf::WhileOp) { ++whileLoops; });
+  moduleOp->walk([&](cf::AssertOp) { ++assertions; });
+  moduleOp->walk([&](arith::SelectOp) { ++selections; });
+  EXPECT_EQ(forLoops, 4);
+  EXPECT_EQ(whileLoops, 0);
+  EXPECT_EQ(assertions, 0);
+  EXPECT_EQ(selections, 0);
+  std::string text;
+  llvm::raw_string_ostream stream(text);
+  moduleOp->print(stream);
+  EXPECT_EQ(text.find("i128"), std::string::npos);
 }
 
 TEST(OpenQASMTargetTest, LowersCheckedIntegerArithmeticAtQCTarget) {
@@ -2100,7 +2162,7 @@ x q[i];
   EXPECT_EQ(powers, 0);
 }
 
-TEST(OpenQASMTargetTest, PreservesEqualConstantIndexJoins) {
+TEST(OpenQASMTargetTest, RejectsAssignedIndexFactsAfterControlFlow) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
@@ -2113,8 +2175,7 @@ x q[i];
 
   MLIRContext context;
   auto moduleOp = qc::translateQASM3ToQC(source, &context);
-  ASSERT_TRUE(moduleOp);
-  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_FALSE(moduleOp);
 }
 
 TEST(OpenQASMTargetTest, LowersShortCircuitBooleanEvaluation) {

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -706,9 +706,7 @@ OPENQASM 3.1;
 include "stdgates.inc";
 qubit[3163] q;
 qubit[3163] aux;
-int i = 0;
-  int j = 1;
-cx q[i], aux[j];
+for int i in [0:0] { cx q[i], aux[i + 1]; }
 )qasm";
 
   MLIRContext context;
@@ -790,8 +788,8 @@ TEST(OpenQASMTargetTest, DoesNotMultiplyCustomGatesByRegisterWidth) {
   source += "}\n"
             "qubit[640] q;\n"
             "qubit[640] aux;\n"
-            "int i = 0;\n"
-            "int j = 1;\n"
+            "const int i = 0;\n"
+            "const int j = 1;\n"
             "expanded q[i], aux[j];\n";
 
   MLIRContext context;
@@ -1451,23 +1449,30 @@ TEST(OpenQASMTargetTest, EmitsStructuredDiagnosticsWithIncludeStacks) {
   EXPECT_EQ(nestedLocation.getLine(), 2);
 }
 
-TEST(OpenQASMTargetTest, RejectsNegativeAndAliasingQuantumIndices) {
-  constexpr llvm::StringLiteral indexSource = R"qasm(
+TEST(OpenQASMTargetTest, NormalizesStaticAndRejectsDynamicQuantumIndices) {
+  constexpr llvm::StringLiteral staticIndexSource = R"qasm(
 OPENQASM 3.1;
 qubit[3] q;
 x q[-1];
 bit[3] c = measure q;
 if (c[-1]) { h q[-1]; }
+)qasm";
+  MLIRContext staticIndexContext;
+  auto staticIndex =
+      qc::translateQASM3ToQC(staticIndexSource, &staticIndexContext);
+  ASSERT_TRUE(staticIndex);
+  EXPECT_TRUE(succeeded(verify(*staticIndex)));
+
+  constexpr llvm::StringLiteral dynamicIndexSource = R"qasm(
+OPENQASM 3.1;
+qubit[3] q;
 int i = -1;
 x q[i];
-c[i] = measure q[i];
-if (c[i]) { x q[0]; }
-output bit[3] result;
-result = measure q;
 )qasm";
-  MLIRContext indexContext;
-  auto indexed = qc::translateQASM3ToQC(indexSource, &indexContext);
-  EXPECT_FALSE(indexed);
+  MLIRContext dynamicIndexContext;
+  auto dynamicIndex =
+      qc::translateQASM3ToQC(dynamicIndexSource, &dynamicIndexContext);
+  EXPECT_FALSE(dynamicIndex);
 
   constexpr llvm::StringLiteral aliasSource = R"qasm(
 OPENQASM 3.1;
@@ -1486,8 +1491,7 @@ TEST(OpenQASMTargetTest, LoadsDynamicQubitGatesDirectly) {
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[2] q;
-int i = 0;
-x q[i];
+for int i in [0:0] { x q[i]; }
 )qasm";
 
   MLIRContext context;
@@ -1549,8 +1553,7 @@ TEST(OpenQASMTargetTest, LoadsDynamicQubitMeasurementsDirectly) {
 OPENQASM 3.1;
 qubit[2] q;
 bit c;
-int i = 0;
-c = measure q[i];
+for int i in [0:0] { c = measure q[i]; }
 )qasm";
 
   MLIRContext context;
@@ -1575,8 +1578,7 @@ TEST(OpenQASMTargetTest, HandlesWidthOneAndMultipleDynamicQubitLoads) {
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[1] q;
-int i = 0;
-x q[i];
+for int i in [0:0] { x q[i]; }
 )qasm";
   MLIRContext widthOneContext;
   auto widthOneModule =
@@ -1596,9 +1598,7 @@ OPENQASM 3.1;
 include "stdgates.inc";
 qubit[2] left;
 qubit[2] right;
-int i = 0;
-int j = 1;
-cx left[i], right[j];
+for int i in [0:0] { cx left[i], right[i + 1]; }
 )qasm";
   MLIRContext nestedContext;
   auto nestedModule = qc::translateQASM3ToQC(nestedSource, &nestedContext);
@@ -1622,12 +1622,13 @@ TEST(OpenQASMTargetTest, LoadsEveryDynamicQuantumStatementDirectly) {
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[4] q;
-int i = 0;
-int j = 1;
-negctrl @ x q[i], q[j];
-bit measured = measure q[i];
-reset q[j];
-barrier q[i], q[j];
+bit measured;
+for int i in [0:0] {
+  negctrl @ x q[i], q[i + 1];
+  measured = measure q[i];
+  reset q[i + 1];
+  barrier q[i], q[i + 1];
+}
 )qasm";
 
   MLIRContext context;
@@ -1663,7 +1664,8 @@ barrier q[i], q[j];
 TEST(OpenQASMTargetTest, QuantumEmissionDoesNotScaleWithRegisterWidth) {
   const auto operationCount = [](const int64_t width) {
     const auto source = "OPENQASM 3.1;\ninclude \"stdgates.inc\";\nqubit[" +
-                        std::to_string(width) + "] q;\nint i = 0;\nh q[i];\n";
+                        std::to_string(width) +
+                        "] q;\nfor int i in [0:0] { h q[i]; }\n";
     MLIRContext context;
     auto moduleOp = qc::translateQASM3ToQC(source, &context);
     EXPECT_TRUE(moduleOp);
@@ -1956,7 +1958,7 @@ TEST(OpenQASMTargetTest, LowersMultiIterationInductionIndicesAtQCTarget) {
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[4] q;
-for uint i in [0:2] { int x = i + 1; h q[x]; }
+for uint i in [0:2] { h q[i + 1]; }
 )qasm";
 
   MLIRContext context;
@@ -1972,7 +1974,7 @@ include "stdgates.inc";
 qubit[8] q;
 qubit[8] left;
 qubit[8] right;
-int last = 7;
+const int last = 7;
 for int i in [0:6] {
   cx q[i], q[i + 1];
   h q[last - i];
@@ -2129,14 +2131,13 @@ for int i in [start:step:stop] { x q; }
   EXPECT_GE(assertions, 1);
 }
 
-TEST(OpenQASMTargetTest, PreservesStaticallySelectedIndexState) {
+TEST(OpenQASMTargetTest, ElidesStaticallyFalseQuantumBranch) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
-qubit[2] q;
-int i = 0;
-if (false) { i = 1; pow(2) @ x q[1]; }
-x q[i];
+qubit[1] q;
+if (false) { pow(2) @ x q[0]; }
+x q[0];
 )qasm";
 
   MLIRContext context;

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -90,7 +90,129 @@ cx q, q;
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
-  EXPECT_NE(analyzed.diagnostics.front().message.find("same qubit"),
+  EXPECT_NE(analyzed.diagnostics.front().message.find("distinct qubits"),
+            std::string::npos);
+}
+
+TEST(OpenQASMFrontendTest, ProvesNestedAffineQuantumIndices) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+qubit[8] q;
+qubit[8] left;
+qubit[8] right;
+int last = 7;
+for int i in [0:6] {
+  x q[i];
+  cx q[i], q[i + 1];
+  h q[last - i];
+  barrier q[i], q[i + 1];
+  for int j in [i + 1:last] {
+    cx q[j], q[i];
+    for int step in [0:j] {
+      cx left[j - step], right[j];
+    }
+  }
+}
+for int i in [0:2:6] { x q[i]; }
+for int i in [0:3] {
+  uint even = 2 * i;
+  h q[even];
+}
+)qasm";
+
+  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+}
+
+TEST(OpenQASMFrontendTest, RejectsUnprovedQuantumIndices) {
+  struct Rejection {
+    llvm::StringRef source;
+    llvm::StringRef diagnostic;
+  };
+  constexpr auto rejections = std::to_array<Rejection>({
+      {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { for int j in "
+       "[0:3] { cx q[i], q[j]; } }",
+       "distinct qubits"},
+      {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i + 1]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[2] q; int i = 0; i = 1; x q[i];",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[2] q; x q[-1];",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[2] q; bit b = measure q[0]; int i = b; "
+       "x q[i];",
+       "not a scalar value"},
+      {"OPENQASM 3.1; qubit[16] q; for int i in [0:3] { x q[i * i]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i / 1]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i % 4]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[4] q; for int i in [0:1] { x q[i ** 1]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[2] q; for int i in [0:1] { "
+       "x q[(i + 9223372036854775807) - 9223372036854775807]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[2] q; for int i in "
+       "[9223372036854775806:9223372036854775807] { "
+       "x q[i - 9223372036854775806]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[4] q; for int i in [0:1] { x q[i << 1]; }",
+       "not supported yet"},
+      {"OPENQASM 3.1; qubit[4] q; for int i in [3:-1:0] { x q[i]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[4] q; int step = 1; for int i in "
+       "[0:step:3] { x q[i]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[4] q; int i = 4; if (i < 4) { x q[i]; }",
+       "cannot prove that qubit index is in bounds"},
+      {"OPENQASM 3.1; qubit[2] q; int i = 0; bit repeat = measure "
+       "q[0]; while (repeat) { x q[i]; i = 1; repeat = measure q[0]; }",
+       "cannot prove that qubit index is in bounds"},
+  });
+
+  for (const auto& rejection : rejections) {
+    SCOPED_TRACE(rejection.source.str());
+    auto analyzed = oq3::frontend::analyzeOpenQASM(rejection.source);
+    ASSERT_FALSE(analyzed);
+    ASSERT_FALSE(analyzed.diagnostics.empty());
+    EXPECT_NE(analyzed.diagnostics.front().message.find(rejection.diagnostic),
+              std::string::npos)
+        << analyzed.diagnostics.front().message;
+  }
+}
+
+TEST(OpenQASMFrontendTest, BoundsAffineDistinctnessProofWork) {
+  std::string source =
+      "OPENQASM 3.1; qubit[100] q; for int i in [0:0] { barrier ";
+  for (size_t index = 0; index < 100; ++index) {
+    if (index != 0) {
+      source += ", ";
+    }
+    source +=
+        "q[" + std::to_string(index) + " * i + " + std::to_string(index) + "]";
+  }
+  source += "; }";
+
+  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  ASSERT_FALSE(analyzed);
+  ASSERT_FALSE(analyzed.diagnostics.empty());
+  EXPECT_NE(analyzed.diagnostics.front().message.find("distinct qubits"),
+            std::string::npos);
+
+  constexpr llvm::StringLiteral broadcastSource = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+gate pair q0, q1, unused { cx q0, q1; }
+qubit[2] q;
+qubit[2048] other;
+for int i in [0:0] { pair q[i], q[i + 1], other; }
+)qasm";
+  auto broadcast = oq3::frontend::analyzeOpenQASM(broadcastSource);
+  ASSERT_FALSE(broadcast);
+  ASSERT_FALSE(broadcast.diagnostics.empty());
+  EXPECT_NE(broadcast.diagnostics.front().message.find("distinct qubits"),
             std::string::npos);
 }
 

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -101,7 +101,8 @@ include "stdgates.inc";
 qubit[8] q;
 qubit[8] left;
 qubit[8] right;
-int last = 7;
+const int last = 7;
+x q[-1];
 for int i in [0:6] {
   x q[i];
   cx q[i], q[i + 1];
@@ -115,10 +116,7 @@ for int i in [0:6] {
   }
 }
 for int i in [0:2:6] { x q[i]; }
-for int i in [0:3] {
-  uint even = 2 * i;
-  h q[even];
-}
+for int i in [0:3] { h q[2 * i]; }
 )qasm";
 
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
@@ -126,64 +124,62 @@ for int i in [0:3] {
 }
 
 TEST(OpenQASMFrontendTest, RejectsUnprovedQuantumIndices) {
-  struct Rejection {
-    llvm::StringRef source;
-    llvm::StringRef diagnostic;
-  };
-  constexpr auto rejections = std::to_array<Rejection>({
-      {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { for int j in "
-       "[0:3] { cx q[i], q[j]; } }",
-       "distinct qubits"},
-      {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i + 1]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[2] q; int i = 0; i = 1; x q[i];",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[2] q; x q[-1];",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[2] q; bit b = measure q[0]; int i = b; "
-       "x q[i];",
-       "not a scalar value"},
-      {"OPENQASM 3.1; qubit[16] q; for int i in [0:3] { x q[i * i]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i / 1]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i % 4]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[4] q; for int i in [0:1] { x q[i ** 1]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[2] q; for int i in [0:1] { "
-       "x q[(i + 9223372036854775807) - 9223372036854775807]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[2] q; for int i in "
-       "[9223372036854775806:9223372036854775807] { "
-       "x q[i - 9223372036854775806]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[4] q; for int i in [0:1] { x q[i << 1]; }",
-       "not supported yet"},
-      {"OPENQASM 3.1; qubit[4] q; for int i in [3:-1:0] { x q[i]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[4] q; int step = 1; for int i in "
-       "[0:step:3] { x q[i]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[4] q; int i = 4; if (i < 4) { x q[i]; }",
-       "cannot prove that qubit index is in bounds"},
-      {"OPENQASM 3.1; qubit[2] q; int i = 0; bit repeat = measure "
-       "q[0]; while (repeat) { x q[i]; i = 1; repeat = measure q[0]; }",
-       "cannot prove that qubit index is in bounds"},
-  });
+  constexpr auto rejections =
+      std::to_array<std::pair<llvm::StringRef, llvm::StringRef>>({
+          {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { for int j in "
+           "[0:3] { cx q[i], q[j]; } }",
+           "distinct qubits"},
+          {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i + 1]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[2] q; int i = 0; i = 1; x q[i];",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[4] q; for int i in [0:2] { "
+           "int x = i + 1; h q[x]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[2] q; bit b = measure q[0]; int i = b; "
+           "x q[i];",
+           "not a scalar value"},
+          {"OPENQASM 3.1; qubit[16] q; for int i in [0:3] { x q[i * i]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i / 1]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i % 4]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[4] q; for int i in [0:1] { x q[i ** 1]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[2] q; for int i in [0:1] { "
+           "x q[(i + 9223372036854775807) - 9223372036854775807]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[2] q; for int i in "
+           "[9223372036854775806:9223372036854775807] { "
+           "x q[i - 9223372036854775806]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[4] q; for int i in [0:1] { x q[i << 1]; }",
+           "not supported yet"},
+          {"OPENQASM 3.1; qubit[4] q; for int i in [3:-1:0] { x q[i]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[4] q; int step = 1; for int i in "
+           "[0:step:3] { x q[i]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[4] q; int i = 4; if (i < 4) { x q[i]; }",
+           "cannot prove that qubit index is in bounds"},
+          {"OPENQASM 3.1; qubit[2] q; int i = 0; bit repeat = measure "
+           "q[0]; while (repeat) { x q[i]; i = 1; repeat = measure q[0]; }",
+           "cannot prove that qubit index is in bounds"},
+      });
 
-  for (const auto& rejection : rejections) {
-    SCOPED_TRACE(rejection.source.str());
-    auto analyzed = oq3::frontend::analyzeOpenQASM(rejection.source);
+  for (const auto& [source, diagnostic] : rejections) {
+    SCOPED_TRACE(source.str());
+    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
-    EXPECT_NE(analyzed.diagnostics.front().message.find(rejection.diagnostic),
+    EXPECT_NE(analyzed.diagnostics.front().message.find(diagnostic),
               std::string::npos)
         << analyzed.diagnostics.front().message;
   }
 }
 
-TEST(OpenQASMFrontendTest, BoundsAffineDistinctnessProofWork) {
+TEST(OpenQASMFrontendTest, BoundsNontrivialAffineDistinctnessProofWork) {
   std::string source =
       "OPENQASM 3.1; qubit[100] q; for int i in [0:0] { barrier ";
   for (size_t index = 0; index < 100; ++index) {
@@ -210,17 +206,14 @@ qubit[2048] other;
 for int i in [0:0] { pair q[i], q[i + 1], other; }
 )qasm";
   auto broadcast = oq3::frontend::analyzeOpenQASM(broadcastSource);
-  ASSERT_FALSE(broadcast);
-  ASSERT_FALSE(broadcast.diagnostics.empty());
-  EXPECT_NE(broadcast.diagnostics.front().message.find("distinct qubits"),
-            std::string::npos);
+  ASSERT_TRUE(broadcast) << broadcast.diagnostics.front().message;
 }
 
 TEST(OpenQASMFrontendTest, RejectsDuplicateBarrierQubits) {
   constexpr auto sources = std::to_array<llvm::StringLiteral>({
       "OPENQASM 3.1; qubit q; barrier q, q;",
       "OPENQASM 3.1; qubit[2] q; barrier q[0], q[0];",
-      "OPENQASM 3.1; qubit[2] q; int i = 0; barrier q, q[i];",
+      "OPENQASM 3.1; qubit[2] q; barrier q, q[0];",
       "OPENQASM 3.1; barrier $0, $0;",
   });
 
@@ -466,10 +459,10 @@ ctrl(9223372036854775807) @ ctrl(9223372036854775807) @ ctrl(2) @ x q;
   constexpr llvm::StringLiteral excessiveDynamicDispatch = R"qasm(
 OPENQASM 3.1;
 qubit[16] q;
-int a = 0;
-int b = 1;
-int c = 2;
-int d = 3;
+const int a = 0;
+const int b = 1;
+const int c = 2;
+const int d = 3;
 mcx q[a], q[b], q[c], q[d];
 )qasm";
 
@@ -647,9 +640,9 @@ OPENQASM 3.1;
 qubit[2] q;
 bit[2] c;
 int i = 0;
-c[i] = measure q[i];
+c[i] = measure q[0];
 i = 1;
-if (c[i]) { x q[i]; }
+if (c[i]) { x q[1]; }
 )qasm";
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
@@ -769,7 +762,7 @@ OPENQASM 3.1;
 qubit[2] q;
 bit[2] c;
 int i = 1;
-if (true) { c[i] = measure q[i]; }
+if (true) { c[i] = measure q[1]; }
 if (c[i]) { x q[0]; }
 output bit result;
 result = measure q[0];

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -101,7 +101,7 @@ include "stdgates.inc";
 qubit[8] q;
 qubit[8] left;
 qubit[8] right;
-const int last = 7;
+int last = 7;
 x q[-1];
 for int i in [0:6] {
   x q[i];
@@ -116,7 +116,27 @@ for int i in [0:6] {
   }
 }
 for int i in [0:2:6] { x q[i]; }
-for int i in [0:3] { h q[2 * i]; }
+for int i in [0:3] {
+  uint even = 2 * i;
+  h q[even];
+}
+int stride = 2;
+for int i in [0:stride:6] { x q[i]; }
+)qasm";
+
+  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+}
+
+TEST(OpenQASMFrontendTest, PreservesEquivalentAffineScalarJoins) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+include "stdgates.inc";
+qubit[2] q;
+int i = 0;
+bit choose = measure q[0];
+if (choose) { i = i + 1; } else { i = 1; }
+x q[i];
 )qasm";
 
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
@@ -130,11 +150,6 @@ TEST(OpenQASMFrontendTest, RejectsUnprovedQuantumIndices) {
            "[0:3] { cx q[i], q[j]; } }",
            "distinct qubits"},
           {"OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[i + 1]; }",
-           "cannot prove that qubit index is in bounds"},
-          {"OPENQASM 3.1; qubit[2] q; int i = 0; i = 1; x q[i];",
-           "cannot prove that qubit index is in bounds"},
-          {"OPENQASM 3.1; qubit[4] q; for int i in [0:2] { "
-           "int x = i + 1; h q[x]; }",
            "cannot prove that qubit index is in bounds"},
           {"OPENQASM 3.1; qubit[2] q; bit b = measure q[0]; int i = b; "
            "x q[i];",
@@ -157,9 +172,6 @@ TEST(OpenQASMFrontendTest, RejectsUnprovedQuantumIndices) {
           {"OPENQASM 3.1; qubit[4] q; for int i in [0:1] { x q[i << 1]; }",
            "not supported yet"},
           {"OPENQASM 3.1; qubit[4] q; for int i in [3:-1:0] { x q[i]; }",
-           "cannot prove that qubit index is in bounds"},
-          {"OPENQASM 3.1; qubit[4] q; int step = 1; for int i in "
-           "[0:step:3] { x q[i]; }",
            "cannot prove that qubit index is in bounds"},
           {"OPENQASM 3.1; qubit[4] q; int i = 4; if (i < 4) { x q[i]; }",
            "cannot prove that qubit index is in bounds"},
@@ -213,7 +225,7 @@ TEST(OpenQASMFrontendTest, RejectsDuplicateBarrierQubits) {
   constexpr auto sources = std::to_array<llvm::StringLiteral>({
       "OPENQASM 3.1; qubit q; barrier q, q;",
       "OPENQASM 3.1; qubit[2] q; barrier q[0], q[0];",
-      "OPENQASM 3.1; qubit[2] q; barrier q, q[0];",
+      "OPENQASM 3.1; qubit[2] q; int i = 0; barrier q, q[i];",
       "OPENQASM 3.1; barrier $0, $0;",
   });
 
@@ -459,10 +471,10 @@ ctrl(9223372036854775807) @ ctrl(9223372036854775807) @ ctrl(2) @ x q;
   constexpr llvm::StringLiteral excessiveDynamicDispatch = R"qasm(
 OPENQASM 3.1;
 qubit[16] q;
-const int a = 0;
-const int b = 1;
-const int c = 2;
-const int d = 3;
+int a = 0;
+int b = 1;
+int c = 2;
+int d = 3;
 mcx q[a], q[b], q[c], q[d];
 )qasm";
 
@@ -640,9 +652,9 @@ OPENQASM 3.1;
 qubit[2] q;
 bit[2] c;
 int i = 0;
-c[i] = measure q[0];
+c[i] = measure q[i];
 i = 1;
-if (c[i]) { x q[1]; }
+if (c[i]) { x q[i]; }
 )qasm";
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
@@ -762,7 +774,7 @@ OPENQASM 3.1;
 qubit[2] q;
 bit[2] c;
 int i = 1;
-if (true) { c[i] = measure q[1]; }
+if (true) { c[i] = measure q[i]; }
 if (c[i]) { x q[0]; }
 output bit result;
 result = measure q[0];

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -1224,7 +1224,7 @@ c[1] = measure q[k];
 const std::string expressionDynamicIntIndex = R"qasm(OPENQASM 3.0;
 include "stdgates.inc";
 qubit[4] q;
-for uint i in [0:2] { int x = i + 1; h q[x]; }
+for uint i in [0:2] { h q[i + 1]; }
 bit[4] c = measure q;
 )qasm";
 
@@ -1350,10 +1350,10 @@ rx(theta) q;
 output bit result;
 result = measure q;
 )qasm";
-static const std::string resolvedDynamicIndex = R"qasm(OPENQASM 3.1;
+static const std::string constantIndex = R"qasm(OPENQASM 3.1;
 include "stdgates.inc";
 qubit[2] q;
-int index = 1;
+const int index = 1;
 x q[index];
 output bit[2] result;
 result = measure q;
@@ -1406,8 +1406,7 @@ llvm::ArrayRef<OpenQASMProgram> standardPipelinePrograms() {
       OpenQASMProgram{.name = "scalar-loop-state", .source = scalarLoopState},
       OpenQASMProgram{.name = "measurement-controlled-while",
                       .source = conditionWhileAnd},
-      OpenQASMProgram{.name = "resolved-dynamic-index",
-                      .source = resolvedDynamicIndex},
+      OpenQASMProgram{.name = "constant-index", .source = constantIndex},
       OpenQASMProgram{.name = "reset", .source = resetQubitAfterSingleOp},
       OpenQASMProgram{.name = "barrier", .source = barrierMultipleQubits},
       OpenQASMProgram{.name = "mixed-controls", .source = mixedControlledX},

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -1358,40 +1358,6 @@ x q[index];
 output bit[2] result;
 result = measure q;
 )qasm";
-static const std::string equalConstantIndexJoin = R"qasm(OPENQASM 3.1;
-include "stdgates.inc";
-qubit[2] q;
-int index = 0;
-bit choose = measure q[0];
-if (choose) { index = 1; } else { index = 1; }
-x q[index];
-output bit[2] result;
-result = measure q;
-)qasm";
-static const std::string runtimeDynamicIndex = R"qasm(OPENQASM 3.1;
-include "stdgates.inc";
-qubit[2] q;
-int index = 0;
-bit choose = measure q[0];
-if (choose) { index = 1; }
-x q[index];
-output bit[2] result;
-result = measure q;
-)qasm";
-static const std::string directDynamicQuantumAccess = R"qasm(OPENQASM 3.1;
-include "stdgates.inc";
-qubit[4] q;
-int first = 0;
-int second = 1;
-bit choose = measure q[3];
-if (choose) { first = 1; second = 2; }
-negctrl @ x q[first], q[second];
-bit measured = measure q[first];
-reset q[second];
-barrier q[first], q[second];
-output bit result;
-result = measure q[first];
-)qasm";
 static const std::string inductionVariableIndex = R"qasm(OPENQASM 3.1;
 include "stdgates.inc";
 qubit[3] q;
@@ -1442,15 +1408,9 @@ llvm::ArrayRef<OpenQASMProgram> standardPipelinePrograms() {
                       .source = conditionWhileAnd},
       OpenQASMProgram{.name = "resolved-dynamic-index",
                       .source = resolvedDynamicIndex},
-      OpenQASMProgram{.name = "equal-constant-index-join",
-                      .source = equalConstantIndexJoin},
       OpenQASMProgram{.name = "reset", .source = resetQubitAfterSingleOp},
       OpenQASMProgram{.name = "barrier", .source = barrierMultipleQubits},
       OpenQASMProgram{.name = "mixed-controls", .source = mixedControlledX},
-      OpenQASMProgram{.name = "runtime-dynamic-index",
-                      .source = runtimeDynamicIndex},
-      OpenQASMProgram{.name = "direct-dynamic-quantum-access",
-                      .source = directDynamicQuantumAccess},
       OpenQASMProgram{.name = "induction-variable-index",
                       .source = inductionVariableIndex},
       OpenQASMProgram{.name = "checked-integer-state",
@@ -1487,18 +1447,14 @@ llvm::ArrayRef<OpenQASMProgram> jeffCompatiblePrograms() {
       OpenQASMProgram{.name = "floating-pow-x", .source = floatingPowX},
       OpenQASMProgram{.name = "runtime-scalar-rounding",
                       .source = runtimeScalarRounding},
+      OpenQASMProgram{.name = "induction-variable-index",
+                      .source = inductionVariableIndex},
   };
   return programs;
 }
 
 llvm::ArrayRef<OpenQASMProgram> jeffIncompatiblePrograms() {
   static const std::array programs{
-      OpenQASMProgram{.name = "runtime-dynamic-index",
-                      .source = runtimeDynamicIndex},
-      OpenQASMProgram{.name = "direct-dynamic-quantum-access",
-                      .source = directDynamicQuantumAccess},
-      OpenQASMProgram{.name = "induction-variable-index",
-                      .source = inductionVariableIndex},
       OpenQASMProgram{.name = "checked-integer-state",
                       .source = checkedIntegerState},
       OpenQASMProgram{.name = "dynamic-range", .source = dynamicRange},

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -1224,7 +1224,7 @@ c[1] = measure q[k];
 const std::string expressionDynamicIntIndex = R"qasm(OPENQASM 3.0;
 include "stdgates.inc";
 qubit[4] q;
-for uint i in [0:2] { h q[i + 1]; }
+for uint i in [0:2] { int x = i + 1; h q[x]; }
 bit[4] c = measure q;
 )qasm";
 
@@ -1350,10 +1350,20 @@ rx(theta) q;
 output bit result;
 result = measure q;
 )qasm";
-static const std::string constantIndex = R"qasm(OPENQASM 3.1;
+static const std::string resolvedDynamicIndex = R"qasm(OPENQASM 3.1;
 include "stdgates.inc";
 qubit[2] q;
-const int index = 1;
+int index = 1;
+x q[index];
+output bit[2] result;
+result = measure q;
+)qasm";
+static const std::string equalConstantIndexJoin = R"qasm(OPENQASM 3.1;
+include "stdgates.inc";
+qubit[2] q;
+int index = 0;
+bit choose = measure q[0];
+if (choose) { index = 1; } else { index = 1; }
 x q[index];
 output bit[2] result;
 result = measure q;
@@ -1406,12 +1416,17 @@ llvm::ArrayRef<OpenQASMProgram> standardPipelinePrograms() {
       OpenQASMProgram{.name = "scalar-loop-state", .source = scalarLoopState},
       OpenQASMProgram{.name = "measurement-controlled-while",
                       .source = conditionWhileAnd},
-      OpenQASMProgram{.name = "constant-index", .source = constantIndex},
+      OpenQASMProgram{.name = "resolved-dynamic-index",
+                      .source = resolvedDynamicIndex},
+      OpenQASMProgram{.name = "equal-constant-index-join",
+                      .source = equalConstantIndexJoin},
       OpenQASMProgram{.name = "reset", .source = resetQubitAfterSingleOp},
       OpenQASMProgram{.name = "barrier", .source = barrierMultipleQubits},
       OpenQASMProgram{.name = "mixed-controls", .source = mixedControlledX},
       OpenQASMProgram{.name = "induction-variable-index",
                       .source = inductionVariableIndex},
+      OpenQASMProgram{.name = "affine-index-alias",
+                      .source = expressionDynamicIntIndex},
       OpenQASMProgram{.name = "checked-integer-state",
                       .source = checkedIntegerState},
       OpenQASMProgram{.name = "dynamic-range", .source = dynamicRange},
@@ -1448,6 +1463,8 @@ llvm::ArrayRef<OpenQASMProgram> jeffCompatiblePrograms() {
                       .source = runtimeScalarRounding},
       OpenQASMProgram{.name = "induction-variable-index",
                       .source = inductionVariableIndex},
+      OpenQASMProgram{.name = "affine-index-alias",
+                      .source = expressionDynamicIntIndex},
   };
   return programs;
 }


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

- Prove nonconstant quantum-register indices in the OpenQASM frontend with affine Presburger constraints.
- Accept nested positive constant-step ranges and benchmark-shaped indices such as `j - step`, `N - 1 - i`, and triangular `j > i` access patterns.
- Reject indices whose bounds or operand distinctness cannot be proved, while preserving dynamic classical indexing and unrelated generic loops.
- Lower proven ranges and indices directly without quantum bounds, negative wrapping, distinctness assertions, or `i128` induction reconstruction.
- Bound affine distinctness work and preserve mixed signed/unsigned range promotion.

The program from #2188 now lowers end to end to `jeff` without quantum-index `i128`, `arith.select`, or `cf.assert` operations. The implementation keeps the proof policy in the typed OpenQASM frontend and adds no OpenQASM-specific contract to shared QC or QCO IR.

Codex assisted with implementation, the rebase onto current `main`, a defect-first review, fixes, validation, and this description. The review found and fixed mixed signed/unsigned range semantics and unbounded pairwise proof work.

Fixes #2188

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

## Validation

- Release build
- 169 OpenQASM frontend and emitter tests
- 2,804 MLIR tests
- 4,301 configured release CTests; one QDMI test skipped under its own condition
- `uvx nox -s lint`
- `git diff --check`