### PR TITLE
💥 Remove `spdlog` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ releases may include breaking changes.
 
 ### Removed
 
+- 💥 Remove the `spdlog` dependency from MQT Core source builds, installed CMake
+  packages, and Python wheels. QDMI diagnostics continue to be written to
+  standard error ([#2270]) ([**@denialhaag**])
 - 💥 Remove `CircuitOptimizer`. Move circuit flattening and final-measurement
   removal to `QuantumComputation`, equivalence-checking transformations to MQT
   QCEC, and mapping transformations to MQT QMAP. Move single-qubit gate fusion
@@ -851,6 +854,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2270]: https://github.com/munich-quantum-toolkit/core/pull/2270
 [#2262]: https://github.com/munich-quantum-toolkit/core/pull/2262
 [#2259]: https://github.com/munich-quantum-toolkit/core/pull/2259
 [#2258]: https://github.com/munich-quantum-toolkit/core/pull/2258

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,18 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Removal of the `spdlog` dependency
+
+MQT Core no longer discovers, downloads, builds, installs, or exports `spdlog`.
+The installed CMake package no longer calls `find_dependency(spdlog)`, and the
+Python wheels no longer contain the `spdlog` headers or shared library. QDMI
+diagnostics continue to use standard error.
+
+Downstream projects that use `spdlog` must declare and package the dependency
+themselves. Stop passing `MQT_CORE_SPDLOG_INSTALL` or `SPDLOG_*` cache variables
+when configuring MQT Core. Configure the downstream project's own `spdlog`
+dependency instead.
+
 ### CircuitOptimizer removal
 
 MQT Core no longer provides `qc::CircuitOptimizer`. Replace the two generic

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -10,7 +10,6 @@
 
 include(FetchContent)
 include(CMakeDependentOption)
-include(GNUInstallDirs)
 set(FETCH_PACKAGES "")
 
 if(BUILD_MQT_CORE_BINDINGS)
@@ -83,95 +82,5 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS ${QDMI_MINIMUM_VERSION})
 list(APPEND FETCH_PACKAGES qdmi)
 
-set(MQT_CORE_MANAGES_SPDLOG OFF)
-if(NOT TARGET spdlog::spdlog)
-  set(SPDLOG_VERSION
-      1.17.0
-      CACHE STRING "spdlog version")
-  set(SPDLOG_URL https://github.com/gabime/spdlog/archive/refs/tags/v${SPDLOG_VERSION}.tar.gz)
-  # Add position independent code for spdlog, this is required for Python bindings on Linux.
-  set(SPDLOG_BUILD_PIC ON)
-  set(SPDLOG_SYSTEM_INCLUDES
-      ON
-      CACHE INTERNAL "Treat the library headers like system headers")
-  cmake_dependent_option(MQT_CORE_SPDLOG_INSTALL "Install spdlog library" ON "MQT_CORE_INSTALL" OFF)
-  # Disable upstream spdlog install rules and install with explicit MQT components below.
-  set(SPDLOG_INSTALL
-      OFF
-      CACHE BOOL "Disable upstream spdlog install rules; handled by mqt-core" FORCE)
-  cmake_dependent_option(SPDLOG_BUILD_SHARED "Build spdlog as shared library" ON
-                         "BUILD_MQT_CORE_SHARED_LIBS" OFF)
-  FetchContent_Declare(spdlog URL ${SPDLOG_URL} FIND_PACKAGE_ARGS ${SPDLOG_VERSION})
-  list(APPEND FETCH_PACKAGES spdlog)
-  set(MQT_CORE_MANAGES_SPDLOG ON)
-endif()
-
 # Make all declared dependencies available.
 FetchContent_MakeAvailable(${FETCH_PACKAGES})
-
-# Ensure external shared libraries end up in a common lib layout used by our RUNPATH
-if(MQT_CORE_MANAGES_SPDLOG AND TARGET spdlog)
-  set_target_properties(
-    spdlog
-    PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
-               ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
-               RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
-endif()
-
-# Install spdlog with explicit MQT components.
-if(MQT_CORE_MANAGES_SPDLOG
-   AND MQT_CORE_SPDLOG_INSTALL
-   AND TARGET spdlog
-   AND TARGET spdlog_header_only)
-  include(CMakePackageConfigHelpers)
-
-  set(MQT_CORE_SPDLOG_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/spdlog")
-  set(MQT_CORE_SPDLOG_CONFIG_TARGETS_FILE "spdlogConfigTargets.cmake")
-  set(MQT_CORE_SPDLOG_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/spdlogConfig.cmake")
-  set(MQT_CORE_SPDLOG_VERSION_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/spdlogConfigVersion.cmake")
-
-  install(
-    TARGETS spdlog spdlog_header_only
-    EXPORT spdlog
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${MQT_CORE_TARGET_NAME}_Runtime
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT ${MQT_CORE_TARGET_NAME}_Runtime
-            NAMELINK_COMPONENT ${MQT_CORE_TARGET_NAME}_Development
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-
-  install(
-    DIRECTORY ${spdlog_SOURCE_DIR}/include/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development
-    PATTERN "fmt/bundled" EXCLUDE)
-
-  if(NOT SPDLOG_USE_STD_FORMAT
-     AND NOT SPDLOG_FMT_EXTERNAL
-     AND NOT SPDLOG_FMT_EXTERNAL_HO)
-    install(
-      DIRECTORY ${spdlog_SOURCE_DIR}/include/spdlog/fmt/bundled/
-      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spdlog/fmt/bundled
-      COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-  endif()
-
-  install(
-    EXPORT spdlog
-    FILE ${MQT_CORE_SPDLOG_CONFIG_TARGETS_FILE}
-    NAMESPACE spdlog::
-    DESTINATION ${MQT_CORE_SPDLOG_CONFIG_INSTALL_DIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-
-  set(config_targets_file ${MQT_CORE_SPDLOG_CONFIG_TARGETS_FILE})
-  configure_package_config_file(
-    ${spdlog_SOURCE_DIR}/cmake/spdlogConfig.cmake.in ${MQT_CORE_SPDLOG_CONFIG_FILE}
-    INSTALL_DESTINATION ${MQT_CORE_SPDLOG_CONFIG_INSTALL_DIR})
-  write_basic_package_version_file(
-    ${MQT_CORE_SPDLOG_VERSION_CONFIG_FILE}
-    VERSION ${SPDLOG_VERSION}
-    COMPATIBILITY SameMajorVersion)
-
-  install(
-    FILES ${MQT_CORE_SPDLOG_CONFIG_FILE} ${MQT_CORE_SPDLOG_VERSION_CONFIG_FILE}
-    DESTINATION ${MQT_CORE_SPDLOG_CONFIG_INSTALL_DIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-endif()

--- a/cmake/mqt-core-config.cmake.in
+++ b/cmake/mqt-core-config.cmake.in
@@ -13,7 +13,6 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 include(CMakeFindDependencyMacro)
-find_dependency(spdlog)
 find_dependency(qdmi)
 
 if(TARGET MQT::Core)

--- a/include/mqt-core/qdmi/common/Diagnostics.hpp
+++ b/include/mqt-core/qdmi/common/Diagnostics.hpp
@@ -16,9 +16,12 @@
 #include <string_view>
 #include <utility>
 
-namespace qdmi::detail {
+namespace qdmi::diagnostics {
 
+/// Severity of a diagnostic.
 enum class DiagnosticLevel : uint8_t { Info, Warning, Error };
+
+namespace detail {
 
 [[nodiscard]] constexpr std::string_view
 diagnosticLevelName(const DiagnosticLevel level) noexcept {
@@ -67,18 +70,38 @@ inline void writeDiagnostic(const DiagnosticLevel level,
 #endif
 }
 
+} // namespace detail
+
 /// Formats and writes one best-effort diagnostic to standard error.
 ///
 /// Writes the unformatted format string if formatting fails.
 template <class... Args>
-void emitDiagnostic(const DiagnosticLevel level,
-                    const std::format_string<Args...> format,
-                    Args&&... args) noexcept {
+void emit(const DiagnosticLevel level, const std::format_string<Args...> format,
+          Args&&... args) noexcept {
   try {
-    writeDiagnostic(level, std::format(format, std::forward<Args>(args)...));
+    detail::writeDiagnostic(level,
+                            std::format(format, std::forward<Args>(args)...));
   } catch (...) {
-    writeDiagnostic(level, format.get());
+    detail::writeDiagnostic(level, format.get());
   }
 }
 
-} // namespace qdmi::detail
+/// Formats and writes an informational diagnostic to standard error.
+template <class... Args>
+void info(const std::format_string<Args...> format, Args&&... args) noexcept {
+  emit(DiagnosticLevel::Info, format, std::forward<Args>(args)...);
+}
+
+/// Formats and writes a warning diagnostic to standard error.
+template <class... Args>
+void warn(const std::format_string<Args...> format, Args&&... args) noexcept {
+  emit(DiagnosticLevel::Warning, format, std::forward<Args>(args)...);
+}
+
+/// Formats and writes an error diagnostic to standard error.
+template <class... Args>
+void error(const std::format_string<Args...> format, Args&&... args) noexcept {
+  emit(DiagnosticLevel::Error, format, std::forward<Args>(args)...);
+}
+
+} // namespace qdmi::diagnostics

--- a/src/qdmi/CMakeLists.txt
+++ b/src/qdmi/CMakeLists.txt
@@ -27,10 +27,9 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/Client.hpp
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/Slurm.hpp)
 
-  target_link_libraries(
-    ${TARGET_NAME}
-    PUBLIC qdmi::qdmi MQT::CoreQDMICommon MQT::CoreQDMIDriver
-    PRIVATE spdlog::spdlog)
+  target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/qdmi)
+
+  target_link_libraries(${TARGET_NAME} PUBLIC qdmi::qdmi MQT::CoreQDMICommon MQT::CoreQDMIDriver)
 
   list(APPEND MQT_CORE_TARGETS ${TARGET_NAME})
 endif()

--- a/src/qdmi/CMakeLists.txt
+++ b/src/qdmi/CMakeLists.txt
@@ -27,8 +27,6 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/Client.hpp
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/Slurm.hpp)
 
-  target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/qdmi)
-
   target_link_libraries(${TARGET_NAME} PUBLIC qdmi::qdmi MQT::CoreQDMICommon MQT::CoreQDMIDriver)
 
   list(APPEND MQT_CORE_TARGETS ${TARGET_NAME})

--- a/src/qdmi/Client.cpp
+++ b/src/qdmi/Client.cpp
@@ -898,10 +898,10 @@ Session::Session(const SessionConfig& config) {
           session_.get(), param, value->size() + 1, value->c_str()));
       if (status == QDMI_ERROR_NOTSUPPORTED) {
         // Optional parameter not supported by session - skip it
-        qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Info,
-                                     {"Session parameter ",
-                                      qdmi::toString(param),
-                                      " not supported (skipped)"});
+        qdmi::detail::emitDiagnostic(
+            qdmi::detail::DiagnosticLevel::Info,
+            "Session parameter {} not supported (skipped)",
+            qdmi::toString(param));
         return;
       }
       if (status == QDMI_SUCCESS) {

--- a/src/qdmi/Client.cpp
+++ b/src/qdmi/Client.cpp
@@ -10,11 +10,11 @@
 
 #include "qdmi/Client.hpp"
 
+#include "Diagnostics.hpp"
 #include "qdmi/common/Common.hpp"
 #include "qdmi/driver/Driver.hpp"
 
 #include <qdmi/client.h>
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <complex>
@@ -898,8 +898,10 @@ Session::Session(const SessionConfig& config) {
           session_.get(), param, value->size() + 1, value->c_str()));
       if (status == QDMI_ERROR_NOTSUPPORTED) {
         // Optional parameter not supported by session - skip it
-        SPDLOG_INFO("Session parameter {} not supported (skipped)",
-                    qdmi::toString(param));
+        qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Info,
+                                     {"Session parameter ",
+                                      qdmi::toString(param),
+                                      " not supported (skipped)"});
         return;
       }
       if (status == QDMI_SUCCESS) {

--- a/src/qdmi/Client.cpp
+++ b/src/qdmi/Client.cpp
@@ -10,8 +10,8 @@
 
 #include "qdmi/Client.hpp"
 
-#include "Diagnostics.hpp"
 #include "qdmi/common/Common.hpp"
+#include "qdmi/common/Diagnostics.hpp"
 #include "qdmi/driver/Driver.hpp"
 
 #include <qdmi/client.h>
@@ -898,10 +898,8 @@ Session::Session(const SessionConfig& config) {
           session_.get(), param, value->size() + 1, value->c_str()));
       if (status == QDMI_ERROR_NOTSUPPORTED) {
         // Optional parameter not supported by session - skip it
-        qdmi::detail::emitDiagnostic(
-            qdmi::detail::DiagnosticLevel::Info,
-            "Session parameter {} not supported (skipped)",
-            qdmi::toString(param));
+        qdmi::diagnostics::info("Session parameter {} not supported (skipped)",
+                                qdmi::toString(param));
         return;
       }
       if (status == QDMI_SUCCESS) {

--- a/src/qdmi/Diagnostics.hpp
+++ b/src/qdmi/Diagnostics.hpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <initializer_list>
+#include <string_view>
+
+namespace qdmi::detail {
+
+enum class DiagnosticLevel : uint8_t { Info, Warning, Error };
+
+[[nodiscard]] constexpr std::string_view
+diagnosticLevelName(const DiagnosticLevel level) noexcept {
+  switch (level) {
+  case DiagnosticLevel::Info:
+    return "info";
+  case DiagnosticLevel::Warning:
+    return "warning";
+  case DiagnosticLevel::Error:
+    return "error";
+  }
+  return "error";
+}
+
+/// Writes one best-effort diagnostic to the process standard error stream.
+///
+/// The writer does not allocate memory. This property lets exception handlers
+/// report allocation failures without throwing another exception.
+inline void
+emitDiagnostic(const DiagnosticLevel level,
+               const std::initializer_list<std::string_view> parts) noexcept {
+#ifdef _WIN32
+  _lock_file(stderr);
+#else
+  // POSIX exposes these declarations through <cstdio>, but include-cleaner
+  // does not associate them with the C++ header.
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  flockfile(stderr);
+#endif
+  const auto write = [](const std::string_view part) noexcept {
+    if (!part.empty()) {
+#ifdef _WIN32
+      _fwrite_nolock(part.data(), sizeof(char), part.size(), stderr);
+#else
+      std::fwrite(part.data(), sizeof(char), part.size(), stderr);
+#endif
+    }
+  };
+  write("[mqt-core] [");
+  write(diagnosticLevelName(level));
+  write("] ");
+  for (const auto part : parts) {
+    write(part);
+  }
+#ifdef _WIN32
+  _fputc_nolock('\n', stderr);
+  _fflush_nolock(stderr);
+#else
+  std::fputc('\n', stderr);
+  std::fflush(stderr);
+#endif
+#ifdef _WIN32
+  _unlock_file(stderr);
+#else
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  funlockfile(stderr);
+#endif
+}
+
+} // namespace qdmi::detail

--- a/src/qdmi/Diagnostics.hpp
+++ b/src/qdmi/Diagnostics.hpp
@@ -12,8 +12,9 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <initializer_list>
+#include <format>
 #include <string_view>
+#include <utility>
 
 namespace qdmi::detail {
 
@@ -32,18 +33,12 @@ diagnosticLevelName(const DiagnosticLevel level) noexcept {
   return "error";
 }
 
-/// Writes one best-effort diagnostic to the process standard error stream.
-///
-/// The writer does not allocate memory. This property lets exception handlers
-/// report allocation failures without throwing another exception.
-inline void
-emitDiagnostic(const DiagnosticLevel level,
-               const std::initializer_list<std::string_view> parts) noexcept {
+/// Writes one diagnostic to standard error without allocating memory.
+inline void writeDiagnostic(const DiagnosticLevel level,
+                            const std::string_view message) noexcept {
 #ifdef _WIN32
   _lock_file(stderr);
 #else
-  // POSIX exposes these declarations through <cstdio>, but include-cleaner
-  // does not associate them with the C++ header.
   // NOLINTNEXTLINE(misc-include-cleaner)
   flockfile(stderr);
 #endif
@@ -59,22 +54,31 @@ emitDiagnostic(const DiagnosticLevel level,
   write("[mqt-core] [");
   write(diagnosticLevelName(level));
   write("] ");
-  for (const auto part : parts) {
-    write(part);
-  }
+  write(message);
 #ifdef _WIN32
   _fputc_nolock('\n', stderr);
   _fflush_nolock(stderr);
+  _unlock_file(stderr);
 #else
   std::fputc('\n', stderr);
   std::fflush(stderr);
-#endif
-#ifdef _WIN32
-  _unlock_file(stderr);
-#else
   // NOLINTNEXTLINE(misc-include-cleaner)
   funlockfile(stderr);
 #endif
+}
+
+/// Formats and writes one best-effort diagnostic to standard error.
+///
+/// Writes the unformatted format string if formatting fails.
+template <class... Args>
+void emitDiagnostic(const DiagnosticLevel level,
+                    const std::format_string<Args...> format,
+                    Args&&... args) noexcept {
+  try {
+    writeDiagnostic(level, std::format(format, std::forward<Args>(args)...));
+  } catch (...) {
+    writeDiagnostic(level, format.get());
+  }
 }
 
 } // namespace qdmi::detail

--- a/src/qdmi/common/CMakeLists.txt
+++ b/src/qdmi/common/CMakeLists.txt
@@ -26,11 +26,13 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/Common.hpp
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/DeviceConfiguration.hpp)
 
+  target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/qdmi)
+
   # Add link libraries
   target_link_libraries(
     ${TARGET_NAME}
     PUBLIC qdmi::qdmi
-    PRIVATE qdmi::qdmi_project_warnings spdlog::spdlog ${CMAKE_DL_LIBS})
+    PRIVATE qdmi::qdmi_project_warnings ${CMAKE_DL_LIBS})
 
   # add to list of MQT core targets
   list(APPEND MQT_CORE_TARGETS ${TARGET_NAME})

--- a/src/qdmi/common/CMakeLists.txt
+++ b/src/qdmi/common/CMakeLists.txt
@@ -24,9 +24,8 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}
            FILES
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/Common.hpp
-           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/DeviceConfiguration.hpp)
-
-  target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/qdmi)
+           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/DeviceConfiguration.hpp
+           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/Diagnostics.hpp)
 
   # Add link libraries
   target_link_libraries(

--- a/src/qdmi/common/DeviceConfiguration.cpp
+++ b/src/qdmi/common/DeviceConfiguration.cpp
@@ -10,7 +10,7 @@
 
 #include "qdmi/common/DeviceConfiguration.hpp"
 
-#include "Diagnostics.hpp"
+#include "qdmi/common/Diagnostics.hpp"
 
 #include <qdmi/device.h>
 
@@ -105,7 +105,7 @@ void reportPath(const std::filesystem::path& path,
     std::forward<Reporter>(reporter)(std::string_view(path.native()));
 #endif
   } catch (...) {
-    emitDiagnostic(DiagnosticLevel::Error, fallback);
+    qdmi::diagnostics::error(fallback);
   }
 }
 
@@ -115,23 +115,22 @@ readFile(const std::filesystem::path& path, const bool bundled, int& status) {
   const auto exists = std::filesystem::exists(path, error);
   if (error) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_PERMISSIONDENIED;
-    reportPath(
-        path, "Cannot inspect QDMI device configuration (details unavailable)",
-        [&error](const std::string_view pathText) {
-          const auto message = error.message();
-          emitDiagnostic(DiagnosticLevel::Error,
-                         "Cannot inspect QDMI device configuration '{}': {}",
-                         pathText, message);
-        });
+    reportPath(path,
+               "Cannot inspect QDMI device configuration (details unavailable)",
+               [&error](const std::string_view pathText) {
+                 const auto message = error.message();
+                 qdmi::diagnostics::error(
+                     "Cannot inspect QDMI device configuration '{}': {}",
+                     pathText, message);
+               });
     return std::nullopt;
   }
   if (!exists) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_NOTFOUND;
     reportPath(path, "QDMI device configuration does not exist",
                [](const std::string_view pathText) {
-                 emitDiagnostic(DiagnosticLevel::Error,
-                                "QDMI device configuration '{}' does not exist",
-                                pathText);
+                 qdmi::diagnostics::error(
+                     "QDMI device configuration '{}' does not exist", pathText);
                });
     return std::nullopt;
   }
@@ -143,8 +142,7 @@ readFile(const std::filesystem::path& path, const bool bundled, int& status) {
     reportPath(path, "Cannot read QDMI device configuration",
                [errorNumber](const std::string_view pathText) {
                  const auto* const message = std::strerror(errorNumber);
-                 emitDiagnostic(
-                     DiagnosticLevel::Error,
+                 qdmi::diagnostics::error(
                      "Cannot read QDMI device configuration '{}': {}", pathText,
                      message == nullptr ? "unknown error" : message);
                });
@@ -156,8 +154,7 @@ readFile(const std::filesystem::path& path, const bool bundled, int& status) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_PERMISSIONDENIED;
     reportPath(path, "Failed while reading QDMI device configuration",
                [](const std::string_view pathText) {
-                 emitDiagnostic(
-                     DiagnosticLevel::Error,
+                 qdmi::diagnostics::error(
                      "Failed while reading QDMI device configuration '{}'",
                      pathText);
                });
@@ -218,8 +215,8 @@ loadDeviceConfiguration(const std::optional<std::string>& inlineJson,
   const auto environmentJson = environment(inlineEnvironment);
   const auto environmentFile = environment(fileEnvironment);
   if (environmentJson && environmentFile) {
-    emitDiagnostic(DiagnosticLevel::Error, "Both {} and {} are set",
-                   inlineEnvironment, fileEnvironment);
+    qdmi::diagnostics::error("Both {} and {} are set", inlineEnvironment,
+                             fileEnvironment);
     status = QDMI_ERROR_INVALIDARGUMENT;
     return std::nullopt;
   }
@@ -233,8 +230,7 @@ loadDeviceConfiguration(const std::optional<std::string>& inlineJson,
   }
   const auto directory = moduleDirectory(anchor);
   if (directory.empty()) {
-    emitDiagnostic(DiagnosticLevel::Error,
-                   "Cannot locate the QDMI provider module");
+    qdmi::diagnostics::error("Cannot locate the QDMI provider module");
     status = QDMI_ERROR_FATAL;
     return std::nullopt;
   }

--- a/src/qdmi/common/DeviceConfiguration.cpp
+++ b/src/qdmi/common/DeviceConfiguration.cpp
@@ -10,8 +10,9 @@
 
 #include "qdmi/common/DeviceConfiguration.hpp"
 
+#include "Diagnostics.hpp"
+
 #include <qdmi/device.h>
-#include <spdlog/spdlog.h>
 
 #include <cerrno>
 #include <cstdlib>
@@ -91,36 +92,73 @@ environment(const std::string_view name) {
 #endif
 }
 
+template <class Reporter>
+void reportPath(const std::filesystem::path& path,
+                const std::string_view fallback, Reporter&& reporter) noexcept {
+  try {
+#ifdef _WIN32
+    const auto pathText = path.string();
+    std::forward<Reporter>(reporter)(std::string_view(pathText));
+#else
+    std::forward<Reporter>(reporter)(std::string_view(path.native()));
+#endif
+  } catch (...) {
+    emitDiagnostic(DiagnosticLevel::Error, {fallback});
+  }
+}
+
 [[nodiscard]] std::optional<LoadedDeviceConfiguration>
 readFile(const std::filesystem::path& path, const bool bundled, int& status) {
   std::error_code error;
   const auto exists = std::filesystem::exists(path, error);
   if (error) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_PERMISSIONDENIED;
-    SPDLOG_ERROR("Cannot inspect QDMI device configuration '{}': {}",
-                 path.string(), error.message());
+    reportPath(path,
+               "Cannot inspect QDMI device configuration (details unavailable)",
+               [&error](const std::string_view pathText) {
+                 const auto message = error.message();
+                 emitDiagnostic(DiagnosticLevel::Error,
+                                {"Cannot inspect QDMI device configuration '",
+                                 pathText, "': ", message});
+               });
     return std::nullopt;
   }
   if (!exists) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_NOTFOUND;
-    SPDLOG_ERROR("QDMI device configuration '{}' does not exist",
-                 path.string());
+    reportPath(path, "QDMI device configuration does not exist",
+               [](const std::string_view pathText) {
+                 emitDiagnostic(DiagnosticLevel::Error,
+                                {"QDMI device configuration '", pathText,
+                                 "' does not exist"});
+               });
     return std::nullopt;
   }
   errno = 0;
   std::ifstream input(path, std::ios::binary);
   if (!input) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_PERMISSIONDENIED;
-    SPDLOG_ERROR("Cannot read QDMI device configuration '{}': {}",
-                 path.string(), std::strerror(errno));
+    const auto errorNumber = errno;
+    reportPath(path, "Cannot read QDMI device configuration",
+               [errorNumber](const std::string_view pathText) {
+                 const auto* const message = std::strerror(errorNumber);
+                 emitDiagnostic(
+                     DiagnosticLevel::Error,
+                     {"Cannot read QDMI device configuration '", pathText,
+                      "': ", message == nullptr ? "unknown error" : message});
+               });
     return std::nullopt;
   }
   std::string json{std::istreambuf_iterator<char>(input),
                    std::istreambuf_iterator<char>()};
   if (!input.eof() && input.fail()) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_PERMISSIONDENIED;
-    SPDLOG_ERROR("Failed while reading QDMI device configuration '{}'",
-                 path.string());
+    reportPath(path, "Failed while reading QDMI device configuration",
+               [](const std::string_view pathText) {
+                 emitDiagnostic(
+                     DiagnosticLevel::Error,
+                     {"Failed while reading QDMI device configuration '",
+                      pathText, "'"});
+               });
     return std::nullopt;
   }
   status = QDMI_SUCCESS;
@@ -178,7 +216,8 @@ loadDeviceConfiguration(const std::optional<std::string>& inlineJson,
   const auto environmentJson = environment(inlineEnvironment);
   const auto environmentFile = environment(fileEnvironment);
   if (environmentJson && environmentFile) {
-    SPDLOG_ERROR("Both {} and {} are set", inlineEnvironment, fileEnvironment);
+    emitDiagnostic(DiagnosticLevel::Error, {"Both ", inlineEnvironment, " and ",
+                                            fileEnvironment, " are set"});
     status = QDMI_ERROR_INVALIDARGUMENT;
     return std::nullopt;
   }
@@ -192,7 +231,8 @@ loadDeviceConfiguration(const std::optional<std::string>& inlineJson,
   }
   const auto directory = moduleDirectory(anchor);
   if (directory.empty()) {
-    SPDLOG_ERROR("Cannot locate the QDMI provider module");
+    emitDiagnostic(DiagnosticLevel::Error,
+                   {"Cannot locate the QDMI provider module"});
     status = QDMI_ERROR_FATAL;
     return std::nullopt;
   }

--- a/src/qdmi/common/DeviceConfiguration.cpp
+++ b/src/qdmi/common/DeviceConfiguration.cpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <ios>
 #include <iterator>
@@ -94,7 +95,8 @@ environment(const std::string_view name) {
 
 template <class Reporter>
 void reportPath(const std::filesystem::path& path,
-                const std::string_view fallback, Reporter&& reporter) noexcept {
+                const std::format_string<> fallback,
+                Reporter&& reporter) noexcept {
   try {
 #ifdef _WIN32
     const auto pathText = path.string();
@@ -103,7 +105,7 @@ void reportPath(const std::filesystem::path& path,
     std::forward<Reporter>(reporter)(std::string_view(path.native()));
 #endif
   } catch (...) {
-    emitDiagnostic(DiagnosticLevel::Error, {fallback});
+    emitDiagnostic(DiagnosticLevel::Error, fallback);
   }
 }
 
@@ -113,14 +115,14 @@ readFile(const std::filesystem::path& path, const bool bundled, int& status) {
   const auto exists = std::filesystem::exists(path, error);
   if (error) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_PERMISSIONDENIED;
-    reportPath(path,
-               "Cannot inspect QDMI device configuration (details unavailable)",
-               [&error](const std::string_view pathText) {
-                 const auto message = error.message();
-                 emitDiagnostic(DiagnosticLevel::Error,
-                                {"Cannot inspect QDMI device configuration '",
-                                 pathText, "': ", message});
-               });
+    reportPath(
+        path, "Cannot inspect QDMI device configuration (details unavailable)",
+        [&error](const std::string_view pathText) {
+          const auto message = error.message();
+          emitDiagnostic(DiagnosticLevel::Error,
+                         "Cannot inspect QDMI device configuration '{}': {}",
+                         pathText, message);
+        });
     return std::nullopt;
   }
   if (!exists) {
@@ -128,8 +130,8 @@ readFile(const std::filesystem::path& path, const bool bundled, int& status) {
     reportPath(path, "QDMI device configuration does not exist",
                [](const std::string_view pathText) {
                  emitDiagnostic(DiagnosticLevel::Error,
-                                {"QDMI device configuration '", pathText,
-                                 "' does not exist"});
+                                "QDMI device configuration '{}' does not exist",
+                                pathText);
                });
     return std::nullopt;
   }
@@ -143,8 +145,8 @@ readFile(const std::filesystem::path& path, const bool bundled, int& status) {
                  const auto* const message = std::strerror(errorNumber);
                  emitDiagnostic(
                      DiagnosticLevel::Error,
-                     {"Cannot read QDMI device configuration '", pathText,
-                      "': ", message == nullptr ? "unknown error" : message});
+                     "Cannot read QDMI device configuration '{}': {}", pathText,
+                     message == nullptr ? "unknown error" : message);
                });
     return std::nullopt;
   }
@@ -156,8 +158,8 @@ readFile(const std::filesystem::path& path, const bool bundled, int& status) {
                [](const std::string_view pathText) {
                  emitDiagnostic(
                      DiagnosticLevel::Error,
-                     {"Failed while reading QDMI device configuration '",
-                      pathText, "'"});
+                     "Failed while reading QDMI device configuration '{}'",
+                     pathText);
                });
     return std::nullopt;
   }
@@ -216,8 +218,8 @@ loadDeviceConfiguration(const std::optional<std::string>& inlineJson,
   const auto environmentJson = environment(inlineEnvironment);
   const auto environmentFile = environment(fileEnvironment);
   if (environmentJson && environmentFile) {
-    emitDiagnostic(DiagnosticLevel::Error, {"Both ", inlineEnvironment, " and ",
-                                            fileEnvironment, " are set"});
+    emitDiagnostic(DiagnosticLevel::Error, "Both {} and {} are set",
+                   inlineEnvironment, fileEnvironment);
     status = QDMI_ERROR_INVALIDARGUMENT;
     return std::nullopt;
   }
@@ -232,7 +234,7 @@ loadDeviceConfiguration(const std::optional<std::string>& inlineJson,
   const auto directory = moduleDirectory(anchor);
   if (directory.empty()) {
     emitDiagnostic(DiagnosticLevel::Error,
-                   {"Cannot locate the QDMI provider module"});
+                   "Cannot locate the QDMI provider module");
     status = QDMI_ERROR_FATAL;
     return std::nullopt;
   }

--- a/src/qdmi/devices/dd/CMakeLists.txt
+++ b/src/qdmi/devices/dd/CMakeLists.txt
@@ -45,7 +45,7 @@ if(NOT TARGET ${TARGET_NAME})
 
   # Add link libraries
   target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreDD MQT::CoreQASM MQT::CoreQDMICommon
-                                               MQT::CoreQIRJIT MQT::CoreQIRRuntime spdlog::spdlog)
+                                               MQT::CoreQIRJIT MQT::CoreQIRRuntime)
 
   mqt_configure_qdmi_device(${TARGET_NAME} ID mqt.ddsim.default PREFIX ${QDMI_PREFIX})
   list(APPEND MQT_CORE_TARGETS ${TARGET_NAME})

--- a/src/qdmi/devices/sc/CMakeLists.txt
+++ b/src/qdmi/devices/sc/CMakeLists.txt
@@ -66,8 +66,6 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/devices/sc/Device.hpp
            ${QDMI_HDRS})
 
-  target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/qdmi)
-
   # add link libraries
   target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreQDMICommon MQT::CoreQDMIScDeviceConfig)
 

