### PR TITLE
👷 Drop Windows Debug CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         include:
           - runs-on: windows-2025
             compiler: msvc
-            preset: debug-windows
+            preset: release-windows
             run-on-draft: true
           - runs-on: windows-11-arm
             compiler: msvc
@@ -106,7 +106,6 @@ jobs:
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
       llvm-version: 23.1.0
-      mlir-debug: ${{ matrix.preset == 'debug-windows' }}
       preset-name: ${{ matrix.preset }}
       run-on-draft: ${{ matrix.run-on-draft }}
     permissions:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -204,8 +204,7 @@ systems and compilers:
 - {code}`macos-26`: {code}`Release` and {code}`Debug` builds using
   {code}`AppleClang`
 - {code}`macos-26-intel`: {code}`Release` build using {code}`AppleClang`
-- {code}`windows-2025`: {code}`Release` and {code}`Debug` builds using
-  {code}`msvc`
+- {code}`windows-2025`: {code}`Release` build using {code}`msvc`
 - {code}`windows-11-arm`: {code}`Release` build using {code}`msvc`
 
 To access the latest build logs, visit the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -204,7 +204,8 @@ systems and compilers:
 - {code}`macos-26`: {code}`Release` and {code}`Debug` builds using
   {code}`AppleClang`
 - {code}`macos-26-intel`: {code}`Release` build using {code}`AppleClang`
-- {code}`windows-2025`: {code}`Release` build using {code}`msvc`
+- {code}`windows-2025`: {code}`Release` and {code}`Debug` builds using
+  {code}`msvc`
 - {code}`windows-11-arm`: {code}`Release` build using {code}`msvc`
 
 To access the latest build logs, visit the


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Run the x64 Windows C++ job in Release mode instead of Debug. The Windows Debug MLIR toolchain uses about 28.9 GiB after extraction and can exhaust the hosted runner C: drive before the build starts, as seen in [this CI job](https://github.com/munich-quantum-toolkit/core/actions/runs/33737007592/job/100591472309).

This change keeps Windows and MSVC coverage on x64 and Arm. Linux and macOS continue to test Debug builds.

Remove the now-unused `mlir-debug` input. The reusable workflow defaults this input to `false`.

## Validation

- `uvx nox -s lint`
- `git diff --check`

## AI notice

Codex investigated the CI failure, prepared the change, and ran the validation commands.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. CI is pending.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
