### PR TITLE
✨ Add more inspection methods to `QCProgram`

### DIFF
--- a/.agent/plans/extend-inspection-methods.md
+++ b/.agent/plans/extend-inspection-methods.md
@@ -32,6 +32,10 @@ textual MLIR.
       complete documentation build cannot finish because the local Graphviz
       `dot` executable is absent; Sphinx reached notebook execution before this
       unrelated environment failure.
+- [x] (2026-08-26 16:43Z) Fixed all nine clang-tidy findings from the draft PR
+      and added Python binding tests for gate histograms, static depth, SCF, and
+      dynamic register indices. The focused Python tests pass on Python 3.11
+      through 3.14.
 
 ## Surprises & Discoveries
 
@@ -52,6 +56,9 @@ textual MLIR.
   executable for an existing notebook. Evidence: Sphinx stopped in
   `docs/dd_package.md` with
   `ExecutableNotFound: failed to execute PosixPath('dot')`.
+- Observation: `getConstantIntValue` is declared by
+  `mlir/Dialect/Utils/StaticValueUtils.h`, not `mlir/IR/Matchers.h`. The draft
+  PR's include-cleaner check identified the indirect declaration.
 
 ## Decision Log
 
@@ -73,10 +80,11 @@ textual MLIR.
 ## Outcomes & Retrospective
 
 The C++ and Python APIs are implemented. All 136 compiler tests and the full
-lint suite pass. A Python smoke test returns `{'ctrl': 1, 'h': 1, 'x': 1}` and
-depth 2 for two parallel gates followed by a controlled gate. The generated stub
-and Python guide expose both methods. The complete documentation build remains
-unavailable only because the local Graphviz executable is missing.
+lint suite pass. Focused Python tests pass on Python 3.11 through 3.14. A Python
+smoke test returns `{'ctrl': 1, 'h': 1, 'x': 1}` and depth 2 for two parallel
+gates followed by a controlled gate. The generated stub and Python guide expose
+both methods. The complete documentation build remains unavailable only because
+the local Graphviz executable is missing.
 
 ## Context and Orientation
 
@@ -196,4 +204,5 @@ the compiler library. Do not introduce a new external dependency.
 
 Plan revision note: Finalized after implementation and validation. Recorded the
 successful compiler tests, stub generation, Python smoke test, and lint suite,
-as well as the unrelated local documentation dependency failure.
+as well as the unrelated local documentation dependency failure. Updated after
+the draft PR review to record the clang-tidy fixes and Python tests.

