### PR TITLE
🐛 Reject nonlinear QTensor shrink chains safely

### DIFF
--- a/mlir/lib/Dialect/QTensor/Transforms/ShrinkRegisters.cpp
+++ b/mlir/lib/Dialect/QTensor/Transforms/ShrinkRegisters.cpp
@@ -62,6 +62,9 @@ struct TensorAccess {
     SmallVectorImpl<TensorAccess>& accesses, DeallocOp& deallocOp) {
   auto tensor = allocOp.getResult();
   while (true) {
+    if (!tensor.hasOneUse()) {
+      return failure();
+    }
     auto* user = *tensor.getUsers().begin();
 
     if (auto currentDealloc = dyn_cast<DeallocOp>(user)) {

--- a/mlir/unittests/Dialect/QTensor/Transforms/test_qtensor_transforms.cpp
+++ b/mlir/unittests/Dialect/QTensor/Transforms/test_qtensor_transforms.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/QTensor/Transforms/Passes.h"
 
 #include <gtest/gtest.h>
+#include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -34,6 +35,7 @@
 #include <mlir/Support/LLVM.h>
 
 #include <cstdint>
+#include <string>
 
 using namespace mlir;
 
@@ -116,6 +118,44 @@ TEST(QTensorTransformsTest, HugeDeclaredTensorUsesSparseShrinkPlan) {
   ASSERT_TRUE(allocation);
   EXPECT_EQ(cast<RankedTensorType>(allocation.getType()).getShape(),
             ArrayRef<int64_t>{1});
+}
+
+TEST(QTensorTransformsTest, RejectsNonLinearChainWithoutMutation) {
+  DialectRegistry registry;
+  registry.insert<arith::ArithDialect, func::FuncDialect, mqt::MQTDialect,
+                  qco::QCODialect, qtensor::QTensorDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @main() {
+        %c1 = arith.constant 1 : index
+        %c3 = arith.constant 3 : index
+        %reg = qtensor.alloc(%c3) : tensor<3x!qco.qubit>
+        %rest, %qubit = qtensor.extract %reg[%c1]
+            : tensor<3x!qco.qubit>
+        qtensor.dealloc %rest : tensor<3x!qco.qubit>
+        qtensor.dealloc %rest : tensor<3x!qco.qubit>
+        return
+      }
+    }
+  )mlir",
+                                              &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  std::string before;
+  llvm::raw_string_ostream(before) << *moduleOp;
+
+  PassManager manager(&context);
+  manager.addPass(qtensor::createShrinkQTensorToFitPass());
+  ASSERT_TRUE(succeeded(manager.run(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  std::string after;
+  llvm::raw_string_ostream(after) << *moduleOp;
+  EXPECT_EQ(after, before);
 }
 
 } // namespace


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Require each tensor in a shrink chain to have exactly one user before dereferencing it.
- Leave nonlinear or incomplete chains unchanged.
- Add a no-mutation regression for a tensor with two deallocation users.

Follow-up to #2295 and part of #2255.

## Validation

- QTensor transforms unit-test suite: 3 passed.
- uvx nox -s lint: passed.
- uvx nox -s cpp-lint: could not start locally because clang-tidy 22 is unavailable; CI will run the canonical check.

AI assistance: Codex extracted the minimal follow-up from the contract audit branch and ran the listed validation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~ (Not applicable: no user-facing documentation change is needed.)
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~ (Not applicable: this focused fix is labeled skip-changelog.)
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~ (Not needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.