### PR TITLE
🐛 Preserve MLIR runtime errors on macOS

### DIFF
--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -39,6 +39,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <filesystem>
 #include <memory>
 #include <optional>
@@ -55,6 +56,23 @@ namespace mqt {
 
 namespace nb = nanobind;
 using namespace nb::literals;
+
+#ifdef __APPLE__
+// Keep the catch in this binary: Darwin cannot reliably match standard-library
+// exception RTTI in nanobind's split-mode backend.
+static void translateRuntimeError(const std::exception_ptr& error,
+                                  void* /*unused*/) {
+  try {
+    std::rethrow_exception(error);
+  } catch (const std::range_error& exception) {
+    PyErr_SetString(PyExc_ValueError, exception.what());
+  } catch (const std::overflow_error& exception) {
+    PyErr_SetString(PyExc_OverflowError, exception.what());
+  } catch (const std::runtime_error& exception) {
+    PyErr_SetString(PyExc_RuntimeError, exception.what());
+  }
+}
+#endif
 
 template <class T>
 [[nodiscard]] static T takeResult(std::optional<T>&& result) {
@@ -322,6 +340,10 @@ generateBenchmark(const std::string_view instanceSpecificationJSON) {
 }
 
 NB_MODULE(MQT_CORE_MODULE_NAME, m) {
+#ifdef __APPLE__
+  nb::register_exception_translator(&translateRuntimeError);
+#endif
+
   m.doc() = "MQT Core MLIR compiler bindings.";
 
   nb::module_::import_("typing");

--- a/test/python/test_bench.py
+++ b/test/python/test_bench.py
@@ -140,6 +140,13 @@ def test_ghz_options_reference_and_json_roundtrip() -> None:
     assert_generates(benchmark)
 
 
+def test_importing_mlir_preserves_benchmark_overflow_error() -> None:
+    """Preserve nanobind's ``OverflowError`` mapping after loading MLIR."""
+    benchmark = ghz.GHZ(ghz.Options(qubits=2))
+    with pytest.raises(OverflowError, match="total shot count exceeds size_t"):
+        benchmark.evaluate({"00": 2**64 - 1, "11": 1})
+
+
 def test_grover_resolves_iterations_and_reports_success() -> None:
     """Expose Grover's resolved default and marked-outcome score."""
     options = grover.Options(marked_bitstring="10")


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Translate standard-library runtime errors inside the Darwin MLIR extension to avoid split-backend RTTI loss.
- Preserve ValueError and OverflowError mappings for derived exceptions in the shared nanobind domain.
- Add a cross-module overflow regression after importing MLIR.

Part of #2255.

## Validation

- LLVM/MLIR 23.1 MLIR and benchmark bindings: built successfully.
- Focused benchmark overflow regression: 1 passed.
- RuntimeError, ValueError, and OverflowError direct probes: passed with original messages.
- Repository pre-commit hooks: passed.

AI assistance: Codex extracted this focused change from the contract audit branch, rebased it onto current main, and ran the listed validation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~ (Not applicable: no user-facing documentation change is needed.)
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~ (Not applicable: this focused fix is labeled skip-changelog.)
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~ (Not needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.