### PR TITLE
🐛 Use valid OpenQASM in DDSIM status test

### DIFF
--- a/test/qdmi/devices/dd/helpers/circuits.hpp
+++ b/test/qdmi/devices/dd/helpers/circuits.hpp
@@ -77,15 +77,13 @@ cx q[0], q[1];
 // Measure all qubits
 c = measure q;
 // Add dynamic component
-if (c == 3) {
+if (c[0]) {
   rx(0.7) q[0];
   ry(0.5) q[1];
   rz(1.1) q[2];
   ry(0.3) q[3];
   rx(0.9) q[4];
 }
-// Measure all qubits again
-c = measure q;
 )";
 
 } // namespace qdmi_test


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Use valid OpenQASM 3 in the DDSIM device-status test fixture:

- branch on the scalar bit `c[0]` instead of comparing a bit register with an integer;
- remove the redundant second full-register measurement, which is ill-typed after indexed access in the current frontend;
- preserve the test's dynamic-circuit workload and BUSY-to-IDLE status coverage.

## Validation

- 20/20 repeated DDSIM QDMI submissions observed `BUSY`, completed with the requested shot count, and returned to `IDLE`
- repository pre-commit hooks
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added or updated appropriate tests that cover the changed functionality.
- [x] Documentation changes are not required for this test-only correction.
- [x] A changelog entry is not required for this test-only correction.
- [x] Migration instructions are not required because the public API is unchanged.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
