### PR TITLE
🔧 Clean up CMake configuration

### DIFF
--- a/cmake/AddMQTPythonBinding.cmake
+++ b/cmake/AddMQTPythonBinding.cmake
@@ -48,21 +48,10 @@ function(add_mqt_python_binding package_name target_name)
   # Keep statically linked dependencies local.
   if(APPLE)
     target_link_options(${target_name} PRIVATE "LINKER:-exported_symbol,_PyInit_${module_name}")
-
-    # Apple's x86-64 ABI requires unique RTTI. Its arm64 ABI compares non-unique RTTI names.
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-      target_link_options(
-        ${target_name}
-        PRIVATE
-        "LINKER:-exported_symbol,__ZTIN8nanobind4abi112python_errorE"
-        "LINKER:-exported_symbol,__ZTSN8nanobind4abi112python_errorE"
-        "LINKER:-exported_symbol,__ZTIN8nanobind4abi117builtin_exceptionE"
-        "LINKER:-exported_symbol,__ZTSN8nanobind4abi117builtin_exceptionE")
-    endif()
   elseif(UNIX)
     target_link_options(${target_name} PRIVATE "LINKER:--exclude-libs,ALL")
 
-    # nanobind 3.0 omits section garbage collection from split-mode targets.
+    # nanobind 3.0 omits section garbage collection from split-mode targets
     target_link_options(
       ${target_name}
       PRIVATE

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -27,10 +27,10 @@ if(BUILD_MQT_CORE_MLIR)
     jeff-mlir
     GIT_REPOSITORY https://github.com/unitaryfoundation/jeff-mlir.git
     GIT_TAG 66c92d058cb498f5c12628f6a2d2a290480d700b)
-  # Cap'n Proto, which is fetched transitively by jeff-mlir, uses the generic BUILD_TESTING option
-  # and defines a global `check` target when it is enabled. Do not let an embedding project's test
-  # setting leak into this third-party dependency.
   function(_mqt_core_make_jeff_available)
+    # Cap'n Proto, which is fetched transitively by jeff-mlir, uses the generic BUILD_TESTING option
+    # and defines a global `check` target when it is enabled. Do not let an embedding project's test
+    # setting leak into this third-party dependency.
     set(BUILD_TESTING OFF)
     # jeff's transitive Cap'n Proto dependency contains source files that cannot share a unity
     # translation unit. Keep the complete dependency subtree out of unity builds.

--- a/scripts/qiskit_c_api_adopt.py
+++ b/scripts/qiskit_c_api_adopt.py
@@ -10,7 +10,7 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#   "nanobind~=3.0.0",
+#   "nanobind~=3.0.1",
 #   "packaging>=24",
 #   "pytest>=9.0.1",
 #   "pytest-xdist>=3.8.0",


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

This PR removes the obsolete x86 macOS RTTI exports from `AddMQTPythonBinding.cmake` now that MQT Core no longer supports x86 macOS systems. It also updates `qiskit_c_api_adopt.py` to use nanobind 3.0.1.

These changes complete already-documented maintenance work, so this PR adds no changelog or upgrade-guide entry.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
