### PR TITLE
📝 Update changelog and upgrade guide after release of `v3.9.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,11 +77,6 @@ releases may include breaking changes.
 
 #### Other additions
 
-- 🚸 Let PennyLane QDMI devices reuse an already-open session, including a
-  device selected from a Slurm license ([#2232]) ([**@burgholzer**])
-- ✨ Add extensible program serializers to QDMI Qiskit backends. [QDMI-on-IQM]
-  now provides the IQM JSON serializer and `MoveGate` integration ([#2114])
-  ([**@marcelwa**])
 - 🐳 Add dev container configuration for a consistent local development
   environment ([#1786]) ([**@denialhaag**])
 
@@ -127,6 +122,27 @@ releases may include breaking changes.
   ([**@burgholzer**])
 - 🔥 Remove `datastructures` (`ds`) (sub)library from MQT Core ([#1458])
   ([**@burgholzer**])
+
+## [3.9.1] - 2026-08-25
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#391)._
+
+### Added
+
+- 🚸 Let PennyLane QDMI devices reuse an already-open session, including a
+  device selected from a Slurm license ([#2232]) ([**@burgholzer**])
+- ✨ Let a package register a program serializer for a program format through
+  the `mqt.core.qiskit.program_serializers` entry point group ([#2114])
+  ([**@marcelwa**], [**@burgholzer**])
+- ✨ Add `mqt.core.qdmi.is_binary_program_format`, which states whether a
+  program format requires exact-byte submission ([#2114]) ([**@marcelwa**],
+  [**@burgholzer**])
+
+### Removed
+
+- 💥 Remove the IQM JSON converter `qiskit_to_iqm_json` and the `MoveGate` from
+  the Qiskit plugin, which [QDMI-on-IQM] now owns ([#2114]) ([**@marcelwa**],
+  [**@burgholzer**])
 
 ## [3.9.0] - 2026-08-19
 
@@ -783,7 +799,8 @@ for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.1...HEAD
+[3.9.1]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.9.1
 [3.9.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.9.0
 [3.8.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.8.0
 [3.7.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.7.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,71 +32,6 @@ The Python bindings depend on `nanobind-backend`, which supplies the
 interpreter-specific nanobind runtime. This dependency does not change the C++
 API or the Python import paths.
 
-### Program serialization for QDMI Qiskit backends
-
-The Qiskit backend no longer decides in its own code how to turn a circuit into
-a program. It takes every program format from a registered _program serializer_,
-and MQT Core registers its own OpenQASM 2 and OpenQASM 3 serializers the same
-way as everyone else.
-
-A serializer takes the circuit and the backend. It returns `str` for a text
-format and `bytes` for a binary format;
-{py:func}`~mqt.core.qdmi.is_binary_program_format` states which kind a format
-carries. Register one at run time:
-
-```python
-import io
-
-from qiskit import qpy
-
-from mqt.core.plugins.qiskit import register_program_serializer
-from mqt.core.qdmi import ProgramFormat
-
-
-def my_qpy_serializer(circuit, backend) -> bytes:
-    buffer = io.BytesIO()
-    qpy.dump(circuit, buffer)
-    return buffer.getvalue()
-
-
-register_program_serializer(ProgramFormat.QPY, my_qpy_serializer)
-```
-
-A package that owns a device advertises its serializer through the
-`mqt.core.qiskit.program_serializers` entry point group instead, so MQT Core
-finds it without importing the package:
-
-```toml
-[project.entry-points."mqt.core.qiskit.program_serializers"]
-IQM_JSON = "iqm.qdmi.serializers:qiskit_to_iqm_json"
-```
-
-`mqt.core.plugins.qiskit.serializers.PROGRAM_FORMAT_PREFERENCE` states which
-format the backend picks when a device accepts several. Pass `replace=True` to
-`register_program_serializer` to take over a format that already has a
-serializer, including OpenQASM 2 and OpenQASM 3.
-
-A backend subclass that must represent a device-native operation outside
-Qiskit's standard gate library sets `_EXTRA_GATES`:
-
-```python
-class MyBackend(QDMIBackend):
-    _EXTRA_GATES = {"move": MoveGate()}
-```
-
-MQT Core no longer provides `qiskit_to_iqm_json` or `MoveGate`.
-[QDMI-on-IQM](https://github.com/iqm-finland/QDMI-on-IQM) owns both. Import them
-from `iqm.qdmi` instead:
-
-```python
-from iqm.qdmi.serializers import qiskit_to_iqm_json
-from iqm.qdmi.gates import MoveGate
-```
-
-Installing `iqm-qdmi` is enough to keep submitting IQM JSON. The package
-advertises its serializer through the entry point group described above, so a
-backend over an IQM device needs no code change.
-
 ### Removal of DD approximation and density-matrix support
 
 MQT Core no longer provides the decision-diagram approximation algorithm. The
@@ -284,6 +219,75 @@ Known limitations:
 MQT Core no longer provides the `datastructures` (`ds`) sublibrary. MQT QMAP was
 its only consumer. Downstream users must depend on MQT QMAP or provide the
 required data structures directly.
+
+## [3.9.1]
+
+### Program serializers for the Qiskit backend
+
+The Qiskit backend no longer decides in its own code how to turn a circuit into
+a program. It takes every program format from a registered _program serializer_,
+and MQT Core registers its own OpenQASM 2 and OpenQASM 3 serializers the same
+way as everyone else.
+
+A serializer takes the circuit and the backend. It returns `str` for a text
+format and `bytes` for a binary format;
+{py:func}`~mqt.core.qdmi.is_binary_program_format` states which kind a format
+carries. Register one at run time:
+
+```python
+import io
+
+from qiskit import qpy
+
+from mqt.core.plugins.qiskit import register_program_serializer
+from mqt.core.qdmi import ProgramFormat
+
+
+def my_qpy_serializer(circuit, backend) -> bytes:
+    buffer = io.BytesIO()
+    qpy.dump(circuit, buffer)
+    return buffer.getvalue()
+
+
+register_program_serializer(ProgramFormat.QPY, my_qpy_serializer)
+```
+
+A package that owns a device advertises its serializer through the
+`mqt.core.qiskit.program_serializers` entry point group instead, so MQT Core
+finds it without importing the package:
+
+```toml
+[project.entry-points."mqt.core.qiskit.program_serializers"]
+IQM_JSON = "iqm.qdmi.serializers:qiskit_to_iqm_json"
+```
+
+`mqt.core.plugins.qiskit.serializers.PROGRAM_FORMAT_PREFERENCE` states which
+format the backend picks when a device accepts several. Pass `replace=True` to
+`register_program_serializer` to take over a format that already has a
+serializer, including OpenQASM 2 and OpenQASM 3.
+
+A backend subclass that must represent a device-native operation outside
+Qiskit's standard gate library sets `_EXTRA_GATES`:
+
+```python
+class MyBackend(QDMIBackend):
+    _EXTRA_GATES = {"move": MoveGate()}
+```
+
+### IQM JSON serialization moved to QDMI-on-IQM
+
+MQT Core no longer provides `qiskit_to_iqm_json` or `MoveGate`.
+[QDMI-on-IQM](https://github.com/iqm-finland/QDMI-on-IQM) owns both. Import them
+from `iqm.qdmi` instead:
+
+```python
+from iqm.qdmi.serializers import qiskit_to_iqm_json
+from iqm.qdmi.gates import MoveGate
+```
+
+Installing `iqm-qdmi` is enough to keep submitting IQM JSON. The package
+advertises its serializer through the entry point group described above, so a
+backend over an IQM device needs no code change.
 
 ## [3.9.0]
 
@@ -873,7 +877,8 @@ It also requires the `uv` library version 0.5.20 or higher.
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.1...HEAD
+[3.9.1]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.0...v3.9.1
 [3.9.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.6.0...v3.7.0


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This PR moves the changes released in `v3.9.1` from the unreleased sections of the changelog and the upgrade guide into dedicated `3.9.1` sections, and updates the comparison links. The main-only v4 entries stay under `Unreleased`. Both new sections match the released `v3.9.1` tag exactly.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
