### PR TITLE
📝 Define in-place target compilation semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ releases may include breaking changes.
   [#1807], [#1808], [#1815], [#1824], [#1869], [#1872], [#1914], [#1925],
   [#1927], [#1935], [#1936], [#1938], [#1975], [#1976], [#2006], [#2014],
   [#2015], [#2017], [#2026], [#2028], [#2054], [#2058], [#2125], [#2136],
-  [#2150], [#2158]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
-  [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
-  [**@simon1hofmann**], [**@J4MMlE**])
+  [#2150], [#2158], [#2210], [#2211]) ([**@burgholzer**], [**@denialhaag**],
+  [**@taminob**], [**@DRovara**], [**@li-mingbao**], [**@Ectras**],
+  [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 - ✨ Add decision diagram-based construction, simulation, and sampling for QCO
   programs ([#1915], [#1973]) ([**@simon1hofmann**])
 - ✨ Add immutable MLIR compiler targets, QDMI device integration, and target
@@ -83,8 +83,6 @@ releases may include breaking changes.
 
 ### Changed
 
-- ⚡️ Canonicalize constant QCO index switches by inlining only the selected
-  region ([#2210]) ([**@simon1hofmann**])
 - 💥 Prune dead and misleading CoreIR APIs and remove random-number generator
   state from `QuantumComputation` ([#2111], [#2112]) ([**@simon1hofmann**])
 - 💥 Update QIR execution for QIR 2.1, isolated runtimes, reproducible
@@ -790,6 +788,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2211]: https://github.com/munich-quantum-toolkit/core/pull/2211
 [#2210]: https://github.com/munich-quantum-toolkit/core/pull/2210
 [#2203]: https://github.com/munich-quantum-toolkit/core/pull/2203
 [#2175]: https://github.com/munich-quantum-toolkit/core/pull/2175

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -786,7 +786,8 @@ operations.)pb");
            &BooleanMemberAdapter<&mlir::QCOProgram::compileForTarget>::call,
            "target"_a, nb::kw_only(), "enable_timing"_a = false,
            "enable_statistics"_a = false,
-           "Compile this QCO program for the target in place.")
+           "Compile this QCO program for the target in place. Do not rely on "
+           "its contents if compilation fails.")
       .def(
           "to_qc",
           [](mlir::QCOProgram& value, const bool copy) {

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -36,9 +36,11 @@ target = CompilerTarget(3, couplings=[(0, 1), (1, 2)])
 ```
 
 Use {py:meth}`~mqt.core.mlir.QCOProgram.compile_for_target` to apply target
-compilation to an existing QCO program. For pass-level benchmarking, the C++ API
-exposes separate factories for pre-routing optimization, mapping, native
-synthesis, and conformance verification.
+compilation to an existing QCO program. Compilation runs in place. If a pass
+fails, earlier passes may already have changed the program. Copy the program
+before compilation if the caller must preserve the input. For pass-level
+benchmarking, the C++ API exposes separate factories for pre-routing
+optimization, mapping, native synthesis, and conformance verification.
 
 Target compilation preserves quantum operations even when their final qubit
 values are not measured or returned. This supports measurement-free programs,

--- a/mlir/include/mlir/Compiler/Programs.h
+++ b/mlir/include/mlir/Compiler/Programs.h
@@ -241,7 +241,9 @@ public:
   /// least 3; default 3 means wider than two-qubit).
   [[nodiscard]] bool decomposeMultiControlled(uint64_t minQubits = 3);
 
-  /// Compile this program for a target.
+  /// Compile this program for a target in place.
+  ///
+  /// Do not rely on the program contents if compilation fails.
   [[nodiscard]] bool compileForTarget(const CompilerTarget& target,
                                       bool enableTiming = false,
                                       bool enableStatistics = false);

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -431,7 +431,7 @@ class QCOProgram(Program):
     def compile_for_target(
         self, target: CompilerTarget, *, enable_timing: bool = False, enable_statistics: bool = False
     ) -> None:
-        """Compile this QCO program for the target in place."""
+        """Compile this QCO program for the target in place. Do not rely on its contents if compilation fails."""
 
     def to_qc(self, *, copy: bool = False) -> QCProgram:
         """Convert this program to QC.


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Define target compilation as an in-place, non-transactional operation. If a pass fails, earlier passes may already have changed the program. Callers that require rollback can opt into the existing `copy()` API before compilation. Target compilation keeps its zero-copy implementation and provides no implicit snapshot or rollback.

The changelog change folds #2210 and this PR into the general MQT Compiler Collection launch entry.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.