--- a/src/qdmi/devices/sc/CMakeLists.txt
+++ b/src/qdmi/devices/sc/CMakeLists.txt
@@ -66,9 +66,10 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/devices/sc/Device.hpp
            ${QDMI_HDRS})
 
+  target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/qdmi)
+
   # add link libraries
-  target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreQDMICommon MQT::CoreQDMIScDeviceConfig
-                                               spdlog::spdlog)
+  target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreQDMICommon MQT::CoreQDMIScDeviceConfig)
 
   mqt_configure_qdmi_device(
     ${TARGET_NAME}

--- a/src/qdmi/devices/sc/Device.cpp
+++ b/src/qdmi/devices/sc/Device.cpp
@@ -14,12 +14,12 @@
 
 #include "qdmi/devices/sc/Device.hpp"
 
-#include "Diagnostics.hpp"
 #include "mqt_sc_qdmi/constants.h"
 #include "mqt_sc_qdmi/device.h"
 #include "mqt_sc_qdmi/types.h"
 #include "qdmi/common/Common.hpp"
 #include "qdmi/common/DeviceConfiguration.hpp"
+#include "qdmi/common/Diagnostics.hpp"
 #include "qdmi/devices/sc/Configuration.hpp"
 
 #include <algorithm>
@@ -169,25 +169,22 @@ int MQT_SC_QDMI_Device_Session_impl_d::init() {
     const std::string_view source =
         loaded ? std::string_view(loaded->source)
                : std::string_view("selected configuration");
-    qdmi::detail::emitDiagnostic(
-        qdmi::detail::DiagnosticLevel::Error,
+    qdmi::diagnostics::error(
         "Out of memory while initializing SC device from {}", source);
     return QDMI_ERROR_OUTOFMEM;
   } catch (const std::invalid_argument& error) {
     const std::string_view source =
         loaded ? std::string_view(loaded->source)
                : std::string_view("selected configuration");
-    qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Error,
-                                 "Invalid SC device configuration from {}: {}",
-                                 source, error.what());
+    qdmi::diagnostics::error("Invalid SC device configuration from {}: {}",
+                             source, error.what());
     return QDMI_ERROR_INVALIDARGUMENT;
   } catch (const std::exception& error) {
     const std::string_view source =
         loaded ? std::string_view(loaded->source)
                : std::string_view("selected configuration");
-    qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Error,
-                                 "Failed to initialize SC device from {}: {}",
-                                 source, error.what());
+    qdmi::diagnostics::error("Failed to initialize SC device from {}: {}",
+                             source, error.what());
     return QDMI_ERROR_FATAL;
   }
 }

