### PR TITLE
🐛 Harden MLIR constant folding

### DIFF
--- a/mlir/include/mlir/Dialect/MQT/Utils/ConstantFolding.h
+++ b/mlir/include/mlir/Dialect/MQT/Utils/ConstantFolding.h
@@ -25,7 +25,7 @@ namespace mlir::mqt {
 [[nodiscard]] std::optional<double> valueToDouble(Value value);
 
 /**
- * Iteratively constant-fold a pure SSA expression DAG to an attribute.
+ * Recursively constant-fold a pure SSA expression DAG to an attribute.
  *
  * The cache memoizes successful and failed evaluations so shared operands are
  * resolved once.
@@ -37,10 +37,10 @@ namespace mlir::mqt {
 valueToConstantAttr(Value value,
                     DenseMap<Value, std::optional<Attribute>>& cache);
 
-/// Iteratively constant-fold a pure SSA expression DAG to an attribute.
+/// Recursively constant-fold a pure SSA expression DAG to an attribute.
 [[nodiscard]] std::optional<Attribute> valueToConstantAttr(Value value);
 
-/// Iteratively constant-fold a pure SSA expression DAG to a double.
+/// Recursively constant-fold a pure SSA expression DAG to a double.
 [[nodiscard]] std::optional<double> valueToConstantDouble(Value value);
 
 } // namespace mlir::mqt

--- a/mlir/include/mlir/Dialect/MQT/Utils/ConstantFolding.h
+++ b/mlir/include/mlir/Dialect/MQT/Utils/ConstantFolding.h
@@ -21,11 +21,11 @@ namespace mlir::mqt {
 /// Convert a floating-point or integer attribute to a double.
 [[nodiscard]] std::optional<double> attributeToDouble(Attribute attr);
 
-/// Convert a direct arithmetic constant to a double.
+/// Convert a direct constant-like value to a double.
 [[nodiscard]] std::optional<double> valueToDouble(Value value);
 
 /**
- * Recursively constant-fold a pure SSA expression DAG to an attribute.
+ * Iteratively constant-fold a pure SSA expression DAG to an attribute.
  *
  * The cache memoizes successful and failed evaluations so shared operands are
  * resolved once.
@@ -37,10 +37,10 @@ namespace mlir::mqt {
 valueToConstantAttr(Value value,
                     DenseMap<Value, std::optional<Attribute>>& cache);
 
-/// Recursively constant-fold a pure SSA expression DAG to an attribute.
+/// Iteratively constant-fold a pure SSA expression DAG to an attribute.
 [[nodiscard]] std::optional<Attribute> valueToConstantAttr(Value value);
 
-/// Recursively constant-fold a pure SSA expression DAG to a double.
+/// Iteratively constant-fold a pure SSA expression DAG to a double.
 [[nodiscard]] std::optional<double> valueToConstantDouble(Value value);
 
 } // namespace mlir::mqt

--- a/mlir/lib/Dialect/MQT/Utils/ConstantFolding.cpp
+++ b/mlir/lib/Dialect/MQT/Utils/ConstantFolding.cpp
@@ -10,7 +10,6 @@
 
 #include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
 
-#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -55,105 +54,39 @@ valueToConstantAttr(Value value,
     return it->second;
   }
 
-  struct Frame {
-    Value value;
-    Operation* operation;
-    unsigned nextOperand = 0;
-  };
-
-  SmallVector<Frame> worklist;
-  llvm::SmallDenseSet<Value> active;
-  const auto schedule = [&](Value candidate) {
-    if (cache.contains(candidate)) {
-      return;
-    }
-    Attribute attr;
-    if (matchPattern(candidate, m_Constant(&attr))) {
-      cache[candidate] = attr;
-      return;
-    }
-    Operation* operation = candidate.getDefiningOp();
-    if (operation == nullptr || operation->getNumRegions() != 0 ||
-        !isPure(operation)) {
-      cache[candidate] = std::nullopt;
-      return;
-    }
-    active.insert(candidate);
-    worklist.push_back({candidate, operation});
-  };
-
-  schedule(value);
-  while (!worklist.empty()) {
-    auto& frame = worklist.back();
-    bool scheduledOperand = false;
-    while (frame.nextOperand < frame.operation->getNumOperands()) {
-      Value operand = frame.operation->getOperand(frame.nextOperand++);
-      if (cache.contains(operand)) {
-        continue;
-      }
-      if (active.contains(operand)) {
-        cache[operand] = std::nullopt;
-        continue;
-      }
-      schedule(operand);
-      scheduledOperand = true;
-      break;
-    }
-    if (scheduledOperand) {
-      continue;
-    }
-
-    SmallVector<Attribute> operands;
-    operands.reserve(frame.operation->getNumOperands());
-    bool failedOperand = false;
-    for (Value operand : frame.operation->getOperands()) {
-      const auto it = cache.find(operand);
-      if (it == cache.end() || !it->second) {
-        failedOperand = true;
-        break;
-      }
-      operands.push_back(*it->second);
-    }
-    if (failedOperand) {
-      active.erase(frame.value);
-      cache[frame.value] = std::nullopt;
-      worklist.pop_back();
-      continue;
-    }
-
-    SmallVector<OpFoldResult, 1> results;
-    if (failed(frame.operation->fold(operands, results)) ||
-        results.size() != 1) {
-      active.erase(frame.value);
-      cache[frame.value] = std::nullopt;
-      worklist.pop_back();
-      continue;
-    }
-    if (auto resultAttr = dyn_cast_if_present<Attribute>(results.front())) {
-      active.erase(frame.value);
-      cache[frame.value] = resultAttr;
-      worklist.pop_back();
-      continue;
-    }
-
-    auto resultValue = dyn_cast_if_present<Value>(results.front());
-    if (!resultValue || resultValue == frame.value ||
-        active.contains(resultValue)) {
-      active.erase(frame.value);
-      cache[frame.value] = std::nullopt;
-      worklist.pop_back();
-      continue;
-    }
-    if (!cache.contains(resultValue)) {
-      schedule(resultValue);
-      continue;
-    }
-    active.erase(frame.value);
-    cache[frame.value] = cache.lookup(resultValue);
-    worklist.pop_back();
+  Attribute attr;
+  if (matchPattern(value, m_Constant(&attr))) {
+    return cache[value] = attr;
   }
 
-  return cache.lookup(value);
+  Operation* operation = value.getDefiningOp();
+  if (operation == nullptr || operation->getNumRegions() != 0 ||
+      !isPure(operation)) {
+    return cache[value] = std::nullopt;
+  }
+
+  SmallVector<Attribute> operands;
+  operands.reserve(operation->getNumOperands());
+  for (Value operand : operation->getOperands()) {
+    const auto folded = valueToConstantAttr(operand, cache);
+    if (!folded) {
+      return cache[value] = std::nullopt;
+    }
+    operands.push_back(*folded);
+  }
+
+  SmallVector<OpFoldResult, 1> results;
+  if (failed(operation->fold(operands, results)) || results.size() != 1) {
+    return cache[value] = std::nullopt;
+  }
+  std::optional<Attribute> folded;
+  if (auto resultAttr = dyn_cast_if_present<Attribute>(results.front())) {
+    folded = resultAttr;
+  } else if (auto resultValue = dyn_cast_if_present<Value>(results.front())) {
+    /* Identity-style folds can return an existing SSA value. */
+    folded = valueToConstantAttr(resultValue, cache);
+  }
+  return cache[value] = folded;
 }
 
 std::optional<Attribute> valueToConstantAttr(Value value) {

--- a/mlir/lib/Dialect/MQT/Utils/ConstantFolding.cpp
+++ b/mlir/lib/Dialect/MQT/Utils/ConstantFolding.cpp
@@ -10,8 +10,8 @@
 
 #include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
 
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/SmallVector.h>
-#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/Matchers.h>
@@ -41,11 +41,11 @@ std::optional<double> attributeToDouble(Attribute attr) {
 }
 
 std::optional<double> valueToDouble(Value value) {
-  auto constantOp = value.getDefiningOp<arith::ConstantOp>();
-  if (!constantOp) {
+  Attribute attr;
+  if (!matchPattern(value, m_Constant(&attr))) {
     return std::nullopt;
   }
-  return attributeToDouble(constantOp.getValue());
+  return attributeToDouble(attr);
 }
 
 std::optional<Attribute>
@@ -55,39 +55,105 @@ valueToConstantAttr(Value value,
     return it->second;
   }
 
-  Attribute attr;
-  if (matchPattern(value, m_Constant(&attr))) {
-    return cache[value] = attr;
-  }
+  struct Frame {
+    Value value;
+    Operation* operation;
+    unsigned nextOperand = 0;
+  };
 
-  Operation* operation = value.getDefiningOp();
-  if (operation == nullptr || operation->getNumRegions() != 0 ||
-      !isPure(operation)) {
-    return cache[value] = std::nullopt;
-  }
-
-  SmallVector<Attribute> operands;
-  operands.reserve(operation->getNumOperands());
-  for (Value operand : operation->getOperands()) {
-    const auto folded = valueToConstantAttr(operand, cache);
-    if (!folded) {
-      return cache[value] = std::nullopt;
+  SmallVector<Frame> worklist;
+  llvm::SmallDenseSet<Value> active;
+  const auto schedule = [&](Value candidate) {
+    if (cache.contains(candidate)) {
+      return;
     }
-    operands.push_back(*folded);
+    Attribute attr;
+    if (matchPattern(candidate, m_Constant(&attr))) {
+      cache[candidate] = attr;
+      return;
+    }
+    Operation* operation = candidate.getDefiningOp();
+    if (operation == nullptr || operation->getNumRegions() != 0 ||
+        !isPure(operation)) {
+      cache[candidate] = std::nullopt;
+      return;
+    }
+    active.insert(candidate);
+    worklist.push_back({candidate, operation});
+  };
+
+  schedule(value);
+  while (!worklist.empty()) {
+    auto& frame = worklist.back();
+    bool scheduledOperand = false;
+    while (frame.nextOperand < frame.operation->getNumOperands()) {
+      Value operand = frame.operation->getOperand(frame.nextOperand++);
+      if (cache.contains(operand)) {
+        continue;
+      }
+      if (active.contains(operand)) {
+        cache[operand] = std::nullopt;
+        continue;
+      }
+      schedule(operand);
+      scheduledOperand = true;
+      break;
+    }
+    if (scheduledOperand) {
+      continue;
+    }
+
+    SmallVector<Attribute> operands;
+    operands.reserve(frame.operation->getNumOperands());
+    bool failedOperand = false;
+    for (Value operand : frame.operation->getOperands()) {
+      const auto it = cache.find(operand);
+      if (it == cache.end() || !it->second) {
+        failedOperand = true;
+        break;
+      }
+      operands.push_back(*it->second);
+    }
+    if (failedOperand) {
+      active.erase(frame.value);
+      cache[frame.value] = std::nullopt;
+      worklist.pop_back();
+      continue;
+    }
+
+    SmallVector<OpFoldResult, 1> results;
+    if (failed(frame.operation->fold(operands, results)) ||
+        results.size() != 1) {
+      active.erase(frame.value);
+      cache[frame.value] = std::nullopt;
+      worklist.pop_back();
+      continue;
+    }
+    if (auto resultAttr = dyn_cast_if_present<Attribute>(results.front())) {
+      active.erase(frame.value);
+      cache[frame.value] = resultAttr;
+      worklist.pop_back();
+      continue;
+    }
+
+    auto resultValue = dyn_cast_if_present<Value>(results.front());
+    if (!resultValue || resultValue == frame.value ||
+        active.contains(resultValue)) {
+      active.erase(frame.value);
+      cache[frame.value] = std::nullopt;
+      worklist.pop_back();
+      continue;
+    }
+    if (!cache.contains(resultValue)) {
+      schedule(resultValue);
+      continue;
+    }
+    active.erase(frame.value);
+    cache[frame.value] = cache.lookup(resultValue);
+    worklist.pop_back();
   }
 
-  SmallVector<OpFoldResult, 1> results;
-  if (failed(operation->fold(operands, results)) || results.size() != 1) {
-    return cache[value] = std::nullopt;
-  }
-  std::optional<Attribute> folded;
-  if (auto resultAttr = dyn_cast_if_present<Attribute>(results.front())) {
-    folded = resultAttr;
-  } else if (auto resultValue = dyn_cast_if_present<Value>(results.front())) {
-    /* Identity-style folds can return an existing SSA value. */
-    folded = valueToConstantAttr(resultValue, cache);
-  }
-  return cache[value] = folded;
+  return cache.lookup(value);
 }
 
 std::optional<Attribute> valueToConstantAttr(Value value) {

--- a/mlir/unittests/Dialect/MQT/Utils/CMakeLists.txt
+++ b/mlir/unittests/Dialect/MQT/Utils/CMakeLists.txt
@@ -8,8 +8,9 @@
 
 set(mqt_utils_target mqt-core-mlir-unittests-mqt-utils)
 add_executable(${mqt_utils_target} test_constant_folding.cpp test_gate_powering.cpp)
-target_link_libraries(${mqt_utils_target} PRIVATE GTest::gtest_main MLIRArithDialect
-                                                  MLIRFuncDialect MLIRIR MLIRMQTUtils)
+target_link_libraries(
+  ${mqt_utils_target} PRIVATE GTest::gtest_main MLIRArithDialect MLIRFuncDialect MLIRIndexDialect
+                              MLIRIR MLIRMQTUtils)
 mqt_mlir_configure_unittest_target(${mqt_utils_target})
 
 gtest_discover_tests(${mqt_utils_target} PROPERTIES LABELS mqt-mlir-unittests DISCOVERY_TIMEOUT 60)

--- a/mlir/unittests/Dialect/MQT/Utils/test_constant_folding.cpp
+++ b/mlir/unittests/Dialect/MQT/Utils/test_constant_folding.cpp
@@ -13,6 +13,8 @@
 #include <gtest/gtest.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Index/IR/IndexDialect.h>
+#include <mlir/Dialect/Index/IR/IndexOps.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/BuiltinTypes.h>
@@ -39,7 +41,8 @@ protected:
   std::unique_ptr<ImplicitLocOpBuilder> builder;
 
   void SetUp() override {
-    context.loadDialect<arith::ArithDialect, func::FuncDialect>();
+    context.loadDialect<arith::ArithDialect, func::FuncDialect,
+                        index::IndexDialect>();
 
     auto loc = FileLineColLoc::get(&context, "<utils-test-builder>", 1, 1);
     module = ModuleOp::create(loc);
@@ -61,6 +64,13 @@ TEST_F(ConstantFoldingTest, valueToDouble) {
 
 TEST_F(ConstantFoldingTest, valueToDoubleCastFromInteger) {
   auto op = arith::ConstantOp::create(*builder, builder->getI32IntegerAttr(42));
+  const auto stdValue = mlir::mqt::valueToDouble(op.getResult());
+  ASSERT_TRUE(stdValue.has_value());
+  EXPECT_DOUBLE_EQ(*stdValue, 42.0);
+}
+
+TEST_F(ConstantFoldingTest, valueToDoubleConstantLike) {
+  auto op = index::ConstantOp::create(*builder, 42);
   const auto stdValue = mlir::mqt::valueToDouble(op.getResult());
   ASSERT_TRUE(stdValue.has_value());
   EXPECT_DOUBLE_EQ(*stdValue, 42.0);
@@ -250,4 +260,17 @@ TEST_F(ConstantFoldingTest, valueToConstantDoubleSharedOperandsFailure) {
     ASSERT_NE(it, cache.end());
     EXPECT_FALSE(it->second.has_value());
   }
+}
+
+TEST_F(ConstantFoldingTest, valueToConstantAttrHandlesDeepExpressions) {
+  constexpr int depth = 10000;
+  Value value = arith::ConstantIntOp::create(*builder, 1, 64);
+  Value zero = arith::ConstantIntOp::create(*builder, 0, 64);
+  for (int i = 0; i < depth; ++i) {
+    value = arith::AddIOp::create(*builder, value, zero);
+  }
+
+  const auto folded = mlir::mqt::valueToConstantAttr(value);
+  ASSERT_TRUE(folded);
+  EXPECT_EQ(cast<IntegerAttr>(*folded).getInt(), 1);
 }

--- a/mlir/unittests/Dialect/MQT/Utils/test_constant_folding.cpp
+++ b/mlir/unittests/Dialect/MQT/Utils/test_constant_folding.cpp
@@ -261,16 +261,3 @@ TEST_F(ConstantFoldingTest, valueToConstantDoubleSharedOperandsFailure) {
     EXPECT_FALSE(it->second.has_value());
   }
 }
-
-TEST_F(ConstantFoldingTest, valueToConstantAttrHandlesDeepExpressions) {
-  constexpr int depth = 10000;
-  Value value = arith::ConstantIntOp::create(*builder, 1, 64);
-  Value zero = arith::ConstantIntOp::create(*builder, 0, 64);
-  for (int i = 0; i < depth; ++i) {
-    value = arith::AddIOp::create(*builder, value, zero);
-  }
-
-  const auto folded = mlir::mqt::valueToConstantAttr(value);
-  ASSERT_TRUE(folded);
-  EXPECT_EQ(cast<IntegerAttr>(*folded).getInt(), 1);
-}


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Extends the shared MQT constant-folding helper found during the #2255 MLIR contract audit.

- keep the existing memoized recursive evaluation of pure SSA expression DAGs;
- recognize dialect-defined constant-like operations through MLIR's existing `m_Constant` matcher instead of accepting only `arith.constant`;
- add a focused `index.constant` regression.

Following review, this drops the speculative iterative worklist and synthetic 10,000-operation depth contract. The PR is now limited to the demonstrated constant-like folding gap.

This is one focused replacement for draft PR #2287. It addresses part of #2255 without closing the umbrella audit issue.

## Validation

- focused MQT utilities target build — passed
- `mqt-core-mlir-unittests-mqt-utils --gtest_brief=1` — 21/21 passed
- commit hooks, including `clang-format` — passed
- `git diff --check` — passed

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

**AI assistance disclosure:** Codex narrowed this focused change in response to review feedback, validated it, and updated this description.