### PR TITLE
🐛 Bound CBit zero-initialization lowering

### DIFF
--- a/mlir/include/mlir/Conversion/CBitToMemRef/CBitToMemRef.td
+++ b/mlir/include/mlir/Conversion/CBitToMemRef/CBitToMemRef.td
@@ -13,13 +13,15 @@ def ConvertCBitToMemRef : Pass<"convert-cbit-to-memref", "mlir::ModuleOp"> {
 
   let description = [{
     This pass explicitly lowers CBit register types and operations to memrefs.
-    A zero-initialized register becomes an allocation followed by one false
-    store for each element. An undefined register becomes an allocation only.
+    A zero-initialized register becomes an allocation followed by a loop that
+    stores false to each element. An undefined register becomes an allocation
+    only.
     The pass also converts function signatures, calls, returns, branches, and
     structural SCF operation types. It does not infer CBit registers from
     existing memrefs.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect",
-                           "mlir::memref::MemRefDialect"];
+                           "mlir::memref::MemRefDialect",
+                           "mlir::scf::SCFDialect"];
 }

--- a/mlir/lib/Conversion/CBitToMemRef/CBitToMemRef.cpp
+++ b/mlir/lib/Conversion/CBitToMemRef/CBitToMemRef.cpp
@@ -18,13 +18,13 @@
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/SCF/Transforms/Patterns.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
 
-#include <cstdint>
 #include <utility>
 
 namespace mlir {
@@ -58,13 +58,17 @@ struct ConvertAllocOp final : OpConversionPattern<cbit::AllocOp> {
     if (op.getInitialization() == cbit::Initialization::Zero) {
       auto zero = arith::ConstantOp::create(rewriter, op.getLoc(),
                                             rewriter.getBoolAttr(false));
-      for (int64_t index = 0; index < type.getDimSize(0); ++index) {
-        auto indexValue =
-            arith::ConstantIndexOp::create(rewriter, op.getLoc(), index);
-        memref::StoreOp::create(rewriter, op.getLoc(), zero.getResult(),
-                                allocation.getResult(),
-                                ValueRange{indexValue.getResult()});
-      }
+      auto lower = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
+      auto upper = arith::ConstantIndexOp::create(rewriter, op.getLoc(),
+                                                  type.getDimSize(0));
+      auto step = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 1);
+      scf::ForOp::create(
+          rewriter, op.getLoc(), lower, upper, step, ValueRange{},
+          [&](OpBuilder& builder, Location location, Value index, ValueRange) {
+            memref::StoreOp::create(builder, location, zero.getResult(),
+                                    allocation.getResult(), ValueRange{index});
+            scf::YieldOp::create(builder, location);
+          });
     }
 
     rewriter.replaceOp(op, allocation.getResult());

--- a/mlir/unittests/Conversion/CBitToMemRef/test_cbit_to_memref.cpp
+++ b/mlir/unittests/Conversion/CBitToMemRef/test_cbit_to_memref.cpp
@@ -24,6 +24,7 @@
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/DialectRegistry.h>
@@ -103,10 +104,34 @@ TEST_F(CBitToMemRefTest, LowersInitializationLoadsAndStores) {
   moduleOp->walk([&](memref::StoreOp) { ++stores; });
   moduleOp->walk([&](memref::LoadOp) { ++loads; });
   EXPECT_EQ(allocations, 2);
-  EXPECT_EQ(stores, 3);
+  EXPECT_EQ(stores, 2);
   EXPECT_EQ(loads, 1);
   ASSERT_TRUE(registerName);
   EXPECT_EQ(registerName.getValue(), "result");
+}
+
+TEST_F(CBitToMemRefTest, LargeZeroInitializationProducesBoundedIR) {
+  auto moduleOp = convert(R"mlir(
+    module {
+      func.func @main() {
+        %reg = cbit.alloc(#cbit.init<zero>) : !cbit.reg<1000000000>
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  SmallVector<scf::ForOp> loops;
+  moduleOp->walk([&](scf::ForOp loop) { loops.emplace_back(loop); });
+  ASSERT_EQ(loops.size(), 1);
+  EXPECT_EQ(getConstantIntValue(loops.front().getLowerBound()), 0);
+  EXPECT_EQ(getConstantIntValue(loops.front().getUpperBound()), 1000000000);
+  EXPECT_EQ(getConstantIntValue(loops.front().getStep()), 1);
+
+  size_t stores = 0;
+  loops.front().getBody()->walk([&](memref::StoreOp) { ++stores; });
+  EXPECT_EQ(stores, 1);
 }
 
 TEST_F(CBitToMemRefTest, ConvertsFunctionSignaturesCallsAndReturns) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Lower zero-initialized CBit registers with one SCF loop instead of one generated store per bit.
- Keep undefined initialization unchanged.
- Cover billion-bit registers without expanding conversion IR linearly.

Part of #2255.

## Validation

- CBit-to-memref unit-test suite: 3 passed.
- Repository pre-commit hooks: passed.
- Clang-Tidy 22.1.8 on changed C++ sources: passed.

AI assistance: Codex extracted this focused change from the contract audit branch, rebased it onto current main, and ran the listed validation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~ (Not applicable: no user-facing documentation change is needed.)
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~ (Not applicable: this focused fix is labeled skip-changelog.)
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~ (Not needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.