### PR TITLE
🐛 Preserve dominance when merging QCO parameters

### DIFF
--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -230,14 +230,18 @@ template <typename OpType>
 LogicalResult mergeOneTargetOneParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the same operation
   auto nextOp = dyn_cast<OpType>(*op.getOutputQubit(0).user_begin());
-  if (!nextOp) {
+  if (!nextOp || op->getBlock() != nextOp->getBlock()) {
     return failure();
   }
 
-  // Compute and set the new parameter
+  // Compute the new parameter where both operands dominate, then move the
+  // merged gate behind it.
+  rewriter.setInsertionPoint(nextOp);
   auto newParameter = arith::AddFOp::create(
       rewriter, op.getLoc(), op.getOperand(1), nextOp.getOperand(1));
-  op->setOperand(1, newParameter.getResult());
+  rewriter.modifyOpInPlace(
+      op, [&] { op->setOperand(1, newParameter.getResult()); });
+  rewriter.moveOpBefore(op, nextOp);
 
   // Replace the second operation with the result of the first operation
   rewriter.replaceOp(nextOp, op.getResult());
@@ -260,6 +264,9 @@ template <typename OpType>
 static LogicalResult mergeTwoTargetOneParameterImpl(OpType op, OpType nextOp,
                                                     PatternRewriter& rewriter,
                                                     bool symmetric = false) {
+  if (op->getBlock() != nextOp->getBlock()) {
+    return failure();
+  }
 
   // Both qubits have to point to the same successor
   auto nextOp2 = *op.getOutputQubit(1).user_begin();
@@ -269,10 +276,14 @@ static LogicalResult mergeTwoTargetOneParameterImpl(OpType op, OpType nextOp,
 
   auto output0 = op.getOutputQubit(0);
   if (symmetric || output0 == nextOp.getInputQubit(0)) {
-    // Compute and set the new parameter
+    // Compute the new parameter where both operands dominate, then move the
+    // merged gate behind it.
+    rewriter.setInsertionPoint(nextOp);
     auto newParameter = arith::AddFOp::create(
         rewriter, op.getLoc(), op.getOperand(2), nextOp.getOperand(2));
-    op->setOperand(2, newParameter.getResult());
+    rewriter.modifyOpInPlace(
+        op, [&] { op->setOperand(2, newParameter.getResult()); });
+    rewriter.moveOpBefore(op, nextOp);
     rewriter.replaceOp(nextOp, nextOp.getInputQubits());
     return success();
   }

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ROp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ROp.cpp
@@ -78,7 +78,7 @@ struct MergeSubsequentR final : OpRewritePattern<ROp> {
   LogicalResult matchAndRewrite(ROp op,
                                 PatternRewriter& rewriter) const override {
     auto nextOp = dyn_cast<ROp>(*op.getOutputQubit(0).user_begin());
-    if (!nextOp) {
+    if (!nextOp || op->getBlock() != nextOp->getBlock()) {
       return failure();
     }
 
@@ -86,9 +86,12 @@ struct MergeSubsequentR final : OpRewritePattern<ROp> {
       return failure();
     }
 
+    rewriter.setInsertionPoint(nextOp);
     auto newParameter = arith::AddFOp::create(rewriter, op.getLoc(),
                                               op.getTheta(), nextOp.getTheta());
-    op->setOperand(1, newParameter.getResult());
+    rewriter.modifyOpInPlace(
+        op, [&] { op->setOperand(1, newParameter.getResult()); });
+    rewriter.moveOpBefore(op, nextOp);
     rewriter.replaceOp(nextOp, op.getResult());
     return success();
   }

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -1643,6 +1643,63 @@ TEST_F(QCOTest, PowExponentIsUnitaryParameter) {
   EXPECT_EQ(unitary.getParameters().front(), powOp.getExponent());
 }
 
+TEST_F(QCOTest, GateMergesPreserveParameterDominance) {
+  auto program = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @rx(%a: f64, %b: f64) {
+        %q0 = qco.alloc : !qco.qubit
+        %q1 = qco.rx(%a) %q0 : !qco.qubit -> !qco.qubit
+        %later = arith.mulf %b, %b : f64
+        %q2 = qco.rx(%later) %q1 : !qco.qubit -> !qco.qubit
+        qco.sink %q2 : !qco.qubit
+        return
+      }
+      func.func @r(%a: f64, %b: f64) {
+        %phi = arith.constant 0.25 : f64
+        %q0 = qco.alloc : !qco.qubit
+        %q1 = qco.r(%a, %phi) %q0 : !qco.qubit -> !qco.qubit
+        %later = arith.mulf %b, %b : f64
+        %q2 = qco.r(%later, %phi) %q1 : !qco.qubit -> !qco.qubit
+        qco.sink %q2 : !qco.qubit
+        return
+      }
+      func.func @rxx(%a: f64, %b: f64) {
+        %q0 = qco.alloc : !qco.qubit
+        %q1 = qco.alloc : !qco.qubit
+        %q2, %q3 = qco.rxx(%a) %q0, %q1 : !qco.qubit, !qco.qubit
+          -> !qco.qubit, !qco.qubit
+        %later = arith.mulf %b, %b : f64
+        %q4, %q5 = qco.rxx(%later) %q2, %q3 : !qco.qubit, !qco.qubit
+          -> !qco.qubit, !qco.qubit
+        qco.sink %q4 : !qco.qubit
+        qco.sink %q5 : !qco.qubit
+        return
+      }
+    }
+  )mlir",
+                                             context.get());
+  ASSERT_TRUE(program);
+  ASSERT_TRUE(succeeded(verify(*program)));
+
+  PassManager manager(context.get());
+  manager.addPass(createCanonicalizerPass());
+  ASSERT_TRUE(succeeded(manager.run(*program)));
+  ASSERT_TRUE(succeeded(verify(*program)));
+
+  size_t rxCount = 0;
+  size_t rCount = 0;
+  size_t rxxCount = 0;
+  size_t addCount = 0;
+  program->walk([&](RXOp) { ++rxCount; });
+  program->walk([&](ROp) { ++rCount; });
+  program->walk([&](RXXOp) { ++rxxCount; });
+  program->walk([&](arith::AddFOp) { ++addCount; });
+  EXPECT_EQ(rxCount, 1U);
+  EXPECT_EQ(rCount, 1U);
+  EXPECT_EQ(rxxCount, 1U);
+  EXPECT_EQ(addCount, 3U);
+}
+
 TEST_F(QCOTest, NestedPowAcrossBranchCutDoesNotMerge) {
   auto program = ::mqt::test::buildMLIRProgram(
       context.get(), MQT_NAMED_BUILDER(nestedPowBranchCut));


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Preserve SSA dominance when canonicalizing adjacent parameterized QCO gates. A dynamic parameter may be defined between two otherwise mergeable gates; building the merged parameter at the first gate then places that use before its definition. This change creates the sum at the second gate and moves the retained gate behind the sum.

The regression covers RX, R, and RXX merges with intervening parameter definitions.

Part of #2255.

## Validation

- `QCOTest.GateMergesPreserveParameterDominance`
- Full QCO IR suite: 489/489 tests passed
- `nox -s lint`
- Changed-file C++ lint: zero clang-format and clang-tidy findings

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] Documentation remains accurate; no documentation update is required for this internal correctness fix.
- [x] No changelog entry is needed for this unreleased MLIR behavior; the `skip-changelog` label is applied.
- [x] No upgrade-guide migration instructions are needed.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks. Local targeted, full-suite, and lint checks pass; CI is pending.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description. Implementation, tests, and PR preparation were assisted by Codex.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
