### PR TITLE
🐛 Make QCProgramBuilder finalization deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,11 +94,6 @@ releases may include breaking changes.
   build MLIR by default, and remove the corresponding build options ([#1356],
   [#1549], [#1953]) ([**@burgholzer**], [**@denialhaag**])
 
-### Fixed
-
-- 🐛 Make QC program finalization deterministic ([#2213])
-  ([**@burgholzer**])
-
 ### Removed
 
 - 💥 Remove the unowned decision-diagram approximation algorithm and
@@ -795,7 +790,6 @@ for previous changelogs._
 
 <!-- PR links -->
 
-[#2213]: https://github.com/munich-quantum-toolkit/core/pull/2213
 [#2210]: https://github.com/munich-quantum-toolkit/core/pull/2210
 [#2203]: https://github.com/munich-quantum-toolkit/core/pull/2203
 [#2175]: https://github.com/munich-quantum-toolkit/core/pull/2175

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ releases may include breaking changes.
   build MLIR by default, and remove the corresponding build options ([#1356],
   [#1549], [#1953]) ([**@burgholzer**], [**@denialhaag**])
 
+### Fixed
+
+- 🐛 Make QC program finalization deterministic ([#2213])
+  ([**@burgholzer**])
+
 ### Removed
 
 - 💥 Remove the unowned decision-diagram approximation algorithm and
@@ -788,6 +793,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2213]: https://github.com/munich-quantum-toolkit/core/pull/2213
 [#2203]: https://github.com/munich-quantum-toolkit/core/pull/2203
 [#2175]: https://github.com/munich-quantum-toolkit/core/pull/2175
 [#2169]: https://github.com/munich-quantum-toolkit/core/pull/2169

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -12,6 +12,7 @@
 
 #include "mlir/Dialect/CBit/IR/CBitAttributes.h"
 
+#include <llvm/ADT/SetVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/OwningOpRef.h>
@@ -1400,10 +1401,10 @@ private:
   Operation* module;
 
   /// Track allocated qubits for automatic deallocation
-  DenseSet<Value> allocatedQubits;
+  SetVector<Value> allocatedQubits;
 
   /// Track allocated memrefs for automatic deallocation
-  DenseSet<Value> allocatedQregs;
+  SetVector<Value> allocatedQregs;
 
   /// Check if the builder has been finalized
   void checkFinalized() const;

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -713,7 +713,7 @@ QCProgramBuilder& QCProgramBuilder::dealloc(Value qubit) {
   }
 
   // Check if the qubit is in the tracking set
-  if (!allocatedQubits.erase(qubit)) {
+  if (!allocatedQubits.remove(qubit)) {
     llvm::reportFatalUsageError("Invalid qubit deallocation");
   }
 

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -217,6 +217,32 @@ TEST_F(QCTest, BuilderSupportsIndependentClassicalRegisterInitialization) {
       "undefined");
 }
 
+TEST_F(QCTest, BuilderDeallocatesDynamicResourcesDeterministically) {
+  QCProgramBuilder builder(context.get());
+  builder.initialize();
+
+  SmallVector<Value> allocatedQubits;
+  SmallVector<Value> allocatedRegisters;
+  for (size_t i = 0; i < 3; ++i) {
+    allocatedQubits.push_back(builder.allocQubit());
+    allocatedRegisters.push_back(builder.allocQubitRegisterStorage(1));
+  }
+
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+
+  SmallVector<Value> deallocatedQubits;
+  SmallVector<Value> deallocatedRegisters;
+  moduleOp->walk(
+      [&](DeallocOp op) { deallocatedQubits.push_back(op.getQubit()); });
+  moduleOp->walk([&](memref::DeallocOp op) {
+    deallocatedRegisters.push_back(op.getMemref());
+  });
+
+  EXPECT_EQ(deallocatedQubits, allocatedQubits);
+  EXPECT_EQ(deallocatedRegisters, allocatedRegisters);
+}
+
 TEST_F(QCTest, BuilderAllowsRepeatedQubitLoadsAcrossNestedRegions) {
   QCProgramBuilder builder(context.get());
   builder.initialize();


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Preserve allocation order when `QCProgramBuilder::finalize` inserts qubit and register deallocations. Iterating the previous dense sets could change serialized program output between runs. `llvm::SetVector` retains efficient membership checks while providing stable iteration order.

Add a regression test for both resource types. This was found while reviewing the benchmark generator in #2135, but fixes the shared builder independently. Codex implemented and locally validated this change.

Local validation: all 336 QC IR tests pass. The full lint suite also passes.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.