### PR TITLE
✨ Expose ordered shots from the DDSIM QDMI device

### DIFF
--- a/.agent/plans/ddsim-ordered-shots.md
+++ b/.agent/plans/ddsim-ordered-shots.md
@@ -1,0 +1,27 @@
+# Ordered DDSIM shots
+
+Status: in progress.
+
+## Scope and decisions
+
+Expose genuine ordered samples through `QDMI_JOB_RESULT_SHOTS` for DDSIM's
+OpenQASM and QIR sampling paths. Preserve the existing histogram and state
+extraction contracts. No QDMI interface or Python binding changes are needed.
+
+The QCO sampler already encodes each outcome with the returned classical
+register mapping. An optional output sequence retains those outcomes before
+aggregation; callers that only need counts allocate no sequence. Terminal
+measurements still simulate once, while dynamic programs execute once per shot.
+The QIR runtime supplies each shot's output directly.
+
+## Work remaining
+
+- [ ] Retain and expose samples in both execution paths.
+- [ ] Check ordering, mapping, dynamic measurements, counts consistency, and
+      QDMI buffer and state contracts.
+- [ ] Build, run focused tests, and run required lint checks.
+
+## Validation
+
+Use the release CMake preset and DDSIM device test binary. Qiskit native
+Sampler integration is covered by its separate plugin change.

--- a/.agent/plans/ddsim-ordered-shots.md
+++ b/.agent/plans/ddsim-ordered-shots.md
@@ -23,5 +23,5 @@ The QIR runtime supplies each shot's output directly.
 
 ## Validation
 
-Use the release CMake preset and DDSIM device test binary. Qiskit native
-Sampler integration is covered by its separate plugin change.
+Use the release CMake preset and DDSIM device test binary. Qiskit native Sampler
+integration is covered by its separate plugin change.

--- a/.agent/plans/ddsim-ordered-shots.md
+++ b/.agent/plans/ddsim-ordered-shots.md
@@ -1,6 +1,6 @@
 # Ordered DDSIM shots
 
-Status: in progress.
+Status: complete.
 
 ## Scope and decisions
 
@@ -14,14 +14,15 @@ aggregation; callers that only need counts allocate no sequence. Terminal
 measurements still simulate once, while dynamic programs execute once per shot.
 The QIR runtime supplies each shot's output directly.
 
-## Work remaining
-
-- [ ] Retain and expose samples in both execution paths.
-- [ ] Check ordering, mapping, dynamic measurements, counts consistency, and
-      QDMI buffer and state contracts.
-- [ ] Build, run focused tests, and run required lint checks.
-
 ## Validation
 
-Use the release CMake preset and DDSIM device test binary. Qiskit native Sampler
-integration is covered by its separate plugin change.
+The release build and `ctest --preset release` passed all 3,870 registered
+tests, with one existing SC-device skip. The DDSIM device binary passed 63
+tests; QCO sampling passed 14 tests. Python QDMI passed 251 tests using the
+built device, including repeated reads and empty shot strings. These checks
+cover terminal and dynamic measurements, QIR Base/Adaptive, classical mapping,
+histogram consistency, reproducible ordering, and buffer/state errors.
+
+`uvx nox -s lint`, `uvx nox -s cpp-lint`, and the documentation build passed.
+The device builds against QDMI 1.3.3. Qiskit native Sampler integration is
+covered by its separate plugin change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ releases may include breaking changes.
 
 #### Other additions
 
