### PR TITLE
✨ Add quantum multiplexer benchmark

### DIFF
--- a/.agent/plans/multiplexer-benchmark.md
+++ b/.agent/plans/multiplexer-benchmark.md
@@ -1,0 +1,233 @@
+# Add a typed quantum multiplexer benchmark
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+MQT Core users can generate typed structured benchmarks, but the library does
+not yet include a quantum multiplexer. This change adds one `multiplexer` family
+to the C++, Python, JSON, command-line, and MLIR interfaces. A user selects the
+total qubit count. MQT Core then supplies the fixed angle schedule, analytic
+reference, manifest, and compact structured QC program.
+
+The command-line tool demonstrates the result. Given
+`{"benchmark":"multiplexer","parameters":{"qubits":7},"schema_version":1}`, the
+tool generates a QC or `jeff` program. The program loops over the 64 control
+states without expanding them into 64 copies in the host process.
+
+## Progress
+
+- [x] (2026-09-01) Added the typed C++ family, strict JSON forms, manifest,
+      analytic reference, and semantic tests.
+- [x] (2026-09-01) Added compact structured QC generation, `jeff` lowering,
+      command-line registration, and MLIR tests.
+- [x] (2026-09-01) Added the Python family binding and its focused behavior
+      tests.
+- [x] (2026-09-01) Added the public glossary terms and folded this change into
+      the existing structured-benchmark changelog entry.
+- [x] (2026-09-01) Validated the final implementation on the cleanup base. The
+      41 C++ benchmark tests, 12 MLIR generation tests, MLIR CLI test, 21
+      focused Python tests, stub session, generated MLIR documentation, and
+      complete documentation build passed.
+- [x] (2026-09-01) Completed the full repository lint and final diff checks.
+
+## Surprises & Discoveries
+
+- Observation: The benchmark program is compact even though its runtime state
+  loop grows exponentially. Evidence: the 31-qubit generation test bounds the
+  host-side MLIR operation count and lowers the result to `jeff`.
+- Observation: The zero input and fixed angle schedule produce the all-zero
+  outcome with probability one. This reference alone cannot detect most wiring
+  errors. Execution coverage must wait for a runtime that can execute the
+  generated `jeff` program.
+- Observation: A fresh worktree must generate the MLIR reference pages before
+  the complete documentation build. Evidence: the first documentation build
+  reported missing `docs/mlir/Dialects`, `docs/mlir/Conversions`, and
+  `docs/mlir/Passes` files; the `mlir-doc` target generated those files and the
+  next build passed.
+
+## Decision Log
+
+- Decision: Expose only the total qubit count and use angle theta(s) =
+  s*pi/2^(qubits - 1). Rationale: this is the schedule used by the existing
+  size-based benchmark and gives each control state one selected Y rotation
+  without adding an arbitrary angle payload. Date/Author: 2026-09-01 / Daniel
+  Haag.
+- Decision: Support 2 through 31 total qubits. Rationale: one qubit is the
+  target, at least one qubit is a control, and the largest state-loop bound is
+  2^30, which fits the signed 32-bit integer representation used by current
+  `jeff` lowering. Date/Author: 2026-09-01 / Daniel Haag.
+- Decision: Store the target measurement at result index zero and control i at
+  index i + 1. Rationale: this preserves the benchmark outcome order in one
+  logical result register. Date/Author: 2026-09-01 / Daniel Haag.
+- Decision: Add one benchmark-family catalog row and keep the parameter parser,
+  schema, emitter, binding, and tests explicit. Rationale: the catalog supplies
+  mechanical JSON and MLIR registration while the family-specific behavior
+  remains readable. Date/Author: 2026-09-01 / Daniel Haag.
+
+## Outcomes & Retrospective
+
+The implementation adds one typed `multiplexer` family across the existing
+benchmark layers. The family uses the same catalog, serialization, binding, and
+generation extension points as the other families. Focused semantic, generation,
+command-line, Python, stub, and documentation validation passes on the cleanup
+base. The full repository lint and final diff checks also pass.
+
+## Context and Orientation
+
+The installed benchmark library lives in `include/mqt-core/bench/` and
+`src/bench/`. Each family owns typed options, validates them, describes one
+logical `Output`, and evaluates sampled counts against an analytic reference.
+`include/mqt-core/bench/BenchmarkFamilies.inc` contains the shared family
+metadata. `src/bench/JSON.cpp` contains the family-specific schemas, manifests,
+and generic evaluation.
+
+Structured generators live in `mlir/bench/programs/`. They use
+`qc::QCProgramBuilder` to construct QC dialect operations. The catalog-generated
+registry in `mlir/bench/Generate.cpp` parses an instance specification and calls
+the typed generator. The normal compiler pipeline can then lower the QC program
+to other supported forms.
+
+Python bindings live in `bindings/bench/`. `register_bench.cpp` creates a direct
+submodule for each family. A family-specific source file in the `mqt` namespace
+registers its types and functions. Files below `python/mqt/core/bench/` are
+generated stubs and must be regenerated with the repository's stub session.
+
+A quantum multiplexer has k control qubits and one target qubit. Each of the 2^k
+control basis states selects one one-qubit operation on the target. This
+benchmark selects evenly spaced Y rotations. The generator uses one outer loop
+over control states. Before each rotation, an inner loop applies X to controls
+whose selected state bit is zero. This turns the selected pattern into the
+all-ones pattern required by one multi-controlled rotation. A second inner loop
+restores the controls.
+
+## Plan of Work
+
+Define `MultiplexerOptions` and `Multiplexer` in
+`include/mqt-core/bench/Multiplexer.hpp` and `src/bench/Multiplexer.cpp`.
+Validate 2 through 31 total qubits. Use one `result` output whose width equals
+the total qubit count. The analytic reference assigns probability one to the
+all-zero outcome and zero to every other valid outcome.
+
+Add the stable ID `multiplexer` and definition version 1 to
+`include/mqt-core/bench/BenchmarkFamilies.inc`. Extend
+`include/mqt-core/bench/JSON.hpp` and `src/bench/JSON.cpp` with the required
+integer `qubits` parameter, canonical instance specifications, manifests, case
+IDs, and generic evaluation. Keep catalog rows in lexical order. Cover the
+contract in `test/bench/test_multiplexer.cpp` and `test/bench/test_json.cpp`.
+
+Implement generation in `mlir/bench/programs/Multiplexer.cpp`. Allocate the
+controls, target, and result register. Emit an angle-carrying outer `scf.for`
+from zero to 2^(qubits - 1). Emit two inner loops that test each bit of the
+current control state and conditionally apply X. Place one multi-controlled Y
+rotation between those loops. Increment the angle by pi/2^(qubits - 1). Measure
+the target at result index zero and each control at the next index.
+
+Register the generator in `mlir/bench/programs/Programs.h`,
+`mlir/bench/programs/CMakeLists.txt`, and `mlir/include/mlir/bench/Generate.h`.
+The catalog row supplies the implementation wrapper and dispatch entry. Extend
+the MLIR unit and command-line tests. The tests must cover representative
+structure, maximum-size compactness, and successful `jeff` lowering.
+
+Register `mqt.core.bench.multiplexer` through
+`bindings/bench/register_multiplexer.cpp` and
+`bindings/bench/register_bench.cpp`. Add the family behavior test, regenerate
+stubs, and add the family to the command-line test.
+
+Define quantum multiplexer and uniformly controlled one-qubit gate in
+`docs/glossary.md`. Add pull request 2299 to the existing unreleased
+structured-benchmark entry in `CHANGELOG.md`; do not add a second entry for an
+extension to an unreleased feature.
+
+## Milestones
+
+The semantic milestone supplies the validated C++ family, exact analytic
+reference, JSON schema, manifest, and case identity. The focused benchmark test
+must accept the boundary sizes, reject invalid sizes and outcomes, and
+round-trip a seven-qubit instance and manifest.
+
+The generation milestone supplies compact QC generation and `jeff` lowering. The
+MLIR tests must generate the family as valid QC and `jeff`, omit redundant
+resets, and keep the 31-qubit operation count bounded.
+
+The public-interface milestone supplies the Python submodule, generated stubs,
+command-line registration, glossary terms, changelog update, and focused family
+behavior test.
+
+## Concrete Steps
+
+Run commands from the repository root. Configure and build the release preset,
+then run the focused native and MLIR tests:
+
+    cmake --preset release
+    cmake --build --preset release --target mqt-core-bench-test \
+        mqt-core-mlir-unittests-benchmark mqt-core-bench
+    ./build/release/test/bench/mqt-core-bench-test
+    ./build/release/mlir/unittests/bench/mqt-core-mlir-unittests-benchmark
+    ctest --test-dir build/release -R '^mqt-core-mlir-benchmark-cli$' \
+        --output-on-failure
+
+Install the changed binding without build isolation, regenerate stubs, and run
+the focused Python tests:
+
+    uv sync --inexact --no-dev --no-build-isolation-package mqt-core
+    uvx nox -s stubs
+    uv run --no-sync pytest test/python/test_bench.py test/python/test_cli.py
+
+Build the documentation and run the repository checks:
+
+    uvx nox --non-interactive -s docs
+    uvx nox -s lint
+    git diff --check
+    git status --short
+
+## Validation and Acceptance
+
+The C++ tests must accept qubit counts 2 and 31, reject 1 and 32, validate
+outcome widths and characters, and calculate exact evaluation metrics. The JSON
+tests must prove canonical serialization, schema bounds, registry order,
+manifest integrity, stable case identity, and generic evaluation.
+
+The MLIR tests must generate every benchmark as QC and `jeff`. For the
+multiplexer, they must verify the maximum state-loop bound, lack of redundant
+resets, compact maximum-size generation, and `jeff` lowering.
+
+Python must expose `mqt.core.bench.multiplexer.Options` and
+`mqt.core.bench.multiplexer.Multiplexer` only in the family submodule. The new
+family must round-trip its JSON forms, evaluate counts, and generate a QC
+program. The command-line tool must list six families and accept a multiplexer
+instance.
+
+The complete documentation build, full lint session, and `git diff --check` must
+pass. Any environment or infrastructure failure must be recorded with its exact
+command and output instead of being presented as a product failure.
+
+## Idempotence and Recovery
+
+The build, test, stub, documentation, and lint commands are repeatable. Build
+output remains below `build/`. Stub generation is deterministic; never edit a
+generated `.pyi` file by hand. If a generated stub differs unexpectedly, inspect
+the native binding and rerun the stub session.
+
+This task uses a dedicated worktree. Do not reset, clean, delete, or overwrite
+another worktree. Preserve unrelated changes and stop if they overlap this
+scope.
+
+## Interfaces and Dependencies
+
+The installed C++ interface adds `MultiplexerOptions` and `Multiplexer` under
+`mqt::bench`, plus matching serialization, manifest, case-ID, and generation
+overloads. The Python interface adds the direct `mqt.core.bench.multiplexer`
+submodule with `Options` and `Multiplexer`.
+
+Use only the dependencies already used by the benchmark library: MQT Core, LLVM,
+MLIR, nanobind, nlohmann JSON, and GoogleTest. Add no dependency.
+
+Revision note (2026-09-01): Rebased the plan on the benchmark-registration
+cleanup, removed stale namespace-contract work, and recorded the catalog-based
+extension points and current validation.

