### PR TITLE
♻️ Derive QIR capabilities before LLVM translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,9 @@ releases may include breaking changes.
   [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570], [#1572],
   [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751], [#1755],
   [#1787], [#1815], [#1823], [#1933], [#1978], [#1979], [#2007], [#2026],
-  [#2030], [#2066]) ([**@burgholzer**], [**@denialhaag**], [**@simon1hofmann**],
-  [**@li-mingbao**], [**@DRovara**], [**@MatthiasReumann**])
+  [#2030], [#2066], [#2217]) ([**@burgholzer**], [**@denialhaag**],
+  [**@simon1hofmann**], [**@li-mingbao**], [**@DRovara**],
+  [**@MatthiasReumann**])
 - ✨ Add OpenQASM import and export to the MQT Compiler Collection, including
   fixed-angle constants and proven affine quantum-register indices ([#1910],
   [#1987], [#1994], [#2003], [#2026], [#2169], [#2203]) ([**@burgholzer**],
@@ -806,6 +807,7 @@ for previous changelogs._
 
 [#2209]: https://github.com/munich-quantum-toolkit/core/pull/2209
 [#2211]: https://github.com/munich-quantum-toolkit/core/pull/2211
+[#2217]: https://github.com/munich-quantum-toolkit/core/pull/2217
 [#2210]: https://github.com/munich-quantum-toolkit/core/pull/2210
 [#2216]: https://github.com/munich-quantum-toolkit/core/pull/2216
 [#2203]: https://github.com/munich-quantum-toolkit/core/pull/2203

--- a/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
+++ b/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
@@ -31,6 +31,7 @@ class Module;
 } // namespace llvm
 
 namespace mlir {
+class ModuleOp;
 class OpBuilder;
 class Operation;
 namespace LLVM {
@@ -47,9 +48,9 @@ namespace mlir::qir {
 /// metadata and only supports array-valued flags for LLVM's own CG profile.
 /// QIR instead requires i1/i2 capability flags and metadata tuples describing
 /// the integer and floating-point widths used by Adaptive Profile classical
-/// computations. This function repairs the scalar flag widths and derives the
-/// optional Adaptive Profile flags from the translated LLVM module.
-void normalizeQIRModuleFlags(llvm::Module& moduleOp, bool useAdaptive);
+/// computations. This function repairs the scalar flag widths and serializes
+/// type metadata that the MLIR pipeline derived before translation.
+void normalizeQIRModuleFlags(llvm::Module& moduleOp, ModuleOp sourceModule);
 
 // QIR function names
 

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -593,20 +593,19 @@ bool QIRProgram::cleanup() {
 QIRProfile QIRProgram::profile() const noexcept { return profile_; }
 
 [[nodiscard]] static std::unique_ptr<llvm::Module>
-translateToLLVM(ModuleOp mod, llvm::LLVMContext& context,
-                const QIRProfile profile) {
+translateToLLVM(ModuleOp mod, llvm::LLVMContext& context) {
   auto llvmModule = translateModuleToLLVMIR(mod, context);
   if (!llvmModule) {
     mod.emitError("failed to translate QIR MLIR to LLVM IR");
     return nullptr;
   }
-  qir::normalizeQIRModuleFlags(*llvmModule, profile == QIRProfile::Adaptive);
+  qir::normalizeQIRModuleFlags(*llvmModule, mod);
   return llvmModule;
 }
 
 std::optional<std::string> QIRProgram::llvmIR() const {
   llvm::LLVMContext context;
-  auto llvmModule = translateToLLVM(mod(), context, profile_);
+  auto llvmModule = translateToLLVM(mod(), context);
   if (!llvmModule) {
     return std::nullopt;
   }
@@ -618,7 +617,7 @@ std::optional<std::string> QIRProgram::llvmIR() const {
 
 std::optional<std::vector<std::byte>> QIRProgram::toBitcode() const {
   llvm::LLVMContext context;
-  auto llvmModule = translateToLLVM(mod(), context, profile_);
+  auto llvmModule = translateToLLVM(mod(), context);
   if (!llvmModule) {
     return std::nullopt;
   }
@@ -633,7 +632,7 @@ std::optional<std::vector<std::byte>> QIRProgram::toBitcode() const {
 
 bool QIRProgram::writeBitcode(const std::filesystem::path& path) const {
   llvm::LLVMContext context;
-  auto llvmModule = translateToLLVM(mod(), context, profile_);
+  auto llvmModule = translateToLLVM(mod(), context);
   if (!llvmModule) {
     return false;
   }

--- a/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
@@ -14,6 +14,7 @@
 
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallSet.h>
 #include <llvm/ADT/StringRef.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
@@ -21,6 +22,7 @@
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Dominance.h>
+#include <mlir/IR/OpDefinition.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
@@ -54,6 +56,11 @@ struct Metadata {
   /// Whether the module uses backward branching (0 = none, 1 = iteration based,
   /// 2 = condition based, 3 = both)
   int backwardsBranching{0};
+  llvm::SmallSet<std::string, 4> integerTypes;
+  llvm::SmallSet<std::string, 4> floatingTypes;
+  bool usesIRFunctions{false};
+  bool usesMultipleTargetBranching{false};
+  bool usesMultipleReturnPoints{false};
 };
 
 /**
@@ -71,8 +78,11 @@ protected:
     if (!main) {
       return;
     }
-    setMetadata(main, useAdaptive ? getAdaptive(main) : getBase(main),
-                rewriter);
+    Metadata metadata = useAdaptive ? getAdaptive(main) : getBase(main);
+    if (useAdaptive) {
+      collectOptionalFeatures(getOperation(), main, metadata);
+    }
+    setMetadata(main, metadata, rewriter);
   }
 
 private:
@@ -139,9 +149,33 @@ private:
                                              metadata.backwardsBranching)));
       flags.emplace_back(createBoolFlag(LLVM::ModFlagBehavior::Error, "arrays",
                                         metadata.useArrays));
+      if (metadata.usesIRFunctions) {
+        flags.emplace_back(
+            createBoolFlag(LLVM::ModFlagBehavior::Error, "ir_functions", true));
+      }
+      if (metadata.usesMultipleTargetBranching) {
+        flags.emplace_back(createBoolFlag(LLVM::ModFlagBehavior::Error,
+                                          "multiple_target_branching", true));
+      }
+      if (metadata.usesMultipleReturnPoints) {
+        flags.emplace_back(createBoolFlag(LLVM::ModFlagBehavior::Error,
+                                          "multiple_return_points", true));
+      }
     }
 
     removeExistingModuleFlags(m, rewriter);
+    const auto setTypes = [&](const StringRef name,
+                              const llvm::SmallSet<std::string, 4>& types) {
+      if (types.empty()) {
+        m->removeAttr(name);
+        return;
+      }
+      SmallVector<StringRef> values(types.begin(), types.end());
+      llvm::sort(values);
+      m->setAttr(name, rewriter.getStrArrayAttr(values));
+    };
+    setTypes("qir.int_computations", metadata.integerTypes);
+    setTypes("qir.float_computations", metadata.floatingTypes);
     LLVM::ModuleFlagsOp::create(rewriter, m.getLoc(),
                                 rewriter.getArrayAttr(flags));
   }
@@ -364,6 +398,54 @@ private:
     });
 
     return std::make_tuple(useDynamicQubit, useDynamicResult, useArrays);
+  }
+
+  static void collectOptionalFeatures(ModuleOp moduleOp,
+                                      LLVM::LLVMFuncOp entryPoint,
+                                      Metadata& metadata) {
+    const auto recordType = [&](const Type type) {
+      if (const auto integer = dyn_cast<IntegerType>(type);
+          integer && integer.getWidth() > 1) {
+        metadata.integerTypes.insert("i" + std::to_string(integer.getWidth()));
+      } else if (type.isF16()) {
+        metadata.floatingTypes.insert("half");
+      } else if (type.isF32()) {
+        metadata.floatingTypes.insert("float");
+      } else if (type.isF64()) {
+        metadata.floatingTypes.insert("double");
+      }
+    };
+
+    moduleOp.walk([&](LLVM::LLVMFuncOp function) {
+      if (function.isExternal()) {
+        return;
+      }
+      metadata.usesIRFunctions |= function != entryPoint;
+      if (function != entryPoint) {
+        recordType(function.getFunctionType().getReturnType());
+      }
+      for (Block& block : function.getBody()) {
+        llvm::for_each(block.getArgumentTypes(), recordType);
+      }
+      size_t returnCount = 0;
+      function.walk([&](Operation* operation) {
+        returnCount += isa<LLVM::ReturnOp>(operation);
+        metadata.usesMultipleTargetBranching |= isa<LLVM::SwitchOp>(operation);
+        if (operation->hasTrait<OpTrait::ConstantLike>()) {
+          return;
+        }
+        const auto hasScalarResult =
+            llvm::any_of(operation->getResultTypes(), [](const Type type) {
+              return isa<IntegerType>(type) || type.isF16() || type.isF32() ||
+                     type.isF64();
+            });
+        if (hasScalarResult && !isa<LLVM::CallOp>(operation)) {
+          llvm::for_each(operation->getOperandTypes(), recordType);
+        }
+        llvm::for_each(operation->getResultTypes(), recordType);
+      });
+      metadata.usesMultipleReturnPoints |= returnCount > 1;
+    });
   }
 
   /// Return the metadata for a QIR base profile compliant program.

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -15,8 +15,6 @@
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
-#include <llvm/IR/Function.h>
-#include <llvm/IR/Instructions.h>
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/Casting.h>
@@ -25,6 +23,7 @@
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/LLVMTypes.h>
 #include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Location.h>
 #include <mlir/IR/Operation.h>
@@ -35,11 +34,9 @@
 #include <mlir/Support/LLVM.h>
 
 #include <cassert>
-#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <limits>
-#include <set>
 #include <string>
 
 namespace mlir::qir {
@@ -65,38 +62,12 @@ static void setIntegerModuleFlag(llvm::Module& moduleOp,
       llvm::ConstantInt::get(llvm::IntegerType::get(context, bitWidth), value));
 }
 
-[[nodiscard]] static llvm::MDNode*
-stringTuple(llvm::LLVMContext& context, const std::set<std::string>& values) {
-  SmallVector<llvm::Metadata*> entries;
-  entries.reserve(values.size());
-  llvm::transform(values, std::back_inserter(entries), [&](const auto& value) {
-    return llvm::MDString::get(context, value);
-  });
-  return llvm::MDTuple::get(context, entries);
-}
-
-static void removeModuleFlags(llvm::Module& moduleOp,
-                              const ArrayRef<StringRef> keys) {
-  auto* flags = moduleOp.getModuleFlagsMetadata();
-  if (flags == nullptr) {
-    return;
-  }
-  SmallVector<llvm::MDNode*> retained;
-  for (auto* flag : flags->operands()) {
-    const auto* key = llvm::dyn_cast<llvm::MDString>(flag->getOperand(1));
-    if (key == nullptr || !llvm::is_contained(keys, key->getString())) {
-      retained.emplace_back(flag);
-    }
-  }
-  flags->clearOperands();
-  for (auto* flag : retained) {
-    flags->addOperand(flag);
-  }
-}
-
-void normalizeQIRModuleFlags(llvm::Module& moduleOp, const bool useAdaptive) {
+void normalizeQIRModuleFlags(llvm::Module& moduleOp,
+                             const ModuleOp sourceModule) {
   for (const auto* const key :
-       {"dynamic_qubit_management", "dynamic_result_management", "arrays"}) {
+       {"dynamic_qubit_management", "dynamic_result_management", "arrays",
+        "ir_functions", "multiple_target_branching",
+        "multiple_return_points"}) {
     if (moduleOp.getModuleFlag(key) != nullptr) {
       setIntegerModuleFlag(moduleOp, llvm::Module::Error, key, 1,
                            moduleFlagIntegerValue(moduleOp, key));
@@ -107,85 +78,23 @@ void normalizeQIRModuleFlags(llvm::Module& moduleOp, const bool useAdaptive) {
         moduleOp, llvm::Module::Error, "backwards_branching", 2,
         moduleFlagIntegerValue(moduleOp, "backwards_branching"));
   }
-  if (!useAdaptive) {
-    removeModuleFlags(moduleOp,
-                      {"int_computations", "float_computations", "ir_functions",
-                       "backwards_branching", "multiple_target_branching",
-                       "multiple_return_points", "arrays"});
-    return;
-  }
-
-  removeModuleFlags(moduleOp,
-                    {"int_computations", "float_computations", "ir_functions",
-                     "multiple_target_branching", "multiple_return_points"});
-
-  std::set<std::string> integerTypes;
-  std::set<std::string> floatingTypes;
-  bool usesIRFunctions = false;
-  bool usesMultipleTargetBranching = false;
-  bool usesMultipleReturnPoints = false;
-
-  const auto recordType = [&](const llvm::Type* type) {
-    if (const auto* integer = llvm::dyn_cast<llvm::IntegerType>(type)) {
-      if (integer->getBitWidth() > 1) {
-        integerTypes.emplace("i" + std::to_string(integer->getBitWidth()));
-      }
-    } else if (type->isHalfTy()) {
-      floatingTypes.emplace("half");
-    } else if (type->isFloatTy()) {
-      floatingTypes.emplace("float");
-    } else if (type->isDoubleTy()) {
-      floatingTypes.emplace("double");
+  const auto setTypes = [&](const StringRef flag, const StringRef attribute) {
+    const auto values = sourceModule->getAttrOfType<ArrayAttr>(attribute);
+    if (!values || values.empty()) {
+      return;
     }
+    SmallVector<llvm::Metadata*> entries;
+    entries.reserve(values.size());
+    llvm::transform(values.getAsRange<StringAttr>(),
+                    std::back_inserter(entries), [&](const StringAttr value) {
+                      return llvm::MDString::get(moduleOp.getContext(),
+                                                 value.getValue());
+                    });
+    moduleOp.setModuleFlag(llvm::Module::Append, flag,
+                           llvm::MDTuple::get(moduleOp.getContext(), entries));
   };
-
-  for (const auto& function : moduleOp.functions()) {
-    if (function.isDeclaration()) {
-      continue;
-    }
-    const auto isEntryPoint = function.hasFnAttribute("entry_point");
-    usesIRFunctions |= !isEntryPoint;
-    if (!isEntryPoint) {
-      recordType(function.getReturnType());
-      for (const auto& argument : function.args()) {
-        recordType(argument.getType());
-      }
-    }
-
-    size_t returnCount = 0;
-    for (const auto& block : function) {
-      for (const auto& instruction : block) {
-        if (llvm::isa<llvm::ReturnInst>(instruction)) {
-          ++returnCount;
-          continue;
-        }
-        usesMultipleTargetBranching |= llvm::isa<llvm::SwitchInst>(instruction);
-        recordType(instruction.getType());
-      }
-    }
-    usesMultipleReturnPoints |= returnCount > 1;
-  }
-
-  auto& context = moduleOp.getContext();
-  if (!integerTypes.empty()) {
-    moduleOp.setModuleFlag(llvm::Module::Append, "int_computations",
-                           stringTuple(context, integerTypes));
-  }
-  if (!floatingTypes.empty()) {
-    moduleOp.setModuleFlag(llvm::Module::Append, "float_computations",
-                           stringTuple(context, floatingTypes));
-  }
-  if (usesIRFunctions) {
-    setIntegerModuleFlag(moduleOp, llvm::Module::Error, "ir_functions", 1, 1);
-  }
-  if (usesMultipleTargetBranching) {
-    setIntegerModuleFlag(moduleOp, llvm::Module::Error,
-                         "multiple_target_branching", 1, 1);
-  }
-  if (usesMultipleReturnPoints) {
-    setIntegerModuleFlag(moduleOp, llvm::Module::Error,
-                         "multiple_return_points", 1, 1);
-  }
+  setTypes("int_computations", "qir.int_computations");
+  setTypes("float_computations", "qir.float_computations");
 }
 
 void emitQISCall(OpBuilder& builder, Operation* anchor, const Location loc,

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -620,8 +620,7 @@ static int runCompiler(int argc, char** argv) {
       llvm::errs() << "Failed to translate MLIR module to LLVM IR\n";
       return 1;
     }
-    qir::normalizeQIRModuleFlags(*llvmMod, *parsedOutputFormat ==
-                                               OutputFormat::QIRAdaptive);
+    qir::normalizeQIRModuleFlags(*llvmMod, *program.mod);
     if (writeOutput<llvm::Module*>(llvmMod.get(), outputFilename).failed()) {
       return 1;
     }

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -11,33 +11,38 @@
 #include "Support/IRVerification.h"
 #include "TestCaseUtils.h"
 #include "mlir/Dialect/QIR/Builder/QIRProgramBuilder.h"
+#include "mlir/Dialect/QIR/Transforms/Passes.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 #include "mlir/Support/Passes.h"
 #include "qir_programs.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/APInt.h>
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constants.h>
-#include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/Casting.h>
-#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/LLVMTypes.h>
+#include <mlir/IR/Block.h>
+#include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 
+#include <array>
 #include <iosfwd>
 #include <memory>
 #include <ostream>
 #include <string>
+#include <tuple>
 
 using namespace mlir;
 using namespace qir;
@@ -72,6 +77,20 @@ protected:
     context->loadAllAvailableDialects();
   }
 };
+
+static LLVM::ModuleFlagAttr findModuleFlag(const ModuleOp moduleOp,
+                                           const StringRef name) {
+  LLVM::ModuleFlagAttr result;
+  moduleOp->walk([&](LLVM::ModuleFlagsOp flagsOp) {
+    for (const auto flag :
+         flagsOp.getFlags().getAsRange<LLVM::ModuleFlagAttr>()) {
+      if (flag.getKey().getValue() == name) {
+        result = flag;
+      }
+    }
+  });
+  return result;
+}
 
 } // namespace
 
@@ -236,65 +255,131 @@ TEST_F(QIRTest, UsesQIR21ModuleFlagWidths) {
         [](QIRProgramBuilder& builder) { return builder.intConstant(0); },
         profile);
   };
-  const auto findFlag = [](ModuleOp moduleOp, const StringRef name) {
-    LLVM::ModuleFlagAttr result;
-    moduleOp->walk([&](LLVM::ModuleFlagsOp flagsOp) {
-      for (const auto flag :
-           flagsOp.getFlags().getAsRange<LLVM::ModuleFlagAttr>()) {
-        if (flag.getKey().getValue() == name) {
-          result = flag;
-        }
-      }
-    });
-    return result;
-  };
-
   auto base = build(QIRProgramBuilder::Profile::Base);
   ASSERT_TRUE(base);
   const auto baseDynamicQubits =
-      findFlag(base.get(), "dynamic_qubit_management");
+      findModuleFlag(base.get(), "dynamic_qubit_management");
   ASSERT_TRUE(baseDynamicQubits);
   EXPECT_TRUE(isa<BoolAttr>(baseDynamicQubits.getValue()));
-  EXPECT_FALSE(findFlag(base.get(), "backwards_branching"));
+  EXPECT_FALSE(findModuleFlag(base.get(), "backwards_branching"));
 
   auto adaptive = build(QIRProgramBuilder::Profile::Adaptive);
   ASSERT_TRUE(adaptive);
   const auto backwardsBranching =
-      findFlag(adaptive.get(), "backwards_branching");
+      findModuleFlag(adaptive.get(), "backwards_branching");
   ASSERT_TRUE(backwardsBranching);
   const auto backwardsBranchingValue =
       dyn_cast<IntegerAttr>(backwardsBranching.getValue());
   ASSERT_TRUE(backwardsBranchingValue);
   EXPECT_EQ(backwardsBranchingValue.getType().getIntOrFloatBitWidth(), 2U);
-  const auto arrays = findFlag(adaptive.get(), "arrays");
+  const auto arrays = findModuleFlag(adaptive.get(), "arrays");
   ASSERT_TRUE(arrays);
   EXPECT_TRUE(isa<BoolAttr>(arrays.getValue()));
 }
 
+TEST_F(QIRTest, DerivesAdaptiveClassicalCapabilities) {
+  OpBuilder builder(context.get());
+  const auto location = builder.getUnknownLoc();
+  auto moduleOp = ModuleOp::create(location);
+  builder.setInsertionPointToStart(moduleOp.getBody());
+
+  const auto mainType = LLVM::LLVMFunctionType::get(builder.getI64Type(), {});
+  auto main = LLVM::LLVMFuncOp::create(builder, location, "main", mainType);
+  main->setAttr("passthrough", builder.getStrArrayAttr({"entry_point"}));
+  auto* mainBlock = main.addEntryBlock(builder);
+  builder.setInsertionPointToEnd(mainBlock);
+  const Value exitCode =
+      LLVM::ConstantOp::create(builder, location, builder.getI64IntegerAttr(0))
+          .getResult();
+  LLVM::ReturnOp::create(builder, location, exitCode);
+
+  builder.setInsertionPointToEnd(moduleOp.getBody());
+  const auto helperType = LLVM::LLVMFunctionType::get(
+      builder.getF64Type(), {builder.getI8Type(), builder.getF32Type()});
+  auto helper =
+      LLVM::LLVMFuncOp::create(builder, location, "helper", helperType);
+  auto* helperEntry = helper.addEntryBlock(builder);
+  auto* defaultBlock = helper.addBlock();
+  auto* caseBlock = helper.addBlock();
+  builder.setInsertionPointToEnd(helperEntry);
+  const Value left =
+      LLVM::ConstantOp::create(builder, location, builder.getI32IntegerAttr(1))
+          .getResult();
+  const Value right =
+      LLVM::ConstantOp::create(builder, location, builder.getI32IntegerAttr(2))
+          .getResult();
+  std::ignore = LLVM::ICmpOp::create(builder, location,
+                                     LLVM::ICmpPredicate::slt, left, right);
+  const Value floating =
+      LLVM::FPExtOp::create(builder, location, builder.getF64Type(),
+                            helperEntry->getArgument(1))
+          .getResult();
+  const Value doubled =
+      LLVM::FAddOp::create(builder, location, floating, floating).getResult();
+  const std::array<APInt, 1> caseValues{APInt(8, 0)};
+  const std::array<Block*, 1> caseDestinations{caseBlock};
+  const std::array<ValueRange, 1> caseOperands{ValueRange{}};
+  LLVM::SwitchOp::create(builder, location, helperEntry->getArgument(0),
+                         defaultBlock, ValueRange{}, caseValues,
+                         BlockRange(caseDestinations), caseOperands);
+  builder.setInsertionPointToEnd(defaultBlock);
+  LLVM::ReturnOp::create(builder, location, doubled);
+  builder.setInsertionPointToEnd(caseBlock);
+  LLVM::ReturnOp::create(builder, location, doubled);
+
+  const auto attachAttributes = [&](const bool useAdaptive) {
+    return runWithPassManager(
+        moduleOp,
+        [&](OpPassManager& manager) {
+          manager.addPass(
+              qir::createQIRSetAttributesAndMetadata({useAdaptive}));
+        },
+        "Failed to attach QIR attributes.");
+  };
+  ASSERT_TRUE(attachAttributes(true).succeeded());
+  const auto integerTypes =
+      moduleOp->getAttrOfType<ArrayAttr>("qir.int_computations");
+  ASSERT_TRUE(integerTypes);
+  ASSERT_EQ(integerTypes.size(), 2U);
+  EXPECT_EQ(cast<StringAttr>(integerTypes[0]).getValue(), "i32");
+  EXPECT_EQ(cast<StringAttr>(integerTypes[1]).getValue(), "i8");
+  const auto floatingTypes =
+      moduleOp->getAttrOfType<ArrayAttr>("qir.float_computations");
+  ASSERT_TRUE(floatingTypes);
+  ASSERT_EQ(floatingTypes.size(), 2U);
+  EXPECT_EQ(cast<StringAttr>(floatingTypes[0]).getValue(), "double");
+  EXPECT_EQ(cast<StringAttr>(floatingTypes[1]).getValue(), "float");
+
+  for (const auto* const flag : {"ir_functions", "multiple_target_branching",
+                                 "multiple_return_points"}) {
+    const auto moduleFlag = findModuleFlag(moduleOp, flag);
+    ASSERT_TRUE(moduleFlag) << flag;
+    EXPECT_EQ(moduleFlag.getValue(), builder.getBoolAttr(true)) << flag;
+  }
+
+  ASSERT_TRUE(attachAttributes(false).succeeded());
+  EXPECT_FALSE(moduleOp->hasAttr("qir.int_computations"));
+  EXPECT_FALSE(moduleOp->hasAttr("qir.float_computations"));
+  EXPECT_FALSE(findModuleFlag(moduleOp, "ir_functions"));
+  EXPECT_FALSE(findModuleFlag(moduleOp, "multiple_target_branching"));
+  EXPECT_FALSE(findModuleFlag(moduleOp, "multiple_return_points"));
+}
+
 TEST(QIRModuleFlagsTest, RecordsAdaptiveClassicalCapabilities) {
-  llvm::LLVMContext context;
-  llvm::Module moduleOp("adaptive", context);
-  auto* function = llvm::Function::Create(
-      llvm::FunctionType::get(llvm::Type::getInt64Ty(context), false),
-      llvm::Function::ExternalLinkage, "main", moduleOp);
-  function->addFnAttr("entry_point");
-  auto* entry = llvm::BasicBlock::Create(context, "entry", function);
-  llvm::IRBuilder builder(entry);
-  builder.CreateRet(builder.getInt64(0));
+  MLIRContext mlirContext;
+  OpBuilder builder(&mlirContext);
+  auto sourceModule = ModuleOp::create(builder.getUnknownLoc());
+  sourceModule->setAttr("qir.int_computations",
+                        builder.getStrArrayAttr({"i8"}));
+  sourceModule->setAttr("qir.float_computations",
+                        builder.getStrArrayAttr({"double"}));
 
-  auto* helper = llvm::Function::Create(
-      llvm::FunctionType::get(builder.getInt8Ty(), {builder.getInt8Ty()},
-                              false),
-      llvm::Function::InternalLinkage, "helper", moduleOp);
-  auto* helperEntry = llvm::BasicBlock::Create(context, "entry", helper);
-  builder.SetInsertPoint(helperEntry);
-  auto* integer = helper->getArg(0);
-  auto* floating = builder.CreateUIToFP(integer, builder.getDoubleTy());
-  builder.CreateFAdd(floating,
-                     llvm::ConstantFP::get(builder.getDoubleTy(), 1.0));
-  builder.CreateRet(builder.CreateAdd(integer, builder.getInt8(1)));
-
-  normalizeQIRModuleFlags(moduleOp, true);
+  llvm::LLVMContext llvmContext;
+  llvm::Module moduleOp("adaptive", llvmContext);
+  moduleOp.addModuleFlag(llvm::Module::Error, "ir_functions", 1U);
+  moduleOp.addModuleFlag(llvm::Module::Error, "multiple_target_branching", 1U);
+  moduleOp.addModuleFlag(llvm::Module::Error, "multiple_return_points", 1U);
+  normalizeQIRModuleFlags(moduleOp, sourceModule);
 
   const auto* integerTypes =
       llvm::dyn_cast<llvm::MDNode>(moduleOp.getModuleFlag("int_computations"));
@@ -310,30 +395,16 @@ TEST(QIRModuleFlagsTest, RecordsAdaptiveClassicalCapabilities) {
   EXPECT_EQ(
       llvm::cast<llvm::MDString>(floatingTypes->getOperand(0))->getString(),
       "double");
-
-  std::string text;
-  llvm::raw_string_ostream(text) << moduleOp;
-  EXPECT_NE(text.find("!\"ir_functions\", i1 true"), std::string::npos);
-
-  helper->eraseFromParent();
-  normalizeQIRModuleFlags(moduleOp, true);
-  EXPECT_EQ(moduleOp.getModuleFlag("int_computations"), nullptr);
-  EXPECT_EQ(moduleOp.getModuleFlag("float_computations"), nullptr);
-  EXPECT_EQ(moduleOp.getModuleFlag("ir_functions"), nullptr);
-}
-
-TEST(QIRModuleFlagsTest, RemovesAdaptiveFlagsFromBaseModules) {
-  llvm::LLVMContext context;
-  llvm::Module moduleOp("base", context);
-  moduleOp.addModuleFlag(llvm::Module::Error, "backwards_branching", 3U);
-  moduleOp.addModuleFlag(llvm::Module::Error, "arrays", 1U);
-  moduleOp.addModuleFlag(llvm::Module::Error, "ir_functions", 1U);
-
-  normalizeQIRModuleFlags(moduleOp, false);
-
-  EXPECT_EQ(moduleOp.getModuleFlag("backwards_branching"), nullptr);
-  EXPECT_EQ(moduleOp.getModuleFlag("arrays"), nullptr);
-  EXPECT_EQ(moduleOp.getModuleFlag("ir_functions"), nullptr);
+  for (const auto* const flag : {"ir_functions", "multiple_target_branching",
+                                 "multiple_return_points"}) {
+    const auto* metadata =
+        llvm::dyn_cast<llvm::ConstantAsMetadata>(moduleOp.getModuleFlag(flag));
+    ASSERT_NE(metadata, nullptr) << flag;
+    const auto* value = llvm::dyn_cast<llvm::ConstantInt>(metadata->getValue());
+    ASSERT_NE(value, nullptr) << flag;
+    EXPECT_EQ(value->getBitWidth(), 1U) << flag;
+    EXPECT_TRUE(value->isOne()) << flag;
+  }
 }
 
 /// \name QIR/Operations/StandardGates/DcxOp.cpp

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -28,6 +28,7 @@
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/LLVMTypes.h>
 #include <mlir/IR/Block.h>
+#include <mlir/IR/BlockSupport.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinOps.h>
@@ -46,6 +47,20 @@
 
 using namespace mlir;
 using namespace qir;
+
+static LLVM::ModuleFlagAttr findModuleFlag(const ModuleOp moduleOp,
+                                           const StringRef name) {
+  LLVM::ModuleFlagAttr result;
+  moduleOp->walk([&](LLVM::ModuleFlagsOp flagsOp) {
+    for (const auto flag :
+         flagsOp.getFlags().getAsRange<LLVM::ModuleFlagAttr>()) {
+      if (flag.getKey().getValue() == name) {
+        result = flag;
+      }
+    }
+  });
+  return result;
+}
 
 namespace {
 
@@ -77,20 +92,6 @@ protected:
     context->loadAllAvailableDialects();
   }
 };
-
-static LLVM::ModuleFlagAttr findModuleFlag(const ModuleOp moduleOp,
-                                           const StringRef name) {
-  LLVM::ModuleFlagAttr result;
-  moduleOp->walk([&](LLVM::ModuleFlagsOp flagsOp) {
-    for (const auto flag :
-         flagsOp.getFlags().getAsRange<LLVM::ModuleFlagAttr>()) {
-      if (flag.getKey().getValue() == name) {
-        result = flag;
-      }
-    }
-  });
-  return result;
-}
 
 } // namespace
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Derive QIR Adaptive Profile capability metadata while the program is still in MLIR. The LLVM translation step now only normalizes scalar widths and serializes the type lists that the MLIR pass produced.

This fixes two problems in the existing late LLVM scan: it could not be reused by target-aware MLIR passes, and it missed operand-only integer widths such as the inputs of an integer comparison. The MLIR derivation covers integer and floating-point computation types, IR functions, multi-target branches, and multiple return points.

This is an independent prerequisite extracted from #2162. It does not add target validation, QDMI integration, or payload capability policy.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.