### PR TITLE
🐛 Preserve yield permutations when unrolling loops

### DIFF
--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/QuantumLoopUnroll.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/QuantumLoopUnroll.cpp
@@ -60,6 +60,15 @@ static SmallVector<scf::ForOp> collectQuantumLoops(FunctionOpInterface func) {
   return loops;
 }
 
+static bool hasIdentityYieldOnlyBody(scf::ForOp loop) {
+  if (!llvm::hasSingleElement(loop.getBody()->getOperations())) {
+    return false;
+  }
+  return llvm::equal(
+      loop.getRegionIterArgs(),
+      cast<scf::YieldOp>(loop.getBody()->getTerminator()).getResults());
+}
+
 namespace {
 
 /**
@@ -101,8 +110,7 @@ protected:
           if (!tripCount) {
             continue;
           }
-          if (tripCount->isZero() ||
-              llvm::hasSingleElement(loop.getBody()->getOperations())) {
+          if (tripCount->isZero() || hasIdentityYieldOnlyBody(loop)) {
             loop.replaceAllUsesWith(loop.getInitArgs());
             loop.erase();
             changed = true;

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_quantum_loop_unroll.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_quantum_loop_unroll.cpp
@@ -167,6 +167,30 @@ TEST_F(QuantumLoopUnrollTest, UnrollFullWithOuterDependentBounds) {
   EXPECT_EQ(range_size(entry.getOps<HOp>()), 1);
 }
 
+TEST_F(QuantumLoopUnrollTest, PreservesYieldOnlyPermutation) {
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+
+  Value q0 = builder.allocQubit();
+  Value q1 = builder.allocQubit();
+  const auto results =
+      builder.scfFor(0, 1, 1, {q0, q1}, [](Value, ValueRange iterArgs) {
+        return SmallVector{iterArgs[1], iterArgs[0]};
+      });
+  builder.sink(results[0]);
+  builder.sink(results[1]);
+  auto m = builder.finalize();
+
+  ASSERT_TRUE(succeeded(runPass(m, QuantumLoopUnrollOptions{})));
+  auto entry = *m->getOps<func::FuncOp>().begin();
+  EXPECT_TRUE(entry.getOps<scf::ForOp>().empty());
+
+  auto sinks = llvm::to_vector(entry.getOps<SinkOp>());
+  ASSERT_EQ(sinks.size(), 2);
+  EXPECT_EQ(sinks[0].getQubit(), q1);
+  EXPECT_EQ(sinks[1].getQubit(), q0);
+}
+
 TEST_F(QuantumLoopUnrollTest, UnrollPartial) {
   auto m = getGHZ(context.get(), 9);
   auto entry = *(m->getOps<func::FuncOp>().begin());


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Preserve result permutations when fully unrolling yield-only quantum loops. The shortcut that erases an empty loop now applies only when every yielded value is the corresponding iteration argument; non-identity yields are handled by the regular unrolling rewrite so their value mapping is retained.

A regression covers a one-iteration loop that swaps two yielded qubits.

Part of #2255.

## Validation

- `QuantumLoopUnrollTest.PreservesYieldOnlyPermutation`
- Full quantum-loop-unroll suite: 6/6 tests passed
- `nox -s lint`
- Changed-file C++ lint: zero clang-format and clang-tidy findings

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] Documentation remains accurate; no documentation update is required for this internal correctness fix.
- [x] No changelog entry is needed for this unreleased MLIR behavior; the `skip-changelog` label is applied.
- [x] No upgrade-guide migration instructions are needed.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks. Local targeted, full-suite, and lint checks pass; CI is pending.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description. Implementation, tests, and PR preparation were assisted by Codex.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
