### PR TITLE
🐛 Canonicalize static qubit roots

### DIFF
--- a/mlir/include/mlir/Conversion/QCToQCO/QCToQCO.td
+++ b/mlir/include/mlir/Conversion/QCToQCO/QCToQCO.td
@@ -8,7 +8,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def QCToQCO : Pass<"qc-to-qco"> {
+def QCToQCO : Pass<"qc-to-qco", "mlir::ModuleOp"> {
   let summary = "Convert QC dialect to QCO dialect.";
 
   let description = [{

--- a/mlir/include/mlir/Dialect/MQT/IR/MQTDialect.h
+++ b/mlir/include/mlir/Dialect/MQT/IR/MQTDialect.h
@@ -24,7 +24,10 @@
 
 namespace mlir::mqt {
 /// Return whether an operation is the program entry point.
-[[nodiscard]] bool isEntryPoint(Operation* operation);
+[[nodiscard]] inline bool isEntryPoint(Operation* operation) {
+  return operation != nullptr &&
+         operation->hasAttr(MQTDialect::EntryPointAttrHelper::getNameStr());
+}
 
 /// Mark an operation as the program entry point.
 void setEntryPoint(Operation* operation);
@@ -33,5 +36,12 @@ void setEntryPoint(Operation* operation);
 void removeEntryPoint(Operation* operation);
 
 /// Return the program entry point, or null if the module has none.
-[[nodiscard]] func::FuncOp getEntryPoint(ModuleOp moduleOp);
+[[nodiscard]] inline func::FuncOp getEntryPoint(ModuleOp moduleOp) {
+  for (auto function : moduleOp.getOps<func::FuncOp>()) {
+    if (isEntryPoint(function)) {
+      return function;
+    }
+  }
+  return nullptr;
+}
 } // namespace mlir::mqt

--- a/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
+++ b/mlir/include/mlir/Dialect/QC/Builder/QCProgramBuilder.h
@@ -12,6 +12,7 @@
 
 #include "mlir/Dialect/CBit/IR/CBitAttributes.h"
 
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SetVector.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -1405,6 +1406,9 @@ private:
 
   /// Track allocated memrefs for automatic deallocation
   SetVector<Value> allocatedQregs;
+
+  /// Reuse each statically addressed qubit.
+  DenseMap<uint64_t, Value> staticQubits;
 
   /// Check if the builder has been finalized
   void checkFinalized() const;

--- a/mlir/include/mlir/Dialect/QC/IR/QCOps.td
+++ b/mlir/include/mlir/Dialect/QC/IR/QCOps.td
@@ -89,6 +89,8 @@ def StaticOp : QCOp<"static", [Pure]> {
   let builders = [OpBuilder<(ins "uint64_t":$index), [{
           build($_builder, $_state, QubitType::get($_builder.getContext()), index);
       }]>];
+
+  let hasCanonicalizer = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -55,7 +55,9 @@ inline bool checkDeadGate(Operation* op) {
          isa<QubitType>(shapedType.getElementType());
 }
 
-/// Verify that every linear QCO value under @p root has exactly one use.
+/// Verify that every linear QCO value under @p root has exactly one use, each
+/// static qubit index names one value, and program-level static roots belong to
+/// the entry block.
 [[nodiscard]] LogicalResult verifyLinearity(Operation* root);
 
 /// Maximum number of modifier targets supported by @ref

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -189,8 +189,11 @@ runPasses(ModuleOp mod,
   if (failed(qco::verifyLinearity(mod))) {
     return failure();
   }
-  return runPasses(mod, populatePasses, failureMessage, enableTiming,
-                   enableStatistics);
+  if (failed(runPasses(mod, populatePasses, failureMessage, enableTiming,
+                       enableStatistics))) {
+    return failure();
+  }
+  return qco::verifyLinearity(mod);
 }
 
 //===----------------------------------------------------------------------===//
@@ -480,7 +483,7 @@ bool QCOProgram::normalizeGlobalPhases() {
   if (!hasValidLinearity()) {
     return false;
   }
-  return succeeded(mqt::normalizeGlobalPhases(mod()));
+  return succeeded(mqt::normalizeGlobalPhases(mod())) && hasValidLinearity();
 }
 
 bool QCOProgram::runPassPipeline(const std::string_view pipeline,
@@ -489,8 +492,9 @@ bool QCOProgram::runPassPipeline(const std::string_view pipeline,
   if (!hasValidLinearity()) {
     return false;
   }
-  return succeeded(
-      ::runPassPipeline(mod(), pipeline, enableTiming, enableStatistics));
+  return succeeded(::runPassPipeline(mod(), pipeline, enableTiming,
+                                     enableStatistics)) &&
+         hasValidLinearity();
 }
 
 bool QCOProgram::mergeSingleQubitRotationGates() {
@@ -555,10 +559,7 @@ bool QCOProgram::decomposeMultiControlled(const uint64_t minQubits) {
 bool QCOProgram::compileForTarget(const CompilerTarget& target,
                                   const bool enableTiming,
                                   const bool enableStatistics) {
-  if (!hasValidLinearity()) {
-    return false;
-  }
-  return succeeded(runPasses(
+  return succeeded(runQCOTransformPasses(
       mod(),
       [&target](OpPassManager& pm) {
         populateTargetCompilationPipeline(pm, target);

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -464,14 +464,7 @@ static void commitQubits(LoweringState& state, Operation* anchor,
 [[nodiscard]] static LogicalResult normalizeStaticQubits(ModuleOp moduleOp) {
   RewritePatternSet patterns(moduleOp.getContext());
   qc::StaticOp::getCanonicalizationPatterns(patterns, moduleOp.getContext());
-  SmallVector<Operation*> staticOps;
-  moduleOp.walk(
-      [&](qc::StaticOp staticOp) { staticOps.emplace_back(staticOp); });
-  GreedyRewriteConfig config;
-  config.setStrictness(GreedyRewriteStrictness::ExistingOps)
-      .enableFolding(false);
-  if (!staticOps.empty() &&
-      failed(applyOpPatternsGreedily(staticOps, std::move(patterns), config))) {
+  if (failed(applyPatternsGreedily(moduleOp, std::move(patterns)))) {
     return failure();
   }
   IRRewriter rewriter(moduleOp.getContext());
@@ -1888,7 +1881,7 @@ struct QCToQCO final : impl::QCToQCOBase<QCToQCO> {
 protected:
   void runOnOperation() override {
     MLIRContext* context = &getContext();
-    auto* moduleOp = getOperation();
+    auto moduleOp = getOperation();
 
     LoweringState preflightState;
     if (failed(validateModifierBodies(moduleOp)) ||
@@ -1898,7 +1891,7 @@ protected:
       return;
     }
 
-    if (failed(normalizeStaticQubits(cast<ModuleOp>(moduleOp)))) {
+    if (failed(normalizeStaticQubits(moduleOp))) {
       signalPassFailure();
       return;
     }

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -33,6 +33,7 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Dominance.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Region.h>
@@ -42,7 +43,9 @@
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Support/WalkResult.h>
+#include <mlir/Transforms/CSE.h>
 #include <mlir/Transforms/DialectConversion.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 #include <mlir/Transforms/RegionUtils.h>
 
 #include <cassert>
@@ -455,6 +458,26 @@ static void commitQubits(LoweringState& state, Operation* anchor,
                      resolveMappedTensors(state, anchor, registers));
   llvm::append_range(qcoTargets, resolveMappedQubits(state, anchor, qcQubits));
   return qcoTargets;
+}
+
+/// Hoist static qubit references and let CSE coalesce them.
+[[nodiscard]] static LogicalResult normalizeStaticQubits(ModuleOp moduleOp) {
+  RewritePatternSet patterns(moduleOp.getContext());
+  qc::StaticOp::getCanonicalizationPatterns(patterns, moduleOp.getContext());
+  SmallVector<Operation*> staticOps;
+  moduleOp.walk(
+      [&](qc::StaticOp staticOp) { staticOps.emplace_back(staticOp); });
+  GreedyRewriteConfig config;
+  config.setStrictness(GreedyRewriteStrictness::ExistingOps)
+      .enableFolding(false);
+  if (!staticOps.empty() &&
+      failed(applyOpPatternsGreedily(staticOps, std::move(patterns), config))) {
+    return failure();
+  }
+  IRRewriter rewriter(moduleOp.getContext());
+  DominanceInfo dominance(moduleOp);
+  eliminateCommonSubExpressions(rewriter, dominance, moduleOp);
+  return success();
 }
 
 /** @brief Rejects quantum SSA sources unsupported by the lowering state. */
@@ -1867,6 +1890,19 @@ protected:
     MLIRContext* context = &getContext();
     auto* moduleOp = getOperation();
 
+    LoweringState preflightState;
+    if (failed(validateModifierBodies(moduleOp)) ||
+        failed(validateQuantumValueSources(moduleOp)) ||
+        failed(collectRegisterAccesses(moduleOp, preflightState))) {
+      signalPassFailure();
+      return;
+    }
+
+    if (failed(normalizeStaticQubits(cast<ModuleOp>(moduleOp)))) {
+      signalPassFailure();
+      return;
+    }
+
     // Create state object to track qubit value flow
     LoweringState state;
 
@@ -1874,9 +1910,7 @@ protected:
     RewritePatternSet patterns(context);
     QCToQCOTypeConverter typeConverter(context);
 
-    if (failed(validateModifierBodies(moduleOp)) ||
-        failed(validateQuantumValueSources(moduleOp)) ||
-        failed(collectRegisterAccesses(moduleOp, state))) {
+    if (failed(collectRegisterAccesses(moduleOp, state))) {
       signalPassFailure();
       return;
     }

--- a/mlir/lib/Dialect/MQT/IR/MQTDialect.cpp
+++ b/mlir/lib/Dialect/MQT/IR/MQTDialect.cpp
@@ -277,11 +277,6 @@ LogicalResult MQTDialect::verifyRegionResultAttribute(
          << "' is not valid on a region result";
 }
 
-bool mlir::mqt::isEntryPoint(Operation* operation) {
-  return operation != nullptr &&
-         operation->hasAttr(MQTDialect::EntryPointAttrHelper::getNameStr());
-}
-
 void mlir::mqt::setEntryPoint(Operation* operation) {
   operation->setAttr(MQTDialect::EntryPointAttrHelper::getNameStr(),
                      UnitAttr::get(operation->getContext()));
@@ -289,13 +284,4 @@ void mlir::mqt::setEntryPoint(Operation* operation) {
 
 void mlir::mqt::removeEntryPoint(Operation* operation) {
   operation->removeAttr(MQTDialect::EntryPointAttrHelper::getNameStr());
-}
-
-func::FuncOp mlir::mqt::getEntryPoint(ModuleOp moduleOp) {
-  for (auto function : moduleOp.getOps<func::FuncOp>()) {
-    if (isEntryPoint(function)) {
-      return function;
-    }
-  }
-  return nullptr;
 }

--- a/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QC/Builder/QCProgramBuilder.cpp
@@ -113,8 +113,16 @@ Value QCProgramBuilder::staticQubit(const uint64_t index) {
   checkFinalized();
   ensureAllocationMode(AllocationMode::Static);
 
-  auto staticOp = StaticOp::create(*this, index);
-  return staticOp.getQubit();
+  if (const auto it = staticQubits.find(index); it != staticQubits.end()) {
+    return it->second;
+  }
+
+  OpBuilder::InsertionGuard guard(*this);
+  auto mainFunc = mqt::getEntryPoint(cast<ModuleOp>(module));
+  setInsertionPointToStart(&mainFunc.getBody().front());
+  auto qubit = StaticOp::create(*this, index).getQubit();
+  staticQubits.try_emplace(index, qubit);
+  return qubit;
 }
 
 QCProgramBuilder::QubitRegister

--- a/mlir/lib/Dialect/QC/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/QC/IR/CMakeLists.txt
@@ -24,6 +24,7 @@ add_mlir_dialect_library(
   LINK_LIBS
   PRIVATE
   MLIRCBitDialect
+  MLIRFuncDialect
   MLIRIR
   MLIRInferTypeOpInterface
   MLIRMQTUtils

--- a/mlir/lib/Dialect/QC/IR/QubitManagement/DeallocOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/QubitManagement/DeallocOp.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/QC/IR/QCOps.h"
 
+#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
@@ -46,9 +47,29 @@ struct RemoveAllocDeallocPair final : OpRewritePattern<DeallocOp> {
   }
 };
 
+struct HoistStaticQubit final : OpRewritePattern<StaticOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(StaticOp op,
+                                PatternRewriter& rewriter) const override {
+    auto funcOp = op->getParentOfType<func::FuncOp>();
+    if (!funcOp || op->getBlock() == &funcOp.getBody().front()) {
+      return failure();
+    }
+    rewriter.moveOpBefore(op, &funcOp.getBody().front(),
+                          funcOp.getBody().front().begin());
+    return success();
+  }
+};
+
 } // namespace
 
 void DeallocOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                             MLIRContext* context) {
   results.add<RemoveAllocDeallocPair>(context);
+}
+
+void StaticOp::getCanonicalizationPatterns(RewritePatternSet& results,
+                                           MLIRContext* context) {
+  results.add<HoistStaticQubit>(context);
 }

--- a/mlir/lib/Dialect/QCO/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCO/IR/CMakeLists.txt
@@ -30,6 +30,7 @@ add_mlir_dialect_library(
   MLIRQCOMatrix
   PRIVATE
   MLIRCBitDialect
+  MLIRFuncDialect
   MLIRIR
   MLIRArithDialect
   MLIRInferTypeOpInterface

--- a/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
@@ -15,10 +15,14 @@
 #include "mlir/Dialect/QCO/Utils/Matrix.h"
 
 #include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/MQT/IR/MQTDialect.h>
 #include <mlir/Dialect/QCO/IR/QCODialect.h>
 #include <mlir/IR/Block.h>
+#include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
@@ -42,7 +46,37 @@ namespace mlir::qco {
 }
 
 LogicalResult verifyLinearity(Operation* root) {
+  func::FuncOp entryPoint;
+  if (auto moduleOp = dyn_cast<ModuleOp>(root)) {
+    for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+      if (funcOp->hasAttr(
+              mqt::MQTDialect::EntryPointAttrHelper::getNameStr())) {
+        entryPoint = funcOp;
+        break;
+      }
+    }
+  }
+
+  DenseSet<uint64_t> staticIndices;
   const auto walkResult = root->walk([&](Operation* op) {
+    if (auto staticOp = dyn_cast<StaticOp>(op)) {
+      if (entryPoint &&
+          (entryPoint.isDeclaration() ||
+           staticOp->getBlock() != &entryPoint.getBody().front())) {
+        staticOp.emitError()
+            << "expected static qubits in the entry block of program entry "
+               "function @"
+            << entryPoint.getSymName();
+        return WalkResult::interrupt();
+      }
+      if (!staticIndices.insert(staticOp.getIndex()).second) {
+        staticOp.emitError()
+            << "expected each static qubit index to identify one linear "
+               "value, but found duplicate index "
+            << staticOp.getIndex();
+        return WalkResult::interrupt();
+      }
+    }
     for (auto result : op->getResults()) {
       if (failed(verifyLinearValue(result))) {
         return WalkResult::interrupt();

--- a/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
@@ -48,13 +48,7 @@ namespace mlir::qco {
 LogicalResult verifyLinearity(Operation* root) {
   func::FuncOp entryPoint;
   if (auto moduleOp = dyn_cast<ModuleOp>(root)) {
-    for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
-      if (funcOp->hasAttr(
-              mqt::MQTDialect::EntryPointAttrHelper::getNameStr())) {
-        entryPoint = funcOp;
-        break;
-      }
-    }
+    entryPoint = mqt::getEntryPoint(moduleOp);
   }
 
   DenseSet<uint64_t> staticIndices;

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Compiler/Programs.h"
 #include "mlir/Compiler/Target.h"
 #include "mlir/Dialect/CBit/IR/CBitDialect.h"
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/QC/Builder/QCProgramBuilder.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
@@ -303,21 +304,61 @@ TEST(CompilerProgramOwnershipTest, ValidatesAndOwnsExistingQCModules) {
 }
 TEST(CompilerProgramOwnershipTest, EnforcesQCOLinearityAtPublicBoundaries) {
   DialectRegistry registry;
-  registry.insert<QCODialect, func::FuncDialect>();
+  registry.insert<mlir::mqt::MQTDialect, QCODialect, func::FuncDialect,
+                  scf::SCFDialect>();
   auto context = std::make_shared<MLIRContext>(registry);
   context->loadAllAvailableDialects();
 
   constexpr llvm::StringLiteral validSource = R"mlir(module {
-    func.func @main() {
+    func.func @main() attributes {mqt.entry_point} {
       %qubit = qco.alloc : !qco.qubit
       qco.sink %qubit : !qco.qubit
       return
     }
   })mlir";
   constexpr llvm::StringLiteral nonlinearSource = R"mlir(module {
-    func.func @main() {
+    func.func @main() attributes {mqt.entry_point} {
       %qubit = qco.alloc : !qco.qubit
       return
+    }
+  })mlir";
+  constexpr llvm::StringLiteral aliasedStaticSource = R"mlir(module {
+    func.func @main() attributes {mqt.entry_point} {
+      %q0 = qco.static 0 : !qco.qubit
+      %q1 = qco.static 0 : !qco.qubit
+      qco.sink %q0 : !qco.qubit
+      qco.sink %q1 : !qco.qubit
+      return
+    }
+  })mlir";
+  constexpr llvm::StringLiteral helperStaticSource = R"mlir(module {
+    func.func @main() attributes {mqt.entry_point} {
+      return
+    }
+    func.func @helper() {
+      %q = qco.static 1 : !qco.qubit
+      qco.sink %q : !qco.qubit
+      return
+    }
+  })mlir";
+  constexpr llvm::StringLiteral nestedStaticSource = R"mlir(module {
+    func.func @main(%condition: i1) attributes {mqt.entry_point} {
+      scf.if %condition {
+        %q = qco.static 0 : !qco.qubit
+        qco.sink %q : !qco.qubit
+      }
+      return
+    }
+  })mlir";
+  constexpr llvm::StringLiteral helperArgumentSource = R"mlir(module {
+    func.func @main() attributes {mqt.entry_point} {
+      %q = qco.static 0 : !qco.qubit
+      %result = func.call @helper(%q) : (!qco.qubit) -> !qco.qubit
+      qco.sink %result : !qco.qubit
+      return
+    }
+    func.func @helper(%q: !qco.qubit) -> !qco.qubit {
+      return %q : !qco.qubit
     }
   })mlir";
 
@@ -351,6 +392,26 @@ TEST(CompilerProgramOwnershipTest, EnforcesQCOLinearityAtPublicBoundaries) {
       parseSourceString<ModuleOp>(nonlinearSource, context.get());
   ASSERT_TRUE(nonlinearModule);
   EXPECT_FALSE(QCOProgram::fromModule(context, std::move(nonlinearModule)));
+
+  auto aliasedStaticModule =
+      parseSourceString<ModuleOp>(aliasedStaticSource, context.get());
+  ASSERT_TRUE(aliasedStaticModule);
+  EXPECT_FALSE(QCOProgram::fromModule(context, std::move(aliasedStaticModule)));
+
+  auto helperStaticModule =
+      parseSourceString<ModuleOp>(helperStaticSource, context.get());
+  ASSERT_TRUE(helperStaticModule);
+  EXPECT_FALSE(QCOProgram::fromModule(context, std::move(helperStaticModule)));
+
+  auto nestedStaticModule =
+      parseSourceString<ModuleOp>(nestedStaticSource, context.get());
+  ASSERT_TRUE(nestedStaticModule);
+  EXPECT_FALSE(QCOProgram::fromModule(context, std::move(nestedStaticModule)));
+
+  auto helperArgumentModule =
+      parseSourceString<ModuleOp>(helperArgumentSource, context.get());
+  ASSERT_TRUE(helperArgumentModule);
+  EXPECT_TRUE(QCOProgram::fromModule(context, std::move(helperArgumentModule)));
 
   auto transformInput = program->copy();
   auto pipelineInput = program->copy();
@@ -437,6 +498,29 @@ h q;
   auto reparsed = parseRecordedModule(roundTrip.str());
   ASSERT_TRUE(reparsed);
   EXPECT_TRUE(mlir::verify(*reparsed).succeeded());
+}
+
+TEST_F(CompilerPipelineTest, ReusesOpenQASMHardwareQubits) {
+  constexpr llvm::StringLiteral qasm = R"(OPENQASM 3.1;
+h $0;
+x $0;
+)";
+
+  auto qcProgram = QCProgram::fromQASMString(qasm.str());
+  ASSERT_TRUE(qcProgram);
+
+  size_t qcStaticOps = 0;
+  qcProgram->module().walk([&](Operation* op) {
+    qcStaticOps += op->getName().getStringRef() == "qc.static";
+  });
+  EXPECT_EQ(qcStaticOps, 1U);
+
+  auto qcoProgram = std::move(*qcProgram).intoQCO();
+  ASSERT_TRUE(qcoProgram);
+
+  size_t qcoStaticOps = 0;
+  qcoProgram->module().walk([&](qco::StaticOp) { ++qcoStaticOps; });
+  EXPECT_EQ(qcoStaticOps, 1U);
 }
 
 namespace {

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -388,25 +388,12 @@ TEST(CompilerProgramOwnershipTest, EnforcesQCOLinearityAtPublicBoundaries) {
   main.getBody().front().getTerminator()->erase();
   EXPECT_FALSE(QCOProgram::fromModule(context, std::move(invalidModule)));
 
-  auto nonlinearModule =
-      parseSourceString<ModuleOp>(nonlinearSource, context.get());
-  ASSERT_TRUE(nonlinearModule);
-  EXPECT_FALSE(QCOProgram::fromModule(context, std::move(nonlinearModule)));
-
-  auto aliasedStaticModule =
-      parseSourceString<ModuleOp>(aliasedStaticSource, context.get());
-  ASSERT_TRUE(aliasedStaticModule);
-  EXPECT_FALSE(QCOProgram::fromModule(context, std::move(aliasedStaticModule)));
-
-  auto helperStaticModule =
-      parseSourceString<ModuleOp>(helperStaticSource, context.get());
-  ASSERT_TRUE(helperStaticModule);
-  EXPECT_FALSE(QCOProgram::fromModule(context, std::move(helperStaticModule)));
-
-  auto nestedStaticModule =
-      parseSourceString<ModuleOp>(nestedStaticSource, context.get());
-  ASSERT_TRUE(nestedStaticModule);
-  EXPECT_FALSE(QCOProgram::fromModule(context, std::move(nestedStaticModule)));
+  for (const auto source : {nonlinearSource, aliasedStaticSource,
+                            helperStaticSource, nestedStaticSource}) {
+    auto rejectedModule = parseSourceString<ModuleOp>(source, context.get());
+    ASSERT_TRUE(rejectedModule);
+    EXPECT_FALSE(QCOProgram::fromModule(context, std::move(rejectedModule)));
+  }
 
   auto helperArgumentModule =
       parseSourceString<ModuleOp>(helperArgumentSource, context.get());

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Support/Passes.h"
@@ -259,6 +260,50 @@ module {
   EXPECT_TRUE(sawLoop);
 
   expectNoQCOperations(*module);
+}
+
+TEST_F(QCToQCORegressionTest, CoalescesStaticQubitsAcrossRegions) {
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main(%condition: i1) attributes {mqt.entry_point} {
+    scf.if %condition {
+      %then0 = qc.static 0 : !qc.qubit
+      %then1 = qc.static 1 : !qc.qubit
+      %then2 = qc.static 2 : !qc.qubit
+      qc.x %then0 : !qc.qubit
+      qc.x %then1 : !qc.qubit
+      qc.x %then2 : !qc.qubit
+    } else {
+      %else0 = qc.static 0 : !qc.qubit
+      %else1 = qc.static 1 : !qc.qubit
+      qc.h %else0 : !qc.qubit
+      qc.h %else1 : !qc.qubit
+    }
+    %after0 = qc.static 0 : !qc.qubit
+    %after1 = qc.static 1 : !qc.qubit
+    qc.z %after0 : !qc.qubit
+    qc.z %after1 : !qc.qubit
+    return
+  }
+}
+)mlir";
+
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+
+  auto main = moduleOp->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  size_t staticOps = 0;
+  moduleOp->walk([&](qco::StaticOp op) {
+    ++staticOps;
+    EXPECT_EQ(op->getBlock(), &main.getBody().front());
+  });
+  EXPECT_EQ(staticOps, 3U);
+  expectNoQCOperations(*moduleOp);
 }
 
 TEST_F(QCToQCORegressionTest, PreservesWhileConditionArgumentsAndOrdering) {

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -150,6 +150,37 @@ TEST_F(QCTest, QubitIsVectorElement) {
   EXPECT_TRUE(isa<QubitType>(vectorType.getElementType()));
 }
 
+TEST_F(QCTest, CleanupHoistsAndCoalescesStaticQubits) {
+  auto module = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @main(%condition: i1) {
+        scf.if %condition {
+          %q0 = qc.static 0 : !qc.qubit
+          %q1 = qc.static 1 : !qc.qubit
+          qc.x %q0 : !qc.qubit
+          qc.x %q1 : !qc.qubit
+        } else {
+          %q0 = qc.static 0 : !qc.qubit
+          qc.h %q0 : !qc.qubit
+        }
+        return
+      }
+    }
+  )mlir",
+                                            context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(runQCCleanupPipeline(*module)));
+
+  auto main = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(main);
+  size_t staticOps = 0;
+  module->walk([&](StaticOp op) {
+    ++staticOps;
+    EXPECT_EQ(op->getBlock(), &main.getBody().front());
+  });
+  EXPECT_EQ(staticOps, 2U);
+}
+
 TEST_F(QCTest, BuilderRejectsMixedStaticAndDynamicQubitAllocationModes) {
   EXPECT_DEATH(
       {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Treat each static qubit index as one physical identity across QC and QCO.

- Reuse hardware-qubit values in `QCProgramBuilder` and place their roots in the entry block.
- Hoist QC static roots during canonicalization and use native CSE to coalesce duplicates before QCO lowering.
- Reject duplicate and non-entry QCO static roots, and recheck QCO programs after transformations.

This extracts static-qubit normalization from #2077 so that it can merge independently. It contains no DD execution or sampling changes.

Local validation passed the full release build, all 4,031 C++ tests, repository lint, and changed-file clang-format and clang-tidy checks.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
