### PR TITLE
📝 Refine MLIR development guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ MQT Core. The project-wide policy for AI-assisted contributions is
   discard or overwrite changes that are outside the task.
 - Follow the repository's documented development policies and the nearest scoped
   `AGENTS.md`. Use neighboring code as evidence of established practice, not as
-  authority when it conflicts with current policy. Prefer the smallest change
-  that fully solves the problem.
+  authority when it conflicts with current policy.
+- Prefer the smallest change that fully solves the problem.
 - Write code comments, documentation, tests, changelog entries, and public text
   for the final design. Never preserve prompts, review chronology, former names,
   or abandoned approaches unless they remain necessary user-facing context.
@@ -116,20 +116,23 @@ MQT Core. The project-wide policy for AI-assisted contributions is
 - Replace `release` with `debug` for a debug build. Consult `CMakePresets.json`
   for other supported configurations.
 
-The C++ code targets C++20 and uses GoogleTest. Write Doxygen comments with
-`///` and follow `docs/development.md`; use `#pragma once` in headers and
-existing project abstractions. Prefer C++20 standard-library facilities over
-custom equivalents. Within `mlir/`, prefer LLVM types such as
-`llvm::SmallVector` and `llvm::function_ref` where appropriate. Do not use
-C-style casts, including casts to `void`; use the appropriate C++ cast or adjust
-the code so that no cast is needed. Use C standard-library typedefs such as
-`size_t` and fixed-width integer types such as `uint64_t` without the `std::`
-namespace qualifier, while directly including the header that provides them. Do
-not use `module` as a C++ variable or parameter name because it conflicts with
-the C++20 keyword. Use `moduleOp` for `mlir::ModuleOp` values. The canonical
-general and MLIR-specific coding policies are documented in
-[`docs/development.md`](docs/development.md) and
-[`docs/mlir/development.md`](docs/mlir/development.md).
+The C++ code targets C++20 and uses GoogleTest. Follow these rules:
+
+- Write Doxygen comments with `///`.
+- Use `#pragma once` in headers and use existing project abstractions.
+- Prefer C++20 standard-library facilities over custom equivalents.
+- Within the `mlir` namespace and its nested namespaces, prefer LLVM types such
+  as `SmallVector` and `function_ref` where appropriate.
+- Do not use C-style casts, including casts to `void`. Use the appropriate C++
+  cast or adjust the code so that no cast is needed.
+- Use C standard-library typedefs such as `size_t` and fixed-width integer types
+  such as `uint64_t` without the `std::` namespace qualifier. Directly include
+  the header that provides each type.
+- Do not use `module` as a C++ variable or parameter name because it conflicts
+  with the C++20 keyword. Use `moduleOp` for `mlir::ModuleOp` values.
+- Follow the canonical general and MLIR-specific coding policies in
+  [`docs/development.md`](docs/development.md) and
+  [`docs/mlir/development.md`](docs/mlir/development.md).
 
 ### Python and Bindings
 

--- a/docs/mlir/development.md
+++ b/docs/mlir/development.md
@@ -80,6 +80,13 @@ LLVM data structure such as `SmallVector`, `DenseMap`, or `MapVector` when its
 storage, lookup, ordering, or API behavior provides a concrete benefit. Keep a
 standard-library type when it already expresses the required contract.
 
+When code in the `mlir` namespace or one of its nested namespaces uses an LLVM
+name that `mlir/Support/LLVM.h` imports, include that header and use the
+unqualified name, such as `SmallVector`, `StringRef`, or `function_ref`. Do not
+rely on `mlir/Support/LLVM.h` for type definitions. Include each LLVM header
+that the source file needs. Keep the `llvm::` qualifier for names that
+`mlir/Support/LLVM.h` does not import.
+
 Do not convert containers in bulk for style. Require a profile, benchmark, or a
 specific allocation or complexity argument for a performance rewrite. Keep
 user-visible output deterministic: never use pointer identity or unspecified


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Clarify MQT Core's agent and MLIR development guidance, including when MLIR code should use the unqualified LLVM names imported by `mlir/Support/LLVM.h`.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
