### PR TITLE
🐛 Break the QCO-QTensor link cycle

### DIFF
--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -132,7 +132,6 @@ def ResetOp : QCOOp<"reset", [Idempotent, SameOperandsAndResultType, Pure]> {
   let assemblyFormat =
       "$qubit_in attr-dict `:` type($qubit_in) `->` type($qubit_out)";
   let hasFolder = 1;
-  let hasCanonicalizer = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
@@ -17,7 +17,6 @@
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVectorExtras.h>
-#include <mlir/Dialect/QTensor/IR/QTensorOps.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
@@ -35,8 +34,7 @@ LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
   const auto hasNonUnitaryOperation =
       body.walk([](Operation* operation) {
             return isa<cbit::AllocOp, cbit::LoadOp, cbit::StoreOp, AllocOp,
-                       SinkOp, StaticOp, MeasureOp, ResetOp, qtensor::ExtractOp,
-                       qtensor::InsertOp>(operation)
+                       SinkOp, StaticOp, MeasureOp, ResetOp>(operation)
                        ? WalkResult::interrupt()
                        : WalkResult::advance();
           })

--- a/mlir/lib/Dialect/QCO/IR/Operations/ResetOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/ResetOp.cpp
@@ -9,99 +9,11 @@
  */
 
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
-#include "mlir/Dialect/QTensor/IR/QTensorOps.h"
-#include "mlir/Dialect/QTensor/IR/QTensorUtils.h"
 
-#include <mlir/Dialect/Utils/StaticValueUtils.h>
-#include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
-#include <mlir/IR/PatternMatch.h>
-#include <mlir/IR/Value.h>
-#include <mlir/Support/LLVM.h>
 
 using namespace mlir;
 using namespace mlir::qco;
-
-/**
- * @brief Check if a `qtensor.extract` operation reads from a `qtensor.alloc`
- * chain.
- *
- * @details In QTensor's linear tensor model, reads/writes on different indices
- * commute. We can therefore skip over `qtensor.insert` on other indices while
- * tracing provenance. A write to the same index invalidates the proof.
- */
-static bool originatesFromQTensorAlloc(qtensor::ExtractOp extractOp) {
-  auto current = extractOp.getTensor();
-
-  auto extractIndex = extractOp.getIndex();
-  if (!getConstantIntValue(extractIndex)) {
-    return false;
-  }
-
-  while (auto* definingOp = current.getDefiningOp()) {
-    if (isa<qtensor::AllocOp>(definingOp)) {
-      return true;
-    }
-
-    if (auto nestedExtractOp = dyn_cast<qtensor::ExtractOp>(definingOp)) {
-      auto nestedExtractIndex = nestedExtractOp.getIndex();
-      if (!getConstantIntValue(nestedExtractIndex)) {
-        return false;
-      }
-      if (qtensor::areEquivalentIndices(extractIndex, nestedExtractIndex)) {
-        return false;
-      }
-      current = nestedExtractOp.getTensor();
-      continue;
-    }
-
-    if (auto insertOp = dyn_cast<qtensor::InsertOp>(definingOp)) {
-      auto insertIndex = insertOp.getIndex();
-      if (!getConstantIntValue(insertIndex)) {
-        return false;
-      }
-      if (qtensor::areEquivalentIndices(extractIndex, insertIndex)) {
-        return false;
-      }
-      current = insertOp.getDest();
-      continue;
-    }
-
-    return false;
-  }
-
-  return false;
-}
-
-namespace {
-
-/**
- * @brief Remove reset operations that immediately follow a `qtensor.extract`
- * operation.
- */
-struct RemoveResetAfterExtract final : OpRewritePattern<ResetOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ResetOp op,
-                                PatternRewriter& rewriter) const override {
-    // Check if the predecessor is an ExtractOp
-    auto extractOp = op.getQubitIn().getDefiningOp<qtensor::ExtractOp>();
-    if (!extractOp) {
-      return failure();
-    }
-
-    // Check if the tensor originates from an AllocOp
-    if (!originatesFromQTensorAlloc(extractOp)) {
-      return failure();
-    }
-
-    // Remove the ResetOp
-    rewriter.replaceOp(op, op.getQubitIn());
-    return success();
-  }
-};
-
-} // namespace
 
 OpFoldResult ResetOp::fold(FoldAdaptor /*adaptor*/) {
   if (getQubitIn().getDefiningOp<AllocOp>()) {
@@ -109,9 +21,4 @@ OpFoldResult ResetOp::fold(FoldAdaptor /*adaptor*/) {
   }
 
   return {};
-}
-
-void ResetOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                          MLIRContext* context) {
-  results.add<RemoveResetAfterExtract>(context);
 }

--- a/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
@@ -9,7 +9,9 @@
  */
 
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
+#include "mlir/Dialect/QTensor/IR/QTensorUtils.h"
 
+#include <mlir/Dialect/QCO/IR/QCOOps.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/OpDefinition.h>
@@ -19,7 +21,60 @@
 using namespace mlir;
 using namespace mlir::qtensor;
 
