### PR TITLE
🐛 Validate output permutations before I/O mapping initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ releases may include breaking changes.
   standalone runner, DDSIM integration, build integration, tests, and
   documentation. ([#2314]) ([**@denialhaag**])
 
+### Fixed
+
+- 🐛 Validate output permutations before I/O mapping initialization ([#2278])
+  ([**@denialhaag**])
+
 ## [3.9.2] - 2026-08-26
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#392)._
@@ -751,6 +756,7 @@ for previous changelogs._
 
 [#2314]: https://github.com/munich-quantum-toolkit/core/pull/2314
 [#2283]: https://github.com/munich-quantum-toolkit/core/pull/2283
+[#2278]: https://github.com/munich-quantum-toolkit/core/pull/2278
 [#2259]: https://github.com/munich-quantum-toolkit/core/pull/2259
 [#2258]: https://github.com/munich-quantum-toolkit/core/pull/2258
 [#2232]: https://github.com/munich-quantum-toolkit/core/pull/2232

--- a/bindings/ir/register_quantum_computation.cpp
+++ b/bindings/ir/register_quantum_computation.cpp
@@ -407,7 +407,12 @@ Examples:
          R"pb(Initialize the I/O mapping of the quantum computation.
 
 If no initial layout is explicitly specified, the initial layout is assumed to be the identity permutation.
-If the circuit contains measurements at the end, these measurements are used to infer the output permutation.)pb");
+If the circuit contains measurements at the end, these measurements are used to infer the output permutation.
+If the output permutation is not empty, it must contain every measured device qubit as a key.
+Clear the output permutation before calling this method to infer it only from measurements.
+
+Raises:
+    ValueError: If a measured device qubit is missing from a non-empty output permutation.)pb");
 
   ///---------------------------------------------------------------------------
   ///                  \n Ancillary and Garbage Handling \n

--- a/docs/mqt_core_ir.md
+++ b/docs/mqt_core_ir.md
@@ -183,6 +183,12 @@ qc.initialize_io_mapping()
 print(qc.qasm3_str())
 ```
 
+If {py:attr}`~mqt.core.ir.QuantumComputation.output_permutation` is not empty,
+{py:meth}`~mqt.core.ir.QuantumComputation.initialize_io_mapping` uses it as an
+existing mapping. The permutation must contain every measured device qubit as a
+key. Clear {py:attr}`~mqt.core.ir.QuantumComputation.output_permutation` before
+the call to infer it only from the measurements.
+
 In the example above, the initial layout is not explicitly specified. A trivial
 layout is thus assumed, where the circuit qubits are mapped to the device qubits
 in order. The output permutation is determined from the measurements and is

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -381,6 +381,14 @@ public:
   /// qubits occurring in the output permutation
   void stripIdleQubits(bool force = false);
 
+  /**
+   * @brief Initializes the input layout and output permutation.
+   * @details If the output permutation is not empty, it must contain every
+   * measured device qubit as a key. Clear the output permutation before this
+   * call to infer it only from measurements.
+   * @throws std::invalid_argument If a measured device qubit is missing from a
+   * non-empty output permutation.
+   */
   void initializeIOMapping();
   // append measurements to the end of the circuit according to the tracked
   // output permutation

--- a/python/mqt/core/ir/__init__.pyi
+++ b/python/mqt/core/ir/__init__.pyi
@@ -383,6 +383,11 @@ class QuantumComputation(MutableSequence[operations.Operation]):
 
         If no initial layout is explicitly specified, the initial layout is assumed to be the identity permutation.
         If the circuit contains measurements at the end, these measurements are used to infer the output permutation.
+        If the output permutation is not empty, it must contain every measured device qubit as a key.
+        Clear the output permutation before calling this method to infer it only from measurements.
+
+        Raises:
+            ValueError: If a measured device qubit is missing from a non-empty output permutation.
         """
 
     @property

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -257,6 +257,26 @@ void QuantumComputation::initializeIOMapping() {
   // physical qubit.
   const bool outputPermutationFound = !outputPermutation.empty();
 
+  if (outputPermutationFound) {
+    for (const auto& opIt : ops) {
+      const auto* const op = dynamic_cast<NonUnitaryOperation*>(opIt.get());
+      if (op == nullptr || op->getType() != Measure) {
+        continue;
+      }
+      for (const auto& qubit : op->getTargets()) {
+        if (outputPermutation.find(qubit) == outputPermutation.end()) {
+          throw std::invalid_argument(
+              "[initializeIOMapping] Measured device qubit " +
+              std::to_string(qubit) +
+              " is missing from the output permutation. A non-empty output "
+              "permutation must contain every measured device qubit. Set a "
+              "consistent output permutation or clear it before "
+              "initialization.");
+        }
+      }
+    }
+  }
+
   // track whether the circuit contains measurements at the end of the circuit
   // if it does, then all qubits that are not measured shall be considered
   // garbage outputs

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -568,6 +568,30 @@ TEST_F(QFRFunctionality, AvoidStrippingIdleQubitWhenInOutputPermutation) {
   EXPECT_EQ(qc.outputPermutation[1], 0U);
 }
 
+TEST_F(QFRFunctionality, InitializeIOMappingRejectsMissingMeasuredDeviceQubit) {
+  QuantumComputation qc(3U, 2U);
+  qc.measure(0, 1);
+  qc.measure(1, 0);
+  qc.setLogicalQubitGarbage(1);
+  const auto outputPermutation = qc.outputPermutation;
+
+  try {
+    qc.initializeIOMapping();
+    FAIL() << "Expected an invalid_argument exception.";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_STREQ(
+        e.what(),
+        "[initializeIOMapping] Measured device qubit 1 is missing from the "
+        "output permutation. A non-empty output permutation must contain every "
+        "measured device qubit. Set a consistent output permutation or clear "
+        "it before initialization.");
+  } catch (...) {
+    FAIL() << "Expected an invalid_argument exception.";
+  }
+
+  EXPECT_EQ(qc.outputPermutation, outputPermutation);
+}
+
 TEST_F(QFRFunctionality, UpdateOutputPermutation) {
   // Update output permutation if swap gate was applied even if physical qubit
   // index matches logical qubit index


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Backport https://github.com/munich-quantum-toolkit/core/pull/2278 to v3.x. This PR is stacked on https://github.com/munich-quantum-toolkit/core/pull/2371.

Validate non-empty output permutations before `initializeIOMapping` mutates mapping state. Missing measured device qubits now raise a descriptive `std::invalid_argument`, exposed as `ValueError` in Python, while empty output permutations continue to be inferred from measurements.

Add the original regression test, public API documentation, generated Python stub update, and changelog entry.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
