### PR TITLE
🐛 Reject nonlinear QCO programs at checked boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ releases may include breaking changes.
   [#1807], [#1808], [#1815], [#1824], [#1869], [#1872], [#1914], [#1925],
   [#1927], [#1935], [#1936], [#1938], [#1975], [#1976], [#2006], [#2014],
   [#2015], [#2017], [#2026], [#2028], [#2054], [#2058], [#2125], [#2136],
-  [#2149], [#2150], [#2158], [#2210], [#2211]) ([**@burgholzer**],
+  [#2149], [#2150], [#2158], [#2210], [#2211], [#2220]) ([**@burgholzer**],
   [**@denialhaag**], [**@taminob**], [**@DRovara**], [**@li-mingbao**],
   [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 - ✨ Add decision diagram-based construction, simulation, and sampling for QCO
@@ -851,6 +851,7 @@ for previous changelogs._
 [#2257]: https://github.com/munich-quantum-toolkit/core/pull/2257
 [#2249]: https://github.com/munich-quantum-toolkit/core/pull/2249
 [#2246]: https://github.com/munich-quantum-toolkit/core/pull/2246
+[#2220]: https://github.com/munich-quantum-toolkit/core/pull/2220
 [#2232]: https://github.com/munich-quantum-toolkit/core/pull/2232
 [#2224]: https://github.com/munich-quantum-toolkit/core/pull/2224
 [#2209]: https://github.com/munich-quantum-toolkit/core/pull/2209

--- a/mlir/include/mlir/Compiler/Programs.h
+++ b/mlir/include/mlir/Compiler/Programs.h
@@ -226,8 +226,6 @@ public:
  */
 class QCOProgram final : public Program {
 public:
-  explicit QCOProgram(Storage storage) : Program(std::move(storage)) {}
-
   /// Parse QCO MLIR assembly.
   [[nodiscard]] static std::optional<QCOProgram>
   fromMLIRString(std::string_view source);
@@ -235,6 +233,17 @@ public:
   /// Parse QCO MLIR assembly from a file.
   [[nodiscard]] static std::optional<QCOProgram>
   fromMLIRFile(const std::filesystem::path& path);
+
+  /**
+   * @brief Take ownership of an MLIR module that contains a QCO program.
+   *
+   * @details The context must own every dialect referenced by the module and
+   * must remain the module's context. The factory verifies the module, requires
+   * at least one operation from the QCO dialect, and verifies QCO linearity.
+   */
+  [[nodiscard]] static std::optional<QCOProgram>
+  fromModule(std::shared_ptr<MLIRContext> context,
+             OwningOpRef<ModuleOp> moduleOp);
 
   /// Create an independent QCO program copy.
   [[nodiscard]] QCOProgram copy() const;
@@ -285,6 +294,13 @@ public:
 
   /// Consume this program and convert it to `jeff` MLIR.
   [[nodiscard]] std::optional<JeffProgram> intoJeff() &&;
+
+private:
+  friend class QCProgram;
+  friend class JeffProgram;
+
+  explicit QCOProgram(Storage storage) : Program(std::move(storage)) {}
+  [[nodiscard]] bool hasValidLinearity() const;
 };
 
 /**

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -50,10 +50,13 @@ inline bool checkDeadGate(Operation* op) {
   if (isa<QubitType>(type)) {
     return true;
   }
-  const auto tensorType = dyn_cast<RankedTensorType>(type);
-  return tensorType && tensorType.getRank() == 1 &&
-         isa<QubitType>(tensorType.getElementType());
+  const auto shapedType = dyn_cast<ShapedType>(type);
+  return isa<RankedTensorType, VectorType>(type) && shapedType.getRank() == 1 &&
+         isa<QubitType>(shapedType.getElementType());
 }
+
+/// Verify that every linear QCO value under @p root has exactly one use.
+[[nodiscard]] LogicalResult verifyLinearity(Operation* root);
 
 /// Maximum number of modifier targets supported by @ref
 /// composeBodyMatrix.

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h"
 #include "mlir/Dialect/QC/Translation/TranslateQCToOpenQASM3.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
@@ -153,18 +154,13 @@ parseMLIRFile(MLIRContext* context, const std::filesystem::path& path) {
 
 template <class ProgramType, class Parse>
 [[nodiscard]] static std::optional<ProgramType>
-parseTypedProgram(const StringRef dialect, Parse&& parse) {
+parseTypedProgram(Parse&& parse) {
   auto context = createCompilerContext();
   auto mod = std::forward<Parse>(parse)(context.get());
   if (failed(mod)) {
     return std::nullopt;
   }
-  if (!moduleUsesDialect(**mod, dialect)) {
-    (**mod)->emitError() << "expected a module using the '" << dialect
-                         << "' dialect";
-    return std::nullopt;
-  }
-  return ProgramType({.context = std::move(context), .mod = std::move(*mod)});
+  return ProgramType::fromModule(std::move(context), std::move(*mod));
 }
 
 [[nodiscard]] static LogicalResult
@@ -184,6 +180,17 @@ runPasses(ModuleOp mod,
     return mod.emitError(failureMessage);
   }
   return success();
+}
+
+[[nodiscard]] static LogicalResult runQCOTransformPasses(
+    ModuleOp mod, const llvm::function_ref<void(OpPassManager&)> populatePasses,
+    const StringRef failureMessage, const bool enableTiming = false,
+    const bool enableStatistics = false) {
+  if (failed(qco::verifyLinearity(mod))) {
+    return failure();
+  }
+  return runPasses(mod, populatePasses, failureMessage, enableTiming,
+                   enableStatistics);
 }
 
 //===----------------------------------------------------------------------===//
@@ -252,16 +259,15 @@ bool OpenQASMProgram::write(const std::filesystem::path& path) const {
 
 std::optional<QCProgram>
 QCProgram::fromMLIRString(const std::string_view source) {
-  return parseTypedProgram<QCProgram>("qc", [source](MLIRContext* context) {
+  return parseTypedProgram<QCProgram>([source](MLIRContext* context) {
     return parseMLIRString(context, source);
   });
 }
 
 std::optional<QCProgram>
 QCProgram::fromMLIRFile(const std::filesystem::path& path) {
-  return parseTypedProgram<QCProgram>("qc", [&path](MLIRContext* context) {
-    return parseMLIRFile(context, path);
-  });
+  return parseTypedProgram<QCProgram>(
+      [&path](MLIRContext* context) { return parseMLIRFile(context, path); });
 }
 
 std::optional<QCProgram>
@@ -296,31 +302,32 @@ QCProgram::fromQASMFile(const std::filesystem::path& path) {
 std::optional<QCProgram>
 QCProgram::fromModule(std::shared_ptr<MLIRContext> context,
                       OwningOpRef<ModuleOp> moduleOp) {
-  if (!moduleOp) {
-    if (context) {
-      emitError(UnknownLoc::get(context.get()),
+  Storage storage{.context = std::move(context), .mod = std::move(moduleOp)};
+  if (!storage.mod) {
+    if (storage.context) {
+      emitError(UnknownLoc::get(storage.context.get()),
                 "cannot construct a QC program from a null module");
     }
     return std::nullopt;
   }
-  if (!context) {
-    moduleOp->emitError(
+  if (!storage.context) {
+    storage.mod->emitError(
         "cannot construct a QC program without its owning context");
     return std::nullopt;
   }
-  if (moduleOp->getContext() != context.get()) {
-    moduleOp->emitError(
+  if (storage.mod->getContext() != storage.context.get()) {
+    storage.mod->emitError(
         "cannot construct a QC program with a different MLIR context");
     return std::nullopt;
   }
-  if (failed(verify(*moduleOp))) {
+  if (failed(verify(*storage.mod))) {
     return std::nullopt;
   }
-  if (!moduleUsesDialect(*moduleOp, "qc")) {
-    moduleOp->emitError("expected a module using the 'qc' dialect");
+  if (!moduleUsesDialect(*storage.mod, "qc")) {
+    storage.mod->emitError("expected a module using the 'qc' dialect");
     return std::nullopt;
   }
-  return QCProgram({.context = std::move(context), .mod = std::move(moduleOp)});
+  return QCProgram(std::move(storage));
 }
 
 QCProgram QCProgram::copy() const { return QCProgram(cloneStorage()); }
@@ -350,6 +357,9 @@ std::optional<QCOProgram> QCProgram::intoQCO() && {
   if (failed(runPasses(
           mod(), [](OpPassManager& pm) { pm.addPass(createQCToQCO()); },
           "failed to convert QC to QCO"))) {
+    return std::nullopt;
+  }
+  if (failed(qco::verifyLinearity(mod()))) {
     return std::nullopt;
   }
   return QCOProgram(std::move(*this).releaseStorage());
@@ -409,38 +419,82 @@ size_t QCProgram::numTwoQubitGates() const {
 
 std::optional<QCOProgram>
 QCOProgram::fromMLIRString(const std::string_view source) {
-  return parseTypedProgram<QCOProgram>("qco", [source](MLIRContext* context) {
+  return parseTypedProgram<QCOProgram>([source](MLIRContext* context) {
     return parseMLIRString(context, source);
   });
 }
 
 std::optional<QCOProgram>
 QCOProgram::fromMLIRFile(const std::filesystem::path& path) {
-  return parseTypedProgram<QCOProgram>("qco", [&path](MLIRContext* context) {
-    return parseMLIRFile(context, path);
-  });
+  return parseTypedProgram<QCOProgram>(
+      [&path](MLIRContext* context) { return parseMLIRFile(context, path); });
+}
+
+std::optional<QCOProgram>
+QCOProgram::fromModule(std::shared_ptr<MLIRContext> context,
+                       OwningOpRef<ModuleOp> moduleOp) {
+  Storage storage{.context = std::move(context), .mod = std::move(moduleOp)};
+  if (!storage.mod) {
+    if (storage.context) {
+      emitError(UnknownLoc::get(storage.context.get()),
+                "cannot construct a QCO program from a null module");
+    }
+    return std::nullopt;
+  }
+  if (!storage.context) {
+    storage.mod->emitError(
+        "cannot construct a QCO program without its owning context");
+    return std::nullopt;
+  }
+  if (storage.mod->getContext() != storage.context.get()) {
+    storage.mod->emitError(
+        "cannot construct a QCO program with a different MLIR context");
+    return std::nullopt;
+  }
+  if (failed(verify(*storage.mod))) {
+    return std::nullopt;
+  }
+  if (!moduleUsesDialect(*storage.mod, "qco")) {
+    storage.mod->emitError("expected a module using the 'qco' dialect");
+    return std::nullopt;
+  }
+  if (failed(qco::verifyLinearity(*storage.mod))) {
+    return std::nullopt;
+  }
+  return QCOProgram(std::move(storage));
 }
 
 QCOProgram QCOProgram::copy() const { return QCOProgram(cloneStorage()); }
 
+bool QCOProgram::hasValidLinearity() const {
+  return succeeded(qco::verifyLinearity(mod()));
+}
+
 bool QCOProgram::cleanup() {
-  return succeeded(runPasses(mod(), populateQCOCleanupPipeline,
-                             "failed to run the QCO cleanup pipeline"));
+  return succeeded(
+      runQCOTransformPasses(mod(), populateQCOCleanupPipeline,
+                            "failed to run the QCO cleanup pipeline"));
 }
 
 bool QCOProgram::normalizeGlobalPhases() {
+  if (!hasValidLinearity()) {
+    return false;
+  }
   return succeeded(mqt::normalizeGlobalPhases(mod()));
 }
 
 bool QCOProgram::runPassPipeline(const std::string_view pipeline,
                                  const bool enableTiming,
                                  const bool enableStatistics) {
+  if (!hasValidLinearity()) {
+    return false;
+  }
   return succeeded(
       ::runPassPipeline(mod(), pipeline, enableTiming, enableStatistics));
 }
 
 bool QCOProgram::mergeSingleQubitRotationGates() {
-  return succeeded(runPasses(
+  return succeeded(runQCOTransformPasses(
       mod(),
       [](OpPassManager& pm) {
         pm.addPass(qco::createMergeSingleQubitRotationGates());
@@ -451,7 +505,7 @@ bool QCOProgram::mergeSingleQubitRotationGates() {
 bool QCOProgram::fuseSingleQubitUnitaryRuns(const std::string_view basis) {
   qco::FuseSingleQubitUnitaryRunsOptions options;
   options.basis = basis;
-  return succeeded(runPasses(
+  return succeeded(runQCOTransformPasses(
       mod(),
       [&options](OpPassManager& pm) {
         pm.addPass(qco::createFuseSingleQubitUnitaryRuns(options));
@@ -462,7 +516,7 @@ bool QCOProgram::fuseSingleQubitUnitaryRuns(const std::string_view basis) {
 bool QCOProgram::unrollQuantumLoops(const int64_t factor) {
   qco::QuantumLoopUnrollOptions options;
   options.unrollFactor = factor;
-  return succeeded(runPasses(
+  return succeeded(runQCOTransformPasses(
       mod(),
       [&options](OpPassManager& pm) {
         pm.addNestedPass<func::FuncOp>(qco::createQuantumLoopUnroll(options));
@@ -471,26 +525,26 @@ bool QCOProgram::unrollQuantumLoops(const int64_t factor) {
 }
 
 bool QCOProgram::liftHadamards() {
-  return succeeded(runPasses(
+  return succeeded(runQCOTransformPasses(
       mod(),
       [](OpPassManager& pm) { pm.addPass(qco::createHadamardLifting()); },
       "failed to lift Hadamard gates"));
 }
 
 bool QCOProgram::reuseQubits() {
-  return succeeded(runPasses(
+  return succeeded(runQCOTransformPasses(
       mod(), [](OpPassManager& pm) { pm.addPass(qco::createReuseQubits()); },
       "failed to reuse qubits"));
 }
 
 bool QCOProgram::runQubitReusePipeline() {
-  return succeeded(runPasses(
+  return succeeded(runQCOTransformPasses(
       mod(), [](OpPassManager& pm) { populateQubitReusePipeline(pm); },
       "failed to run the qubit reuse pipeline"));
 }
 
 bool QCOProgram::decomposeMultiControlled(const uint64_t minQubits) {
-  return succeeded(runPasses(
+  return succeeded(runQCOTransformPasses(
       mod(),
       [minQubits](OpPassManager& pm) {
         populateDecomposeMultiControlledPipeline(pm, minQubits);
@@ -501,6 +555,9 @@ bool QCOProgram::decomposeMultiControlled(const uint64_t minQubits) {
 bool QCOProgram::compileForTarget(const CompilerTarget& target,
                                   const bool enableTiming,
                                   const bool enableStatistics) {
+  if (!hasValidLinearity()) {
+    return false;
+  }
   return succeeded(runPasses(
       mod(),
       [&target](OpPassManager& pm) {
@@ -511,7 +568,7 @@ bool QCOProgram::compileForTarget(const CompilerTarget& target,
 }
 
 std::optional<QCProgram> QCOProgram::intoQC() && {
-  if (failed(runPasses(
+  if (failed(runQCOTransformPasses(
           mod(), [](OpPassManager& pm) { pm.addPass(createQCOToQC()); },
           "failed to convert QCO to QC"))) {
     return std::nullopt;
@@ -520,7 +577,7 @@ std::optional<QCProgram> QCOProgram::intoQC() && {
 }
 
 std::optional<JeffProgram> QCOProgram::intoJeff() && {
-  if (failed(runPasses(
+  if (failed(runQCOTransformPasses(
           mod(),
           [](OpPassManager& pm) {
             pm.addPass(mqt::createUnrollModifiers());
@@ -597,6 +654,9 @@ std::optional<QCOProgram> JeffProgram::intoQCO() && {
   if (failed(runPasses(
           mod(), [](OpPassManager& pm) { pm.addPass(createJeffToQCO()); },
           "failed to convert jeff to QCO"))) {
+    return std::nullopt;
+  }
+  if (failed(qco::verifyLinearity(mod()))) {
     return std::nullopt;
   }
   return QCOProgram(std::move(*this).releaseStorage());
@@ -744,7 +804,7 @@ runDefaultPipeline(CompilerInput&& program, const ProgramFormat output,
         }
       },
       std::move(program));
-  if (!qco) {
+  if (!qco || failed(qco::verifyLinearity(qco->module()))) {
     return std::nullopt;
   }
   if (output == ProgramFormat::QCO) {

--- a/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
@@ -19,15 +19,48 @@
 #include <llvm/ADT/TypeSwitch.h>
 #include <mlir/Dialect/QCO/IR/QCODialect.h>
 #include <mlir/IR/Block.h>
+#include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/Visitors.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Support/WalkResult.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 
 namespace mlir::qco {
+
+[[nodiscard]] static LogicalResult verifyLinearValue(Value value) {
+  if (!isLinearQubitType(value.getType()) || value.hasOneUse()) {
+    return success();
+  }
+  return emitError(value.getLoc())
+         << "expected linear QCO value to have exactly one use, but found "
+         << value.getNumUses();
+}
+
+LogicalResult verifyLinearity(Operation* root) {
+  const auto walkResult = root->walk([&](Operation* op) {
+    for (auto result : op->getResults()) {
+      if (failed(verifyLinearValue(result))) {
+        return WalkResult::interrupt();
+      }
+    }
+    for (Region& region : op->getRegions()) {
+      for (Block& block : region) {
+        for (auto argument : block.getArguments()) {
+          if (failed(verifyLinearValue(argument))) {
+            return WalkResult::interrupt();
+          }
+        }
+      }
+    }
+    return WalkResult::advance();
+  });
+  return walkResult.wasInterrupted() ? failure() : success();
+}
 
 /// Returns the wire index for @p wire in @p wireIds, or `std::nullopt` if
 /// untracked.

--- a/mlir/lib/Dialect/QTensor/Transforms/ShrinkRegisters.cpp
+++ b/mlir/lib/Dialect/QTensor/Transforms/ShrinkRegisters.cpp
@@ -88,9 +88,6 @@ collectLiveIndices(AllocOp allocOp, BitVector& live, DeallocOp& deallocOp) {
   auto tensor = allocOp.getResult();
   while (true) {
     auto* user = getLinearTensorUser(tensor);
-    if (user == nullptr) {
-      return failure();
-    }
 
     if (auto currentDealloc = dyn_cast<DeallocOp>(user)) {
       if (currentDealloc.getTensor() != tensor) {
@@ -177,9 +174,6 @@ struct ShrinkStaticQTensor final : OpRewritePattern<AllocOp> {
     auto currentTensor = newAlloc.getResult();
     while (true) {
       Operation* currentOp = getLinearTensorUser(oldTensor);
-      if (currentOp == nullptr) {
-        return failure();
-      }
 
       if (auto deallocOp = dyn_cast<DeallocOp>(currentOp)) {
         if (deallocOp != oldDeallocOp || deallocOp.getTensor() != oldTensor) {
@@ -207,9 +201,6 @@ struct ShrinkStaticQTensor final : OpRewritePattern<AllocOp> {
         }
         auto oldOutTensor = extractOp.getOutTensor();
         auto* nextOp = getLinearTensorUser(oldOutTensor);
-        if (nextOp == nullptr) {
-          return failure();
-        }
 
         rewriter.setInsertionPoint(extractOp);
         auto index = arith::ConstantIndexOp::create(
@@ -243,9 +234,6 @@ struct ShrinkStaticQTensor final : OpRewritePattern<AllocOp> {
         }
         auto oldResultTensor = insertOp.getResult();
         auto* nextOp = getLinearTensorUser(oldResultTensor);
-        if (nextOp == nullptr) {
-          return failure();
-        }
 
         rewriter.setInsertionPoint(insertOp);
         auto index = arith::ConstantIndexOp::create(rewriter, insertOp.getLoc(),

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h"
 #include "mlir/Dialect/QC/Translation/TranslateQCToOpenQASM3.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Support/Passes.h"
@@ -522,6 +523,10 @@ static int runCompiler(int argc, char** argv) {
         pm.addPass(createQCToQCO());
         return success();
       }))) {
+    return 1;
+  }
+  if (*parsedOutputFormat != OutputFormat::QCImport &&
+      failed(qco::verifyLinearity(*program.mod))) {
     return 1;
   }
 

--- a/mlir/unittests/Compiler/mqt-cc/CMakeLists.txt
+++ b/mlir/unittests/Compiler/mqt-cc/CMakeLists.txt
@@ -18,5 +18,6 @@ add_test(
   NAME mqt-core-mqt-cc-invalid-mlir-test
   COMMAND
     ${CMAKE_COMMAND} "-DMQT_CC=$<TARGET_FILE:mqt-cc>"
+    "-DNONLINEAR_QCO_INPUT=${CMAKE_CURRENT_SOURCE_DIR}/nonlinear.qco.mlir"
     "-DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/output-$<CONFIG>" -P
     "${CMAKE_CURRENT_SOURCE_DIR}/verify_invalid_mlir.cmake")

--- a/mlir/unittests/Compiler/mqt-cc/nonlinear.qco.mlir
+++ b/mlir/unittests/Compiler/mqt-cc/nonlinear.qco.mlir
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+// Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+// All rights reserved.
+//
+// SPDX-License-Identifier: MIT
+//
+// Licensed under the MIT License
+
+module {
+  func.func @main() {
+    %qubit = qco.alloc : !qco.qubit
+    return
+  }
+}

--- a/mlir/unittests/Compiler/mqt-cc/verify_invalid_mlir.cmake
+++ b/mlir/unittests/Compiler/mqt-cc/verify_invalid_mlir.cmake
@@ -6,18 +6,20 @@
 #
 # Licensed under the MIT License
 
+function(require_failure description expected)
+  execute_process(
+    COMMAND ${ARGN}
+    RESULT_VARIABLE result
+    ERROR_VARIABLE error)
+  if(NOT result EQUAL 1 OR NOT error MATCHES "${expected}")
+    message(FATAL_ERROR "${description} did not fail as expected:\n${error}")
+  endif()
+endfunction()
+
 file(MAKE_DIRECTORY "${OUTPUT_DIR}")
 set(input_file "${OUTPUT_DIR}/invalid.mlir")
 file(WRITE "${input_file}" "module {\n")
 
-execute_process(
-  COMMAND "${MQT_CC}" "${input_file}"
-  RESULT_VARIABLE result
-  ERROR_VARIABLE error)
-
-if(NOT result EQUAL 1)
-  message(FATAL_ERROR "mqt-cc returned ${result} for invalid MLIR:\n${error}")
-endif()
-if(NOT error MATCHES "expected operation name")
-  message(FATAL_ERROR "mqt-cc did not report the invalid MLIR:\n${error}")
-endif()
+require_failure("invalid MLIR" "expected operation name" "${MQT_CC}" "${input_file}")
+require_failure("nonlinear QCO" "expected linear QCO value to have exactly one use" "${MQT_CC}"
+                "${NONLINEAR_QCO_INPUT}" "--emit=qco")

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -283,6 +283,72 @@ TEST(CompilerProgramOwnershipTest, ValidatesAndOwnsExistingQCModules) {
   EXPECT_FALSE(
       QCProgram::fromModule(otherContext, std::move(mismatchedModule)));
 }
+TEST(CompilerProgramOwnershipTest, EnforcesQCOLinearityAtPublicBoundaries) {
+  DialectRegistry registry;
+  registry.insert<QCODialect, func::FuncDialect>();
+  auto context = std::make_shared<MLIRContext>(registry);
+  context->loadAllAvailableDialects();
+
+  constexpr llvm::StringLiteral validSource = R"mlir(module {
+    func.func @main() {
+      %qubit = qco.alloc : !qco.qubit
+      qco.sink %qubit : !qco.qubit
+      return
+    }
+  })mlir";
+  constexpr llvm::StringLiteral nonlinearSource = R"mlir(module {
+    func.func @main() {
+      %qubit = qco.alloc : !qco.qubit
+      return
+    }
+  })mlir";
+
+  auto moduleOp = parseSourceString<ModuleOp>(validSource, context.get());
+  ASSERT_TRUE(moduleOp);
+  auto program = QCOProgram::fromModule(context, std::move(moduleOp));
+  ASSERT_TRUE(program);
+
+  EXPECT_FALSE(QCOProgram::fromModule(context, {}));
+
+  auto contextlessModule =
+      parseSourceString<ModuleOp>(validSource, context.get());
+  ASSERT_TRUE(contextlessModule);
+  EXPECT_FALSE(QCOProgram::fromModule({}, std::move(contextlessModule)));
+
+  auto mismatchedModule =
+      parseSourceString<ModuleOp>(validSource, context.get());
+  ASSERT_TRUE(mismatchedModule);
+  auto otherContext = std::make_shared<MLIRContext>(registry);
+  EXPECT_FALSE(
+      QCOProgram::fromModule(otherContext, std::move(mismatchedModule)));
+
+  auto invalidModule = parseSourceString<ModuleOp>(validSource, context.get());
+  ASSERT_TRUE(invalidModule);
+  auto main = invalidModule->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  main.getBody().front().getTerminator()->erase();
+  EXPECT_FALSE(QCOProgram::fromModule(context, std::move(invalidModule)));
+
+  auto nonlinearModule =
+      parseSourceString<ModuleOp>(nonlinearSource, context.get());
+  ASSERT_TRUE(nonlinearModule);
+  EXPECT_FALSE(QCOProgram::fromModule(context, std::move(nonlinearModule)));
+
+  auto transformInput = program->copy();
+  auto pipelineInput = program->copy();
+  const auto eraseSink = [](QCOProgram& input) {
+    Operation* sink = nullptr;
+    input.module().walk([&sink](SinkOp op) { sink = op.getOperation(); });
+    ASSERT_NE(sink, nullptr);
+    sink->erase();
+  };
+  eraseSink(transformInput);
+  eraseSink(pipelineInput);
+
+  EXPECT_FALSE(transformInput.cleanup());
+  EXPECT_FALSE(runDefaultPipeline(CompilerInput{std::move(pipelineInput)},
+                                  ProgramFormat::QCO));
+}
 
 /** @brief Raw QCO stops before the registered default optimization pipeline. */
 TEST_F(CompilerPipelineTest, RawAndOptimizedQCOAreDistinctCheckpoints) {
@@ -881,6 +947,55 @@ h q;
   ASSERT_TRUE(qcoFromQC);
   EXPECT_FALSE(QCProgram::fromMLIRString(qcoFromQC->str()));
   EXPECT_FALSE(QCOProgram::fromMLIRString(mlir));
+}
+
+/**
+ * @brief Test: QCO imports require each linear value to have one use.
+ */
+TEST_F(CompilerPipelineTest, QCOProgramImportsEnforceLinearity) {
+  const std::string valid = R"mlir(module {
+    func.func @main() {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %reg = qtensor.alloc(%c1) : tensor<1x!qco.qubit>
+      %rest, %qubit = qtensor.extract %reg[%c0]
+          : tensor<1x!qco.qubit>
+      qco.sink %qubit : !qco.qubit
+      qtensor.dealloc %rest : tensor<1x!qco.qubit>
+      return
+    }
+  })mlir";
+  const std::string unusedResult = R"mlir(module {
+    func.func @main() {
+      %qubit = qco.alloc : !qco.qubit
+      return
+    }
+  })mlir";
+  const std::string reusedBlockArgument = R"mlir(module {
+    func.func @main(%reg: tensor<1x!qco.qubit>) {
+      qtensor.dealloc %reg : tensor<1x!qco.qubit>
+      qtensor.dealloc %reg : tensor<1x!qco.qubit>
+      %qubit = qco.alloc : !qco.qubit
+      qco.sink %qubit : !qco.qubit
+      return
+    }
+  })mlir";
+  const std::string unusedVectorArgument = R"mlir(module {
+    func.func @main(%qubits: vector<2x!qco.qubit>) {
+      %qubit = qco.alloc : !qco.qubit
+      qco.sink %qubit : !qco.qubit
+      return
+    }
+  })mlir";
+
+  EXPECT_TRUE(QCOProgram::fromMLIRString(valid));
+  EXPECT_FALSE(QCOProgram::fromMLIRString(unusedResult));
+  EXPECT_FALSE(QCOProgram::fromMLIRString(unusedVectorArgument));
+
+  const auto path = std::filesystem::path(testing::TempDir()) /
+                    "nonlinear_block_argument.qco.mlir";
+  std::ofstream(path) << reusedBlockArgument;
+  EXPECT_FALSE(QCOProgram::fromMLIRFile(path));
 }
 
 /**


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Reject QCO programs that violate the linear quantum-value invariant at every checked ownership boundary.

Scalar qubits and rank-one qubit tensors and vectors are linear. Every quantum operation result and block argument must therefore have exactly one use. Transformation passes may rely on that invariant and do not need recovery paths for malformed IR.

This pull request:

- adds the shared `qco::verifyLinearity(Operation*)` semantic verifier;
- checks every nested quantum result and block argument and reports the actual use count;
- routes textual and owned-module construction through checked `QCOProgram` factories;
- validates direct QCO and converted QC/jeff input at the C++ pipeline and `mqt-cc` boundaries;
- rejects a `QCOProgram` that a caller invalidated through mutable low-level MLIR access before any public transform runs; and
- keeps QTensor transforms built on the linearity invariant and removes unreachable recovery branches.

This PR is based directly on `main`.

Validation:

- complete compiler unit suite: 135/135 passed;
- QTensor transform CTest: 1/1 passed;
- `mqt-cc` CTests: 2/2 passed;
- C++ lint: passed; and
- full repository lint: passed.

Hosted CI is pending for the rebased revision.

AI assistance: OpenAI Codex assisted with implementation, review, testing, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.