### PR TITLE
🐛 Preserve static-qubit isolation during cleanup

### DIFF
--- a/mlir/lib/Dialect/QC/IR/QubitManagement/DeallocOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/QubitManagement/DeallocOp.cpp
@@ -53,7 +53,9 @@ struct HoistStaticQubit final : OpRewritePattern<StaticOp> {
   LogicalResult matchAndRewrite(StaticOp op,
                                 PatternRewriter& rewriter) const override {
     auto funcOp = op->getParentOfType<func::FuncOp>();
-    if (!funcOp || op->getBlock() == &funcOp.getBody().front()) {
+    if (!funcOp ||
+        op->getParentWithTrait<OpTrait::IsIsolatedFromAbove>() != funcOp ||
+        op->getBlock() == &funcOp.getBody().front()) {
       return failure();
     }
     rewriter.moveOpBefore(op, &funcOp.getBody().front(),

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -181,6 +181,30 @@ TEST_F(QCTest, CleanupHoistsAndCoalescesStaticQubits) {
   EXPECT_EQ(staticOps, 2U);
 }
 
+TEST_F(QCTest, CleanupDoesNotHoistStaticQubitsAcrossIsolationBoundaries) {
+  auto module = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @main() {
+        "builtin.module"() ({
+          %q = qc.static 0 : !qc.qubit
+          qc.x %q : !qc.qubit
+        }) : () -> ()
+        return
+      }
+    }
+  )mlir",
+                                            context.get());
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_TRUE(succeeded(runQCCleanupPipeline(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  StaticOp staticOp;
+  module->walk([&](StaticOp op) { staticOp = op; });
+  ASSERT_TRUE(staticOp);
+  EXPECT_TRUE(isa<ModuleOp>(staticOp->getParentOp()));
+}
+
 TEST_F(QCTest, BuilderRejectsMixedStaticAndDynamicQubitAllocationModes) {
   EXPECT_DEATH(
       {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Prevents the `HoistStaticQubit` cleanup pattern from moving `qc.static` across
an `IsolatedFromAbove` boundary.

A zero-operand static root nested inside an isolated operation previously could
be moved to the surrounding function entry block, leaving its nested users with
an invalid capture from above. The pattern now hoists only when the function is
the operation's nearest isolation scope.

This is one focused replacement for draft PR #2287 and addresses part of #2255.

## Validation

- `mqt-core-mlir-unittest-qc-ir --gtest_brief=1` — 339/339 passed
- `uvx nox -s lint` — passed
- `git diff --check origin/main...HEAD` — passed

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

**AI assistance disclosure:** Codex extracted this focused change from the
authorized #2255 audit, validated it, and drafted this description.