+- ✨ Expose ordered shots from DDSIM QDMI OpenQASM and QIR jobs, with matching
+  histograms ([#2368]) ([**@burgholzer**])
 - 🐳 Add dev container configuration for a consistent local development
   environment ([#1786]) ([**@denialhaag**])
 
@@ -869,6 +871,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2368]: https://github.com/munich-quantum-toolkit/core/pull/2368
 [#2337]: https://github.com/munich-quantum-toolkit/core/pull/2337
 [#2336]: https://github.com/munich-quantum-toolkit/core/pull/2336
 [#2335]: https://github.com/munich-quantum-toolkit/core/pull/2335

--- a/docs/qdmi/ddsim_device.md
+++ b/docs/qdmi/ddsim_device.md
@@ -46,8 +46,11 @@ partially initialized output register fail during import. The Qiskit backend
 preserves Qiskit's zero-initialized classical-bit semantics by writing every
 classical bit before submitting its generated OpenQASM 3 program.
 
-The device implements the full QDMI job interface (except for the
-`QDMI_JOB_RESULT_SHOTS` result format not supported by the simulator).
+Sampling returns ordered bitstrings through `QDMI_JOB_RESULT_SHOTS` and their
+histogram through `QDMI_JOB_RESULT_HIST_KEYS` and `QDMI_JOB_RESULT_HIST_VALUES`.
+Both results come from the same samples, including mid-circuit measurements.
+OpenQASM classical registers use reverse declaration order, with each register
+most-significant-bit first. QIR samples follow the program's recorded outputs.
 
 ## Compile and execute QIR
 
@@ -75,4 +78,5 @@ job = device.submit_job(
 )
 job.wait()
 print(job.get_counts())
+print(job.get_shots())
 ```

--- a/include/mqt-core/qdmi/devices/dd/Device.hpp
+++ b/include/mqt-core/qdmi/devices/dd/Device.hpp
@@ -211,6 +211,9 @@ private:
   /// The measurement counts for the job
   std::map<std::string, std::size_t> counts_;
 
+  /// Measurement outcomes in sampling order.
+  std::vector<std::string> shots_;
+
   /// The DD package used for the state vector simulation
   std::unique_ptr<dd::Package> dd_;
 
@@ -232,6 +235,9 @@ private:
   /// Translate counts to QDMI histogram
   auto getHistogram(QDMI_Job_Result result, size_t size, void* data,
                     size_t* sizeRet) -> QDMI_STATUS;
+
+  /// Copy ordered outcomes to the QDMI comma-separated shot representation.
+  auto getShots(size_t size, void* data, size_t* sizeRet) const -> QDMI_STATUS;
 
   /// Translate the state vector DD to a dense state vector for QDMI
   auto getStateVector(size_t size, void* data, size_t* sizeRet) -> QDMI_STATUS;

--- a/mlir/include/mlir/Dialect/QCO/Utils/DDFunctionality.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/DDFunctionality.h
@@ -23,6 +23,7 @@
 #include <map>
 #include <random>
 #include <string>
+#include <vector>
 
 namespace mlir::qco {
 
@@ -106,8 +107,11 @@ FailureOr<dd::VectorDD> simulateStatevector(
 /// @param shots Number of samples.
 /// @param seed RNG seed. Zero selects nondeterministic seeding.
 /// @param argumentBindings Scalar values and dynamic QTensor argument sizes.
+/// @param shotResults Optional output, cleared then filled in sampling order.
+/// On failure, it may contain an incomplete sequence.
 /// @return Outcome counts, or failure for an unsupported program.
 FailureOr<std::map<std::string, size_t>>
 sample(func::FuncOp func, size_t shots, uint64_t seed = 0,
-       const DDArgumentBindings& argumentBindings = DDArgumentBindings());
+       const DDArgumentBindings& argumentBindings = DDArgumentBindings(),
+       std::vector<std::string>* shotResults = nullptr);
 } // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
@@ -1888,7 +1888,8 @@ static FailureOr<std::string> encodeOutcome(ArrayRef<Value> outputs,
 
 static FailureOr<std::map<std::string, size_t>>
 sampleImpl(func::FuncOp func, const dd::VectorDD& in, dd::Package& dd,
-           size_t shots, std::mt19937_64& rng, const PreparedState& prepared) {
+           size_t shots, std::mt19937_64& rng, const PreparedState& prepared,
+           std::vector<std::string>* shotResults) {
   const auto inputGuard = llvm::make_scope_exit([&] { dd.decRef(in); });
   auto plan = getSamplingPlan(func);
   if (failed(plan)) {
@@ -1915,6 +1916,9 @@ sampleImpl(func::FuncOp func, const dd::VectorDD& in, dd::Package& dd,
       return failure();
     }
     ++counts[*outcome];
+    if (shotResults != nullptr) {
+      shotResults->push_back(std::move(*outcome));
+    }
     return success();
   };
 
@@ -1961,7 +1965,12 @@ sampleImpl(func::FuncOp func, const dd::VectorDD& in, dd::Package& dd,
 
 FailureOr<std::map<std::string, size_t>>
 sample(func::FuncOp func, size_t shots, uint64_t seed,
-       const DDArgumentBindings& argumentBindings) {
+       const DDArgumentBindings& argumentBindings,
+       std::vector<std::string>* shotResults) {
+  if (shotResults != nullptr) {
+    shotResults->clear();
+    shotResults->reserve(shots);
+  }
   auto dd = std::make_unique<dd::Package>();
   std::mt19937_64 rng(seed == 0 ? std::random_device{}() : seed);
   auto prepared = prepare(func, *dd, argumentBindings);
@@ -1969,7 +1978,7 @@ sample(func::FuncOp func, size_t shots, uint64_t seed,
     return failure();
   }
   return sampleImpl(func, dd::makeZeroState(prepared->qubits.numQubits, *dd),
-                    *dd, shots, rng, *prepared);
+                    *dd, shots, rng, *prepared, shotResults);
 }
 
 } // namespace mlir::qco

--- a/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
@@ -2161,6 +2161,16 @@ TEST_F(QCODDFunctionalityTest,
   const auto histogram = sample(mainFunc(*mod), 64, 11);
   ASSERT_TRUE(succeeded(histogram));
   EXPECT_EQ(*histogram, (std::map<std::string, size_t>{{"1", 64}}));
+
+  std::vector<std::string> shots{"stale output"};
+  const auto withShots =
+      sample(mainFunc(*mod), 64, 11, DDArgumentBindings{}, &shots);
+  ASSERT_TRUE(succeeded(withShots));
+  EXPECT_EQ(*withShots, *histogram);
+  EXPECT_EQ(shots, std::vector<std::string>(64, "1"));
+  EXPECT_TRUE(
+      succeeded(sample(mainFunc(*mod), 0, 11, DDArgumentBindings{}, &shots)));
+  EXPECT_TRUE(shots.empty());
 }
 
 TEST_F(QCODDFunctionalityTest, SampleDefersAllocatedQubitMeasurement) {

--- a/src/qdmi/devices/dd/Device.cpp
+++ b/src/qdmi/devices/dd/Device.cpp
@@ -517,7 +517,8 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQASMProgramSampling()
       return false;
     }
     auto counts = mlir::qco::sample(entryPoint, numShots_,
-                                    static_cast<uint64_t>(seed_.value_or(0)));
+                                    static_cast<uint64_t>(seed_.value_or(0)),
+                                    mlir::qco::DDArgumentBindings{}, &shots_);
     if (mlir::failed(counts)) {
       std::cerr << "Error: failed to sample the QCO program\n";
       return false;
@@ -570,6 +571,7 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgramSampling()
     std::ostringstream output;
     runtime.setOstream(output);
     runtime.outputProgramHeader();
+    shots_.reserve(numShots_);
     for (size_t i = 0; i < numShots_; ++i) {
       runtime.reset();
       runtime.outputShotStart();
@@ -579,8 +581,8 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgramSampling()
         std::cerr << "Error: QIR program failed with error: " << rc << '\n';
         return false;
       }
-      // Update the measurement counts.
-      ++counts_[runtime.getMeasurements()];
+      shots_.push_back(runtime.getMeasurements());
+      ++counts_[shots_.back()];
     }
     return true;
   });
@@ -675,6 +677,33 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::wait(const size_t timeout) const
     }
   } else {
     jobHandle_.wait();
+  }
+  return QDMI_SUCCESS;
+}
+auto MQT_DDSIM_QDMI_Device_Job_impl_d::getShots(const size_t size, void* data,
+                                                size_t* sizeRet) const
+    -> QDMI_STATUS {
+  const size_t required =
+      std::accumulate(shots_.begin(), shots_.end(), size_t{0},
+                      [](const size_t total, const auto& shot) {
+                        return total + shot.size() + 1;
+                      });
+  if (sizeRet != nullptr) {
+    *sizeRet = required;
+  }
+  if (data != nullptr) {
+    if (size < required) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    auto output = std::span(static_cast<char*>(data), required);
+    for (const auto& shot : shots_) {
+      std::ranges::copy(shot, output.begin());
+      output[shot.size()] = ',';
+      output = output.subspan(shot.size() + 1);
+    }
+    if (required > 0) {
+      std::span(static_cast<char*>(data), required).back() = '\0';
+    }
   }
   return QDMI_SUCCESS;
 }
@@ -858,6 +887,11 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::getResults(const QDMI_Job_Result result,
     return QDMI_ERROR_BADSTATE;
   }
   switch (result) {
+  case QDMI_JOB_RESULT_SHOTS:
+    if (numShots_ == 0) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    return getShots(size, data, sizeRet);
   case QDMI_JOB_RESULT_HIST_KEYS:
   case QDMI_JOB_RESULT_HIST_VALUES:
     if (numShots_ == 0) {

--- a/test/python/qdmi/test_qdmi.py
+++ b/test/python/qdmi/test_qdmi.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections import Counter
 from pathlib import Path
 from typing import cast
 
@@ -784,6 +785,22 @@ def test_job_get_counts_is_consistent(submitted_job: Job) -> None:
 
     # Results should be identical
     assert counts1 == counts2
+
+
+def test_job_shots_match_counts(submitted_job: Job) -> None:
+    """Keep the same ordered samples on repeated reads and in the histogram."""
+    submitted_job.wait()
+    shots = submitted_job.get_shots()
+    assert len(shots) == submitted_job.num_shots
+    assert Counter(shots) == submitted_job.get_counts()
+    assert submitted_job.get_shots() == shots
+
+
+def test_empty_program_has_empty_shot_strings(ddsim_device: Device) -> None:
+    """Preserve shot cardinality when the program has no output bits."""
+    job = ddsim_device.submit_job("OPENQASM 3.0;", ProgramFormat.QASM3, num_shots=4)
+    job.wait()
+    assert job.get_shots() == [""] * 4
 
 
 @pytest.fixture

--- a/test/qdmi/devices/dd/results_sampling_test.cpp
+++ b/test/qdmi/devices/dd/results_sampling_test.cpp
@@ -24,6 +24,7 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <map>
 #include <memory>
@@ -283,8 +284,8 @@ TEST(ResultsSampling, EmptyQASM3YieldsEmptyHistogram) {
   ASSERT_EQ(qdmi_test::setShots(j.job, 4), QDMI_SUCCESS);
   ASSERT_EQ(qdmi_test::submitAndWait(j.job, 0), QDMI_SUCCESS);
 
-  constexpr QDMI_Job_Result results[]{QDMI_JOB_RESULT_HIST_KEYS,
-                                      QDMI_JOB_RESULT_HIST_VALUES};
+  constexpr std::array results{QDMI_JOB_RESULT_HIST_KEYS,
+                               QDMI_JOB_RESULT_HIST_VALUES};
   char dummy{};
   for (const auto result : results) {
     size_t size = 1;

--- a/test/qdmi/devices/dd/results_sampling_test.cpp
+++ b/test/qdmi/devices/dd/results_sampling_test.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -36,6 +37,20 @@
 
 namespace {
 
+std::vector<std::string> getShots(MQT_DDSIM_QDMI_Device_Job job) {
+  const size_t size = qdmi_test::querySize(job, QDMI_JOB_RESULT_SHOTS);
+  std::string result(size, '\0');
+  EXPECT_EQ(MQT_DDSIM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_SHOTS,
+                                                  size, result.data(), nullptr),
+            QDMI_SUCCESS);
+  EXPECT_FALSE(result.empty());
+  if (!result.empty()) {
+    EXPECT_EQ(result.back(), '\0');
+    result.pop_back();
+  }
+  return qdmi_test::splitCSV(result);
+}
+
 class HistogramTest : public ::testing::Test {
 protected:
   using Histogram = std::pair<std::vector<std::string>, std::vector<size_t>>;
@@ -44,7 +59,8 @@ protected:
 
   static Histogram runProgram(const QDMI_Program_Format format,
                               const std::string_view program,
-                              const std::optional<int> seed = std::nullopt) {
+                              const std::optional<int> seed = std::nullopt,
+                              std::vector<std::string>* samples = nullptr) {
     const qdmi_test::SessionGuard s{};
     const qdmi_test::JobGuard j{s.session};
     EXPECT_EQ(qdmi_test::setProgram(j.job, format, program), QDMI_SUCCESS);
@@ -53,7 +69,24 @@ protected:
       EXPECT_EQ(qdmi_test::setSeed(j.job, *seed), QDMI_SUCCESS);
     }
     EXPECT_EQ(qdmi_test::submitAndWait(j.job, 0), QDMI_SUCCESS);
-    return qdmi_test::getHistogram(j.job);
+    auto shots = getShots(j.job);
+    EXPECT_EQ(shots.size(), NUM_SHOTS);
+    EXPECT_EQ(shots, getShots(j.job));
+    std::map<std::string, size_t> counts;
+    for (const auto& shot : shots) {
+      ++counts[shot];
+    }
+    const auto histogram = qdmi_test::getHistogram(j.job);
+    const auto& [keys, values] = histogram;
+    EXPECT_EQ(keys.size(), counts.size());
+    EXPECT_EQ(keys.size(), values.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+      EXPECT_EQ(counts.at(keys[i]), values.at(i));
+    }
+    if (samples != nullptr) {
+      *samples = std::move(shots);
+    }
+    return histogram;
   }
 
   static void checkHistogram(const Histogram& hist) {
@@ -201,13 +234,44 @@ TEST_F(QIRHistogramTestString, AdaptiveRecordOutputs) {
 TEST_F(HistogramTest, SeedReproducesQASMSampling) {
   constexpr auto format = QDMI_PROGRAM_FORMAT_QASM3;
   constexpr std::string_view program = qdmi_test::QASM3_BELL_SAMPLING;
-  EXPECT_EQ(runProgram(format, program, 7), runProgram(format, program, 7));
+  std::vector<std::string> first;
+  std::vector<std::string> second;
+  EXPECT_EQ(runProgram(format, program, 7, &first),
+            runProgram(format, program, 7, &second));
+  EXPECT_EQ(first, second);
+  EXPECT_FALSE(std::ranges::is_sorted(first));
 }
 
 TEST_F(QIRHistogramTestString, SeedReproducesQIRSampling) {
   constexpr auto format = QDMI_PROGRAM_FORMAT_QIRBASESTRING;
   const auto program = qdmi_test::getQIRProgram("BellPairStatic.ll");
-  EXPECT_EQ(runProgram(format, program, 7), runProgram(format, program, 7));
+  std::vector<std::string> first;
+  std::vector<std::string> second;
+  EXPECT_EQ(runProgram(format, program, 7, &first),
+            runProgram(format, program, 7, &second));
+  EXPECT_EQ(first, second);
+  EXPECT_FALSE(std::ranges::is_sorted(first));
+}
+
+TEST_F(HistogramTest, QASM3DynamicShotsPreserveClassicalMapping) {
+  constexpr std::string_view program = R"qasm(OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q;
+bit[2] a;
+bit[2] b;
+a[0] = false;
+a[1] = false;
+b[0] = false;
+b[1] = false;
+h q[0];
+a[1] = measure q[0];
+if (a[1]) { x q[1]; }
+b[0] = measure q[1];
+)qasm";
+  const auto [keys, values] = runProgram(QDMI_PROGRAM_FORMAT_QASM3, program, 7);
+  EXPECT_EQ(keys, (std::vector<std::string>{"0000", "0110"}));
+  EXPECT_EQ(std::accumulate(values.begin(), values.end(), size_t{0}),
+            NUM_SHOTS);
 }
 
 TEST(ResultsSampling, EmptyQASM3YieldsEmptyHistogram) {
@@ -242,6 +306,14 @@ TEST(ResultsSampling, BufferTooSmallErrors) {
             QDMI_SUCCESS);
   ASSERT_EQ(qdmi_test::setShots(j.job, 512), QDMI_SUCCESS);
   ASSERT_EQ(qdmi_test::submitAndWait(j.job, 0), QDMI_SUCCESS);
+
+  const size_t shotsSize = qdmi_test::querySize(j.job, QDMI_JOB_RESULT_SHOTS);
+  ASSERT_EQ(shotsSize, 512U * 3U);
+  std::vector<char> shotsTooSmall(shotsSize - 1);
+  EXPECT_EQ(MQT_DDSIM_QDMI_device_job_get_results(
+                j.job, QDMI_JOB_RESULT_SHOTS, shotsTooSmall.size(),
+                shotsTooSmall.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
 
   if (const size_t ks = qdmi_test::querySize(j.job, QDMI_JOB_RESULT_HIST_KEYS);
       ks > 0) {

--- a/test/qdmi/devices/dd/results_statevector_test.cpp
+++ b/test/qdmi/devices/dd/results_statevector_test.cpp
@@ -156,7 +156,7 @@ TEST(ResultsStatevector, SparseNormalizedAndBufferTooSmall) {
   }
 }
 
-TEST(ResultsStatevector, HistogramRequestsInvalidWithShotsZero) {
+TEST(ResultsStatevector, SamplingRequestsInvalidWithShotsZero) {
   const qdmi_test::SessionGuard s{};
   const qdmi_test::JobGuard j{s.session};
   ASSERT_EQ(qdmi_test::setProgram(j.job, QDMI_PROGRAM_FORMAT_QASM3,
@@ -165,6 +165,9 @@ TEST(ResultsStatevector, HistogramRequestsInvalidWithShotsZero) {
   ASSERT_EQ(qdmi_test::setShots(j.job, 0), QDMI_SUCCESS);
   ASSERT_EQ(qdmi_test::submitAndWait(j.job, 0), QDMI_SUCCESS);
 
+  EXPECT_EQ(MQT_DDSIM_QDMI_device_job_get_results(j.job, QDMI_JOB_RESULT_SHOTS,
+                                                  0, nullptr, nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
   EXPECT_EQ(MQT_DDSIM_QDMI_device_job_get_results(
                 j.job, QDMI_JOB_RESULT_HIST_KEYS, 0, nullptr, nullptr),
             QDMI_ERROR_INVALIDARGUMENT);

--- a/test/qdmi/devices/dd/results_statevector_test.cpp
+++ b/test/qdmi/devices/dd/results_statevector_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cmath>
 #include <complex>
 #include <cstddef>
@@ -71,13 +72,12 @@ TEST(ResultsStatevector, EmptyQASM3YieldsEmptyResults) {
   ASSERT_EQ(qdmi_test::setShots(j.job, 0), QDMI_SUCCESS);
   ASSERT_EQ(qdmi_test::submitAndWait(j.job, 0), QDMI_SUCCESS);
 
-  constexpr QDMI_Job_Result results[]{
-      QDMI_JOB_RESULT_STATEVECTOR_DENSE,
-      QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS,
-      QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES,
-      QDMI_JOB_RESULT_PROBABILITIES_DENSE,
-      QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
-      QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES};
+  constexpr std::array results{QDMI_JOB_RESULT_STATEVECTOR_DENSE,
+                               QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS,
+                               QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES,
+                               QDMI_JOB_RESULT_PROBABILITIES_DENSE,
+                               QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
+                               QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES};
   char dummy{};
   for (const auto result : results) {
     size_t size = 1;


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Expose genuine ordered `SHOTS` from the DDSIM QDMI device for OpenQASM and
QIR jobs. Histograms use the same samples. This enables memory consumers,
including Qiskit's native Sampler, without reconstructing shot order from counts.

The QCO sampler can optionally retain its existing per-shot outcomes. Its
counts-only callers allocate no sequence, and terminal measurements still use
one simulation. QIR records each runtime outcome directly. No QDMI interface,
dependency, or Python binding changes are required; QDMI 1.3.3 remains supported.

Local validation covers terminal and dynamic measurements, QIR Base/Adaptive,
classical-register ordering, histogram consistency, repeat reads, reproducible
shot order, empty outputs, and QDMI buffer/state errors. The DDSIM device suite
passed 63 tests, focused QCO sampling passed 14 tests, and Python QDMI passed
251 tests. Full CTest passed all 3,870 registered tests (one existing SC-device
skip). Lint, C++ lint, and documentation builds passed. Native Qiskit Sampler
integration is covered by the dependent #2358.

Codex assisted with implementation, tests, validation, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.