### PR TITLE
🐛 Keep release drafts branch-specific

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,6 +3,7 @@
 
 name-template: "MQT Core $RESOLVED_VERSION Release"
 tag-template: "v$RESOLVED_VERSION"
+filter-by-commitish: true
 categories:
   - title: "⚛️ MQT Core IR"
     when:
@@ -85,7 +86,7 @@ categories:
       label: "patch"
   - type: "version-resolver"
     semver-increment: "patch"
-change-template: "- $TITLE ([#$NUMBER]($URL)) (**@$AUTHOR**)"
+change-template: "- $TITLE (#$NUMBER) (@$AUTHOR)"
 change-title-escapes: '\<*_&'
 
 template: |

--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -31,7 +31,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write # Needed to push the templating branch
           permission-pull-requests: write # Needed to open the templating pull request
-      - uses: munich-quantum-toolkit/templates@f87a5f152d33b64e3cc4fad41c402bf7ce892f5d # v1.4.3
+      - uses: munich-quantum-toolkit/templates@8caeb0bd8d0e2ebf906e7c3a826c06f72844a83b # v1.5.0
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: Core
@@ -39,4 +39,5 @@ jobs:
           project-type: c++-mlir-python
           repository: ${{ github.event.repository.name }}
           synchronize-agents-md: false
+          synchronize-gitignore: false
           release-drafter-categories: ${{ steps.read-release-drafter-categories.outputs.release_drafter_categories }}


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Keep the `main` and `v3.x` Release Drafter drafts and comparison baselines separate. This prevents maintenance releases from replacing the v4 draft.

Use GitHub's native pull request and user autolinks in change entries. This reduces the failing 133,205-character release body by approximately 38,000 characters without removing titles or authors.

The corresponding source-template change is munich-quantum-toolkit/templates#424. The Core templating workflow now pins templates v1.5.0 and disables `.gitignore` synchronization to preserve Core's repository-specific ignore rules.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

Validation: rendered with the updated source template; `uvx nox -s lint` passed. The source-template render tests are in munich-quantum-toolkit/templates#424.
