### PR TITLE
🐛 Avoid Windows benchmark import-library collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ releases may include breaking changes.
   [**@MatthiasReumann**], [**@simon1hofmann**], [**@J4MMlE**])
 - ✨ Add a library for typed structured quantum benchmarks with versioned
   instance specifications, analytic references, deterministic manifests, and
-  C++, Python, and command-line interfaces ([#2135], [#2299], [#2315], [#2337])
-  ([**@burgholzer**], [**@denialhaag**])
+  C++, Python, and command-line interfaces ([#2135], [#2299], [#2315], [#2337],
+  [#2380]) ([**@burgholzer**], [**@denialhaag**])
 - ✨ Add DD construction, simulation, statevector extraction, and sampling for
   QCO programs with structured control and dynamic quantum data, including
   direct lowering and dense-array helpers for supported compiler inputs
@@ -878,6 +878,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2380]: https://github.com/munich-quantum-toolkit/core/pull/2380
 [#2368]: https://github.com/munich-quantum-toolkit/core/pull/2368
 [#2358]: https://github.com/munich-quantum-toolkit/core/pull/2358
 [#2349]: https://github.com/munich-quantum-toolkit/core/pull/2349

--- a/mlir/bench/CMakeLists.txt
+++ b/mlir/bench/CMakeLists.txt
@@ -16,6 +16,10 @@ mqt_mlir_target_use_project_options(MQTBenchmarkGenerate)
 
 # The executable that generates and evaluates configured benchmarks.
 add_executable(mqt-core-bench MQTCoreBench.cpp)
+if(WIN32)
+  # Keep the executable import library distinct from the benchmark library.
+  set_target_properties(mqt-core-bench PROPERTIES ARCHIVE_OUTPUT_NAME mqt-core-bench-executable)
+endif()
 target_link_libraries(mqt-core-bench PRIVATE MQT::CoreBenchGenerate MLIRSupport)
 set(LLVM_REQUIRES_EH ON)
 mqt_mlir_target_use_project_options(mqt-core-bench)


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Give the Windows benchmark executable's import library a distinct archive output name. This prevents MSVC from producing `mqt-core-bench.lib` while linking the benchmark static library with the same filename, which otherwise fails with LNK1149.

The collision first surfaced in [FullStaQD/qcc](https://github.com/FullStaQD/qcc)'s Windows CI while validating its LLVM 23.1 upgrade: https://github.com/FullStaQD/qcc/actions/runs/33881479603/job/101051072748?pr=139

The executable remains `mqt-core-bench.exe`, the benchmark library keeps its existing `mqt-core-bench.lib` name, and non-Windows builds are unchanged.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
