### PR TITLE
✨ Preserve target-native controlled operations

### DIFF
--- a/.agent/plans/preserve-supported-controlled-operations.md
+++ b/.agent/plans/preserve-supported-controlled-operations.md
@@ -1,0 +1,190 @@
+# Preserve supported controlled operations
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+The compiler currently decomposes every supported multi-controlled X, Z, phase,
+SWAP, and RCCX operation before it checks whether an all-to-all target can
+execute that operation directly. After this change, target compilation keeps
+controlled operations that the `CompilerTarget` reports as native. The
+standalone `decompose-multi-controlled` pass remains target-independent, and
+targets with explicit couplings still receive the existing decomposition before
+mapping.
+
+The change is visible by compiling a circuit for the QDMI DDSIM device. Broad
+controlled gates, including controlled single-, two-, and three-target base
+gates, remain in QCO until QIR lowering and execute with the same complex
+statevector as the source circuit.
+
+## Progress
+
+- [x] (2026-09-01 00:00Z) Read the compiler target and multi-controlled
+      decomposition contracts.
+- [x] (2026-09-01 00:20Z) Added a target-aware construction path to the existing
+      decomposition pass.
+- [x] (2026-09-01 00:25Z) Used the target-aware pass in target compilation
+      without changing the command-line pass.
+- [x] (2026-09-01 00:45Z) Added focused compiler and DDSIM execution
+      regressions.
+- [x] (2026-09-01 19:14Z) Ran focused and full compiler tests, the focused DDSIM
+      execution test, C++ lint, repository lint, and inspected the final diff.
+- [x] (2026-09-01 21:22Z) Restacked on the final compiler-target change and
+      verified the Qiskit regression in current and minimum dependency sessions.
+
+## Surprises & Discoveries
+
+- Observation: The existing decomposition pass only rewrites controlled X, Z,
+  constant phase, SWAP, and bare RCCX operations. Controlled H, RX, RXX, and
+  RCCX bodies already pass through unchanged, so the regression must include X,
+  phase, SWAP, and bare RCCX to exercise the new skip path as well as broader
+  bodies to protect end-to-end target support.
+- Observation: Qiskit 2.5 emits a deprecation warning when `Gate.control()`
+  receives its former implicit `annotated=None` value, and the test suite treats
+  that warning as an error. Evidence: The first integration run failed in
+  `HGate.control(2)` before compilation. Passing `annotated=False` constructs
+  the concrete controlled gate that the importer needs.
+- Observation: The minimum dependency session installs Qiskit 1.1, while the
+  compiler translation supports Qiskit 2.5.x. The end-to-end regression must use
+  the same version guard as the existing Qiskit translation tests.
+
+## Decision Log
+
+- Decision: Reuse `DecomposeMultiControlled` with an optional immutable
+  `CompilerTarget`, exposed by one overloaded factory. The target-independent
+  generated factory keeps its current behavior. Rationale: This puts the support
+  check at the only rewrite point and avoids a second pass or operation filter.
+  Date/Author: 2026-09-01 / Codex.
+- Decision: Preserve target-supported operations only for all-to-all
+  connectivity. Rationale: The current mapper accepts at most two-qubit
+  operations, so explicit topologies must retain the established decomposition
+  before mapping. Date/Author: 2026-09-01 / Codex.
+
+## Outcomes & Retrospective
+
+The target pipeline now retains native controlled operations on all-to-all
+targets and keeps the established decomposition on explicit topologies. The
+compiler regression covers controlled H, RX, RXX, SWAP, RCCX, X, and phase, plus
+bare RCCX and global phase. The QDMI regression executes the resulting QIR on
+DDSIM and matches Qiskit's complex statevector exactly. The minimum dependency
+session skips this Qiskit translation regression. All focused tests, the full
+compiler test binary, repository lint, and C++ lint pass.
+
+## Context and Orientation
+
+`mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp`
+implements the existing target-independent decomposition pass. Generated pass
+factories come from `mlir/include/mlir/Dialect/QCO/Transforms/Passes.td`, while
+hand-written factories are declared in
+`mlir/include/mlir/Dialect/QCO/Transforms/Passes.h`.
+
+`mlir/lib/Compiler/TargetCompilation.cpp` assembles the canonical target
+pipeline. It currently invokes the generic decomposition pipeline before
+choosing placement for all-to-all connectivity or mapping for explicit
+couplings. `CompilerTarget::supports(Operation*)`, declared in
+`mlir/include/mlir/Compiler/Target.h`, recognizes structurally controlled base
+operations with variadic target arity.
+
+`mlir/unittests/Compiler/test_compiler_pipeline.cpp` owns compiler-pipeline
+behavior. `test/python/qdmi/test_qdmi.py` can compile Qiskit circuits against
+the registered DDSIM target, submit QIR with zero shots, and read the exact
+dense statevector.
+
+## Plan of Work
+
+Extend the existing pass class with an optional compiler target. Give the two
+rewrite patterns access to that target. Before an eligible rewrite, return
+without changing the operation when the target is all-to-all and reports the
+operation as supported. Apply the same rule to bare RCCX because it is a native
+DDSIM operation that this pass otherwise expands.
+
+Declare and implement one overload of `createDecomposeMultiControlled` that
+accepts a compiler target and the existing minimum-qubit threshold. Replace the
+generic decomposition step in `populateTargetCompilationPipeline` with this
+overload. The pass itself enforces the all-to-all condition, so an explicit
+target still takes the old rewrite path.
+
+Add a compiler test that derives the target from the registered DDSIM device,
+compiles controlled H, RX, RXX, SWAP, RCCX, X, and phase operations, and checks
+that each supported controlled body remains. Keep the existing explicit-target
+test as the regression that unsupported higher-arity controls decompose before
+mapping. Add one Python QDMI test that executes a small circuit containing the
+same gate families and a nonzero global phase, then compares every complex
+amplitude with Qiskit's reference statevector.
+
+## Concrete Steps
+
+From the repository root, edit the pass, factory declaration, target pipeline,
+and focused tests described above. Build and run:
+
+    cmake --build --preset release --target mqt-core-mlir-unittests-compiler
+    ./build/release/mlir/unittests/Compiler/mqt-core-mlir-unittests-compiler --gtest_filter='CompilerPipelineTest.*Controlled*'
+    uvx nox -s tests-3.12 -- test/python/qdmi/test_qdmi.py -k 'controlled or qir' -q
+    uvx nox -s minimums-3.12 -- test/python/qdmi/test_qdmi.py -k 'controlled or qir' -q
+    uvx nox -s cpp-lint -- origin/codex/generalize-compiler-target
+    uvx nox -s lint
+
+The focused C++ and Python tests must pass. The Python execution test must
+report equal complex statevectors, including their global phase.
+
+## Validation and Acceptance
+
+Acceptance requires three behaviors. Target compilation for the DDSIM all-to-all
+target keeps every controlled operation that the target reports as supported.
+Compilation for an explicit-coupling target still has no operation wider than
+two qubits before mapping completes. Zero-shot QIR execution on DDSIM produces
+the same complex statevector as Qiskit for a circuit containing broad controlled
+gates and a nonzero global phase.
+
+The final tree must also pass `git diff --check`,
+`uvx nox -s cpp-lint -- origin/codex/generalize-compiler-target`, and
+`uvx nox -s lint`.
+
+## Idempotence and Recovery
+
+All edits and test commands are repeatable. The change does not alter external
+state, create recovery branches, or modify another worktree. If the Python
+integration test exposes an unrelated importer limitation, retain the focused
+C++ regression and record the exact limitation here instead of adding a large
+workaround.
+
+## Artifacts and Notes
+
+The compiler binary passed 144 tests. The current QDMI integration test passed:
+
+    1 passed in 1.14s
+
+The minimum dependency session installed Qiskit 1.1 and skipped the unsupported
+translation as expected:
+
+    1 skipped in 1.94s
+
+`uvx nox -s lint`, focused compiler tests, `git diff --check`, and manual
+clang-tidy on all three changed C++ sources passed. The aggregate C++ lint
+selected all three changed sources and passed without findings.
+
+## Interfaces and Dependencies
+
+At completion, `mlir/include/mlir/Dialect/QCO/Transforms/Passes.h` declares:
+
+    std::unique_ptr<Pass>
+    createDecomposeMultiControlled(const CompilerTarget& target,
+                                   uint64_t minQubits = 3);
+
+The implementation reuses `CompilerTarget::supports(Operation*)` and adds no
+dependency. Existing generated factories and command-line options remain
+unchanged.
+
+Revision note: Created this plan on 2026-09-01 for the independent target-aware
+controlled-operation workstream.
+
+Revision note: Updated progress, discoveries, outcomes, and validation evidence
+after implementation on 2026-09-01.
+
+Revision note: Restacked on the final compiler-target commit and verified the
+minimum dependency session on 2026-09-01.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ releases may include breaking changes.
   [#1807], [#1808], [#1815], [#1824], [#1869], [#1872], [#1914], [#1925],
   [#1927], [#1935], [#1936], [#1938], [#1975], [#1976], [#2006], [#2014],
   [#2015], [#2017], [#2026], [#2028], [#2054], [#2058], [#2125], [#2136],
-  [#2149], [#2150], [#2158], [#2194], [#2210], [#2211], [#2220], [#2218])
-  ([**@burgholzer**], [**@denialhaag**], [**@taminob**], [**@DRovara**],
-  [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
+  [#2149], [#2150], [#2158], [#2194], [#2210], [#2211], [#2220], [#2218],
+  [#2323]) ([**@burgholzer**], [**@denialhaag**], [**@taminob**],
+  [**@DRovara**], [**@li-mingbao**], [**@Ectras**], [**@MatthiasReumann**],
   [**@simon1hofmann**], [**@J4MMlE**])
 - ✨ Add a library for typed structured quantum benchmarks with versioned
   instance specifications, analytic references, deterministic manifests, and
@@ -865,6 +865,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2323]: https://github.com/munich-quantum-toolkit/core/pull/2323
 [#2315]: https://github.com/munich-quantum-toolkit/core/pull/2315
 [#2298]: https://github.com/munich-quantum-toolkit/core/pull/2298
 [#2284]: https://github.com/munich-quantum-toolkit/core/pull/2284

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
@@ -14,6 +14,7 @@
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassRegistry.h>
 
+#include <cstdint>
 #include <memory>
 
 namespace mlir {
@@ -37,6 +38,14 @@ namespace mlir::qco {
  * @brief Create target-independent two-qubit gate fusion.
  */
 [[nodiscard]] std::unique_ptr<Pass> createFuseTwoQubitGates();
+
+/// Create multi-controlled decomposition for one compiler target.
+///
+/// Supported operations remain native on all-to-all targets. Targets with
+/// explicit connectivity use the target-independent decomposition.
+[[nodiscard]] std::unique_ptr<Pass>
+createDecomposeMultiControlled(const CompilerTarget& target,
+                               uint64_t minQubits = 3);
 
 /**
  * @brief Create post-routing synthesis for one immutable compiler target.

--- a/mlir/lib/Compiler/TargetCompilation.cpp
+++ b/mlir/lib/Compiler/TargetCompilation.cpp
@@ -23,7 +23,7 @@ namespace mlir {
 void populateTargetCompilationPipeline(OpPassManager& pm,
                                        const CompilerTarget& target) {
   populateQCOCleanupPipeline(pm);
-  populateDecomposeMultiControlledPipeline(pm, 3);
+  pm.addPass(qco::createDecomposeMultiControlled(target));
   populateDefaultQCOOptimizationPipeline(pm);
   pm.addPass(qco::createFuseTwoQubitGates());
   switch (target.connectivityKind()) {

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
@@ -23,6 +23,7 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/Visitors.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
@@ -1447,11 +1448,30 @@ protected:
                        CompilerTarget::Connectivity::Kind::AllToAll
             ? &*target_
             : nullptr;
+
+    SmallVector<Operation*> rewriteOps;
+    getOperation().walk<WalkOrder::PreOrder>([&](UnitaryOpInterface op) {
+      if (nativeTarget != nullptr &&
+          nativeTarget->supports(op.getOperation())) {
+        return WalkResult::skip();
+      }
+      if (isa<CtrlOp, RCCXOp>(op)) {
+        rewriteOps.push_back(op.getOperation());
+      }
+      return WalkResult::advance();
+    });
+    if (rewriteOps.empty()) {
+      return;
+    }
+
     RewritePatternSet patterns(&getContext());
     patterns.add<DecomposeControlledGatePattern, DecomposeRCCXPattern>(
         &getContext(), minQubits, nativeTarget);
 
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    GreedyRewriteConfig config;
+    config.setStrictness(GreedyRewriteStrictness::ExistingAndNewOps);
+    if (failed(
+            applyOpPatternsGreedily(rewriteOps, std::move(patterns), config))) {
       signalPassFailure();
     }
   }

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "mlir/Compiler/Target.h"
 #include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
 #include "mlir/Dialect/MQT/Utils/Modifiers.h"
 #include "mlir/Dialect/MQT/Utils/Parameters.h"
@@ -1318,12 +1319,17 @@ namespace {
 
 struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
   explicit DecomposeControlledGatePattern(MLIRContext* context,
-                                          uint64_t minQubits)
-      : OpRewritePattern<CtrlOp>(context), minQubits_(minQubits) {}
+                                          uint64_t minQubits,
+                                          const CompilerTarget* target)
+      : OpRewritePattern<CtrlOp>(context), minQubits_(minQubits),
+        target_(target) {}
 
   LogicalResult matchAndRewrite(CtrlOp op,
                                 PatternRewriter& rewriter) const override {
     if (op.getNumQubits() < minQubits_) {
+      return failure();
+    }
+    if (target_ != nullptr && target_->supports(op.getOperation())) {
       return failure();
     }
 
@@ -1389,15 +1395,21 @@ struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
 
 private:
   uint64_t minQubits_;
+  const CompilerTarget* target_;
 };
 
 struct DecomposeRCCXPattern final : OpRewritePattern<RCCXOp> {
-  explicit DecomposeRCCXPattern(MLIRContext* context, uint64_t minQubits)
-      : OpRewritePattern<RCCXOp>(context), minQubits_(minQubits) {}
+  explicit DecomposeRCCXPattern(MLIRContext* context, uint64_t minQubits,
+                                const CompilerTarget* target)
+      : OpRewritePattern<RCCXOp>(context), minQubits_(minQubits),
+        target_(target) {}
 
   LogicalResult matchAndRewrite(RCCXOp op,
                                 PatternRewriter& rewriter) const override {
     if (RCCXOp::getNumQubits() < minQubits_) {
+      return failure();
+    }
+    if (target_ != nullptr && target_->supports(op.getOperation())) {
       return failure();
     }
     rewriter.setInsertionPoint(op);
@@ -1409,11 +1421,17 @@ struct DecomposeRCCXPattern final : OpRewritePattern<RCCXOp> {
 
 private:
   uint64_t minQubits_;
+  const CompilerTarget* target_;
 };
 
 struct DecomposeMultiControlled final
     : impl::DecomposeMultiControlledBase<DecomposeMultiControlled> {
   using DecomposeMultiControlledBase::DecomposeMultiControlledBase;
+
+  DecomposeMultiControlled(const CompilerTarget& target, uint64_t minQubitsIn)
+      : target_(target) {
+    minQubits = minQubitsIn;
+  }
 
 protected:
   void runOnOperation() override {
@@ -1424,16 +1442,30 @@ protected:
       return;
     }
 
+    const CompilerTarget* nativeTarget =
+        target_ && target_->connectivityKind() ==
+                       CompilerTarget::Connectivity::Kind::AllToAll
+            ? &*target_
+            : nullptr;
     RewritePatternSet patterns(&getContext());
     patterns.add<DecomposeControlledGatePattern, DecomposeRCCXPattern>(
-        &getContext(), minQubits);
+        &getContext(), minQubits, nativeTarget);
 
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }
   }
+
+private:
+  std::optional<CompilerTarget> target_;
 };
 
 } // namespace
+
+std::unique_ptr<Pass>
+createDecomposeMultiControlled(const CompilerTarget& target,
+                               uint64_t minQubits) {
+  return std::make_unique<DecomposeMultiControlled>(target, minQubits);
+}
 
 } // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
@@ -23,7 +23,6 @@
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Value.h>
-#include <mlir/IR/Visitors.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
@@ -1316,6 +1315,19 @@ synthesizeControlledSwap(OpBuilder& builder, Location loc, ValueRange controls,
 // Patterns and pass
 //===----------------------------------------------------------------------===//
 
+static bool isWithinTargetNativeUnitary(Operation* op,
+                                        const CompilerTarget* target) {
+  if (target == nullptr) {
+    return false;
+  }
+  for (; op != nullptr; op = op->getParentOp()) {
+    if (isa<UnitaryOpInterface>(op) && target->supports(op)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 namespace {
 
 struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
@@ -1330,7 +1342,7 @@ struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
     if (op.getNumQubits() < minQubits_) {
       return failure();
     }
-    if (target_ != nullptr && target_->supports(op.getOperation())) {
+    if (isWithinTargetNativeUnitary(op.getOperation(), target_)) {
       return failure();
     }
 
@@ -1410,7 +1422,7 @@ struct DecomposeRCCXPattern final : OpRewritePattern<RCCXOp> {
     if (RCCXOp::getNumQubits() < minQubits_) {
       return failure();
     }
-    if (target_ != nullptr && target_->supports(op.getOperation())) {
+    if (isWithinTargetNativeUnitary(op.getOperation(), target_)) {
       return failure();
     }
     rewriter.setInsertionPoint(op);
@@ -1449,29 +1461,11 @@ protected:
             ? &*target_
             : nullptr;
 
-    SmallVector<Operation*> rewriteOps;
-    getOperation().walk<WalkOrder::PreOrder>([&](UnitaryOpInterface op) {
-      if (nativeTarget != nullptr &&
-          nativeTarget->supports(op.getOperation())) {
-        return WalkResult::skip();
-      }
-      if (isa<CtrlOp, RCCXOp>(op)) {
-        rewriteOps.push_back(op.getOperation());
-      }
-      return WalkResult::advance();
-    });
-    if (rewriteOps.empty()) {
-      return;
-    }
-
     RewritePatternSet patterns(&getContext());
     patterns.add<DecomposeControlledGatePattern, DecomposeRCCXPattern>(
         &getContext(), minQubits, nativeTarget);
 
-    GreedyRewriteConfig config;
-    config.setStrictness(GreedyRewriteStrictness::ExistingAndNewOps);
-    if (failed(
-            applyOpPatternsGreedily(rewriteOps, std::move(patterns), config))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
@@ -1315,13 +1315,13 @@ synthesizeControlledSwap(OpBuilder& builder, Location loc, ValueRange controls,
 // Patterns and pass
 //===----------------------------------------------------------------------===//
 
-static bool isWithinTargetNativeUnitary(Operation* op,
+static bool isWithinTargetNativeUnitary(UnitaryOpInterface op,
                                         const CompilerTarget* target) {
   if (target == nullptr) {
     return false;
   }
-  for (; op != nullptr; op = op->getParentOp()) {
-    if (isa<UnitaryOpInterface>(op) && target->supports(op)) {
+  for (; op; op = op->getParentOfType<UnitaryOpInterface>()) {
+    if (target->supports(op.getOperation())) {
       return true;
     }
   }
@@ -1342,7 +1342,7 @@ struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
     if (op.getNumQubits() < minQubits_) {
       return failure();
     }
-    if (isWithinTargetNativeUnitary(op.getOperation(), target_)) {
+    if (isWithinTargetNativeUnitary(op, target_)) {
       return failure();
     }
 
@@ -1422,7 +1422,7 @@ struct DecomposeRCCXPattern final : OpRewritePattern<RCCXOp> {
     if (RCCXOp::getNumQubits() < minQubits_) {
       return failure();
     }
-    if (isWithinTargetNativeUnitary(op.getOperation(), target_)) {
+    if (isWithinTargetNativeUnitary(op, target_)) {
       return failure();
     }
     rewriter.setInsertionPoint(op);

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -11,6 +11,7 @@
 #include "Support/IRVerification.h"
 #include "TestCaseUtils.h"
 #include "mlir/Compiler/Programs.h"
+#include "mlir/Compiler/QDMIAdapter.h"
 #include "mlir/Compiler/Target.h"
 #include "mlir/Dialect/CBit/IR/CBitDialect.h"
 #include "mlir/Dialect/MQT/IR/MQTDialect.h"
@@ -1426,6 +1427,55 @@ TEST_F(CompilerPipelineTest,
   pm.addPass(createRemoveDeadValuesPass());
   ASSERT_TRUE(pm.run(program->module()).succeeded());
   EXPECT_EQ(program->str(), before);
+}
+
+TEST_F(CompilerPipelineTest, QCOProgramPreservesDDSIMControlledOperations) {
+  constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.0;
+include "stdgates.inc";
+qubit[5] q;
+x q[0];
+x q[1];
+ctrl(2) @ h q[0], q[1], q[2];
+ctrl(2) @ rx(0.2) q[0], q[1], q[2];
+ctrl @ rxx(0.3) q[0], q[3], q[4];
+ctrl @ swap q[0], q[3], q[4];
+ctrl @ rccx q[0], q[1], q[2], q[3];
+ctrl(2) @ x q[0], q[1], q[4];
+ctrl(2) @ p(0.4) q[0], q[1], q[4];
+rccx q[0], q[1], q[2];
+gphase(0.5);
+)qasm";
+  auto qc = QCProgram::fromQASMString(source);
+  ASSERT_TRUE(qc);
+  auto qco = std::move(*qc).intoQCO();
+  ASSERT_TRUE(qco);
+
+  const auto target =
+      llvm::cantFail(compilerTargetFromDeviceId("mqt.ddsim.default"));
+  ASSERT_TRUE(qco->compileForTarget(target));
+
+  auto compiled = parseRecordedModule(qco->str());
+  ASSERT_TRUE(compiled);
+  EXPECT_TRUE(verify(*compiled).succeeded());
+
+  llvm::StringMap<size_t> controlledOperations;
+  size_t rccxOperations = 0;
+  size_t globalPhases = 0;
+  compiled->walk([&](Operation* operation) {
+    if (auto controlled = dyn_cast<CtrlOp>(operation)) {
+      ASSERT_EQ(controlled.getNumBodyUnitaries(), 1U);
+      ++controlledOperations[controlled.getBodyUnitary(0).getBaseSymbol()];
+    }
+    rccxOperations += isa<RCCXOp>(operation);
+    globalPhases += isa<GPhaseOp>(operation);
+  });
+
+  for (const auto* const name : {"h", "rx", "rxx", "swap", "rccx", "x", "p"}) {
+    EXPECT_EQ(controlledOperations.lookup(name), 1U) << name;
+  }
+  EXPECT_EQ(controlledOperations.size(), 7U);
+  EXPECT_EQ(rccxOperations, 2U);
+  EXPECT_EQ(globalPhases, 1U);
 }
 
 TEST_F(CompilerPipelineTest, QCOProgramCompilesDynamicRunForSupportedTargets) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
@@ -12,6 +12,7 @@
 #include "dd/Package.hpp"
 #include "dd/RealNumber.hpp"
 #include "dd/StateGeneration.hpp"
+#include "mlir/Compiler/Target.h"
 #include "mlir/Dialect/MQT/Utils/Modifiers.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
@@ -21,6 +22,7 @@
 #include "mlir/Dialect/QCO/Utils/DDFunctionality.h"
 
 #include <gtest/gtest.h>
+#include <llvm/Support/Error.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/BuiltinOps.h>
@@ -625,6 +627,38 @@ TEST_F(MultiControlledDecompositionTest, LeavesRCCXWhenMinQubitsIsFour) {
   DecomposeMultiControlledOptions options;
   options.minQubits = 4;
   ASSERT_TRUE(runDecomposeMultiControlled(moduleOp.get(), options).succeeded());
+  EXPECT_EQ(countRCCXOps(moduleOp.get()), 1U);
+}
+
+TEST_F(MultiControlledDecompositionTest,
+       PreservesTargetNativeControlledRCCXBody) {
+  auto moduleOp =
+      QCOProgramBuilder::build(context(), [](QCOProgramBuilder& builder) {
+        std::ignore =
+            builder.crccx(builder.staticQubit(0), builder.staticQubit(1),
+                          builder.staticQubit(2), builder.staticQubit(3));
+        return SmallVector<Value>{};
+      });
+  ASSERT_TRUE(moduleOp);
+
+  using Operation = CompilerTarget::Operation;
+  std::vector operations{llvm::cantFail(
+      Operation::create("rccx", Operation::Arity::variadic(4), 0))};
+  const auto target = llvm::cantFail(CompilerTarget::create(
+      4, CompilerTarget::Connectivity::allToAll(),
+      CompilerTarget::NativeOperations::fromOperations(operations)));
+
+  CtrlOp shell;
+  moduleOp->walk([&](CtrlOp op) { shell = op; });
+  ASSERT_TRUE(shell);
+  ASSERT_EQ(shell.getNumBodyUnitaries(), 1U);
+  ASSERT_TRUE(target.supports(shell.getOperation()));
+  ASSERT_FALSE(target.supports(shell.getBodyUnitary(0).getOperation()));
+
+  PassManager pm(context());
+  pm.addPass(createDecomposeMultiControlled(target));
+  ASSERT_TRUE(pm.run(moduleOp.get()).succeeded());
+  EXPECT_EQ(countMultiControlledOps(moduleOp.get(), 1), 1U);
   EXPECT_EQ(countRCCXOps(moduleOp.get()), 1U);
 }
 

--- a/test/python/qdmi/test_qdmi.py
+++ b/test/python/qdmi/test_qdmi.py
@@ -11,10 +11,12 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import cast
 
 import pytest
+from packaging import version
 
 from mqt.core.mlir import CompilerTarget, OutputFormat, compile_program
 from mqt.core.qdmi import (
@@ -563,6 +565,38 @@ c = measure q;
     counts = job.get_counts()
     assert set(counts) == {"00", "11"}
     assert sum(counts.values()) == 1024
+
+
+def test_device_executes_controlled_qir_with_exact_phase(ddsim_device: Device) -> None:
+    """Keep DDSIM-native controlled gates and their global phase."""
+    qiskit = pytest.importorskip("qiskit")
+    if not (
+        version.parse("2.5") <= version.parse(qiskit.__version__) < version.parse("2.6")
+        or qiskit.__version__ == os.environ.get("MQT_QISKIT_TEST_CANDIDATE_VERSION")
+    ):
+        pytest.skip(f"no Qiskit translation is registered for {qiskit.__version__}")
+    circuit_library = pytest.importorskip("qiskit.circuit.library")
+    quantum_info = pytest.importorskip("qiskit.quantum_info")
+
+    circuit = qiskit.QuantumCircuit(5)
+    circuit.global_phase = 0.37
+    circuit.x(0)
+    circuit.x(1)
+    circuit.append(circuit_library.HGate().control(2, annotated=False), [0, 1, 2])
+    circuit.append(circuit_library.RXGate(0.23).control(2, annotated=False), [0, 1, 2])
+    circuit.append(circuit_library.RXXGate(0.31).control(annotated=False), [0, 3, 4])
+    circuit.append(circuit_library.SwapGate().control(annotated=False), [0, 3, 4])
+    circuit.append(circuit_library.RCCXGate().control(annotated=False), [0, 1, 2, 3])
+    circuit.mcx([0, 1], 4)
+    circuit.mcp(0.41, [0, 1], 4)
+    expected = quantum_info.Statevector.from_instruction(circuit).data
+
+    target = CompilerTarget.from_device(ddsim_device)
+    program = compile_program(circuit, output=OutputFormat.QIR_BASE, target=target)
+    job = ddsim_device.submit_job(program.llvm_ir, ProgramFormat.QIR_BASE_STRING, num_shots=0)
+    job.wait()
+
+    assert job.get_dense_statevector() == pytest.approx(expected)
 
 
 def test_device_executes_binary_qir_program(ddsim_device: Device) -> None:

--- a/test/qdmi/test_client.cpp
+++ b/test/qdmi/test_client.cpp
@@ -547,10 +547,12 @@ TEST_P(DeviceTest, UnsupportedCustomPropertyReturnsNullopt) {
             std::nullopt);
 }
 
+#ifdef MQT_CORE_QDMI_HAS_DDSIM_DEVICE
 TEST_F(DDSimulatorDeviceTest, ReportsCompilerTargetMetadata) {
   EXPECT_EQ(device.queryCustomProperty<std::string>(CustomProperty::Custom1),
             "mqt.compiler-target.v1:all-to-all-homogeneous");
 }
+#endif
 
 TEST_P(SiteTest, Index) {
   for (const auto& site : sites) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This PR makes the canonical target-compilation pipeline preserve controlled operations that an all-to-all `CompilerTarget` reports as native. It reuses the existing multi-controlled decomposition pass with one target-aware factory; the standalone and command-line pass remain target-independent, and explicit-connectivity targets retain the established decomposition before mapping.

This lets the DDSIM target capability introduced by #2218 apply broadly rather than special-casing `mcx` and `mcp`. The compiler regression covers arbitrarily controlled H, RX, RXX, SWAP, RCCX, X, and phase operations plus bare RCCX and global phase. An end-to-end QDMI regression compiles a Qiskit circuit to QIR, executes it on DDSIM, and compares the exact complex statevector—including nonzero global phase—with Qiskit. Minimum dependency sessions skip this regression because they install Qiskit 1.1, while the registered translator supports Qiskit 2.5.x and explicit candidate builds.

This PR is one signed commit stacked on #2218 at `c7e94438069dfa6635da7e45bf9b3642b8922af8`. It adds no new abstraction or dependency: target ownership stays in the existing pass, `CompilerTarget::supports` remains the single capability check, and unsupported operations continue through the current decomposition path.

Capability checks are intentionally not cached. `CompilerTarget` already indexes operations in a `StringMap`, and the pass performs one cheap structural lookup for each candidate `CtrlOp` or `RCCXOp`. An operation-pointer cache would need invalidation without reducing demonstrated cost.

The changelog records #2323 in the existing MQT Compiler Collection launch entry rather than adding a separate entry for unreleased functionality. Its PR-link definition block remains numeric descending. New Doxygen comments use `///`.

## Validation

- Compiler unit tests: 144 passed.
- Current Qiskit 2.5 QDMI/DDSIM statevector test: 1 passed.
- Minimums Qiskit 1.1 session: 1 expected skip.
- `uvx nox -s lint`
- `uvx nox -s cpp-lint -- origin/codex/generalize-compiler-target`
- `git diff --check`
- `git verify-commit HEAD`
- An independent final audit found no concrete issue.

Implementation and pull-request text were prepared with OpenAI Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