--- a/src/qdmi/devices/sc/Device.cpp
+++ b/src/qdmi/devices/sc/Device.cpp
@@ -14,14 +14,13 @@
 
 #include "qdmi/devices/sc/Device.hpp"
 
+#include "Diagnostics.hpp"
 #include "mqt_sc_qdmi/constants.h"
 #include "mqt_sc_qdmi/device.h"
 #include "mqt_sc_qdmi/types.h"
 #include "qdmi/common/Common.hpp"
 #include "qdmi/common/DeviceConfiguration.hpp"
 #include "qdmi/devices/sc/Configuration.hpp"
-
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -34,6 +33,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -63,16 +63,17 @@ int MQT_SC_QDMI_Device_Session_impl_d::init() {
   if (status != Status::ALLOCATED) {
     return QDMI_ERROR_BADSTATE;
   }
-  int loadStatus = QDMI_SUCCESS;
-  const auto loaded = qdmi::detail::loadDeviceConfiguration(
-      inlineConfiguration, fileConfiguration, "MQT_CORE_QDMI_SC_CONFIG_JSON",
-      "MQT_CORE_QDMI_SC_CONFIG_FILE", "mqt-core-qdmi-sc-device.json",
-      reinterpret_cast<const void*>(&MQT_SC_QDMI_device_initialize),
-      loadStatus);
-  if (!loaded) {
-    return loadStatus;
-  }
+  std::optional<qdmi::detail::LoadedDeviceConfiguration> loaded;
   try {
+    int loadStatus = QDMI_SUCCESS;
+    loaded = qdmi::detail::loadDeviceConfiguration(
+        inlineConfiguration, fileConfiguration, "MQT_CORE_QDMI_SC_CONFIG_JSON",
+        "MQT_CORE_QDMI_SC_CONFIG_FILE", "mqt-core-qdmi-sc-device.json",
+        reinterpret_cast<const void*>(&MQT_SC_QDMI_device_initialize),
+        loadStatus);
+    if (!loaded) {
+      return loadStatus;
+    }
     const auto configuration = sc::readJSON(loaded->json, loaded->source);
 
     std::vector<std::unique_ptr<MQT_SC_QDMI_Site_impl_d>> newSiteStorage;
@@ -165,16 +166,28 @@ int MQT_SC_QDMI_Device_Session_impl_d::init() {
     status = Status::INITIALIZED;
     return QDMI_SUCCESS;
   } catch (const std::bad_alloc&) {
-    SPDLOG_ERROR("Out of memory while initializing SC device from {}",
-                 loaded->source);
+    const std::string_view source =
+        loaded ? std::string_view(loaded->source)
+               : std::string_view("selected configuration");
+    qdmi::detail::emitDiagnostic(
+        qdmi::detail::DiagnosticLevel::Error,
+        {"Out of memory while initializing SC device from ", source});
     return QDMI_ERROR_OUTOFMEM;
   } catch (const std::invalid_argument& error) {
-    SPDLOG_ERROR("Invalid SC device configuration from {}: {}", loaded->source,
-                 error.what());
+    const std::string_view source =
+        loaded ? std::string_view(loaded->source)
+               : std::string_view("selected configuration");
+    qdmi::detail::emitDiagnostic(
+        qdmi::detail::DiagnosticLevel::Error,
+        {"Invalid SC device configuration from ", source, ": ", error.what()});
     return QDMI_ERROR_INVALIDARGUMENT;
   } catch (const std::exception& error) {
-    SPDLOG_ERROR("Failed to initialize SC device from {}: {}", loaded->source,
-                 error.what());
+    const std::string_view source =
+        loaded ? std::string_view(loaded->source)
+               : std::string_view("selected configuration");
+    qdmi::detail::emitDiagnostic(
+        qdmi::detail::DiagnosticLevel::Error,
+        {"Failed to initialize SC device from ", source, ": ", error.what()});
     return QDMI_ERROR_FATAL;
   }
 }

--- a/src/qdmi/devices/sc/Device.cpp
+++ b/src/qdmi/devices/sc/Device.cpp
@@ -171,23 +171,23 @@ int MQT_SC_QDMI_Device_Session_impl_d::init() {
                : std::string_view("selected configuration");
     qdmi::detail::emitDiagnostic(
         qdmi::detail::DiagnosticLevel::Error,
-        {"Out of memory while initializing SC device from ", source});
+        "Out of memory while initializing SC device from {}", source);
     return QDMI_ERROR_OUTOFMEM;
   } catch (const std::invalid_argument& error) {
     const std::string_view source =
         loaded ? std::string_view(loaded->source)
                : std::string_view("selected configuration");
-    qdmi::detail::emitDiagnostic(
-        qdmi::detail::DiagnosticLevel::Error,
-        {"Invalid SC device configuration from ", source, ": ", error.what()});
+    qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Error,
+                                 "Invalid SC device configuration from {}: {}",
+                                 source, error.what());
     return QDMI_ERROR_INVALIDARGUMENT;
   } catch (const std::exception& error) {
     const std::string_view source =
         loaded ? std::string_view(loaded->source)
                : std::string_view("selected configuration");
-    qdmi::detail::emitDiagnostic(
-        qdmi::detail::DiagnosticLevel::Error,
-        {"Failed to initialize SC device from ", source, ": ", error.what()});
+    qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Error,
+                                 "Failed to initialize SC device from {}: {}",
+                                 source, error.what());
     return QDMI_ERROR_FATAL;
   }
 }

