### PR TITLE
📝 Link to stable documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,4 +5,4 @@
 
 Thank you for your interest in contributing to MQT Core! An extensive
 contribution guide is available in our
-[documentation](https://mqt.readthedocs.io/projects/core/en/latest/contributing.html).
+[documentation](https://mqt.readthedocs.io/projects/core/en/stable/contributing.html).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To support this endeavor, please consider:
   requests
 - Citing the MQT in your publications (see [Cite This](#cite-this))
 - Citing our research in your publications (see
-  [References](https://mqt.readthedocs.io/projects/core/en/latest/references.html))
+  [References](https://mqt.readthedocs.io/projects/core/en/stable/references.html))
 - Using the MQT in research and teaching, and sharing feedback and use cases
 - Sponsoring us on GitHub: <https://github.com/sponsors/munich-quantum-toolkit>
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -694,7 +694,7 @@ access to QDMI devices.
 Install with Qiskit support: `uv pip install "mqt-core[qiskit]"`
 
 See the
-[Qiskit Backend documentation](https://mqt.readthedocs.io/projects/core/en/latest/qdmi/qdmi_backend.html)
+[Qiskit Backend documentation](https://mqt.readthedocs.io/projects/core/en/stable/qdmi/qdmi_backend.html)
 for details.
 
 ### Argument name changes in `QuantumComputation` and `CompoundOperation` dunder methods


### PR DESCRIPTION
## Description

This PR updates all links to MQT Core's documentation to point to the stable version. Since we updated Read the Docs, the latest version fails to build, timing out after 15 minutes. Given @burgholzer's comment below, it is more sensible to link to the stable version anyway.

Fixes #2242

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
