### PR TITLE
♻️ Split compiler programs from the pipeline library

### DIFF
--- a/.agent/plans/split-compiler-programs.md
+++ b/.agent/plans/split-compiler-programs.md
@@ -1,0 +1,229 @@
+# Split compiler programs from pipeline orchestration
+
+This ExecPlan is a living document. The sections `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must
+be kept up to date as work proceeds.
+
+This ExecPlan must be maintained in accordance with `.agent/PLANS.md` from the
+repository root.
+
+## Purpose / Big Picture
+
+The DDSIM QDMI device accepts OpenQASM by translating it to the QC dialect and
+then to the QCO dialect before simulation. It currently links the complete
+compiler pipeline library for those two conversions. After this change, DDSIM
+links a focused compiler-program library and does not depend on target
+compilation, QIR or jeff conversion, or default-pipeline orchestration.
+
+The public compiler API and all runtime behavior remain unchanged. The result is
+visible in the generated DDSIM link command: it contains `MQTCompilerPrograms`
+and no `MQTCompilerPipeline`. Existing OpenQASM DDSIM, compiler, and
+command-line tests continue to pass.
+
+## Progress
+
+- [x] (2026-09-03 05:00 CEST) Read issue #2329, the originating #2288 review
+      thread, repository policy, and the current compiler and DDSIM dependency
+      paths.
+- [x] (2026-09-03 05:00 CEST) Checked open compiler work. PRs #2339 and #2340
+      change `Programs.cpp`, but do not implement this boundary and have no
+      relevant unresolved review comments.
+- [x] (2026-09-03 07:08 CEST) Added the focused compiler-program target and
+      split pass-backed and output functionality into the higher-level pipeline
+      source without changing the public header.
+- [x] (2026-09-03 07:08 CEST) Linked DDSIM only to the compiler-program target
+      and verified that its generated link command excludes the compiler
+      pipeline, compiler target, QCO transforms, and jeff and QIR converters.
+- [x] (2026-09-03 07:08 CEST) Built every affected non-unity target and passed
+      148 compiler tests, 62 DDSIM device tests, two `mqt-cc` tests, repository
+      lint, C++ lint with zero findings, and `git diff --check`.
+
+## Surprises & Discoveries
+
+- Observation: `mlir/lib/Compiler/Programs.cpp` combines program storage and
+  parsing with QC and QCO transformations, target compilation, jeff and QIR
+  conversion, and the default pipeline. A new target around the unchanged file
+  would retain all unwanted dependencies.
+- Observation: Unity builds can combine every source of one target into a single
+  object. Splitting the source without splitting the CMake target would not
+  establish the requested link boundary.
+- Observation: MQT compiler MLIR libraries are build-tree targets rather than
+  entries in the installed `MQT_CORE_TARGETS` export. This issue therefore does
+  not need a new installed alias or package component.
+- Observation: PRs #2339 and #2340 add inliner preparation to both the compiler
+  context factory that remains in `Programs.cpp` and higher-level methods that
+  move to `Pipeline.cpp`. Restacking #2340 must preserve registration on both
+  sides of the target boundary and link the inliner-extension libraries to each
+  target that performs it.
+- Observation: The lower target still links the jeff dialect because the shared
+  compiler context registers that dialect. It does not link jeff conversion or
+  translation libraries.
+
+## Decision Log
+
+- Decision: Add `MQTCompilerPrograms` below `MQTCompilerPipeline`. The lower
+  target owns program storage, parsing, validation, copying, inspection, and the
+  OpenQASM-to-QC-to-QCO path. Rationale: These are the exact facilities DDSIM
+  uses, and they do not need target compilation or output conversion.
+  Date/Author: 2026-09-03 / Codex.
+- Decision: Keep `MQTCompilerPipeline` as a public umbrella that links
+  `MQTCompilerPrograms`. Rationale: Existing bindings, tools, benchmarks, and
+  tests keep their current target dependency and source API. Date/Author:
+  2026-09-03 / Codex.
+- Decision: Keep `mlir/Compiler/Programs.h` as the shared public header. Do not
+  split the C++ type hierarchy or add a device-specific parsing API. Rationale:
+  The requested boundary is a link dependency, not a new user-facing concept.
+  Date/Author: 2026-09-03 / Codex.
+- Decision: Put pass-backed cleanup, optimization, output conversion, target
+  compilation, and default orchestration in one new `Pipeline.cpp`. Rationale:
+  One higher-level source is sufficient; additional internal layers would not
+  reduce dependencies or improve the contract. Date/Author: 2026-09-03 / Codex.
+- Decision: Do not add changelog or upgrade-guide text. Rationale: This internal
+  refactor preserves behavior and changes no released API. Date/Author:
+  2026-09-03 / Codex.
+
+## Outcomes & Retrospective
+
+The split establishes the requested link boundary while retaining the existing
+compiler API. The generated DDSIM link command includes
+`libMQTCompilerPrograms.a` and excludes `libMQTCompilerPipeline.a`,
+`libMQTCompilerTarget.a`, QCO transforms, jeff converters, and QC-to-QIR
+converters.
+
+All affected non-unity targets build. The compiler unit suite passes 148 tests,
+the complete DDSIM device suite passes 62 tests, and the two `mqt-cc` CTests
+pass. Repository lint and `git diff --check` also pass. No new behavior test was
+needed: the existing compiler and DDSIM suites directly exercise the moved
+symbols and the device path whose dependency was narrowed. C++ lint reports zero
+clang-format and zero clang-tidy findings for both changed sources.
+
+When #2339 and #2340 are restacked, their higher-level additions belong in
+`Pipeline.cpp`. Inliner registration from #2340 must remain available both to
+the factory in `Programs.cpp` and to higher-level paths that accept caller-owned
+contexts; one file-local helper cannot serve both targets.
+
+## Context and Orientation
+
+`mlir/include/mlir/Compiler/Programs.h` declares owned program types for QC,
+QCO, jeff, QIR, and OpenQASM. `mlir/lib/Compiler/Programs.cpp` currently
+implements all of those types and `runDefaultPipeline`. The latter is the
+high-level operation that coordinates optimization, target compilation, and
+output conversion.
+
+`mlir/lib/Compiler/TargetCompilation.cpp` builds the target-specific QCO pass
+pipeline. `mlir/lib/Compiler/CMakeLists.txt` currently compiles both sources
+into `MQTCompilerPipeline` and attaches `Programs.h` and `TargetCompilation.h`
+to that target.
+
+`src/qdmi/devices/dd/Device.cpp` translates QASM in `parseQASMToQCO` by calling
+`QCProgram::fromQASMString` and then `QCProgram::intoQCO`. The device only
+borrows the resulting QCO module for DD sampling or statevector simulation.
+Nevertheless, `src/qdmi/devices/dd/CMakeLists.txt` links `MQTCompilerPipeline`,
+which exposes the device to every higher-level compiler dependency.
+
+A CMake target is a named group of sources and link requirements. A public link
+from `MQTCompilerPipeline` to `MQTCompilerPrograms` means existing pipeline
+consumers also receive the lower target. A private DDSIM link to
+`MQTCompilerPrograms` gives the device only the narrower dependency closure.
+
+## Plan of Work
+
+First, update `mlir/lib/Compiler/CMakeLists.txt`. Add `MQTCompilerPrograms` with
+`Programs.cpp`, the `Programs.h` file set, and only the dialect, parser,
+pass-manager, OpenQASM import, and QC-to-QCO conversion libraries used by that
+source. Change `MQTCompilerPipeline` to compile `Pipeline.cpp` and
+`TargetCompilation.cpp`, link `MQTCompilerPrograms` publicly, and retain the
+dependencies used by the higher-level methods.
+
+Second, trim `Programs.cpp` to the foundational implementation. Retain compiler
+context creation, source and module parsing, program storage, OpenQASM source
+I/O, QC and QCO construction and copying, QC gate counts, QCO linearity checks,
+and `QCProgram::intoQCO`. Implement that one conversion with its own small pass
+manager so the lower source does not need an internal cross-library helper.
+
+Move the remaining definitions without changing their bodies into a new
+`mlir/lib/Compiler/Pipeline.cpp`: QC cleanup, phase normalization, OpenQASM and
+QIR output; all pass-backed QCO methods; QC and jeff output conversions; jeff
+and QIR program methods; LLVM IR and bitcode output; and `runDefaultPipeline`.
+Keep shared pass helpers private to that source.
+
+Third, replace `MQTCompilerPipeline` with `MQTCompilerPrograms` in
+`src/qdmi/devices/dd/CMakeLists.txt`. Leave all other consumers on the umbrella
+pipeline target. Inspect generated link commands to prove that the device does
+not regain the pipeline transitively.
+
+## Concrete Steps
+
+Run all commands from the repository root. Configure and build the affected
+non-unity targets with:
+
+    cmake --preset release -DCMAKE_UNITY_BUILD=OFF
+    cmake --build --preset release --target MQTCompilerPrograms
+    cmake --build --preset release --target MQTCompilerPipeline
+    cmake --build --preset release --target mqt-core-qdmi-ddsim-device
+    cmake --build --preset release --target mqt-core-mlir-unittests-compiler
+    cmake --build --preset release --target mqt-cc
+
+Run the focused and umbrella behavior checks with:
+
+    ./build/release/mlir/unittests/Compiler/mqt-core-mlir-unittests-compiler
+    ./build/release/test/qdmi/devices/dd/mqt-core-qdmi-ddsim-device-test \
+      --gtest_filter='HistogramTest.QASM2Program:HistogramTest.QASM3Program'
+    ctest --test-dir build/release -R mqt-cc --output-on-failure
+
+Inspect the generated DDSIM link command with Ninja's command tool. The output
+must contain the compiler-program archive and must not contain the compiler
+pipeline archive:
+
+    ninja -C build/release -t commands mqt-core-qdmi-ddsim-device
+
+Finish with:
+
+    git diff --check
+    uvx nox -s cpp-lint
+    uvx nox -s lint
+
+## Validation and Acceptance
+
+The project must build with unity disabled so no accidental same-target source
+aggregation can hide the boundary. `MQTCompilerPrograms`, `MQTCompilerPipeline`,
+DDSIM, the compiler unit test, and `mqt-cc` must all link.
+
+The DDSIM command closure must contain `MQTCompilerPrograms` and exclude
+`MQTCompilerPipeline`. The compiler unit tests must still cover program
+construction, conversions, pass methods, target compilation, and default
+orchestration through the umbrella target. QASM 2 and QASM 3 jobs submitted to
+DDSIM must retain their previous results. The `mqt-cc` tests must retain the
+driver behavior.
+
+Cpp-linter must report zero clang-format and clang-tidy findings for changed C++
+files. The complete repository lint suite must pass. No generated, installed, or
+public API file should change except the CMake ownership of the existing header.
+
+## Idempotence and Recovery
+
+The source move, configuration, builds, tests, and link-command inspection are
+repeatable. The work is isolated from the branches for #2330, #2331, and #2332.
+If #2339 or #2340 lands first, rebase and place their higher-level additions in
+`Pipeline.cpp`; keep factory-side inliner registration in `Programs.cpp` and
+link its required extension library to the lower target. Do not restore the
+combined source or broaden DDSIM's dependency.
+
+## Artifacts and Notes
+
+The originating #2288 review thread is resolved. It asks for a Programs library
+instead of a device dependency on the complete compiler pipeline. Issue #2329
+has no comments. No open PR already implements this split.
+
+## Interfaces and Dependencies
+
+`MQTCompilerPrograms` must provide the existing symbols used by the DDSIM path:
+
+    mlir::QCProgram::fromQASMString(std::string_view)
+    mlir::QCProgram::intoQCO() &&
+    mlir::Program::module() const
+
+It must not link `MQTCompilerPipeline`, `MQTCompilerTarget`, QCO transform
+libraries, QIR conversion libraries, or jeff conversion libraries.
+`MQTCompilerPipeline` must link `MQTCompilerPrograms` publicly and continue to
+provide every existing program and pipeline symbol to its current consumers.

--- a/mlir/lib/Compiler/CMakeLists.txt
+++ b/mlir/lib/Compiler/CMakeLists.txt
@@ -46,23 +46,60 @@ target_sources(
   MQTCompilerQDMIAdapter PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_MLIR_SOURCE_INCLUDE_DIR} FILES
                                 ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Compiler/QDMIAdapter.h)
 
+# Build the compiler program model and OpenQASM-to-QCO path
+add_mlir_library(
+  MQTCompilerPrograms
+  PARTIAL_SOURCES_INTENDED
+  Programs.cpp
+  ADDITIONAL_HEADER_DIRS
+  ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Compiler
+  LINK_LIBS
+  PUBLIC
+  LLVMSupport
+  MLIRArithDialect
+  MLIRBuiltinToLLVMIRTranslation
+  MLIRCBitDialect
+  MLIRControlFlowDialect
+  MLIRFuncDialect
+  MLIRIR
+  MLIRJeff
+  MLIRLLVMDialect
+  MLIRLLVMToLLVMIRTranslation
+  MLIRMathDialect
+  MLIRMemRefDialect
+  MLIRMQTDialect
+  MLIRParser
+  MLIRPass
+  MLIRQCDialect
+  MLIRQCOpenQASMTranslation
+  MLIRQCToQCO
+  MLIRQCODialect
+  MLIRQTensorDialect
+  MLIRSCFDialect
+  MLIRSupport
+  MLIRTensorDialect)
+
+mqt_mlir_target_use_project_options(MQTCompilerPrograms)
+
+target_sources(
+  MQTCompilerPrograms PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_MLIR_SOURCE_INCLUDE_DIR} FILES
+                             ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Compiler/Programs.h)
+
 # Build the compiler pipeline library
 add_mlir_library(
   MQTCompilerPipeline
   PARTIAL_SOURCES_INTENDED
-  Programs.cpp
+  Pipeline.cpp
   TargetCompilation.cpp
   ADDITIONAL_HEADER_DIRS
   ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Compiler
   LINK_LIBS
   PUBLIC
   LLVMBitWriter
-  MLIRCBitDialect
   MLIRPass
   MLIRTransforms
   MLIRTransformUtils
   MLIRMQTTransforms
-  MLIRQCToQCO
   MLIRQCOToQC
   MLIRQCOToJeff
   MLIRQCToQIRBase
@@ -70,22 +107,15 @@ add_mlir_library(
   MLIRQIRUtils
   MLIRQCOTransforms
   MLIRQCOpenQASMTranslation
-  MLIRParser
   MLIRJeffTranslation
   MLIRJeffToQCO
   MLIRTargetLLVMIRExport
-  MLIRBuiltinToLLVMIRTranslation
-  MLIRLLVMToLLVMIRTranslation
-  MLIRMathDialect
-  MLIRMQTDialect
+  MQTCompilerPrograms
   MQTCompilerTarget
   MQT::MLIRSupport)
 
 mqt_mlir_target_use_project_options(MQTCompilerPipeline)
 
-# collect header files
-file(GLOB_RECURSE COMPILER_HEADERS_SOURCE "${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Compiler/*.h")
-list(FILTER COMPILER_HEADERS_SOURCE EXCLUDE REGEX "/(QDMIAdapter|Target)\\.h$")
-
-target_sources(MQTCompilerPipeline PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_MLIR_SOURCE_INCLUDE_DIR}
-                                          FILES ${COMPILER_HEADERS_SOURCE})
+target_sources(
+  MQTCompilerPipeline PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_MLIR_SOURCE_INCLUDE_DIR} FILES
+                             ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mlir/Compiler/TargetCompilation.h)

--- a/mlir/lib/Compiler/Pipeline.cpp
+++ b/mlir/lib/Compiler/Pipeline.cpp
@@ -210,9 +210,9 @@ bool QCOProgram::reuseQubits() {
 }
 
 bool QCOProgram::runQubitReusePipeline() {
-  return succeeded(runQCOTransformPasses(
-      mod(), [](OpPassManager& pm) { populateQubitReusePipeline(pm); },
-      "failed to run the qubit reuse pipeline"));
+  return succeeded(
+      runQCOTransformPasses(mod(), populateQubitReusePipeline,
+                            "failed to run the qubit reuse pipeline"));
 }
 
 bool QCOProgram::decomposeMultiControlled(uint64_t minQubits) {
@@ -509,21 +509,13 @@ runDefaultPipeline(CompilerInput&& program, ProgramFormat output,
     return CompilerProgram(std::move(*qc));
   }
   if (output == ProgramFormat::OpenQASM3) {
-    auto openQASM = qc->toOpenQASM3();
-    if (!openQASM) {
-      return std::nullopt;
-    }
-    return CompilerProgram(std::move(*openQASM));
+    return qc->toOpenQASM3();
   }
 
   const auto profile = output == ProgramFormat::QIRAdaptive
                            ? QIRProfile::Adaptive
                            : QIRProfile::Base;
-  auto qir = std::move(*qc).intoQIR(profile);
-  if (!qir) {
-    return std::nullopt;
-  }
-  return CompilerProgram(std::move(*qir));
+  return std::move(*qc).intoQIR(profile);
 }
 
 } // namespace mlir

--- a/mlir/lib/Compiler/Pipeline.cpp
+++ b/mlir/lib/Compiler/Pipeline.cpp
@@ -60,10 +60,9 @@
 namespace mlir {
 
 [[nodiscard]] static LogicalResult
-runPasses(ModuleOp mod,
-          const llvm::function_ref<void(OpPassManager&)> populatePasses,
-          const StringRef failureMessage, const bool enableTiming = false,
-          const bool enableStatistics = false) {
+runPasses(ModuleOp mod, llvm::function_ref<void(OpPassManager&)> populatePasses,
+          StringRef failureMessage, bool enableTiming = false,
+          bool enableStatistics = false) {
   PassManager pm(mod.getContext());
   if (enableTiming) {
     pm.enableTiming();
@@ -78,10 +77,11 @@ runPasses(ModuleOp mod,
   return success();
 }
 
-[[nodiscard]] static LogicalResult runQCOTransformPasses(
-    ModuleOp mod, const llvm::function_ref<void(OpPassManager&)> populatePasses,
-    const StringRef failureMessage, const bool enableTiming = false,
-    const bool enableStatistics = false) {
+[[nodiscard]] static LogicalResult
+runQCOTransformPasses(ModuleOp mod,
+                      llvm::function_ref<void(OpPassManager&)> populatePasses,
+                      StringRef failureMessage, bool enableTiming = false,
+                      bool enableStatistics = false) {
   if (failed(qco::verifyLinearity(mod))) {
     return failure();
   }
@@ -117,7 +117,7 @@ std::optional<OpenQASMProgram> QCProgram::toOpenQASM3() const {
   return OpenQASMProgram(std::move(*source));
 }
 
-std::optional<QIRProgram> QCProgram::intoQIR(const QIRProfile profile) && {
+std::optional<QIRProgram> QCProgram::intoQIR(QIRProfile profile) && {
   if (failed(runPasses(
           mod(),
           [profile](OpPassManager& pm) {
@@ -155,9 +155,8 @@ bool QCOProgram::normalizeGlobalPhases() {
   return succeeded(mqt::normalizeGlobalPhases(mod())) && hasValidLinearity();
 }
 
-bool QCOProgram::runPassPipeline(const std::string_view pipeline,
-                                 const bool enableTiming,
-                                 const bool enableStatistics) {
+bool QCOProgram::runPassPipeline(std::string_view pipeline, bool enableTiming,
+                                 bool enableStatistics) {
   if (!hasValidLinearity()) {
     return false;
   }
@@ -175,7 +174,7 @@ bool QCOProgram::mergeSingleQubitRotationGates() {
       "failed to merge single-qubit rotation gates"));
 }
 
-bool QCOProgram::fuseSingleQubitUnitaryRuns(const std::string_view basis) {
+bool QCOProgram::fuseSingleQubitUnitaryRuns(std::string_view basis) {
   qco::FuseSingleQubitUnitaryRunsOptions options;
   options.basis = basis;
   return succeeded(runQCOTransformPasses(
@@ -186,7 +185,7 @@ bool QCOProgram::fuseSingleQubitUnitaryRuns(const std::string_view basis) {
       "failed to fuse single-qubit unitary runs"));
 }
 
-bool QCOProgram::unrollQuantumLoops(const int64_t factor) {
+bool QCOProgram::unrollQuantumLoops(int64_t factor) {
   qco::QuantumLoopUnrollOptions options;
   options.unrollFactor = factor;
   return succeeded(runQCOTransformPasses(
@@ -216,7 +215,7 @@ bool QCOProgram::runQubitReusePipeline() {
       "failed to run the qubit reuse pipeline"));
 }
 
-bool QCOProgram::decomposeMultiControlled(const uint64_t minQubits) {
+bool QCOProgram::decomposeMultiControlled(uint64_t minQubits) {
   return succeeded(runQCOTransformPasses(
       mod(),
       [minQubits](OpPassManager& pm) {
@@ -226,8 +225,7 @@ bool QCOProgram::decomposeMultiControlled(const uint64_t minQubits) {
 }
 
 bool QCOProgram::compileForTarget(const CompilerTarget& target,
-                                  const bool enableTiming,
-                                  const bool enableStatistics) {
+                                  bool enableTiming, bool enableStatistics) {
   return succeeded(runQCOTransformPasses(
       mod(),
       [&target](OpPassManager& pm) {
@@ -264,7 +262,7 @@ std::optional<JeffProgram> QCOProgram::intoJeff() && {
 //===----------------------------------------------------------------------===//
 
 std::optional<JeffProgram>
-JeffProgram::fromBytes(const std::span<const std::byte> bytes) {
+JeffProgram::fromBytes(std::span<const std::byte> bytes) {
   if (bytes.size() % sizeof(capnp::word) != 0U) {
     auto context = createCompilerContext();
     emitError(UnknownLoc::get(context.get()),
@@ -336,7 +334,7 @@ std::optional<QCOProgram> JeffProgram::intoQCO() && {
 // QIRProgram
 //===----------------------------------------------------------------------===//
 
-QIRProgram::QIRProgram(Storage storage, const QIRProfile profile)
+QIRProgram::QIRProgram(Storage storage, QIRProfile profile)
     : Program(std::move(storage)), profile_(profile) {}
 
 QIRProgram QIRProgram::copy() const { return {cloneStorage(), profile_}; }
@@ -419,10 +417,9 @@ bool QIRProgram::writeBitcode(const std::filesystem::path& path) const {
 //===----------------------------------------------------------------------===//
 
 std::optional<CompilerProgram>
-runDefaultPipeline(CompilerInput&& program, const ProgramFormat output,
-                   const CompilerTarget* const target,
-                   const std::string_view qcoPipeline, const bool enableTiming,
-                   const bool enableStatistics) {
+runDefaultPipeline(CompilerInput&& program, ProgramFormat output,
+                   const CompilerTarget* target, std::string_view qcoPipeline,
+                   bool enableTiming, bool enableStatistics) {
   if (target != nullptr &&
       (output == ProgramFormat::QCImport || output == ProgramFormat::QCO ||
        output == ProgramFormat::Jeff)) {

--- a/mlir/lib/Compiler/Pipeline.cpp
+++ b/mlir/lib/Compiler/Pipeline.cpp
@@ -1,0 +1,532 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Compiler/Programs.h"
+#include "mlir/Compiler/TargetCompilation.h"
+#include "mlir/Conversion/JeffToQCO/JeffToQCO.h"
+#include "mlir/Conversion/QCOToJeff/QCOToJeff.h"
+#include "mlir/Conversion/QCOToQC/QCOToQC.h"
+#include "mlir/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.h"
+#include "mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.h"
+#include "mlir/Dialect/MQT/Transforms/GlobalPhaseNormalization.h"
+#include "mlir/Dialect/MQT/Transforms/Passes.h"
+#include "mlir/Dialect/QC/Translation/TranslateQCToOpenQASM3.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
+#include "mlir/Dialect/QIR/Utils/QIRUtils.h"
+#include "mlir/Support/Passes.h"
+
+#include <capnp/common.h>
+#include <jeff/Translation/Deserialize.hpp>
+#include <jeff/Translation/Serialize.hpp>
+#include <kj/array.h>
+#include <llvm/ADT/STLFunctionalExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Bitcode/BitcodeWriter.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/raw_ostream.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/Diagnostics.h>
+#include <mlir/IR/Location.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Target/LLVMIR/ModuleTranslation.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace mlir {
+
+[[nodiscard]] static LogicalResult
+runPasses(ModuleOp mod,
+          const llvm::function_ref<void(OpPassManager&)> populatePasses,
+          const StringRef failureMessage, const bool enableTiming = false,
+          const bool enableStatistics = false) {
+  PassManager pm(mod.getContext());
+  if (enableTiming) {
+    pm.enableTiming();
+  }
+  if (enableStatistics) {
+    pm.enableStatistics();
+  }
+  populatePasses(pm);
+  if (failed(pm.run(mod))) {
+    return mod.emitError(failureMessage);
+  }
+  return success();
+}
+
+[[nodiscard]] static LogicalResult runQCOTransformPasses(
+    ModuleOp mod, const llvm::function_ref<void(OpPassManager&)> populatePasses,
+    const StringRef failureMessage, const bool enableTiming = false,
+    const bool enableStatistics = false) {
+  if (failed(qco::verifyLinearity(mod))) {
+    return failure();
+  }
+  if (failed(runPasses(mod, populatePasses, failureMessage, enableTiming,
+                       enableStatistics))) {
+    return failure();
+  }
+  return qco::verifyLinearity(mod);
+}
+
+//===----------------------------------------------------------------------===//
+// QCProgram
+//===----------------------------------------------------------------------===//
+
+bool QCProgram::cleanup() {
+  return succeeded(runPasses(mod(), populateQCCleanupPipeline,
+                             "failed to run the QC cleanup pipeline"));
+}
+
+bool QCProgram::normalizeGlobalPhases() {
+  return succeeded(mqt::normalizeGlobalPhases(mod()));
+}
+
+std::optional<OpenQASMProgram> QCProgram::toOpenQASM3() const {
+  auto cleaned = copy();
+  if (!cleaned.cleanup()) {
+    return std::nullopt;
+  }
+  auto source = qc::translateQCToOpenQASM3(cleaned.mod());
+  if (failed(source)) {
+    return std::nullopt;
+  }
+  return OpenQASMProgram(std::move(*source));
+}
+
+std::optional<QIRProgram> QCProgram::intoQIR(const QIRProfile profile) && {
+  if (failed(runPasses(
+          mod(),
+          [profile](OpPassManager& pm) {
+            pm.addPass(mqt::createUnrollModifiers());
+            if (profile == QIRProfile::Adaptive) {
+              pm.addPass(createQCToQIRAdaptive());
+            } else {
+              pm.addPass(createQCToQIRBase());
+            }
+          },
+          "failed to convert QC to QIR"))) {
+    return std::nullopt;
+  }
+  auto result = QIRProgram(std::move(*this).releaseStorage(), profile);
+  if (!result.cleanup()) {
+    return std::nullopt;
+  }
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
+// QCOProgram
+//===----------------------------------------------------------------------===//
+
+bool QCOProgram::cleanup() {
+  return succeeded(
+      runQCOTransformPasses(mod(), populateQCOCleanupPipeline,
+                            "failed to run the QCO cleanup pipeline"));
+}
+
+bool QCOProgram::normalizeGlobalPhases() {
+  if (!hasValidLinearity()) {
+    return false;
+  }
+  return succeeded(mqt::normalizeGlobalPhases(mod())) && hasValidLinearity();
+}
+
+bool QCOProgram::runPassPipeline(const std::string_view pipeline,
+                                 const bool enableTiming,
+                                 const bool enableStatistics) {
+  if (!hasValidLinearity()) {
+    return false;
+  }
+  return succeeded(::runPassPipeline(mod(), pipeline, enableTiming,
+                                     enableStatistics)) &&
+         hasValidLinearity();
+}
+
+bool QCOProgram::mergeSingleQubitRotationGates() {
+  return succeeded(runQCOTransformPasses(
+      mod(),
+      [](OpPassManager& pm) {
+        pm.addPass(qco::createMergeSingleQubitRotationGates());
+      },
+      "failed to merge single-qubit rotation gates"));
+}
+
+bool QCOProgram::fuseSingleQubitUnitaryRuns(const std::string_view basis) {
+  qco::FuseSingleQubitUnitaryRunsOptions options;
+  options.basis = basis;
+  return succeeded(runQCOTransformPasses(
+      mod(),
+      [&options](OpPassManager& pm) {
+        pm.addPass(qco::createFuseSingleQubitUnitaryRuns(options));
+      },
+      "failed to fuse single-qubit unitary runs"));
+}
+
+bool QCOProgram::unrollQuantumLoops(const int64_t factor) {
+  qco::QuantumLoopUnrollOptions options;
+  options.unrollFactor = factor;
+  return succeeded(runQCOTransformPasses(
+      mod(),
+      [&options](OpPassManager& pm) {
+        pm.addNestedPass<func::FuncOp>(qco::createQuantumLoopUnroll(options));
+      },
+      "failed to unroll quantum loops"));
+}
+
+bool QCOProgram::liftHadamards() {
+  return succeeded(runQCOTransformPasses(
+      mod(),
+      [](OpPassManager& pm) { pm.addPass(qco::createHadamardLifting()); },
+      "failed to lift Hadamard gates"));
+}
+
+bool QCOProgram::reuseQubits() {
+  return succeeded(runQCOTransformPasses(
+      mod(), [](OpPassManager& pm) { pm.addPass(qco::createReuseQubits()); },
+      "failed to reuse qubits"));
+}
+
+bool QCOProgram::runQubitReusePipeline() {
+  return succeeded(runQCOTransformPasses(
+      mod(), [](OpPassManager& pm) { populateQubitReusePipeline(pm); },
+      "failed to run the qubit reuse pipeline"));
+}
+
+bool QCOProgram::decomposeMultiControlled(const uint64_t minQubits) {
+  return succeeded(runQCOTransformPasses(
+      mod(),
+      [minQubits](OpPassManager& pm) {
+        populateDecomposeMultiControlledPipeline(pm, minQubits);
+      },
+      "failed to decompose multi-controlled gates"));
+}
+
+bool QCOProgram::compileForTarget(const CompilerTarget& target,
+                                  const bool enableTiming,
+                                  const bool enableStatistics) {
+  return succeeded(runQCOTransformPasses(
+      mod(),
+      [&target](OpPassManager& pm) {
+        populateTargetCompilationPipeline(pm, target);
+      },
+      "failed to compile the QCO program for the target", enableTiming,
+      enableStatistics));
+}
+
+std::optional<QCProgram> QCOProgram::intoQC() && {
+  if (failed(runQCOTransformPasses(
+          mod(), [](OpPassManager& pm) { pm.addPass(createQCOToQC()); },
+          "failed to convert QCO to QC"))) {
+    return std::nullopt;
+  }
+  return QCProgram(std::move(*this).releaseStorage());
+}
+
+std::optional<JeffProgram> QCOProgram::intoJeff() && {
+  if (failed(runQCOTransformPasses(
+          mod(),
+          [](OpPassManager& pm) {
+            pm.addPass(mqt::createUnrollModifiers());
+            pm.addPass(createQCOToJeff());
+          },
+          "failed to convert QCO to jeff"))) {
+    return std::nullopt;
+  }
+  return JeffProgram(std::move(*this).releaseStorage());
+}
+
+//===----------------------------------------------------------------------===//
+// JeffProgram
+//===----------------------------------------------------------------------===//
+
+std::optional<JeffProgram>
+JeffProgram::fromBytes(const std::span<const std::byte> bytes) {
+  if (bytes.size() % sizeof(capnp::word) != 0U) {
+    auto context = createCompilerContext();
+    emitError(UnknownLoc::get(context.get()),
+              "jeff data size must be a multiple of the Cap'n Proto word size");
+    return std::nullopt;
+  }
+
+  auto words = kj::heapArray<capnp::word>(bytes.size() / sizeof(capnp::word));
+  std::memcpy(words.begin(), bytes.data(), bytes.size());
+
+  auto context = createCompilerContext();
+  auto mod = deserialize(context.get(), words.asPtr());
+  if (!mod) {
+    emitError(UnknownLoc::get(context.get()),
+              "failed to deserialize jeff bytes");
+    return std::nullopt;
+  }
+  return JeffProgram({.context = std::move(context), .mod = std::move(mod)});
+}
+
+std::optional<JeffProgram>
+JeffProgram::fromFile(const std::filesystem::path& path) {
+  auto context = createCompilerContext();
+  auto mod = deserializeFromFile(context.get(), path.string());
+  if (!mod) {
+    emitError(UnknownLoc::get(context.get()))
+        << "failed to deserialize jeff file '" << path.string() << "'";
+    return std::nullopt;
+  }
+  return JeffProgram({.context = std::move(context), .mod = std::move(mod)});
+}
+
+JeffProgram JeffProgram::copy() const { return JeffProgram(cloneStorage()); }
+
+bool JeffProgram::cleanup() {
+  return succeeded(runPasses(mod(), populateJeffCleanupPipeline,
+                             "failed to run the jeff cleanup pipeline"));
+}
+
+std::vector<std::byte> JeffProgram::toBytes() const {
+  const auto serialized = serialize(mod());
+  const auto bytes = serialized.asBytes();
+  std::vector<std::byte> result(bytes.size());
+  std::memcpy(result.data(), bytes.begin(), bytes.size());
+  return result;
+}
+
+bool JeffProgram::write(const std::filesystem::path& path) const {
+  if (failed(serializeToFile(mod(), path.string()))) {
+    mod().emitError() << "failed to write jeff file '" << path.string() << "'";
+    return false;
+  }
+  return true;
+}
+
+std::optional<QCOProgram> JeffProgram::intoQCO() && {
+  if (failed(runPasses(
+          mod(), [](OpPassManager& pm) { pm.addPass(createJeffToQCO()); },
+          "failed to convert jeff to QCO"))) {
+    return std::nullopt;
+  }
+  if (failed(qco::verifyLinearity(mod()))) {
+    return std::nullopt;
+  }
+  return QCOProgram(std::move(*this).releaseStorage());
+}
+
+//===----------------------------------------------------------------------===//
+// QIRProgram
+//===----------------------------------------------------------------------===//
+
+QIRProgram::QIRProgram(Storage storage, const QIRProfile profile)
+    : Program(std::move(storage)), profile_(profile) {}
+
+QIRProgram QIRProgram::copy() const { return {cloneStorage(), profile_}; }
+
+bool QIRProgram::cleanup() {
+  return succeeded(runPasses(
+      mod(),
+      [this](OpPassManager& pm) {
+        populateQIRCleanupPipeline(pm, profile_ == QIRProfile::Adaptive);
+      },
+      "failed to run the QIR cleanup pipeline"));
+}
+
+QIRProfile QIRProgram::profile() const noexcept { return profile_; }
+
+[[nodiscard]] static std::unique_ptr<llvm::Module>
+translateToLLVM(ModuleOp mod, llvm::LLVMContext& context) {
+  auto llvmModule = translateModuleToLLVMIR(mod, context);
+  if (!llvmModule) {
+    mod.emitError("failed to translate QIR MLIR to LLVM IR");
+    return nullptr;
+  }
+  qir::normalizeQIRModuleFlags(*llvmModule, mod);
+  return llvmModule;
+}
+
+std::optional<std::string> QIRProgram::llvmIR() const {
+  llvm::LLVMContext context;
+  auto llvmModule = translateToLLVM(mod(), context);
+  if (!llvmModule) {
+    return std::nullopt;
+  }
+  std::string result;
+  llvm::raw_string_ostream stream(result);
+  llvmModule->print(stream, nullptr);
+  return result;
+}
+
+std::optional<std::vector<std::byte>> QIRProgram::toBitcode() const {
+  llvm::LLVMContext context;
+  auto llvmModule = translateToLLVM(mod(), context);
+  if (!llvmModule) {
+    return std::nullopt;
+  }
+
+  SmallVector<char> storage;
+  llvm::raw_svector_ostream stream(storage);
+  llvm::WriteBitcodeToFile(*llvmModule, stream);
+  std::vector<std::byte> result(storage.size());
+  std::memcpy(result.data(), storage.data(), storage.size());
+  return result;
+}
+
+bool QIRProgram::writeBitcode(const std::filesystem::path& path) const {
+  llvm::LLVMContext context;
+  auto llvmModule = translateToLLVM(mod(), context);
+  if (!llvmModule) {
+    return false;
+  }
+
+  std::error_code error;
+  llvm::raw_fd_ostream stream(path.string(), error, llvm::sys::fs::OF_None);
+  if (error) {
+    mod().emitError() << "failed to open bitcode output file '" << path.string()
+                      << "': " << error.message();
+    return false;
+  }
+  llvm::WriteBitcodeToFile(*llvmModule, stream);
+  stream.flush();
+  if (stream.has_error()) {
+    mod().emitError() << "failed to write bitcode file '" << path.string()
+                      << "'";
+    return false;
+  }
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Pipeline
+//===----------------------------------------------------------------------===//
+
+std::optional<CompilerProgram>
+runDefaultPipeline(CompilerInput&& program, const ProgramFormat output,
+                   const CompilerTarget* const target,
+                   const std::string_view qcoPipeline, const bool enableTiming,
+                   const bool enableStatistics) {
+  if (target != nullptr &&
+      (output == ProgramFormat::QCImport || output == ProgramFormat::QCO ||
+       output == ProgramFormat::Jeff)) {
+    llvm::errs()
+        << "a compiler target requires QCOOptimized, QC, OpenQASM3, or QIR "
+           "output.\n";
+    return std::nullopt;
+  }
+  if (target != nullptr && qcoPipeline != "mqt-qco-default") {
+    llvm::errs() << "a custom QCO pass pipeline cannot be combined with a "
+                    "compiler target.\n";
+    return std::nullopt;
+  }
+  if ((output == ProgramFormat::QCImport || output == ProgramFormat::QCO) &&
+      qcoPipeline != "mqt-qco-default") {
+    llvm::errs() << "a custom QCO pass pipeline cannot be used with an output "
+                    "that stops before QCO optimization.\n";
+    return std::nullopt;
+  }
+  if (output == ProgramFormat::QCImport) {
+    if (std::holds_alternative<QCProgram>(program)) {
+      return CompilerProgram(std::move(std::get<QCProgram>(program)));
+    }
+    if (std::holds_alternative<OpenQASMProgram>(program)) {
+      auto qc = QCProgram::fromQASMString(
+          std::get<OpenQASMProgram>(program).source());
+      if (qc) {
+        return CompilerProgram(std::move(*qc));
+      }
+    }
+    llvm::errs() << "QCImport output is only available for QC or OpenQASM "
+                    "input.\n";
+    return std::nullopt;
+  }
+
+  auto qco = std::visit(
+      []<typename T>(T&& value) -> std::optional<QCOProgram> {
+        using ProgramType = std::remove_cvref_t<T>;
+        if constexpr (std::is_same_v<ProgramType, QCOProgram>) {
+          return std::forward<T>(value);
+        } else if constexpr (std::is_same_v<ProgramType, OpenQASMProgram>) {
+          auto qc = QCProgram::fromQASMString(value.source());
+          if (!qc) {
+            return std::nullopt;
+          }
+          return std::move(*qc).intoQCO();
+        } else {
+          return std::forward<T>(value).intoQCO();
+        }
+      },
+      std::move(program));
+  if (!qco || failed(qco::verifyLinearity(qco->module()))) {
+    return std::nullopt;
+  }
+  if (output == ProgramFormat::QCO) {
+    return CompilerProgram(std::move(*qco));
+  }
+
+  if (target != nullptr) {
+    if (!qco->compileForTarget(*target, enableTiming, enableStatistics)) {
+      return std::nullopt;
+    }
+  } else {
+    if (!qco->cleanup() ||
+        !qco->runPassPipeline(qcoPipeline, enableTiming, enableStatistics) ||
+        !qco->cleanup()) {
+      return std::nullopt;
+    }
+  }
+  if (output == ProgramFormat::QCOOptimized) {
+    return CompilerProgram(std::move(*qco));
+  }
+
+  if (output == ProgramFormat::Jeff) {
+    auto jeff = std::move(*qco).intoJeff();
+    if (!jeff || !jeff->cleanup()) {
+      return std::nullopt;
+    }
+    return CompilerProgram(std::move(*jeff));
+  }
+
+  auto qc = std::move(*qco).intoQC();
+  if (!qc || !qc->cleanup()) {
+    return std::nullopt;
+  }
+  if (output == ProgramFormat::QC) {
+    return CompilerProgram(std::move(*qc));
+  }
+  if (output == ProgramFormat::OpenQASM3) {
+    auto openQASM = qc->toOpenQASM3();
+    if (!openQASM) {
+      return std::nullopt;
+    }
+    return CompilerProgram(std::move(*openQASM));
+  }
+
+  const auto profile = output == ProgramFormat::QIRAdaptive
+                           ? QIRProfile::Adaptive
+                           : QIRProfile::Base;
+  auto qir = std::move(*qc).intoQIR(profile);
+  if (!qir) {
+    return std::nullopt;
+  }
+  return CompilerProgram(std::move(*qir));
+}
+
+} // namespace mlir

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -10,40 +10,20 @@
 
 #include "mlir/Compiler/Programs.h"
 
-#include "mlir/Compiler/TargetCompilation.h"
-#include "mlir/Conversion/JeffToQCO/JeffToQCO.h"
-#include "mlir/Conversion/QCOToJeff/QCOToJeff.h"
-#include "mlir/Conversion/QCOToQC/QCOToQC.h"
 #include "mlir/Conversion/QCToQCO/QCToQCO.h"
-#include "mlir/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.h"
-#include "mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.h"
 #include "mlir/Dialect/CBit/IR/CBitDialect.h"
 #include "mlir/Dialect/MQT/IR/MQTDialect.h"
-#include "mlir/Dialect/MQT/Transforms/GlobalPhaseNormalization.h"
-#include "mlir/Dialect/MQT/Transforms/Passes.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h"
-#include "mlir/Dialect/QC/Translation/TranslateQCToOpenQASM3.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/QCOUtils.h"
-#include "mlir/Dialect/QCO/Transforms/Passes.h"
-#include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
-#include "mlir/Support/Passes.h"
 
-#include <capnp/common.h>
 #include <jeff/IR/JeffDialect.h>
-#include <jeff/Translation/Deserialize.hpp>
-#include <jeff/Translation/Serialize.hpp>
-#include <kj/array.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
-#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
-#include <llvm/Bitcode/BitcodeWriter.h>
-#include <llvm/IR/LLVMContext.h>
-#include <llvm/IR/Module.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_ostream.h>
@@ -68,23 +48,16 @@
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h>
 #include <mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h>
-#include <mlir/Target/LLVMIR/ModuleTranslation.h>
 
 #include <cassert>
 #include <cstddef>
-#include <cstdint>
-#include <cstring>
 #include <filesystem>
 #include <memory>
 #include <optional>
-#include <span>
 #include <string>
 #include <string_view>
 #include <system_error>
-#include <type_traits>
 #include <utility>
-#include <variant>
-#include <vector>
 
 namespace mlir {
 
@@ -164,39 +137,6 @@ parseTypedProgram(Parse&& parse) {
     return std::nullopt;
   }
   return ProgramType::fromModule(std::move(context), std::move(*mod));
-}
-
-[[nodiscard]] static LogicalResult
-runPasses(ModuleOp mod,
-          const llvm::function_ref<void(OpPassManager&)> populatePasses,
-          const StringRef failureMessage, const bool enableTiming = false,
-          const bool enableStatistics = false) {
-  PassManager pm(mod.getContext());
-  if (enableTiming) {
-    pm.enableTiming();
-  }
-  if (enableStatistics) {
-    pm.enableStatistics();
-  }
-  populatePasses(pm);
-  if (failed(pm.run(mod))) {
-    return mod.emitError(failureMessage);
-  }
-  return success();
-}
-
-[[nodiscard]] static LogicalResult runQCOTransformPasses(
-    ModuleOp mod, const llvm::function_ref<void(OpPassManager&)> populatePasses,
-    const StringRef failureMessage, const bool enableTiming = false,
-    const bool enableStatistics = false) {
-  if (failed(qco::verifyLinearity(mod))) {
-    return failure();
-  }
-  if (failed(runPasses(mod, populatePasses, failureMessage, enableTiming,
-                       enableStatistics))) {
-    return failure();
-  }
-  return qco::verifyLinearity(mod);
 }
 
 //===----------------------------------------------------------------------===//
@@ -338,58 +278,17 @@ QCProgram::fromModule(std::shared_ptr<MLIRContext> context,
 
 QCProgram QCProgram::copy() const { return QCProgram(cloneStorage()); }
 
-bool QCProgram::cleanup() {
-  return succeeded(runPasses(mod(), populateQCCleanupPipeline,
-                             "failed to run the QC cleanup pipeline"));
-}
-
-bool QCProgram::normalizeGlobalPhases() {
-  return succeeded(mqt::normalizeGlobalPhases(mod()));
-}
-
-std::optional<OpenQASMProgram> QCProgram::toOpenQASM3() const {
-  auto cleaned = copy();
-  if (!cleaned.cleanup()) {
-    return std::nullopt;
-  }
-  auto source = qc::translateQCToOpenQASM3(cleaned.mod());
-  if (failed(source)) {
-    return std::nullopt;
-  }
-  return OpenQASMProgram(std::move(*source));
-}
-
 std::optional<QCOProgram> QCProgram::intoQCO() && {
-  if (failed(runPasses(
-          mod(), [](OpPassManager& pm) { pm.addPass(createQCToQCO()); },
-          "failed to convert QC to QCO"))) {
+  PassManager pm(mod().getContext());
+  pm.addPass(createQCToQCO());
+  if (failed(pm.run(mod()))) {
+    mod().emitError("failed to convert QC to QCO");
     return std::nullopt;
   }
   if (failed(qco::verifyLinearity(mod()))) {
     return std::nullopt;
   }
   return QCOProgram(std::move(*this).releaseStorage());
-}
-
-std::optional<QIRProgram> QCProgram::intoQIR(const QIRProfile profile) && {
-  if (failed(runPasses(
-          mod(),
-          [profile](OpPassManager& pm) {
-            pm.addPass(mqt::createUnrollModifiers());
-            if (profile == QIRProfile::Adaptive) {
-              pm.addPass(createQCToQIRAdaptive());
-            } else {
-              pm.addPass(createQCToQIRBase());
-            }
-          },
-          "failed to convert QC to QIR"))) {
-    return std::nullopt;
-  }
-  auto result = QIRProgram(std::move(*this).releaseStorage(), profile);
-  if (!result.cleanup()) {
-    return std::nullopt;
-  }
-  return result;
 }
 
 static size_t
@@ -477,393 +376,6 @@ QCOProgram QCOProgram::copy() const { return QCOProgram(cloneStorage()); }
 
 bool QCOProgram::hasValidLinearity() const {
   return succeeded(qco::verifyLinearity(mod()));
-}
-
-bool QCOProgram::cleanup() {
-  return succeeded(
-      runQCOTransformPasses(mod(), populateQCOCleanupPipeline,
-                            "failed to run the QCO cleanup pipeline"));
-}
-
-bool QCOProgram::normalizeGlobalPhases() {
-  if (!hasValidLinearity()) {
-    return false;
-  }
-  return succeeded(mqt::normalizeGlobalPhases(mod())) && hasValidLinearity();
-}
-
-bool QCOProgram::runPassPipeline(const std::string_view pipeline,
-                                 const bool enableTiming,
-                                 const bool enableStatistics) {
-  if (!hasValidLinearity()) {
-    return false;
-  }
-  return succeeded(::runPassPipeline(mod(), pipeline, enableTiming,
-                                     enableStatistics)) &&
-         hasValidLinearity();
-}
-
-bool QCOProgram::mergeSingleQubitRotationGates() {
-  return succeeded(runQCOTransformPasses(
-      mod(),
-      [](OpPassManager& pm) {
-        pm.addPass(qco::createMergeSingleQubitRotationGates());
-      },
-      "failed to merge single-qubit rotation gates"));
-}
-
-bool QCOProgram::fuseSingleQubitUnitaryRuns(const std::string_view basis) {
-  qco::FuseSingleQubitUnitaryRunsOptions options;
-  options.basis = basis;
-  return succeeded(runQCOTransformPasses(
-      mod(),
-      [&options](OpPassManager& pm) {
-        pm.addPass(qco::createFuseSingleQubitUnitaryRuns(options));
-      },
-      "failed to fuse single-qubit unitary runs"));
-}
-
-bool QCOProgram::unrollQuantumLoops(const int64_t factor) {
-  qco::QuantumLoopUnrollOptions options;
-  options.unrollFactor = factor;
-  return succeeded(runQCOTransformPasses(
-      mod(),
-      [&options](OpPassManager& pm) {
-        pm.addNestedPass<func::FuncOp>(qco::createQuantumLoopUnroll(options));
-      },
-      "failed to unroll quantum loops"));
-}
-
-bool QCOProgram::liftHadamards() {
-  return succeeded(runQCOTransformPasses(
-      mod(),
-      [](OpPassManager& pm) { pm.addPass(qco::createHadamardLifting()); },
-      "failed to lift Hadamard gates"));
-}
-
-bool QCOProgram::reuseQubits() {
-  return succeeded(runQCOTransformPasses(
-      mod(), [](OpPassManager& pm) { pm.addPass(qco::createReuseQubits()); },
-      "failed to reuse qubits"));
-}
-
-bool QCOProgram::runQubitReusePipeline() {
-  return succeeded(runQCOTransformPasses(
-      mod(), [](OpPassManager& pm) { populateQubitReusePipeline(pm); },
-      "failed to run the qubit reuse pipeline"));
-}
-
-bool QCOProgram::decomposeMultiControlled(const uint64_t minQubits) {
-  return succeeded(runQCOTransformPasses(
-      mod(),
-      [minQubits](OpPassManager& pm) {
-        populateDecomposeMultiControlledPipeline(pm, minQubits);
-      },
-      "failed to decompose multi-controlled gates"));
-}
-
-bool QCOProgram::compileForTarget(const CompilerTarget& target,
-                                  const bool enableTiming,
-                                  const bool enableStatistics) {
-  return succeeded(runQCOTransformPasses(
-      mod(),
-      [&target](OpPassManager& pm) {
-        populateTargetCompilationPipeline(pm, target);
-      },
-      "failed to compile the QCO program for the target", enableTiming,
-      enableStatistics));
-}
-
-std::optional<QCProgram> QCOProgram::intoQC() && {
-  if (failed(runQCOTransformPasses(
-          mod(), [](OpPassManager& pm) { pm.addPass(createQCOToQC()); },
-          "failed to convert QCO to QC"))) {
-    return std::nullopt;
-  }
-  return QCProgram(std::move(*this).releaseStorage());
-}
-
-std::optional<JeffProgram> QCOProgram::intoJeff() && {
-  if (failed(runQCOTransformPasses(
-          mod(),
-          [](OpPassManager& pm) {
-            pm.addPass(mqt::createUnrollModifiers());
-            pm.addPass(createQCOToJeff());
-          },
-          "failed to convert QCO to jeff"))) {
-    return std::nullopt;
-  }
-  return JeffProgram(std::move(*this).releaseStorage());
-}
-
-//===----------------------------------------------------------------------===//
-// JeffProgram
-//===----------------------------------------------------------------------===//
-
-std::optional<JeffProgram>
-JeffProgram::fromBytes(const std::span<const std::byte> bytes) {
-  if (bytes.size() % sizeof(capnp::word) != 0U) {
-    auto context = createCompilerContext();
-    emitError(UnknownLoc::get(context.get()),
-              "jeff data size must be a multiple of the Cap'n Proto word size");
-    return std::nullopt;
-  }
-
-  auto words = kj::heapArray<capnp::word>(bytes.size() / sizeof(capnp::word));
-  std::memcpy(words.begin(), bytes.data(), bytes.size());
-
-  auto context = createCompilerContext();
-  auto mod = deserialize(context.get(), words.asPtr());
-  if (!mod) {
-    emitError(UnknownLoc::get(context.get()),
-              "failed to deserialize jeff bytes");
-    return std::nullopt;
-  }
-  return JeffProgram({.context = std::move(context), .mod = std::move(mod)});
-}
-
-std::optional<JeffProgram>
-JeffProgram::fromFile(const std::filesystem::path& path) {
-  auto context = createCompilerContext();
-  auto mod = deserializeFromFile(context.get(), path.string());
-  if (!mod) {
-    emitError(UnknownLoc::get(context.get()))
-        << "failed to deserialize jeff file '" << path.string() << "'";
-    return std::nullopt;
-  }
-  return JeffProgram({.context = std::move(context), .mod = std::move(mod)});
-}
-
-JeffProgram JeffProgram::copy() const { return JeffProgram(cloneStorage()); }
-
-bool JeffProgram::cleanup() {
-  return succeeded(runPasses(mod(), populateJeffCleanupPipeline,
-                             "failed to run the jeff cleanup pipeline"));
-}
-
-std::vector<std::byte> JeffProgram::toBytes() const {
-  const auto serialized = serialize(mod());
-  const auto bytes = serialized.asBytes();
-  std::vector<std::byte> result(bytes.size());
-  std::memcpy(result.data(), bytes.begin(), bytes.size());
-  return result;
-}
-
-bool JeffProgram::write(const std::filesystem::path& path) const {
-  if (failed(serializeToFile(mod(), path.string()))) {
-    mod().emitError() << "failed to write jeff file '" << path.string() << "'";
-    return false;
-  }
-  return true;
-}
-
-std::optional<QCOProgram> JeffProgram::intoQCO() && {
-  if (failed(runPasses(
-          mod(), [](OpPassManager& pm) { pm.addPass(createJeffToQCO()); },
-          "failed to convert jeff to QCO"))) {
-    return std::nullopt;
-  }
-  if (failed(qco::verifyLinearity(mod()))) {
-    return std::nullopt;
-  }
-  return QCOProgram(std::move(*this).releaseStorage());
-}
-
-//===----------------------------------------------------------------------===//
-// QIRProgram
-//===----------------------------------------------------------------------===//
-
-QIRProgram::QIRProgram(Storage storage, const QIRProfile profile)
-    : Program(std::move(storage)), profile_(profile) {}
-
-QIRProgram QIRProgram::copy() const { return {cloneStorage(), profile_}; }
-
-bool QIRProgram::cleanup() {
-  return succeeded(runPasses(
-      mod(),
-      [this](OpPassManager& pm) {
-        populateQIRCleanupPipeline(pm, profile_ == QIRProfile::Adaptive);
-      },
-      "failed to run the QIR cleanup pipeline"));
-}
-
-QIRProfile QIRProgram::profile() const noexcept { return profile_; }
-
-[[nodiscard]] static std::unique_ptr<llvm::Module>
-translateToLLVM(ModuleOp mod, llvm::LLVMContext& context) {
-  auto llvmModule = translateModuleToLLVMIR(mod, context);
-  if (!llvmModule) {
-    mod.emitError("failed to translate QIR MLIR to LLVM IR");
-    return nullptr;
-  }
-  qir::normalizeQIRModuleFlags(*llvmModule, mod);
-  return llvmModule;
-}
-
-std::optional<std::string> QIRProgram::llvmIR() const {
-  llvm::LLVMContext context;
-  auto llvmModule = translateToLLVM(mod(), context);
-  if (!llvmModule) {
-    return std::nullopt;
-  }
-  std::string result;
-  llvm::raw_string_ostream stream(result);
-  llvmModule->print(stream, nullptr);
-  return result;
-}
-
-std::optional<std::vector<std::byte>> QIRProgram::toBitcode() const {
-  llvm::LLVMContext context;
-  auto llvmModule = translateToLLVM(mod(), context);
-  if (!llvmModule) {
-    return std::nullopt;
-  }
-
-  SmallVector<char> storage;
-  llvm::raw_svector_ostream stream(storage);
-  llvm::WriteBitcodeToFile(*llvmModule, stream);
-  std::vector<std::byte> result(storage.size());
-  std::memcpy(result.data(), storage.data(), storage.size());
-  return result;
-}
-
-bool QIRProgram::writeBitcode(const std::filesystem::path& path) const {
-  llvm::LLVMContext context;
-  auto llvmModule = translateToLLVM(mod(), context);
-  if (!llvmModule) {
-    return false;
-  }
-
-  std::error_code error;
-  llvm::raw_fd_ostream stream(path.string(), error, llvm::sys::fs::OF_None);
-  if (error) {
-    mod().emitError() << "failed to open bitcode output file '" << path.string()
-                      << "': " << error.message();
-    return false;
-  }
-  llvm::WriteBitcodeToFile(*llvmModule, stream);
-  stream.flush();
-  if (stream.has_error()) {
-    mod().emitError() << "failed to write bitcode file '" << path.string()
-                      << "'";
-    return false;
-  }
-  return true;
-}
-
-//===----------------------------------------------------------------------===//
-// Pipeline
-//===----------------------------------------------------------------------===//
-
-std::optional<CompilerProgram>
-runDefaultPipeline(CompilerInput&& program, const ProgramFormat output,
-                   const CompilerTarget* const target,
-                   const std::string_view qcoPipeline, const bool enableTiming,
-                   const bool enableStatistics) {
-  if (target != nullptr &&
-      (output == ProgramFormat::QCImport || output == ProgramFormat::QCO ||
-       output == ProgramFormat::Jeff)) {
-    llvm::errs()
-        << "a compiler target requires QCOOptimized, QC, OpenQASM3, or QIR "
-           "output.\n";
-    return std::nullopt;
-  }
-  if (target != nullptr && qcoPipeline != "mqt-qco-default") {
-    llvm::errs() << "a custom QCO pass pipeline cannot be combined with a "
-                    "compiler target.\n";
-    return std::nullopt;
-  }
-  if ((output == ProgramFormat::QCImport || output == ProgramFormat::QCO) &&
-      qcoPipeline != "mqt-qco-default") {
-    llvm::errs() << "a custom QCO pass pipeline cannot be used with an output "
-                    "that stops before QCO optimization.\n";
-    return std::nullopt;
-  }
-  if (output == ProgramFormat::QCImport) {
-    if (std::holds_alternative<QCProgram>(program)) {
-      return CompilerProgram(std::move(std::get<QCProgram>(program)));
-    }
-    if (std::holds_alternative<OpenQASMProgram>(program)) {
-      auto qc = QCProgram::fromQASMString(
-          std::get<OpenQASMProgram>(program).source());
-      if (qc) {
-        return CompilerProgram(std::move(*qc));
-      }
-    }
-    llvm::errs() << "QCImport output is only available for QC or OpenQASM "
-                    "input.\n";
-    return std::nullopt;
-  }
-
-  auto qco = std::visit(
-      []<typename T>(T&& value) -> std::optional<QCOProgram> {
-        using ProgramType = std::remove_cvref_t<T>;
-        if constexpr (std::is_same_v<ProgramType, QCOProgram>) {
-          return std::forward<T>(value);
-        } else if constexpr (std::is_same_v<ProgramType, OpenQASMProgram>) {
-          auto qc = QCProgram::fromQASMString(value.source());
-          if (!qc) {
-            return std::nullopt;
-          }
-          return std::move(*qc).intoQCO();
-        } else {
-          return std::forward<T>(value).intoQCO();
-        }
-      },
-      std::move(program));
-  if (!qco || failed(qco::verifyLinearity(qco->module()))) {
-    return std::nullopt;
-  }
-  if (output == ProgramFormat::QCO) {
-    return CompilerProgram(std::move(*qco));
-  }
-
-  if (target != nullptr) {
-    if (!qco->compileForTarget(*target, enableTiming, enableStatistics)) {
-      return std::nullopt;
-    }
-  } else {
-    if (!qco->cleanup() ||
-        !qco->runPassPipeline(qcoPipeline, enableTiming, enableStatistics) ||
-        !qco->cleanup()) {
-      return std::nullopt;
-    }
-  }
-  if (output == ProgramFormat::QCOOptimized) {
-    return CompilerProgram(std::move(*qco));
-  }
-
-  if (output == ProgramFormat::Jeff) {
-    auto jeff = std::move(*qco).intoJeff();
-    if (!jeff || !jeff->cleanup()) {
-      return std::nullopt;
-    }
-    return CompilerProgram(std::move(*jeff));
-  }
-
-  auto qc = std::move(*qco).intoQC();
-  if (!qc || !qc->cleanup()) {
-    return std::nullopt;
-  }
-  if (output == ProgramFormat::QC) {
-    return CompilerProgram(std::move(*qc));
-  }
-  if (output == ProgramFormat::OpenQASM3) {
-    auto openQASM = qc->toOpenQASM3();
-    if (!openQASM) {
-      return std::nullopt;
-    }
-    return CompilerProgram(std::move(*openQASM));
-  }
-
-  const auto profile = output == ProgramFormat::QIRAdaptive
-                           ? QIRProfile::Adaptive
-                           : QIRProfile::Base;
-  auto qir = std::move(*qc).intoQIR(profile);
-  if (!qir) {
-    return std::nullopt;
-  }
-  return CompilerProgram(std::move(*qir));
 }
 
 } // namespace mlir

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -1233,6 +1233,8 @@ x q;
   EXPECT_TRUE(mlir::verify(*reparsed).succeeded());
   const std::vector<std::byte> invalid(1);
   EXPECT_FALSE(JeffProgram::fromBytes(invalid));
+  EXPECT_FALSE(
+      JeffProgram::fromFile(path.parent_path() / "missing" / "input.jeff"));
   EXPECT_FALSE(jeff.write(path.parent_path() / "missing" / "output.jeff"));
 }
 

--- a/src/qdmi/devices/dd/CMakeLists.txt
+++ b/src/qdmi/devices/dd/CMakeLists.txt
@@ -45,7 +45,7 @@ if(NOT TARGET ${TARGET_NAME})
     # LLVM's process-wide registries when it loads this device.
     target_link_options(${TARGET_NAME} PRIVATE "LINKER:--exclude-libs,ALL")
   endif()
-  target_link_libraries(${TARGET_NAME} PRIVATE MLIRQCODDFunctionality MQTCompilerPipeline
+  target_link_libraries(${TARGET_NAME} PRIVATE MLIRQCODDFunctionality MQTCompilerPrograms
                                                MQT::CoreQIRJIT MQT::CoreQIRRuntime)
 
   mqt_configure_qdmi_device(${TARGET_NAME} ID mqt.ddsim.default PREFIX ${QDMI_PREFIX})


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Split the reusable compiler-program model and OpenQASM-to-QCO path from higher-level pipeline orchestration:

- add `MQTCompilerPrograms` for program storage, parsing, validation, and the QC-to-QCO conversion;
- keep pass-backed transformations, target compilation, output conversion, and default orchestration in `MQTCompilerPipeline`;
- retain `MQTCompilerPipeline` as the compatibility umbrella for existing consumers;
- link the DDSIM QDMI device only to the narrower programs target.

This preserves the public compiler API and runtime behavior. The DDSIM link closure no longer includes the compiler pipeline, compiler target, QCO transforms, jeff converters, or QC-to-QIR converters.

Fixes #2329.

## Validation

- non-unity builds of both compiler targets, DDSIM, compiler tests, and `mqt-cc`
- compiler unit tests: 148 passed
- focused missing-input test after the coverage update
- DDSIM device tests: 62 passed
- `mqt-cc` CTests: 2 passed
- C++ lint: 0 clang-format and 0 clang-tidy findings
- repository lint and `git diff --check`

## Integration note

PRs #2339 and #2340 modify methods moved to `Pipeline.cpp`. When restacked, #2340 must preserve inliner registration in both `Programs.cpp` for the context factory and `Pipeline.cpp` for caller-owned contexts.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] A changelog entry is not required for this internal, unreleased refactor.
- [x] Migration instructions are not required because the public API is unchanged.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