--- a/src/qdmi/driver/CMakeLists.txt
+++ b/src/qdmi/driver/CMakeLists.txt
@@ -26,12 +26,14 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/driver/Driver.hpp
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/driver/SessionConfig.hpp)
 
+  target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/qdmi)
+
   # Add link libraries
   target_link_libraries(
     ${TARGET_NAME}
     PUBLIC qdmi::qdmi MQT::CoreQDMICommon
     PRIVATE qdmi::qdmi_project_warnings $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>
-            spdlog::spdlog ${CMAKE_DL_LIBS})
+            ${CMAKE_DL_LIBS})
 
   mqt_get_qdmi_device_targets(QDMI_DEVICE_TARGETS)
 

--- a/src/qdmi/driver/CMakeLists.txt
+++ b/src/qdmi/driver/CMakeLists.txt
@@ -26,8 +26,6 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/driver/Driver.hpp
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/driver/SessionConfig.hpp)
 
-  target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/qdmi)
-
   # Add link libraries
   target_link_libraries(
     ${TARGET_NAME}

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -11,11 +11,11 @@
 #include "qdmi/driver/Driver.hpp"
 
 #include "DeviceRegistry.hpp"
+#include "Diagnostics.hpp"
 #include "qdmi/common/Common.hpp"
 
 #include <qdmi/client.h>
 #include <qdmi/device.h>
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <cassert>
@@ -268,9 +268,10 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(
       }
 
       if (status == QDMI_ERROR_NOTSUPPORTED) {
-        SPDLOG_INFO(
-            "Device session parameter {} not supported by device (skipped)",
-            qdmi::toString(param));
+        qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Info,
+                                     {"Device session parameter ",
+                                      qdmi::toString(param),
+                                      " not supported by device (skipped)"});
         return;
       }
       library_->device_session_free(deviceSession_);
