### PR TITLE
🐛 Make Pauli-twirling traversal stack-safe

### DIFF
--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/PauliTwirling.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/PauliTwirling.cpp
@@ -19,9 +19,7 @@
 #include <mlir/IR/Location.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
-#include <mlir/IR/Visitors.h>
 #include <mlir/Support/LLVM.h>
-#include <mlir/Support/WalkResult.h>
 
 #include <array>
 #include <cstdint>
@@ -219,13 +217,25 @@ protected:
       const std::array<Twirl, 16>* table;
     };
     SmallVector<Candidate> gates;
-    getOperation().walk<WalkOrder::PreOrder>([&](Operation* op) {
+    SmallVector<Operation*> worklist{getOperation()};
+    while (!worklist.empty()) {
+      Operation* op = worklist.pop_back_val();
       if (const auto* table = getTwirlTable(op)) {
         gates.push_back({.gate = cast<UnitaryOpInterface>(op), .table = table});
       }
-      return isa<CtrlOp, InvOp, PowOp>(op) ? WalkResult::skip()
-                                           : WalkResult::advance();
-    });
+      if (isa<CtrlOp, InvOp, PowOp>(op)) {
+        continue;
+      }
+      SmallVector<Operation*> nested;
+      for (Region& region : op->getRegions()) {
+        for (Block& block : region) {
+          for (Operation& operation : block) {
+            nested.push_back(&operation);
+          }
+        }
+      }
+      worklist.append(nested.rbegin(), nested.rend());
+    }
 
     IRRewriter rewriter(&getContext());
     std::mt19937_64 rng(seed);

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_pauli_twirling.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_pauli_twirling.cpp
@@ -15,19 +15,23 @@
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <set>
 #include <string>
@@ -49,7 +53,8 @@ protected:
 
   void SetUp() override {
     DialectRegistry registry;
-    registry.insert<QCODialect, arith::ArithDialect, func::FuncDialect>();
+    registry.insert<QCODialect, arith::ArithDialect, func::FuncDialect,
+                    scf::SCFDialect>();
     context.appendDialectRegistry(registry);
     context.loadAllAvailableDialects();
     builder.initialize();
@@ -128,6 +133,54 @@ TEST_F(PauliTwirlingTest, SameSeedProducesSameProgram) {
   ASSERT_TRUE(succeeded(runPass(*first, 12345)));
   ASSERT_TRUE(succeeded(runPass(*second, 12345)));
   EXPECT_EQ(print(*first), print(*second));
+}
+
+TEST_F(PauliTwirlingTest, TwirlsGateInsideDeepNonModifierRegions) {
+  constexpr size_t depth = 256;
+  std::string source = R"mlir(
+module {
+  func.func @main() {
+    %q0 = qco.static 0 : !qco.qubit
+    %q1 = qco.static 1 : !qco.qubit
+)mlir";
+  for (size_t i = 0; i < depth; ++i) {
+    source += "    scf.execute_region {\n";
+  }
+  source += R"mlir(
+    %out0, %out1 = qco.ecr %q0, %q1 : !qco.qubit, !qco.qubit
+      -> !qco.qubit, !qco.qubit
+    qco.sink %out0 : !qco.qubit
+    qco.sink %out1 : !qco.qubit
+)mlir";
+  for (size_t i = 0; i < depth; ++i) {
+    source += "      scf.yield\n    }\n";
+  }
+  source += R"mlir(
+    return
+  }
+}
+)mlir";
+
+  auto module = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  auto function = module->lookupSymbol<func::FuncOp>("main");
+  ASSERT_TRUE(function);
+  auto execute = *function.getOps<scf::ExecuteRegionOp>().begin();
+  for (size_t i = 1; i < depth; ++i) {
+    execute =
+        *execute.getRegion().front().getOps<scf::ExecuteRegionOp>().begin();
+  }
+  Block* innermostBlock = &execute.getRegion().front();
+
+  ASSERT_TRUE(succeeded(runPass(*module, 42)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+
+  const auto pauliCount = llvm::count_if(*innermostBlock, [](Operation& op) {
+    return isa<IdOp, XOp, YOp, ZOp>(op);
+  });
+  EXPECT_EQ(pauliCount, 4);
 }
 
 TEST_F(PauliTwirlingTest, PreservesExistingPhaseWhenRewriting) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Replace recursive preorder traversal with an explicit worklist.
- Preserve source preorder and modifier-region skipping.
- Cover gates inside 256 nested non-modifier regions.

Part of #2255.

## Validation

- Pauli-twirling focused tests: 4 passed.
- Repository pre-commit hooks: passed.
- Clang-Tidy 22.1.8 on changed C++ sources: passed.

AI assistance: Codex extracted this focused change from the contract audit branch, rebased it onto current main, and ran the listed validation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~ (Not applicable: no user-facing documentation change is needed.)
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~ (Not applicable: this focused fix is labeled skip-changelog.)
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~ (Not needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.