### PR TITLE
🚸 Reuse open QDMI devices in the PennyLane adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ releases may include breaking changes.
 
 #### Other additions
 
+- 🚸 Let PennyLane QDMI devices reuse an already-open session, including a
+  device selected from a Slurm license ([#2232]) ([**@burgholzer**])
 - ✨ Add extensible program serializers to QDMI Qiskit backends. [QDMI-on-IQM]
   now provides the IQM JSON serializer and `MoveGate` integration ([#2114])
   ([**@marcelwa**])
@@ -805,6 +807,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2232]: https://github.com/munich-quantum-toolkit/core/pull/2232
 [#2209]: https://github.com/munich-quantum-toolkit/core/pull/2209
 [#2211]: https://github.com/munich-quantum-toolkit/core/pull/2211
 [#2217]: https://github.com/munich-quantum-toolkit/core/pull/2217

--- a/docs/qdmi/pennylane_device.md
+++ b/docs/qdmi/pennylane_device.md
@@ -308,6 +308,20 @@ device = QDMIDevice(
 )
 ```
 
+An integration can return an already-open device. Pass that handle directly to
+the generic class. Do not repeat session parameters because the session already
+exists. For example, a Slurm job can reuse the device selected by its license:
+
+```python
+from mqt.core.plugins.pennylane import QDMIDevice
+from mqt.core.qdmi import slurm
+
+device = QDMIDevice(
+    device=slurm.open_device_from_license(),
+    shots=1000,
+)
+```
+
 Arbitrary PennyLane wire labels map deterministically to contiguous QASM
 indices. The converter validates the one- and two-qubit loci advertised through
 QDMI but does not route circuits. A topology-incompatible program therefore

--- a/docs/qdmi/slurm.md
+++ b/docs/qdmi/slurm.md
@@ -166,6 +166,11 @@ Submit the job with this command:
 sbatch bell.sbatch
 ```
 
+The same open handle works with application adapters. Pass it to
+{py:class}`mqt.core.plugins.qiskit.backend.QDMIBackend` or to the PennyLane
+{py:class}`mqt.core.plugins.pennylane.device.QDMIDevice`. See the
+{doc}`pennylane_device` guide for the PennyLane constructor.
+
 ## Check concurrent jobs
 
 For a scheduling test, add a sufficiently long classical post-processing step

--- a/python/mqt/core/plugins/pennylane/device.py
+++ b/python/mqt/core/plugins/pennylane/device.py
@@ -110,39 +110,54 @@ class QDMIDevice(Device):
     """Execute PennyLane programs on a gate-based QDMI device.
 
     Args:
-        device_id: Stable ID from the QDMI device registry.
+        device_id: Stable ID from the QDMI device registry. Use either this
+            argument or ``device``.
         wires: PennyLane wire labels or number of wires. By default all QDMI
             qubits are exposed as consecutive integer wires.
         shots: Finite default shot configuration.
+        device: An already-open QDMI device. Use this for a session selected by
+            an integration such as Slurm.
         session_parameters: QDMI device-session keyword arguments.
         job_parameters: QDMI custom job keyword arguments.
     """
 
     def __init__(
         self,
-        device_id: str,
+        device_id: str | None = None,
         wires: int | Sequence[Hashable] | None = None,
         shots: int | Sequence[int | tuple[int, int]] | Shots | None = 1024,
         *,
+        device: QDMIDeviceHandle | None = None,
         session_parameters: QDMISessionParameters | None = None,
         job_parameters: QDMIJobParameters | None = None,
     ) -> None:
-        """Initialize and open a fresh QDMI device session.
+        """Initialize from a stable ID or an open QDMI device.
 
         Raises:
             PennyLaneConfigurationError: If configuration or requested wires are invalid.
         """
-        self._device_id = device_id
         self._session_parameters = dict(session_parameters or {})
         self._job_parameters = dict(job_parameters or {})
         _validate_parameter_names(self._session_parameters, _SESSION_PARAMETERS, "session")
         _validate_parameter_names(self._job_parameters, _JOB_PARAMETERS, "job")
 
-        try:
-            self._qdmi_device = open_device(device_id, **self._session_parameters)
-        except (IndexError, RuntimeError, ValueError) as exc:
-            msg = f"Failed to open QDMI device '{device_id}': {exc}"
-            raise ConfigurationError(msg) from exc
+        if (device_id is None) == (device is None):
+            msg = "Specify exactly one of device_id and device."
+            raise ConfigurationError(msg)
+        if device is not None:
+            if self._session_parameters:
+                msg = "session_parameters cannot be used with an already-open QDMI device."
+                raise ConfigurationError(msg)
+            self._qdmi_device = device
+        else:
+            assert device_id is not None
+            try:
+                self._qdmi_device = open_device(device_id, **self._session_parameters)
+            except (IndexError, RuntimeError, ValueError) as exc:
+                msg = f"Failed to open QDMI device '{device_id}': {exc}"
+                raise ConfigurationError(msg) from exc
+        self._device_id = device_id
+        self._device_name = device_id or self._qdmi_device.name()
 
         num_qubits = self._qdmi_device.qubits_num()
         resolved_wires: int | Sequence[Hashable] = num_qubits if wires is None else wires
@@ -151,7 +166,10 @@ class QDMIDevice(Device):
             msg = "A QDMI PennyLane device requires at least one wire."
             raise ConfigurationError(msg)
         if requested_wires > num_qubits:
-            msg = f"QDMI device '{device_id}' exposes {num_qubits} qubits, but {requested_wires} wires were requested."
+            msg = (
+                f"QDMI device '{self._device_name}' exposes {num_qubits} qubits, "
+                f"but {requested_wires} wires were requested."
+            )
             raise ConfigurationError(msg)
 
         # PennyLane deprecates passing device-level shots to Device.__init__,
@@ -166,8 +184,8 @@ class QDMIDevice(Device):
         self._execution_time = 0.0
 
     @property
-    def device_id(self) -> str:
-        """Stable QDMI device ID."""
+    def device_id(self) -> str | None:
+        """Stable QDMI device ID, if the device was opened by ID."""
         return self._device_id
 
     @property
@@ -199,7 +217,7 @@ class QDMIDevice(Device):
             return ProgramFormat.QASM3
         if ProgramFormat.QASM2 in formats:
             return ProgramFormat.QASM2
-        msg = f"QDMI device '{self._device_id}' advertises neither OpenQASM 3 nor OpenQASM 2."
+        msg = f"QDMI device '{self._device_name}' advertises neither OpenQASM 3 nor OpenQASM 2."
         raise UnsupportedFormatError(msg)
 
     def preprocess_transforms(self, execution_config: ExecutionConfig | None = None) -> CompilePipeline:
@@ -331,7 +349,7 @@ class QDMIDevice(Device):
             self._submitted_jobs += 1
             job.wait()
         except (RuntimeError, ValueError) as exc:
-            msg = f"QDMI execution on '{self._device_id}' failed: {exc}"
+            msg = f"QDMI execution on '{self._device_name}' failed: {exc}"
             raise ExecutionError(msg) from exc
         self._require_done(job)
         return job

--- a/test/python/plugins/qdmi_pennylane/test_device.py
+++ b/test/python/plugins/qdmi_pennylane/test_device.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import math
 from collections import Counter
+from typing import cast
 
 import numpy as np
 import pytest
@@ -29,9 +30,24 @@ from mqt.core.plugins.pennylane import (
     PennyLaneValidationError,
     QDMIDevice,
 )
+from mqt.core.qdmi import Device as QDMIDeviceHandle
 from mqt.core.qdmi import ProgramFormat
 
 from .helpers import StubDevice, patch_open_device, rotation_results, stub_device
+
+
+def test_uses_already_open_qdmi_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reuse a device session selected outside the PennyLane adapter."""
+    qdmi = stub_device()
+    monkeypatch.setattr(
+        "mqt.core.plugins.pennylane.device.open_device",
+        lambda *_args, **_kwargs: pytest.fail("The adapter reopened the QDMI device."),
+    )
+
+    device = QDMIDevice(device=cast("QDMIDeviceHandle", qdmi), wires=2, shots=10)
+
+    assert device.qdmi_device is qdmi
+    assert device.device_id is None
 
 
 def test_samples_counts_probabilities_expectations_and_variances(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -216,6 +232,15 @@ def test_validates_configuration_and_width(monkeypatch: pytest.MonkeyPatch) -> N
         )
     with pytest.raises(PennyLaneConfigurationError, match="3 wires"):
         QDMIDevice("fake.qdmi", wires=3)
+    with pytest.raises(PennyLaneConfigurationError, match="exactly one"):
+        QDMIDevice()
+    with pytest.raises(PennyLaneConfigurationError, match="exactly one"):
+        QDMIDevice("fake.qdmi", device=cast("QDMIDeviceHandle", qdmi))
+    with pytest.raises(PennyLaneConfigurationError, match="session_parameters"):
+        QDMIDevice(
+            device=cast("QDMIDeviceHandle", qdmi),
+            session_parameters={"token": "unused"},
+        )
 
 
 def test_rejects_device_without_openqasm(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Allow the PennyLane `QDMIDevice` to consume an already-open QDMI device handle as an alternative to opening a fresh session by registry ID. This lets application adapters preserve sessions selected by integrations such as Slurm, while rejecting ambiguous ID/handle combinations and session parameters that can no longer be applied.

The PennyLane and Slurm guides now show the direct handle path. The implementation preserves the existing ID-based constructor and job-parameter behavior.

Validation:

- 40 PennyLane QDMI adapter tests on Python 3.14
- warning-as-error documentation build
- `uvx nox -s lint`
- live 10-shot provider-backed SV1 execution using a handle passed to this constructor

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

AI assistance was used to implement, test, document, and submit this change. The final human-responsibility confirmation remains for the maintainer.
