### PR TITLE
🐛 Make QIR metadata attachment idempotent

### DIFF
--- a/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
+++ b/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
@@ -143,8 +143,7 @@ void emitQISCall(OpBuilder& builder, Operation* anchor, Location loc,
  * @brief Find the main LLVM function
  *
  * @details
- * Searches first for the MQT program entry-point marker. It also accepts the
- * lowered QIR `entry_point` passthrough attribute.
+ * Searches for the QIR `entry_point` passthrough attribute.
  *
  * @param op The module operation to search in
  * @return The main LLVM function, or nullptr unless exactly one exists

--- a/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
+++ b/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
@@ -147,7 +147,7 @@ void emitQISCall(OpBuilder& builder, Operation* anchor, Location loc,
  * lowered QIR `entry_point` passthrough attribute.
  *
  * @param op The module operation to search in
- * @return The main LLVM function, or nullptr if not found
+ * @return The main LLVM function, or nullptr unless exactly one exists
  */
 LLVM::LLVMFuncOp getMainFunction(Operation* op);
 

--- a/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
@@ -14,9 +14,11 @@
 #include "mlir/Dialect/CBit/IR/CBitAttributes.h"
 #include "mlir/Dialect/CBit/IR/CBitDialect.h"
 #include "mlir/Dialect/CBit/IR/CBitOps.h"
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/MQT/Transforms/GlobalPhaseNormalization.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/Dialect/QIR/QIRDefinitions.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
@@ -685,6 +687,13 @@ protected:
   void runOnOperation() override {
     MLIRContext* ctx = &getContext();
     auto moduleOp = getOperation();
+    auto entryPoint = mqt::getEntryPoint(moduleOp);
+    if (!entryPoint) {
+      moduleOp->emitError("no main function with mqt.entry_point found");
+      signalPassFailure();
+      return;
+    }
+    auto entryPointName = entryPoint.getSymNameAttr();
     if (failed(mqt::normalizeGlobalPhases(moduleOp))) {
       signalPassFailure();
       return;
@@ -728,12 +737,15 @@ protected:
       }
     }
 
-    auto main = getMainFunction(moduleOp);
+    auto main = moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(entryPointName);
     if (!main) {
       moduleOp->emitError("no main function with mqt.entry_point found");
       signalPassFailure();
       return;
     }
+    main.setPassthroughAttr(
+        ArrayAttr::get(ctx, {StringAttr::get(ctx, ::qir::ENTRY_POINT_ATTR)}));
+    mqt::removeEntryPoint(main);
 
     // Stage 3: Create block structure
     ensureBlocks(main, state);

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/MQT/Transforms/GlobalPhaseNormalization.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/Dialect/QIR/QIRDefinitions.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
@@ -458,12 +459,18 @@ protected:
     MLIRContext* ctx = &getContext();
     auto moduleOp = getOperation();
     auto entryPoint = mqt::getEntryPoint(moduleOp);
-    if (entryPoint && !entryPoint.getBody().hasOneBlock()) {
+    if (!entryPoint) {
+      moduleOp->emitError("no main function with mqt.entry_point found");
+      signalPassFailure();
+      return;
+    }
+    if (!entryPoint.getBody().hasOneBlock()) {
       entryPoint.emitError(
           "QIR Base Profile requires a single-block entry function");
       signalPassFailure();
       return;
     }
+    auto entryPointName = entryPoint.getSymNameAttr();
     if (failed(mqt::normalizeGlobalPhases(moduleOp))) {
       signalPassFailure();
       return;
@@ -494,12 +501,15 @@ protected:
       }
     }
 
-    auto main = getMainFunction(moduleOp);
+    auto main = moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(entryPointName);
     if (!main) {
       moduleOp->emitError("no main function with mqt.entry_point found");
       signalPassFailure();
       return;
     }
+    main.setPassthroughAttr(
+        ArrayAttr::get(ctx, {StringAttr::get(ctx, ::qir::ENTRY_POINT_ATTR)}));
+    mqt::removeEntryPoint(main);
 
     // Stage 2: Create block structure
     ensureBlocks(main, state);

--- a/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
@@ -8,7 +8,6 @@
  * Licensed under the MIT License
  */
 
-#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/QIR/QIRDefinitions.h"
 #include "mlir/Dialect/QIR/Transforms/Passes.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
@@ -123,10 +122,7 @@ private:
       return createI32Flag(behavior, name, value ? 1 : 0);
     };
 
-    const auto isQIRFunctionAttribute = [](Attribute attribute) {
-      if (const auto name = dyn_cast<StringAttr>(attribute)) {
-        return name.getValue() == StringRef(::qir::ENTRY_POINT_ATTR);
-      }
+    const auto isQIRFunctionMetadata = [](Attribute attribute) {
       const auto pair = dyn_cast<ArrayAttr>(attribute);
       const auto key = pair && pair.size() == 2 ? dyn_cast<StringAttr>(pair[0])
                                                 : StringAttr{};
@@ -140,10 +136,9 @@ private:
     if (const auto passthrough = main.getPassthroughAttr()) {
       attributes.append(passthrough.begin(), passthrough.end());
     }
-    llvm::erase_if(attributes, isQIRFunctionAttribute);
+    llvm::erase_if(attributes, isQIRFunctionMetadata);
     attributes.append(
-        {rewriter.getStringAttr(::qir::ENTRY_POINT_ATTR),
-         rewriter.getStrArrayAttr(
+        {rewriter.getStrArrayAttr(
              {::qir::OUTPUT_LABELING_SCHEMA_ATTR, ::qir::LABELED_SCHEMA}),
          rewriter.getStrArrayAttr(
              {::qir::QIR_PROFILES_ATTR,
@@ -154,7 +149,6 @@ private:
              {"required_num_results", std::to_string(metadata.numResults)})});
 
     main.setPassthroughAttr(rewriter.getArrayAttr(attributes));
-    mqt::removeEntryPoint(main);
 
     rewriter.setInsertionPointToEnd(m.getBody());
 

--- a/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
@@ -32,6 +32,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -64,6 +65,14 @@ struct Metadata {
   bool usesMultipleReturnPoints{false};
 };
 
+[[nodiscard]] static bool hasQIREntryPointAttribute(LLVM::LLVMFuncOp function) {
+  const auto passthrough = function->getAttrOfType<ArrayAttr>("passthrough");
+  return passthrough && llvm::any_of(passthrough, [](Attribute attribute) {
+           const auto name = dyn_cast<StringAttr>(attribute);
+           return name && name.getValue() == StringRef(::qir::ENTRY_POINT_ATTR);
+         });
+}
+
 /**
  * @brief Attaches the required attributes to the function marked as
  * entry_point.
@@ -74,15 +83,27 @@ struct QIRSetAttributesAndMetadata final
 
 protected:
   void runOnOperation() override {
-    IRRewriter rewriter(&getContext());
-    auto main = getMainFunction(getOperation());
-    if (!main) {
+    SmallVector<LLVM::LLVMFuncOp> entryPoints;
+    for (auto function : getOperation().getOps<LLVM::LLVMFuncOp>()) {
+      if (mqt::isEntryPoint(function) || hasQIREntryPointAttribute(function)) {
+        entryPoints.push_back(function);
+      }
+    }
+    if (entryPoints.size() != 1) {
+      getOperation().emitError()
+          << "QIR metadata attachment requires exactly one entry point, but "
+             "found "
+          << entryPoints.size();
+      signalPassFailure();
       return;
     }
+
+    auto main = entryPoints.front();
     Metadata metadata = useAdaptive ? getAdaptive(main) : getBase(main);
     if (useAdaptive) {
       collectOptionalFeatures(getOperation(), main, metadata);
     }
+    IRRewriter rewriter(&getContext());
     setMetadata(main, metadata, rewriter);
   }
 
@@ -119,30 +140,55 @@ private:
       return createI32Flag(behavior, name, value ? 1 : 0);
     };
 
-    const SmallVector<Attribute> attributes{
-        rewriter.getStringAttr(::qir::ENTRY_POINT_ATTR),
-        rewriter.getStrArrayAttr(
-            {::qir::OUTPUT_LABELING_SCHEMA_ATTR, ::qir::LABELED_SCHEMA}),
-        rewriter.getStrArrayAttr(
-            {::qir::QIR_PROFILES_ATTR,
-             useAdaptive ? ::qir::ADAPTIVE_PROFILE : ::qir::BASE_PROFILE}),
-        rewriter.getStrArrayAttr(
-            {"required_num_qubits", std::to_string(metadata.numQubits)}),
-        rewriter.getStrArrayAttr(
-            {"required_num_results", std::to_string(metadata.numResults)})};
+    const auto isQIRFunctionAttribute = [](Attribute attribute) {
+      if (const auto name = dyn_cast<StringAttr>(attribute)) {
+        return name.getValue() == StringRef(::qir::ENTRY_POINT_ATTR);
+      }
+      const auto pair = dyn_cast<ArrayAttr>(attribute);
+      const auto key = pair && pair.size() == 2 ? dyn_cast<StringAttr>(pair[0])
+                                                : StringAttr{};
+      return key &&
+             (key.getValue() == StringRef(::qir::OUTPUT_LABELING_SCHEMA_ATTR) ||
+              key.getValue() == StringRef(::qir::QIR_PROFILES_ATTR) ||
+              key.getValue() == "required_num_qubits" ||
+              key.getValue() == "required_num_results");
+    };
+    SmallVector<Attribute> attributes;
+    if (const auto passthrough =
+            main->getAttrOfType<ArrayAttr>("passthrough")) {
+      llvm::copy_if(passthrough, std::back_inserter(attributes),
+                    [&](Attribute attribute) {
+                      return !isQIRFunctionAttribute(attribute);
+                    });
+    }
+    attributes.append(
+        {rewriter.getStringAttr(::qir::ENTRY_POINT_ATTR),
+         rewriter.getStrArrayAttr(
+             {::qir::OUTPUT_LABELING_SCHEMA_ATTR, ::qir::LABELED_SCHEMA}),
+         rewriter.getStrArrayAttr(
+             {::qir::QIR_PROFILES_ATTR,
+              useAdaptive ? ::qir::ADAPTIVE_PROFILE : ::qir::BASE_PROFILE}),
+         rewriter.getStrArrayAttr(
+             {"required_num_qubits", std::to_string(metadata.numQubits)}),
+         rewriter.getStrArrayAttr(
+             {"required_num_results", std::to_string(metadata.numResults)})});
 
     main->setAttr("passthrough", rewriter.getArrayAttr(attributes));
     mqt::removeEntryPoint(main);
 
     rewriter.setInsertionPointToEnd(m.getBody());
 
-    SmallVector<Attribute> flags{
-        createI32Flag(LLVM::ModFlagBehavior::Error, "qir_major_version", 2),
-        createI32Flag(LLVM::ModFlagBehavior::Max, "qir_minor_version", 1),
-        createBoolFlag(LLVM::ModFlagBehavior::Error, "dynamic_qubit_management",
-                       metadata.useDynamicQubit),
-        createBoolFlag(LLVM::ModFlagBehavior::Error,
-                       "dynamic_result_management", metadata.useDynamicResult)};
+    SmallVector<Attribute> flags = collectUnrelatedModuleFlags(m, rewriter);
+    flags.emplace_back(
+        createI32Flag(LLVM::ModFlagBehavior::Error, "qir_major_version", 2));
+    flags.emplace_back(
+        createI32Flag(LLVM::ModFlagBehavior::Max, "qir_minor_version", 1));
+    flags.emplace_back(createBoolFlag(LLVM::ModFlagBehavior::Error,
+                                      "dynamic_qubit_management",
+                                      metadata.useDynamicQubit));
+    flags.emplace_back(createBoolFlag(LLVM::ModFlagBehavior::Error,
+                                      "dynamic_result_management",
+                                      metadata.useDynamicResult));
 
     if (useAdaptive) {
       flags.emplace_back(createI32Flag(LLVM::ModFlagBehavior::Error,
@@ -164,7 +210,6 @@ private:
       }
     }
 
-    removeExistingModuleFlags(m, rewriter);
     const auto setTypes = [&](const StringRef name,
                               const llvm::SmallSet<std::string, 4>& types) {
       if (types.empty()) {
@@ -181,13 +226,32 @@ private:
                                 rewriter.getArrayAttr(flags));
   }
 
-  /// Remove existing module flag operations from module.
-  /// Note that this might also erase non-QIR module flag operations, but for
-  /// now, we assume that there are no others.
-  static void removeExistingModuleFlags(ModuleOp m, IRRewriter& rewriter) {
-    SmallVector<Operation*> flagOps;
-    m->walk([&](LLVM::ModuleFlagsOp op) { flagOps.emplace_back(op); });
-    llvm::for_each(flagOps, [&](Operation* op) { rewriter.eraseOp(op); });
+  static bool isQIRModuleFlag(StringRef key) {
+    return key == "qir_major_version" || key == "qir_minor_version" ||
+           key == "dynamic_qubit_management" ||
+           key == "dynamic_result_management" || key == "backwards_branching" ||
+           key == "arrays" || key == "ir_functions" ||
+           key == "multiple_target_branching" ||
+           key == "multiple_return_points" || key == "int_computations" ||
+           key == "float_computations";
+  }
+
+  /// Remove existing top-level QIR module flags and return every unrelated
+  /// flag unchanged.
+  static SmallVector<Attribute>
+  collectUnrelatedModuleFlags(ModuleOp moduleOp, IRRewriter& rewriter) {
+    SmallVector<Attribute> preserved;
+    for (auto flagsOp :
+         llvm::make_early_inc_range(moduleOp.getOps<LLVM::ModuleFlagsOp>())) {
+      for (const auto flag :
+           flagsOp.getFlags().getAsRange<LLVM::ModuleFlagAttr>()) {
+        if (!isQIRModuleFlag(flag.getKey().getValue())) {
+          preserved.emplace_back(flag);
+        }
+      }
+      rewriter.eraseOp(flagsOp);
+    }
+    return preserved;
   }
 
   /// Count the number of uniquely indexed qubit pointers.

--- a/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
@@ -32,7 +32,6 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <iterator>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -40,14 +39,6 @@
 namespace mlir::qir {
 #define GEN_PASS_DEF_QIRSETATTRIBUTESANDMETADATA
 #include "mlir/Dialect/QIR/Transforms/Passes.h.inc"
-
-[[nodiscard]] static bool hasQIREntryPointAttribute(LLVM::LLVMFuncOp function) {
-  const auto passthrough = function->getAttrOfType<ArrayAttr>("passthrough");
-  return passthrough && llvm::any_of(passthrough, [](Attribute attribute) {
-           const auto name = dyn_cast<StringAttr>(attribute);
-           return name && name.getValue() == StringRef(::qir::ENTRY_POINT_ATTR);
-         });
-}
 
 namespace {
 
@@ -83,22 +74,14 @@ struct QIRSetAttributesAndMetadata final
 
 protected:
   void runOnOperation() override {
-    SmallVector<LLVM::LLVMFuncOp> entryPoints;
-    for (auto function : getOperation().getOps<LLVM::LLVMFuncOp>()) {
-      if (mqt::isEntryPoint(function) || hasQIREntryPointAttribute(function)) {
-        entryPoints.push_back(function);
-      }
-    }
-    if (entryPoints.size() != 1) {
-      getOperation().emitError()
-          << "QIR metadata attachment requires exactly one entry point, but "
-             "found "
-          << entryPoints.size();
+    auto main = getMainFunction(getOperation());
+    if (!main) {
+      getOperation().emitError(
+          "QIR metadata attachment requires exactly one entry point");
       signalPassFailure();
       return;
     }
 
-    auto main = entryPoints.front();
     Metadata metadata = useAdaptive ? getAdaptive(main) : getBase(main);
     if (useAdaptive) {
       collectOptionalFeatures(getOperation(), main, metadata);
@@ -154,13 +137,10 @@ private:
               key.getValue() == "required_num_results");
     };
     SmallVector<Attribute> attributes;
-    if (const auto passthrough =
-            main->getAttrOfType<ArrayAttr>("passthrough")) {
-      llvm::copy_if(passthrough, std::back_inserter(attributes),
-                    [&](Attribute attribute) {
-                      return !isQIRFunctionAttribute(attribute);
-                    });
+    if (const auto passthrough = main.getPassthroughAttr()) {
+      attributes.append(passthrough.begin(), passthrough.end());
     }
+    llvm::erase_if(attributes, isQIRFunctionAttribute);
     attributes.append(
         {rewriter.getStringAttr(::qir::ENTRY_POINT_ATTR),
          rewriter.getStrArrayAttr(
@@ -173,22 +153,20 @@ private:
          rewriter.getStrArrayAttr(
              {"required_num_results", std::to_string(metadata.numResults)})});
 
-    main->setAttr("passthrough", rewriter.getArrayAttr(attributes));
+    main.setPassthroughAttr(rewriter.getArrayAttr(attributes));
     mqt::removeEntryPoint(main);
 
     rewriter.setInsertionPointToEnd(m.getBody());
 
     SmallVector<Attribute> flags = collectUnrelatedModuleFlags(m, rewriter);
-    flags.emplace_back(
-        createI32Flag(LLVM::ModFlagBehavior::Error, "qir_major_version", 2));
-    flags.emplace_back(
-        createI32Flag(LLVM::ModFlagBehavior::Max, "qir_minor_version", 1));
-    flags.emplace_back(createBoolFlag(LLVM::ModFlagBehavior::Error,
-                                      "dynamic_qubit_management",
-                                      metadata.useDynamicQubit));
-    flags.emplace_back(createBoolFlag(LLVM::ModFlagBehavior::Error,
-                                      "dynamic_result_management",
-                                      metadata.useDynamicResult));
+    flags.append(
+        {createI32Flag(LLVM::ModFlagBehavior::Error, "qir_major_version", 2),
+         createI32Flag(LLVM::ModFlagBehavior::Max, "qir_minor_version", 1),
+         createBoolFlag(LLVM::ModFlagBehavior::Error,
+                        "dynamic_qubit_management", metadata.useDynamicQubit),
+         createBoolFlag(LLVM::ModFlagBehavior::Error,
+                        "dynamic_result_management",
+                        metadata.useDynamicResult)});
 
     if (useAdaptive) {
       flags.emplace_back(createI32Flag(LLVM::ModFlagBehavior::Error,

--- a/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
@@ -41,6 +41,14 @@ namespace mlir::qir {
 #define GEN_PASS_DEF_QIRSETATTRIBUTESANDMETADATA
 #include "mlir/Dialect/QIR/Transforms/Passes.h.inc"
 
+[[nodiscard]] static bool hasQIREntryPointAttribute(LLVM::LLVMFuncOp function) {
+  const auto passthrough = function->getAttrOfType<ArrayAttr>("passthrough");
+  return passthrough && llvm::any_of(passthrough, [](Attribute attribute) {
+           const auto name = dyn_cast<StringAttr>(attribute);
+           return name && name.getValue() == StringRef(::qir::ENTRY_POINT_ATTR);
+         });
+}
+
 namespace {
 
 /// State object for tracking QIR metadata during conversion
@@ -64,14 +72,6 @@ struct Metadata {
   bool usesMultipleTargetBranching{false};
   bool usesMultipleReturnPoints{false};
 };
-
-[[nodiscard]] static bool hasQIREntryPointAttribute(LLVM::LLVMFuncOp function) {
-  const auto passthrough = function->getAttrOfType<ArrayAttr>("passthrough");
-  return passthrough && llvm::any_of(passthrough, [](Attribute attribute) {
-           const auto name = dyn_cast<StringAttr>(attribute);
-           return name && name.getValue() == StringRef(::qir::ENTRY_POINT_ATTR);
-         });
-}
 
 /**
  * @brief Attaches the required attributes to the function marked as

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -241,23 +241,24 @@ LLVM::LLVMFuncOp getMainFunction(Operation* op) {
     return nullptr;
   }
 
-  for (auto funcOp : moduleOp.getOps<LLVM::LLVMFuncOp>()) {
-    if (mqt::isEntryPoint(funcOp)) {
-      return funcOp;
-    }
-    auto passthrough = funcOp->getAttrOfType<ArrayAttr>("passthrough");
-    if (!passthrough) {
+  LLVM::LLVMFuncOp main;
+  for (auto function : moduleOp.getOps<LLVM::LLVMFuncOp>()) {
+    const auto passthrough = function.getPassthroughAttr();
+    const bool isEntryPoint =
+        mqt::isEntryPoint(function) ||
+        (passthrough && llvm::any_of(passthrough, [](Attribute attribute) {
+           const auto name = dyn_cast<StringAttr>(attribute);
+           return name && name.getValue() == StringRef(::qir::ENTRY_POINT_ATTR);
+         }));
+    if (!isEntryPoint) {
       continue;
     }
-    if (llvm::any_of(passthrough, [](Attribute attr) {
-          const auto strAttr = dyn_cast<StringAttr>(attr);
-          return strAttr &&
-                 strAttr.getValue().compare(::qir::ENTRY_POINT_ATTR) == 0;
-        })) {
-      return funcOp;
+    if (main) {
+      return nullptr;
     }
+    main = function;
   }
-  return nullptr;
+  return main;
 }
 
 LLVM::LLVMFuncOp getOrCreateFunctionDeclaration(OpBuilder& builder,

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -10,7 +10,6 @@
 
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
-#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/QIR/QIRDefinitions.h"
 
 #include <llvm/ADT/STLExtras.h>
@@ -242,15 +241,11 @@ LLVM::LLVMFuncOp getMainFunction(Operation* op) {
   }
 
   LLVM::LLVMFuncOp main;
+  const auto entryPoint =
+      StringAttr::get(op->getContext(), ::qir::ENTRY_POINT_ATTR);
   for (auto function : moduleOp.getOps<LLVM::LLVMFuncOp>()) {
     const auto passthrough = function.getPassthroughAttr();
-    const bool isEntryPoint =
-        mqt::isEntryPoint(function) ||
-        (passthrough && llvm::any_of(passthrough, [](Attribute attribute) {
-           const auto name = dyn_cast<StringAttr>(attribute);
-           return name && name.getValue() == StringRef(::qir::ENTRY_POINT_ATTR);
-         }));
-    if (!isEntryPoint) {
+    if (!passthrough || !llvm::is_contained(passthrough, entryPoint)) {
       continue;
     }
     if (main) {

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -24,7 +24,6 @@
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/Casting.h>
-#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/LLVMTypes.h>
@@ -35,6 +34,7 @@
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
@@ -65,18 +65,11 @@ static LLVM::ModuleFlagAttr findModuleFlag(ModuleOp moduleOp,
   return result;
 }
 
-static size_t countPassthroughEntries(LLVM::LLVMFuncOp function,
-                                      StringRef name) {
-  const auto passthrough = function->getAttrOfType<ArrayAttr>("passthrough");
-  if (!passthrough) {
-    return 0;
-  }
-  return llvm::count_if(passthrough, [&](Attribute attribute) {
-    const auto pair = dyn_cast<ArrayAttr>(attribute);
-    const auto key =
-        pair && pair.size() == 2 ? dyn_cast<StringAttr>(pair[0]) : StringAttr{};
-    return key && key.getValue() == name;
-  });
+static LogicalResult attachQIRMetadata(ModuleOp module,
+                                       bool useAdaptive = false) {
+  PassManager manager(module.getContext());
+  manager.addPass(qir::createQIRSetAttributesAndMetadata({useAdaptive}));
+  return manager.run(module);
 }
 
 namespace {
@@ -256,18 +249,14 @@ TEST_F(QIRTest, MetadataPassRequiresExactlyOneEntryPointAtomically) {
     }
     ASSERT_TRUE(succeeded(verify(module)));
 
-    std::string before;
-    llvm::raw_string_ostream(before) << module;
-    PassManager manager(context.get());
-    manager.addPass(qir::createQIRSetAttributesAndMetadata({false}));
-    EXPECT_TRUE(failed(manager.run(module)));
-    std::string after;
-    llvm::raw_string_ostream(after) << module;
-    EXPECT_EQ(after, before);
+    OwningOpRef<ModuleOp> before = cast<ModuleOp>(module->clone());
+    EXPECT_TRUE(failed(attachQIRMetadata(module)));
+    EXPECT_TRUE(OperationEquivalence::isEquivalentTo(
+        module, before->getOperation(), OperationEquivalence::Flags::None));
   }
 }
 
-TEST_F(QIRTest, PreservesUnrelatedModuleFlags) {
+TEST_F(QIRTest, PreservesUnrelatedMetadataIdempotently) {
   OpBuilder builder(context.get());
   const auto location = builder.getUnknownLoc();
   auto module = ModuleOp::create(location);
@@ -284,15 +273,18 @@ TEST_F(QIRTest, PreservesUnrelatedModuleFlags) {
   const auto functionType =
       LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(context.get()), {});
   auto main = LLVM::LLVMFuncOp::create(builder, location, "main", functionType);
-  main->setAttr("passthrough", builder.getStrArrayAttr({"entry_point"}));
+  const auto nounwind = builder.getStringAttr("nounwind");
+  const auto target = builder.getStrArrayAttr({"target-cpu", "generic"});
+  const auto staleProfile =
+      builder.getStrArrayAttr({"qir_profiles", "stale_profile"});
+  main.setPassthroughAttr(builder.getArrayAttr(
+      {builder.getStringAttr("entry_point"), nounwind, target, staleProfile}));
   auto* block = main.addEntryBlock(builder);
   builder.setInsertionPointToEnd(block);
   LLVM::ReturnOp::create(builder, location, ValueRange{});
   ASSERT_TRUE(succeeded(verify(module)));
 
-  PassManager manager(context.get());
-  manager.addPass(qir::createQIRSetAttributesAndMetadata({false}));
-  ASSERT_TRUE(succeeded(manager.run(module)));
+  ASSERT_TRUE(succeeded(attachQIRMetadata(module)));
   const auto preserved = findModuleFlag(module, "Debug Info Version");
   ASSERT_TRUE(preserved);
   EXPECT_EQ(preserved.getBehavior(), LLVM::ModFlagBehavior::Warning);
@@ -300,43 +292,21 @@ TEST_F(QIRTest, PreservesUnrelatedModuleFlags) {
   const auto qirMajor = findModuleFlag(module, "qir_major_version");
   ASSERT_TRUE(qirMajor);
   EXPECT_EQ(cast<IntegerAttr>(qirMajor.getValue()).getInt(), 2);
-}
 
-TEST_F(QIRTest, PreservesUnrelatedFunctionPassthroughAttributesIdempotently) {
-  OpBuilder builder(context.get());
-  const auto location = builder.getUnknownLoc();
-  auto module = ModuleOp::create(location);
-  builder.setInsertionPointToStart(module.getBody());
-  const auto functionType =
-      LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(context.get()), {});
-  auto main = LLVM::LLVMFuncOp::create(builder, location, "main", functionType);
-  const auto nounwind = builder.getStringAttr("nounwind");
-  const auto target = builder.getStrArrayAttr({"target-cpu", "generic"});
-  main->setAttr(
-      "passthrough",
-      builder.getArrayAttr(
-          {builder.getStringAttr("entry_point"), nounwind, target,
-           builder.getStrArrayAttr({"qir_profiles", "stale_profile"})}));
-  auto* block = main.addEntryBlock(builder);
-  builder.setInsertionPointToEnd(block);
-  LLVM::ReturnOp::create(builder, location, ValueRange{});
-  ASSERT_TRUE(succeeded(verify(module)));
-
-  const auto runPass = [&] {
-    PassManager manager(context.get());
-    manager.addPass(qir::createQIRSetAttributesAndMetadata({false}));
-    return manager.run(module);
-  };
-  ASSERT_TRUE(succeeded(runPass()));
-  auto passthrough = main->getAttrOfType<ArrayAttr>("passthrough");
+  const auto passthrough = main.getPassthroughAttr();
   ASSERT_TRUE(passthrough);
   EXPECT_TRUE(llvm::is_contained(passthrough, nounwind));
   EXPECT_TRUE(llvm::is_contained(passthrough, target));
-  EXPECT_EQ(countPassthroughEntries(main, "qir_profiles"), 1U);
-  const auto afterFirstRun = passthrough;
+  const auto baseProfile =
+      builder.getStrArrayAttr({"qir_profiles", "base_profile"});
+  EXPECT_EQ(llvm::count(passthrough, baseProfile), 1U);
+  EXPECT_FALSE(llvm::is_contained(passthrough, staleProfile));
 
-  ASSERT_TRUE(succeeded(runPass()));
-  EXPECT_EQ(main->getAttrOfType<ArrayAttr>("passthrough"), afterFirstRun);
+  OwningOpRef<ModuleOp> afterFirstRun = cast<ModuleOp>(module->clone());
+  ASSERT_TRUE(succeeded(attachQIRMetadata(module)));
+  EXPECT_TRUE(OperationEquivalence::isEquivalentTo(
+      module, afterFirstRun->getOperation(),
+      OperationEquivalence::Flags::None));
 }
 
 TEST_F(QIRTest, AdaptiveBuilderSelectsControlledSpecializationsByArity) {
@@ -494,16 +464,7 @@ TEST_F(QIRTest, DerivesAdaptiveClassicalCapabilities) {
   builder.setInsertionPointToEnd(caseBlock);
   LLVM::ReturnOp::create(builder, location, doubled);
 
-  const auto attachAttributes = [&](const bool useAdaptive) {
-    return runWithPassManager(
-        moduleOp,
-        [&](OpPassManager& manager) {
-          manager.addPass(
-              qir::createQIRSetAttributesAndMetadata({useAdaptive}));
-        },
-        "Failed to attach QIR attributes.");
-  };
-  ASSERT_TRUE(attachAttributes(true).succeeded());
+  ASSERT_TRUE(attachQIRMetadata(moduleOp, true).succeeded());
   const auto integerTypes =
       moduleOp->getAttrOfType<ArrayAttr>("qir.int_computations");
   ASSERT_TRUE(integerTypes);
@@ -524,7 +485,7 @@ TEST_F(QIRTest, DerivesAdaptiveClassicalCapabilities) {
     EXPECT_EQ(moduleFlag.getValue(), builder.getI32IntegerAttr(1)) << flag;
   }
 
-  ASSERT_TRUE(attachAttributes(false).succeeded());
+  ASSERT_TRUE(attachQIRMetadata(moduleOp).succeeded());
   EXPECT_FALSE(moduleOp->hasAttr("qir.int_computations"));
   EXPECT_FALSE(moduleOp->hasAttr("qir.float_computations"));
   EXPECT_FALSE(findModuleFlag(moduleOp, "ir_functions"));

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -24,6 +24,7 @@
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/Casting.h>
+#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/LLVMIR/LLVMAttrs.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/LLVMTypes.h>
@@ -38,7 +39,9 @@
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 
+#include <algorithm>
 #include <array>
+#include <cstddef>
 #include <iosfwd>
 #include <memory>
 #include <ostream>
@@ -60,6 +63,20 @@ static LLVM::ModuleFlagAttr findModuleFlag(ModuleOp moduleOp,
     }
   });
   return result;
+}
+
+static size_t countPassthroughEntries(LLVM::LLVMFuncOp function,
+                                      StringRef name) {
+  const auto passthrough = function->getAttrOfType<ArrayAttr>("passthrough");
+  if (!passthrough) {
+    return 0;
+  }
+  return llvm::count_if(passthrough, [&](Attribute attribute) {
+    const auto pair = dyn_cast<ArrayAttr>(attribute);
+    const auto key =
+        pair && pair.size() == 2 ? dyn_cast<StringAttr>(pair[0]) : StringAttr{};
+    return key && key.getValue() == name;
+  });
 }
 
 namespace {
@@ -214,6 +231,112 @@ TEST_F(QIRTest, ReusedIrreversibleDeclarationsPreservePassthroughIdempotently) {
     EXPECT_EQ(llvm::count(passthrough, builder.getStringAttr("irreversible")),
               1);
   }
+}
+
+TEST_F(QIRTest, MetadataPassRequiresExactlyOneEntryPointAtomically) {
+  for (const size_t numEntryPoints : {0U, 2U}) {
+    SCOPED_TRACE(testing::Message() << "numEntryPoints=" << numEntryPoints);
+    OpBuilder builder(context.get());
+    const auto location = builder.getUnknownLoc();
+    auto module = ModuleOp::create(location);
+    builder.setInsertionPointToStart(module.getBody());
+    const auto functionType =
+        LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(context.get()), {});
+    for (size_t i = 0; i < std::max<size_t>(numEntryPoints, 1); ++i) {
+      auto function = LLVM::LLVMFuncOp::create(
+          builder, location, "function" + std::to_string(i), functionType);
+      if (i < numEntryPoints) {
+        function->setAttr("passthrough",
+                          builder.getStrArrayAttr({"entry_point"}));
+      }
+      auto* block = function.addEntryBlock(builder);
+      builder.setInsertionPointToEnd(block);
+      LLVM::ReturnOp::create(builder, location, ValueRange{});
+      builder.setInsertionPointToEnd(module.getBody());
+    }
+    ASSERT_TRUE(succeeded(verify(module)));
+
+    std::string before;
+    llvm::raw_string_ostream(before) << module;
+    PassManager manager(context.get());
+    manager.addPass(qir::createQIRSetAttributesAndMetadata({false}));
+    EXPECT_TRUE(failed(manager.run(module)));
+    std::string after;
+    llvm::raw_string_ostream(after) << module;
+    EXPECT_EQ(after, before);
+  }
+}
+
+TEST_F(QIRTest, PreservesUnrelatedModuleFlags) {
+  OpBuilder builder(context.get());
+  const auto location = builder.getUnknownLoc();
+  auto module = ModuleOp::create(location);
+  builder.setInsertionPointToStart(module.getBody());
+  const auto unrelated =
+      LLVM::ModuleFlagAttr::get(context.get(), LLVM::ModFlagBehavior::Warning,
+                                builder.getStringAttr("Debug Info Version"),
+                                builder.getI32IntegerAttr(3));
+  const auto staleQIR = LLVM::ModuleFlagAttr::get(
+      context.get(), LLVM::ModFlagBehavior::Error,
+      builder.getStringAttr("qir_major_version"), builder.getI32IntegerAttr(1));
+  LLVM::ModuleFlagsOp::create(builder, location,
+                              builder.getArrayAttr({unrelated, staleQIR}));
+  const auto functionType =
+      LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(context.get()), {});
+  auto main = LLVM::LLVMFuncOp::create(builder, location, "main", functionType);
+  main->setAttr("passthrough", builder.getStrArrayAttr({"entry_point"}));
+  auto* block = main.addEntryBlock(builder);
+  builder.setInsertionPointToEnd(block);
+  LLVM::ReturnOp::create(builder, location, ValueRange{});
+  ASSERT_TRUE(succeeded(verify(module)));
+
+  PassManager manager(context.get());
+  manager.addPass(qir::createQIRSetAttributesAndMetadata({false}));
+  ASSERT_TRUE(succeeded(manager.run(module)));
+  const auto preserved = findModuleFlag(module, "Debug Info Version");
+  ASSERT_TRUE(preserved);
+  EXPECT_EQ(preserved.getBehavior(), LLVM::ModFlagBehavior::Warning);
+  EXPECT_EQ(cast<IntegerAttr>(preserved.getValue()).getInt(), 3);
+  const auto qirMajor = findModuleFlag(module, "qir_major_version");
+  ASSERT_TRUE(qirMajor);
+  EXPECT_EQ(cast<IntegerAttr>(qirMajor.getValue()).getInt(), 2);
+}
+
+TEST_F(QIRTest, PreservesUnrelatedFunctionPassthroughAttributesIdempotently) {
+  OpBuilder builder(context.get());
+  const auto location = builder.getUnknownLoc();
+  auto module = ModuleOp::create(location);
+  builder.setInsertionPointToStart(module.getBody());
+  const auto functionType =
+      LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(context.get()), {});
+  auto main = LLVM::LLVMFuncOp::create(builder, location, "main", functionType);
+  const auto nounwind = builder.getStringAttr("nounwind");
+  const auto target = builder.getStrArrayAttr({"target-cpu", "generic"});
+  main->setAttr(
+      "passthrough",
+      builder.getArrayAttr(
+          {builder.getStringAttr("entry_point"), nounwind, target,
+           builder.getStrArrayAttr({"qir_profiles", "stale_profile"})}));
+  auto* block = main.addEntryBlock(builder);
+  builder.setInsertionPointToEnd(block);
+  LLVM::ReturnOp::create(builder, location, ValueRange{});
+  ASSERT_TRUE(succeeded(verify(module)));
+
+  const auto runPass = [&] {
+    PassManager manager(context.get());
+    manager.addPass(qir::createQIRSetAttributesAndMetadata({false}));
+    return manager.run(module);
+  };
+  ASSERT_TRUE(succeeded(runPass()));
+  auto passthrough = main->getAttrOfType<ArrayAttr>("passthrough");
+  ASSERT_TRUE(passthrough);
+  EXPECT_TRUE(llvm::is_contained(passthrough, nounwind));
+  EXPECT_TRUE(llvm::is_contained(passthrough, target));
+  EXPECT_EQ(countPassthroughEntries(main, "qir_profiles"), 1U);
+  const auto afterFirstRun = passthrough;
+
+  ASSERT_TRUE(succeeded(runPass()));
+  EXPECT_EQ(main->getAttrOfType<ArrayAttr>("passthrough"), afterFirstRun);
 }
 
 TEST_F(QIRTest, AdaptiveBuilderSelectsControlledSpecializationsByArity) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Require exactly one QIR entry point before changing the module.
- Recognize an existing QIR entry-point passthrough attribute on repeated runs.
- Replace stale QIR metadata while preserving unrelated function passthrough entries and LLVM module flags.

Part of #2255.

## Validation

- QIR IR unit-test suite: 120 passed.
- uvx nox -s lint: passed.
- uvx nox -s cpp-lint: could not start locally because clang-tidy 22 is unavailable; CI will run the canonical check.

AI assistance: Codex extracted this focused change from the contract audit branch, rebased it onto current main, added focused regressions, and ran the listed validation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~ (Not applicable: no user-facing documentation change is needed.)
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~ (Not applicable: this focused fix is labeled skip-changelog.)
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~ (Not needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.