@@ -838,17 +839,23 @@ void Driver::materializeClientCatalog() {
       try {
         clientDevices.emplace_back(open(id));
       } catch (const std::exception& ex) {
-        std::string library = "<unknown>";
-        {
+        std::string library;
+        try {
           const std::scoped_lock lock(stateMutex_);
           if (const auto definition =
                   std::ranges::find(definitions_, id, &DeviceDefinition::id);
               definition != definitions_.end()) {
             library = definition->library.string();
           }
+        } catch (...) {
+          library.clear();
         }
-        SPDLOG_WARN("Skipping configured QDMI device '{}' from '{}': {}", id,
-                    library, ex.what());
+        const std::string_view libraryText =
+            library.empty() ? "<unknown>" : std::string_view(library);
+        qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Warning,
+                                     {"Skipping configured QDMI device '", id,
+                                      "' from '", libraryText,
+                                      "': ", ex.what()});
       }
     }
     const std::scoped_lock lock(stateMutex_);

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -11,8 +11,8 @@
 #include "qdmi/driver/Driver.hpp"
 
 #include "DeviceRegistry.hpp"
-#include "Diagnostics.hpp"
 #include "qdmi/common/Common.hpp"
+#include "qdmi/common/Diagnostics.hpp"
 
 #include <qdmi/client.h>
 #include <qdmi/device.h>
