### PR TITLE
🐛 Fix reset conversion in QCO control flow

### DIFF
--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -117,21 +117,21 @@ private:
 ///
 /// @param sourceRegion Source region where the operations are moved from
 /// @param targetRegion Target region where the operations are moved to
-/// @param offset Offset to the arguments that are dropped
 /// @param replacementValues Values to replace the uses of the arguments
 /// @param rewriter PatternRewriter of the current conversion pass
 static void inlineRegion(Region& sourceRegion, Region& targetRegion,
-                         unsigned int offset, ValueRange replacementValues,
+                         ValueRange replacementValues,
                          ConversionPatternRewriter& rewriter) {
   rewriter.inlineRegionBefore(sourceRegion, targetRegion, targetRegion.end());
   auto& block = targetRegion.front();
-  assert(block.getNumArguments() == offset + replacementValues.size() &&
+  assert(block.getNumArguments() == replacementValues.size() &&
          "Number of replacement values must match number of block arguments");
-  for (auto [arg, replacementVal] : llvm::zip_equal(
-           block.getArguments().drop_front(offset), replacementValues)) {
-    arg.replaceAllUsesWith(replacementVal);
+  TypeConverter::SignatureConversion signature(block.getNumArguments());
+  for (auto [arg, replacementVal] :
+       llvm::zip_equal(block.getArguments(), replacementValues)) {
+    signature.remapInput(arg.getArgNumber(), replacementVal);
   }
-  block.eraseArguments(offset, replacementValues.size());
+  rewriter.applySignatureConversion(&block, signature);
 }
 
 [[nodiscard]] static bool isQuantumStateType(const Type type) {
@@ -168,23 +168,23 @@ static void inlineSCFRegion(Region& sourceRegion, Region& targetRegion,
   assert(block.getNumArguments() == offset + originalState.size() &&
          "region arguments must match the original loop state");
 
-  SmallVector<unsigned int> quantumArguments;
+  TypeConverter::SignatureConversion signature(block.getNumArguments());
+  for (auto arg : block.getArguments().take_front(offset)) {
+    signature.addInputs(arg.getArgNumber(), arg.getType());
+  }
   size_t quantumIndex = 0;
   for (const auto [index, original] : llvm::enumerate(originalState)) {
     if (!isQuantumStateType(original.getType())) {
+      signature.addInputs(offset + index, original.getType());
       continue;
     }
     assert(quantumIndex < quantumReplacements.size() &&
            "missing replacement for quantum loop state");
-    block.getArgument(offset + index)
-        .replaceAllUsesWith(quantumReplacements[quantumIndex++]);
-    quantumArguments.push_back(static_cast<unsigned int>(offset + index));
+    signature.remapInput(offset + index, quantumReplacements[quantumIndex++]);
   }
   assert(quantumIndex == quantumReplacements.size() &&
          "unused replacement for quantum loop state");
-  for (const auto argument : llvm::reverse(quantumArguments)) {
-    block.eraseArgument(argument);
-  }
+  rewriter.applySignatureConversion(&block, signature);
 }
 
 [[nodiscard]] static SmallVector<Value>
@@ -1153,14 +1153,14 @@ struct ConvertQCOIfOp final : OpConversionPattern<IfOp> {
     rewriter.eraseBlock(&newThenRegion.front());
 
     // Inline the region and replace the block arguments
-    inlineRegion(op.getThenRegion(), newThenRegion, 0, adaptor.getQubits(),
+    inlineRegion(op.getThenRegion(), newThenRegion, adaptor.getQubits(),
                  rewriter);
 
     // Inline the else block when it has observable operations or must produce
     // classical results.
     if (keepElseRegion) {
       rewriter.eraseBlock(&newIf.getElseRegion().front());
-      inlineRegion(oldElseRegion, newIf.getElseRegion(), 0, adaptor.getQubits(),
+      inlineRegion(oldElseRegion, newIf.getElseRegion(), adaptor.getQubits(),
                    rewriter);
     }
 
@@ -1214,11 +1214,11 @@ struct ConvertQCOIndexSwitchOp final : OpConversionPattern<IndexSwitchOp> {
     const auto oldRegions = op.getCaseRegions();
     const auto newCaseRegions = newOp.getCaseRegions();
     for (size_t i = 0; i < op.getNumCases(); ++i) {
-      inlineRegion(oldRegions[i], newCaseRegions[i], 0, adaptor.getTargets(),
+      inlineRegion(oldRegions[i], newCaseRegions[i], adaptor.getTargets(),
                    rewriter);
     }
 
-    inlineRegion(op.getDefaultRegion(), newOp.getDefaultRegion(), 0,
+    inlineRegion(op.getDefaultRegion(), newOp.getDefaultRegion(),
                  adaptor.getTargets(), rewriter);
 
     SmallVector<Value> replacements(newOp.getResults());

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -451,10 +451,10 @@ module {
     %else = arith.constant 2 : i64
     %result, %q1 = qco.if %condition args(%arg = %q0)
         -> (i64, !qco.qubit) {
-      %q2 = qco.h %arg : !qco.qubit -> !qco.qubit
+      %q2 = qco.reset %arg : !qco.qubit -> !qco.qubit
       qco.yield %then, %q2 : i64, !qco.qubit
     } else args(%arg = %q0) {
-      %q2 = qco.x %arg : !qco.qubit -> !qco.qubit
+      %q2 = qco.reset %arg : !qco.qubit -> !qco.qubit
       qco.yield %else, %q2 : i64, !qco.qubit
     }
     qco.sink %q1 : !qco.qubit
@@ -479,6 +479,9 @@ module {
   ASSERT_TRUE(main);
   auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
   EXPECT_EQ(returnOp.getOperand(0), ifOp.getResult(0));
+  for (auto& region : ifOp->getRegions()) {
+    EXPECT_EQ(llvm::range_size(region.getOps<qc::ResetOp>()), 1);
+  }
 
   bool containsQCOOperations = false;
   moduleOp->walk([&](Operation* operation) {
@@ -503,12 +506,12 @@ module {
     %q0 = qco.alloc : !qco.qubit
     %result, %q1 = qco.index_switch %index -> (i64, !qco.qubit)
     case 0 args(%arg0 = %q0) {
-      %q2 = qco.h %arg0 : !qco.qubit -> !qco.qubit
+      %q2 = qco.reset %arg0 : !qco.qubit -> !qco.qubit
       %case = arith.constant 1 : i64
       qco.yield %case, %q2 : i64, !qco.qubit
     }
     default args(%arg0 = %q0) {
-      %q2 = qco.x %arg0 : !qco.qubit -> !qco.qubit
+      %q2 = qco.reset %arg0 : !qco.qubit -> !qco.qubit
       %default = arith.constant 2 : i64
       qco.yield %default, %q2 : i64, !qco.qubit
     }
@@ -535,6 +538,9 @@ module {
   ASSERT_TRUE(main);
   auto returnOp = cast<func::ReturnOp>(main.getBody().front().getTerminator());
   EXPECT_EQ(returnOp.getOperand(0), switchOp.getResult(0));
+  for (auto& region : switchOp->getRegions()) {
+    EXPECT_EQ(llvm::range_size(region.getOps<qc::ResetOp>()), 1);
+  }
 
   bool containsQCOOperations = false;
   moduleOp->walk([&](Operation* operation) {
@@ -564,7 +570,7 @@ module {
     %result, %q1 = scf.for %iv = %lb to %ub step %step
         iter_args(%value = %initial, %q = %q0) -> (i64, !qco.qubit) {
       %next = arith.addi %value, %one : i64
-      %q2 = qco.h %q : !qco.qubit -> !qco.qubit
+      %q2 = qco.reset %q : !qco.qubit -> !qco.qubit
       scf.yield %next, %q2 : i64, !qco.qubit
     }
     qco.sink %q1 : !qco.qubit
@@ -582,6 +588,7 @@ module {
   scf::ForOp loop;
   moduleOp->walk([&](scf::ForOp candidate) { loop = candidate; });
   ASSERT_TRUE(loop);
+  EXPECT_EQ(llvm::range_size(loop.getBody()->getOps<qc::ResetOp>()), 1);
   ASSERT_EQ(loop.getInitArgs().size(), 1);
   EXPECT_TRUE(loop.getInitArgs().front().getType().isInteger(64));
   ASSERT_EQ(loop.getNumResults(), 1);
@@ -642,6 +649,60 @@ module {
   auto yield = cast<scf::YieldOp>(loop.getAfterBody()->getTerminator());
   ASSERT_EQ(yield.getNumOperands(), 1);
   EXPECT_TRUE(yield.getOperand(0).getType().isF32());
+}
+
+TEST(QCOToQCRegressionTest, PreservesResetQubitsInWhileRegions) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, arith::ArithDialect,
+                  func::FuncDialect, scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+
+  constexpr llvm::StringLiteral source = R"mlir(
+module {
+  func.func @main() {
+    %q0 = qco.alloc : !qco.qubit
+    %q1 = qco.alloc : !qco.qubit
+    %out:2 = scf.while (%a = %q0, %b = %q1)
+        : (!qco.qubit, !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+      %a0 = qco.reset %a : !qco.qubit -> !qco.qubit
+      %b0 = qco.reset %b : !qco.qubit -> !qco.qubit
+      %condition = arith.constant false
+      scf.condition(%condition) %a0, %b0 : !qco.qubit, !qco.qubit
+    } do {
+    ^bb0(%a: !qco.qubit, %b: !qco.qubit):
+      %a0 = qco.reset %a : !qco.qubit -> !qco.qubit
+      %b0 = qco.reset %b : !qco.qubit -> !qco.qubit
+      scf.yield %a0, %b0 : !qco.qubit, !qco.qubit
+    }
+    qco.sink %out#0 : !qco.qubit
+    qco.sink %out#1 : !qco.qubit
+    return
+  }
+}
+)mlir";
+
+  auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCOToQCConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  auto function = *moduleOp->getOps<func::FuncOp>().begin();
+  auto allocations = llvm::to_vector(function.getOps<qc::AllocOp>());
+  ASSERT_EQ(allocations.size(), 2U);
+  auto loops = llvm::to_vector(function.getOps<scf::WhileOp>());
+  ASSERT_EQ(loops.size(), 1U);
+  auto loop = loops.front();
+  EXPECT_EQ(loop.getNumOperands(), 0U);
+  EXPECT_EQ(loop.getNumResults(), 0U);
+  for (auto& region : loop->getRegions()) {
+    EXPECT_EQ(region.front().getNumArguments(), 0U);
+    auto resets = llvm::to_vector(region.getOps<qc::ResetOp>());
+    ASSERT_EQ(resets.size(), 2U);
+    EXPECT_EQ(resets[0].getQubit(), allocations[0].getResult());
+    EXPECT_EQ(resets[1].getQubit(), allocations[1].getResult());
+  }
 }
 
 TEST_P(QCOToQCTest, ProgramEquivalence) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

QCO-to-QC conversion could assert in `ResetOp::fold` when a reset consumed a control-flow block argument. Region inlining replaced the QCO argument with a QC reference before converting the nested operation, violating the fold's operand type assumption.

Use MLIR signature conversion in the shared region helpers so pending QCO operations retain their operand types. This covers `scf.while`, `scf.for`, `qco.if`, and `qco.index_switch`. Remove the branch helper's unused offset parameter. Regression coverage checks resets in both while regions, qubit identity, and classical state in loops and branches.

Fixes #2356

Validation on LLVM/MLIR 23.1.0:

- Release build of the QCO-to-QC tests and `mqt-cc`.
- All 147 QCO-to-QC tests pass.
- The original issue example converts successfully through `mqt-cc`.
- `uvx nox -s lint`, `uvx nox -s cpp-lint`, and `git diff --check` pass.

Codex assisted with diagnosis, implementation, regression tests, review, and PR preparation. The Ponytail review found no remaining unnecessary complexity. Documentation, changelog, and migration updates are not needed for this internal fix to unreleased v4 functionality.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
