### PR TITLE
⚡️ Canonicalize constant QCO index switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ⚡️ Canonicalize constant QCO index switches by inlining only the selected
+  region ([#2210]) ([**@simon1hofmann**])
 - 💥 Prune dead and misleading CoreIR APIs and remove random-number generator
   state from `QuantumComputation` ([#2111], [#2112]) ([**@simon1hofmann**])
 - 💥 Update QIR execution for QIR 2.1, isolated runtimes, reproducible
@@ -788,6 +790,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2210]: https://github.com/munich-quantum-toolkit/core/pull/2210
 [#2203]: https://github.com/munich-quantum-toolkit/core/pull/2203
 [#2175]: https://github.com/munich-quantum-toolkit/core/pull/2175
 [#2169]: https://github.com/munich-quantum-toolkit/core/pull/2169

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1722,6 +1722,7 @@ def IndexSwitchOp
         }
     }];
 
+  let hasCanonicalizer = 1;
   let hasVerifier = 1;
 }
 

--- a/mlir/lib/Dialect/QCO/IR/SCF/IndexSwitchOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IndexSwitchOp.cpp
@@ -19,6 +19,8 @@
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Location.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
@@ -148,6 +150,42 @@ ValueRange IndexSwitchOp::getSuccessorInputs(RegionSuccessor successor) {
 OperandRange
 IndexSwitchOp::getEntrySuccessorOperands(RegionSuccessor /*successor*/) {
   return getTargets();
+}
+
+namespace {
+/** Inline the selected region when the switch argument is constant. */
+struct RemoveStaticSelector final : OpRewritePattern<IndexSwitchOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IndexSwitchOp op,
+                                PatternRewriter& rewriter) const override {
+    IntegerAttr selector;
+    if (!matchPattern(op.getArg(), m_Constant(&selector))) {
+      return failure();
+    }
+
+    Region* selectedRegion = &op.getDefaultRegion();
+    const auto* const selectedCase =
+        llvm::find(op.getCases(), selector.getInt());
+    if (selectedCase != op.getCases().end()) {
+      const auto caseIndex = static_cast<size_t>(
+          std::distance(op.getCases().begin(), selectedCase));
+      selectedRegion = &op.getCaseRegions()[caseIndex];
+    }
+
+    Block* selectedBlock = &selectedRegion->front();
+    Operation* terminator = selectedBlock->getTerminator();
+    rewriter.inlineBlockBefore(selectedBlock, op, op.getTargets());
+    rewriter.replaceOp(op, terminator->getOperands());
+    rewriter.eraseOp(terminator);
+    return success();
+  }
+};
+} // namespace
+
+void IndexSwitchOp::getCanonicalizationPatterns(RewritePatternSet& results,
+                                                MLIRContext* context) {
+  results.add<RemoveStaticSelector>(context);
 }
 
 LogicalResult IndexSwitchOp::verify() {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -1414,6 +1414,84 @@ TEST_F(QCOTest, IndexSwitchConstantSuccessor) {
   EXPECT_TRUE(switchOp.verify().failed());
 }
 
+TEST_F(QCOTest, CanonicalizesConstantIndexSwitchToSelectedCaseOrDefault) {
+  constexpr StringLiteral mlirCode = R"mlir(
+    module {
+      func.func @selected_case() -> i64 {
+        %c1 = arith.constant 1 : index
+        %q0 = qco.alloc : !qco.qubit
+        %number, %q1 = qco.index_switch %c1 -> (i64, !qco.qubit)
+        case 1 args(%arg0 = %q0) {
+          %caseQubit = qco.x %arg0 : !qco.qubit -> !qco.qubit
+          %caseNumber = arith.constant 11 : i64
+          qco.yield %caseNumber, %caseQubit : i64, !qco.qubit
+        }
+        default args(%arg0 = %q0) {
+          %defaultQubit = qco.z %arg0 : !qco.qubit -> !qco.qubit
+          %defaultNumber = arith.constant 12 : i64
+          qco.yield %defaultNumber, %defaultQubit : i64, !qco.qubit
+        }
+        %q2 = qco.h %q1 : !qco.qubit -> !qco.qubit
+        qco.sink %q2 : !qco.qubit
+        return %number : i64
+      }
+
+      func.func @selected_default() -> i64 {
+        %c7 = arith.constant 7 : index
+        %q0 = qco.alloc : !qco.qubit
+        %number, %q1 = qco.index_switch %c7 -> (i64, !qco.qubit)
+        case 1 args(%arg0 = %q0) {
+          %caseQubit = qco.x %arg0 : !qco.qubit -> !qco.qubit
+          %caseNumber = arith.constant 21 : i64
+          qco.yield %caseNumber, %caseQubit : i64, !qco.qubit
+        }
+        default args(%arg0 = %q0) {
+          %defaultQubit = qco.z %arg0 : !qco.qubit -> !qco.qubit
+          %defaultNumber = arith.constant 22 : i64
+          qco.yield %defaultNumber, %defaultQubit : i64, !qco.qubit
+        }
+        %q2 = qco.h %q1 : !qco.qubit -> !qco.qubit
+        qco.sink %q2 : !qco.qubit
+        return %number : i64
+      }
+    }
+  )mlir";
+
+  auto module = parseSourceString<ModuleOp>(mlirCode, context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCOCleanupPipeline(module.get())));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  bool containsSwitch = false;
+  module->walk([&](IndexSwitchOp) { containsSwitch = true; });
+  EXPECT_FALSE(containsSwitch);
+
+  const auto checkSelectedRegion = [&](const StringRef functionName,
+                                       const int64_t expectedNumber,
+                                       const StringRef expectedGate) {
+    auto func = module->lookupSymbol<func::FuncOp>(functionName);
+    ASSERT_TRUE(func);
+
+    HOp consumer;
+    func->walk([&](HOp candidate) { consumer = candidate; });
+    ASSERT_TRUE(consumer);
+    const Value input = cast<UnitaryOpInterface>(consumer.getOperation())
+                            .getInputQubits()
+                            .front();
+    ASSERT_TRUE(input.getDefiningOp());
+    EXPECT_EQ(input.getDefiningOp()->getName().getStringRef(), expectedGate);
+
+    auto returnOp = cast<func::ReturnOp>(func.getBody().back().back());
+    APInt number;
+    ASSERT_TRUE(matchPattern(returnOp.getOperand(0), m_ConstantInt(&number)));
+    EXPECT_EQ(number.getSExtValue(), expectedNumber);
+  };
+
+  checkSelectedRegion("selected_case", 11, "qco.x");
+  checkSelectedRegion("selected_default", 22, "qco.z");
+}
+
 /// \name QCO/SCF/IfOp.cpp
 /// @{
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Canonicalize `qco.index_switch` when its selector is constant. QCO cleanup now inlines only the selected case or default region and preserves both classical and linear results.

This focused change is extracted from #2162. It has no dependency on QDMI or target-capability modeling. The commit preserves @simon1hofmann as the author of the implementation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.