### PR TITLE
🐛 Handle gate counts without an entry point

### DIFF
--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -39,6 +39,7 @@
 #include <jeff/Translation/Serialize.hpp>
 #include <kj/array.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/IR/LLVMContext.h>
@@ -86,6 +87,17 @@
 #include <vector>
 
 namespace mlir {
+
+static void pushNestedOperations(Operation* operation,
+                                 SmallVectorImpl<Operation*>& worklist) {
+  for (Region& region : operation->getRegions()) {
+    for (Block& block : region) {
+      for (Operation& nested : block) {
+        worklist.push_back(&nested);
+      }
+    }
+  }
+}
 
 std::shared_ptr<MLIRContext> createCompilerContext() {
   DialectRegistry registry;
@@ -145,11 +157,15 @@ parseMLIRFile(MLIRContext* context, const std::filesystem::path& path) {
  */
 [[nodiscard]] static bool moduleUsesDialect(ModuleOp mod,
                                             const StringRef dialect) {
-  auto found = false;
-  mod->walk([&](Operation* operation) {
-    found |= operation->getDialect()->getNamespace() == dialect;
-  });
-  return found;
+  SmallVector<Operation*> worklist{mod};
+  while (!worklist.empty()) {
+    Operation* operation = worklist.pop_back_val();
+    if (operation->getDialect()->getNamespace() == dialect) {
+      return true;
+    }
+    pushNestedOperations(operation, worklist);
+  }
+  return false;
 }
 
 template <class ProgramType, class Parse>
@@ -392,13 +408,23 @@ std::optional<QIRProgram> QCProgram::intoQIR(const QIRProfile profile) && {
 static size_t
 countGatesIf(ModuleOp moduleOp,
              const llvm::function_ref<bool(qc::UnitaryOpInterface)> predicate) {
-  size_t count = 0;
   auto entryPoint = mqt::getEntryPoint(moduleOp);
-  entryPoint.walk<WalkOrder::PreOrder>([&](qc::UnitaryOpInterface op) {
-    count += !isa<qc::BarrierOp>(op) && predicate(op);
-    return isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(op) ? WalkResult::skip()
-                                                     : WalkResult::advance();
-  });
+  if (!entryPoint) {
+    return 0;
+  }
+  size_t count = 0;
+  SmallVector<Operation*> worklist{entryPoint};
+  while (!worklist.empty()) {
+    Operation* operation = worklist.pop_back_val();
+    auto unitary = dyn_cast<qc::UnitaryOpInterface>(operation);
+    if (unitary) {
+      count += !isa<qc::BarrierOp>(unitary) && predicate(unitary);
+      if (isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(unitary)) {
+        continue;
+      }
+    }
+    pushNestedOperations(operation, worklist);
+  }
   return count;
 }
 

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -418,7 +418,9 @@ countGatesIf(ModuleOp moduleOp,
     Operation* operation = worklist.pop_back_val();
     auto unitary = dyn_cast<qc::UnitaryOpInterface>(operation);
     if (unitary) {
-      count += !isa<qc::BarrierOp>(unitary) && predicate(unitary);
+      if (!isa<qc::BarrierOp>(unitary) && predicate(unitary)) {
+        ++count;
+      }
       if (isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(unitary)) {
         continue;
       }

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -88,17 +88,6 @@
 
 namespace mlir {
 
-static void pushNestedOperations(Operation* operation,
-                                 SmallVectorImpl<Operation*>& worklist) {
-  for (Region& region : operation->getRegions()) {
-    for (Block& block : region) {
-      for (Operation& nested : block) {
-        worklist.push_back(&nested);
-      }
-    }
-  }
-}
-
 std::shared_ptr<MLIRContext> createCompilerContext() {
   DialectRegistry registry;
   registry.insert<cbit::CBitDialect, mqt::MQTDialect, qc::QCDialect,
@@ -157,15 +146,13 @@ parseMLIRFile(MLIRContext* context, const std::filesystem::path& path) {
  */
 [[nodiscard]] static bool moduleUsesDialect(ModuleOp mod,
                                             const StringRef dialect) {
-  SmallVector<Operation*> worklist{mod};
-  while (!worklist.empty()) {
-    Operation* operation = worklist.pop_back_val();
-    if (operation->getDialect()->getNamespace() == dialect) {
-      return true;
-    }
-    pushNestedOperations(operation, worklist);
-  }
-  return false;
+  return mod
+      ->walk([&](Operation* operation) {
+        return operation->getDialect()->getNamespace() == dialect
+                   ? WalkResult::interrupt()
+                   : WalkResult::advance();
+      })
+      .wasInterrupted();
 }
 
 template <class ProgramType, class Parse>
@@ -413,20 +400,11 @@ countGatesIf(ModuleOp moduleOp,
     return 0;
   }
   size_t count = 0;
-  SmallVector<Operation*> worklist{entryPoint};
-  while (!worklist.empty()) {
-    Operation* operation = worklist.pop_back_val();
-    auto unitary = dyn_cast<qc::UnitaryOpInterface>(operation);
-    if (unitary) {
-      if (!isa<qc::BarrierOp>(unitary) && predicate(unitary)) {
-        ++count;
-      }
-      if (isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(unitary)) {
-        continue;
-      }
-    }
-    pushNestedOperations(operation, worklist);
-  }
+  entryPoint.walk<WalkOrder::PreOrder>([&](qc::UnitaryOpInterface op) {
+    count += !isa<qc::BarrierOp>(op) && predicate(op);
+    return isa<qc::CtrlOp, qc::InvOp, qc::PowOp>(op) ? WalkResult::skip()
+                                                     : WalkResult::advance();
+  });
   return count;
 }
 

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -1940,6 +1940,21 @@ barrier q[0], q[1];
   EXPECT_EQ(qc->numTwoQubitGates(), 3);
 }
 
+TEST_F(CompilerPipelineTest, QCProgramCountGatesWithoutEntryPoint) {
+  constexpr llvm::StringLiteral source = R"mlir(module {
+    func.func @helper() {
+      %qubit = qc.alloc : !qc.qubit
+      qc.dealloc %qubit : !qc.qubit
+      return
+    }
+  })mlir";
+  auto qc = QCProgram::fromMLIRString(source);
+  ASSERT_TRUE(qc);
+  EXPECT_EQ(qc->numGates(), 0);
+  EXPECT_EQ(qc->numSingleQubitGates(), 0);
+  EXPECT_EQ(qc->numTwoQubitGates(), 0);
+}
+
 /**
  * @brief Test: gate counting includes each structured control-flow region once.
  */


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Short-circuit dialect discovery with the native MLIR interruptible walker.
- Treat QC modules without an entry point as containing zero gates.
- Preserve the existing gate traversal and modifier-body semantics.

Part of #2255.

## Validation

- Focused compiler tests: 2 passed, including the missing-entry-point regression.
- Compiler pipeline production object: built successfully.
- Repository hooks and clang-format on the changed files: passed.
- Clang-Tidy 22.1.8 on the changed production code: passed.
- A full local compiler-target rebuild remains blocked by pre-existing LLVM 23 API errors in QCO SCF operations; CI remains authoritative for the complete build.

AI assistance: Codex narrowed the original audit extraction in response to review feedback and ran the listed checks.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~ (Not applicable: no user-facing documentation change is needed.)
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~ (Not applicable: this focused fix is labeled skip-changelog.)
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~ (Not needed.)
- [x] The changes follow the project style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.