--- a/.agent/plans/multiplexer-benchmark.md
+++ b/.agent/plans/multiplexer-benchmark.md
@@ -1,4 +1,4 @@
-# Add a typed quantum multiplexer benchmark
+# Add a scalable, validated quantum multiplexer benchmark
 
 This ExecPlan is a living document. The sections `Progress`,
 `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
@@ -9,158 +9,150 @@ repository root.
 
 ## Purpose / Big Picture
 
-MQT Core users can generate typed structured benchmarks, but the library does
-not yet include a quantum multiplexer. This change adds one `multiplexer` family
-to the C++, Python, JSON, command-line, and MLIR interfaces. A user selects the
-total qubit count. MQT Core then supplies the fixed angle schedule, analytic
-reference, manifest, and compact structured QC program.
+MQT Core users can generate a typed quantum multiplexer benchmark whose output
+is nontrivial and independently checkable. The program prepares every control
+state with equal probability and rotates one target qubit by an angle selected
+from the control value. The analytic reference predicts the complete sampled
+distribution, so an execution test detects incorrect controls, angles, target
+placement, and result-bit order.
 
-The command-line tool demonstrates the result. Given
-`{"benchmark":"multiplexer","parameters":{"qubits":7},"schema_version":1}`, the
-tool generates a QC or `jeff` program. The program loops over the 64 control
-states without expanding them into 64 copies in the host process.
+The fixed angle schedule has an exact linear implementation. A benchmark with
+`k` controls executes `k` Hadamard gates and `k` singly controlled Y rotations
+instead of iterating over all `2^k` control states. The generated QC program
+keeps those operations in structured loops and remains compact at the supported
+maximum of 1024 total qubits.
 
 ## Progress
 
-- [x] (2026-09-01) Added the typed C++ family, strict JSON forms, manifest,
-      analytic reference, and semantic tests.
-- [x] (2026-09-01) Added compact structured QC generation, `jeff` lowering,
-      command-line registration, and MLIR tests.
-- [x] (2026-09-01) Added the Python family binding and its focused behavior
-      tests.
-- [x] (2026-09-01) Folded this change into the existing structured-benchmark
-      changelog entry.
-- [x] (2026-09-01) Validated the final implementation on the cleanup base. The
-      41 C++ benchmark tests, 12 MLIR generation tests, MLIR CLI test, 21
-      focused Python tests, stub session, generated MLIR documentation, and
-      complete documentation build passed.
-- [x] (2026-09-01) Completed the full repository lint and final diff checks.
+- [x] (2026-09-01) Added the typed C++ family, strict JSON forms, manifest, MLIR
+      generator, Python binding, command-line registration, and initial tests.
+- [x] (2026-09-02 14:20Z) Replaced the trivial reference with the analytic
+      uniform-control distribution and raised the maximum to 1024 qubits.
+- [x] (2026-09-02 14:20Z) Replaced the exponential selector with an exact
+      structured linear circuit.
+- [x] (2026-09-02 14:20Z) Added focused native distribution tests, generator
+      structure checks, and a maximum-size Jeff byte round-trip.
+- [x] (2026-09-02 14:20Z) Added and passed the Python QC-to-QCO DD sampling test
+      with 16,384 shots and a fixed seed.
+- [x] (2026-09-02 14:40Z) Passed the complete focused suites, full release build
+      and CTest suite, generated-stub check, documentation build, C++ lint, and
+      full lint; completed the final diff inspection.
 
 ## Surprises & Discoveries
 
-- Observation: The benchmark program is compact even though its runtime state
-  loop grows exponentially. Evidence: the 31-qubit generation test bounds the
-  host-side MLIR operation count and lowers the result to `jeff`.
-- Observation: The zero input and fixed angle schedule produce the all-zero
-  outcome with probability one. This reference alone cannot detect most wiring
-  errors. Execution coverage must wait for a runtime that can execute the
-  generated `jeff` program.
-- Observation: A fresh worktree must generate the MLIR reference pages before
-  the complete documentation build. Evidence: the first documentation build
-  reported missing `docs/mlir/Dialects`, `docs/mlir/Conversions`, and
-  `docs/mlir/Passes` files; the `mlir-doc` target generated those files and the
-  next build passed.
+- Observation: The fixed schedule is not a general arbitrary-angle multiplexer.
+  For control bits `b_i`, its angle is
+  `pi * s / 2^k = sum_i b_i * pi / 2^(k-i)`. Controlled Y rotations around the
+  same axis add, so one singly controlled rotation per bit implements the exact
+  same unitary.
+- Observation: Uniform control preparation turns the former all-zero output into
+  a distribution that tests every control state in one execution.
+- Observation: The 1024-qubit program lowers to Jeff, serializes to bytes, and
+  deserializes as valid Jeff in the focused MLIR test.
+- Observation: The three-qubit program passes the public Python generation, QCO
+  lowering, DD sampling, and analytic evaluation path with total variation
+  distance below 0.03.
+- Observation: Running `stubs` before `docs` left the shared MinSizeRel Python
+  build tree configured with `BUILD_MQT_CORE_DOCUMENTATION=OFF`. The first docs
+  attempt therefore reported 25 missing generated MLIR reference files. An
+  explicit `mqt-core` reinstall with the docs session's CMake arguments
+  regenerated those files, after which the unmodified docs command passed.
 
 ## Decision Log
 
-- Decision: Expose only the total qubit count and use angle theta(s) =
-  s*pi/2^(qubits - 1). Rationale: this is the schedule used by the existing
-  size-based benchmark and gives each control state one selected Y rotation
-  without adding an arbitrary angle payload. Date/Author: 2026-09-01 / Daniel
+- Decision: Keep the fixed schedule `theta(s) = s*pi/2^k`, where `k` is the
+  control count. Rationale: it retains the existing one-parameter family and
+  permits an exact linear circuit without an exponential angle payload.
+  Date/Author: 2026-09-02 / Daniel Haag.
+- Decision: Apply Hadamard gates to all controls and leave the target in `|0>`.
+  Rationale: the resulting distribution exercises the multiplexer semantics
+  instead of selecting only state zero. Date/Author: 2026-09-02 / Daniel Haag.
+- Decision: Traverse controls from most to least significant, start the
+  controlled Y angle at `pi/2`, and halve it after each iteration. Rationale:
+  this directly implements the binary weights without an integer state count or
+  a `2^k` loop. Date/Author: 2026-09-02 / Daniel Haag.
+- Decision: Support 2 through 1024 total qubits. Rationale: 1024 is a clear
+  power-of-two catalogue ceiling; at 1023 controls both the uniform control
+  weight and the smallest scheduled angle remain nonzero as binary64 values, and
+  the maximum program round-trips through Jeff. Date/Author: 2026-09-02 / Daniel
   Haag.
-- Decision: Support 2 through 31 total qubits. Rationale: one qubit is the
-  target, at least one qubit is a control, and the largest state-loop bound is
-  2^30, which fits the signed 32-bit integer representation used by current
-  `jeff` lowering. Date/Author: 2026-09-01 / Daniel Haag.
-- Decision: Store the target measurement at result index zero and control i at
-  index i + 1. Rationale: this preserves the benchmark outcome order in one
-  logical result register. Date/Author: 2026-09-01 / Daniel Haag.
-- Decision: Add one benchmark-family catalog row and keep the parameter parser,
-  schema, emitter, binding, and tests explicit. Rationale: the catalog supplies
-  mechanical JSON and MLIR registration while the family-specific behavior
-  remains readable. Date/Author: 2026-09-01 / Daniel Haag.
+- Decision: Store the target measurement at result index zero and control `i` at
+  index `i + 1`. Rationale: the displayed big-endian result is `c[k-1]...c[0]t`,
+  which permits direct binary interpretation of its control prefix. Date/Author:
+  2026-09-02 / Daniel Haag.
+- Decision: Keep family ID `multiplexer`, definition version 1, and the sole
+  `qubits` parameter. Rationale: the family is unreleased and needs no
+  compatibility method or arbitrary-angle variant. Date/Author: 2026-09-02 /
+  Daniel Haag.
 
 ## Outcomes & Retrospective
 
-The implementation adds one typed `multiplexer` family across the existing
-benchmark layers. The family uses the same catalog, serialization, binding, and
-generation extension points as the other families. Focused semantic, generation,
-command-line, Python, stub, and documentation validation passes on the cleanup
-base. The full repository lint and final diff checks also pass.
+The implementation now has a nontrivial analytic reference and an exact linear
+generator. The maximum is 1024 qubits, where the compact structured program
+lowers to Jeff and survives a stable byte round-trip. The public Python path
+executes the generated circuit through QCO and the DD sampler and agrees with
+the analytic distribution. All focused and repository-wide validation passes.
 
 ## Context and Orientation
 
-The installed benchmark library lives in `include/mqt-core/bench/` and
-`src/bench/`. Each family owns typed options, validates them, describes one
-logical `Output`, and evaluates sampled counts against an analytic reference.
-`include/mqt-core/bench/BenchmarkFamilies.inc` contains the shared family
-metadata. `src/bench/JSON.cpp` contains the family-specific schemas, manifests,
-and generic evaluation.
+The benchmark interface lives in `include/mqt-core/bench/Multiplexer.hpp` and
+`src/bench/Multiplexer.cpp`. It validates the qubit count, describes one logical
+`result` output, returns ideal probabilities, and evaluates sampled counts.
+`src/bench/JSON.cpp` supplies the strict parameter schema, canonical instance
+specification, manifest, and generic evaluation integration.
 
-Structured generators live in `mlir/bench/programs/`. They use
-`qc::QCProgramBuilder` to construct QC dialect operations. The catalog-generated
-registry in `mlir/bench/Generate.cpp` parses an instance specification and calls
-the typed generator. The normal compiler pipeline can then lower the QC program
-to other supported forms.
+The generator lives in `mlir/bench/programs/Multiplexer.cpp`. It uses
+`qc::QCProgramBuilder` and standard `scf.for` operations to construct compact QC
+dialect IR. The normal compiler pipeline lowers that program to QCO and Jeff.
+The Python binding in `bindings/bench/register_multiplexer.cpp` exposes the same
+typed family and calls the shared generator.
 
-Python bindings live in `bindings/bench/`. `register_bench.cpp` creates a direct
-submodule for each family. A family-specific source file in the `mqt` namespace
-registers its types and functions. Files below `python/mqt/core/bench/` are
-generated stubs and must be regenerated with the repository's stub session.
-
-A quantum multiplexer has k control qubits and one target qubit. Each of the 2^k
-control basis states selects one one-qubit operation on the target. This
-benchmark selects evenly spaced Y rotations. The generator uses one outer loop
-over control states. Before each rotation, an inner loop applies X to controls
-whose selected state bit is zero. This turns the selected pattern into the
-all-ones pattern required by one multi-controlled rotation. A second inner loop
-restores the controls.
+For `q` total qubits, let `k = q - 1`. A displayed outcome is `c[k-1]...c[0]t`,
+where `t` is the target bit. Interpret the control prefix as the binary fraction
+`x = 0.c[k-1]...c[0]`, so the selected rotation is `theta = pi*x`. Its ideal
+probability is `2^-k * cos(theta/2)^2` for `t = 0` and `2^-k * sin(theta/2)^2`
+for `t = 1`.
 
 ## Plan of Work
 
-Define `MultiplexerOptions` and `Multiplexer` in
-`include/mqt-core/bench/Multiplexer.hpp` and `src/bench/Multiplexer.cpp`.
-Validate 2 through 31 total qubits. Use one `result` output whose width equals
-the total qubit count. The analytic reference assigns probability one to the
-all-zero outcome and zero to every other valid outcome.
+Set `MultiplexerOptions::MAX_QUBITS` to 1024 and align constructor diagnostics
+and the JSON schema. In `Multiplexer::probability`, validate the outcome, build
+the binary control fraction without converting the 1023-bit prefix to an
+integer, and return the appropriate squared sine or cosine times `2^-k`.
 
-Add the stable ID `multiplexer` and definition version 1 to
-`include/mqt-core/bench/BenchmarkFamilies.inc`. Extend
-`include/mqt-core/bench/JSON.hpp` and `src/bench/JSON.cpp` with the required
-integer `qubits` parameter, canonical instance specifications, manifests, case
-IDs, and generic evaluation. Keep catalog rows in lexical order. Cover the
-contract in `test/bench/test_multiplexer.cpp` and `test/bench/test_json.cpp`.
+In the MLIR generator, allocate control-register storage without eager loads.
+Emit one structured loop that applies Hadamard to each control. Emit a second
+structured loop with a carried `f64` angle. Start at `pi/2`, load control
+`k - 1 - step`, apply one singly controlled Y rotation to the target, multiply
+the angle by `0.5`, and yield it to the next iteration. Keep the existing target
+and control measurement order.
 
-Implement generation in `mlir/bench/programs/Multiplexer.cpp`. Allocate the
-controls, target, and result register. Emit an angle-carrying outer `scf.for`
-from zero to 2^(qubits - 1). Emit two inner loops that test each bit of the
-current control state and conditionally apply X. Place one multi-controlled Y
-rotation between those loops. Increment the angle by pi/2^(qubits - 1). Measure
-the target at result index zero and each control at the next index.
-
-Register the generator in `mlir/bench/programs/Programs.h`,
-`mlir/bench/programs/CMakeLists.txt`, and `mlir/include/mlir/bench/Generate.h`.
-The catalog row supplies the implementation wrapper and dispatch entry. Extend
-the MLIR unit and command-line tests. The tests must cover representative
-structure, maximum-size compactness, and successful `jeff` lowering.
-
-Register `mqt.core.bench.multiplexer` through
-`bindings/bench/register_multiplexer.cpp` and
-`bindings/bench/register_bench.cpp`. Add the family behavior test, regenerate
-stubs, and add the family to the command-line test.
-
-Add pull request 2299 to the existing unreleased structured-benchmark entry in
-`CHANGELOG.md`; do not add a second entry for an extension to an unreleased
-feature.
+Replace tests that accepted the all-zero distribution or a `2^30` loop. Test the
+complete three-qubit analytic distribution, normalization, evaluation, bit
+order, structured linear generator, 1024-qubit Jeff byte round-trip, and the
+public Python DD sampling path. Do not add an arbitrary-angle interface, new
+dependency, or a separate benchmark method.
 
 ## Milestones
 
-The semantic milestone supplies the validated C++ family, exact analytic
-reference, JSON schema, manifest, and case identity. The focused benchmark test
-must accept the boundary sizes, reject invalid sizes and outcomes, and
-round-trip a seven-qubit instance and manifest.
+The semantic milestone is complete when the three-qubit probabilities match the
+closed form, sum to one, and an intentionally incomplete histogram produces the
+expected evaluation metrics. Boundary construction must accept 1024 and reject
+1025.
 
-The generation milestone supplies compact QC generation and `jeff` lowering. The
-MLIR tests must generate the family as valid QC and `jeff`, omit redundant
-resets, and keep the 31-qubit operation count bounded.
+The generation milestone is complete when the QC module contains one
+Hadamard-loop body and one single-control Y-rotation-loop body, with a
+descending control index and halved angle. The maximum case must lower to Jeff
+and round-trip through the binary APIs.
 
-The public-interface milestone supplies the Python submodule, generated stubs,
-command-line registration, changelog update, and focused family behavior test.
+The execution milestone is complete when a generated three-qubit program lowers
+to QCO, samples through the DD runtime for 16,384 fixed-seed shots, and
+evaluates with total variation distance below 0.03.
 
 ## Concrete Steps
 
-Run commands from the repository root. Configure and build the release preset,
-then run the focused native and MLIR tests:
+Run commands from the repository root. Build and execute the focused native and
+MLIR tests:
 
     cmake --preset release
     cmake --build --preset release --target mqt-core-bench-test \
@@ -170,15 +162,17 @@ then run the focused native and MLIR tests:
     ctest --test-dir build/release -R '^mqt-core-mlir-benchmark-cli$' \
         --output-on-failure
 
-Install the changed binding without build isolation, regenerate stubs, and run
-the focused Python tests:
+Install the changed binding, verify generated stubs, and run Python tests:
 
     uv sync --inexact --no-dev --no-build-isolation-package mqt-core
     uvx nox -s stubs
     uv run --no-sync pytest test/python/test_bench.py test/python/test_cli.py
 
-Build the documentation and run the repository checks:
+Run full validation and repository checks:
 
+    cmake --build --preset release
+    ctest --preset release
+    uvx nox -s cpp-lint
     uvx nox --non-interactive -s docs
     uvx nox -s lint
     git diff --check
@@ -186,46 +180,67 @@ Build the documentation and run the repository checks:
 
 ## Validation and Acceptance
 
-The C++ tests must accept qubit counts 2 and 31, reject 1 and 32, validate
-outcome widths and characters, and calculate exact evaluation metrics. The JSON
-tests must prove canonical serialization, schema bounds, registry order,
-manifest integrity, stable case identity, and generic evaluation.
+The C++ tests must accept qubit counts 2 and 1024, reject 1 and 1025, validate
+outcome widths and characters, and match all eight three-qubit probabilities.
+The JSON tests must publish 1024 as the maximum and retain strict parsing,
+canonical manifests, and stable case identity.
 
-The MLIR tests must generate every benchmark as QC and `jeff`. For the
-multiplexer, they must verify the maximum state-loop bound, lack of redundant
-resets, compact maximum-size generation, and `jeff` lowering.
+The MLIR tests must inspect semantic operations rather than a textual snapshot.
+They must prove uniform control preparation, one single-control rotation body,
+the correct binary angle order, no state-selection X gates, bounded generated
+IR, and a successful maximum-size Jeff byte round-trip.
 
-Python must expose `mqt.core.bench.multiplexer.Options` and
-`mqt.core.bench.multiplexer.Multiplexer` only in the family submodule. The new
-family must round-trip its JSON forms, evaluate counts, and generate a QC
-program. The command-line tool must list six families and accept a multiplexer
-instance.
+The Python test must exercise the public family, generator, QC-to-QCO lowering,
+DD sampler, output order, and analytic evaluator in one path. Compilation alone
+does not satisfy this acceptance criterion.
 
-The complete documentation build, full lint session, and `git diff --check` must
-pass. Any environment or infrastructure failure must be recorded with its exact
-command and output instead of being presented as a product failure.
+All focused tests, the full CTest suite, stub check, documentation build, C++
+lint, full lint, and final diff checks must pass. Record an environment or
+infrastructure failure with its command and output instead of presenting it as a
+product failure.
 
 ## Idempotence and Recovery
 
 The build, test, stub, documentation, and lint commands are repeatable. Build
 output remains below `build/`. Stub generation is deterministic; never edit a
-generated `.pyi` file by hand. If a generated stub differs unexpectedly, inspect
-the native binding and rerun the stub session.
+generated `.pyi` file by hand. This task uses a dedicated worktree. Preserve
+unrelated changes and do not reset, clean, delete, or overwrite another
+worktree.
 
-This task uses a dedicated worktree. Do not reset, clean, delete, or overwrite
-another worktree. Preserve unrelated changes and stop if they overlap this
-scope.
+## Artifacts and Notes
+
+Validation on 2026-09-02 produced these results:
+
+    13 tests from Multiplexer and BenchmarkJSON passed.
+    2 multiplexer MLIR generation tests passed.
+    1 end-to-end Python multiplexer test passed.
+    42 native benchmark tests passed.
+    12 MLIR benchmark generation tests passed.
+    21 Python benchmark and CLI tests passed.
+    The MLIR benchmark CLI test passed.
+    The full release build completed.
+    CTest reported 100% with 0 failures across 3972 tests; one pre-existing test was skipped.
+    Stub generation completed without a tracked stub diff.
+    C++ lint reported 0 clang-format and 0 clang-tidy findings.
+    Documentation and full repository lint completed successfully.
+    `git diff --check` completed without diagnostics.
+
+The maximum-size MLIR test lowers the 1024-qubit program to Jeff, verifies that
+serialization returns nonempty bytes, deserializes those bytes, verifies the
+restored program, and checks that reserialization is stable.
 
 ## Interfaces and Dependencies
 
-The installed C++ interface adds `MultiplexerOptions` and `Multiplexer` under
-`mqt::bench`, plus matching serialization, manifest, case-ID, and generation
-overloads. The Python interface adds the direct `mqt.core.bench.multiplexer`
-submodule with `Options` and `Multiplexer`.
+The installed C++ and Python interfaces remain `MultiplexerOptions`/`Options`
+and `Multiplexer`, with `qubits` as their only parameter. The supported maximum
+changes from 31 to 1024 and the ideal probability changes from an all-zero
+placeholder to the documented uniform-control distribution. Family ID
+`multiplexer` and definition version 1 remain unchanged.
 
-Use only the dependencies already used by the benchmark library: MQT Core, LLVM,
-MLIR, nanobind, nlohmann JSON, and GoogleTest. Add no dependency.
+Use only MQT Core, LLVM, MLIR, nanobind, nlohmann JSON, GoogleTest, and the
+existing DD runtime. Add no dependency.
 
-Revision note (2026-09-01): Rebased the plan on the benchmark-registration
-cleanup, removed stale namespace-contract work, and recorded the catalog-based
-extension points and current validation.
+Revision note (2026-09-02): Replaced the exponential selector and trivial
+reference with the exact linear fixed-schedule circuit, uniform-control
+distribution, 1024-qubit boundary, semantic execution test, and current
+validation evidence.

--- a/.agent/plans/multiplexer-benchmark.md
+++ b/.agent/plans/multiplexer-benchmark.md
@@ -28,8 +28,8 @@ states without expanding them into 64 copies in the host process.
       command-line registration, and MLIR tests.
 - [x] (2026-09-01) Added the Python family binding and its focused behavior
       tests.
-- [x] (2026-09-01) Added the public glossary terms and folded this change into
-      the existing structured-benchmark changelog entry.
+- [x] (2026-09-01) Folded this change into the existing structured-benchmark
+      changelog entry.
 - [x] (2026-09-01) Validated the final implementation on the cleanup base. The
       41 C++ benchmark tests, 12 MLIR generation tests, MLIR CLI test, 21
       focused Python tests, stub session, generated MLIR documentation, and
@@ -139,10 +139,9 @@ Register `mqt.core.bench.multiplexer` through
 `bindings/bench/register_bench.cpp`. Add the family behavior test, regenerate
 stubs, and add the family to the command-line test.
 
-Define quantum multiplexer and uniformly controlled one-qubit gate in
-`docs/glossary.md`. Add pull request 2299 to the existing unreleased
-structured-benchmark entry in `CHANGELOG.md`; do not add a second entry for an
-extension to an unreleased feature.
+Add pull request 2299 to the existing unreleased structured-benchmark entry in
+`CHANGELOG.md`; do not add a second entry for an extension to an unreleased
+feature.
 
 ## Milestones
 
@@ -156,8 +155,7 @@ MLIR tests must generate the family as valid QC and `jeff`, omit redundant
 resets, and keep the 31-qubit operation count bounded.
 
 The public-interface milestone supplies the Python submodule, generated stubs,
-command-line registration, glossary terms, changelog update, and focused family
-behavior test.
+command-line registration, changelog update, and focused family behavior test.
 
 ## Concrete Steps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ releases may include breaking changes.
   [**@Ectras**], [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 - ✨ Add a library for typed structured quantum benchmarks with versioned
   instance specifications, analytic references, deterministic manifests, and
-  C++, Python, and command-line interfaces ([#2135], [#2315])
+  C++, Python, and command-line interfaces ([#2135], [#2299], [#2315])
   ([**@burgholzer**], [**@denialhaag**])
 - ✨ Add decision diagram-based construction, simulation, and output-aware
   sampling for QCO programs, with C++ and Python APIs and support for classical
@@ -867,6 +867,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#2315]: https://github.com/munich-quantum-toolkit/core/pull/2315
+[#2299]: https://github.com/munich-quantum-toolkit/core/pull/2299
 [#2298]: https://github.com/munich-quantum-toolkit/core/pull/2298
 [#2284]: https://github.com/munich-quantum-toolkit/core/pull/2284
 [#2278]: https://github.com/munich-quantum-toolkit/core/pull/2278

--- a/bindings/bench/CMakeLists.txt
+++ b/bindings/bench/CMakeLists.txt
@@ -7,8 +7,14 @@
 # Licensed under the MIT License
 
 if(NOT TARGET ${MQT_CORE_TARGET_NAME}-bench-bindings)
-  set(BENCH_SOURCES register_bench.cpp register_bv.cpp register_ghz.cpp register_grover.cpp
-                    register_qft.cpp register_qpe.cpp)
+  set(BENCH_SOURCES
+      register_bench.cpp
+      register_bv.cpp
+      register_ghz.cpp
+      register_grover.cpp
+      register_multiplexer.cpp
+      register_qft.cpp
+      register_qpe.cpp)
 
   add_mqt_python_binding(
     CORE

--- a/bindings/bench/register_bench.cpp
+++ b/bindings/bench/register_bench.cpp
@@ -22,6 +22,7 @@ namespace nb = nanobind;
 void registerBV(const nb::module_& m);
 void registerGHZ(const nb::module_& m);
 void registerGrover(const nb::module_& m);
+void registerMultiplexer(const nb::module_& m);
 void registerQFT(const nb::module_& m);
 void registerQPE(const nb::module_& m);
 
@@ -58,6 +59,10 @@ NB_MODULE(MQT_CORE_MODULE_NAME, m) {
   const nb::module_ grover =
       m.def_submodule("grover", "Grover benchmark instances and options.");
   registerGrover(grover);
+
+  const nb::module_ multiplexer = m.def_submodule(
+      "multiplexer", "Quantum multiplexer benchmark instances and options.");
+  registerMultiplexer(multiplexer);
 
   const nb::module_ qft =
       m.def_submodule("qft", "QFT benchmark instances and options.");

--- a/bindings/bench/register_multiplexer.cpp
+++ b/bindings/bench/register_multiplexer.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "bench/JSON.hpp"
+#include "bench/Multiplexer.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/map.h>         // NOLINT(misc-include-cleaner)
+#include <nanobind/stl/string.h>      // NOLINT(misc-include-cleaner)
+#include <nanobind/stl/string_view.h> // NOLINT(misc-include-cleaner)
+
+#include <cstddef>
+
+namespace mqt {
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void registerMultiplexer(const nb::module_& m) {
+  nb::class_<bench::MultiplexerOptions>(
+      m, "Options", "Parameters for a quantum multiplexer benchmark.")
+      .def(nb::init<size_t>(), nb::kw_only(), "qubits"_a)
+      .def_ro("qubits", &bench::MultiplexerOptions::qubits,
+              "The total number of control and target qubits.");
+
+  auto multiplexer = nb::class_<bench::Multiplexer>(
+      m, "Multiplexer", "A validated quantum multiplexer benchmark.");
+  multiplexer.def(nb::init<bench::MultiplexerOptions>(), "options"_a)
+      .def_prop_ro("options", &bench::Multiplexer::options,
+                   nb::rv_policy::reference_internal,
+                   "The resolved benchmark parameters.")
+      .def_prop_ro("output", &bench::Multiplexer::output,
+                   nb::rv_policy::reference_internal,
+                   "The logical output register.")
+      .def("probability", &bench::Multiplexer::probability, "outcome"_a,
+           "Return the ideal probability of an outcome.")
+      .def("evaluate", &bench::Multiplexer::evaluate, "counts"_a,
+           "Compare sampled counts with the ideal distribution.")
+      .def(
+          "generate",
+          [](const bench::Multiplexer& value) {
+            return nb::module_::import_("mqt.core.mlir")
+                .attr("_generate_benchmark")(
+                    bench::toInstanceSpecificationJSON(value));
+          },
+          nb::sig("def generate(self) -> mqt.core.mlir.QCProgram"),
+          "Generate the benchmark as a QC program.")
+      .def_prop_ro(
+          "instance_specification_json",
+          [](const bench::Multiplexer& value) {
+            return bench::toInstanceSpecificationJSON(value);
+          },
+          "The canonical instance specification JSON.")
+      .def_prop_ro(
+          "manifest_json",
+          [](const bench::Multiplexer& value) {
+            return bench::toManifestJSON(value);
+          },
+          "The canonical manifest JSON.")
+      .def_prop_ro(
+          "case_id",
+          [](const bench::Multiplexer& value) { return bench::caseId(value); },
+          "The stable semantic case ID.")
+      .def_static("from_instance_specification_json",
+                  &bench::multiplexerFromInstanceSpecificationJSON, "json"_a,
+                  nb::kw_only(), "source"_a = "<instance-specification>",
+                  "Parse a strict benchmark instance specification.")
+      .def_static("from_manifest_json", &bench::multiplexerFromManifestJSON,
+                  "json"_a, nb::kw_only(), "source"_a = "<manifest>",
+                  "Parse a strict benchmark manifest.");
+}
+
+} // namespace mqt

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -248,14 +248,6 @@ iQPE
   reuses one query qubit for each output bit. Each round applies corrections
   controlled by earlier measurement results.
 
-quantum multiplexer
-uniformly controlled one-qubit gate
-  **Preferred term:** quantum multiplexer. **Accepted alias:** uniformly
-  controlled one-qubit gate. A gate block in which the basis state of k control
-  qubits selects one of 2^k one-qubit operations on a target. The structured
-  benchmark uses evenly spaced Y rotations as the selected operations. See the
-  [uniformly controlled gate construction](https://arxiv.org/abs/quant-ph/0410066).
-
 semiclassical quantum Fourier transform
 semiclassical QFT
   **Preferred term:** semiclassical quantum Fourier transform. **Accepted

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -248,6 +248,14 @@ iQPE
   reuses one query qubit for each output bit. Each round applies corrections
   controlled by earlier measurement results.
 
+quantum multiplexer
+uniformly controlled one-qubit gate
+  **Preferred term:** quantum multiplexer. **Accepted alias:** uniformly
+  controlled one-qubit gate. A gate block in which the basis state of k control
+  qubits selects one of 2^k one-qubit operations on a target. The structured
+  benchmark uses evenly spaced Y rotations as the selected operations. See the
+  [uniformly controlled gate construction](https://arxiv.org/abs/quant-ph/0410066).
+
 semiclassical quantum Fourier transform
 semiclassical QFT
   **Preferred term:** semiclassical quantum Fourier transform. **Accepted

--- a/include/mqt-core/bench/BenchmarkFamilies.inc
+++ b/include/mqt-core/bench/BenchmarkFamilies.inc
@@ -28,6 +28,7 @@
 MQT_BENCHMARK_FAMILY(BV, bv, "bv", 1)
 MQT_BENCHMARK_FAMILY(GHZ, ghz, "ghz", 1)
 MQT_BENCHMARK_FAMILY(Grover, grover, "grover", 1)
+MQT_BENCHMARK_FAMILY(Multiplexer, multiplexer, "multiplexer", 1)
 MQT_BENCHMARK_FAMILY(QFT, qft, "qft", 1)
 MQT_BENCHMARK_FAMILY(QPE, qpe, "qpe", 1)
 

--- a/include/mqt-core/bench/JSON.hpp
+++ b/include/mqt-core/bench/JSON.hpp
@@ -14,6 +14,7 @@
 #include "bench/Evaluation.hpp"
 #include "bench/GHZ.hpp"
 #include "bench/Grover.hpp"
+#include "bench/Multiplexer.hpp"
 #include "bench/QFT.hpp"
 #include "bench/QPE.hpp"
 #include "bench/mqt_core_bench_export.h"

--- a/include/mqt-core/bench/Multiplexer.hpp
+++ b/include/mqt-core/bench/Multiplexer.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include "bench/Evaluation.hpp"
+#include "bench/mqt_core_bench_export.h"
+
+#include <cstddef>
+#include <string_view>
+
+namespace mqt::bench {
+
+/// Parameters for one quantum multiplexer benchmark instance.
+struct MultiplexerOptions {
+  static constexpr size_t MAX_QUBITS = 31;
+
+  /// Total number of control and target qubits.
+  size_t qubits;
+};
+
+/// A validated quantum multiplexer benchmark and its analytic reference.
+class MQT_CORE_BENCH_EXPORT Multiplexer final {
+public:
+  explicit Multiplexer(MultiplexerOptions options);
+
+  [[nodiscard]] const MultiplexerOptions& options() const noexcept;
+  [[nodiscard]] const Output& output() const noexcept;
+  /// Return the ideal probability of a big-endian logical outcome.
+  [[nodiscard]] double probability(std::string_view outcome) const;
+  /// Compare sampled logical outcomes with the ideal distribution.
+  [[nodiscard]] Evaluation evaluate(const Counts& counts) const;
+
+private:
+  MultiplexerOptions options_;
+  Output output_;
+};
+
+} // namespace mqt::bench

--- a/include/mqt-core/bench/Multiplexer.hpp
+++ b/include/mqt-core/bench/Multiplexer.hpp
@@ -20,7 +20,7 @@ namespace mqt::bench {
 
 /// Parameters for one quantum multiplexer benchmark instance.
 struct MultiplexerOptions {
-  static constexpr size_t MAX_QUBITS = 31;
+  static constexpr size_t MAX_QUBITS = 1'024;
 
   /// Total number of control and target qubits.
   size_t qubits;

--- a/mlir/bench/programs/CMakeLists.txt
+++ b/mlir/bench/programs/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 # Licensed under the MIT License
 
-add_library(MQTBenchmarkPrograms STATIC BV.cpp GHZ.cpp Grover.cpp QFT.cpp QPE.cpp)
+add_library(MQTBenchmarkPrograms STATIC BV.cpp GHZ.cpp Grover.cpp Multiplexer.cpp QFT.cpp QPE.cpp)
 target_link_libraries(MQTBenchmarkPrograms PUBLIC MQT::CoreBench MLIRQCProgramBuilder
                                                   MLIRArithDialect MLIRTensorDialect)
 mqt_mlir_target_use_project_options(MQTBenchmarkPrograms)

--- a/mlir/bench/programs/Multiplexer.cpp
+++ b/mlir/bench/programs/Multiplexer.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "bench/Multiplexer.hpp"
+
+#include "Programs.h"
+#include "mlir/Dialect/QC/Builder/QCProgramBuilder.h"
+
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LLVM.h>
+
+#include <cstdint>
+#include <numbers>
+
+namespace mqt::bench {
+
+using namespace mlir;
+
+SmallVector<Value> multiplexer(qc::QCProgramBuilder& builder,
+                               const Multiplexer& benchmark) {
+  const auto numControls = static_cast<int64_t>(benchmark.options().qubits - 1);
+  const auto numStates = int64_t{1} << numControls;
+  auto controls = builder.allocQubitRegister(numControls, "controls");
+  auto target = builder.allocQubit();
+  auto result = builder.allocClassicalBitRegister(
+      static_cast<int64_t>(benchmark.output().width), benchmark.output().name);
+
+  auto zero = builder.indexConstant(0);
+  auto one = builder.indexConstant(1);
+
+  const auto flipZeroControls = [&](Value state) {
+    builder.scfFor(0, numControls, 1, [&](Value bitPosition) {
+      auto shifted = arith::ShRSIOp::create(builder, state, bitPosition);
+      auto bit = arith::AndIOp::create(builder, shifted, one);
+      auto isZero =
+          arith::CmpIOp::create(builder, arith::CmpIPredicate::eq, bit, zero);
+      builder.scfIf(isZero, [&] {
+        builder.x(builder.loadQubit(controls.value, bitPosition));
+      });
+    });
+  };
+
+  auto states = builder.indexConstant(numStates);
+  auto firstAngle = builder.floatConstant(0.);
+  auto angleIncrement =
+      builder.floatConstant(std::numbers::pi / static_cast<double>(numStates));
+  auto stateLoop =
+      scf::ForOp::create(builder, zero, states, one, ValueRange{firstAngle});
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(stateLoop.getBody());
+    auto angle = stateLoop.getRegionIterArg(0);
+    auto state = stateLoop.getInductionVar();
+    flipZeroControls(state);
+    builder.mcry(angle, controls.qubits, target);
+    flipZeroControls(state);
+    auto nextAngle = arith::AddFOp::create(builder, angle, angleIncrement);
+    scf::YieldOp::create(builder, ValueRange{nextAngle});
+  }
+
+  builder.measure(target, result, 0);
+  builder.scfFor(0, numControls, 1, [&](Value index) {
+    auto resultIndex = arith::AddIOp::create(builder, index, one);
+    builder.measure(builder.loadQubit(controls.value, index), result,
+                    resultIndex);
+  });
+  return {result};
+}
+
+} // namespace mqt::bench

--- a/mlir/bench/programs/Multiplexer.cpp
+++ b/mlir/bench/programs/Multiplexer.cpp
@@ -30,8 +30,7 @@ using namespace mlir;
 SmallVector<Value> multiplexer(qc::QCProgramBuilder& builder,
                                const Multiplexer& benchmark) {
   const auto numControls = static_cast<int64_t>(benchmark.options().qubits - 1);
-  const auto numStates = int64_t{1} << numControls;
-  auto controls = builder.allocQubitRegister(numControls, "controls");
+  auto controls = builder.allocQubitRegisterStorage(numControls, "controls");
   auto target = builder.allocQubit();
   auto result = builder.allocClassicalBitRegister(
       static_cast<int64_t>(benchmark.output().width), benchmark.output().name);
@@ -39,41 +38,31 @@ SmallVector<Value> multiplexer(qc::QCProgramBuilder& builder,
   auto zero = builder.indexConstant(0);
   auto one = builder.indexConstant(1);
 
-  const auto flipZeroControls = [&](Value state) {
-    builder.scfFor(0, numControls, 1, [&](Value bitPosition) {
-      auto shifted = arith::ShRSIOp::create(builder, state, bitPosition);
-      auto bit = arith::AndIOp::create(builder, shifted, one);
-      auto isZero =
-          arith::CmpIOp::create(builder, arith::CmpIPredicate::eq, bit, zero);
-      builder.scfIf(isZero, [&] {
-        builder.x(builder.loadQubit(controls.value, bitPosition));
-      });
-    });
-  };
+  builder.scfFor(0, numControls, 1, [&](Value index) {
+    builder.h(builder.loadQubit(controls, index));
+  });
 
-  auto states = builder.indexConstant(numStates);
-  auto firstAngle = builder.floatConstant(0.);
-  auto angleIncrement =
-      builder.floatConstant(std::numbers::pi / static_cast<double>(numStates));
-  auto stateLoop =
-      scf::ForOp::create(builder, zero, states, one, ValueRange{firstAngle});
+  auto upper = builder.indexConstant(numControls);
+  auto last = builder.indexConstant(numControls - 1);
+  auto firstAngle = builder.floatConstant(std::numbers::pi / 2.);
+  auto half = builder.floatConstant(0.5);
+  auto rotationLoop =
+      scf::ForOp::create(builder, zero, upper, one, ValueRange{firstAngle});
   {
     OpBuilder::InsertionGuard guard(builder);
-    builder.setInsertionPointToStart(stateLoop.getBody());
-    auto angle = stateLoop.getRegionIterArg(0);
-    auto state = stateLoop.getInductionVar();
-    flipZeroControls(state);
-    builder.mcry(angle, controls.qubits, target);
-    flipZeroControls(state);
-    auto nextAngle = arith::AddFOp::create(builder, angle, angleIncrement);
+    builder.setInsertionPointToStart(rotationLoop.getBody());
+    auto angle = rotationLoop.getRegionIterArg(0);
+    auto control =
+        arith::SubIOp::create(builder, last, rotationLoop.getInductionVar());
+    builder.cry(angle, builder.loadQubit(controls, control), target);
+    auto nextAngle = arith::MulFOp::create(builder, angle, half);
     scf::YieldOp::create(builder, ValueRange{nextAngle});
   }
 
   builder.measure(target, result, 0);
   builder.scfFor(0, numControls, 1, [&](Value index) {
     auto resultIndex = arith::AddIOp::create(builder, index, one);
-    builder.measure(builder.loadQubit(controls.value, index), result,
-                    resultIndex);
+    builder.measure(builder.loadQubit(controls, index), result, resultIndex);
   });
   return {result};
 }

--- a/mlir/bench/programs/Programs.h
+++ b/mlir/bench/programs/Programs.h
@@ -21,6 +21,7 @@ namespace mqt::bench {
 class BV;
 class GHZ;
 class Grover;
+class Multiplexer;
 class QFT;
 class QPE;
 } // namespace mqt::bench
@@ -38,6 +39,10 @@ SmallVector<Value> ghz(qc::QCProgramBuilder& builder, const GHZ& benchmark);
 /// Emit one configured Grover benchmark.
 SmallVector<Value> grover(qc::QCProgramBuilder& builder,
                           const Grover& benchmark);
+
+/// Emit one configured quantum multiplexer benchmark.
+SmallVector<Value> multiplexer(qc::QCProgramBuilder& builder,
+                               const Multiplexer& benchmark);
 
 /// Emit one configured QFT benchmark.
 SmallVector<Value> qft(qc::QCProgramBuilder& builder, const QFT& benchmark);

--- a/mlir/include/mlir/bench/Generate.h
+++ b/mlir/include/mlir/bench/Generate.h
@@ -20,6 +20,7 @@ namespace mqt::bench {
 class BV;
 class GHZ;
 class Grover;
+class Multiplexer;
 class QFT;
 class QPE;
 
@@ -39,6 +40,10 @@ struct GeneratedBenchmark {
 
 /// Generate the QC program for a configured Grover benchmark.
 [[nodiscard]] std::optional<mlir::QCProgram> generate(const Grover& benchmark);
+
+/// Generate the QC program for a configured quantum multiplexer benchmark.
+[[nodiscard]] std::optional<mlir::QCProgram>
+generate(const Multiplexer& benchmark);
 
 /// Generate a configured quantum Fourier-transform benchmark.
 [[nodiscard]] std::optional<mlir::QCProgram> generate(const QFT& benchmark);

--- a/mlir/unittests/bench/test_benchmark_cli.cmake
+++ b/mlir/unittests/bench/test_benchmark_cli.cmake
@@ -45,19 +45,32 @@ endif()
 
 run_success("benchmark listing" list_output "${CLI}" list)
 string(JSON benchmark_count LENGTH "${list_output}" benchmarks)
-if(NOT benchmark_count EQUAL 5)
-  message(FATAL_ERROR "list returned ${benchmark_count} benchmarks instead of 5")
+if(NOT benchmark_count EQUAL 6)
+  message(FATAL_ERROR "list returned ${benchmark_count} benchmarks instead of 6")
 endif()
 
-run_success("QPE description" describe_output "${CLI}" describe qpe)
+run_success("multiplexer description" describe_output "${CLI}" describe multiplexer)
 string(JSON schema GET "${describe_output}" "$schema")
 if(NOT schema STREQUAL "https://json-schema.org/draft/2020-12/schema")
   message(FATAL_ERROR "describe did not return a JSON Schema")
 endif()
+string(
+  JSON
+  minimum_qubits
+  GET
+  "${describe_output}"
+  properties
+  parameters
+  properties
+  qubits
+  minimum)
+if(NOT minimum_qubits EQUAL 2)
+  message(FATAL_ERROR "multiplexer schema returned minimum ${minimum_qubits} instead of 2")
+endif()
 
 set(instance_specification "${OUTPUT_DIR}/instance-specification.json")
 file(WRITE "${instance_specification}"
-     "{\"schema_version\":1,\"benchmark\":\"ghz\",\"parameters\":{\"qubits\":2}}\n")
+     "{\"schema_version\":1,\"benchmark\":\"multiplexer\",\"parameters\":{\"qubits\":2}}\n")
 set(qc_directory "${OUTPUT_DIR}/qc")
 run_success(
   "QC generation"
@@ -77,11 +90,11 @@ if(NOT EXISTS "${program_path}" OR NOT EXISTS "${manifest_path}")
   message(FATAL_ERROR "generate did not publish both output files")
 endif()
 get_filename_component(program_name "${program_path}" NAME)
-if(NOT program_name MATCHES "^ghz-sha256-[0-9a-f]+\\.qc\\.mlir$")
+if(NOT program_name MATCHES "^multiplexer-sha256-[0-9a-f]+\\.qc\\.mlir$")
   message(FATAL_ERROR "unexpected program name: ${program_name}")
 endif()
 get_filename_component(manifest_name "${manifest_path}" NAME)
-if(NOT manifest_name MATCHES "^ghz-sha256-[0-9a-f]+\\.qc\\.manifest\\.json$")
+if(NOT manifest_name MATCHES "^multiplexer-sha256-[0-9a-f]+\\.qc\\.manifest\\.json$")
   message(FATAL_ERROR "unexpected manifest name: ${manifest_name}")
 endif()
 file(SHA256 "${program_path}" original_program_hash)
@@ -148,7 +161,7 @@ if(NOT EXISTS "${percent_program_path}" OR NOT EXISTS "${percent_manifest_path}"
 endif()
 
 set(counts "${OUTPUT_DIR}/counts.json")
-file(WRITE "${counts}" "{\"schema_version\":1,\"counts\":{\"00\":5,\"11\":5}}\n")
+file(WRITE "${counts}" "{\"schema_version\":1,\"counts\":{\"00\":10}}\n")
 execute_process(
   COMMAND "${CLI}" evaluate --manifest "${manifest_path}" --counts -
   INPUT_FILE "${counts}"

--- a/mlir/unittests/bench/test_benchmark_cli.cmake
+++ b/mlir/unittests/bench/test_benchmark_cli.cmake
@@ -161,7 +161,7 @@ if(NOT EXISTS "${percent_program_path}" OR NOT EXISTS "${percent_manifest_path}"
 endif()
 
 set(counts "${OUTPUT_DIR}/counts.json")
-file(WRITE "${counts}" "{\"schema_version\":1,\"counts\":{\"00\":10}}\n")
+file(WRITE "${counts}" "{\"schema_version\":1,\"counts\":{\"00\":2,\"10\":1,\"11\":1}}\n")
 execute_process(
   COMMAND "${CLI}" evaluate --manifest "${manifest_path}" --counts -
   INPUT_FILE "${counts}"
@@ -176,7 +176,7 @@ if(NOT evaluation_result EQUAL 0)
 endif()
 string(JSON evaluated_case_id GET "${evaluation_output}" case_id)
 string(JSON total_variation_distance GET "${evaluation_output}" metrics total_variation_distance)
-if(NOT evaluated_case_id STREQUAL case_id OR NOT total_variation_distance EQUAL 0)
+if(NOT evaluated_case_id STREQUAL case_id OR total_variation_distance GREATER 1e-15)
   message(FATAL_ERROR "evaluation did not use the generated manifest reference")
 endif()
 

--- a/mlir/unittests/bench/test_benchmark_generate.cpp
+++ b/mlir/unittests/bench/test_benchmark_generate.cpp
@@ -202,7 +202,60 @@ TEST(GenerateProgramTest, EmitsDirectGroverOracleWithBigEndianMarkedState) {
   EXPECT_EQ(markedStateFlips, 2U);
 }
 
-TEST(GenerateProgramTest, KeepsLargeQuantumMultiplexerStructured) {
+TEST(GenerateProgramTest, EmitsUniformLinearQuantumMultiplexer) {
+  auto program = generate(Multiplexer{{.qubits = 3}});
+  ASSERT_TRUE(program);
+  auto moduleOp = program->module();
+
+  EXPECT_EQ(countOps<qc::HOp>(moduleOp), 1U);
+  EXPECT_EQ(countOps<qc::CtrlOp>(moduleOp), 1U);
+  EXPECT_EQ(countOps<qc::RYOp>(moduleOp), 1U);
+  EXPECT_EQ(countOps<qc::XOp>(moduleOp), 0U);
+
+  qc::CtrlOp controlledRotation;
+  moduleOp.walk([&](qc::CtrlOp op) { controlledRotation = op; });
+  ASSERT_TRUE(controlledRotation);
+  EXPECT_EQ(controlledRotation.getNumControls(), 1U);
+
+  auto rotationLoop = controlledRotation->getParentOfType<scf::ForOp>();
+  ASSERT_TRUE(rotationLoop);
+  ASSERT_EQ(rotationLoop.getInitArgs().size(), 1U);
+  auto upper =
+      rotationLoop.getUpperBound().getDefiningOp<arith::ConstantIndexOp>();
+  ASSERT_TRUE(upper);
+  EXPECT_EQ(upper.value(), 2);
+
+  auto controlLoad =
+      controlledRotation.getControl(0).getDefiningOp<memref::LoadOp>();
+  ASSERT_TRUE(controlLoad);
+  auto controlIndex =
+      controlLoad.getIndices().front().getDefiningOp<arith::SubIOp>();
+  ASSERT_TRUE(controlIndex);
+  EXPECT_EQ(controlIndex.getRhs(), rotationLoop.getInductionVar());
+  auto lastControl =
+      controlIndex.getLhs().getDefiningOp<arith::ConstantIndexOp>();
+  ASSERT_TRUE(lastControl);
+  EXPECT_EQ(lastControl.value(), 1);
+
+  auto firstAngle =
+      rotationLoop.getInitArgs().front().getDefiningOp<arith::ConstantOp>();
+  ASSERT_TRUE(firstAngle);
+  auto firstAngleValue = dyn_cast<FloatAttr>(firstAngle.getValue());
+  ASSERT_TRUE(firstAngleValue);
+  EXPECT_DOUBLE_EQ(firstAngleValue.getValueAsDouble(), std::numbers::pi / 2.);
+
+  arith::MulFOp scaleAngle;
+  rotationLoop.walk([&](arith::MulFOp op) { scaleAngle = op; });
+  ASSERT_TRUE(scaleAngle);
+  EXPECT_EQ(scaleAngle.getLhs(), rotationLoop.getRegionIterArg(0));
+  auto scale = scaleAngle.getRhs().getDefiningOp<arith::ConstantOp>();
+  ASSERT_TRUE(scale);
+  auto scaleValue = dyn_cast<FloatAttr>(scale.getValue());
+  ASSERT_TRUE(scaleValue);
+  EXPECT_DOUBLE_EQ(scaleValue.getValueAsDouble(), 0.5);
+}
+
+TEST(GenerateProgramTest, SerializesTheLargestQuantumMultiplexer) {
   auto program =
       generate(Multiplexer{{.qubits = MultiplexerOptions::MAX_QUBITS}});
   ASSERT_TRUE(program);
@@ -216,7 +269,8 @@ TEST(GenerateProgramTest, KeepsLargeQuantumMultiplexerStructured) {
   auto upper =
       stateLoop.getUpperBound().getDefiningOp<arith::ConstantIndexOp>();
   ASSERT_TRUE(upper);
-  EXPECT_EQ(upper.value(), int64_t{1} << (MultiplexerOptions::MAX_QUBITS - 1));
+  EXPECT_EQ(upper.value(),
+            static_cast<int64_t>(MultiplexerOptions::MAX_QUBITS - 1));
 
   size_t operations = 0;
   program->module().walk([&](Operation*) { ++operations; });
@@ -225,7 +279,14 @@ TEST(GenerateProgramTest, KeepsLargeQuantumMultiplexerStructured) {
   auto compiled = runDefaultPipeline(CompilerInput{std::move(*program)},
                                      ProgramFormat::Jeff);
   ASSERT_TRUE(compiled);
-  EXPECT_TRUE(std::holds_alternative<JeffProgram>(*compiled));
+  ASSERT_TRUE(std::holds_alternative<JeffProgram>(*compiled));
+  auto& jeff = std::get<JeffProgram>(*compiled);
+  const auto bytes = jeff.toBytes();
+  ASSERT_FALSE(bytes.empty());
+  auto restored = JeffProgram::fromBytes(bytes);
+  ASSERT_TRUE(restored);
+  EXPECT_TRUE(restored->isValid());
+  EXPECT_EQ(restored->toBytes(), bytes);
 }
 
 TEST(GenerateProgramTest, KeepsStandardQPEPowerAndResultOrderAligned) {

--- a/mlir/unittests/bench/test_benchmark_generate.cpp
+++ b/mlir/unittests/bench/test_benchmark_generate.cpp
@@ -11,6 +11,7 @@
 #include "bench/BV.hpp"
 #include "bench/GHZ.hpp"
 #include "bench/Grover.hpp"
+#include "bench/Multiplexer.hpp"
 #include "bench/QFT.hpp"
 #include "bench/QPE.hpp"
 #include "mlir/Dialect/CBit/IR/CBitOps.h"
@@ -65,6 +66,7 @@ TEST(GenerateProgramTest, GeneratesEveryBenchmarkMethodAsQCAndJeff) {
       BV{{.hiddenBitstring = "101", .method = BVMethod::Dynamic}});
   expectValidQCAndJeff(GHZ{{.qubits = 3}});
   expectValidQCAndJeff(Grover{{.markedBitstring = "101"}});
+  expectValidQCAndJeff(Multiplexer{{.qubits = 3}});
   expectValidQCAndJeff(QFT{{.qubits = 3, .periodExponent = 1}});
   expectValidQCAndJeff(QFT{
       {.qubits = 3, .periodExponent = 1, .method = QFTMethod::Semiclassical}});
@@ -78,6 +80,9 @@ TEST(GenerateProgramTest, OmitsAllocationAdjacentResets) {
   EXPECT_EQ(countOps<qc::ResetOp>(
                 generate(Grover{{.markedBitstring = "101"}})->module()),
             0U);
+  EXPECT_EQ(
+      countOps<qc::ResetOp>(generate(Multiplexer{{.qubits = 3}})->module()),
+      0U);
   EXPECT_EQ(
       countOps<qc::ResetOp>(generate(BV{{.hiddenBitstring = "101"}})->module()),
       0U);
@@ -195,6 +200,32 @@ TEST(GenerateProgramTest, EmitsDirectGroverOracleWithBigEndianMarkedState) {
     EXPECT_EQ(index.value(), 1);
   });
   EXPECT_EQ(markedStateFlips, 2U);
+}
+
+TEST(GenerateProgramTest, KeepsLargeQuantumMultiplexerStructured) {
+  auto program =
+      generate(Multiplexer{{.qubits = MultiplexerOptions::MAX_QUBITS}});
+  ASSERT_TRUE(program);
+  scf::ForOp stateLoop;
+  program->module().walk([&](scf::ForOp loop) {
+    if (!loop.getInitArgs().empty()) {
+      stateLoop = loop;
+    }
+  });
+  ASSERT_TRUE(stateLoop);
+  auto upper =
+      stateLoop.getUpperBound().getDefiningOp<arith::ConstantIndexOp>();
+  ASSERT_TRUE(upper);
+  EXPECT_EQ(upper.value(), int64_t{1} << (MultiplexerOptions::MAX_QUBITS - 1));
+
+  size_t operations = 0;
+  program->module().walk([&](Operation*) { ++operations; });
+  EXPECT_LT(operations, 150U);
+
+  auto compiled = runDefaultPipeline(CompilerInput{std::move(*program)},
+                                     ProgramFormat::Jeff);
+  ASSERT_TRUE(compiled);
+  EXPECT_TRUE(std::holds_alternative<JeffProgram>(*compiled));
 }
 
 TEST(GenerateProgramTest, KeepsStandardQPEPowerAndResultOrderAligned) {

--- a/python/mqt/core/bench/__init__.pyi
+++ b/python/mqt/core/bench/__init__.pyi
@@ -11,6 +11,7 @@
 from mqt.core.bench import bv as bv
 from mqt.core.bench import ghz as ghz
 from mqt.core.bench import grover as grover
+from mqt.core.bench import multiplexer as multiplexer
 from mqt.core.bench import qft as qft
 from mqt.core.bench import qpe as qpe
 

--- a/python/mqt/core/bench/multiplexer.pyi
+++ b/python/mqt/core/bench/multiplexer.pyi
@@ -1,0 +1,63 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Quantum multiplexer benchmark instances and options."""
+
+from collections.abc import Mapping
+
+import mqt.core.bench
+import mqt.core.mlir
+
+class Options:
+    """Parameters for a quantum multiplexer benchmark."""
+
+    def __init__(self, *, qubits: int) -> None: ...
+    @property
+    def qubits(self) -> int:
+        """The total number of control and target qubits."""
+
+class Multiplexer:
+    """A validated quantum multiplexer benchmark."""
+
+    def __init__(self, options: Options) -> None: ...
+    @property
+    def options(self) -> Options:
+        """The resolved benchmark parameters."""
+
+    @property
+    def output(self) -> mqt.core.bench.Output:
+        """The logical output register."""
+
+    def probability(self, outcome: str) -> float:
+        """Return the ideal probability of an outcome."""
+
+    def evaluate(self, counts: Mapping[str, int]) -> mqt.core.bench.Evaluation:
+        """Compare sampled counts with the ideal distribution."""
+
+    def generate(self) -> mqt.core.mlir.QCProgram:
+        """Generate the benchmark as a QC program."""
+
+    @property
+    def instance_specification_json(self) -> str:
+        """The canonical instance specification JSON."""
+
+    @property
+    def manifest_json(self) -> str:
+        """The canonical manifest JSON."""
+
+    @property
+    def case_id(self) -> str:
+        """The stable semantic case ID."""
+
+    @staticmethod
+    def from_instance_specification_json(json: str, *, source: str = "<instance-specification>") -> Multiplexer:
+        """Parse a strict benchmark instance specification."""
+
+    @staticmethod
+    def from_manifest_json(json: str, *, source: str = "<manifest>") -> Multiplexer:
+        """Parse a strict benchmark manifest."""

--- a/src/bench/JSON.cpp
+++ b/src/bench/JSON.cpp
@@ -15,6 +15,7 @@
 #include "bench/Evaluation.hpp"
 #include "bench/GHZ.hpp"
 #include "bench/Grover.hpp"
+#include "bench/Multiplexer.hpp"
 #include "bench/QFT.hpp"
 #include "bench/QPE.hpp"
 
@@ -365,6 +366,19 @@ void requireBenchmark(const Json& root, const std::string_view expected,
   }
 }
 
+[[nodiscard]] Multiplexer
+parseMultiplexerParameters(const Json& parameters,
+                           const std::string_view source) {
+  rejectUnknownKeys(parameters, {"qubits"}, source, "$/parameters");
+  try {
+    return Multiplexer({.qubits = sizeValue(required(parameters, "qubits",
+                                                     source, "$/parameters"),
+                                            source, "$/parameters/qubits")});
+  } catch (const std::invalid_argument& error) {
+    fail(source, "$/parameters", error.what());
+  }
+}
+
 [[nodiscard]] QFT parseQFTParameters(const Json& parameters,
                                      const std::string_view source) {
   rejectUnknownKeys(parameters, {"qubits", "period_exponent", "method"}, source,
@@ -471,6 +485,10 @@ void requireBenchmark(const Json& root, const std::string_view expected,
           {"marked_bitstring", options.markedBitstring}};
 }
 
+[[nodiscard]] Json parametersJSON(const Multiplexer& benchmark) {
+  return {{"qubits", benchmark.options().qubits}};
+}
+
 [[nodiscard]] Json parametersJSON(const QFT& benchmark) {
   const auto& options = benchmark.options();
   return {{"method", methodName(options.method)},
@@ -510,6 +528,14 @@ void requireBenchmark(const Json& root, const std::string_view expected,
           {"outcome_order", "big_endian"},
           {"output", benchmark.output().name},
           {"success_outcome", benchmark.options().markedBitstring},
+          {"version", 1}};
+}
+
+[[nodiscard]] Json referenceJSON(const Multiplexer& benchmark) {
+  return {{"kind", "analytic"},
+          {"model", "multiplexer"},
+          {"outcome_order", "big_endian"},
+          {"output", benchmark.output().name},
           {"version", 1}};
 }
 
@@ -659,6 +685,18 @@ template <class Benchmark>
            {"pattern", "^[01]+$"},
            {"type", "string"}}}}},
        {"required", {"marked_bitstring"}},
+       {"type", "object"}});
+}
+
+[[nodiscard]] Json multiplexerInstanceSpecificationSchema() {
+  return baseInstanceSpecificationSchema<Multiplexer>(
+      {{"additionalProperties", false},
+       {"properties",
+        {{"qubits",
+          {{"maximum", MultiplexerOptions::MAX_QUBITS},
+           {"minimum", 2},
+           {"type", "integer"}}}}},
+       {"required", {"qubits"}},
        {"type", "object"}});
 }
 

--- a/src/bench/Multiplexer.cpp
+++ b/src/bench/Multiplexer.cpp
@@ -13,6 +13,8 @@
 #include "EvaluationUtils.hpp"
 #include "bench/Evaluation.hpp"
 
+#include <cmath>
+#include <numbers>
 #include <stdexcept>
 #include <string_view>
 
@@ -21,7 +23,8 @@ namespace mqt::bench {
 Multiplexer::Multiplexer(MultiplexerOptions options)
     : options_(options), output_{.name = "result", .width = options_.qubits} {
   if (options_.qubits < 2 || options_.qubits > MultiplexerOptions::MAX_QUBITS) {
-    throw std::invalid_argument("multiplexer qubits must be between 2 and 31");
+    throw std::invalid_argument(
+        "multiplexer qubits must be between 2 and 1024");
   }
 }
 
@@ -33,7 +36,18 @@ const Output& Multiplexer::output() const noexcept { return output_; }
 
 double Multiplexer::probability(const std::string_view outcome) const {
   detail::validateOutcome(outcome, output_.width);
-  return outcome.find('1') == std::string_view::npos ? 1. : 0.;
+
+  double state = 0.;
+  double weight = 0.5;
+  for (const auto bit : outcome.substr(0, outcome.size() - 1)) {
+    state += bit == '1' ? weight : 0.;
+    weight *= 0.5;
+  }
+  const auto angle = std::numbers::pi * state;
+  const auto amplitude =
+      outcome.back() == '0' ? std::cos(angle / 2.) : std::sin(angle / 2.);
+  return std::ldexp(amplitude * amplitude,
+                    1 - static_cast<int>(options_.qubits));
 }
 
 Evaluation Multiplexer::evaluate(const Counts& counts) const {

--- a/src/bench/Multiplexer.cpp
+++ b/src/bench/Multiplexer.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "bench/Multiplexer.hpp"
+
+#include "EvaluationUtils.hpp"
+#include "bench/Evaluation.hpp"
+
+#include <stdexcept>
+#include <string_view>
+
+namespace mqt::bench {
+
+Multiplexer::Multiplexer(MultiplexerOptions options)
+    : options_(options), output_{.name = "result", .width = options_.qubits} {
+  if (options_.qubits < 2 || options_.qubits > MultiplexerOptions::MAX_QUBITS) {
+    throw std::invalid_argument("multiplexer qubits must be between 2 and 31");
+  }
+}
+
+const MultiplexerOptions& Multiplexer::options() const noexcept {
+  return options_;
+}
+
+const Output& Multiplexer::output() const noexcept { return output_; }
+
+double Multiplexer::probability(const std::string_view outcome) const {
+  detail::validateOutcome(outcome, output_.width);
+  return outcome.find('1') == std::string_view::npos ? 1. : 0.;
+}
+
+Evaluation Multiplexer::evaluate(const Counts& counts) const {
+  return detail::evaluate(
+      output_, counts,
+      [this](const std::string_view outcome) { return probability(outcome); });
+}
+
+} // namespace mqt::bench

--- a/test/bench/test_json.cpp
+++ b/test/bench/test_json.cpp
@@ -13,6 +13,7 @@
 #include "bench/GHZ.hpp"
 #include "bench/Grover.hpp"
 #include "bench/JSON.hpp"
+#include "bench/Multiplexer.hpp"
 #include "bench/QFT.hpp"
 #include "bench/QPE.hpp"
 
@@ -49,6 +50,9 @@ using mqt::bench::Grover;
 using mqt::bench::groverFromInstanceSpecificationJSON;
 using mqt::bench::groverFromManifestJSON;
 using mqt::bench::listBenchmarksJSON;
+using mqt::bench::Multiplexer;
+using mqt::bench::multiplexerFromInstanceSpecificationJSON;
+using mqt::bench::multiplexerFromManifestJSON;
 using mqt::bench::Phase;
 using mqt::bench::QFT;
 using mqt::bench::qftFromInstanceSpecificationJSON;
@@ -97,6 +101,13 @@ TEST(BenchmarkJSON,
       toInstanceSpecificationJSON(grover),
       R"({"benchmark":"grover","parameters":{"iterations":1,"marked_bitstring":"10"},"schema_version":1})");
 
+  const auto multiplexer = multiplexerFromInstanceSpecificationJSON(
+      R"({"schema_version":1,"benchmark":"multiplexer","parameters":{"qubits":7}})");
+  EXPECT_EQ(multiplexer.options().qubits, 7);
+  EXPECT_EQ(
+      toInstanceSpecificationJSON(multiplexer),
+      R"({"benchmark":"multiplexer","parameters":{"qubits":7},"schema_version":1})");
+
   const auto qft = qftFromInstanceSpecificationJSON(
       R"({"schema_version":1,"benchmark":"qft","parameters":{"qubits":4,"period_exponent":2}})");
   EXPECT_EQ(qft.options().method, QFTMethod::Standard);
@@ -118,6 +129,7 @@ TEST(BenchmarkJSON, RoundTripsSelfCheckingManifests) {
   const GHZ ghz{
       {.qubits = 4, .topology = GHZTopology::Star, .basis = GHZBasis::X}};
   const Grover grover{{.markedBitstring = "001", .iterations = 2}};
+  const Multiplexer multiplexer{{.qubits = 7}};
   const QFT qft{
       {.qubits = 4, .periodExponent = 2, .method = QFTMethod::Semiclassical}};
   const QPE qpe{
@@ -126,22 +138,28 @@ TEST(BenchmarkJSON, RoundTripsSelfCheckingManifests) {
   const auto bvManifest = toManifestJSON(bv);
   const auto ghzManifest = toManifestJSON(ghz);
   const auto groverManifest = toManifestJSON(grover);
+  const auto multiplexerManifest = toManifestJSON(multiplexer);
   const auto qftManifest = toManifestJSON(qft);
   const auto qpeManifest = toManifestJSON(qpe);
   EXPECT_EQ(toManifestJSON(bvFromManifestJSON(bvManifest)), bvManifest);
   EXPECT_EQ(toManifestJSON(ghzFromManifestJSON(ghzManifest)), ghzManifest);
   EXPECT_EQ(toManifestJSON(groverFromManifestJSON(groverManifest)),
             groverManifest);
+  EXPECT_EQ(toManifestJSON(multiplexerFromManifestJSON(multiplexerManifest)),
+            multiplexerManifest);
   EXPECT_EQ(toManifestJSON(qftFromManifestJSON(qftManifest)), qftManifest);
   EXPECT_EQ(toManifestJSON(qpeFromManifestJSON(qpeManifest)), qpeManifest);
   EXPECT_EQ(benchmarkIdFromManifestJSON(bvManifest), "bv");
   EXPECT_EQ(benchmarkIdFromManifestJSON(ghzManifest), "ghz");
   EXPECT_EQ(benchmarkIdFromManifestJSON(groverManifest), "grover");
+  EXPECT_EQ(benchmarkIdFromManifestJSON(multiplexerManifest), "multiplexer");
   EXPECT_EQ(benchmarkIdFromManifestJSON(qftManifest), "qft");
   EXPECT_EQ(benchmarkIdFromManifestJSON(qpeManifest), "qpe");
   EXPECT_NE(ghzManifest.find("\"case_id\":\"" + caseId(ghz) + "\""),
             std::string::npos);
   EXPECT_NE(groverManifest.find("\"success_outcome\":\"001\""),
+            std::string::npos);
+  EXPECT_NE(multiplexerManifest.find("\"model\":\"multiplexer\""),
             std::string::npos);
   EXPECT_EQ(qpeManifest.find("0.333"), std::string::npos);
 }
@@ -158,6 +176,10 @@ TEST(BenchmarkJSON, UsesStableSemanticCaseIds) {
             caseId(QFT{{.qubits = 3,
                         .periodExponent = 1,
                         .method = QFTMethod::Semiclassical}}));
+  EXPECT_EQ(caseId(Multiplexer{{.qubits = 7}}),
+            caseId(Multiplexer{{.qubits = 7}}));
+  EXPECT_NE(caseId(Multiplexer{{.qubits = 7}}),
+            caseId(Multiplexer{{.qubits = 6}}));
   EXPECT_EQ(caseId(linear), "sha256-a222c0c57bcecb4f5e7ea72bab439683"
                             "92861a52c5cb7c9c13aeaffffa059a65");
 }
@@ -221,6 +243,18 @@ TEST(BenchmarkJSON,
       "between 1 and 1075");
   expectInvalid(
       [] {
+        static_cast<void>(multiplexerFromInstanceSpecificationJSON(
+            R"({"schema_version":1,"benchmark":"multiplexer","parameters":{"qubits":1}})"));
+      },
+      "between 2 and 31");
+  expectInvalid(
+      [] {
+        static_cast<void>(multiplexerFromInstanceSpecificationJSON(
+            R"({"schema_version":1,"benchmark":"multiplexer","parameters":{"qubits":7,"angles":[]}})"));
+      },
+      "unknown key 'angles'");
+  expectInvalid(
+      [] {
         static_cast<void>(ghzFromInstanceSpecificationJSON(
             R"({"schema_version":1,"benchmark":"new","parameters":{}})"));
       },
@@ -279,10 +313,11 @@ TEST(BenchmarkJSON, RejectsAlteredOrUnresolvedManifestData) {
 TEST(BenchmarkJSON, ListsBenchmarksAndDescribesStandardSchemas) {
   EXPECT_EQ(
       listBenchmarksJSON(),
-      R"({"benchmarks":[{"definition_version":1,"id":"bv"},{"definition_version":1,"id":"ghz"},{"definition_version":1,"id":"grover"},{"definition_version":1,"id":"qft"},{"definition_version":1,"id":"qpe"}],"schema_version":1})");
+      R"({"benchmarks":[{"definition_version":1,"id":"bv"},{"definition_version":1,"id":"ghz"},{"definition_version":1,"id":"grover"},{"definition_version":1,"id":"multiplexer"},{"definition_version":1,"id":"qft"},{"definition_version":1,"id":"qpe"}],"schema_version":1})");
   const auto bv = describeBenchmarkJSON("bv");
   const auto ghz = describeBenchmarkJSON("ghz");
   const auto grover = describeBenchmarkJSON("grover");
+  const auto multiplexer = describeBenchmarkJSON("multiplexer");
   const auto qft = describeBenchmarkJSON("qft");
   const auto qpe = describeBenchmarkJSON("qpe");
   EXPECT_NE(ghz.find("https://json-schema.org/draft/2020-12/schema"),
@@ -292,6 +327,8 @@ TEST(BenchmarkJSON, ListsBenchmarksAndDescribesStandardSchemas) {
   EXPECT_NE(ghz.find("\"maximum\":1075"), std::string::npos);
   EXPECT_NE(bv.find("\"dynamic\""), std::string::npos);
   EXPECT_NE(grover.find("\"maxLength\":62"), std::string::npos);
+  EXPECT_NE(multiplexer.find("\"maximum\":31"), std::string::npos);
+  EXPECT_NE(multiplexer.find("\"minimum\":2"), std::string::npos);
   EXPECT_NE(qft.find("\"period_exponent\""), std::string::npos);
   EXPECT_NE(qpe.find("\"iterative\""), std::string::npos);
   EXPECT_THROW(static_cast<void>(describeBenchmarkJSON("unknown")),
@@ -317,6 +354,15 @@ TEST(BenchmarkJSON, ParsesCountsAndSerializesEvaluations) {
   const auto generic = evaluateJSON(
       toManifestJSON(bv), R"({"schema_version":1,"counts":{"11":8,"00":2}})");
   EXPECT_NE(generic.find("\"success_probability\":0.8"), std::string::npos);
+
+  const Multiplexer multiplexer{{.qubits = 2}};
+  const auto multiplexerEvaluation =
+      evaluateJSON(toManifestJSON(multiplexer),
+                   R"({"schema_version":1,"counts":{"00":8,"01":2}})");
+  EXPECT_NE(multiplexerEvaluation.find("\"success_probability\":null"),
+            std::string::npos);
+  EXPECT_NE(multiplexerEvaluation.find("\"total_variation_distance\":"),
+            std::string::npos);
 
   expectInvalid(
       [] {

--- a/test/bench/test_json.cpp
+++ b/test/bench/test_json.cpp
@@ -246,7 +246,7 @@ TEST(BenchmarkJSON,
         static_cast<void>(multiplexerFromInstanceSpecificationJSON(
             R"({"schema_version":1,"benchmark":"multiplexer","parameters":{"qubits":1}})"));
       },
-      "between 2 and 31");
+      "between 2 and 1024");
   expectInvalid(
       [] {
         static_cast<void>(multiplexerFromInstanceSpecificationJSON(
@@ -327,7 +327,7 @@ TEST(BenchmarkJSON, ListsBenchmarksAndDescribesStandardSchemas) {
   EXPECT_NE(ghz.find("\"maximum\":1075"), std::string::npos);
   EXPECT_NE(bv.find("\"dynamic\""), std::string::npos);
   EXPECT_NE(grover.find("\"maxLength\":62"), std::string::npos);
-  EXPECT_NE(multiplexer.find("\"maximum\":31"), std::string::npos);
+  EXPECT_NE(multiplexer.find("\"maximum\":1024"), std::string::npos);
   EXPECT_NE(multiplexer.find("\"minimum\":2"), std::string::npos);
   EXPECT_NE(qft.find("\"period_exponent\""), std::string::npos);
   EXPECT_NE(qpe.find("\"iterative\""), std::string::npos);

--- a/test/bench/test_multiplexer.cpp
+++ b/test/bench/test_multiplexer.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "bench/Evaluation.hpp"
+#include "bench/Multiplexer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using mqt::bench::Multiplexer;
+using mqt::bench::MultiplexerOptions;
+using mqt::bench::Output;
+
+TEST(Multiplexer, StoresTheTotalQubitCountAndOutput) {
+  const Multiplexer benchmark{{.qubits = 7}};
+  EXPECT_EQ(benchmark.options().qubits, 7);
+  EXPECT_EQ(benchmark.output(), (Output{"result", 7}));
+}
+
+TEST(Multiplexer, ValidatesTheConfiguredInstance) {
+  EXPECT_THROW(static_cast<void>(Multiplexer{{.qubits = 1}}),
+               std::invalid_argument);
+  EXPECT_NO_THROW(static_cast<void>(Multiplexer{{.qubits = 2}}));
+  EXPECT_NO_THROW(static_cast<void>(
+      Multiplexer{{.qubits = MultiplexerOptions::MAX_QUBITS}}));
+  EXPECT_THROW(static_cast<void>(
+                   Multiplexer{{.qubits = MultiplexerOptions::MAX_QUBITS + 1}}),
+               std::invalid_argument);
+}
+
+TEST(Multiplexer, HasTheExactZeroInputReference) {
+  const Multiplexer benchmark{{.qubits = 3}};
+  EXPECT_DOUBLE_EQ(benchmark.probability("000"), 1.);
+  EXPECT_DOUBLE_EQ(benchmark.probability("001"), 0.);
+  EXPECT_DOUBLE_EQ(benchmark.probability("100"), 0.);
+  EXPECT_THROW(static_cast<void>(benchmark.probability("00")),
+               std::invalid_argument);
+  EXPECT_THROW(static_cast<void>(benchmark.probability("00x")),
+               std::invalid_argument);
+}
+
+TEST(Multiplexer, EvaluatesTheReferenceWithoutASuccessOutcome) {
+  const Multiplexer benchmark{{.qubits = 3}};
+  const auto evaluation = benchmark.evaluate({{"000", 80}, {"001", 20}});
+  EXPECT_DOUBLE_EQ(evaluation.totalVariationDistance, 0.2);
+  EXPECT_DOUBLE_EQ(evaluation.squaredHellingerFidelity, 0.8);
+  EXPECT_FALSE(evaluation.successProbability);
+}
+
+} // namespace

--- a/test/bench/test_multiplexer.cpp
+++ b/test/bench/test_multiplexer.cpp
@@ -13,6 +13,7 @@
 
 #include <gtest/gtest.h>
 
+#include <numbers>
 #include <stdexcept>
 #include <string>
 
@@ -39,11 +40,26 @@ TEST(Multiplexer, ValidatesTheConfiguredInstance) {
                std::invalid_argument);
 }
 
-TEST(Multiplexer, HasTheExactZeroInputReference) {
+TEST(Multiplexer, GivesTheUniformControlDistribution) {
   const Multiplexer benchmark{{.qubits = 3}};
-  EXPECT_DOUBLE_EQ(benchmark.probability("000"), 1.);
-  EXPECT_DOUBLE_EQ(benchmark.probability("001"), 0.);
-  EXPECT_DOUBLE_EQ(benchmark.probability("100"), 0.);
+  const auto high = (2. + std::numbers::sqrt2) / 16.;
+  const auto low = (2. - std::numbers::sqrt2) / 16.;
+
+  EXPECT_NEAR(benchmark.probability("000"), 0.25, 1e-15);
+  EXPECT_NEAR(benchmark.probability("001"), 0., 1e-15);
+  EXPECT_NEAR(benchmark.probability("010"), high, 1e-15);
+  EXPECT_NEAR(benchmark.probability("011"), low, 1e-15);
+  EXPECT_NEAR(benchmark.probability("100"), 0.125, 1e-15);
+  EXPECT_NEAR(benchmark.probability("101"), 0.125, 1e-15);
+  EXPECT_NEAR(benchmark.probability("110"), low, 1e-15);
+  EXPECT_NEAR(benchmark.probability("111"), high, 1e-15);
+
+  double total = 0.;
+  for (const auto* outcome :
+       {"000", "001", "010", "011", "100", "101", "110", "111"}) {
+    total += benchmark.probability(outcome);
+  }
+  EXPECT_NEAR(total, 1., 1e-15);
   EXPECT_THROW(static_cast<void>(benchmark.probability("00")),
                std::invalid_argument);
   EXPECT_THROW(static_cast<void>(benchmark.probability("00x")),
@@ -52,10 +68,17 @@ TEST(Multiplexer, HasTheExactZeroInputReference) {
 
 TEST(Multiplexer, EvaluatesTheReferenceWithoutASuccessOutcome) {
   const Multiplexer benchmark{{.qubits = 3}};
-  const auto evaluation = benchmark.evaluate({{"000", 80}, {"001", 20}});
-  EXPECT_DOUBLE_EQ(evaluation.totalVariationDistance, 0.2);
-  EXPECT_DOUBLE_EQ(evaluation.squaredHellingerFidelity, 0.8);
+  const auto evaluation = benchmark.evaluate({{"000", 100}});
+  EXPECT_DOUBLE_EQ(evaluation.totalVariationDistance, 0.75);
+  EXPECT_DOUBLE_EQ(evaluation.squaredHellingerFidelity, 0.25);
   EXPECT_FALSE(evaluation.successProbability);
+}
+
+TEST(Multiplexer, KeepsTheLargestUniformControlWeightRepresentable) {
+  const Multiplexer benchmark{{.qubits = MultiplexerOptions::MAX_QUBITS}};
+  EXPECT_GT(
+      benchmark.probability(std::string(MultiplexerOptions::MAX_QUBITS, '0')),
+      0.);
 }
 
 } // namespace

--- a/test/python/test_bench.py
+++ b/test/python/test_bench.py
@@ -16,10 +16,12 @@ from fractions import Fraction
 import pytest
 
 from mqt.core import bench, mlir
-from mqt.core.bench import bv, ghz, grover, qft, qpe
+from mqt.core.bench import bv, ghz, grover, multiplexer, qft, qpe
 
 
-def assert_generates(benchmark: bv.BV | ghz.GHZ | grover.Grover | qft.QFT | qpe.QPE) -> None:
+def assert_generates(
+    benchmark: bv.BV | ghz.GHZ | grover.Grover | multiplexer.Multiplexer | qft.QFT | qpe.QPE,
+) -> None:
     """Exercise the shared Python-to-MLIR generation boundary."""
     program = benchmark.generate()
     assert isinstance(program, mlir.QCProgram)
@@ -85,6 +87,26 @@ def test_grover_resolves_iterations_and_reports_success() -> None:
     copy = grover.Grover.from_manifest_json(benchmark.manifest_json)
     assert copy.instance_specification_json == benchmark.instance_specification_json
     assert copy.case_id == benchmark.case_id
+    assert_generates(benchmark)
+
+
+def test_multiplexer_reference_json_and_generation() -> None:
+    """Expose the fixed-angle quantum multiplexer as one typed family."""
+    benchmark = multiplexer.Multiplexer(multiplexer.Options(qubits=3))
+    assert benchmark.output.name == "result"
+    assert benchmark.output.width == 3
+    assert benchmark.probability("000") == 1
+    assert benchmark.probability("001") == 0
+
+    evaluation = benchmark.evaluate({"000": 8, "001": 2})
+    assert evaluation.total_variation_distance == pytest.approx(0.2)
+    assert evaluation.squared_hellinger_fidelity == pytest.approx(0.8)
+    assert evaluation.success_probability is None
+    assert json.loads(benchmark.instance_specification_json)["parameters"] == {"qubits": 3}
+
+    instance_copy = multiplexer.Multiplexer.from_instance_specification_json(benchmark.instance_specification_json)
+    manifest_copy = multiplexer.Multiplexer.from_manifest_json(benchmark.manifest_json)
+    assert instance_copy.case_id == manifest_copy.case_id == benchmark.case_id
     assert_generates(benchmark)
 
 

--- a/test/python/test_bench.py
+++ b/test/python/test_bench.py
@@ -17,6 +17,7 @@ import pytest
 
 from mqt.core import bench, mlir
 from mqt.core.bench import bv, ghz, grover, multiplexer, qft, qpe
+from mqt.core.dd import DDPackage
 
 
 def assert_generates(
@@ -95,18 +96,23 @@ def test_multiplexer_reference_json_and_generation() -> None:
     benchmark = multiplexer.Multiplexer(multiplexer.Options(qubits=3))
     assert benchmark.output.name == "result"
     assert benchmark.output.width == 3
-    assert benchmark.probability("000") == 1
+    assert benchmark.probability("000") == pytest.approx(0.25)
     assert benchmark.probability("001") == 0
 
-    evaluation = benchmark.evaluate({"000": 8, "001": 2})
-    assert evaluation.total_variation_distance == pytest.approx(0.2)
-    assert evaluation.squared_hellinger_fidelity == pytest.approx(0.8)
+    evaluation = benchmark.evaluate({"000": 10})
+    assert evaluation.total_variation_distance == pytest.approx(0.75)
+    assert evaluation.squared_hellinger_fidelity == pytest.approx(0.25)
     assert evaluation.success_probability is None
     assert json.loads(benchmark.instance_specification_json)["parameters"] == {"qubits": 3}
 
     instance_copy = multiplexer.Multiplexer.from_instance_specification_json(benchmark.instance_specification_json)
     manifest_copy = multiplexer.Multiplexer.from_manifest_json(benchmark.manifest_json)
     assert instance_copy.case_id == manifest_copy.case_id == benchmark.case_id
+
+    shots = 16_384
+    counts = benchmark.generate().to_qco().sample(DDPackage(3), shots=shots, seed=17)
+    assert sum(counts.values()) == shots
+    assert benchmark.evaluate(counts).total_variation_distance < 0.03
     assert_generates(benchmark)
 
 

--- a/test/python/test_cli.py
+++ b/test/python/test_cli.py
@@ -122,6 +122,7 @@ def test_benchmark_cli(script_runner: ScriptRunner) -> None:
     assert ret.success
     assert '"ghz"' in ret.stdout
     assert '"grover"' in ret.stdout
+    assert '"multiplexer"' in ret.stdout
     assert '"qpe"' in ret.stdout
 
 


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Add a typed quantum multiplexer benchmark with C++ and Python APIs, strict instance specifications and manifests, an analytic reference, command-line support, and compact structured MLIR generation.

The benchmark uses evenly spaced RY angles and supports 2 to 31 total qubits. It keeps control-state selection in structured loops so host-side generation remains compact.

The changelog includes the new family in the existing unreleased benchmark-library entry.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