--- a/.agent/plans/extend-inspection-methods.md
+++ b/.agent/plans/extend-inspection-methods.md
@@ -1,0 +1,199 @@
+# Extend QC program inspection methods
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+Users can currently count all, single-qubit, and two-qubit unitary operations in
+a `QCProgram`. This change adds a per-operation gate histogram and a static gate
+depth. Both methods describe the entry-point MLIR representation rather than the
+number of operations executed at runtime. A user can call
+`program.gate_counts()` and `program.static_depth()` from Python without parsing
+textual MLIR.
+
+## Progress
+
+- [x] (2026-08-26 15:30Z) Investigated the QC reference model, SCF constructs,
+      modifier semantics, existing gate walk, Python bindings, and
+      documentation.
+- [x] (2026-08-26 15:40Z) Added the C++ gate histogram and static-depth
+  interfaces and implementation.
+- [x] (2026-08-26 15:40Z) Added C++ tests for straight-line code, modifiers,
+  barriers, branches, loop bodies, and dynamic register indices.
+- [x] (2026-08-26 15:40Z) Added Python bindings, regenerated stubs, and extended
+  the Python MLIR guide.
+- [x] (2026-08-26 15:40Z) Ran validation. All 136 compiler tests, stub
+      generation, the Python smoke test, and the full lint suite pass. The
+      complete documentation build cannot finish because the local Graphviz
+      `dot` executable is absent; Sphinx reached notebook execution before this
+      unrelated environment failure.
+
+## Surprises & Discoveries
+
+- Observation: QC uses mutable qubit references, and a qubit-register access can
+  use a dynamic index. Distinct SSA values can therefore refer to the same
+  runtime qubit. Evidence: `collectRegisterAccesses` in
+  `mlir/lib/Conversion/QCToQCO/QCToQCO.cpp` records each `memref.load` as a
+  register and index pair instead of relying only on the load result.
+- Observation: Modifier operations implement `UnitaryOpInterface` and can
+  contain several nested gates. The existing counts treat the outer modifier as
+  one gate and skip its body.
+- Observation: A dynamic loop index makes the selected register element unknown
+  even though the loop body appears only once in the static metric. The focused
+  test confirms that the analysis synchronizes this access with a preceding
+  constant-index access. Evidence: `QCProgramStaticDepthWithDynamicIndex`
+  returns 2 for `h q[0]` followed by `x q[i]` in a loop body.
+- Observation: The complete documentation build requires the Graphviz `dot`
+  executable for an existing notebook. Evidence: Sphinx stopped in
+  `docs/dd_package.md` with
+  `ExecutableNotFound: failed to execute PosixPath('dot')`.
+
+## Decision Log
+
+- Decision: `gateCounts()` returns `std::map<std::string, size_t>` and uses
+  `UnitaryOpInterface::getBaseSymbol()` for each key. Rationale: The result is
+  deterministic, maps directly to a Python dictionary, and partitions the
+  existing `numGates()` result. Modifier keys are `ctrl`, `inv`, and `pow`.
+  Date/Author: 2026-08-26 / Codex.
+- Decision: `staticDepth()` measures unitary gate layers in the static IR. It
+  skips barriers and modifier bodies, takes the maximum of mutually exclusive
+  `scf.if` and `scf.index_switch` branches, and analyzes each loop region once.
+  Rationale: This metric shows the compact structure of SCF IR without claiming
+  to predict runtime iterations. Date/Author: 2026-08-26 / Codex.
+- Decision: Dynamic accesses to one register must conservatively alias every
+  access to that register. Constant register indices remain distinct. Rationale:
+  This prevents an underestimated depth when the index is known only at runtime.
+  Date/Author: 2026-08-26 / Codex.
+
+## Outcomes & Retrospective
+
+The C++ and Python APIs are implemented. All 136 compiler tests and the full
+lint suite pass. A Python smoke test returns `{'ctrl': 1, 'h': 1, 'x': 1}` and
+depth 2 for two parallel gates followed by a controlled gate. The generated stub
+and Python guide expose both methods. The complete documentation build remains
+unavailable only because the local Graphviz executable is missing.
+
+## Context and Orientation
+
+`mlir/include/mlir/Compiler/Programs.h` declares the typed compiler program API.
+`mlir/lib/Compiler/Programs.cpp` implements it and contains `countGatesIf`,
+which walks the entry-point operation and counts QC operations that implement
+`UnitaryOpInterface`. The walk includes every nested region once, skips
+barriers, and does not descend into `qc.ctrl`, `qc.inv`, or `qc.pow`.
+
+QC has reference semantics: a `!qc.qubit` value denotes a mutable qubit.
+`qc.alloc` creates a dynamic scalar qubit, `qc.static` identifies a hardware
+qubit by a fixed integer, and `memref.load` can retrieve a qubit from register
+storage. Static depth is the number of unitary gate layers on the longest
+qubit-dependency chain in the IR. Gates on disjoint qubits can share a layer.
+
+`bindings/mlir/register_mlir.cpp` exposes `QCProgram` through nanobind.
+`python/mqt/core/mlir.pyi` is generated and must only change through
+`uvx nox -s stubs`. `docs/mlir/python_compiler_collection.md` shows Python users
+how to inspect compiler programs. The focused C++ tests live in
+`mlir/unittests/Compiler/test_compiler_pipeline.cpp` and run through
+`build/release/mlir/unittests/Compiler/mqt-core-mlir-unittests-compiler`.
+
+## Plan of Work
+
+First, refactor the existing gate traversal in `mlir/lib/Compiler/Programs.cpp`
+so the histogram and scalar counts use the same gate selection rules. Add
+`QCProgram::gateCounts()` to increment the entry for each outer gate's base
+symbol.
+
+Next, implement a small static-depth analysis in the same source file. Track a
+depth for scalar qubits, static indices, and register elements. Resolve constant
+register indices separately. Treat a dynamic index as an access to the complete
+register and synchronize it with every known element. For a gate, take the
+maximum depth of all its qubits, add one, and write that value back to every
+qubit resource. Ignore zero-qubit gates because they have no qubit dependency.
+
+Walk straight-line regions in operation order. Analyze each `scf.if` and
+`scf.index_switch` branch from the same input state, then merge states by taking
+the maximum depth for each resource. Analyze `scf.for` once. Analyze the before
+and after regions of `scf.while` once in execution order. Skip modifier bodies
+because the outer modifier is one logical gate.
+
+Add tests that prove the histogram sums to `numGates()`, modifier names are
+outer operation names, independent gates share a layer, dependent gates add a
+layer, branches take a maximum instead of a sum, and loop bodies count once.
+Include a register-index case to protect resource identity.
+
+Finally, bind the methods as `gate_counts` and `static_depth`, regenerate Python
+stubs, and update the inspection example and semantic explanation in the Python
+compiler guide.
+
+## Concrete Steps
+
+Run all commands from the repository root.
+
+After editing the C++ API and implementation, build and run the focused tests:
+
+    cmake --build --preset release --target mqt-core-mlir-unittests-compiler
+    ./build/release/mlir/unittests/Compiler/mqt-core-mlir-unittests-compiler \
+      --gtest_filter='CompilerPipelineTest.QCProgram*'
+
+After editing bindings, regenerate the checked-in type stub:
+
+    uvx nox -s stubs
+
+Validate the documentation and all repository checks:
+
+    uvx nox --non-interactive -s docs
+    uvx nox -s lint
+
+## Validation and Acceptance
+
+For a program containing two parallel one-qubit gates followed by a two-qubit
+gate, `staticDepth()` must return 2. For an if statement with branch depths 1
+and 2, it must return 2 before later gates are considered; the branches must not
+add to 3. A loop with a body depth of 1 must contribute 1 regardless of its
+runtime trip count.
+
+For every test program, summing `gateCounts()` values must equal `numGates()`.
+Barriers must appear in neither result. A controlled modifier around `x` must
+increment `ctrl`, not `x`, because the public count treats the modifier as one
+logical gate.
+
+The focused C++ test binary, documentation build, and `uvx nox -s lint` must
+finish successfully. Stub generation must leave only the intended API additions
+in `python/mqt/core/mlir.pyi`.
+
+## Idempotence and Recovery
+
+Build, test, documentation, stub, and lint commands are repeatable. Stub
+generation may rewrite the generated file; inspect its diff and rerun it after
+each binding signature change. Preserve unrelated working-tree changes and do
+not reset files to recover from a failed check.
+
+## Artifacts and Notes
+
+The existing gate-count contract is the reference for gate selection:
+
+    operations in each nested region count once;
+    barriers do not count;
+    a modifier counts once and its body does not count again.
+
+## Interfaces and Dependencies
+
+At completion, `mlir::QCProgram` must provide:
+
+    [[nodiscard]] std::map<std::string, size_t> gateCounts() const;
+    [[nodiscard]] size_t staticDepth() const;
+
+Python must provide:
+
+    def gate_counts(self) -> dict[str, int]: ...
+    def static_depth(self) -> int: ...
+
+Use MLIR's QC operation interfaces and SCF operation classes already linked by
+the compiler library. Do not introduce a new external dependency.
+
+Plan revision note: Finalized after implementation and validation. Recorded the
+successful compiler tests, stub generation, Python smoke test, and lint suite,
+as well as the unrelated local documentation dependency failure.

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -18,6 +18,7 @@
 #include <llvm/Support/Error.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/filesystem.h>  // NOLINT(misc-include-cleaner)