+/// Check whether an extract reads from a tensor allocated in this IR.
+static bool originatesFromAlloc(ExtractOp extract) {
+  auto current = extract.getTensor();
+  const auto extractIndex = extract.getIndex();
+  if (!getConstantIntValue(extractIndex)) {
+    return false;
+  }
+
+  while (auto* definingOp = current.getDefiningOp()) {
+    if (isa<AllocOp>(definingOp)) {
+      return true;
+    }
+
+    if (auto nestedExtract = dyn_cast<ExtractOp>(definingOp)) {
+      if (!getConstantIntValue(nestedExtract.getIndex()) ||
+          areEquivalentIndices(extractIndex, nestedExtract.getIndex())) {
+        return false;
+      }
+      current = nestedExtract.getTensor();
+      continue;
+    }
+
+    if (auto insert = dyn_cast<InsertOp>(definingOp)) {
+      if (!getConstantIntValue(insert.getIndex()) ||
+          areEquivalentIndices(extractIndex, insert.getIndex())) {
+        return false;
+      }
+      current = insert.getDest();
+      continue;
+    }
+
+    return false;
+  }
+
+  return false;
+}
+
 namespace {
+/// Remove a reset after extracting a freshly allocated qubit.
+struct RemoveResetAfterExtract final : OpRewritePattern<qco::ResetOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(qco::ResetOp reset,
+                                PatternRewriter& rewriter) const override {
+    const auto extract = reset.getQubitIn().getDefiningOp<ExtractOp>();
+    if (extract == nullptr || !originatesFromAlloc(extract)) {
+      return failure();
+    }
+
+    rewriter.replaceOp(reset, reset.getQubitIn());
+    return success();
+  }
+};
+
 /**
  * @brief Fold an insert followed immediately by an extract at the same index.
  */
@@ -43,6 +98,12 @@ struct FoldExtractAfterInsertPattern final : OpRewritePattern<ExtractOp> {
 } // namespace
 
 LogicalResult ExtractOp::verify() {
+  if (getOperation()->getParentOfType<qco::CtrlOp>() ||
+      getOperation()->getParentOfType<qco::InvOp>() ||
+      getOperation()->getParentOfType<qco::PowOp>()) {
+    return emitOpError("cannot access a qubit tensor inside a QCO modifier");
+  }
+
   auto tensorDim = getTensor().getType().getDimSize(0);
   auto index = getConstantIntValue(getIndex());
 
@@ -59,5 +120,5 @@ LogicalResult ExtractOp::verify() {
 
 void ExtractOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                             MLIRContext* context) {
-  results.add<FoldExtractAfterInsertPattern>(context);
+  results.add<FoldExtractAfterInsertPattern, RemoveResetAfterExtract>(context);
 }

--- a/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 
+#include <mlir/Dialect/QCO/IR/QCOOps.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/MLIRContext.h>
@@ -92,6 +93,12 @@ struct CommuteAdjacentInsertExtractPattern final : OpRewritePattern<InsertOp> {
 } // namespace
 
 LogicalResult InsertOp::verify() {
+  if (getOperation()->getParentOfType<qco::CtrlOp>() ||
+      getOperation()->getParentOfType<qco::InvOp>() ||
+      getOperation()->getParentOfType<qco::PowOp>()) {
+    return emitOpError("cannot access a qubit tensor inside a QCO modifier");
+  }
+
   auto dstDim = getDest().getType().getDimSize(0);
   auto index = getConstantIntValue(getIndex());
 

--- a/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
+++ b/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
@@ -273,6 +273,35 @@ TEST_F(QTensorTest, InsertOpIndexAtDimFailsVerification) {
   EXPECT_TRUE(verify(*module).failed());
 }
 
+TEST_F(QTensorTest, NestedRegisterAccessInsideModifierFailsVerification) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  const auto tensor = builder.qtensorAlloc(1);
+  const auto target = builder.allocQubit();
+  const auto condition = builder.boolConstant(true);
+  auto index = arith::ConstantIndexOp::create(builder, 0);
+  Operation* extractOperation = nullptr;
+  Operation* insertOperation = nullptr;
+
+  qco::InvOp::create(builder, target, [&](Value argument) {
+    return qco::IfOp::create(builder, condition, argument,
+                             [&](Value nestedArgument) {
+                               auto extract = ExtractOp::create(
+                                   builder, tensor, index.getResult());
+                               auto insert = InsertOp::create(
+                                   builder, extract.getResult(),
+                                   extract.getOutTensor(), index.getResult());
+                               extractOperation = extract;
+                               insertOperation = insert;
+                               return nestedArgument;
+                             })
+        .getResult(0);
+  });
+
+  EXPECT_TRUE(verify(extractOperation).failed());
+  EXPECT_TRUE(verify(insertOperation).failed());
+}
+
 } // namespace
 
 // ============================================================================


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Break the implementation-level dependency from MLIRQCODialect to MLIRQTensorDialect. QTensor already depends on QCO, so the QTensor-specific modifier validation and reset-after-extract canonicalization now live with the QTensor operations that own those semantics.

This removes the static-library cycle that required downstream consumers such as FullStaQD/qcc#134 to wrap the QCO and QTensor archives in a linker rescan group. The qcc PR head builds and runs without that workaround when configured against this branch.

No public API, documentation, changelog, or migration change is needed.

AI assistance: OpenAI Codex traced the static-library dependency, moved the dialect-owned behavior, added the regression test, and ran the validations below.

Validation:

- uvx nox -s lint
- uvx nox -s cpp-lint
- cmake --preset release
- cmake --build --preset release
- ctest --preset release (4,055 tests passed; one test skipped by its existing configuration)
- qcc PR FullStaQD/qcc#134 qcc target with the rescan workaround removed

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.