### PR TITLE
🐛 Fully unroll nested quantum loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,9 @@ releases may include breaking changes.
 #### Passes and transformations
 
 - ✨ Add quantum loop unrolling and qubit reuse passes ([#1705], [#1718],
-  [#1755], [#1756], [#1923], [#1924], [#2039], [#2118]) ([**@MatthiasReumann**],
-  [**@DRovara**], [**@burgholzer**], [**@simon1hofmann**])
+  [#1755], [#1756], [#1923], [#1924], [#2039], [#2118], [#2216])
+  ([**@MatthiasReumann**], [**@DRovara**], [**@burgholzer**],
+  [**@simon1hofmann**])
 - ✨ Add a compiler-target-aware `place-and-route` pass ([#1537], [#1547],
   [#1568], [#1581], [#1583], [#1588], [#1600], [#1664], [#1709], [#1716],
   [#1748], [#1805], [#1870], [#1904], [#1911], [#1951], [#1997], [#2016],
@@ -93,11 +94,6 @@ releases may include breaking changes.
 - 💥 Require LLVM/MLIR 22.1 and QIR support in every MQT Core source build,
   build MLIR by default, and remove the corresponding build options ([#1356],
   [#1549], [#1953]) ([**@burgholzer**], [**@denialhaag**])
-
-### Fixed
-
-- 🐛 Fully unroll nested quantum loops whose bounds depend on outer induction
-  variables ([#2216]) ([**@burgholzer**])
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ releases may include breaking changes.
   build MLIR by default, and remove the corresponding build options ([#1356],
   [#1549], [#1953]) ([**@burgholzer**], [**@denialhaag**])
 
+### Fixed
+
+- 🐛 Fully unroll nested quantum loops whose bounds depend on outer induction
+  variables ([#2216]) ([**@burgholzer**])
+
 ### Removed
 
 - 💥 Remove the unowned decision-diagram approximation algorithm and
@@ -788,6 +793,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2216]: https://github.com/munich-quantum-toolkit/core/pull/2216
 [#2203]: https://github.com/munich-quantum-toolkit/core/pull/2203
 [#2175]: https://github.com/munich-quantum-toolkit/core/pull/2175
 [#2169]: https://github.com/munich-quantum-toolkit/core/pull/2169

--- a/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCO/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ add_mlir_library(
   MLIRMQTTransforms
   MLIRMQTUtils
   MLIRSCFUtils
+  MLIRTransformUtils
   DEPENDS
   MLIRQCOTransformsIncGen)
 

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/QuantumLoopUnroll.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/QuantumLoopUnroll.cpp
@@ -14,8 +14,8 @@
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/SCF/Utils/Utils.h>
-#include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Visitors.h>
 #include <mlir/Interfaces/FunctionInterfaces.h>
 #include <mlir/Support/LLVM.h>
@@ -95,28 +95,20 @@ protected:
           return;
         }
 
-        SmallVector<Operation*> unrolled;
         bool changed = false;
         for (auto loop : loops) {
-          const auto lower = getConstantIntValue(loop.getLowerBound());
-          const auto upper = getConstantIntValue(loop.getUpperBound());
-          const auto step = getConstantIntValue(loop.getStep());
-          if (!lower || !upper || !step || *step <= 0) {
-            continue;
-          }
-
           const auto tripCount = loop.getStaticTripCount();
           if (!tripCount) {
             continue;
           }
-          if (tripCount->isZero()) {
+          if (tripCount->isZero() ||
+              llvm::hasSingleElement(loop.getBody()->getOperations())) {
             loop.replaceAllUsesWith(loop.getInitArgs());
             loop.erase();
             changed = true;
             continue;
           }
 
-          unrolled.emplace_back(loop.getOperation());
           if (failed(loopUnrollFull(loop))) {
             loop.emitError() << "failed to fully unroll";
             signalPassFailure();
@@ -131,18 +123,8 @@ protected:
           return;
         }
 
-        RewritePatternSet patterns(&getContext());
-        if (failed(
-                applyPatternsGreedily(getOperation(), std::move(patterns)))) {
-          signalPassFailure();
-          return;
-        }
-        auto remaining = collectQuantumLoops(getOperation());
-        const auto unchanged = llvm::find_if(remaining, [&](auto loop) {
-          return llvm::is_contained(unrolled, loop.getOperation());
-        });
-        if (unchanged != remaining.end()) {
-          unchanged->emitError() << "failed to fully unroll";
+        if (failed(applyPatternsGreedily(getOperation(),
+                                         RewritePatternSet(&getContext())))) {
           signalPassFailure();
           return;
         }

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/QuantumLoopUnroll.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/QuantumLoopUnroll.cpp
@@ -14,10 +14,12 @@
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/SCF/Utils/Utils.h>
+#include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Visitors.h>
 #include <mlir/Interfaces/FunctionInterfaces.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 namespace mlir::qco {
 
@@ -87,14 +89,64 @@ protected:
 
     // If the unroll factor is -1, fully unroll all loops.
     if (unrollFactor == -1) {
-      for (auto loop : collectQuantumLoops(getOperation())) {
-        if (failed(loopUnrollFull(loop))) {
-          loop.emitError() << "failed to fully unroll";
+      while (true) {
+        auto loops = collectQuantumLoops(getOperation());
+        if (loops.empty()) {
+          return;
+        }
+
+        SmallVector<Operation*> unrolled;
+        bool changed = false;
+        for (auto loop : loops) {
+          const auto lower = getConstantIntValue(loop.getLowerBound());
+          const auto upper = getConstantIntValue(loop.getUpperBound());
+          const auto step = getConstantIntValue(loop.getStep());
+          if (!lower || !upper || !step || *step <= 0) {
+            continue;
+          }
+
+          const auto tripCount = loop.getStaticTripCount();
+          if (!tripCount) {
+            continue;
+          }
+          if (tripCount->isZero()) {
+            loop.replaceAllUsesWith(loop.getInitArgs());
+            loop.erase();
+            changed = true;
+            continue;
+          }
+
+          unrolled.emplace_back(loop.getOperation());
+          if (failed(loopUnrollFull(loop))) {
+            loop.emitError() << "failed to fully unroll";
+            signalPassFailure();
+            return;
+          }
+          changed = true;
+        }
+
+        if (!changed) {
+          loops.front().emitError() << "failed to fully unroll";
+          signalPassFailure();
+          return;
+        }
+
+        RewritePatternSet patterns(&getContext());
+        if (failed(
+                applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+          signalPassFailure();
+          return;
+        }
+        auto remaining = collectQuantumLoops(getOperation());
+        const auto unchanged = llvm::find_if(remaining, [&](auto loop) {
+          return llvm::is_contained(unrolled, loop.getOperation());
+        });
+        if (unchanged != remaining.end()) {
+          unchanged->emitError() << "failed to fully unroll";
           signalPassFailure();
           return;
         }
       }
-      return;
     }
 
     for (auto loop : collectQuantumLoops(getOperation())) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_quantum_loop_unroll.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_quantum_loop_unroll.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_quantum_loop_unroll.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_quantum_loop_unroll.cpp
@@ -138,6 +138,34 @@ TEST_F(QuantumLoopUnrollTest, UnrollFull) {
   EXPECT_EQ(range_size(entry.getOps<qtensor::InsertOp>()), 5);
 }
 
+TEST_F(QuantumLoopUnrollTest, UnrollFullWithOuterDependentBounds) {
+  auto m = QCOProgramBuilder::build(context.get(), [](QCOProgramBuilder& b) {
+    auto tensor = b.qtensorAlloc(2);
+    auto upper = arith::ConstantIndexOp::create(b, 2).getResult();
+    auto step = arith::ConstantIndexOp::create(b, 1).getResult();
+    tensor =
+        b.scfFor(0, 2, 1, {tensor}, [&](Value outer, ValueRange outerArgs) {
+          auto lower = arith::AddIOp::create(b, outer, step).getResult();
+          return b.scfFor(
+              lower, upper, step, outerArgs, [&](Value, ValueRange innerArgs) {
+                auto tensor = innerArgs.front();
+                Value qubit;
+                std::tie(tensor, qubit) = b.qtensorExtract(tensor, 0);
+                tensor = b.qtensorInsert(b.h(qubit), tensor, 0);
+                return SmallVector{tensor};
+              });
+        })[0];
+    b.qtensorDealloc(tensor);
+    return b.intConstant(0);
+  });
+  ASSERT_TRUE(m);
+
+  EXPECT_TRUE(succeeded(runPass(m, QuantumLoopUnrollOptions{})));
+  auto entry = *m->getOps<func::FuncOp>().begin();
+  EXPECT_TRUE(entry.getOps<scf::ForOp>().empty());
+  EXPECT_EQ(range_size(entry.getOps<HOp>()), 1);
+}
+
 TEST_F(QuantumLoopUnrollTest, UnrollPartial) {
   auto m = getGHZ(context.get(), 9);
   auto entry = *(m->getOps<func::FuncOp>().begin());


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Make the existing `quantum-loop-unroll` pass fulfill its full-unroll contract for nested quantum loops whose inner bounds depend on an outer induction variable.

The pass now unrolls each currently constant wave, folds the cloned constant bounds, and recollects the remaining loops. It also removes zero-trip loops explicitly because MLIR's full-unroll helper can report success without erasing them. The regression checks both loop removal and the surviving quantum body operation.

Daniel Haag's structured QPE implementation in #2135 exposed this generic pass bug. Codex implemented, simplified, and locally validated the independent fix.

Local validation: all five quantum-loop-unroll tests pass. The full lint suite also passes.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.