### PR TITLE
🐛 Preserve attributes on reused QIR declarations

### DIFF
--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -282,15 +282,26 @@ LLVM::LLVMFuncOp getOrCreateFunctionDeclaration(OpBuilder& builder,
     builder.setInsertionPointToEnd(moduleOp.getBody());
 
     fnDecl = LLVM::LLVMFuncOp::create(builder, op->getLoc(), fnName, fnType);
-
-    // Add irreversible attribute to irreversible quantum operations
-    if (fnName == QIR_MEASURE || fnName == QIR_RESET) {
-      fnDecl->setAttr("passthrough",
-                      builder.getStrArrayAttr({::qir::IRREVERSIBLE_ATTR}));
-    }
   }
 
-  return cast<LLVM::LLVMFuncOp>(fnDecl);
+  auto function = cast<LLVM::LLVMFuncOp>(fnDecl);
+  if (fnName != QIR_MEASURE && fnName != QIR_RESET) {
+    return function;
+  }
+
+  const auto irreversible = builder.getStringAttr(::qir::IRREVERSIBLE_ATTR);
+  const auto passthrough = function->getAttrOfType<ArrayAttr>("passthrough");
+  if (passthrough && llvm::is_contained(passthrough, irreversible)) {
+    return function;
+  }
+
+  SmallVector<Attribute> entries;
+  if (passthrough) {
+    entries.append(passthrough.begin(), passthrough.end());
+  }
+  entries.push_back(irreversible);
+  function->setAttr("passthrough", builder.getArrayAttr(entries));
+  return function;
 }
 
 LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -180,6 +180,42 @@ TEST_F(QIRTest, BuilderReturnsCompleteClassicalRegister) {
   EXPECT_FALSE(returnedRegister.array);
 }
 
+TEST_F(QIRTest, ReusedIrreversibleDeclarationsPreservePassthroughIdempotently) {
+  OpBuilder builder(context.get());
+  const auto location = builder.getUnknownLoc();
+  auto moduleOp = ModuleOp::create(location);
+  builder.setInsertionPointToStart(moduleOp.getBody());
+  const auto ptrType = LLVM::LLVMPointerType::get(context.get());
+  const auto voidType = LLVM::LLVMVoidType::get(context.get());
+  const auto nounwind = builder.getStringAttr("nounwind");
+  const auto targetCPU = builder.getStrArrayAttr({"target-cpu", "generic"});
+
+  for (const StringRef name : {StringRef(QIR_MEASURE), StringRef(QIR_RESET)}) {
+    const SmallVector<Type> parameters(name == QIR_MEASURE ? 2 : 1, ptrType);
+    const auto functionType = LLVM::LLVMFunctionType::get(voidType, parameters);
+    auto declaration =
+        LLVM::LLVMFuncOp::create(builder, location, name, functionType);
+    declaration->setAttr("passthrough",
+                         builder.getArrayAttr({nounwind, targetCPU}));
+
+    EXPECT_EQ(
+        getOrCreateFunctionDeclaration(builder, moduleOp, name, functionType),
+        declaration);
+    EXPECT_EQ(
+        getOrCreateFunctionDeclaration(builder, moduleOp, name, functionType),
+        declaration);
+
+    const auto passthrough =
+        declaration->getAttrOfType<ArrayAttr>("passthrough");
+    ASSERT_TRUE(passthrough);
+    ASSERT_EQ(passthrough.size(), 3U);
+    EXPECT_EQ(passthrough[0], nounwind);
+    EXPECT_EQ(passthrough[1], targetCPU);
+    EXPECT_EQ(llvm::count(passthrough, builder.getStringAttr("irreversible")),
+              1);
+  }
+}
+
 TEST_F(QIRTest, AdaptiveBuilderSelectsControlledSpecializationsByArity) {
   auto module = QIRProgramBuilder::build(
       context.get(),


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Preserves QIR runtime declaration attributes when an existing declaration is
reused.

`getOrCreateFunctionDeclaration` previously replaced the complete
`passthrough` array when adding the `irreversible` marker. The helper now merges
that marker into the existing array, preserves unrelated attributes, and avoids
duplicates across repeated calls.

This is one focused replacement for draft PR #2287 and addresses part of #2255.

## Validation

- focused passthrough regression — passed
- full QIR IR suite — 117/117 passed
- `uvx nox -s lint` — passed
- `git diff --check` — passed

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

**AI assistance disclosure:** Codex extracted this focused change from the
authorized #2255 audit, validated it, and drafted this description.
