### PR TITLE
🐛 Harden MLIR conversion pass boundaries

### DIFF
--- a/mlir/include/mlir/Conversion/CBitToMemRef/CBitToMemRef.td
+++ b/mlir/include/mlir/Conversion/CBitToMemRef/CBitToMemRef.td
@@ -8,7 +8,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def ConvertCBitToMemRef : Pass<"convert-cbit-to-memref"> {
+def ConvertCBitToMemRef : Pass<"convert-cbit-to-memref", "mlir::ModuleOp"> {
   let summary = "Lower CBit registers to memrefs";
 
   let description = [{

--- a/mlir/include/mlir/Conversion/JeffToQCO/JeffToQCO.td
+++ b/mlir/include/mlir/Conversion/JeffToQCO/JeffToQCO.td
@@ -8,7 +8,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def JeffToQCO : Pass<"jeff-to-qco"> {
+def JeffToQCO : Pass<"jeff-to-qco", "mlir::ModuleOp"> {
   let summary = "Convert `jeff` operations to QCO operations";
 
   let description = [{

--- a/mlir/include/mlir/Conversion/QCOToJeff/QCOToJeff.td
+++ b/mlir/include/mlir/Conversion/QCOToJeff/QCOToJeff.td
@@ -8,7 +8,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def QCOToJeff : Pass<"qco-to-jeff"> {
+def QCOToJeff : Pass<"qco-to-jeff", "mlir::ModuleOp"> {
   let summary = "Convert QCO operations to `jeff` operations";
 
   let description = [{

--- a/mlir/include/mlir/Conversion/QCOToQC/QCOToQC.td
+++ b/mlir/include/mlir/Conversion/QCOToQC/QCOToQC.td
@@ -8,7 +8,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def QCOToQC : Pass<"qco-to-qc"> {
+def QCOToQC : Pass<"qco-to-qc", "mlir::ModuleOp"> {
   let summary = "Convert QCO dialect to QC dialect.";
 
   let description = [{

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.td
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.td
@@ -8,7 +8,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def QCToQIRAdaptive : Pass<"qc-to-qir-adaptive"> {
+def QCToQIRAdaptive : Pass<"qc-to-qir-adaptive", "mlir::ModuleOp"> {
   let summary = "Lower the QC dialect to the LLVM dialect compliant with the "
                 "QIR Adaptive Profile 2.1";
 

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
@@ -8,7 +8,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def QCToQIRBase : Pass<"qc-to-qir-base"> {
+def QCToQIRBase : Pass<"qc-to-qir-base", "mlir::ModuleOp"> {
   let summary = "Lower the QC dialect to the LLVM dialect compliant with the "
                 "QIR Base Profile 2.1";
 

--- a/mlir/lib/Conversion/CBitToMemRef/CBitToMemRef.cpp
+++ b/mlir/lib/Conversion/CBitToMemRef/CBitToMemRef.cpp
@@ -103,7 +103,7 @@ struct ConvertCBitToMemRef final
 protected:
   void runOnOperation() override {
     MLIRContext* context = &getContext();
-    auto* moduleOp = getOperation();
+    auto moduleOp = getOperation();
     CBitTypeConverter typeConverter;
     ConversionTarget target(*context);
     RewritePatternSet patterns(context);

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -204,20 +204,15 @@ static void createBarrierOp(jeff::CustomOp& op, jeff::CustomOpAdaptor& adaptor,
 /**
  * @brief Gets the name of the entry point from the module attributes
  */
-static StringRef getEntryPointName(Operation* op) {
-  auto module = dyn_cast<ModuleOp>(op);
-  if (!module) {
-    llvm::reportFatalInternalError("Expected a module operation");
-  }
-
-  auto entryPointAttr = module->getAttr("jeff.entrypoint");
+static StringRef getEntryPointName(ModuleOp moduleOp) {
+  auto entryPointAttr = moduleOp->getAttr("jeff.entrypoint");
   if (!entryPointAttr) {
     llvm::reportFatalInternalError(
         "Module is missing 'jeff.entrypoint' attribute");
   }
   auto entryPoint = cast<IntegerAttr>(entryPointAttr).getUInt();
 
-  auto stringsAttr = module->getAttr("jeff.strings");
+  auto stringsAttr = moduleOp->getAttr("jeff.strings");
   if (!stringsAttr) {
     llvm::reportFatalInternalError(
         "Module is missing 'jeff.strings' attribute");
@@ -234,25 +229,17 @@ static StringRef getEntryPointName(Operation* op) {
 /**
  * @brief Cleans up the module after conversion
  *
- * @param op The module operation to clean up
- * @return LogicalResult Success or failure of the cleanup
+ * @param moduleOp The module operation to clean up
  */
-static LogicalResult cleanUp(Operation* op) {
-  auto module = dyn_cast<ModuleOp>(op);
-  if (!module) {
-    return failure();
-  }
-
-  // Remove module attributes
-  module->removeAttr("jeff.entrypoint");
-  module->removeAttr("jeff.strings");
-  module->removeAttr("jeff.tool");
-  module->removeAttr("jeff.toolVersion");
-  module->removeAttr("jeff.version");
-  module->removeAttr("jeff.versionMinor");
-  module->removeAttr("jeff.versionPatch");
-
-  return success();
+static void cleanUp(ModuleOp moduleOp) {
+  /// Remove module attributes.
+  moduleOp->removeAttr("jeff.entrypoint");
+  moduleOp->removeAttr("jeff.strings");
+  moduleOp->removeAttr("jeff.tool");
+  moduleOp->removeAttr("jeff.toolVersion");
+  moduleOp->removeAttr("jeff.version");
+  moduleOp->removeAttr("jeff.versionMinor");
+  moduleOp->removeAttr("jeff.versionPatch");
 }
 
 /**
@@ -1288,7 +1275,7 @@ struct JeffToQCO final : impl::JeffToQCOBase<JeffToQCO> {
 protected:
   void runOnOperation() override {
     MLIRContext* context = &getContext();
-    auto* module = getOperation();
+    auto moduleOp = getOperation();
 
     ConversionTarget target(*context);
     RewritePatternSet patterns(context);
@@ -1302,7 +1289,7 @@ protected:
                          tensor::TensorDialect, scf::SCFDialect>();
 
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
-      return (op.getSymName() != getEntryPointName(module) ||
+      return (op.getSymName() != getEntryPointName(moduleOp) ||
               mqt::isEntryPoint(op)) &&
              typeConverter.isSignatureLegal(op.getFunctionType()) &&
              typeConverter.isLegal(&op.getBody());
@@ -1343,14 +1330,12 @@ protected:
                                                           context);
 
     // Apply the conversion
-    if (applyPartialConversion(module, target, std::move(patterns)).failed()) {
+    if (applyPartialConversion(moduleOp, target, std::move(patterns)).failed()) {
       signalPassFailure();
       return;
     }
 
-    if (cleanUp(module).failed()) {
-      signalPassFailure();
-    }
+    cleanUp(moduleOp);
   }
 };
 

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -24,7 +24,6 @@
 #include <jeff/IR/JeffOps.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
@@ -204,26 +203,28 @@ static void createBarrierOp(jeff::CustomOp& op, jeff::CustomOpAdaptor& adaptor,
 /**
  * @brief Gets the name of the entry point from the module attributes
  */
-static StringRef getEntryPointName(ModuleOp moduleOp) {
-  auto entryPointAttr = moduleOp->getAttr("jeff.entrypoint");
-  if (!entryPointAttr) {
-    llvm::reportFatalInternalError(
-        "Module is missing 'jeff.entrypoint' attribute");
+static FailureOr<StringRef> getEntryPointName(ModuleOp moduleOp) {
+  auto entryPointAttr = moduleOp->getAttrOfType<IntegerAttr>("jeff.entrypoint");
+  if (!entryPointAttr || !entryPointAttr.getType().isUnsignedInteger()) {
+    return moduleOp.emitError(
+        "requires an unsigned integer 'jeff.entrypoint' attribute");
   }
-  auto entryPoint = cast<IntegerAttr>(entryPointAttr).getUInt();
+  auto entryPoint = entryPointAttr.getUInt();
 
-  auto stringsAttr = moduleOp->getAttr("jeff.strings");
+  auto stringsAttr = moduleOp->getAttrOfType<ArrayAttr>("jeff.strings");
   if (!stringsAttr) {
-    llvm::reportFatalInternalError(
-        "Module is missing 'jeff.strings' attribute");
-  }
-  auto strings = cast<ArrayAttr>(stringsAttr);
-
-  if (entryPoint >= strings.size()) {
-    llvm::reportFatalInternalError("Entry point index is out of bounds");
+    return moduleOp.emitError("requires an array 'jeff.strings' attribute");
   }
 
-  return cast<StringAttr>(strings[entryPoint]).getValue();
+  if (entryPoint >= stringsAttr.size()) {
+    return moduleOp.emitError("'jeff.entrypoint' index is out of bounds");
+  }
+
+  auto name = dyn_cast<StringAttr>(stringsAttr[entryPoint]);
+  if (!name) {
+    return moduleOp.emitError("'jeff.entrypoint' must index a string");
+  }
+  return name.getValue();
 }
 
 /**
@@ -1276,6 +1277,11 @@ protected:
   void runOnOperation() override {
     MLIRContext* context = &getContext();
     auto moduleOp = getOperation();
+    auto entryPointName = getEntryPointName(moduleOp);
+    if (failed(entryPointName)) {
+      signalPassFailure();
+      return;
+    }
 
     ConversionTarget target(*context);
     RewritePatternSet patterns(context);
@@ -1289,8 +1295,7 @@ protected:
                          tensor::TensorDialect, scf::SCFDialect>();
 
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
-      return (op.getSymName() != getEntryPointName(moduleOp) ||
-              mqt::isEntryPoint(op)) &&
+      return (op.getSymName() != *entryPointName || mqt::isEntryPoint(op)) &&
              typeConverter.isSignatureLegal(op.getFunctionType()) &&
              typeConverter.isLegal(&op.getBody());
     });
@@ -1330,7 +1335,8 @@ protected:
                                                           context);
 
     // Apply the conversion
-    if (applyPartialConversion(moduleOp, target, std::move(patterns)).failed()) {
+    if (applyPartialConversion(moduleOp, target, std::move(patterns))
+            .failed()) {
       signalPassFailure();
       return;
     }

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -228,22 +228,6 @@ static FailureOr<StringRef> getEntryPointName(ModuleOp moduleOp) {
 }
 
 /**
- * @brief Cleans up the module after conversion
- *
- * @param moduleOp The module operation to clean up
- */
-static void cleanUp(ModuleOp moduleOp) {
-  /// Remove module attributes.
-  moduleOp->removeAttr("jeff.entrypoint");
-  moduleOp->removeAttr("jeff.strings");
-  moduleOp->removeAttr("jeff.tool");
-  moduleOp->removeAttr("jeff.toolVersion");
-  moduleOp->removeAttr("jeff.version");
-  moduleOp->removeAttr("jeff.versionMinor");
-  moduleOp->removeAttr("jeff.versionPatch");
-}
-
-/**
  * @brief Checks if a type is a linear type
  */
 static bool isLinearType(Type t) {
@@ -1341,7 +1325,13 @@ protected:
       return;
     }
 
-    cleanUp(moduleOp);
+    moduleOp->removeAttr("jeff.entrypoint");
+    moduleOp->removeAttr("jeff.strings");
+    moduleOp->removeAttr("jeff.tool");
+    moduleOp->removeAttr("jeff.toolVersion");
+    moduleOp->removeAttr("jeff.version");
+    moduleOp->removeAttr("jeff.versionMinor");
+    moduleOp->removeAttr("jeff.versionPatch");
   }
 };
 

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -483,7 +483,6 @@ static LogicalResult cleanUp(ModuleOp moduleOp, LoweringState& state) {
   }
   const auto entryPoint = static_cast<uint16_t>(distance);
 
-  /// Set module attributes.
   OpBuilder builder(moduleOp.getContext());
   auto uint16Type = builder.getIntegerType(16, false);
 
@@ -502,10 +501,8 @@ static LogicalResult cleanUp(ModuleOp moduleOp, LoweringState& state) {
                     builder.getStringAttr(MQT_CORE_VERSION));
 
   moduleOp->setAttr("jeff.version", builder.getIntegerAttr(uint16Type, 0));
-  moduleOp->setAttr("jeff.versionMinor",
-                    builder.getIntegerAttr(uint16Type, 3));
-  moduleOp->setAttr("jeff.versionPatch",
-                    builder.getIntegerAttr(uint16Type, 0));
+  moduleOp->setAttr("jeff.versionMinor", builder.getIntegerAttr(uint16Type, 3));
+  moduleOp->setAttr("jeff.versionPatch", builder.getIntegerAttr(uint16Type, 0));
 
   return success();
 }

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -436,11 +436,11 @@ static void createPPROp(QCOOpType& op, ConversionPatternRewriter& rewriter,
 }
 
 /**
- * @brief Updates all `jeff.yield` operations in @p module to use the latest
+ * @brief Updates all `jeff.yield` operations in @p moduleOp to use the latest
  * classical-bit-register array values.
  */
-static void patchCregYields(Operation* module, LoweringState& state) {
-  module->walk([&](jeff::YieldOp yieldOp) {
+static void patchCregYields(ModuleOp moduleOp, LoweringState& state) {
+  moduleOp->walk([&](jeff::YieldOp yieldOp) {
     auto* values = state.cbitState.getRegionValues(yieldOp->getParentRegion());
     if (values == nullptr) {
       return;
@@ -460,21 +460,16 @@ static void patchCregYields(Operation* module, LoweringState& state) {
 /**
  * @brief Cleans up the module after conversion
  *
- * @param op The module operation to clean up
+ * @param moduleOp The module operation to clean up
  * @param state The lowering state
  * @return LogicalResult Success or failure of the cleanup
  */
-static LogicalResult cleanUp(Operation* op, LoweringState& state) {
+static LogicalResult cleanUp(ModuleOp moduleOp, LoweringState& state) {
   if (state.entryPointName.empty()) {
     return failure();
   }
 
-  auto module = dyn_cast<ModuleOp>(op);
-  if (!module) {
-    return failure();
-  }
-
-  for (auto funcOp : module.getOps<func::FuncOp>()) {
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
     state.strings.emplace_back(funcOp.getSymName());
   }
 
@@ -488,26 +483,29 @@ static LogicalResult cleanUp(Operation* op, LoweringState& state) {
   }
   const auto entryPoint = static_cast<uint16_t>(distance);
 
-  // Set module attributes
-  OpBuilder builder(module.getContext());
+  /// Set module attributes.
+  OpBuilder builder(moduleOp.getContext());
   auto uint16Type = builder.getIntegerType(16, false);
 
-  module->setAttr("jeff.entrypoint",
-                  builder.getIntegerAttr(uint16Type, entryPoint));
+  moduleOp->setAttr("jeff.entrypoint",
+                    builder.getIntegerAttr(uint16Type, entryPoint));
 
   SmallVector<StringRef> stringRefs;
   stringRefs.reserve(state.strings.size());
   for (const auto& str : state.strings) {
     stringRefs.emplace_back(str);
   }
-  module->setAttr("jeff.strings", builder.getStrArrayAttr(stringRefs));
+  moduleOp->setAttr("jeff.strings", builder.getStrArrayAttr(stringRefs));
 
-  module->setAttr("jeff.tool", builder.getStringAttr("mqt-cc"));
-  module->setAttr("jeff.toolVersion", builder.getStringAttr(MQT_CORE_VERSION));
+  moduleOp->setAttr("jeff.tool", builder.getStringAttr("mqt-cc"));
+  moduleOp->setAttr("jeff.toolVersion",
+                    builder.getStringAttr(MQT_CORE_VERSION));
 
-  module->setAttr("jeff.version", builder.getIntegerAttr(uint16Type, 0));
-  module->setAttr("jeff.versionMinor", builder.getIntegerAttr(uint16Type, 3));
-  module->setAttr("jeff.versionPatch", builder.getIntegerAttr(uint16Type, 0));
+  moduleOp->setAttr("jeff.version", builder.getIntegerAttr(uint16Type, 0));
+  moduleOp->setAttr("jeff.versionMinor",
+                    builder.getIntegerAttr(uint16Type, 3));
+  moduleOp->setAttr("jeff.versionPatch",
+                    builder.getIntegerAttr(uint16Type, 0));
 
   return success();
 }
@@ -1854,8 +1852,8 @@ struct QCOToJeff final : impl::QCOToJeffBase<QCOToJeff> {
 protected:
   void runOnOperation() override {
     MLIRContext* context = &getContext();
-    auto* moduleOp = getOperation();
-    if (failed(mqt::normalizeGlobalPhases(cast<ModuleOp>(moduleOp)))) {
+    auto moduleOp = getOperation();
+    if (failed(mqt::normalizeGlobalPhases(moduleOp))) {
       signalPassFailure();
       return;
     }

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -1174,7 +1174,7 @@ struct QCOToQC final : impl::QCOToQCBase<QCOToQC> {
 protected:
   void runOnOperation() override {
     MLIRContext* context = &getContext();
-    auto* module = getOperation();
+    auto moduleOp = getOperation();
 
     // Create state object to track the qubit addressing mode
     LoweringState state;
@@ -1251,7 +1251,7 @@ protected:
     populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
 
     // Apply the conversion
-    if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
+    if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
@@ -684,8 +684,8 @@ protected:
    */
   void runOnOperation() override {
     MLIRContext* ctx = &getContext();
-    auto* moduleOp = getOperation();
-    if (failed(mqt::normalizeGlobalPhases(cast<ModuleOp>(moduleOp)))) {
+    auto moduleOp = getOperation();
+    if (failed(mqt::normalizeGlobalPhases(moduleOp))) {
       signalPassFailure();
       return;
     }

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -461,8 +461,8 @@ protected:
    */
   void runOnOperation() override {
     MLIRContext* ctx = &getContext();
-    auto* moduleOp = getOperation();
-    if (failed(mqt::normalizeGlobalPhases(cast<ModuleOp>(moduleOp)))) {
+    auto moduleOp = getOperation();
+    if (failed(mqt::normalizeGlobalPhases(moduleOp))) {
       signalPassFailure();
       return;
     }

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -13,12 +13,12 @@
 #include "mlir/Conversion/QCToQIR/QIRCommon/QIRCommon.h"
 #include "mlir/Dialect/CBit/IR/CBitDialect.h"
 #include "mlir/Dialect/CBit/IR/CBitOps.h"
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/MQT/Transforms/GlobalPhaseNormalization.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
-#include <llvm/Support/ErrorHandling.h>
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
 #include <mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h>
 #include <mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h>
@@ -380,11 +380,6 @@ struct QCToQIRBase final : impl::QCToQIRBaseBase<QCToQIRBase> {
    * @param main The main LLVM function to restructure
    */
   static void ensureBlocks(LLVM::LLVMFuncOp& main, LoweringState& state) {
-    if (main.getBlocks().size() > 1) {
-      llvm::reportFatalInternalError(
-          "Modules with multiple blocks are not supported in the Base Profile");
-    }
-
     // Get the existing block
     auto* bodyBlock = &main.front();
     OpBuilder builder(main.getBody());
@@ -462,6 +457,13 @@ protected:
   void runOnOperation() override {
     MLIRContext* ctx = &getContext();
     auto moduleOp = getOperation();
+    auto entryPoint = mqt::getEntryPoint(moduleOp);
+    if (entryPoint && !entryPoint.getBody().hasOneBlock()) {
+      entryPoint.emitError(
+          "QIR Base Profile requires a single-block entry function");
+      signalPassFailure();
+      return;
+    }
     if (failed(mqt::normalizeGlobalPhases(moduleOp))) {
       signalPassFailure();
       return;

--- a/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
+++ b/mlir/unittests/Conversion/JeffRoundTrip/test_jeff_round_trip.cpp
@@ -354,17 +354,65 @@ static Value nestedWhileOpIfOp(qco::QCOProgramBuilder& b) {
   return b.measure(res[0]).second;
 }
 
-static LogicalResult convertQCOToJeff(ModuleOp module) {
-  PassManager pm(module.getContext());
+static LogicalResult convertQCOToJeff(ModuleOp moduleOp) {
+  PassManager pm(moduleOp.getContext());
   pm.addPass(mlir::mqt::createUnrollModifiers());
   pm.addPass(createQCOToJeff());
-  return pm.run(module);
+  return pm.run(moduleOp);
 }
 
-static LogicalResult convertJeffToQCO(ModuleOp module) {
-  PassManager pm(module.getContext());
+static LogicalResult convertJeffToQCO(ModuleOp moduleOp) {
+  PassManager pm(moduleOp.getContext());
   pm.addPass(createJeffToQCO());
-  return pm.run(module);
+  return pm.run(moduleOp);
+}
+
+TEST(JeffRoundTripRegressionTest, RejectsInvalidJeffModuleMetadata) {
+  DialectRegistry registry;
+  registry.insert<mlir::mqt::MQTDialect, func::FuncDialect, jeff::JeffDialect,
+                  qco::QCODialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  OpBuilder builder(&context);
+
+  const auto rejects = [&](const ArrayRef<NamedAttribute> attributes,
+                           const StringRef expected) {
+    auto moduleOp = ModuleOp::create(builder.getUnknownLoc());
+    moduleOp->setAttrs(builder.getDictionaryAttr(attributes));
+    bool sawExpectedDiagnostic = false;
+    ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+      std::string message;
+      llvm::raw_string_ostream stream(message);
+      diagnostic.print(stream);
+      sawExpectedDiagnostic |= StringRef(message).contains(expected);
+      return success();
+    });
+    EXPECT_TRUE(failed(convertJeffToQCO(moduleOp)));
+    EXPECT_TRUE(sawExpectedDiagnostic);
+  };
+
+  const auto uint16Type = builder.getIntegerType(16, false);
+  const auto entryPoint = builder.getNamedAttr(
+      "jeff.entrypoint", builder.getIntegerAttr(uint16Type, 0));
+  const auto strings =
+      builder.getNamedAttr("jeff.strings", builder.getStrArrayAttr({"main"}));
+  rejects({}, "requires an unsigned integer 'jeff.entrypoint' attribute");
+  rejects(
+      {builder.getNamedAttr("jeff.entrypoint", builder.getStringAttr("main"))},
+      "requires an unsigned integer 'jeff.entrypoint' attribute");
+  rejects(
+      {builder.getNamedAttr("jeff.entrypoint", builder.getI16IntegerAttr(0))},
+      "requires an unsigned integer 'jeff.entrypoint' attribute");
+  rejects({entryPoint}, "requires an array 'jeff.strings' attribute");
+  rejects({builder.getNamedAttr("jeff.entrypoint",
+                                builder.getIntegerAttr(uint16Type, 1)),
+           strings},
+          "'jeff.entrypoint' index is out of bounds");
+  rejects(
+      {entryPoint, builder.getNamedAttr(
+                       "jeff.strings",
+                       builder.getArrayAttr({builder.getI32IntegerAttr(0)}))},
+      "'jeff.entrypoint' must index a string");
 }
 
 TEST(JeffRoundTripRegressionTest, RestoresStatusResultAtEndOfEntryPoint) {

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
@@ -84,11 +84,11 @@ protected:
 
 } // namespace
 
-static LogicalResult runQCToQIRBaseConversion(ModuleOp module) {
-  PassManager pm(module.getContext());
+static LogicalResult runQCToQIRBaseConversion(ModuleOp moduleOp) {
+  PassManager pm(moduleOp.getContext());
   pm.addPass(mlir::mqt::createUnrollModifiers());
   pm.addPass(createQCToQIRBase());
-  return pm.run(module);
+  return pm.run(moduleOp);
 }
 
 static void expectFollowingXIsUncontrolled(
@@ -124,6 +124,37 @@ TEST(QCToQIRBaseNativeTest, EmptyCtrlDoesNotControlFollowingGate) {
       [](qc::QCProgramBuilder& builder, Value control, Value target) {
         builder.ctrl(control, target, [](Value) {});
       });
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsMultiBlockEntryFunctionWithoutMutation) {
+  MLIRContext context;
+  context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
+                      LLVM::LLVMDialect>();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  auto entryPoint = moduleOp->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(entryPoint);
+  auto* extraBlock = &entryPoint.getBody().emplaceBlock();
+  builder.setInsertionPointToEnd(extraBlock);
+  auto status =
+      arith::ConstantIntOp::create(builder, builder.getUnknownLoc(), 0, 64);
+  func::ReturnOp::create(builder, builder.getUnknownLoc(), status.getResult());
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    std::string message;
+    llvm::raw_string_ostream stream(message);
+    diagnostic.print(stream);
+    sawExpectedDiagnostic |= StringRef(message).contains(
+        "QIR Base Profile requires a single-block entry function");
+    return success();
+  });
+  EXPECT_TRUE(failed(runQCToQIRBaseConversion(*moduleOp)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
+  EXPECT_EQ(entryPoint.getBlocks().size(), 2);
 }
 
 TEST(QCToQIRBaseNativeTest, ControlledBarrierDoesNotControlFollowingGate) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Make the module-wide MLIR conversion contract explicit and fail closed at two unsafe conversion boundaries.

- Anchor the CBit-to-MemRef, Jeff/QCO, QCO/QC, and QC/QIR passes on `mlir::ModuleOp`, then use the typed pass root directly.
- Validate Jeff entry-point metadata and report malformed attributes as pass diagnostics instead of terminating the process.
- Reject multi-block QIR Base entry functions before normalization can mutate unsupported input.
- Inline the now-infallible, one-call Jeff cleanup path found by the Ponytail re-audit.

No new dependencies or public API changes are introduced.

Codex materially assisted with implementation, review, validation, and this pull-request text.

Validation:

- `uvx nox -s lint`
- `uvx nox -s cpp-lint`
- `cmake --build --preset release -j2`
- `ctest --preset release --output-on-failure` (4,033 passed; one expected skip)

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes. (Not applicable: no user-facing contract changed.)
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals. (Not applicable: internal hardening only.)
- [x] I have added migration instructions to the upgrade guide (if needed). (Not needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.