### PR TITLE
🐛 Keep terminal measurements after routing swaps

### DIFF
--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1598,21 +1598,61 @@ private:
         // At this point the wire iterators either point to
         // std::default_sentinel or a multi-qubit gate (incl. barriers) of
         // the current or subsequent layers. The former must be decremented
-        // twice (sentinel → sink → unitary/static). For the latter, we
-        // must ensure the insertion point is before the multi-qubit gates.
+        // twice (sentinel → sink → final op). For the latter, we must ensure
+        // the insertion point is before the multi-qubit gates.
 
+        Operation* latest = nullptr;
+        bool comparable = true;
+        for (WireIterator it : wires) {
+          if (it == std::default_sentinel) {
+            std::advance(it, -2);
+            while (isa_and_nonnull<MeasureOp>(it.operation())) {
+              std::advance(it, -1);
+            }
+          } else {
+            std::advance(it, -1);
+          }
+
+          Operation* operation = it.operation();
+          if (operation == nullptr) {
+            continue;
+          }
+          if (latest != nullptr &&
+              operation->getBlock() != latest->getBlock()) {
+            comparable = false;
+            break;
+          }
+          if (latest == nullptr || latest->isBeforeInBlock(operation)) {
+            latest = operation;
+          }
+        }
+
+        // Keep terminal measurements after routing SWAPs. A measurement can
+        // only move past the routing frontier if doing so does not move it past
+        // a classical use of its result.
         for (auto& it : wires) {
           if (it != std::default_sentinel) {
             std::advance(it, -1);
             continue;
           }
+
           std::advance(it, -2);
-          // Keep a terminal irreversible suffix after routing SWAPs. Moving a
-          // logical state through a SWAP and then measuring/resetting that
-          // state is equivalent, while routing the collapsed/reset state would
-          // introduce a mid-circuit irreversible operation unnecessarily.
-          while (it.operation() != nullptr &&
-                 isa<MeasureOp, ResetOp>(it.operation())) {
+          if (!comparable) {
+            continue;
+          }
+          while (auto measure = dyn_cast_or_null<MeasureOp>(it.operation())) {
+            if (latest != nullptr &&
+                llvm::any_of(measure.getResult().getUsers(),
+                             [&](Operation* user) {
+                               while (user != nullptr &&
+                                      user->getBlock() != latest->getBlock()) {
+                                 user = user->getParentOp();
+                               }
+                               return user == nullptr || user == latest ||
+                                      user->isBeforeInBlock(latest);
+                             })) {
+              break;
+            }
             std::advance(it, -1);
           }
         }

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -1602,7 +1602,19 @@ private:
         // must ensure the insertion point is before the multi-qubit gates.
 
         for (auto& it : wires) {
-          std::advance(it, it == std::default_sentinel ? -2 : -1);
+          if (it != std::default_sentinel) {
+            std::advance(it, -1);
+            continue;
+          }
+          std::advance(it, -2);
+          // Keep a terminal irreversible suffix after routing SWAPs. Moving a
+          // logical state through a SWAP and then measuring/resetting that
+          // state is equivalent, while routing the collapsed/reset state would
+          // introduce a mid-circuit irreversible operation unnecessarily.
+          while (it.operation() != nullptr &&
+                 isa<MeasureOp, ResetOp>(it.operation())) {
+            std::advance(it, -1);
+          }
         }
       }
 

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -359,6 +359,74 @@ TEST_F(MappingPassFixture, MapTopologyOnlyWithEmptyOperationSet) {
   size_t numSwaps = 0;
   m->walk([&](SWAPOp) { ++numSwaps; });
   EXPECT_GT(numSwaps, 0);
+
+  size_t numMeasurements = 0;
+  size_t numMeasurementsAfterSwap = 0;
+  m->walk([&](MeasureOp op) {
+    ++numMeasurements;
+    if (op.getQubitIn().getDefiningOp<SWAPOp>()) {
+      ++numMeasurementsAfterSwap;
+    }
+    const bool hasOneUse = op.getQubitOut().hasOneUse();
+    EXPECT_TRUE(hasOneUse);
+    if (hasOneUse) {
+      EXPECT_TRUE(isa<SinkOp>(*op.getQubitOut().getUsers().begin()));
+    }
+  });
+  EXPECT_EQ(numMeasurements, size);
+  EXPECT_GT(numMeasurementsAfterSwap, 0);
+}
+
+TEST_F(MappingPassFixture, KeepTerminalResetsAfterRoutingSwaps) {
+  constexpr int64_t size = 3;
+
+  const auto target = llvm::cantFail(CompilerTarget::create(
+      3, std::vector<CompilerTarget::Coupling>{{0, 1}, {1, 2}},
+      std::vector<CompilerTarget::Operation>{}));
+
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  SmallVector<Value> qubits(size);
+  for (int64_t i = 0; i < size; ++i) {
+    qubits[i] = builder.allocQubit();
+  }
+
+  qubits[0] = builder.x(qubits[0]);
+  std::tie(qubits[0], qubits[1]) = builder.rxx(0.25, qubits[0], qubits[1]);
+  std::tie(qubits[1], qubits[2]) = builder.rzx(0.5, qubits[1], qubits[2]);
+  std::tie(qubits[0], qubits[2]) = builder.cx(qubits[0], qubits[2]);
+
+  for (Value& qubit : qubits) {
+    qubit = builder.reset(qubit);
+    builder.sink(qubit);
+  }
+
+  auto m = builder.finalize();
+  ASSERT_TRUE(
+      runPass(m.get(), target, MappingPassOptions{.ntrials = 1}).succeeded());
+  ASSERT_TRUE(succeeded(verify(*m)));
+  EXPECT_TRUE(isExecutable(getEntryPoint(m.get()), target));
+
+  size_t numSwaps = 0;
+  m->walk([&](SWAPOp) { ++numSwaps; });
+  EXPECT_GT(numSwaps, 0);
+
+  size_t numResets = 0;
+  size_t numResetsAfterSwap = 0;
+  m->walk([&](ResetOp op) {
+    ++numResets;
+    if (op.getQubitIn().getDefiningOp<SWAPOp>()) {
+      ++numResetsAfterSwap;
+    }
+    const bool hasOneUse = op.getQubitOut().hasOneUse();
+    EXPECT_TRUE(hasOneUse);
+    if (hasOneUse) {
+      EXPECT_TRUE(isa<SinkOp>(*op.getQubitOut().getUsers().begin()));
+    }
+  });
+  EXPECT_EQ(numResets, size);
+  EXPECT_GT(numResetsAfterSwap, 0);
 }
 
 TEST_F(MappingPassFixture, PreserveNoncontiguousTargetSiteIds) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -377,9 +377,8 @@ TEST_F(MappingPassFixture, MapTopologyOnlyWithEmptyOperationSet) {
   EXPECT_GT(numMeasurementsAfterSwap, 0);
 }
 