@@ -268,8 +268,7 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(
       }
 
       if (status == QDMI_ERROR_NOTSUPPORTED) {
-        qdmi::detail::emitDiagnostic(
-            qdmi::detail::DiagnosticLevel::Info,
+        qdmi::diagnostics::info(
             "Device session parameter {} not supported by device (skipped)",
             qdmi::toString(param));
         return;
@@ -852,8 +851,7 @@ void Driver::materializeClientCatalog() {
         }
         const std::string_view libraryText =
             library.empty() ? "<unknown>" : std::string_view(library);
-        qdmi::detail::emitDiagnostic(
-            qdmi::detail::DiagnosticLevel::Warning,
+        qdmi::diagnostics::warn(
             "Skipping configured QDMI device '{}' from '{}': {}", id,
             libraryText, ex.what());
       }

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -268,10 +268,10 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(
       }
 
       if (status == QDMI_ERROR_NOTSUPPORTED) {
-        qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Info,
-                                     {"Device session parameter ",
-                                      qdmi::toString(param),
-                                      " not supported by device (skipped)"});
+        qdmi::detail::emitDiagnostic(
+            qdmi::detail::DiagnosticLevel::Info,
+            "Device session parameter {} not supported by device (skipped)",
+            qdmi::toString(param));
         return;
       }
       library_->device_session_free(deviceSession_);
@@ -852,10 +852,10 @@ void Driver::materializeClientCatalog() {
         }
         const std::string_view libraryText =
             library.empty() ? "<unknown>" : std::string_view(library);
-        qdmi::detail::emitDiagnostic(qdmi::detail::DiagnosticLevel::Warning,
-                                     {"Skipping configured QDMI device '", id,
-                                      "' from '", libraryText,
-                                      "': ", ex.what()});
+        qdmi::detail::emitDiagnostic(
+            qdmi::detail::DiagnosticLevel::Warning,
+            "Skipping configured QDMI device '{}' from '{}': {}", id,
+            libraryText, ex.what());
       }
     }
     const std::scoped_lock lock(stateMutex_);

