### PR TITLE
🐛 Fix multiplexer benchmark sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ releases may include breaking changes.
   [**@simon1hofmann**], [**@J4MMlE**])
 - ✨ Add a library for typed structured quantum benchmarks with versioned
   instance specifications, analytic references, deterministic manifests, and
-  C++, Python, and command-line interfaces ([#2135], [#2299], [#2315])
+  C++, Python, and command-line interfaces ([#2135], [#2299], [#2315], [#2337])
   ([**@burgholzer**], [**@denialhaag**])
 - ✨ Add DD construction, simulation, statevector extraction, and sampling for
   QCO programs with structured control and dynamic quantum data ([#1915],
@@ -865,6 +865,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2337]: https://github.com/munich-quantum-toolkit/core/pull/2337
 [#2323]: https://github.com/munich-quantum-toolkit/core/pull/2323
 [#2315]: https://github.com/munich-quantum-toolkit/core/pull/2315
 [#2299]: https://github.com/munich-quantum-toolkit/core/pull/2299

--- a/test/python/test_bench.py
+++ b/test/python/test_bench.py
@@ -17,7 +17,6 @@ import pytest
 
 from mqt.core import bench, mlir
 from mqt.core.bench import bv, ghz, grover, multiplexer, qft, qpe
-from mqt.core.dd import DDPackage
 
 
 def assert_generates(
@@ -110,7 +109,7 @@ def test_multiplexer_reference_json_and_generation() -> None:
     assert instance_copy.case_id == manifest_copy.case_id == benchmark.case_id
 
     shots = 16_384
-    counts = benchmark.generate().to_qco().sample(DDPackage(3), shots=shots, seed=17)
+    counts = benchmark.generate().to_qco().sample(shots=shots, seed=17)
     assert sum(counts.values()) == shots
     assert benchmark.evaluate(counts).total_variation_distance < 0.03
     assert_generates(benchmark)


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Update the multiplexer benchmark test to use the current `QCOProgram.sample(shots, seed)` API. The explicit `DDPackage` parameter was removed from that binding, so the stale call made Python tests fail at runtime and `ty` fail during lint on current `main`.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