-TEST_F(MappingPassFixture, KeepTerminalResetsAfterRoutingSwaps) {
-  constexpr int64_t size = 3;
-
+TEST_F(MappingPassFixture,
+       KeepClassicallyDependentMeasurementBeforeRoutingSwaps) {
   const auto target = llvm::cantFail(CompilerTarget::create(
       3, std::vector<CompilerTarget::Coupling>{{0, 1}, {1, 2}},
       std::vector<CompilerTarget::Operation>{}));
@@ -387,46 +386,32 @@ TEST_F(MappingPassFixture, KeepTerminalResetsAfterRoutingSwaps) {
   QCOProgramBuilder builder(context.get());
   builder.initialize();
 
-  SmallVector<Value> qubits(size);
-  for (int64_t i = 0; i < size; ++i) {
-    qubits[i] = builder.allocQubit();
-  }
+  auto q0 = builder.allocQubit();
+  auto q1 = builder.allocQubit();
+  auto q2 = builder.allocQubit();
+  std::tie(q0, q1) = builder.cx(q0, q1);
+  std::tie(q0, q2) = builder.cx(q0, q2);
 
-  qubits[0] = builder.x(qubits[0]);
-  std::tie(qubits[0], qubits[1]) = builder.rxx(0.25, qubits[0], qubits[1]);
-  std::tie(qubits[1], qubits[2]) = builder.rzx(0.5, qubits[1], qubits[2]);
-  std::tie(qubits[0], qubits[2]) = builder.cx(qubits[0], qubits[2]);
-
-  for (Value& qubit : qubits) {
-    qubit = builder.reset(qubit);
-    builder.sink(qubit);
-  }
+  Value bit;
+  std::tie(q0, bit) = builder.measure(q0);
+  builder.sink(q0);
+  auto angle = arith::UIToFPOp::create(builder, builder.getF64Type(), bit);
+  q1 = builder.rz(angle, q1);
+  std::tie(q1, q2) = builder.cx(q1, q2);
+  builder.sink(q1);
+  builder.sink(q2);
 
   auto m = builder.finalize();
   ASSERT_TRUE(
-      runPass(m.get(), target, MappingPassOptions{.ntrials = 1}).succeeded());
+      runPass(m.get(), target, MappingPassOptions{.ntrials = 1, .seed = 0})
+          .succeeded());
   ASSERT_TRUE(succeeded(verify(*m)));
-  EXPECT_TRUE(isExecutable(getEntryPoint(m.get()), target));
 
-  size_t numSwaps = 0;
-  m->walk([&](SWAPOp) { ++numSwaps; });
-  EXPECT_GT(numSwaps, 0);
-
-  size_t numResets = 0;
-  size_t numResetsAfterSwap = 0;
-  m->walk([&](ResetOp op) {
-    ++numResets;
-    if (op.getQubitIn().getDefiningOp<SWAPOp>()) {
-      ++numResetsAfterSwap;
-    }
-    const bool hasOneUse = op.getQubitOut().hasOneUse();
-    EXPECT_TRUE(hasOneUse);
-    if (hasOneUse) {
-      EXPECT_TRUE(isa<SinkOp>(*op.getQubitOut().getUsers().begin()));
-    }
-  });
-  EXPECT_EQ(numResets, size);
-  EXPECT_GT(numResetsAfterSwap, 0);
+  MeasureOp measurement;
+  m->walk([&](MeasureOp op) { measurement = op; });
+  ASSERT_TRUE(measurement);
+  ASSERT_TRUE(measurement.getQubitOut().hasOneUse());
+  EXPECT_TRUE(isa<SWAPOp>(*measurement.getQubitOut().getUsers().begin()));
 }
 
 TEST_F(MappingPassFixture, PreserveNoncontiguousTargetSiteIds) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Insert routing SWAPs before terminal measurements on finished wires, preventing routing from adding quantum operations after measurement.
- Keep a measurement in place when its classical result feeds an operation before the routing frontier, preserving SSA dependencies for adaptive programs.
- Leave reset placement unchanged.

When routing a pending two-qubit gate, the mapper may use the physical site of an otherwise finished wire as an intermediate path. Previously, if that wire ended in a measurement, the routing SWAP consumed the measured qubit value. This changed an input with terminal measurements into one containing quantum operations after measurement, conflicting with the [QIR Base Profile](https://github.com/qir-alliance/qir-spec/blob/main/specification/profiles/Base_Profile.md) restriction that qubits must not be used after an irreversible operation.

Part of #2255.

## Validation

- Mapping unit-test suite: 83 passed.
- `uvx nox -s lint`: passed.
- `uvx nox -s cpp-lint`: passed.
- Hosted checks for the amended head are running.

AI assistance: Codex analyzed the routing insertion contract, identified and repaired the classical-dependency edge case, and rescoped the implementation and tests to measurements only.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~ (Not applicable: no user-facing documentation change is needed.)
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~ (Not applicable: this focused fix is labeled skip-changelog.)
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~ (Not needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. (Hosted checks are running for the amended head.)
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