--- a/test/qdmi/devices/sc/test_device.cpp
+++ b/test/qdmi/devices/sc/test_device.cpp
@@ -228,8 +228,16 @@ TEST(ScRuntimeConfiguration, ValidatesRawParameterStringsAndRetry) {
                 session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1,
                 malformed.size(), malformed.data()),
             QDMI_SUCCESS);
-  EXPECT_EQ(MQT_SC_QDMI_device_session_init(session),
-            QDMI_ERROR_INVALIDARGUMENT);
+  testing::internal::CaptureStderr();
+  const auto malformedStatus = MQT_SC_QDMI_device_session_init(session);
+  const auto malformedDiagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(malformedStatus, QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_THAT(
+      malformedDiagnostic,
+      testing::AllOf(testing::HasSubstr("[mqt-core] [error]"),
+                     testing::HasSubstr("Invalid SC device configuration from "
+                                        "inline session configuration"),
+                     testing::HasSubstr("invalid JSON")));
   ASSERT_EQ(MQT_SC_QDMI_device_session_set_parameter(
                 session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1,
                 std::strlen(CUSTOM_SC) + 1, CUSTOM_SC),
@@ -370,8 +378,16 @@ TEST(ScRuntimeConfiguration, SelectsEnvironmentAndExplicitFileSources) {
   MQT_SC_QDMI_Device_Session conflictingEnvironmentSession = nullptr;
   ASSERT_EQ(MQT_SC_QDMI_device_session_alloc(&conflictingEnvironmentSession),
             QDMI_SUCCESS);
-  EXPECT_EQ(MQT_SC_QDMI_device_session_init(conflictingEnvironmentSession),
-            QDMI_ERROR_INVALIDARGUMENT);
+  testing::internal::CaptureStderr();
+  const auto conflictingStatus =
+      MQT_SC_QDMI_device_session_init(conflictingEnvironmentSession);
+  const auto conflictingDiagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(conflictingStatus, QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_THAT(conflictingDiagnostic,
+              testing::AllOf(
+                  testing::HasSubstr("[mqt-core] [error]"),
+                  testing::HasSubstr("Both MQT_CORE_QDMI_SC_CONFIG_JSON and "
+                                     "MQT_CORE_QDMI_SC_CONFIG_FILE are set")));
   MQT_SC_QDMI_device_session_free(conflictingEnvironmentSession);
 }
 
@@ -384,7 +400,17 @@ TEST(ScRuntimeConfiguration, MapsMissingExplicitFileToNotFound) {
                 session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2, missing.size(),
                 missing.data()),
             QDMI_SUCCESS);
-  EXPECT_EQ(MQT_SC_QDMI_device_session_init(session), QDMI_ERROR_NOTFOUND);
+  testing::internal::CaptureStderr();
+  const auto status = MQT_SC_QDMI_device_session_init(session);
+  const auto diagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(status, QDMI_ERROR_NOTFOUND);
+  EXPECT_THAT(
+      diagnostic,
+      testing::AllOf(
+          testing::HasSubstr("[mqt-core] [error]"),
+          testing::HasSubstr("QDMI device configuration "
+                             "'missing-sc-device-configuration.json' does not "
+                             "exist")));
   MQT_SC_QDMI_device_session_free(session);
 }
 

--- a/test/qdmi/driver/CMakeLists.txt
+++ b/test/qdmi/driver/CMakeLists.txt
@@ -40,6 +40,21 @@ if(TARGET MQT::CoreQDMIDriver)
 
   package_add_test(${TARGET_NAME} MQT::CoreQDMIDriver test_driver.cpp)
   target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreQDMI)
