### PR TITLE
🐛 Preserve QIR runtime management metadata

### DIFF
--- a/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
@@ -53,17 +53,21 @@ namespace mlir::qir {
 }
 
 [[nodiscard]] static bool moduleHasDynamicQubitRuntimeCalls(ModuleOp module) {
-  return llvm::any_of(module.getOps<LLVM::CallOp>(), [](LLVM::CallOp callOp) {
+  bool found = false;
+  module.walk([&](LLVM::CallOp callOp) {
     const auto callee = getCalleeName(callOp);
-    return callee == QIR_QUBIT_ALLOC || callee == QIR_QUBIT_ARRAY_ALLOC;
+    found |= callee == QIR_QUBIT_ALLOC || callee == QIR_QUBIT_ARRAY_ALLOC;
   });
+  return found;
 }
 
 [[nodiscard]] static bool moduleHasDynamicResultRuntimeCalls(ModuleOp module) {
-  return llvm::any_of(module.getOps<LLVM::CallOp>(), [](LLVM::CallOp callOp) {
+  bool found = false;
+  module.walk([&](LLVM::CallOp callOp) {
     const auto callee = getCalleeName(callOp);
-    return callee == QIR_RESULT_ALLOC || callee == QIR_RESULT_ARRAY_ALLOC;
+    found |= callee == QIR_RESULT_ALLOC || callee == QIR_RESULT_ARRAY_ALLOC;
   });
+  return found;
 }
 
 static void dropUnusedExternalDeclarations(ModuleOp module) {

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -378,6 +378,50 @@ TEST_F(QIRTest, BaseBuilderUsesGenericSpecializationForThreeControls) {
                       StringAttr::get(context.get(), "base_profile")})));
 }
 
+TEST_F(QIRTest, CleanupPreservesMetadataForNestedRuntimeCalls) {
+  OpBuilder builder(context.get());
+  const auto location = builder.getUnknownLoc();
+  auto module = ModuleOp::create(location);
+  builder.setInsertionPointToStart(module.getBody());
+
+  const auto pointerType = LLVM::LLVMPointerType::get(context.get());
+  const auto allocateType =
+      LLVM::LLVMFunctionType::get(pointerType, {pointerType});
+  auto allocateQubit = LLVM::LLVMFuncOp::create(builder, location,
+                                                QIR_QUBIT_ALLOC, allocateType);
+  auto allocateResult = LLVM::LLVMFuncOp::create(
+      builder, location, QIR_RESULT_ALLOC, allocateType);
+  const auto mainType =
+      LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(context.get()), {});
+  auto main = LLVM::LLVMFuncOp::create(builder, location, "main", mainType);
+  const auto dynamicQubitManagement =
+      builder.getStrArrayAttr({"dynamic_qubit_management", "true"});
+  const auto dynamicResultManagement =
+      builder.getStrArrayAttr({"dynamic_result_management", "true"});
+  main.setPassthroughAttr(builder.getArrayAttr({
+      builder.getStringAttr("entry_point"),
+      dynamicQubitManagement,
+      dynamicResultManagement,
+  }));
+  auto* block = main.addEntryBlock(builder);
+  builder.setInsertionPointToEnd(block);
+  auto null = LLVM::ZeroOp::create(builder, location, pointerType);
+  LLVM::CallOp::create(builder, location, allocateQubit, null.getResult());
+  LLVM::CallOp::create(builder, location, allocateResult, null.getResult());
+  LLVM::ReturnOp::create(builder, location, ValueRange{});
+  ASSERT_TRUE(succeeded(verify(module)));
+
+  PassManager manager(context.get());
+  manager.addPass(qir::createQIRCleanupPass());
+  ASSERT_TRUE(succeeded(manager.run(module)));
+  ASSERT_TRUE(succeeded(verify(module)));
+  ASSERT_TRUE(main.getPassthroughAttr());
+  EXPECT_TRUE(
+      llvm::is_contained(main.getPassthroughAttr(), dynamicQubitManagement));
+  EXPECT_TRUE(
+      llvm::is_contained(main.getPassthroughAttr(), dynamicResultManagement));
+}
+
 TEST_F(QIRTest, UsesTranslationCompatibleModuleFlagWidths) {
   const auto build = [&](const QIRProgramBuilder::Profile profile) {
     return QIRProgramBuilder::build(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Make QIR cleanup inspect runtime allocation calls nested inside functions. These calls are not direct module children, so the previous top-level iteration missed them and could remove the dynamic qubit/result management metadata required by valid QIR modules.

The regression covers both dynamic qubit and dynamic result allocation calls inside the entry function.

Part of #2255.

## Validation

- `QIRTest.CleanupPreservesMetadataForNestedRuntimeCalls`
- Full QIR IR suite: 120/120 tests passed
- `nox -s lint`
- Changed-file C++ lint: zero clang-format and clang-tidy findings

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] Documentation remains accurate; no documentation update is required for this internal correctness fix.
- [x] No changelog entry is needed for this unreleased MLIR behavior; the `skip-changelog` label is applied.
- [x] No upgrade-guide migration instructions are needed.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks. Local targeted, full-suite, and lint checks pass; CI is pending.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description. Implementation, tests, and PR preparation were assisted by Codex.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
