### PR TITLE
🐛 Avoid releasing static QIR qubits

### DIFF
--- a/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
@@ -412,6 +412,10 @@ struct ConvertQCDeallocOp final : StatefulOpConversionPattern<DeallocOp> {
   matchAndRewrite(DeallocOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
     auto& state = getState();
+    if (state.allocationMode == AllocationMode::Static) {
+      rewriter.eraseOp(op);
+      return success();
+    }
     auto* ctx = getContext();
     auto ptrType = LLVM::LLVMPointerType::get(ctx);
 

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
@@ -11,9 +11,11 @@
 #include "Support/IRVerification.h"
 #include "TestCaseUtils.h"
 #include "mlir/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.h"
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/MQT/Transforms/Passes.h"
 #include "mlir/Dialect/QC/Builder/QCProgramBuilder.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QIR/Builder/QIRProgramBuilder.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 #include "mlir/Support/Passes.h"
@@ -30,6 +32,7 @@
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
@@ -152,6 +155,29 @@ TEST(QCToQIRAdaptiveNativeTest, RejectsControlledPhaseWithNonHoistableAngle) {
   });
   EXPECT_TRUE(failed(runQCToQIRAdaptiveConversion(*moduleOp)));
   EXPECT_TRUE(sawExpectedDiagnostic);
+}
+
+TEST(QCToQIRAdaptiveNativeTest, DoesNotReleaseStaticQubits) {
+  MLIRContext context;
+  context.loadDialect<mlir::mqt::MQTDialect, qc::QCDialect, func::FuncDialect,
+                      LLVM::LLVMDialect>();
+  OpBuilder builder(&context);
+  auto location = builder.getUnknownLoc();
+  auto moduleOp = ModuleOp::create(location);
+  builder.setInsertionPointToStart(moduleOp.getBody());
+  auto main = func::FuncOp::create(builder, location, "main",
+                                   builder.getFunctionType({}, {}));
+  mlir::mqt::setEntryPoint(main);
+  auto* entry = main.addEntryBlock();
+  builder.setInsertionPointToEnd(entry);
+  auto qubit = qc::StaticOp::create(builder, location, 0);
+  qc::DeallocOp::create(builder, location, qubit);
+  func::ReturnOp::create(builder, location);
+  ASSERT_TRUE(succeeded(verify(moduleOp)));
+
+  ASSERT_TRUE(succeeded(runQCToQIRAdaptiveConversionSimple(moduleOp)));
+  ASSERT_TRUE(succeeded(verify(moduleOp)));
+  EXPECT_FALSE(moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(qir::QIR_QUBIT_RELEASE));
 }
 
 TEST(QCToQIRAdaptiveNativeTest, LowersControlFlowAssertions) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Avoid lowering source qubit deallocations to `__quantum__rt__qubit_release` when Adaptive QIR uses static allocation. Static qubits are runtime-owned handles rather than dynamically allocated resources, so their source deallocations must be discarded instead of passed to the dynamic release API.

A regression verifies that valid static-allocation input emits no release call.

Part of #2255.

## Validation

- `QCToQIRAdaptiveNativeTest.DoesNotReleaseStaticQubits`
- Full Adaptive QIR suite: 147/147 tests passed
- `nox -s lint`
- Changed-file C++ lint: zero clang-format and clang-tidy findings

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] Documentation remains accurate; no documentation update is required for this internal correctness fix.
- [x] No changelog entry is needed for this unreleased MLIR behavior; the `skip-changelog` label is applied.
- [x] No upgrade-guide migration instructions are needed.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks. Local targeted, full-suite, and lint checks pass; CI is pending.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description. Implementation, tests, and PR preparation were assisted by Codex.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