+#include <nanobind/stl/map.h>         // NOLINT(misc-include-cleaner)
 #include <nanobind/stl/optional.h>    // NOLINT(misc-include-cleaner)
 #include <nanobind/stl/pair.h>        // NOLINT(misc-include-cleaner)
 #include <nanobind/stl/string.h>      // NOLINT(misc-include-cleaner)
@@ -29,6 +30,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <map>
 #include <memory>
 #include <optional>
 #include <span>
@@ -758,7 +760,31 @@ are not counted recursively, and barriers are skipped.)pb")
 Any operation that implements the ``UnitaryOpInterface`` and acts on two qubits
 is counted. Operations in every structured control-flow region are counted
 once, regardless of how often the region executes. Operations within modifiers
-are not counted recursively, and barriers are skipped.)pb");
+are not counted recursively, and barriers are skipped.)pb")
+      .def(
+          "gate_counts",
+          [](const mlir::QCProgram& program) {
+            requireValid(program);
+            return program.gateCounts();
+          },
+          R"pb(Count gates by operation mnemonic.
+
+The counts use the same static-IR semantics as :meth:`num_gates`. Modifier
+operations use the ``ctrl``, ``inv``, and ``pow`` mnemonics. Their bodies are
+not counted recursively, and barriers are skipped.)pb")
+      .def(
+          "static_depth",
+          [](const mlir::QCProgram& program) {
+            requireValid(program);
+            return program.staticDepth();
+          },
+          R"pb(Calculate the static gate depth of the program.
+
+The depth describes the entry-point IR rather than runtime execution. Mutually
+exclusive structured control-flow branches contribute their maximum depth.
+Each loop region contributes once, regardless of its runtime iteration count.
+Modifier operations contribute one layer, but their bodies do not contribute
+again. Barriers and zero-qubit operations do not contribute.)pb");
 
   auto qcoProgram = nb::class_<mlir::QCOProgram, mlir::Program>(
       m, "QCOProgram", R"pb(A compiler program in the QCO dialect.

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -30,7 +30,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
-#include <map>
 #include <memory>
 #include <optional>
 #include <span>

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -75,11 +75,16 @@ gates without parsing the textual IR:
 print("Gates:", compiled.num_gates())
 print("Single-qubit gates:", compiled.num_single_qubit_gates())
 print("Two-qubit gates:", compiled.num_two_qubit_gates())
+print("Gates by operation:", compiled.gate_counts())
+print("Static gate depth:", compiled.static_depth())
 ```
 
 These counts describe the entry-point IR. A gate in each structured control-flow
 region counts once, regardless of the runtime path or loop iteration count.
 Barriers do not count, and operations inside gate modifiers do not count again.
+The static depth uses the same gate semantics. It takes the maximum depth of
+mutually exclusive branches and includes each loop body once. It does not
+estimate the depth of the executed program.
 
 ## Select an output format
 

--- a/mlir/include/mlir/Compiler/Programs.h
+++ b/mlir/include/mlir/Compiler/Programs.h
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <map>
 #include <memory>
 #include <optional>
 #include <span>
@@ -219,6 +220,27 @@ public:
    * skipped.
    */
   [[nodiscard]] size_t numTwoQubitGates() const;
+
+  /**
+   * @brief Count gates by operation mnemonic.
+   *
+   * @details The counts use the same static-IR semantics as `numGates()`.
+   * Modifier operations use the `ctrl`, `inv`, and `pow` mnemonics. Their
+   * bodies are not counted recursively. Barriers are skipped.
+   */
+  [[nodiscard]] std::map<std::string, size_t> gateCounts() const;
+
+  /**
+   * @brief Calculate the static gate depth of the program.
+   *
+   * @details The depth describes the entry-point IR rather than runtime
+   * execution. Mutually exclusive structured control-flow branches contribute
+   * their maximum depth. Each loop region contributes once, regardless of its
+   * runtime iteration count. Modifier operations contribute one layer, but
+   * their bodies do not contribute again. Barriers and zero-qubit operations
+   * do not contribute.
+   */
+  [[nodiscard]] size_t staticDepth() const;
 };
 
 /**

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -37,6 +37,7 @@
 #include <jeff/Translation/Deserialize.hpp>
 #include <jeff/Translation/Serialize.hpp>
 #include <kj/array.h>
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
@@ -53,10 +54,14 @@
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/IR/Block.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/Location.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/Region.h>
+#include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/IR/Visitors.h>
 #include <mlir/Parser/Parser.h>
@@ -68,11 +73,13 @@
 #include <mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h>
 #include <mlir/Target/LLVMIR/ModuleTranslation.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
+#include <map>
 #include <memory>
 #include <optional>
 #include <span>
@@ -376,18 +383,200 @@ std::optional<QIRProgram> QCProgram::intoQIR(const QIRProfile profile) && {
   return result;
 }
 
-static size_t
-countGatesIf(ModuleOp moduleOp,
-             const llvm::function_ref<bool(qc::UnitaryOpInterface)> predicate) {
-  size_t count = 0;
+/**
+ * @brief Visit each gate in the entry point.
+ *
+ * @details The walk visits each gate in nested regions once, so the result
+ * describes the static IR rather than runtime execution. Modifier operations
+ * count as gates, but the walk skips their bodies. Barriers do not count.
+ */
+template <typename Callback>
+static void walkGates(ModuleOp moduleOp, const Callback& callback) {
   auto entryPoint = mqt::getEntryPoint(moduleOp);
   entryPoint.walk<WalkOrder::PreOrder>([&](qc::UnitaryOpInterface op) {
-    count += !isa<qc::BarrierOp>(op) && predicate(op);
-    return isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(op) ? WalkResult::skip()
-                                                     : WalkResult::advance();
+    if (!isa<qc::BarrierOp>(op)) {
+      callback(op);
+    }
+    if (isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(op)) {
+      return WalkResult::skip();
+    }
+    return WalkResult::advance();
+  });
+}
+
+template <typename Predicate>
+static size_t countGatesIf(ModuleOp moduleOp, const Predicate& predicate = {}) {
+  size_t count = 0;
+  walkGates(moduleOp, [&](qc::UnitaryOpInterface op) {
+    if (predicate(op)) {
+      ++count;
+    }
   });
   return count;
 }
+
+namespace {
+
+struct RegisterDepths {
+  size_t dynamic = 0;
+  DenseMap<int64_t, size_t> constants;
+
+  void mergeMax(const RegisterDepths& other) {
+    dynamic = std::max(dynamic, other.dynamic);
+    for (const auto& [index, depth] : other.constants) {
+      constants[index] = std::max(constants[index], depth);
+    }
+  }
+
+  [[nodiscard]] size_t maximum() const {
+    auto result = dynamic;
+    for (const auto& entry : constants) {
+      result = std::max(result, entry.second);
+    }
+    return result;
+  }
+};
+
+struct GateDepthState {
+  DenseMap<Value, size_t> values;
+  DenseMap<uint64_t, size_t> staticQubits;
+  DenseMap<Value, RegisterDepths> registers;
+
+  void mergeMax(const GateDepthState& other) {
+    for (const auto& [value, depth] : other.values) {
+      values[value] = std::max(values[value], depth);
+    }
+    for (const auto& [index, depth] : other.staticQubits) {
+      staticQubits[index] = std::max(staticQubits[index], depth);
+    }
+    for (const auto& [value, depths] : other.registers) {
+      registers[value].mergeMax(depths);
+    }
+  }
+
+  [[nodiscard]] size_t maximum() const {
+    size_t result = 0;
+    for (const auto& entry : values) {
+      result = std::max(result, entry.second);
+    }
+    for (const auto& entry : staticQubits) {
+      result = std::max(result, entry.second);
+    }
+    for (const auto& entry : registers) {
+      result = std::max(result, entry.second.maximum());
+    }
+    return result;
+  }
+
+  [[nodiscard]] size_t get(Value qubit) {
+    if (auto staticOp = qubit.getDefiningOp<qc::StaticOp>()) {
+      return staticQubits[staticOp.getIndex()];
+    }
+    if (auto loadOp = qubit.getDefiningOp<memref::LoadOp>();
+        loadOp && isa<qc::QubitType>(loadOp.getType())) {
+      auto& depths = registers[loadOp.getMemref()];
+      if (loadOp.getIndices().size() == 1) {
+        if (const auto index =
+                getConstantIntValue(loadOp.getIndices().front())) {
+          return std::max(depths.dynamic, depths.constants[*index]);
+        }
+      }
+      return depths.maximum();
+    }
+    return values[qubit];
+  }
+
+  void set(Value qubit, const size_t depth) {
+    if (auto staticOp = qubit.getDefiningOp<qc::StaticOp>()) {
+      staticQubits[staticOp.getIndex()] = depth;
+      return;
+    }
+    if (auto loadOp = qubit.getDefiningOp<memref::LoadOp>();
+        loadOp && isa<qc::QubitType>(loadOp.getType())) {
+      auto& depths = registers[loadOp.getMemref()];
+      if (loadOp.getIndices().size() == 1) {
+        if (const auto index =
+                getConstantIntValue(loadOp.getIndices().front())) {
+          depths.constants[*index] = depth;
+          return;
+        }
+      }
+      depths.dynamic = depth;
+      return;
+    }
+    values[qubit] = depth;
+  }
+};
+
+static void updateGateDepth(qc::UnitaryOpInterface gate,
+                            GateDepthState& state) {
+  if (isa<qc::BarrierOp>(gate) || gate.getNumQubits() == 0) {
+    return;
+  }
+  size_t depth = 0;
+  for (const auto qubit : gate.getQubits()) {
+    depth = std::max(depth, state.get(qubit));
+  }
+  ++depth;
+  for (const auto qubit : gate.getQubits()) {
+    state.set(qubit, depth);
+  }
+}
+
+static void calculateRegionDepth(Region& region, GateDepthState& state);
+
+static void calculateOperationDepth(Operation& operation,
+                                    GateDepthState& state) {
+  if (auto gate = dyn_cast<qc::UnitaryOpInterface>(&operation)) {
+    updateGateDepth(gate, state);
+    return;
+  }
+  if (auto ifOp = dyn_cast<scf::IfOp>(&operation)) {
+    GateDepthState merged = state;
+    auto thenState = state;
+    calculateRegionDepth(ifOp.getThenRegion(), thenState);
+    merged.mergeMax(thenState);
+    if (!ifOp.getElseRegion().empty()) {
+      auto elseState = state;
+      calculateRegionDepth(ifOp.getElseRegion(), elseState);
+      merged.mergeMax(elseState);
+    }
+    state = std::move(merged);
+    return;
+  }
+  if (auto switchOp = dyn_cast<scf::IndexSwitchOp>(&operation)) {
+    GateDepthState merged = state;
+    for (auto& region : switchOp->getRegions()) {
+      auto branchState = state;
+      calculateRegionDepth(region, branchState);
+      merged.mergeMax(branchState);
+    }
+    state = std::move(merged);
+    return;
+  }
+  if (auto forOp = dyn_cast<scf::ForOp>(&operation)) {
+    calculateRegionDepth(forOp.getRegion(), state);
+    return;
+  }
+  if (auto whileOp = dyn_cast<scf::WhileOp>(&operation)) {
+    calculateRegionDepth(whileOp.getBefore(), state);
+    calculateRegionDepth(whileOp.getAfter(), state);
+    return;
+  }
+  for (auto& region : operation.getRegions()) {
+    calculateRegionDepth(region, state);
+  }
+}
+
+static void calculateRegionDepth(Region& region, GateDepthState& state) {
+  for (auto& block : region) {
+    for (auto& operation : block) {
+      calculateOperationDepth(operation, state);
+    }
+  }
+}
+
+} // namespace
 
 size_t QCProgram::numGates() const {
   return countGatesIf(mod(), [](qc::UnitaryOpInterface) { return true; });
@@ -401,6 +590,23 @@ size_t QCProgram::numSingleQubitGates() const {
 size_t QCProgram::numTwoQubitGates() const {
   return countGatesIf(
       mod(), [](qc::UnitaryOpInterface op) { return op.isTwoQubit(); });
+}
+
+std::map<std::string, size_t> QCProgram::gateCounts() const {
+  std::map<std::string, size_t> counts;
+  walkGates(mod(), [&](qc::UnitaryOpInterface op) {
+    ++counts[op.getBaseSymbol().str()];
+  });
+  return counts;
+}
+
+size_t QCProgram::staticDepth() const {
+  GateDepthState state;
+  auto entryPoint = mqt::getEntryPoint(mod());
+  for (auto& region : entryPoint->getRegions()) {
+    calculateRegionDepth(region, state);
+  }
+  return state.maximum();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -383,34 +383,15 @@ std::optional<QIRProgram> QCProgram::intoQIR(const QIRProfile profile) && {
   return result;
 }
 
-/**
- * @brief Visit each gate in the entry point.
- *
- * @details The walk visits each gate in nested regions once, so the result
- * describes the static IR rather than runtime execution. Modifier operations
- * count as gates, but the walk skips their bodies. Barriers do not count.
- */
-template <typename Callback>
-static void walkGates(ModuleOp moduleOp, const Callback& callback) {
+static size_t
+countGatesIf(ModuleOp moduleOp,
+             const llvm::function_ref<bool(qc::UnitaryOpInterface)> predicate) {
+  size_t count = 0;
   auto entryPoint = mqt::getEntryPoint(moduleOp);
   entryPoint.walk<WalkOrder::PreOrder>([&](qc::UnitaryOpInterface op) {
-    if (!isa<qc::BarrierOp>(op)) {
-      callback(op);
-    }
-    if (isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(op)) {
-      return WalkResult::skip();
-    }
-    return WalkResult::advance();
-  });
-}
-
-template <typename Predicate>
-static size_t countGatesIf(ModuleOp moduleOp, const Predicate& predicate = {}) {
-  size_t count = 0;
-  walkGates(moduleOp, [&](qc::UnitaryOpInterface op) {
-    if (predicate(op)) {
-      ++count;
-    }
+    count += !isa<qc::BarrierOp>(op) && predicate(op);
+    return isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(op) ? WalkResult::skip()
+                                                     : WalkResult::advance();
   });
   return count;
 }
@@ -594,8 +575,13 @@ size_t QCProgram::numTwoQubitGates() const {
 
 std::map<std::string, size_t> QCProgram::gateCounts() const {
   std::map<std::string, size_t> counts;
-  walkGates(mod(), [&](qc::UnitaryOpInterface op) {
-    ++counts[op.getBaseSymbol().str()];
+  auto entryPoint = mqt::getEntryPoint(mod());
+  entryPoint.walk<WalkOrder::PreOrder>([&](qc::UnitaryOpInterface op) {
+    if (!isa<qc::BarrierOp>(op)) {
+      ++counts[op.getBaseSymbol().str()];
+    }
+    return isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(op) ? WalkResult::skip()
+                                                     : WalkResult::advance();
   });
   return counts;
 }

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -54,11 +54,11 @@
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/Location.h>
-#include <mlir/IR/Matchers.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Region.h>
 #include <mlir/IR/Value.h>
@@ -508,6 +508,8 @@ struct GateDepthState {
   }
 };
 
+} // namespace
+
 static void updateGateDepth(qc::UnitaryOpInterface gate,
                             GateDepthState& state) {
   if (isa<qc::BarrierOp>(gate) || gate.getNumQubits() == 0) {
@@ -575,8 +577,6 @@ static void calculateRegionDepth(Region& region, GateDepthState& state) {
     }
   }
 }
-
-} // namespace
 
 size_t QCProgram::numGates() const {
   return countGatesIf(mod(), [](qc::UnitaryOpInterface) { return true; });

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -64,6 +64,7 @@
 #include <fstream>
 #include <iosfwd>
 #include <iterator>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -1610,6 +1611,27 @@ barrier q[0], q[1];
   EXPECT_EQ(qc->numGates(), 6);
   EXPECT_EQ(qc->numSingleQubitGates(), 1);
   EXPECT_EQ(qc->numTwoQubitGates(), 3);
+  const std::map<std::string, size_t> expectedCounts{
+      {"ctrl", 3}, {"h", 1}, {"inv", 1}, {"swap", 1}};
+  EXPECT_EQ(qc->gateCounts(), expectedCounts);
+}
+
+/**
+ * @brief Test: static depth tracks dependencies and skips modifier bodies.
+ */
+TEST_F(CompilerPipelineTest, QCProgramStaticDepth) {
+  const std::string qasm = R"(OPENQASM 3.0;
+include "stdgates.inc";
+qubit[3] q;
+h q[0];
+x q[1];
+cx q[0], q[1];
+inv @ x q[2];
+barrier q[0], q[1], q[2];
+)";
+  auto qc = QCProgram::fromQASMString(qasm);
+  ASSERT_TRUE(qc);
+  EXPECT_EQ(qc->staticDepth(), 2);
 }
 
 /**
@@ -1645,6 +1667,51 @@ switch (selector) {
   EXPECT_EQ(qc->numGates(), 5);
   EXPECT_EQ(qc->numSingleQubitGates(), 2);
   EXPECT_EQ(qc->numTwoQubitGates(), 3);
+  const std::map<std::string, size_t> expectedCounts{
+      {"ctrl", 2}, {"swap", 1}, {"x", 1}, {"z", 1}};
+  EXPECT_EQ(qc->gateCounts(), expectedCounts);
+  EXPECT_EQ(qc->staticDepth(), 3);
+}
+
+/**
+ * @brief Test: static depth takes the maximum SCF branch and one loop body.
+ */
+TEST_F(CompilerPipelineTest, QCProgramStaticDepthInStructuredControlFlow) {
+  const std::string qasm = R"(OPENQASM 3.0;
+include "stdgates.inc";
+qubit[3] q;
+bit condition = measure q[0];
+if (condition) {
+  h q[0];
+  x q[0];
+} else {
+  h q[1];
+}
+cx q[0], q[1];
+for int i in [0:999999] {
+  z q[2];
+}
+)";
+  auto qc = QCProgram::fromQASMString(qasm);
+  ASSERT_TRUE(qc);
+  EXPECT_EQ(qc->staticDepth(), 3);
+}
+
+/**
+ * @brief Test: dynamic register indices conservatively alias each element.
+ */
+TEST_F(CompilerPipelineTest, QCProgramStaticDepthWithDynamicIndex) {
+  const std::string qasm = R"(OPENQASM 3.0;
+include "stdgates.inc";
+qubit[3] q;
+h q[0];
+for int i in [0:2] {
+  x q[i];
+}
+)";
+  auto qc = QCProgram::fromQASMString(qasm);
+  ASSERT_TRUE(qc);
+  EXPECT_EQ(qc->staticDepth(), 2);
 }
 
 } // namespace mqt::test::compiler

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -406,6 +406,24 @@ class QCProgram(Program):
         are not counted recursively, and barriers are skipped.
         """
 
+    def gate_counts(self) -> dict[str, int]:
+        """Count gates by operation mnemonic.
+
+        The counts use the same static-IR semantics as :meth:`num_gates`. Modifier
+        operations use the ``ctrl``, ``inv``, and ``pow`` mnemonics. Their bodies are
+        not counted recursively, and barriers are skipped.
+        """
+
+    def static_depth(self) -> int:
+        """Calculate the static gate depth of the program.
+
+        The depth describes the entry-point IR rather than runtime execution. Mutually
+        exclusive structured control-flow branches contribute their maximum depth.
+        Each loop region contributes once, regardless of its runtime iteration count.
+        Modifier operations contribute one layer, but their bodies do not contribute
+        again. Barriers and zero-qubit operations do not contribute.
+        """
+
 class QCOProgram(Program):
     """A compiler program in the QCO dialect.
 

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -701,3 +701,51 @@ def test_qc_program_num_gates() -> None:
     assert program.num_gates() == 2
     assert program.num_single_qubit_gates() == 1
     assert program.num_two_qubit_gates() == 1
+    assert program.gate_counts() == {"ctrl": 1, "h": 1}
+    assert program.static_depth() == 2
+
+
+def test_qc_program_num_gates_in_structured_control_flow() -> None:
+    """Gate counting includes each structured control-flow region once."""
+    program = QCProgram.from_qasm_str("""OPENQASM 3.0;
+include "stdgates.inc";
+qubit[3] q;
+bit condition = measure q[0];
+int selector = 1;
+if (condition) {
+  for int i in [0:2] {
+    x q[i];
+  }
+} else {
+  cx q[0], q[1];
+}
+while (condition) {
+  ctrl @ x q[0], q[1];
+}
+switch (selector) {
+  case 1 {
+    swap q[0], q[1];
+  }
+  default {
+    z q[2];
+  }
+}
+""")
+    assert program.num_gates() == 5
+    assert program.num_single_qubit_gates() == 2
+    assert program.num_two_qubit_gates() == 3
+    assert program.gate_counts() == {"ctrl": 2, "swap": 1, "x": 1, "z": 1}
+    assert program.static_depth() == 3
+
+
+def test_qc_program_static_depth_with_dynamic_index() -> None:
+    """A dynamic register index conservatively aliases each element."""
+    program = QCProgram.from_qasm_str("""OPENQASM 3.0;
+include "stdgates.inc";
+qubit[3] q;
+h q[0];
+for int i in [0:2] {
+  x q[i];
+}
+""")
+    assert program.static_depth() == 2


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Add `gate_counts` and `static_depth` inspection methods to `QCProgram` in C++ and Python. Gate counts group the existing static-IR gate metric by operation mnemonic.

Static depth follows qubit dependencies, takes the maximum across mutually exclusive SCF branches, visits each loop body once, and conservatively handles dynamic register indices. The methods share the existing modifier and barrier semantics and include C++ tests and Python documentation.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