+
+  set(DIAGNOSTIC_TARGET_NAME mqt-core-qdmi-driver-diagnostic-test)
+  set(diagnostic_config_file
+      "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/diagnostic-configured-device.json")
+  file(
+    GENERATE
+    OUTPUT "${diagnostic_config_file}"
+    CONTENT
+      "{\n  \"schema-version\": 1,\n  \"qdmi\": {\n    \"devices\": [\n      {\"id\": \"broken.diagnostic\", \"library\": \"${CMAKE_CURRENT_BINARY_DIR}/missing-diagnostic-device-library\", \"prefix\": \"BROKEN\"}\n    ]\n  }\n}\n"
+  )
+  package_add_test(${DIAGNOSTIC_TARGET_NAME} MQT::CoreQDMIDriver test_driver_diagnostics.cpp)
+  target_compile_definitions(
+    ${DIAGNOSTIC_TARGET_NAME}
+    PRIVATE "MQT_CORE_QDMI_DIAGNOSTIC_CONFIG_FILE=\"${diagnostic_config_file}\"")
+
   set(config_file "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/configured-devices.json")
   file(
     GENERATE

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -1494,6 +1494,23 @@ TEST(DeviceSessionConfigTest, OpenWithBaseUrl) {
   }
 }
 
+TEST(DeviceSessionConfigTest, ReportsSkippedUnsupportedParameter) {
+  const auto [library, prefix] = TEST_DEVICE_LIBRARIES.front();
+  qdmi::DeviceSessionConfig config;
+  config.baseUrl = "http://localhost:8080";
+
+  testing::internal::CaptureStderr();
+  EXPECT_NO_THROW(
+      { static_cast<void>(openTestDevice(library, prefix, config)); });
+  const auto diagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_THAT(
+      diagnostic,
+      testing::AllOf(
+          testing::HasSubstr("[mqt-core] [info]"),
+          testing::HasSubstr("Device session parameter BASE URL not supported "
+                             "by device (skipped)")));
+}
+
 TEST(DeviceSessionConfigTest, OpenWithCustomParameters) {
   qdmi::DeviceSessionConfig config;
   config.custom3 = "RESONANCE_COCOS_V1";

--- a/test/qdmi/driver/test_driver_diagnostics.cpp
+++ b/test/qdmi/driver/test_driver_diagnostics.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <qdmi/client.h>
+
+#include <cstdlib>
+
+namespace {
+
+TEST(DriverDiagnosticTest, ReportsSkippedConfiguredDevice) {
+#ifdef _WIN32
+  ASSERT_EQ(_putenv_s("MQT_CORE_QDMI_CONFIG_FILE",
+                      MQT_CORE_QDMI_DIAGNOSTIC_CONFIG_FILE),
+            0);
+#else
+  // POSIX exposes setenv through <cstdlib>, but include-cleaner does not
+  // associate the global declaration with that C++ header.
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  ASSERT_EQ(setenv("MQT_CORE_QDMI_CONFIG_FILE",
+                   MQT_CORE_QDMI_DIAGNOSTIC_CONFIG_FILE, 1),
+            0);
+#endif
+
+  testing::internal::CaptureStderr();
+  QDMI_Session session = nullptr;
+  const auto status = QDMI_session_alloc(&session);
+  const auto diagnostic = testing::internal::GetCapturedStderr();
+
+  ASSERT_EQ(status, QDMI_SUCCESS);
+  EXPECT_THAT(
+      diagnostic,
+      testing::AllOf(testing::HasSubstr("[mqt-core] [warning]"),
+                     testing::HasSubstr("Skipping configured QDMI device "
+                                        "'broken.diagnostic'"),
+                     testing::HasSubstr("missing-diagnostic-device-library")));
+  QDMI_session_free(session);
+}
+
+} // namespace

--- a/test/qdmi/driver/test_driver_diagnostics.cpp
+++ b/test/qdmi/driver/test_driver_diagnostics.cpp
@@ -22,8 +22,6 @@ TEST(DriverDiagnosticTest, ReportsSkippedConfiguredDevice) {
                       MQT_CORE_QDMI_DIAGNOSTIC_CONFIG_FILE),
             0);
 #else
-  // POSIX exposes setenv through <cstdlib>, but include-cleaner does not
-  // associate the global declaration with that C++ header.
   // NOLINTNEXTLINE(misc-include-cleaner)
   ASSERT_EQ(setenv("MQT_CORE_QDMI_CONFIG_FILE",
                    MQT_CORE_QDMI_DIAGNOSTIC_CONFIG_FILE, 1),

--- a/test/qdmi/test_client.cpp
+++ b/test/qdmi/test_client.cpp
@@ -1153,6 +1153,20 @@ TEST(AuthenticationTest, SessionConstructionWithToken) {
   EXPECT_NO_THROW({ const Session session(config3); });
 }
 
+TEST(AuthenticationTest, ReportsSkippedUnsupportedParameter) {
+  SessionConfig config;
+  config.token = "test-token";
+
+  testing::internal::CaptureStderr();
+  EXPECT_NO_THROW({ const Session session(config); });
+  const auto diagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_THAT(
+      diagnostic,
+      testing::AllOf(testing::HasSubstr("[mqt-core] [info]"),
+                     testing::HasSubstr(
+                         "Session parameter TOKEN not supported (skipped)")));
+}
+
 TEST(AuthenticationTest, SessionConstructionWithAuthUrl) {
   // Valid HTTPS URL
   SessionConfig config1;


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Remove the `spdlog` dependency from source builds, installed CMake packages, and Python wheels. Replace the remaining QDMI log calls with a small private diagnostic writer that preserves actionable messages on standard error without adding a public logging API.

Keep configuration-path diagnostics safe in failure paths and prevent initialization exceptions from crossing the QDMI C API boundary. Add stderr-capture tests for client, driver, configuration, and SC-device diagnostics.

Fixes #2104

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
