### PR TITLE
♻️ Consolidate DD circuit execution

### DIFF
--- a/.agent/plans/consolidate-dd-circuit-simulation.md
+++ b/.agent/plans/consolidate-dd-circuit-simulation.md
@@ -1,0 +1,380 @@
+# Consolidate DD circuit execution
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+MQT Core and MQT DDSIM currently contain overlapping decision-diagram (DD)
+circuit-execution loops. A DD is a graph representation of a quantum state or
+operation. The overlap has already produced different handling of repeated
+measurements, result widths, output permutations, random-number generators, and
+final-state ownership.
+
+After this change, Core owns one low-level exact execution kernel because its
+QDMI reference device must execute circuits without depending on DDSIM. DDSIM
+continues to own the public simulator class and its approximation and noise
+policies. Its ordinary exact `CircuitSimulator` delegates to Core and receives
+counts, the retained final state, and the number of circuit executions.
+High-level Python users import `sample` and `simulate_statevector` from DDSIM;
+Core retains the package-aware primitives needed by its QDMI device, QCEC, and
+SyReC.
+
+The result can be observed in tests: the same seeded circuits produce stable
+counts for terminal and dynamic measurements, repeated calls continue the same
+random stream, final DD roots remain balanced, and the moved Python helpers
+return the former result types.
+
+## Progress
+
+- [x] (2026-08-27 21:40 UTC) Read issue #2103, repository policy, the ExecPlan
+  requirements, and the relevant Core, DDSIM, QCEC, SyReC, and ProblemSolver
+  sources.
+- [x] (2026-08-27 21:40 UTC) Inventory execution behavior, public Python
+  helpers, downstream consumers, tests, and overlapping Core-v4 work.
+- [x] (2026-08-28 00:10 CEST) Implement Core's exact result-bearing kernel,
+  explicit root ownership, ordered measurement formatting, finalization, and
+  private virtual-operation helpers.
+- [x] (2026-08-28 00:15 CEST) Add Core regressions for dynamic execution,
+  repeated assignments, result widths, permutations, garbage, global phase,
+  random-number continuation, zero shots, failures, and root counts.
+- [x] (2026-08-28 00:25 CEST) Delegate DDSIM's ordinary exact simulator to Core
+      while retaining DDSIM's hook loop for approximation, derived simulators,
+      and density-matrix noise.
+- [x] (2026-08-28 00:35 CEST) Move the high-level Python helpers to DDSIM,
+      migrate ProblemSolver with a Python 3.10 fallback, regenerate Core stubs,
+      and update migration documentation.
+- [x] (2026-08-28 00:42 CEST) Build the DDSIM Python binding against this Core
+  worktree and pass all ten focused Python helper tests.
+- [x] (2026-08-28 00:55 CEST) Finish validation and final inspection. Core DD,
+      QDMI, stubs, focused Python, and full lint pass. DDSIM focused C++, built
+      Python, and full lint pass. ProblemSolver's source checks pass; its lock
+      and type session are blocked only by the unreleased DDSIM 2.6 dependency.
+- [ ] Add Core and DDSIM changelog entries after pull request numbers exist,
+      update DDSIM's Core-v4 pins, and regenerate ProblemSolver's lock file
+      after the coordinated releases are available.
+
+## Surprises & Discoveries
+
+- Observation: `DeterministicNoiseSimulator` inherits the old
+  `CircuitSimulator::simulate` loop but substitutes a density-matrix DD through
+  virtual hooks. Sending every subclass through the exact vector-state kernel
+  would silently remove noise. Evidence: its repeated simulation test only
+  passes when it explicitly retains the hook path.
+- Observation: DDSIM approximation is scheduled at established operation
+  boundaries and counts approximation runs. A generic post-operation callback in
+  Core changed this schedule. The final Core API is therefore exact-only; DDSIM
+  keeps its specialized hook loop for approximation and subclasses.
+- Observation: both old samplers stored terminal measurement assignments in a
+  map keyed by qubit. Measuring one qubit into two bits dropped an assignment.
+  The new ordered assignment vector returns `11` for a prepared `|1>` measured
+  into both bits.
+- Observation: DDSIM's retained hook path initially kept the same lossy map, so
+  exact base and derived simulators disagreed for repeated terminal
+  measurements. It now uses the same ordered assignment semantics, and its
+  derived-hook regression also returns `11`.
+- Observation: implicit sampling used the classical-bit count when an unused
+  classical register existed. It must use the qubit count, while explicit
+  measurements use the classical-bit count.
+- Observation: `dd::applyGlobalPhase` changed an edge weight without
+  transferring the package's registered root. The new implementation registers
+  the output before releasing the input; the global-phase root test passes.
+- Observation: dynamic measurement can collapse a by-value edge before a later
+  bounds failure, which invalidates an exception guard. The kernel now validates
+  measurement sizes, mapped qubits, and classical bits before executing a shot.
+- Observation: DDSIM's deterministic density initialization leaked the prior
+  matrix root across repeated jobs. Aligning the density edge before `decRef`
+  and tracking initialization leaves one registered root after two jobs.
+- Observation: QCEC cannot yet build against Core v4 because it still includes a
+  random-Clifford helper removed by separate work. DDSIM's broad test build also
+  awaits its active Core-v4 compatibility stack. Neither blocker belongs to
+  issue #2103.
+- Observation: ProblemSolver still supports Python 3.10, whereas the Core-v4 and
+  DDSIM migration requires Python 3.11. A conditional dependency/import uses
+  DDSIM on 3.11+ and the released Core 3.x helper on 3.10.
+- Observation: Core's Python `VectorDD.get_vector()` already allocates a NumPy
+  buffer with independent capsule ownership. Returning that array directly
+  avoids a second exponential-size allocation and remains valid after the DD
+  root and package are released.
+
+## Decision Log
+
+- Decision: Keep the exact circuit kernel in Core and the public simulator class
+  in DDSIM. Rationale: Core's QDMI DD device requires exact execution and cannot
+  depend on DDSIM, while public simulator policy belongs in DDSIM. Date/Author:
+  2026-08-27 / Codex.
+- Decision: Expose `dd::SamplingResult` and an exact `dd::sample` overload that
+  accepts a caller-owned generator. Do not expose a callback or execution class
+  hierarchy. Rationale: counts, retained state, execution count, and generator
+  continuation are the only shared exact contract; hooks changed DDSIM's
+  approximation semantics. Date/Author: 2026-08-28 / Codex.
+- Decision: Transfer the one registered input root into the exact kernel and
+  return exactly one registered output root. Rationale: this matches Core's
+  existing package-aware sampling behavior and makes exception cleanup and DDSIM
+  state replacement explicit. Date/Author: 2026-08-28 / Codex.
+- Decision: Let only the exact, non-approximating base `CircuitSimulator`
+  delegate to Core. Derived simulators and approximation use
+  `simulateWithHooks`; deterministic noise has an explicit override. Rationale:
+  those paths own distinct DDSIM behavior that depends on virtual hooks and an
+  established approximation schedule. Date/Author: 2026-08-28 / Codex.
+- Decision: Retain Core's package-aware C++ `simulate` and `sample` adapters.
+  Rationale: QCEC and SyReC use them with caller-managed DD packages and input
+  states. Date/Author: 2026-08-27 / Codex.
+- Decision: Move only zero-state Python `sample` and `simulate_statevector` to
+  DDSIM. Rationale: they are public circuit-simulator conveniences; arbitrary
+  input DD simulation remains a Core package primitive. Date/Author: 2026-08-27
+  / Codex.
+- Decision: Preserve Core's seed-zero random convention in the DDSIM helper by
+  mapping zero to DDSIM's random sentinel and accept non-negative signed 64-bit
+  seeds. Rationale: DDSIM's binding accepts signed seeds; a clear `ValueError`
+  is preferable to overflow-dependent binding behavior. Date/Author: 2026-08-28
+  / Codex.
+- Decision: Defer changelog numbers, DDSIM Core-version pins, and the
+  ProblemSolver lock update until the coordinated pull requests/releases exist.
+  Rationale: inventing unavailable PR numbers or released dependency versions
+  would leave invalid metadata. Date/Author: 2026-08-28 / Codex.
+
+## Outcomes & Retrospective
+
+The implementation now establishes the intended ownership boundary. Core has one
+exact kernel covering unitary operations, virtual swaps, terminal and dynamic
+measurement, reset, classical control, RNG reuse, permutations, garbage, and
+global phase. DDSIM's exact base simulator consumes that result; DDSIM alone
+retains approximation, subclass hooks, and noisy density execution. The two
+high-level Python helpers live in DDSIM, and Core's generated stub no longer
+exports them.
+
+Focused and broad validation found and fixed three ownership defects: the
+global-phase edge, repeated DDSIM vector roots, and repeated deterministic
+density roots. It also found the malformed dynamic-measurement exception path,
+which is now prevalidated, and a hook-path measurement-order discrepancy, which
+is now covered. Remaining work is release coordination rather than feature
+design: the DDSIM branch is stacked on its active Core-v4 migration, Core and
+DDSIM changelog entries need eventual PR numbers, DDSIM's dependency pins must
+move to Core v4, and ProblemSolver's lock file can only resolve after DDSIM 2.6
+exists.
+
+## Context and Orientation
+
+`dd::Package` in `include/mqt-core/dd/Package.hpp` owns DD nodes. A returned
+root edge is kept alive by explicit `incRef` and `decRef` calls. The new result
+contract must therefore describe whether the input or output owns a registered
+root, including on exceptions and zero-shot jobs.
+
+Core declares circuit helpers in `include/mqt-core/dd/Simulation.hpp` and
+implements them in `src/dd/Simulation.cpp`. `dd::simulate` applies a unitary
+`qc::QuantumComputation` to a caller-supplied state. `dd::sample` has a
+caller-supplied package overload and a zero-state compatibility overload. The
+Core QDMI DD device calls these functions from `src/qdmi/devices/dd/Device.cpp`.
+
+DDSIM's public `CircuitSimulator` is declared in `include/CircuitSimulator.hpp`
+and implemented in `src/CircuitSimulator.cpp`. It stores a circuit, a DD
+package, a persistent random-number generator, and the final `rootEdge`. Its
+exact base path calls Core. `simulateWithHooks` remains for DDSIM-owned
+approximation and subclass behavior. `DeterministicNoiseSimulator` explicitly
+selects that hook path and uses density-matrix DDs.
+
+Core Python bindings are registered in `bindings/dd/register_dd.cpp`. DDSIM's
+moved helpers are implemented in `python/mqt/ddsim/_simulation.py` and
+re-exported by `python/mqt/ddsim/__init__.py`. ProblemSolver imports sampling in
+`src/mqt/problemsolver/csp.py` and `src/mqt/problemsolver/tsp.py`.
+
+QCEC uses caller-supplied unitary `dd::simulate`. SyReC uses caller-supplied
+`dd::sample` on reversible circuits. Neither repository should acquire a DDSIM
+dependency.
+
+## Milestones
+
+### Milestone 1: Establish one exact Core execution contract
+
+Add `dd::SamplingResult` and the generator-aware `dd::sample` overload in
+`include/mqt-core/dd/Simulation.hpp`. Implement circuit analysis and exact
+execution in `src/dd/Simulation.cpp`. Static circuits execute once even for zero
+shots and retain an uncollapsed canonical state. Dynamic circuits execute once
+per shot; zero shots return the input unchanged, otherwise the last collapsed
+canonical state is retained. The input registered root transfers to the
+function, and the returned state owns one root.
+
+Use an ordered list for terminal measurement assignments. Explicit results use
+the classical width; implicit sampling uses the qubit width. Finalization
+applies the output permutation, removes garbage qubits, and applies global
+phase. Move virtual execution helpers into the implementation file and fix
+`applyGlobalPhase` ownership in `src/dd/Operations.cpp`.
+
+This milestone is complete because the Core DD tests cover all of these
+behaviors, including malformed measurement cleanup.
+
+### Milestone 2: Delegate DDSIM's exact base simulator
+
+In `src/CircuitSimulator.cpp`, call Core only when the object is the exact base
+class and approximation is disabled. Preserve the previous root until Core
+returns successfully, then release it, install the returned root, and add the
+reported execution count. Keep `simulateWithHooks` for behavior that genuinely
+depends on DDSIM virtual hooks. Give deterministic noise an explicit override
+and release its prior aligned density root on reinitialization.
+
+This milestone is complete because nine focused C++ tests cover exact static and
+dynamic execution, zero shots, RNG continuation, failed-job recovery, derived
+hooks, approximation scheduling, and deterministic density roots.
+
+### Milestone 3: Move Python ownership and migrate the consumer
+
+Remove Core's `sample` and `simulate_statevector` bindings and regenerate
+`python/mqt/core/dd.pyi`. Add equivalent DDSIM helpers in
+`python/mqt/ddsim/_simulation.py`. `sample` constructs a `CircuitSimulator`;
+`simulate_statevector` uses Core's package-aware unitary primitive, copies the
+NumPy view, and releases the final root in `finally`.
+
+Update both upgrade guides and relevant simulator documentation. Add DDSIM as a
+conditional ProblemSolver dependency on Python 3.11+ and retain the Core 3.x
+import on Python 3.10. Do not change QCEC or SyReC.
+
+This milestone is complete because the built DDSIM binding passes all ten
+focused standalone tests against the modified Core package.
+
+### Milestone 4: Validate and coordinate releases
+
+Run Core's DD, QDMI, stub, Python, documentation, formatting, and lint checks.
+Build DDSIM against the Core worktree and run the focused C++ and Python tests,
+then run formatting and lint. Run ProblemSolver tests after its dependency can
+resolve. Inspect every diff and record independent blockers.
+
+Before merge, add changelog entries using actual pull request numbers. Land and
+release Core v4 first, update and land DDSIM's Core-v4 migration plus this work,
+release DDSIM 2.6, then regenerate the ProblemSolver lock and run its tests.
+
+## Plan of Work
+
+The implementation order is Core, DDSIM, then ProblemSolver. In Core, edit
+`include/mqt-core/dd/Simulation.hpp`, `src/dd/Simulation.cpp`,
+`include/mqt-core/dd/Operations.hpp`, and `src/dd/Operations.cpp`, followed by
+focused DD tests. Remove the high-level bindings, regenerate the stub, and
+update the DD guide and upgrade guide.
+
+In DDSIM, change the base simulator's exact path, retain a clearly named hook
+fallback, repair repeated density-root ownership, add the two Python helpers,
+and cover both exact delegation and specialized fallbacks. In ProblemSolver,
+change only the dependency and the two imports needed for the moved helper.
+
+Finally, run validation, search for stale Core Python imports and obsolete
+callback design text, and inspect diffs relative to the correct base in each
+repository. Do not publish, push, or modify GitHub without separate
+authorization.
+
+## Concrete Steps
+
+From the Core repository root, run:
+
+    cmake --build build/release --target mqt-core-dd-test -j2
+    build/release/test/dd/mqt-core-dd-test
+    cmake --build build/release --target mqt-core-qdmi-ddsim-device-test -j2
+    build/release/test/qdmi/devices/dd/mqt-core-qdmi-ddsim-device-test
+    uvx nox -s stubs
+    uvx nox -s tests -- test/python/dd/test_dd_package.py
+    uvx nox --non-interactive -s docs
+    uvx nox -s lint
+
+From the DDSIM repository root, configure against the Core source worktree,
+build `mqt-ddsim`, manually link the focused test if the broader pending Core-v4
+migration prevents the existing test target from configuring, and run:
+
+    /path/to/focused-test --gtest_filter='CircuitExecutionTest.*'
+
+Build `mqt-ddsim-bindings`, stage its extension beside the source package in a
+temporary directory, and run:
+
+    python -m pytest test/python/simulator/test_standalone_simulator.py -n 0
+
+Then run DDSIM's Ruff, Markdown, ClangFormat, and diff checks. From the
+ProblemSolver repository root, run Ruff immediately; after DDSIM 2.6 is
+available, regenerate `uv.lock` and run the CSP and TSP tests.
+
+## Validation and Acceptance
+
+Core is accepted when a seeded generator continues across calls; every success
+returns exactly one referenced final state; every failure releases the
+transferred input; static circuits report one execution even for zero shots; and
+dynamic circuits report one execution per shot. Counts are big-endian, explicit
+measurements preserve every assignment at classical width, and implicit results
+use qubit width. Layouts, virtual swaps, output permutations, garbage, and
+global phase produce a canonical retained state.
+
+DDSIM is accepted when the ordinary exact base simulator delegates to Core,
+repeated calls do not leak roots, failed calls preserve the previous state,
+fixed seeds continue the same stream, and approximation and derived/noisy
+simulators retain their DDSIM-owned hook behavior. Python is accepted when
+`mqt.ddsim.sample` and `mqt.ddsim.simulate_statevector` return counts and an
+independent NumPy array, while the generated Core stub no longer exports them.
+
+No new Core production dependency is permitted. QCEC and SyReC must not gain a
+DDSIM dependency. The only downstream dependency addition is ProblemSolver's
+conditional DDSIM requirement.
+
+## Idempotence and Recovery
+
+Source edits, generation, builds, and tests are safe to repeat. Preserve
+unrelated user changes and never reset another task's worktree. DDSIM's work is
+stacked on a separate Core-v4 migration, so compare it with that migration base
+until the prerequisite lands.
+
+The exact kernel owns the input root immediately. A guard releases it on every
+throw, and successful callers must eventually release the returned root. If a
+root-set test fails, inspect the precise `incRef`/`decRef` transition rather
+than suppressing the error. Stub generation is the only permitted way to edit
+Core's `.pyi` file.
+
+## Artifacts and Notes
+
+Recorded final evidence:
+
+    Core DD suite: 292 tests passed
+    Core QDMI DD device: 51 tests passed
+    Core stub generation: passed
+    Core focused Python sessions (3.11-3.14): passed
+    Core full lint session: passed
+    DDSIM focused circuit execution: 9 tests passed
+    DDSIM focused Python helper file: 10 tests passed
+    DDSIM full lint session: passed
+    ProblemSolver Ruff/format/Markdown checks: passed
+    ClangFormat and git diff checks: passed for all changed files
+
+The DDSIM focused Python test used an actual locally built extension linked
+against this Core worktree. Broad DDSIM configuration remains coupled to its
+separate active Core-v4 migration. ProblemSolver's lock cannot include an
+unreleased DDSIM 2.6 artifact. QCEC's independent removed-header failure is not
+evidence against this execution change.
+
+The Core documentation build reached the changed DD guide but the existing
+documentation environment failed independently: generated C++ namespace pages
+did not recognize `doxygennamespace`, and the spawned Markdown build loaded a
+stale Core shared library with a missing `buildFunctionalityRecursive` symbol.
+Markdown lint and all source-level documentation checks pass.
+
+## Interfaces and Dependencies
+
+`include/mqt-core/dd/Simulation.hpp` exposes:
+
+    struct SamplingResult {
+      std::map<std::string, std::size_t> counts;
+      VectorDD state;
+      std::size_t executions;
+    };
+
+    [[nodiscard]] SamplingResult sample(
+        const qc::QuantumComputation&, VectorDD, Package&, std::size_t,
+        std::mt19937_64&);
+
+The `VectorDD` argument owns one registered root that transfers to the function.
+`SamplingResult::state` owns one registered root on success. Core continues to
+depend only on its IR and DD targets. DDSIM already depends on Core DD and calls
+this exact kernel. ProblemSolver adds a direct conditional Python dependency on
+`mqt-ddsim`; no other dependency edge changes.
+
+Plan revision note (2026-08-28): Replaced the discarded callback design with the
+implemented exact-only contract, corrected input ownership, recorded the DDSIM
+specialization fallback, added discovered exception and root-lifetime bugs, and
+updated progress, evidence, blockers, and release order.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ releases may include breaking changes.
 
 #### Other additions
 
