### PR TITLE
🐛 Reject nonlinear Hadamard-lifting inputs safely

### DIFF
--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/HadamardLifting.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/HadamardLifting.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/MQT/Utils/Modifiers.h"
 #include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
 #include <llvm/ADT/STLExtras.h>
@@ -228,6 +229,10 @@ protected:
   void runOnOperation() override {
     auto op = getOperation();
     auto* ctx = &getContext();
+    if (failed(qco::verifyLinearity(op))) {
+      signalPassFailure();
+      return;
+    }
 
     // Define the set of patterns to use.
     RewritePatternSet patterns(ctx);

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_hadamard_lifting.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_hadamard_lifting.cpp
@@ -20,8 +20,11 @@
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/DialectRegistry.h>
+#include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
@@ -80,6 +83,56 @@ protected:
 };
 
 } // namespace
+
+TEST_F(QCOHadamardLiftingTest, HandlesUnusedPauliOutput) {
+  auto input = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @main() {
+        %q = qco.static 0 : !qco.qubit
+        %unused = qco.x %q : !qco.qubit -> !qco.qubit
+        return
+      }
+    }
+  )mlir",
+                                           &context);
+  ASSERT_TRUE(input);
+  ASSERT_TRUE(succeeded(verify(*input)));
+  OwningOpRef<ModuleOp> original(input->clone());
+
+  EXPECT_TRUE(failed(runHadamardLiftingPass(*input)));
+  EXPECT_TRUE(OperationEquivalence::isEquivalentTo(
+      input->getOperation(), original->getOperation(),
+      OperationEquivalence::Flags::None));
+}
+
+TEST_F(QCOHadamardLiftingTest, HandlesUnusedCnotControlOutput) {
+  auto input = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @main() {
+        %control = qco.static 0 : !qco.qubit
+        %target = qco.static 1 : !qco.qubit
+        %unused, %target_out = qco.ctrl(%control) targets(%arg = %target) {
+          %body = qco.x %arg : !qco.qubit -> !qco.qubit
+          qco.yield %body : !qco.qubit
+        } : ({!qco.qubit}, {!qco.qubit})
+          -> ({!qco.qubit}, {!qco.qubit})
+        %hadamard = qco.h %target_out : !qco.qubit -> !qco.qubit
+        %measured, %result = qco.measure %hadamard : !qco.qubit
+        qco.sink %measured : !qco.qubit
+        return
+      }
+    }
+  )mlir",
+                                           &context);
+  ASSERT_TRUE(input);
+  ASSERT_TRUE(succeeded(verify(*input)));
+  OwningOpRef<ModuleOp> original(input->clone());
+
+  EXPECT_TRUE(failed(runHadamardLiftingPass(*input)));
+  EXPECT_TRUE(OperationEquivalence::isEquivalentTo(
+      input->getOperation(), original->getOperation(),
+      OperationEquivalence::Flags::None));
+}
 
 // ##################################################
 // # Raise Hadamard over uncontrolled Pauli gate Tests


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Validate QCO linearity before greedy Hadamard lifting mutates the IR.
- Reject unused Pauli and CNOT outputs through pass failure.
- Verify that failure leaves the input unchanged.

Part of #2255.

## Validation

- Hadamard-lifting focused tests: 12 passed.
- Repository pre-commit hooks: passed.
- Clang-Tidy 22.1.8 on changed C++ sources: passed.

AI assistance: Codex extracted this focused change from the contract audit branch, rebased it onto current main, and ran the listed validation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~ (Not applicable: no user-facing documentation change is needed.)
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~ (Not applicable: this focused fix is labeled skip-changelog.)
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~ (Not needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.