### PR TITLE
⬆️ Update jeff-mlir for the generated-source linkage fix

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -26,7 +26,7 @@ endif()
 FetchContent_Declare(
   jeff-mlir
   GIT_REPOSITORY https://github.com/unitaryfoundation/jeff-mlir.git
-  GIT_TAG f702b20b9551beb38ced989c288b2e95af758801)
+  GIT_TAG 66c92d058cb498f5c12628f6a2d2a290480d700b)
 # Cap'n Proto, which is fetched transitively by jeff-mlir, uses the generic BUILD_TESTING option and
 # defines a global `check` target when it is enabled. Do not let an embedding project's test setting
 # leak into this third-party dependency.


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Update `jeff-mlir` from `f702b20` to `66c92d0`. The new revision includes unitaryfoundation/jeff-mlir#36, which compiles the generated Cap'n Proto source only in `MLIRJeffTranslation`. This prevents duplicate symbols when a static library and an executable both link the translation library.

This extracts Daniel Haag's original dependency update from #2135. The commit keeps his authorship and author date. Codex prepared the extraction, local validation, and this description.

Local validation: the release build and all 143 Jeff round-trip tests pass. The full lint suite also passes.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