+- ✨ Add a low-level package-aware `dd::sample` overload that accepts a
+  caller-owned random-number generator and returns counts, the retained state,
+  and the execution count ([#2273]) ([**@simon1hofmann**])
 - 🐳 Add dev container configuration for a consistent local development
   environment ([#1786]) ([**@denialhaag**])
 
@@ -113,6 +116,9 @@ releases may include breaking changes.
 
 ### Removed
 
+- 💥 Move the high-level `mqt.core.dd.sample` and
+  `mqt.core.dd.simulate_statevector` helpers to MQT DDSIM and make virtual DD
+  execution internal ([#2273]) ([**@simon1hofmann**])
 - 💥 Remove `CircuitOptimizer`. Move circuit flattening and final-measurement
   removal to `QuantumComputation`, equivalence-checking transformations to MQT
   QCEC, and mapping transformations to MQT QMAP. Move single-qubit gate fusion
@@ -851,6 +857,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2273]: https://github.com/munich-quantum-toolkit/core/pull/2273
 [#2262]: https://github.com/munich-quantum-toolkit/core/pull/2262
 [#2259]: https://github.com/munich-quantum-toolkit/core/pull/2259
 [#2258]: https://github.com/munich-quantum-toolkit/core/pull/2258

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -75,6 +75,18 @@ factories. Move required implementations to the package that uses them. The
 `BUILD_MQT_CORE_BENCHMARKS` option and its legacy DD evaluation target were also
 removed.
 
+### Circuit simulation helpers
+
+The high-level Python `mqt.core.dd.sample` and
+`mqt.core.dd.simulate_statevector` helpers moved to `mqt.ddsim`. Import the same
+names from `mqt.ddsim>=2.6.0` instead. The package-aware C++ `dd::sample` and
+`dd::simulate` primitives and the Python `mqt.core.dd.simulate` binding remain
+available for callers that manage a DD package and input state directly.
+
+The public `dd::isExecutableVirtually` and `dd::applyVirtualOperation` helpers
+were removed. Virtual execution is an internal detail of Core's circuit
+simulation and has no public replacement.
+
 ### Python 3.11 and split-mode wheels
 
 MQT Core now requires Python 3.11 or newer. Upgrade the Python environment

--- a/bindings/dd/register_dd.cpp
+++ b/bindings/dd/register_dd.cpp
@@ -13,7 +13,6 @@
 #include "dd/Node.hpp"
 #include "dd/Package.hpp"
 #include "dd/Simulation.hpp"
-#include "dd/StateGeneration.hpp"
 #include "ir/QuantumComputation.hpp"
 
 #include <nanobind/nanobind.h>
@@ -56,61 +55,6 @@ NB_MODULE(MQT_CORE_MODULE_NAME, m) {
   registerDDPackage(m);
 
   m.def(
-      "sample",
-      [](const qc::QuantumComputation& qc, const size_t shots = 1024U,
-         const size_t seed = 0U) { return dd::sample(qc, shots, seed); },
-      "qc"_a, "shots"_a = 1024U, "seed"_a = 0U,
-      R"pb(Sample from the output distribution of a quantum computation.
-
-This function classically simulates the quantum computation and repeatedly samples from the output distribution.
-It supports mid-circuit measurements, resets, and classical control.
-
-Args:
-    qc: The quantum computation.
-    shots: The number of samples to take.
-        If the quantum computation contains no mid-circuit measurements or resets, the circuit is simulated once and the samples are drawn from the final state.
-        Otherwise, the circuit is simulated once for each sample.
-        Defaults to 1024.
-    seed: The seed for the random number generator.
-        If set to a specific non-zero value, the simulation is deterministic.
-        If set to 0, the RNG is randomly seeded.
-        Defaults to 0.
-
-Returns:
-    A histogram of the samples.
-    Each sample is a bitstring representing the measurement outcomes of the qubits in the quantum computation.
-    The leftmost bit corresponds to the most significant qubit, that is, the qubit with the highest index (big-endian).
-    If the circuit contains measurements, only the qubits that are actively measured are included in the output distribution.
-    Otherwise, all qubits in the circuit are measured.)pb");
-
-  m.def(
-      "simulate_statevector",
-      [](const qc::QuantumComputation& qc) {
-        const auto dd = std::make_unique<dd::Package>(qc.getNqubits());
-        const auto in = makeZeroState(qc.getNqubits(), *dd);
-        const auto sim = simulate(qc, in, *dd);
-        return getVector(sim);
-      },
-      "qc"_a,
-      R"pb(Simulate the quantum computation and return the final state vector.
-
-This function classically simulates the quantum computation and returns the state vector of the final state.
-It does not support measurements, resets, or classical control.
-
-Since the state vector is guaranteed to be exponentially large in the number of qubits, this function is only suitable for small quantum computations.
-Consider using the :func:`~mqt.core.dd.simulate` or the :func:`~mqt.core.dd.sample` functions, which never explicitly construct the state vector, for larger quantum computations.
-
-Notes:
-    This function internally constructs a :class:`~mqt.core.dd.DDPackage`, creates the zero state, and simulates the quantum computation via the :func:`simulate` function.
-    The state vector is then extracted from the resulting DD via the :meth:`~mqt.core.dd.VectorDD.get_vector` method.
-
-Args:
-    qc: The quantum computation. Must only contain unitary operations.
-
-Returns:
-    The state vector of the final state.)pb");
-
-  m.def(
       "build_unitary",
       [](const qc::QuantumComputation& qc) {
         const auto dd = std::make_unique<dd::Package>(qc.getNqubits());
@@ -140,8 +84,7 @@ Returns:
         R"pb(Simulate a quantum computation.
 
 This function classically simulates a quantum computation for a given initial state and returns the final state (represented as a DD).
-Compared to the `sample` function, this function does not support measurements, resets, or classical control.
-It only supports unitary operations.
+This function only supports unitary operations; it does not support measurements, resets, or classical control.
 
 The simulation is effectively computed by sequentially applying the operations of the quantum computation to the initial state.
 

--- a/docs/dd_package.md
+++ b/docs/dd_package.md
@@ -28,134 +28,22 @@ to work with decision diagrams in MQT Core from Python.
 
 ## Quickstart
 
-In its simplest use case, the MQT Core DD package can be used as a classical
-circuit simulator using the {py:func}`~mqt.core.dd.sample` function. The
-underlying simulation approach supports mid-circuit measurements, reset
-operations, as well as classically-controlled operations. For example, the
-following code snippet demonstrates how to simulate the iterative quantum phase
-estimation algorithm shown in
-[the MQT Core IR Quickstart guide](mqt_core_ir).
+MQT DDSIM 2.6 or newer owns high-level decision-diagram circuit simulation. Use
+its `mqt.ddsim.sample` helper for sampling—including dynamic circuits—and
+`mqt.ddsim.simulate_statevector` for a full state vector. MQT Core exposes the
+lower-level DD package operations used to build specialized tools.
+
+The {py:func}`~mqt.core.dd.build_unitary` function constructs the unitary matrix
+representation of a circuit:
 
 ```{code-cell} ipython3
-from mqt.core.dd import sample
-from mqt.core.ir import QuantumComputation
-from mqt.core.ir.operations import OpType
-
-from math import pi
-
-theta = 3 * pi / 8
-precision = 3
-
-# Create an empty quantum computation
-qc = QuantumComputation()
-
-# Counting register
-q = qc.add_qubit_register(1, "q")
-
-# Eigenstate register
-psi = qc.add_qubit_register(1, "psi")
-
-# Classical register for the result, the estimated phase is `0.c_2 c_1 c_0 * pi`
-c = qc.add_classical_register(precision, "c")
-
-# Prepare psi in the eigenstate |1>
-qc.x(psi[0])
-
-for i in range(precision):
-  # Hadamard on the working qubit
-  qc.h(q[0])
-
-  # Controlled phase gate
-  qc.cp(2**(precision - i - 1) * theta, q[0], psi[0])
-
-  # Iterative inverse QFT
-  for j in range(i):
-    qc.if_(op_type=OpType.p, target=q[0], control_bit=c[j], params=[-pi / 2**(i - j)])
-  qc.h(q[0])
-
-  # Measure the result
-  qc.measure(q[0], c[i])
-
-  # Reset the qubit if not finished
-  if i < precision - 1:
-    qc.reset(q[0])
-
-# Run the simulation
-counts = sample(qc, 1024)
-```
-
-```{code-cell} ipython3
----
-tags: [remove-cell]
----
-from pathlib import Path
-from matplotlib import pyplot as plt
-
-def generate_plot(counts: dict[str, int], name: str, light: bool) -> None:
-    if light:
-        plt.style.use('default')
-    else:
-        plt.style.use('dark_background')
-
-    # Create the bar plot
-    fig, ax = plt.subplots()
-    bars = ax.bar(counts.keys(), counts.values(), color='#0065bd')
-
-    # Annotate counts above the bars
-    for bar in bars:
-        height = bar.get_height()
-        ax.annotate(f'{height}',
-                    xy=(bar.get_x() + bar.get_width() / 2, height),
-                    xytext=(0, 3),  # 3 points vertical offset
-                    textcoords="offset points",
-                    ha='center', va='bottom')
-
-    # Set background to transparent
-    fig.patch.set_alpha(0.0)
-    ax.patch.set_alpha(0.0)
-
-    # Remove top and right borders
-    ax.spines['top'].set_visible(False)
-    ax.spines['right'].set_visible(False)
-
-    plt.xlabel("Measurement Outcome")
-    plt.ylabel("Counts")
-
-    # export to SVG (ensure the directory exists)
-    Path("_build/html/_images").mkdir(parents=True, exist_ok=True)
-    filename = "_build/html/_images/fig-" + name + ("-light" if light else "-dark") + ".svg"
-    plt.savefig(filename, format="svg")
-
-name = 'qpe'
-generate_plot(counts, name, light=True)
-generate_plot(counts, name, light=False)
-```
-
-```{raw} html
-<img src="_images/fig-qpe-light.svg" class="only-light" style="display: block; margin: auto; width: 75%;" alt="QPE measurement counts">
-<img src="_images/fig-qpe-dark.svg" class="only-dark" style="display: block; margin: auto; width: 75%;" alt="QPE measurement counts">
-```
-
-The {py:func}`~mqt.core.dd.sample` function is a high-level interface to the
-decision diagram package that does not require any knowledge of the underlying
-data structure. In a similar fashion, the
-{py:func}`~mqt.core.dd.simulate_statevector` and
-{py:func}`~mqt.core.dd.build_unitary` functions can be used to perform
-statevector simulation or to construct the unitary matrix representation of a
-quantum circuit, respectively.
-
-```{code-cell} ipython3
-from mqt.core.dd import simulate_statevector
-
 import numpy as np
+
+from mqt.core.ir import QuantumComputation
 
 qc = QuantumComputation(2)
 qc.h(0)
 qc.cx(0, 1)
-
-vec = np.array(simulate_statevector(qc), copy=False)
-with np.printoptions(precision=3, suppress=True):
-  print(vec)
 ```
 
 ```{code-cell} ipython3
@@ -166,15 +54,14 @@ with np.printoptions(precision=3, suppress=True):
   print(unitary)
 ```
 
-Both of these functions are inherently limited in their scalability due to the
-exponential growth of the resulting data structures. MQT Core also allows one to
-work with decision diagrams directly, which is particularly useful for larger
-quantum circuits. To this end, the {py:class}`~mqt.core.dd.DDPackage` class
-provides a low-level interface to the decision diagram package. An instance of
-this class can be used to simulate quantum circuits (see
-{py:func}`~mqt.core.dd.simulate`), construct unitary matrices (see
-{py:func}`~mqt.core.dd.build_functionality`), or perform other operations on
-decision diagrams.
+This function is inherently limited in its scalability due to the exponential
+growth of the resulting data structures. MQT Core also allows one to work with
+decision diagrams directly, which is particularly useful for larger quantum
+circuits. To this end, the {py:class}`~mqt.core.dd.DDPackage` class provides a
+low-level interface to the decision diagram package. An instance of this class
+can be used to simulate quantum circuits (see {py:func}`~mqt.core.dd.simulate`),
+construct unitary matrices (see {py:func}`~mqt.core.dd.build_functionality`), or
+perform other operations on decision diagrams.
 
 ```{code-cell} ipython3
 from mqt.core.dd import DDPackage, simulate

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -207,31 +207,17 @@ VectorDD applyIfElseOperation(const qc::IfElseOperation& op, const VectorDD& in,
                               const qc::Permutation& permutation = {});
 
 /**
- * @brief Check whether @p op is virtually executable.
- *
- * @param op The operation in question.
- * @return Whether @p op is virtually executable.
- */
-bool isExecutableVirtually(const qc::Operation& op) noexcept;
-
-/**
- * @brief Apply virtual operation @p op.
- *
- * @param op The virtual operation to apply.
- * @param permutation If suitable, the to be updated permutation.
- */
-void applyVirtualOperation(const qc::Operation& op,
-                           qc::Permutation& permutation) noexcept;
-
-/**
  * @brief Apply global phase to a given DD.
+ *
+ * @details The registered root reference owned by @p in is transferred to this
+ * function. The returned DD owns exactly one registered root reference.
  *
  * @param in The input DD
  * @param phase The phase to apply
  * @param dd The DD package to use
  * @return The output DD
  */
-VectorDD applyGlobalPhase(VectorDD& in, const fp& phase, Package& dd);
+VectorDD applyGlobalPhase(const VectorDD& in, const fp& phase, Package& dd);
 
 /**
  * @brief Change the permutation of a given DD.

--- a/include/mqt-core/dd/Simulation.hpp
+++ b/include/mqt-core/dd/Simulation.hpp
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <map>
+#include <random>
 #include <string>
 
 namespace qc {
@@ -25,6 +26,13 @@ class QuantumComputation;
 }
 
 namespace dd {
+
+/** @brief Result of sampling a quantum computation. */
+struct SamplingResult {
+  std::map<std::string, std::size_t> counts{};
+  VectorDD state{};
+  std::size_t executions = 0U;
+};
 
 /**
  * @brief Simulate a purely-quantum @ref qc::QuantumComputation on a given input
@@ -48,6 +56,32 @@ namespace dd {
  */
 VectorDD simulate(const qc::QuantumComputation& qc, const VectorDD& in,
                   Package& dd);
+
+/**
+ * @brief Execute and sample a quantum computation using a caller-owned state,
+ * package, and random-number generator.
+ *
+ * @details This is the low-level execution primitive underlying the sampling
+ * convenience functions. Static circuits are executed once and sampled
+ * without collapsing the retained state. Dynamic circuits are executed once
+ * per shot and retain the final state from the last execution.
+ *
+ * The registered root reference owned by @p in is transferred to this
+ * function. The returned @ref SamplingResult::state owns exactly one
+ * registered root reference in @p dd and must eventually be passed to
+ * @ref Package::decRef. For a dynamic circuit with zero shots, the input state
+ * is returned unchanged and no execution is reported.
+ *
+ * @param qc The quantum computation to execute
+ * @param in The input state whose registered root reference is transferred
+ * @param dd The DD package to use for execution
+ * @param shots The number of samples to draw
+ * @param rng The random-number generator to use
+ * @return Counts, the retained final state, and the number of executions
+ */
+[[nodiscard]] SamplingResult sample(const qc::QuantumComputation& qc,
+                                    VectorDD in, Package& dd, std::size_t shots,
+                                    std::mt19937_64& rng);
 
 /**
  * @brief Sample from the output distribution of a quantum computation
@@ -81,10 +115,11 @@ std::map<std::string, std::size_t> sample(const qc::QuantumComputation& qc,
  *
  * @details This is a more general version of @ref dd::sample that allows for
  * choosing the input state to simulate as well as the DD package to use for the
- * simulation.
+ * simulation. The registered root reference owned by @p in is transferred to
+ * this function.
  *
  * @param qc The quantum computation to simulate
- * @param in The input state to simulate. Represented as a vector DD.
+ * @param in The input state whose registered root reference is transferred.
  * @param dd The DD package to use for the simulation
  * @param shots The number of shots to sample
  * @param seed The seed for the random number generator

--- a/python/mqt/core/dd.pyi
+++ b/python/mqt/core/dd.pyi
@@ -866,51 +866,6 @@ class BasisStates(enum.Enum):
     The superposition state :math:`|L\\rangle = \\frac{1}{\\sqrt{2}} (|0\\rangle + i |1\\rangle)`.
     """
 
-def sample(qc: mqt.core.ir.QuantumComputation, shots: int = 1024, seed: int = 0) -> dict[str, int]:
-    """Sample from the output distribution of a quantum computation.
-
-    This function classically simulates the quantum computation and repeatedly samples from the output distribution.
-    It supports mid-circuit measurements, resets, and classical control.
-
-    Args:
-        qc: The quantum computation.
-        shots: The number of samples to take.
-            If the quantum computation contains no mid-circuit measurements or resets, the circuit is simulated once and the samples are drawn from the final state.
-            Otherwise, the circuit is simulated once for each sample.
-            Defaults to 1024.
-        seed: The seed for the random number generator.
-            If set to a specific non-zero value, the simulation is deterministic.
-            If set to 0, the RNG is randomly seeded.
-            Defaults to 0.
-
-    Returns:
-        A histogram of the samples.
-        Each sample is a bitstring representing the measurement outcomes of the qubits in the quantum computation.
-        The leftmost bit corresponds to the most significant qubit, that is, the qubit with the highest index (big-endian).
-        If the circuit contains measurements, only the qubits that are actively measured are included in the output distribution.
-        Otherwise, all qubits in the circuit are measured.
-    """
-
-def simulate_statevector(qc: mqt.core.ir.QuantumComputation) -> Annotated[NDArray[np.complex128], {"shape": (None,)}]:
-    """Simulate the quantum computation and return the final state vector.
-
-    This function classically simulates the quantum computation and returns the state vector of the final state.
-    It does not support measurements, resets, or classical control.
-
-    Since the state vector is guaranteed to be exponentially large in the number of qubits, this function is only suitable for small quantum computations.
-    Consider using the :func:`~mqt.core.dd.simulate` or the :func:`~mqt.core.dd.sample` functions, which never explicitly construct the state vector, for larger quantum computations.
-
-    Notes:
-        This function internally constructs a :class:`~mqt.core.dd.DDPackage`, creates the zero state, and simulates the quantum computation via the :func:`simulate` function.
-        The state vector is then extracted from the resulting DD via the :meth:`~mqt.core.dd.VectorDD.get_vector` method.
-
-    Args:
-        qc: The quantum computation. Must only contain unitary operations.
-
-    Returns:
-        The state vector of the final state.
-    """
-
 def build_unitary(qc: mqt.core.ir.QuantumComputation) -> Annotated[NDArray[np.complex128], {"shape": (None, None)}]:
     """Build a unitary matrix representation of a quantum computation.
 
@@ -935,8 +890,7 @@ def simulate(qc: mqt.core.ir.QuantumComputation, initial_state: VectorDD, dd_pac
     """Simulate a quantum computation.
 
     This function classically simulates a quantum computation for a given initial state and returns the final state (represented as a DD).
-    Compared to the `sample` function, this function does not support measurements, resets, or classical control.
-    It only supports unitary operations.
+    This function only supports unitary operations; it does not support measurements, resets, or classical control.
 
     The simulation is effectively computed by sequentially applying the operations of the quantum computation to the initial state.
 

--- a/src/dd/Operations.cpp
+++ b/src/dd/Operations.cpp
@@ -310,31 +310,13 @@ VectorDD applyIfElseOperation(const qc::IfElseOperation& op, const VectorDD& in,
   return applyUnitaryOperation(*thenOp, in, dd, permutation);
 }
 
-bool isExecutableVirtually(const qc::Operation& op) noexcept {
-  switch (op.getType()) {
-  case qc::I:
-  case qc::Barrier:
-    return true;
-  case qc::SWAP:
-    return !op.isControlled();
-  default:
-    return false;
-  }
-}
-
-void applyVirtualOperation(const qc::Operation& op,
-                           qc::Permutation& permutation) noexcept {
-  // SWAP gates can be executed virtually by changing the permutation
-  if (op.getType() == qc::SWAP) {
-    const auto& targets = op.getTargets();
-    std::swap(permutation.at(targets[0U]), permutation.at(targets[1U]));
-  }
-}
-
-VectorDD applyGlobalPhase(VectorDD& in, const fp& phase, Package& dd) {
-  in.w = dd.cn.lookup(in.w * ComplexValue{std::polar(1.0, phase)});
-
-  return in;
+VectorDD applyGlobalPhase(const VectorDD& in, const fp& phase, Package& dd) {
+  auto out = in;
+  out.w = dd.cn.lookup(in.w * ComplexValue{std::polar(1.0, phase)});
+  dd.incRef(out);
+  dd.decRef(in);
+  dd.garbageCollect();
+  return out;
 }
 
 } // namespace dd

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -14,6 +14,7 @@
 #include "dd/Package.hpp"
 #include "dd/StateGeneration.hpp"
 #include "ir/Definitions.hpp"
+#include "ir/Permutation.hpp"
 #include "ir/QuantumComputation.hpp"
 #include "ir/operations/IfElseOperation.hpp"
 #include "ir/operations/NonUnitaryOperation.hpp"
@@ -26,214 +27,320 @@
 #include <map>
 #include <memory>
 #include <random>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace dd {
+namespace {
 
-std::map<std::string, std::size_t> sample(const qc::QuantumComputation& qc,
-                                          const VectorDD& in, Package& dd,
-                                          const std::size_t shots,
-                                          const std::size_t seed) {
-  auto isDynamicCircuit = false;
-  auto hasMeasurements = false;
-  auto measurementsLast = true;
+using MeasurementAssignment = std::pair<qc::Qubit, std::size_t>;
 
-  std::mt19937_64 mt{};
-  if (seed != 0U) {
-    mt.seed(seed);
-  } else {
-    // create and properly seed rng
-    std::array<std::mt19937_64::result_type, std::mt19937_64::state_size>
-        randomData{};
-    std::random_device rd;
-    std::ranges::generate(randomData, [&rd]() { return rd(); });
-    std::seed_seq seeds(std::begin(randomData), std::end(randomData));
-    mt.seed(seeds);
+struct CircuitAnalysis {
+  bool isDynamic = false;
+  bool hasMeasurements = false;
+  std::vector<MeasurementAssignment> terminalMeasurements{};
+};
+
+class VectorRootGuard {
+public:
+  VectorRootGuard(Package& package, VectorDD state)
+      : package(package), state(state) {}
+
+  VectorRootGuard(const VectorRootGuard&) = delete;
+  VectorRootGuard& operator=(const VectorRootGuard&) = delete;
+  VectorRootGuard(VectorRootGuard&&) = delete;
+  VectorRootGuard& operator=(VectorRootGuard&&) = delete;
+
+  ~VectorRootGuard() { package.decRef(state); }
+
+  [[nodiscard]] VectorDD& get() noexcept { return state; }
+
+  [[nodiscard]] VectorDD release() noexcept {
+    const auto released = state;
+    state = VectorDD::zero();
+    return released;
   }
 
-  std::map<qc::Qubit, std::size_t> measurementMap{};
+private:
+  Package& package;
+  VectorDD state;
+};
 
-  // rudimentary check whether circuit is dynamic
-  for (const auto& op : qc) {
-    // if it contains any dynamic circuit primitives, it certainly is dynamic
-    if (op->isIfElseOperation() || op->getType() == qc::Reset) {
-      isDynamicCircuit = true;
-      break;
+[[nodiscard]] CircuitAnalysis
+analyzeCircuit(const qc::QuantumComputation& circuit) {
+  auto analysis = CircuitAnalysis{};
+  auto measurementSeen = false;
+
+  for (const auto& operation : circuit) {
+    if (operation->isIfElseOperation() || operation->getType() == qc::Reset) {
+      analysis.isDynamic = true;
     }
 
-    // once a measurement is encountered we store the corresponding mapping
-    // (qubit -> bit)
-    if (const auto* measure = dynamic_cast<qc::NonUnitaryOperation*>(op.get());
-        measure != nullptr && measure->getType() == qc::Measure) {
-      hasMeasurements = true;
+    if (const auto* measurement =
+            dynamic_cast<const qc::NonUnitaryOperation*>(operation.get());
+        measurement != nullptr && measurement->getType() == qc::Measure) {
+      analysis.hasMeasurements = true;
+      measurementSeen = true;
 
-      const auto& quantum = measure->getTargets();
-      const auto& classic = measure->getClassics();
-
-      for (std::size_t i = 0; i < quantum.size(); ++i) {
-        measurementMap[quantum.at(i)] = classic.at(i);
+      const auto& qubits = measurement->getTargets();
+      const auto& bits = measurement->getClassics();
+      if (qubits.size() != bits.size()) {
+        throw std::invalid_argument(
+            "Measurement targets and classical bits must have equal sizes.");
       }
-    }
-
-    // if an operation happens after a measurement, the resulting circuit can
-    // only be simulated in single shots
-    if (hasMeasurements && (op->isUnitary() || op->isIfElseOperation())) {
-      measurementsLast = false;
-    }
-  }
-
-  if (!measurementsLast) {
-    isDynamicCircuit = true;
-  }
-
-  if (!isDynamicCircuit) {
-    // if all gates are unitary (besides measurements at the end), we just
-    // simulate once and measure all qubits repeatedly
-    auto permutation = qc.initialLayout;
-    auto e = in;
-
-    for (const auto& op : qc) {
-      // simply skip any non-unitary
-      if (!op->isUnitary()) {
-        continue;
-      }
-
-      if (isExecutableVirtually(*op)) {
-        applyVirtualOperation(*op, permutation);
-        continue;
-      }
-
-      e = applyUnitaryOperation(*op, e, dd, permutation);
-    }
-
-    // correct permutation if necessary
-    if (!hasMeasurements) {
-      changePermutation(e, permutation, qc.outputPermutation, dd);
-      e = dd.reduceGarbage(e, qc.getGarbage());
-    }
-
-    // measure all qubits
-    std::map<std::string, std::size_t> counts{};
-    for (std::size_t i = 0U; i < shots; ++i) {
-      // measure all returns a string of the form "q(n-1) ... q(0)"
-      auto measurement = dd.measureAll(e, false, mt);
-      counts.operator[](measurement) += 1U;
-    }
-    // reduce reference count of measured state
-    dd.decRef(e);
-
-    std::map<std::string, std::size_t> actualCounts{};
-    const auto numBits =
-        qc.getClassicalRegisters().empty() ? qc.getNqubits() : qc.getNcbits();
-    for (const auto& [bitstring, count] : counts) {
-      std::string measurement(numBits, '0');
-      if (hasMeasurements) {
-        // if the circuit contains measurements, we only want to return the
-        // measured bits
-        for (const auto& [qubit, bit] : measurementMap) {
-          // measurement map specifies that the circuit `qubit` is measured into
-          // a certain `bit`
-          measurement[numBits - 1U - bit] =
-              bitstring[bitstring.size() - 1U - permutation.at(qubit)];
+      for (std::size_t i = 0U; i < qubits.size(); ++i) {
+        const auto qubit = qubits.at(i);
+        const auto bit = bits.at(i);
+        if (circuit.initialLayout.apply(qubit) >= circuit.getNqubits()) {
+          throw std::out_of_range("Measurement qubit is out of range.");
         }
-      } else {
-        // otherwise, we consider the output permutation for determining where
-        // to measure the qubits to
-        for (const auto& [qubit, bit] : qc.outputPermutation) {
-          measurement[numBits - 1U - bit] =
-              bitstring[bitstring.size() - 1U - qubit];
+        if (bit >= circuit.getNcbits()) {
+          throw std::out_of_range("Measurement bit is out of range.");
         }
+        analysis.terminalMeasurements.emplace_back(qubit, bit);
       }
-      actualCounts[measurement] += count;
+      continue;
     }
-    return actualCounts;
+
+    if (measurementSeen &&
+        (operation->isUnitary() || operation->isIfElseOperation())) {
+      analysis.isDynamic = true;
+    }
   }
 
+  return analysis;
+}
+
+[[nodiscard]] bool
+isExecutableVirtually(const qc::Operation& operation) noexcept {
+  switch (operation.getType()) {
+  case qc::I:
+  case qc::Barrier:
+    return true;
+  case qc::SWAP:
+    return !operation.isControlled();
+  default:
+    return false;
+  }
+}
+
+void applyVirtualOperation(const qc::Operation& operation,
+                           qc::Permutation& permutation) noexcept {
+  if (operation.getType() == qc::SWAP) {
+    const auto& targets = operation.getTargets();
+    std::swap(permutation.at(targets[0U]), permutation.at(targets[1U]));
+  }
+}
+
+void finalizeState(const qc::QuantumComputation& circuit, VectorDD& state,
+                   qc::Permutation& permutation, Package& package) {
+  changePermutation(state, permutation, circuit.outputPermutation, package);
+  state = package.reduceGarbage(state, circuit.getGarbage());
+  if (circuit.hasGlobalPhase()) {
+    state = applyGlobalPhase(state, circuit.getGlobalPhase(), package);
+  }
+}
+
+[[nodiscard]] std::map<std::string, std::size_t>
+sampleState(VectorDD& state, const std::size_t shots, Package& package,
+            std::mt19937_64& rng) {
   std::map<std::string, std::size_t> counts{};
-
-  for (std::size_t i = 0U; i < shots; i++) {
-    std::vector<bool> measurements(qc.getNcbits(), false);
-
-    auto permutation = qc.initialLayout;
-    auto e = in;
-    dd.incRef(e);
-    for (const auto& op : qc) {
-      if (op->isUnitary()) {
-        // SWAP gates can be executed virtually by changing the permutation
-        if (isExecutableVirtually(*op)) {
-          applyVirtualOperation(*op, permutation);
-          continue;
-        }
-
-        e = applyUnitaryOperation(*op, e, dd, permutation);
-        continue;
-      }
-
-      if (op->getType() == qc::OpType::Measure) {
-        const auto& measure = dynamic_cast<const qc::NonUnitaryOperation&>(*op);
-        e = applyMeasurement(measure, e, dd, mt, measurements, permutation);
-        continue;
-      }
-
-      if (op->getType() == qc::OpType::Reset) {
-        const auto& reset = dynamic_cast<const qc::NonUnitaryOperation&>(*op);
-        e = applyReset(reset, e, dd, mt, permutation);
-        continue;
-      }
-
-      if (op->isIfElseOperation()) {
-        const auto& ifElse = dynamic_cast<const qc::IfElseOperation&>(*op);
-        e = applyIfElseOperation(ifElse, e, dd, measurements, permutation);
-        continue;
-      }
-
-      qc::unreachable();
-    }
-
-    // reduce reference count of measured state
-    dd.decRef(e);
-
-    std::string shot(qc.getNcbits(), '0');
-    for (size_t bit = 0U; bit < qc.getNcbits(); ++bit) {
-      if (measurements[bit]) {
-        shot[qc.getNcbits() - bit - 1U] = '1';
-      }
-    }
-    counts[shot]++;
+  for (std::size_t shot = 0U; shot < shots; ++shot) {
+    ++counts[package.measureAll(state, false, rng)];
   }
   return counts;
 }
 
-VectorDD simulate(const qc::QuantumComputation& qc, const VectorDD& in,
-                  Package& dd) {
-  auto permutation = qc.initialLayout;
-  auto out = in;
-  for (const auto& op : qc) {
-    if (isExecutableVirtually(*op)) {
-      applyVirtualOperation(*op, permutation);
+[[nodiscard]] std::string formatExplicitMeasurement(
+    const std::string& measuredQubits,
+    const std::vector<MeasurementAssignment>& measurements,
+    const qc::Permutation& permutation, const std::size_t numClassicalBits) {
+  std::string result(numClassicalBits, '0');
+  for (const auto& [qubit, bit] : measurements) {
+    result.at(numClassicalBits - 1U - bit) =
+        measuredQubits.at(measuredQubits.size() - 1U - permutation.at(qubit));
+  }
+  return result;
+}
+
+[[nodiscard]] std::string
+formatImplicitMeasurement(const std::string& measuredQubits,
+                          const qc::QuantumComputation& circuit) {
+  const auto numQubits = circuit.getNqubits();
+  if (measuredQubits.size() > numQubits) {
+    throw std::invalid_argument(
+        "Measured state contains more qubits than the circuit.");
+  }
+  return std::string(numQubits - measuredQubits.size(), '0') + measuredQubits;
+}
+
+void executeStateOperation(const qc::Operation& operation, VectorDD& state,
+                           Package& package, qc::Permutation& permutation,
+                           const std::vector<bool>& measurements) {
+  if (operation.isUnitary()) {
+    if (isExecutableVirtually(operation)) {
+      applyVirtualOperation(operation, permutation);
     } else {
-      out = applyUnitaryOperation(*op, out, dd, permutation);
+      state = applyUnitaryOperation(operation, state, package, permutation);
+    }
+    return;
+  }
+
+  if (operation.isIfElseOperation()) {
+    const auto& ifElse = dynamic_cast<const qc::IfElseOperation&>(operation);
+    state =
+        applyIfElseOperation(ifElse, state, package, measurements, permutation);
+    return;
+  }
+
+  qc::unreachable();
+}
+
+} // namespace
+
+SamplingResult sample(const qc::QuantumComputation& circuit, VectorDD in,
+                      Package& package, const std::size_t shots,
+                      std::mt19937_64& rng) {
+  auto inputRoot = VectorRootGuard(package, in);
+  const auto analysis = analyzeCircuit(circuit);
+
+  if (!analysis.isDynamic) {
+    auto permutation = circuit.initialLayout;
+    auto& state = inputRoot.get();
+
+    for (const auto& operation : circuit) {
+      if (operation->isUnitary()) {
+        executeStateOperation(*operation, state, package, permutation, {});
+      }
+    }
+
+    std::map<std::string, std::size_t> counts{};
+    if (analysis.hasMeasurements) {
+      for (const auto& [rawResult, count] :
+           sampleState(state, shots, package, rng)) {
+        const auto result =
+            formatExplicitMeasurement(rawResult, analysis.terminalMeasurements,
+                                      permutation, circuit.getNcbits());
+        counts[result] += count;
+      }
+      finalizeState(circuit, state, permutation, package);
+    } else {
+      finalizeState(circuit, state, permutation, package);
+      for (const auto& [rawResult, count] :
+           sampleState(state, shots, package, rng)) {
+        counts[formatImplicitMeasurement(rawResult, circuit)] += count;
+      }
+    }
+
+    return {.counts = std::move(counts),
+            .state = inputRoot.release(),
+            .executions = 1U};
+  }
+
+  if (shots == 0U) {
+    return {.counts = {}, .state = inputRoot.release(), .executions = 0U};
+  }
+
+  std::map<std::string, std::size_t> counts{};
+  auto finalState = VectorDD{};
+  for (std::size_t shot = 0U; shot < shots; ++shot) {
+    auto measurements = std::vector<bool>(circuit.getNcbits(), false);
+    auto permutation = circuit.initialLayout;
+    package.incRef(inputRoot.get());
+    auto stateRoot = VectorRootGuard(package, inputRoot.get());
+    auto& state = stateRoot.get();
+
+    for (const auto& operation : circuit) {
+      if (operation->isUnitary() || operation->isIfElseOperation()) {
+        executeStateOperation(*operation, state, package, permutation,
+                              measurements);
+      } else if (operation->getType() == qc::Measure) {
+        const auto& measurement =
+            dynamic_cast<const qc::NonUnitaryOperation&>(*operation);
+        state = applyMeasurement(measurement, state, package, rng, measurements,
+                                 permutation);
+      } else if (operation->getType() == qc::Reset) {
+        const auto& reset =
+            dynamic_cast<const qc::NonUnitaryOperation&>(*operation);
+        state = applyReset(reset, state, package, rng, permutation);
+      } else {
+        qc::unreachable();
+      }
+    }
+
+    std::string result{};
+    if (analysis.hasMeasurements) {
+      result.assign(circuit.getNcbits(), '0');
+      for (std::size_t bit = 0U; bit < measurements.size(); ++bit) {
+        if (measurements.at(bit)) {
+          result.at(measurements.size() - 1U - bit) = '1';
+        }
+      }
+      if (shot + 1U == shots) {
+        finalizeState(circuit, state, permutation, package);
+      }
+    } else {
+      finalizeState(circuit, state, permutation, package);
+      result = formatImplicitMeasurement(package.measureAll(state, false, rng),
+                                         circuit);
+    }
+    ++counts[result];
+
+    if (shot + 1U == shots) {
+      finalState = stateRoot.release();
     }
   }
 
-  changePermutation(out, permutation, qc.outputPermutation, dd);
-  out = dd.reduceGarbage(out, qc.getGarbage());
+  return {
+      .counts = std::move(counts), .state = finalState, .executions = shots};
+}
 
-  // properly account for the global phase of the circuit
-  if (qc.hasGlobalPhase()) {
-    out = applyGlobalPhase(out, qc.getGlobalPhase(), dd);
+std::map<std::string, std::size_t> sample(const qc::QuantumComputation& circuit,
+                                          const VectorDD& in, Package& package,
+                                          const std::size_t shots,
+                                          const std::size_t seed) {
+  std::mt19937_64 rng{};
+  if (seed != 0U) {
+    rng.seed(seed);
+  } else {
+    std::array<std::mt19937_64::result_type, std::mt19937_64::state_size>
+        randomData{};
+    std::random_device randomDevice;
+    std::ranges::generate(randomData,
+                          [&randomDevice]() { return randomDevice(); });
+    std::seed_seq seeds(std::begin(randomData), std::end(randomData));
+    rng.seed(seeds);
   }
 
+  auto result = sample(circuit, in, package, shots, rng);
+  package.decRef(result.state);
+  return std::move(result.counts);
+}
+
+VectorDD simulate(const qc::QuantumComputation& circuit, const VectorDD& in,
+                  Package& package) {
+  auto permutation = circuit.initialLayout;
+  auto out = in;
+  for (const auto& operation : circuit) {
+    if (isExecutableVirtually(*operation)) {
+      applyVirtualOperation(*operation, permutation);
+    } else {
+      out = applyUnitaryOperation(*operation, out, package, permutation);
+    }
+  }
+
+  finalizeState(circuit, out, permutation, package);
   return out;
 }
 
-std::map<std::string, std::size_t> sample(const qc::QuantumComputation& qc,
+std::map<std::string, std::size_t> sample(const qc::QuantumComputation& circuit,
                                           const std::size_t shots,
                                           const std::size_t seed) {
-  const auto nqubits = qc.getNqubits();
-  const auto dd = std::make_unique<Package>(nqubits);
-  return sample(qc, makeZeroState(nqubits, *dd), *dd, shots, seed);
+  const auto nqubits = circuit.getNqubits();
+  const auto package = std::make_unique<Package>(nqubits);
+  return sample(circuit, makeZeroState(nqubits, *package), *package, shots,
+                seed);
 }
 } // namespace dd

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -40,7 +40,7 @@ using MeasurementAssignment = std::pair<qc::Qubit, std::size_t>;
 struct CircuitAnalysis {
   bool isDynamic = false;
   bool hasMeasurements = false;
-  std::vector<MeasurementAssignment> terminalMeasurements{};
+  std::vector<MeasurementAssignment> terminalMeasurements;
 };
 
 class VectorRootGuard {
@@ -53,6 +53,8 @@ public:
   VectorRootGuard(VectorRootGuard&&) = delete;
   VectorRootGuard& operator=(VectorRootGuard&&) = delete;
 
+  // The guard owns the registered root, so decRef cannot throw here.
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~VectorRootGuard() { package.decRef(state); }
 
   [[nodiscard]] VectorDD& get() noexcept { return state; }

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "dd/DDDefinitions.hpp"
 #include "dd/FunctionalityConstruction.hpp"
 #include "dd/Node.hpp"
 #include "dd/Operations.hpp"
@@ -26,7 +27,9 @@
 
 #include <algorithm>
 #include <array>
+#include <complex>
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <random>
 #include <stdexcept>

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -511,3 +511,269 @@ TEST_F(DDFunctionality, DynamicCircuitSimulationWithSWAP) {
   EXPECT_EQ(value, shots);
   EXPECT_EQ(key, "11");
 }
+
+TEST_F(DDFunctionality, SamplingRetainsReferencedStateWithGlobalPhase) {
+  QuantumComputation qc(1U);
+  qc.x(0U);
+  qc.gphase(qc::PI_2);
+
+  Package dd(qc.getNqubits());
+  std::mt19937_64 rng(0U);
+  auto result = sample(qc, makeZeroState(qc.getNqubits(), dd), dd, 0U, rng);
+
+  EXPECT_TRUE(result.counts.empty());
+  EXPECT_EQ(result.executions, 1U);
+  const auto amplitudes = result.state.getVector();
+  ASSERT_EQ(amplitudes.size(), 2U);
+  EXPECT_NEAR(amplitudes.at(0U).real(), 0., 1e-12);
+  EXPECT_NEAR(amplitudes.at(0U).imag(), 0., 1e-12);
+  EXPECT_NEAR(amplitudes.at(1U).real(), 0., 1e-12);
+  EXPECT_NEAR(amplitudes.at(1U).imag(), 1., 1e-12);
+
+  const auto& roots = dd.getRootSet<vNode>();
+  ASSERT_EQ(roots.size(), 1U);
+  EXPECT_EQ(roots.at(result.state), 1U);
+  EXPECT_NO_THROW(dd.decRef(result.state));
+  EXPECT_TRUE(roots.empty());
+}
+
+TEST_F(DDFunctionality, SamplingPreservesTerminalMeasurementOrder) {
+  QuantumComputation repeatedQubit(1U, 2U);
+  repeatedQubit.x(0U);
+  repeatedQubit.measure(0U, 0U);
+  repeatedQubit.measure(0U, 1U);
+  EXPECT_EQ(sample(repeatedQubit, 8U, 1U),
+            (std::map<std::string, std::size_t>{{"11", 8U}}));
+
+  QuantumComputation repeatedBit(2U, 1U);
+  repeatedBit.x(0U);
+  repeatedBit.measure(1U, 0U);
+  repeatedBit.measure(0U, 0U);
+  EXPECT_EQ(sample(repeatedBit, 8U, 1U),
+            (std::map<std::string, std::size_t>{{"1", 8U}}));
+}
+
+TEST_F(DDFunctionality, SamplingWithoutMeasurementsUsesQuantumWidth) {
+  QuantumComputation qc(2U, 1U);
+  qc.x(1U);
+
+  EXPECT_EQ(sample(qc, 8U, 1U),
+            (std::map<std::string, std::size_t>{{"10", 8U}}));
+}
+
+TEST_F(DDFunctionality, SamplingUsesOutputPermutation) {
+  QuantumComputation qc(2U);
+  qc.x(0U);
+  qc.outputPermutation = {{0U, 1U}, {1U, 0U}};
+
+  Package dd(qc.getNqubits());
+  std::mt19937_64 rng(17U);
+  auto result = sample(qc, makeZeroState(qc.getNqubits(), dd), dd, 8U, rng);
+
+  EXPECT_EQ(result.counts, (std::map<std::string, std::size_t>{{"10", 8U}}));
+  const auto amplitudes = result.state.getVector();
+  ASSERT_EQ(amplitudes.size(), 4U);
+  EXPECT_NEAR(std::abs(amplitudes.at(2U)), 1., 1e-12);
+  dd.decRef(result.state);
+}
+
+TEST_F(DDFunctionality, SamplingRetainsCanonicalStateAcrossVirtualSwap) {
+  QuantumComputation qc(2U, 2U);
+  qc.x(0U);
+  qc.swap(0U, 1U);
+  qc.measure(0U, 0U);
+  qc.measure(1U, 1U);
+
+  Package dd(qc.getNqubits());
+  std::mt19937_64 rng(17U);
+  auto result = sample(qc, makeZeroState(qc.getNqubits(), dd), dd, 8U, rng);
+
+  EXPECT_EQ(result.counts, (std::map<std::string, std::size_t>{{"10", 8U}}));
+  EXPECT_EQ(result.executions, 1U);
+  const auto amplitudes = result.state.getVector();
+  ASSERT_EQ(amplitudes.size(), 4U);
+  EXPECT_NEAR(std::abs(amplitudes.at(2U)), 1., 1e-12);
+  dd.decRef(result.state);
+}
+
+TEST_F(DDFunctionality, SamplingReducesGarbageInCountsAndRetainedState) {
+  QuantumComputation qc(3U);
+  qc.h(0U);
+  qc.cx(0U, 2U);
+  qc.setLogicalQubitGarbage(2U);
+  qc.outputPermutation = {{0U, 1U}, {1U, 0U}};
+
+  Package dd(qc.getNqubits());
+  std::mt19937_64 rng(17U);
+  auto result = sample(qc, makeZeroState(qc.getNqubits(), dd), dd, 32U, rng);
+
+  EXPECT_EQ(result.executions, 1U);
+  EXPECT_EQ(result.counts.size(), 2U);
+  EXPECT_EQ(result.counts.at("000") + result.counts.at("010"), 32U);
+  const auto amplitudes = result.state.getVector();
+  ASSERT_EQ(amplitudes.size(), 8U);
+  EXPECT_NEAR(std::abs(amplitudes.at(0U)), dd::SQRT2_2, 1e-12);
+  EXPECT_NEAR(std::abs(amplitudes.at(2U)), dd::SQRT2_2, 1e-12);
+  for (const auto index : {1U, 3U, 4U, 5U, 6U, 7U}) {
+    EXPECT_NEAR(std::abs(amplitudes.at(index)), 0., 1e-12);
+  }
+  dd.decRef(result.state);
+}
+
+TEST_F(DDFunctionality, DynamicSamplingRetainsLastStateAndBalancesRoots) {
+  QuantumComputation qc(1U, 1U);
+  qc.x(0U);
+  qc.measure(0U, 0U);
+  qc.reset(0U);
+
+  Package dd(qc.getNqubits());
+  std::mt19937_64 rng(17U);
+  auto result = sample(qc, makeZeroState(qc.getNqubits(), dd), dd, 8U, rng);
+
+  EXPECT_EQ(result.counts, (std::map<std::string, std::size_t>{{"1", 8U}}));
+  EXPECT_EQ(result.executions, 8U);
+  const auto amplitudes = result.state.getVector();
+  ASSERT_EQ(amplitudes.size(), 2U);
+  EXPECT_NEAR(std::abs(amplitudes.at(0U)), 1., 1e-12);
+  EXPECT_NEAR(std::abs(amplitudes.at(1U)), 0., 1e-12);
+  const auto& roots = dd.getRootSet<vNode>();
+  ASSERT_EQ(roots.size(), 1U);
+  EXPECT_EQ(roots.at(result.state), 1U);
+  dd.decRef(result.state);
+  EXPECT_TRUE(roots.empty());
+}
+
+TEST_F(DDFunctionality, DynamicSamplingReusesCallerRandomNumberGenerator) {
+  QuantumComputation qc(1U, 1U);
+  qc.h(0U);
+  qc.measure(0U, 0U);
+  qc.x(0U);
+
+  Package splitPackage(qc.getNqubits());
+  std::mt19937_64 splitRng(0U);
+  auto first = sample(qc, makeZeroState(qc.getNqubits(), splitPackage),
+                      splitPackage, 17U, splitRng);
+  auto second = sample(qc, makeZeroState(qc.getNqubits(), splitPackage),
+                       splitPackage, 23U, splitRng);
+  auto splitCounts = first.counts;
+  for (const auto& [state, count] : second.counts) {
+    splitCounts[state] += count;
+  }
+
+  Package combinedPackage(qc.getNqubits());
+  std::mt19937_64 combinedRng(0U);
+  auto combined = sample(qc, makeZeroState(qc.getNqubits(), combinedPackage),
+                         combinedPackage, 40U, combinedRng);
+
+  EXPECT_EQ(splitCounts, combined.counts);
+  EXPECT_EQ(splitRng, combinedRng);
+  EXPECT_EQ(first.executions, 17U);
+  EXPECT_EQ(second.executions, 23U);
+  EXPECT_EQ(combined.executions, 40U);
+
+  splitPackage.decRef(first.state);
+  splitPackage.decRef(second.state);
+  combinedPackage.decRef(combined.state);
+}
+
+TEST_F(DDFunctionality, ResetWithoutMeasurementsUsesQuantumWidth) {
+  QuantumComputation qc(2U, 1U);
+  qc.x(1U);
+  qc.reset(0U);
+
+  EXPECT_EQ(sample(qc, 8U, 1U),
+            (std::map<std::string, std::size_t>{{"10", 8U}}));
+}
+
+TEST_F(DDFunctionality, PackageAwareSampleConsumesDynamicInput) {
+  QuantumComputation qc(1U, 1U);
+  qc.h(0U);
+  qc.measure(0U, 0U);
+  qc.x(0U);
+
+  Package dd(qc.getNqubits());
+  EXPECT_EQ(sample(qc, makeZeroState(qc.getNqubits(), dd), dd, 8U, 17U).size(),
+            2U);
+  EXPECT_TRUE(dd.getRootSet<vNode>().empty());
+}
+
+TEST_F(DDFunctionality, SamplingReleasesTransferredInputOnAnalysisFailure) {
+  QuantumComputation qc(1U, 1U);
+  qc.measure(0U, 0U);
+  auto& measurement = dynamic_cast<NonUnitaryOperation&>(*qc.at(0U));
+  measurement.getClassics().clear();
+
+  Package dd(qc.getNqubits());
+  std::mt19937_64 rng(17U);
+  EXPECT_THROW(static_cast<void>(
+                   sample(qc, makeZeroState(qc.getNqubits(), dd), dd, 1U, rng)),
+               std::invalid_argument);
+  EXPECT_TRUE(dd.getRootSet<vNode>().empty());
+}
+
+TEST_F(DDFunctionality,
+       SamplingReleasesTransferredInputOnInvalidMeasurementBit) {
+  QuantumComputation qc(1U, 1U);
+  qc.h(0U);
+  qc.measure(0U, 0U);
+  qc.x(0U);
+  auto& measurement = dynamic_cast<NonUnitaryOperation&>(*qc.at(1U));
+  measurement.getClassics().at(0U) = 1U;
+
+  Package dd(qc.getNqubits());
+  std::mt19937_64 rng(17U);
+  EXPECT_THROW(static_cast<void>(
+                   sample(qc, makeZeroState(qc.getNqubits(), dd), dd, 1U, rng)),
+               std::out_of_range);
+  EXPECT_TRUE(dd.getRootSet<vNode>().empty());
+}
+
+TEST_F(DDFunctionality, DynamicSamplingZeroShotsRetainsInput) {
+  QuantumComputation qc(1U, 1U);
+  qc.measure(0U, 0U);
+  qc.x(0U);
+
+  Package dd(qc.getNqubits());
+  std::mt19937_64 rng(0U);
+  const auto input = makeZeroState(qc.getNqubits(), dd);
+  auto result = sample(qc, input, dd, 0U, rng);
+
+  EXPECT_TRUE(result.counts.empty());
+  EXPECT_EQ(result.executions, 0U);
+  EXPECT_EQ(result.state, input);
+  const auto& roots = dd.getRootSet<vNode>();
+  ASSERT_EQ(roots.size(), 1U);
+  EXPECT_EQ(roots.at(result.state), 1U);
+  dd.decRef(result.state);
+}
+
+TEST_F(DDFunctionality, SamplingReusesCallerRandomNumberGenerator) {
+  QuantumComputation qc(1U);
+  qc.h(0U);
+
+  Package splitPackage(qc.getNqubits());
+  std::mt19937_64 splitRng(0U);
+  auto first = sample(qc, makeZeroState(qc.getNqubits(), splitPackage),
+                      splitPackage, 17U, splitRng);
+  auto second = sample(qc, makeZeroState(qc.getNqubits(), splitPackage),
+                       splitPackage, 23U, splitRng);
+  auto splitCounts = first.counts;
+  for (const auto& [state, count] : second.counts) {
+    splitCounts[state] += count;
+  }
+
+  Package combinedPackage(qc.getNqubits());
+  std::mt19937_64 combinedRng(0U);
+  auto combined = sample(qc, makeZeroState(qc.getNqubits(), combinedPackage),
+                         combinedPackage, 40U, combinedRng);
+
+  EXPECT_EQ(splitCounts, combined.counts);
+  EXPECT_EQ(splitRng, combinedRng);
+  EXPECT_EQ(first.executions, 1U);
+  EXPECT_EQ(second.executions, 1U);
+  EXPECT_EQ(combined.executions, 1U);
+
+  splitPackage.decRef(first.state);
+  splitPackage.decRef(second.state);
+  combinedPackage.decRef(combined.state);
+}

--- a/test/python/dd/test_dd_package.py
+++ b/test/python/dd/test_dd_package.py
@@ -14,38 +14,8 @@ import sys
 
 import numpy as np
 
-from mqt.core.dd import DDPackage, build_functionality, build_unitary, sample, simulate
+from mqt.core.dd import DDPackage, build_functionality, build_unitary, simulate
 from mqt.core.ir import QuantumComputation
-from mqt.core.ir.operations import OpType
-
-
-def test_sample_simple_circuit() -> None:
-    """Test sampling a simple circuit."""
-    qc = QuantumComputation(2)
-    qc.x(0)
-    qc.measure_all()
-
-    shots = 1000
-    results = sample(qc, shots)
-    assert results == {"01": shots}
-
-
-def test_sample_dynamic_circuit() -> None:
-    """Test sampling a dynamic circuit."""
-    qc = QuantumComputation(1, 1)
-    # put the qubit into superposition
-    qc.h(0)
-    # reset the qubit
-    qc.measure(0, 0)
-    qc.if_(OpType.x, target=0, control_bit=0)
-    # flip to |1>
-    qc.x(0)
-    # measure the qubit
-    qc.measure(0, 0)
-
-    shots = 1000
-    results = sample(qc, shots)
-    assert results == {"1": shots}
 
 
 def test_build_unitary_and_functionality_simple_circuit() -> None:


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Consolidate decision-diagram circuit execution in MQT Core while keeping DDSIM
as the owner of the public simulator abstraction:

- add a package-aware `dd::sample` primitive that returns counts, retained
  state, and execution count while continuing a caller-owned random-number
  generator;
- use one execution implementation for unitary operations, virtual swaps,
  measurements, resets, classical control, permutations, garbage, and global
  phase;
- preserve the retained Core QDMI device without adding a Core dependency on
  DDSIM;
- move the high-level Python `sample` and `simulate_statevector` helpers to
  DDSIM;
- make virtual-operation helpers internal and document the public API
  migrations; and
- add coverage for static and dynamic circuits, repeated execution, seeding,
  measurement assignments, layouts, output permutations, ownership, and
  failures.

Fixes #2103

## Downstream migrations

- DDSIM: https://github.com/munich-quantum-toolkit/ddsim/pull/978
- ProblemSolver: https://github.com/munich-quantum-toolkit/problemsolver/pull/529

DDSIM remains stacked on its existing Core-v4 migration. ProblemSolver retains
its Core 3.x import on Python 3.10 and uses DDSIM on Python 3.11 and newer.
QCEC and SyReC keep their existing Core-only C++ integrations.

## Validation

- Core DD suite: 292 tests passed
- Core QDMI DD device: 51 tests passed
- Core stub generation passed
- focused Core Python tests passed on Python 3.11 through 3.14
- full Core lint session passed
- DDSIM integration against this Core branch: 9 C++ and 10 Python tests passed
- ProblemSolver source formatting and lint checks passed
- changed documentation passed Markdown and source-level checks
- full local Sphinx generation was blocked by pre-existing generated-namespace
  and stale-library environment failures; CI remains pending

## AI assistance

Codex materially assisted with the cross-repository design, implementation,
tests, validation, independent review, migration work, and this pull request
description. A human must review and understand the changes before merge.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. Local validation passes; CI is pending.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
