### PR TITLE
💥 Make `nlohmann_json` private and remove `spdlog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ releases may include breaking changes.
 - 💥 Remove the entire MQT Core QIR stack, including its runtime, JIT,
   standalone runner, DDSIM integration, build integration, tests, and
   documentation. ([#2314]) ([**@denialhaag**])
+- 💥 Remove the `spdlog` dependency from MQT Core source builds, installed CMake
+  packages, and Python wheels. QDMI diagnostics continue to be written to
+  standard error ([#2270]) ([**@denialhaag**])
 - 💥 Remove the unused decision-diagram approximation algorithm, including the
   `dd/Approximation.hpp` header, `dd::ApproximationMetadata`, and
   `dd::approximate`. No replacement is provided ([#2154]) ([**@burgholzer**])
@@ -778,6 +781,7 @@ for previous changelogs._
 [#2314]: https://github.com/munich-quantum-toolkit/core/pull/2314
 [#2283]: https://github.com/munich-quantum-toolkit/core/pull/2283
 [#2278]: https://github.com/munich-quantum-toolkit/core/pull/2278
+[#2270]: https://github.com/munich-quantum-toolkit/core/pull/2270
 [#2259]: https://github.com/munich-quantum-toolkit/core/pull/2259
 [#2258]: https://github.com/munich-quantum-toolkit/core/pull/2258
 [#2232]: https://github.com/munich-quantum-toolkit/core/pull/2232

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ releases may include breaking changes.
 - 💥 Remove the unused decision-diagram approximation algorithm, including the
   `dd/Approximation.hpp` header, `dd::ApproximationMetadata`, and
   `dd::approximate`. No replacement is provided ([#2154]) ([**@burgholzer**])
+- 💥 Remove `nlohmann_json` from the public package contract. MQT Core no longer
+  installs or exports the library, no installed header exposes a `nlohmann`
+  type, and the decision-diagram statistics report through strings and streams
+  ([#2138]) ([**@denialhaag**])
 - 💥 Remove the neutral-atom stack, which moves to MQT QMAP. This drops the
   neutral-atom computation model, the neutral-atom FoMaC device session, the
   neutral-atom QDMI device and its configuration, the `mqt.core.na` Python
@@ -785,6 +789,7 @@ for previous changelogs._
 [#2148]: https://github.com/munich-quantum-toolkit/core/pull/2148
 [#2147]: https://github.com/munich-quantum-toolkit/core/pull/2147
 [#2141]: https://github.com/munich-quantum-toolkit/core/pull/2141
+[#2138]: https://github.com/munich-quantum-toolkit/core/pull/2138
 [#2137]: https://github.com/munich-quantum-toolkit/core/pull/2137
 [#2124]: https://github.com/munich-quantum-toolkit/core/pull/2124
 [#2116]: https://github.com/munich-quantum-toolkit/core/pull/2116

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,18 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Removal of the `spdlog` dependency
+
+MQT Core no longer discovers, downloads, builds, installs, or exports `spdlog`.
+The installed CMake package no longer calls `find_dependency(spdlog)`, and the
+Python wheels no longer contain the `spdlog` headers or shared library. QDMI
+diagnostics continue to use standard error.
+
+Downstream projects that use `spdlog` must declare and package the dependency
+themselves. Stop passing `MQT_CORE_SPDLOG_INSTALL` or `SPDLOG_*` cache variables
+when configuring MQT Core. Configure the downstream project's own `spdlog`
+dependency instead.
+
 ### macOS support
 
 MQT Core no longer supports x86 macOS. Use Apple silicon with macOS 13.3 or

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,6 +22,28 @@ configurations.
 The bundled DDSIM QDMI device no longer accepts QIR Base or Adaptive Profile
 programs in string or module form. Use QASM2 or QASM3 with this device.
 
+### Private `nlohmann_json` dependency
+
+MQT Core uses `nlohmann_json` only inside its implementation. It no longer
+installs the library, exports it, or looks for it in its package configuration.
+Depend on `nlohmann_json` directly if your project uses it.
+
+No installed header includes a `nlohmann` header any more. The decision-diagram
+statistics report through strings and streams instead. MQT Core removed the
+following names:
+
+- `dd::Statistics::json`, `dd::MemoryManagerStatistics::json`,
+  `dd::TableStatistics::json`, and `dd::UniqueTableStatistics::json`. Use
+  `toString`, the stream operator, or the individual counters.
+- `dd::UniqueTable::getStatsJson`. Use `dd::getStatisticsString`.
+- `dd::getStatistics` and `dd::getDataStructureStatistics`. Use
+  `dd::getStatisticsString` and `dd::getDataStructureStatisticsString`, which
+  return the same report as a JSON-formatted string.
+- The `MQT_CORE_JSON_INSTALL` CMake option.
+
+`dd::getStatisticsString` takes the `includeIndividualTables` flag that
+`dd::getStatistics` used to take.
+
 ### Removal of the neutral-atom stack
 
 MQT Core no longer contains neutral-atom functionality. The complete stack moved

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -10,7 +10,6 @@
 
 include(FetchContent)
 include(CMakeDependentOption)
-include(GNUInstallDirs)
 set(FETCH_PACKAGES "")
 
 if(BUILD_MQT_CORE_BINDINGS)
@@ -66,95 +65,5 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS ${QDMI_MINIMUM_VERSION})
 list(APPEND FETCH_PACKAGES qdmi)
 
-set(MQT_CORE_MANAGES_SPDLOG OFF)
-if(NOT TARGET spdlog::spdlog)
-  set(SPDLOG_VERSION
-      1.17.0
-      CACHE STRING "spdlog version")
-  set(SPDLOG_URL https://github.com/gabime/spdlog/archive/refs/tags/v${SPDLOG_VERSION}.tar.gz)
-  # Add position independent code for spdlog, this is required for Python bindings on Linux.
-  set(SPDLOG_BUILD_PIC ON)
-  set(SPDLOG_SYSTEM_INCLUDES
-      ON
-      CACHE INTERNAL "Treat the library headers like system headers")
-  cmake_dependent_option(MQT_CORE_SPDLOG_INSTALL "Install spdlog library" ON "MQT_CORE_INSTALL" OFF)
-  # Disable upstream spdlog install rules and install with explicit MQT components below.
-  set(SPDLOG_INSTALL
-      OFF
-      CACHE BOOL "Disable upstream spdlog install rules; handled by mqt-core" FORCE)
-  cmake_dependent_option(SPDLOG_BUILD_SHARED "Build spdlog as shared library" ON
-                         "BUILD_MQT_CORE_SHARED_LIBS" OFF)
-  FetchContent_Declare(spdlog URL ${SPDLOG_URL} FIND_PACKAGE_ARGS ${SPDLOG_VERSION})
-  list(APPEND FETCH_PACKAGES spdlog)
-  set(MQT_CORE_MANAGES_SPDLOG ON)
-endif()
-
 # Make all declared dependencies available.
 FetchContent_MakeAvailable(${FETCH_PACKAGES})
-
-# Ensure external shared libraries end up in a common lib layout used by our RUNPATH
-if(MQT_CORE_MANAGES_SPDLOG AND TARGET spdlog)
-  set_target_properties(
-    spdlog
-    PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
-               ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
-               RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
-endif()
-
-# Install spdlog with explicit MQT components.
-if(MQT_CORE_MANAGES_SPDLOG
-   AND MQT_CORE_SPDLOG_INSTALL
-   AND TARGET spdlog
-   AND TARGET spdlog_header_only)
-  include(CMakePackageConfigHelpers)
-
-  set(MQT_CORE_SPDLOG_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/spdlog")
-  set(MQT_CORE_SPDLOG_CONFIG_TARGETS_FILE "spdlogConfigTargets.cmake")
-  set(MQT_CORE_SPDLOG_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/spdlogConfig.cmake")
-  set(MQT_CORE_SPDLOG_VERSION_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/spdlogConfigVersion.cmake")
-
-  install(
-    TARGETS spdlog spdlog_header_only
-    EXPORT spdlog
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${MQT_CORE_TARGET_NAME}_Runtime
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT ${MQT_CORE_TARGET_NAME}_Runtime
-            NAMELINK_COMPONENT ${MQT_CORE_TARGET_NAME}_Development
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-
-  install(
-    DIRECTORY ${spdlog_SOURCE_DIR}/include/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development
-    PATTERN "fmt/bundled" EXCLUDE)
-
-  if(NOT SPDLOG_USE_STD_FORMAT
-     AND NOT SPDLOG_FMT_EXTERNAL
-     AND NOT SPDLOG_FMT_EXTERNAL_HO)
-    install(
-      DIRECTORY ${spdlog_SOURCE_DIR}/include/spdlog/fmt/bundled/
-      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spdlog/fmt/bundled
-      COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-  endif()
-
-  install(
-    EXPORT spdlog
-    FILE ${MQT_CORE_SPDLOG_CONFIG_TARGETS_FILE}
-    NAMESPACE spdlog::
-    DESTINATION ${MQT_CORE_SPDLOG_CONFIG_INSTALL_DIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-
-  set(config_targets_file ${MQT_CORE_SPDLOG_CONFIG_TARGETS_FILE})
-  configure_package_config_file(
-    ${spdlog_SOURCE_DIR}/cmake/spdlogConfig.cmake.in ${MQT_CORE_SPDLOG_CONFIG_FILE}
-    INSTALL_DESTINATION ${MQT_CORE_SPDLOG_CONFIG_INSTALL_DIR})
-  write_basic_package_version_file(
-    ${MQT_CORE_SPDLOG_VERSION_CONFIG_FILE}
-    VERSION ${SPDLOG_VERSION}
-    COMPATIBILITY SameMajorVersion)
-
-  install(
-    FILES ${MQT_CORE_SPDLOG_CONFIG_FILE} ${MQT_CORE_SPDLOG_VERSION_CONFIG_FILE}
-    DESTINATION ${MQT_CORE_SPDLOG_CONFIG_INSTALL_DIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-endif()

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -29,12 +29,6 @@ set(JSON_URL https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}
 set(JSON_SystemInclude
     ON
     CACHE INTERNAL "Treat the library headers like system headers")
-cmake_dependent_option(MQT_CORE_JSON_INSTALL "Install nlohmann_json library" ON "MQT_CORE_INSTALL"
-                       OFF)
-# Disable upstream nlohmann_json install rules and install with explicit MQT components below.
-set(JSON_Install
-    OFF
-    CACHE BOOL "Disable upstream nlohmann_json install rules; handled by mqt-core" FORCE)
 FetchContent_Declare(nlohmann_json URL ${JSON_URL} FIND_PACKAGE_ARGS ${JSON_VERSION})
 list(APPEND FETCH_PACKAGES nlohmann_json)
 
@@ -97,64 +91,6 @@ endif()
 
 # Make all declared dependencies available.
 FetchContent_MakeAvailable(${FETCH_PACKAGES})
-
-# Install nlohmann_json with explicit MQT components.
-if(MQT_CORE_JSON_INSTALL AND TARGET nlohmann_json)
-  set(MQT_CORE_JSON_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/nlohmann_json")
-  set(MQT_CORE_JSON_TARGETS_EXPORT_NAME "nlohmann_jsonTargets")
-  set(MQT_CORE_JSON_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/nlohmann_jsonConfig.cmake")
-  set(MQT_CORE_JSON_VERSION_CONFIG_FILE
-      "${CMAKE_CURRENT_BINARY_DIR}/nlohmann_jsonConfigVersion.cmake")
-
-  # nlohmann_json's upstream templates expect these names.
-  set(_mqt_core_saved_project_name "${PROJECT_NAME}")
-  set(_mqt_core_saved_project_version "${PROJECT_VERSION}")
-  set(_mqt_core_saved_project_version_major "${PROJECT_VERSION_MAJOR}")
-  set(PROJECT_NAME "nlohmann_json")
-  set(PROJECT_VERSION "${JSON_VERSION}")
-  string(REGEX MATCH "^[0-9]+" PROJECT_VERSION_MAJOR "${JSON_VERSION}")
-  set(NLOHMANN_JSON_TARGET_NAME "nlohmann_json")
-  set(NLOHMANN_JSON_TARGETS_EXPORT_NAME "${MQT_CORE_JSON_TARGETS_EXPORT_NAME}")
-
-  configure_file(${nlohmann_json_SOURCE_DIR}/cmake/config.cmake.in ${MQT_CORE_JSON_CONFIG_FILE}
-                 @ONLY)
-  configure_file(${nlohmann_json_SOURCE_DIR}/cmake/nlohmann_jsonConfigVersion.cmake.in
-                 ${MQT_CORE_JSON_VERSION_CONFIG_FILE} @ONLY)
-
-  set(PROJECT_NAME "${_mqt_core_saved_project_name}")
-  set(PROJECT_VERSION "${_mqt_core_saved_project_version}")
-  set(PROJECT_VERSION_MAJOR "${_mqt_core_saved_project_version_major}")
-  unset(_mqt_core_saved_project_name)
-  unset(_mqt_core_saved_project_version)
-  unset(_mqt_core_saved_project_version_major)
-  unset(NLOHMANN_JSON_TARGET_NAME)
-  unset(NLOHMANN_JSON_TARGETS_EXPORT_NAME)
-
-  install(
-    DIRECTORY ${nlohmann_json_SOURCE_DIR}/include/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-
-  if(MSVC)
-    install(
-      FILES ${nlohmann_json_SOURCE_DIR}/nlohmann_json.natvis
-      DESTINATION .
-      COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-  endif()
-
-  install(TARGETS nlohmann_json EXPORT ${MQT_CORE_JSON_TARGETS_EXPORT_NAME})
-
-  install(
-    EXPORT ${MQT_CORE_JSON_TARGETS_EXPORT_NAME}
-    NAMESPACE nlohmann_json::
-    DESTINATION ${MQT_CORE_JSON_CONFIG_INSTALL_DIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-
-  install(
-    FILES ${MQT_CORE_JSON_CONFIG_FILE} ${MQT_CORE_JSON_VERSION_CONFIG_FILE}
-    DESTINATION ${MQT_CORE_JSON_CONFIG_INSTALL_DIR}
-    COMPONENT ${MQT_CORE_TARGET_NAME}_Development)
-endif()
 
 # Ensure external shared libraries end up in a common lib layout used by our RUNPATH
 if(MQT_CORE_MANAGES_SPDLOG AND TARGET spdlog)

--- a/cmake/mqt-core-config.cmake.in
+++ b/cmake/mqt-core-config.cmake.in
@@ -13,7 +13,6 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 include(CMakeFindDependencyMacro)
-find_dependency(spdlog)
 find_dependency(qdmi)
 
 if(TARGET MQT::Core)

--- a/cmake/mqt-core-config.cmake.in
+++ b/cmake/mqt-core-config.cmake.in
@@ -13,7 +13,6 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 include(CMakeFindDependencyMacro)
-find_dependency(nlohmann_json)
 find_dependency(spdlog)
 find_dependency(qdmi)
 

--- a/eval/CMakeLists.txt
+++ b/eval/CMakeLists.txt
@@ -9,4 +9,4 @@
 add_executable(mqt-core-dd-eval eval_dd_package.cpp)
 target_link_libraries(
   mqt-core-dd-eval PRIVATE MQT::CoreDD MQT::CoreAlgorithms MQT::CoreCircuitOptimizer
-                           MQT::ProjectOptions MQT::ProjectWarnings)
+                           nlohmann_json::nlohmann_json MQT::ProjectOptions MQT::ProjectWarnings)

--- a/eval/eval_dd_package.cpp
+++ b/eval/eval_dd_package.cpp
@@ -87,7 +87,7 @@ benchmarkSimulate(const qc::QuantumComputation& qc) {
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
       std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-  exp->stats = getStatistics(*exp->dd);
+  exp->stats = nlohmann::basic_json<>::parse(getStatisticsString(*exp->dd));
   return exp;
 }
 
@@ -101,7 +101,7 @@ benchmarkFunctionalityConstruction(const qc::QuantumComputation& qc) {
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
       std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-  exp->stats = getStatistics(*exp->dd);
+  exp->stats = nlohmann::basic_json<>::parse(getStatisticsString(*exp->dd));
   return exp;
 }
 
@@ -142,7 +142,7 @@ benchmarkSimulateGrover(const qc::Qubit nq,
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
       std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-  exp->stats = getStatistics(*exp->dd);
+  exp->stats = nlohmann::basic_json<>::parse(getStatisticsString(*exp->dd));
   return exp;
 }
 
@@ -190,7 +190,7 @@ benchmarkFunctionalityConstructionGrover(
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
       std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-  exp->stats = getStatistics(*exp->dd);
+  exp->stats = nlohmann::basic_json<>::parse(getStatisticsString(*exp->dd));
   return exp;
 }
 

--- a/include/mqt-core/dd/UniqueTable.hpp
+++ b/include/mqt-core/dd/UniqueTable.hpp
@@ -21,8 +21,6 @@
 #include "dd/statistics/UniqueTableStatistics.hpp"
 #include "ir/Definitions.hpp"
 
-#include <nlohmann/json_fwd.hpp>
-
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -132,10 +130,6 @@ public:
   /// Get a reference to individual statistics
   [[nodiscard]] const UniqueTableStatistics&
   getStats(std::size_t idx) const noexcept;
-
-  /// Get a JSON object with the statistics
-  [[nodiscard]] nlohmann::basic_json<>
-  getStatsJson(bool includeIndividualTables = false) const;
 
   /// Get the total number of entries
   [[nodiscard]] std::size_t getNumEntries() const noexcept;

--- a/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
+++ b/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
@@ -11,9 +11,9 @@
 #pragma once
 
 #include "dd/statistics/Statistics.hpp"
-#include "nlohmann/json_fwd.hpp"
 
 #include <cstddef>
+#include <string>
 
 namespace dd {
 
@@ -77,8 +77,8 @@ struct MemoryManagerStatistics final : Statistics {
   /// Reset all statistics (except for the peak values)
   void reset() noexcept override;
 
-  /// Get a JSON representation of the statistics
-  [[nodiscard]] nlohmann::json json() const override;
+  /// Get a JSON-formatted string representation of the statistics
+  [[nodiscard]] std::string toString() const override;
 };
 
 } // namespace dd

--- a/include/mqt-core/dd/statistics/PackageStatistics.hpp
+++ b/include/mqt-core/dd/statistics/PackageStatistics.hpp
@@ -12,8 +12,6 @@
 
 #include "dd/Package.hpp"
 
-#include <nlohmann/json_fwd.hpp>
-
 #include <iostream>
 #include <string>
 
@@ -40,16 +38,20 @@ namespace dd {
  */
 [[nodiscard]] double computePeakMemoryMiB(const Package& package);
 
-[[nodiscard]] nlohmann::json
-getStatistics(Package& package, bool includeIndividualTables = false);
+/**
+ * @brief Get key statistics about the data structures used by the DD package.
+ * @return A JSON-formatted string representation of the statistics
+ */
+[[nodiscard]] std::string getDataStructureStatisticsString();
 
 /**
- * @brief Get some key statistics about data structures used by the DD package
- * @return A JSON representation of the statistics
+ * @brief Get key statistics about the data structures held by @p package.
+ * @param package The package instance
+ * @param includeIndividualTables Whether to report every unique table
+ * @return A JSON-formatted string representation of the statistics
  */
-[[nodiscard]] nlohmann::json getDataStructureStatistics();
-
-[[nodiscard]] std::string getStatisticsString(Package& package);
+[[nodiscard]] std::string
+getStatisticsString(Package& package, bool includeIndividualTables = false);
 
 void printStatistics(Package& package, std::ostream& os = std::cout);
 

--- a/include/mqt-core/dd/statistics/Statistics.hpp
+++ b/include/mqt-core/dd/statistics/Statistics.hpp
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include "nlohmann/json_fwd.hpp"
-
 #include <ostream>
 #include <string>
 
@@ -28,10 +26,7 @@ struct Statistics {
   /// Reset all statistics (except for peak values)
   virtual void reset() noexcept {};
 
-  /// Get a JSON representation of the statistics
-  [[nodiscard]] virtual nlohmann::json json() const;
-
-  /// Get a pretty-printed string representation of the statistics
+  /// Get a JSON-formatted string representation of the statistics
   [[nodiscard]] virtual std::string toString() const;
 
   /**

--- a/include/mqt-core/dd/statistics/TableStatistics.hpp
+++ b/include/mqt-core/dd/statistics/TableStatistics.hpp
@@ -12,9 +12,8 @@
 
 #include "dd/statistics/Statistics.hpp"
 
-#include <nlohmann/json_fwd.hpp>
-
 #include <cstddef>
+#include <string>
 
 namespace dd {
 
@@ -73,8 +72,8 @@ struct TableStatistics : Statistics {
   /// Get the amount of memory required for the table in MiB
   [[nodiscard]] double getMemoryMiB() const noexcept;
 
-  /// Get a JSON representation of the statistics
-  [[nodiscard]] nlohmann::json json() const override;
+  /// Get a JSON-formatted string representation of the statistics
+  [[nodiscard]] std::string toString() const override;
 };
 
 } // namespace dd

--- a/include/mqt-core/dd/statistics/UniqueTableStatistics.hpp
+++ b/include/mqt-core/dd/statistics/UniqueTableStatistics.hpp
@@ -12,9 +12,8 @@
 
 #include "dd/statistics/TableStatistics.hpp"
 
-#include <nlohmann/json_fwd.hpp>
-
 #include <cstddef>
+#include <string>
 
 namespace dd {
 /// \brief A class for storing statistics of a unique table
@@ -25,8 +24,8 @@ struct UniqueTableStatistics : TableStatistics {
   /// Reset all statistics (except for the peak values)
   void reset() noexcept override;
 
-  /// Get a JSON representation of the statistics
-  [[nodiscard]] nlohmann::json json() const override;
+  /// Get a JSON-formatted string representation of the statistics
+  [[nodiscard]] std::string toString() const override;
 };
 
 } // namespace dd

--- a/include/mqt-core/qdmi/common/Diagnostics.hpp
+++ b/include/mqt-core/qdmi/common/Diagnostics.hpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <format>
+#include <string_view>
+#include <utility>
+
+namespace qdmi::diagnostics {
+
+/// Severity of a diagnostic.
+enum class DiagnosticLevel : uint8_t { Info, Warning, Error };
+
+namespace detail {
+
+[[nodiscard]] constexpr std::string_view
+diagnosticLevelName(const DiagnosticLevel level) noexcept {
+  switch (level) {
+  case DiagnosticLevel::Info:
+    return "info";
+  case DiagnosticLevel::Warning:
+    return "warning";
+  case DiagnosticLevel::Error:
+    return "error";
+  }
+  return "error";
+}
+
+/// Writes one diagnostic to standard error without allocating memory.
+inline void writeDiagnostic(const DiagnosticLevel level,
+                            const std::string_view message) noexcept {
+#ifdef _WIN32
+  _lock_file(stderr);
+#else
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  flockfile(stderr);
+#endif
+  const auto write = [](const std::string_view part) noexcept {
+    if (!part.empty()) {
+#ifdef _WIN32
+      _fwrite_nolock(part.data(), sizeof(char), part.size(), stderr);
+#else
+      std::fwrite(part.data(), sizeof(char), part.size(), stderr);
+#endif
+    }
+  };
+  write("[mqt-core] [");
+  write(diagnosticLevelName(level));
+  write("] ");
+  write(message);
+#ifdef _WIN32
+  _fputc_nolock('\n', stderr);
+  _fflush_nolock(stderr);
+  _unlock_file(stderr);
+#else
+  std::fputc('\n', stderr);
+  std::fflush(stderr);
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  funlockfile(stderr);
+#endif
+}
+
+} // namespace detail
+
+/// Formats and writes one best-effort diagnostic to standard error.
+///
+/// Writes the unformatted format string if formatting fails.
+template <class... Args>
+void emit(const DiagnosticLevel level, const std::format_string<Args...> format,
+          Args&&... args) noexcept {
+  try {
+    detail::writeDiagnostic(level,
+                            std::format(format, std::forward<Args>(args)...));
+  } catch (...) {
+    detail::writeDiagnostic(level, format.get());
+  }
+}
+
+/// Formats and writes an informational diagnostic to standard error.
+template <class... Args>
+void info(const std::format_string<Args...> format, Args&&... args) noexcept {
+  emit(DiagnosticLevel::Info, format, std::forward<Args>(args)...);
+}
+
+/// Formats and writes a warning diagnostic to standard error.
+template <class... Args>
+void warn(const std::format_string<Args...> format, Args&&... args) noexcept {
+  emit(DiagnosticLevel::Warning, format, std::forward<Args>(args)...);
+}
+
+/// Formats and writes an error diagnostic to standard error.
+template <class... Args>
+void error(const std::format_string<Args...> format, Args&&... args) noexcept {
+  emit(DiagnosticLevel::Error, format, std::forward<Args>(args)...);
+}
+
+} // namespace qdmi::diagnostics

--- a/src/dd/CMakeLists.txt
+++ b/src/dd/CMakeLists.txt
@@ -23,7 +23,10 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-dd)
                                       FILES ${DD_HEADERS})
 
   # add link libraries
-  target_link_libraries(${MQT_CORE_TARGET_NAME}-dd PUBLIC MQT::CoreIR nlohmann_json::nlohmann_json)
+  target_link_libraries(
+    ${MQT_CORE_TARGET_NAME}-dd
+    PUBLIC MQT::CoreIR
+    PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 
   # generate export header
   include(GenerateExportHeader)

--- a/src/dd/UniqueTable.cpp
+++ b/src/dd/UniqueTable.cpp
@@ -12,6 +12,7 @@
 
 #include "dd/MemoryManager.hpp"
 #include "dd/Node.hpp"
+#include "statistics/StatisticsJson.hpp"
 
 #include <nlohmann/json.hpp>
 
@@ -113,8 +114,9 @@ UniqueTable::getStats(const std::size_t idx) const noexcept {
   return stats.at(idx);
 }
 
-nlohmann::basic_json<>
-UniqueTable::getStatsJson(const bool includeIndividualTables) const {
+nlohmann::basic_json<> toJson(const UniqueTable& table,
+                              const bool includeIndividualTables) {
+  const auto& stats = table.getStats();
   if (std::ranges::all_of(stats, [](const UniqueTableStatistics& stat) {
         return stat.peakNumEntries == 0U;
       })) {
@@ -135,11 +137,11 @@ UniqueTable::getStatsJson(const bool includeIndividualTables) const {
   }
 
   nlohmann::basic_json<> j;
-  j["total"] = totalStats.json();
+  j["total"] = toJson(totalStats);
   if (includeIndividualTables) {
     std::size_t v = 0U;
     for (const auto& stat : stats) {
-      j[std::to_string(v)] = stat.json();
+      j[std::to_string(v)] = toJson(stat);
       ++v;
     }
   }

--- a/src/dd/statistics/MemoryManagerStatistics.cpp
+++ b/src/dd/statistics/MemoryManagerStatistics.cpp
@@ -10,12 +10,13 @@
 
 #include "dd/statistics/MemoryManagerStatistics.hpp"
 
-#include "dd/statistics/Statistics.hpp"
+#include "StatisticsJson.hpp"
 
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
 #include <cstddef>
+#include <string>
 
 namespace dd {
 
@@ -74,24 +75,28 @@ void MemoryManagerStatistics::reset() noexcept {
   numAvailableForReuse = 0U;
 }
 
-nlohmann::basic_json<> MemoryManagerStatistics::json() const {
-  if (peakNumUsed == 0) {
+std::string MemoryManagerStatistics::toString() const {
+  return toJson(*this).dump(2U);
+}
+
+nlohmann::basic_json<> toJson(const MemoryManagerStatistics& s) {
+  if (s.peakNumUsed == 0) {
     return "unused";
   }
 
-  auto j = Statistics::json();
-  j["memory_allocated_MiB"] = getAllocatedMemoryMiB();
-  j["memory_used_MiB"] = getUsedMemoryMiB();
-  j["memory_used_MiB_peak"] = getPeakUsedMemoryMiB();
-  j["num_allocated"] = numAllocated;
-  j["num_allocations"] = numAllocations;
-  j["num_available_for_reuse"] = numAvailableForReuse;
-  j["num_available_for_reuse_peak"] = peakNumAvailableForReuse;
-  j["num_available_from_chunks"] = getNumAvailableFromChunks();
-  j["num_available_total"] = getTotalNumAvailable();
-  j["num_used"] = numUsed;
-  j["num_used_peak"] = peakNumUsed;
-  j["usage_ratio"] = getUsageRatio();
+  nlohmann::basic_json<> j;
+  j["memory_allocated_MiB"] = s.getAllocatedMemoryMiB();
+  j["memory_used_MiB"] = s.getUsedMemoryMiB();
+  j["memory_used_MiB_peak"] = s.getPeakUsedMemoryMiB();
+  j["num_allocated"] = s.numAllocated;
+  j["num_allocations"] = s.numAllocations;
+  j["num_available_for_reuse"] = s.numAvailableForReuse;
+  j["num_available_for_reuse_peak"] = s.peakNumAvailableForReuse;
+  j["num_available_from_chunks"] = s.getNumAvailableFromChunks();
+  j["num_available_total"] = s.getTotalNumAvailable();
+  j["num_used"] = s.numUsed;
+  j["num_used_peak"] = s.peakNumUsed;
+  j["usage_ratio"] = s.getUsageRatio();
   return j;
 }
 

--- a/src/dd/statistics/PackageStatistics.cpp
+++ b/src/dd/statistics/PackageStatistics.cpp
@@ -10,6 +10,7 @@
 
 #include "dd/statistics/PackageStatistics.hpp"
 
+#include "StatisticsJson.hpp"
 #include "dd/Complex.hpp"
 #include "dd/ComplexNumbers.hpp"
 #include "dd/ComplexValue.hpp"
@@ -78,8 +79,11 @@ double computePeakMemoryMiB(const Package& package) {
   return memoryForNodes + memoryForEdges + memoryForRealNumbers;
 }
 
-nlohmann::basic_json<> getStatistics(Package& package,
-                                     const bool includeIndividualTables) {
+namespace {
+[[nodiscard]] nlohmann::basic_json<> getDataStructureStatistics();
+
+[[nodiscard]] nlohmann::basic_json<>
+getStatistics(Package& package, const bool includeIndividualTables) {
   nlohmann::basic_json<> j;
 
   j["data_structure"] = getDataStructureStatistics();
@@ -89,43 +93,43 @@ nlohmann::basic_json<> getStatistics(Package& package,
 
   auto& vector = j["vector"];
   auto& vectorUniqueTable = vector["unique_table"];
-  vectorUniqueTable =
-      package.vUniqueTable.getStatsJson(includeIndividualTables);
+  vectorUniqueTable = toJson(package.vUniqueTable, includeIndividualTables);
   if (vectorUniqueTable != "unused") {
     vectorUniqueTable["total"]["num_active_entries"] = activeVectorNodes;
   }
-  vector["memory_manager"] = package.vMemoryManager.getStats().json();
+  vector["memory_manager"] = toJson(package.vMemoryManager.getStats());
 
   auto& matrix = j["matrix"];
   auto& matrixUniqueTable = matrix["unique_table"];
-  matrixUniqueTable =
-      package.mUniqueTable.getStatsJson(includeIndividualTables);
+  matrixUniqueTable = toJson(package.mUniqueTable, includeIndividualTables);
   if (matrixUniqueTable != "unused") {
     matrixUniqueTable["total"]["num_active_entries"] = activeMatrixNodes;
   }
-  matrix["memory_manager"] = package.mMemoryManager.getStats().json();
+  matrix["memory_manager"] = toJson(package.mMemoryManager.getStats());
 
   auto& realNumbers = j["real_numbers"];
   auto& realNumbersUniqueTable = realNumbers["unique_table"];
-  realNumbersUniqueTable = package.cUniqueTable.getStats().json();
+  realNumbersUniqueTable = toJson(package.cUniqueTable.getStats());
   if (realNumbersUniqueTable != "unused") {
     realNumbersUniqueTable["num_active_entries"] = activeRealNumbers;
   }
-  realNumbers["memory_manager"] = package.cMemoryManager.getStats().json();
+  realNumbers["memory_manager"] = toJson(package.cMemoryManager.getStats());
 
   auto& computeTables = j["compute_tables"];
-  computeTables["vector_add"] = package.vectorAdd.getStats().json();
-  computeTables["matrix_add"] = package.matrixAdd.getStats().json();
+  computeTables["vector_add"] = toJson(package.vectorAdd.getStats());
+  computeTables["matrix_add"] = toJson(package.matrixAdd.getStats());
   computeTables["matrix_conjugate_transpose"] =
-      package.conjugateMatrixTranspose.getStats().json();
+      toJson(package.conjugateMatrixTranspose.getStats());
   computeTables["matrix_vector_mult"] =
-      package.matrixVectorMultiplication.getStats().json();
+      toJson(package.matrixVectorMultiplication.getStats());
   computeTables["matrix_matrix_mult"] =
-      package.matrixMatrixMultiplication.getStats().json();
-  computeTables["vector_kronecker"] = package.vectorKronecker.getStats().json();
-  computeTables["matrix_kronecker"] = package.matrixKronecker.getStats().json();
+      toJson(package.matrixMatrixMultiplication.getStats());
+  computeTables["vector_kronecker"] =
+      toJson(package.vectorKronecker.getStats());
+  computeTables["matrix_kronecker"] =
+      toJson(package.matrixKronecker.getStats());
   computeTables["vector_inner_product"] =
-      package.vectorInnerProduct.getStats().json();
+      toJson(package.vectorInnerProduct.getStats());
 
   j["active_memory_mib"] = computeActiveMemoryMiB(package);
   j["peak_memory_mib"] = computePeakMemoryMiB(package);
@@ -133,7 +137,7 @@ nlohmann::basic_json<> getStatistics(Package& package,
   return j;
 }
 
-nlohmann::basic_json<> getDataStructureStatistics() {
+[[nodiscard]] nlohmann::basic_json<> getDataStructureStatistics() {
   nlohmann::basic_json<> j;
 
   // Information about key data structures
@@ -222,8 +226,15 @@ nlohmann::basic_json<> getDataStructureStatistics() {
   return j;
 }
 
-std::string getStatisticsString(Package& package) {
-  return getStatistics(package).dump(2U);
+} // namespace
+
+std::string getDataStructureStatisticsString() {
+  return getDataStructureStatistics().dump(2U);
+}
+
+std::string getStatisticsString(Package& package,
+                                const bool includeIndividualTables) {
+  return getStatistics(package, includeIndividualTables).dump(2U);
 }
 
 void printStatistics(Package& package, std::ostream& os) {

--- a/src/dd/statistics/Statistics.cpp
+++ b/src/dd/statistics/Statistics.cpp
@@ -10,14 +10,11 @@
 
 #include "dd/statistics/Statistics.hpp"
 
-#include <nlohmann/json.hpp>
-
 #include <string>
 
 namespace dd {
 
-nlohmann::basic_json<> Statistics::json() const { return nlohmann::json{}; }
-
-std::string Statistics::toString() const { return json().dump(2U); }
+/// The base class carries no statistics, which JSON renders as a null value.
+std::string Statistics::toString() const { return "null"; }
 
 } // namespace dd

--- a/src/dd/statistics/StatisticsJson.hpp
+++ b/src/dd/statistics/StatisticsJson.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/** @file StatisticsJson.hpp
+ * @brief Internal JSON rendering for decision-diagram statistics.
+ * @details This header is not installed. It keeps nlohmann_json out of the
+ * public headers while the statistics reports stay JSON-formatted.
+ */
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace dd {
+
+class UniqueTable;
+struct MemoryManagerStatistics;
+struct TableStatistics;
+struct UniqueTableStatistics;
+
+/// Render the memory-manager statistics, or "unused" if nothing was used.
+[[nodiscard]] nlohmann::basic_json<> toJson(const MemoryManagerStatistics& s);
+
+/// Render the table statistics, or "unused" if the table was never queried.
+[[nodiscard]] nlohmann::basic_json<> toJson(const TableStatistics& s);
+
+/// Render the unique-table statistics, or "unused" if it was never queried.
+[[nodiscard]] nlohmann::basic_json<> toJson(const UniqueTableStatistics& s);
+
+/**
+ * @brief Render the statistics of every table in a unique table.
+ * @param table The unique table
+ * @param includeIndividualTables Whether to add an entry per variable
+ * @return The rendered statistics, or "unused" if no table holds entries
+ */
+[[nodiscard]] nlohmann::basic_json<> toJson(const UniqueTable& table,
+                                            bool includeIndividualTables);
+
+} // namespace dd

--- a/src/dd/statistics/TableStatistics.cpp
+++ b/src/dd/statistics/TableStatistics.cpp
@@ -10,11 +10,12 @@
 
 #include "dd/statistics/TableStatistics.hpp"
 
-#include "dd/statistics/Statistics.hpp"
+#include "StatisticsJson.hpp"
 
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <string>
 
 namespace dd {
 
@@ -55,23 +56,25 @@ double TableStatistics::getMemoryMiB() const noexcept {
   return static_cast<double>(numBuckets) * getEntrySizeMiB();
 }
 
-nlohmann::basic_json<> TableStatistics::json() const {
-  if (lookups == 0) {
+std::string TableStatistics::toString() const { return toJson(*this).dump(2U); }
+
+nlohmann::basic_json<> toJson(const TableStatistics& s) {
+  if (s.lookups == 0) {
     return "unused";
   }
 
-  auto j = Statistics::json();
-  j["num_buckets"] = numBuckets;
-  j["memory_MiB"] = getMemoryMiB();
-  j["num_entries"] = numEntries;
-  j["peak_num_entries"] = peakNumEntries;
-  j["collisions"] = collisions;
-  j["hits"] = hits;
-  j["lookups"] = lookups;
-  j["inserts"] = inserts;
-  j["hit_ratio"] = hitRatio();
-  j["col_ratio"] = colRatio();
-  j["load_factor"] = loadFactor();
+  nlohmann::basic_json<> j;
+  j["num_buckets"] = s.numBuckets;
+  j["memory_MiB"] = s.getMemoryMiB();
+  j["num_entries"] = s.numEntries;
+  j["peak_num_entries"] = s.peakNumEntries;
+  j["collisions"] = s.collisions;
+  j["hits"] = s.hits;
+  j["lookups"] = s.lookups;
+  j["inserts"] = s.inserts;
+  j["hit_ratio"] = s.hitRatio();
+  j["col_ratio"] = s.colRatio();
+  j["load_factor"] = s.loadFactor();
   return j;
 }
 

--- a/src/dd/statistics/UniqueTableStatistics.cpp
+++ b/src/dd/statistics/UniqueTableStatistics.cpp
@@ -10,21 +10,28 @@
 
 #include "dd/statistics/UniqueTableStatistics.hpp"
 
+#include "StatisticsJson.hpp"
 #include "dd/statistics/TableStatistics.hpp"
 
 #include <nlohmann/json.hpp>
+
+#include <string>
 
 namespace dd {
 
 void UniqueTableStatistics::reset() noexcept { TableStatistics::reset(); }
 
-nlohmann::basic_json<> UniqueTableStatistics::json() const {
-  if (lookups == 0) {
+std::string UniqueTableStatistics::toString() const {
+  return toJson(*this).dump(2U);
+}
+
+nlohmann::basic_json<> toJson(const UniqueTableStatistics& s) {
+  if (s.lookups == 0) {
     return "unused";
   }
 
-  auto j = TableStatistics::json();
-  j["gc_runs"] = gcRuns;
+  auto j = toJson(static_cast<const TableStatistics&>(s));
+  j["gc_runs"] = s.gcRuns;
   return j;
 }
 } // namespace dd

--- a/src/fomac/CMakeLists.txt
+++ b/src/fomac/CMakeLists.txt
@@ -27,10 +27,7 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}/fomac/Slurm.hpp)
 
   # Add link libraries
-  target_link_libraries(
-    ${TARGET_NAME}
-    PUBLIC qdmi::qdmi MQT::CoreQDMICommon MQT::CoreQDMIDriver
-    PRIVATE spdlog::spdlog)
+  target_link_libraries(${TARGET_NAME} PUBLIC qdmi::qdmi MQT::CoreQDMICommon MQT::CoreQDMIDriver)
 
   # add to list of MQT core targets
   set(MQT_CORE_TARGETS

--- a/src/fomac/FoMaC.cpp
+++ b/src/fomac/FoMaC.cpp
@@ -11,10 +11,10 @@
 #include "fomac/FoMaC.hpp"
 
 #include "qdmi/common/Common.hpp"
+#include "qdmi/common/Diagnostics.hpp"
 #include "qdmi/driver/Driver.hpp"
 
 #include <qdmi/client.h>
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <complex>
@@ -898,8 +898,8 @@ Session::Session(const SessionConfig& config) {
           session_.get(), param, value->size() + 1, value->c_str()));
       if (status == QDMI_ERROR_NOTSUPPORTED) {
         // Optional parameter not supported by session - skip it
-        SPDLOG_INFO("Session parameter {} not supported (skipped)",
-                    qdmi::toString(param));
+        qdmi::diagnostics::info("Session parameter {} not supported (skipped)",
+                                qdmi::toString(param));
         return;
       }
       if (status == QDMI_SUCCESS) {

--- a/src/qdmi/common/CMakeLists.txt
+++ b/src/qdmi/common/CMakeLists.txt
@@ -24,13 +24,14 @@ if(NOT TARGET ${TARGET_NAME})
            ${MQT_CORE_INCLUDE_BUILD_DIR}
            FILES
            ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/Common.hpp
-           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/DeviceConfiguration.hpp)
+           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/DeviceConfiguration.hpp
+           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/common/Diagnostics.hpp)
 
   # Add link libraries
   target_link_libraries(
     ${TARGET_NAME}
     PUBLIC qdmi::qdmi
-    PRIVATE qdmi::qdmi_project_warnings spdlog::spdlog ${CMAKE_DL_LIBS})
+    PRIVATE qdmi::qdmi_project_warnings ${CMAKE_DL_LIBS})
 
   # add to list of MQT core targets
   list(APPEND MQT_CORE_TARGETS ${TARGET_NAME})

--- a/src/qdmi/common/DeviceConfiguration.cpp
+++ b/src/qdmi/common/DeviceConfiguration.cpp
@@ -10,13 +10,15 @@
 
 #include "qdmi/common/DeviceConfiguration.hpp"
 
+#include "qdmi/common/Diagnostics.hpp"
+
 #include <qdmi/device.h>
-#include <spdlog/spdlog.h>
 
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <ios>
 #include <iterator>
@@ -91,36 +93,71 @@ environment(const std::string_view name) {
 #endif
 }
 
+template <class Reporter>
+void reportPath(const std::filesystem::path& path,
+                const std::format_string<> fallback,
+                Reporter&& reporter) noexcept {
+  try {
+#ifdef _WIN32
+    const auto pathText = path.string();
+    std::forward<Reporter>(reporter)(std::string_view(pathText));
+#else
+    std::forward<Reporter>(reporter)(std::string_view(path.native()));
+#endif
+  } catch (...) {
+    qdmi::diagnostics::error(fallback);
+  }
+}
+
 [[nodiscard]] std::optional<LoadedDeviceConfiguration>
 readFile(const std::filesystem::path& path, const bool bundled, int& status) {
   std::error_code error;
   const auto exists = std::filesystem::exists(path, error);
   if (error) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_PERMISSIONDENIED;
-    SPDLOG_ERROR("Cannot inspect QDMI device configuration '{}': {}",
-                 path.string(), error.message());
+    reportPath(path,
+               "Cannot inspect QDMI device configuration (details unavailable)",
+               [&error](const std::string_view pathText) {
+                 const auto message = error.message();
+                 qdmi::diagnostics::error(
+                     "Cannot inspect QDMI device configuration '{}': {}",
+                     pathText, message);
+               });
     return std::nullopt;
   }
   if (!exists) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_NOTFOUND;
-    SPDLOG_ERROR("QDMI device configuration '{}' does not exist",
-                 path.string());
+    reportPath(path, "QDMI device configuration does not exist",
+               [](const std::string_view pathText) {
+                 qdmi::diagnostics::error(
+                     "QDMI device configuration '{}' does not exist", pathText);
+               });
     return std::nullopt;
   }
   errno = 0;
   std::ifstream input(path, std::ios::binary);
   if (!input) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_PERMISSIONDENIED;
-    SPDLOG_ERROR("Cannot read QDMI device configuration '{}': {}",
-                 path.string(), std::strerror(errno));
+    const auto errorNumber = errno;
+    reportPath(path, "Cannot read QDMI device configuration",
+               [errorNumber](const std::string_view pathText) {
+                 const auto* const message = std::strerror(errorNumber);
+                 qdmi::diagnostics::error(
+                     "Cannot read QDMI device configuration '{}': {}", pathText,
+                     message == nullptr ? "unknown error" : message);
+               });
     return std::nullopt;
   }
   std::string json{std::istreambuf_iterator<char>(input),
                    std::istreambuf_iterator<char>()};
   if (!input.eof() && input.fail()) {
     status = bundled ? QDMI_ERROR_FATAL : QDMI_ERROR_PERMISSIONDENIED;
-    SPDLOG_ERROR("Failed while reading QDMI device configuration '{}'",
-                 path.string());
+    reportPath(path, "Failed while reading QDMI device configuration",
+               [](const std::string_view pathText) {
+                 qdmi::diagnostics::error(
+                     "Failed while reading QDMI device configuration '{}'",
+                     pathText);
+               });
     return std::nullopt;
   }
   status = QDMI_SUCCESS;
@@ -178,7 +215,8 @@ loadDeviceConfiguration(const std::optional<std::string>& inlineJson,
   const auto environmentJson = environment(inlineEnvironment);
   const auto environmentFile = environment(fileEnvironment);
   if (environmentJson && environmentFile) {
-    SPDLOG_ERROR("Both {} and {} are set", inlineEnvironment, fileEnvironment);
+    qdmi::diagnostics::error("Both {} and {} are set", inlineEnvironment,
+                             fileEnvironment);
     status = QDMI_ERROR_INVALIDARGUMENT;
     return std::nullopt;
   }
@@ -192,7 +230,7 @@ loadDeviceConfiguration(const std::optional<std::string>& inlineJson,
   }
   const auto directory = moduleDirectory(anchor);
   if (directory.empty()) {
-    SPDLOG_ERROR("Cannot locate the QDMI provider module");
+    qdmi::diagnostics::error("Cannot locate the QDMI provider module");
     status = QDMI_ERROR_FATAL;
     return std::nullopt;
   }

--- a/src/qdmi/devices/dd/CMakeLists.txt
+++ b/src/qdmi/devices/dd/CMakeLists.txt
@@ -39,7 +39,7 @@ if(NOT TARGET ${TARGET_NAME})
 
   # Add link libraries
   target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreDD MQT::CoreQASM MQT::CoreCircuitOptimizer
-                                               MQT::CoreQDMICommon spdlog::spdlog)
+                                               MQT::CoreQDMICommon)
 
   mqt_configure_qdmi_device(${TARGET_NAME} ID mqt.ddsim.default PREFIX ${QDMI_PREFIX})
   list(APPEND MQT_CORE_TARGETS ${TARGET_NAME})

--- a/src/qdmi/devices/sc/CMakeLists.txt
+++ b/src/qdmi/devices/sc/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT TARGET ${TARGET_NAME})
     ${TARGET_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS ${MQT_CORE_INCLUDE_BUILD_DIR} FILES
                           ${MQT_CORE_INCLUDE_BUILD_DIR}/qdmi/devices/sc/Configuration.hpp)
 
-  target_link_libraries(${TARGET_NAME} PUBLIC nlohmann_json::nlohmann_json)
+  target_link_libraries(${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 
   list(APPEND MQT_CORE_TARGETS ${TARGET_NAME})
 

--- a/src/qdmi/devices/sc/CMakeLists.txt
+++ b/src/qdmi/devices/sc/CMakeLists.txt
@@ -67,8 +67,7 @@ if(NOT TARGET ${TARGET_NAME})
            ${QDMI_HDRS})
 
   # add link libraries
-  target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreQDMICommon MQT::CoreQDMIScDeviceConfig
-                                               spdlog::spdlog)
+  target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreQDMICommon MQT::CoreQDMIScDeviceConfig)
 
   mqt_configure_qdmi_device(
     ${TARGET_NAME}

--- a/src/qdmi/devices/sc/Device.cpp
+++ b/src/qdmi/devices/sc/Device.cpp
@@ -19,9 +19,8 @@
 #include "mqt_sc_qdmi/types.h"
 #include "qdmi/common/Common.hpp"
 #include "qdmi/common/DeviceConfiguration.hpp"
+#include "qdmi/common/Diagnostics.hpp"
 #include "qdmi/devices/sc/Configuration.hpp"
-
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -34,6 +33,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -63,16 +63,17 @@ int MQT_SC_QDMI_Device_Session_impl_d::init() {
   if (status != Status::ALLOCATED) {
     return QDMI_ERROR_BADSTATE;
   }
-  int loadStatus = QDMI_SUCCESS;
-  const auto loaded = qdmi::detail::loadDeviceConfiguration(
-      inlineConfiguration, fileConfiguration, "MQT_CORE_QDMI_SC_CONFIG_JSON",
-      "MQT_CORE_QDMI_SC_CONFIG_FILE", "mqt-core-qdmi-sc-device.json",
-      reinterpret_cast<const void*>(&MQT_SC_QDMI_device_initialize),
-      loadStatus);
-  if (!loaded) {
-    return loadStatus;
-  }
+  std::optional<qdmi::detail::LoadedDeviceConfiguration> loaded;
   try {
+    int loadStatus = QDMI_SUCCESS;
+    loaded = qdmi::detail::loadDeviceConfiguration(
+        inlineConfiguration, fileConfiguration, "MQT_CORE_QDMI_SC_CONFIG_JSON",
+        "MQT_CORE_QDMI_SC_CONFIG_FILE", "mqt-core-qdmi-sc-device.json",
+        reinterpret_cast<const void*>(&MQT_SC_QDMI_device_initialize),
+        loadStatus);
+    if (!loaded) {
+      return loadStatus;
+    }
     const auto configuration = sc::readJSON(loaded->json, loaded->source);
 
     std::vector<std::unique_ptr<MQT_SC_QDMI_Site_impl_d>> newSiteStorage;
@@ -165,16 +166,25 @@ int MQT_SC_QDMI_Device_Session_impl_d::init() {
     status = Status::INITIALIZED;
     return QDMI_SUCCESS;
   } catch (const std::bad_alloc&) {
-    SPDLOG_ERROR("Out of memory while initializing SC device from {}",
-                 loaded->source);
+    const std::string_view source =
+        loaded ? std::string_view(loaded->source)
+               : std::string_view("selected configuration");
+    qdmi::diagnostics::error(
+        "Out of memory while initializing SC device from {}", source);
     return QDMI_ERROR_OUTOFMEM;
   } catch (const std::invalid_argument& error) {
-    SPDLOG_ERROR("Invalid SC device configuration from {}: {}", loaded->source,
-                 error.what());
+    const std::string_view source =
+        loaded ? std::string_view(loaded->source)
+               : std::string_view("selected configuration");
+    qdmi::diagnostics::error("Invalid SC device configuration from {}: {}",
+                             source, error.what());
     return QDMI_ERROR_INVALIDARGUMENT;
   } catch (const std::exception& error) {
-    SPDLOG_ERROR("Failed to initialize SC device from {}: {}", loaded->source,
-                 error.what());
+    const std::string_view source =
+        loaded ? std::string_view(loaded->source)
+               : std::string_view("selected configuration");
+    qdmi::diagnostics::error("Failed to initialize SC device from {}: {}",
+                             source, error.what());
     return QDMI_ERROR_FATAL;
   }
 }

--- a/src/qdmi/driver/CMakeLists.txt
+++ b/src/qdmi/driver/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT TARGET ${TARGET_NAME})
     ${TARGET_NAME}
     PUBLIC qdmi::qdmi MQT::CoreQDMICommon
     PRIVATE qdmi::qdmi_project_warnings $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>
-            spdlog::spdlog ${CMAKE_DL_LIBS})
+            ${CMAKE_DL_LIBS})
 
   mqt_get_qdmi_device_targets(QDMI_DEVICE_TARGETS)
 

--- a/src/qdmi/driver/CMakeLists.txt
+++ b/src/qdmi/driver/CMakeLists.txt
@@ -23,8 +23,8 @@ if(NOT TARGET ${TARGET_NAME})
   target_link_libraries(
     ${TARGET_NAME}
     PUBLIC qdmi::qdmi MQT::CoreQDMICommon
-    PRIVATE qdmi::qdmi_project_warnings nlohmann_json::nlohmann_json spdlog::spdlog
-            ${CMAKE_DL_LIBS})
+    PRIVATE qdmi::qdmi_project_warnings $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>
+            spdlog::spdlog ${CMAKE_DL_LIBS})
 
   mqt_get_qdmi_device_targets(QDMI_DEVICE_TARGETS)
 

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -12,10 +12,10 @@
 
 #include "DeviceRegistry.hpp"
 #include "qdmi/common/Common.hpp"
+#include "qdmi/common/Diagnostics.hpp"
 
 #include <qdmi/client.h>
 #include <qdmi/device.h>
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <cassert>
@@ -268,7 +268,7 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(
       }
 
       if (status == QDMI_ERROR_NOTSUPPORTED) {
-        SPDLOG_INFO(
+        qdmi::diagnostics::info(
             "Device session parameter {} not supported by device (skipped)",
             qdmi::toString(param));
         return;
@@ -838,17 +838,22 @@ void Driver::materializeClientCatalog() {
       try {
         clientDevices.emplace_back(open(id));
       } catch (const std::exception& ex) {
-        std::string library = "<unknown>";
-        {
+        std::string library;
+        try {
           const std::scoped_lock lock(stateMutex_);
           if (const auto definition =
                   std::ranges::find(definitions_, id, &DeviceDefinition::id);
               definition != definitions_.end()) {
             library = definition->library.string();
           }
+        } catch (...) {
+          library.clear();
         }
-        SPDLOG_WARN("Skipping configured QDMI device '{}' from '{}': {}", id,
-                    library, ex.what());
+        const std::string_view libraryText =
+            library.empty() ? "<unknown>" : std::string_view(library);
+        qdmi::diagnostics::warn(
+            "Skipping configured QDMI device '{}' from '{}': {}", id,
+            libraryText, ex.what());
       }
     }
     const std::scoped_lock lock(stateMutex_);

--- a/test/dd/CMakeLists.txt
+++ b/test/dd/CMakeLists.txt
@@ -9,5 +9,6 @@
 if(TARGET MQT::CoreDD)
   file(GLOB_RECURSE DD_TEST_SOURCES *.cpp)
   package_add_test(mqt-core-dd-test MQT::CoreDD ${DD_TEST_SOURCES})
-  target_link_libraries(mqt-core-dd-test PRIVATE MQT::CoreCircuitOptimizer MQT::CoreQASM)
+  target_link_libraries(mqt-core-dd-test PRIVATE MQT::CoreCircuitOptimizer MQT::CoreQASM
+                                                 nlohmann_json::nlohmann_json)
 endif()

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include <array>
 #include <cmath>
@@ -2488,7 +2489,7 @@ TEST(DDPackageTest, CTPerformanceRegressionTest) {
 TEST(DDPackageTest, DataStructureStatistics) {
   constexpr auto nqubits = 1U;
   const auto dd = std::make_unique<Package>(nqubits);
-  const auto stats = getDataStructureStatistics();
+  const auto stats = nlohmann::json::parse(getDataStructureStatisticsString());
 
   EXPECT_EQ(stats["vNode"]["size_B"], 64U);
   EXPECT_EQ(stats["vNode"]["alignment_B"], 8U);
@@ -2507,9 +2508,10 @@ TEST(DDPackageTest, DDStatistics) {
   const auto dd = std::make_unique<Package>(nqubits);
   const auto dummyGate = getDD(qc::StandardOperation(0U, qc::X), *dd);
   EXPECT_NE(dummyGate.p, nullptr);
-  const auto stats = getStatistics(*dd, true);
+  const auto statsString = getStatisticsString(*dd, true);
+  const auto stats = nlohmann::json::parse(statsString);
 
-  std::cout << stats.dump(2) << "\n";
+  std::cout << statsString << "\n";
   EXPECT_TRUE(stats.contains("vector"));
   ASSERT_TRUE(stats.contains("matrix"));
   EXPECT_TRUE(stats.contains("real_numbers"));

--- a/test/fomac/test_fomac.cpp
+++ b/test/fomac/test_fomac.cpp
@@ -1155,6 +1155,20 @@ TEST(AuthenticationTest, SessionConstructionWithToken) {
   EXPECT_NO_THROW({ const Session session(config3); });
 }
 
+TEST(AuthenticationTest, ReportsSkippedUnsupportedParameter) {
+  SessionConfig config;
+  config.token = "test-token";
+
+  testing::internal::CaptureStderr();
+  EXPECT_NO_THROW({ const Session session(config); });
+  const auto diagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_THAT(
+      diagnostic,
+      testing::AllOf(testing::HasSubstr("[mqt-core] [info]"),
+                     testing::HasSubstr(
+                         "Session parameter TOKEN not supported (skipped)")));
+}
+
 TEST(AuthenticationTest, SessionConstructionWithAuthUrl) {
   // Valid HTTPS URL
   SessionConfig config1;

--- a/test/qdmi/devices/sc/test_device.cpp
+++ b/test/qdmi/devices/sc/test_device.cpp
@@ -228,8 +228,16 @@ TEST(ScRuntimeConfiguration, ValidatesRawParameterStringsAndRetry) {
                 session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1,
                 malformed.size(), malformed.data()),
             QDMI_SUCCESS);
-  EXPECT_EQ(MQT_SC_QDMI_device_session_init(session),
-            QDMI_ERROR_INVALIDARGUMENT);
+  testing::internal::CaptureStderr();
+  const auto malformedStatus = MQT_SC_QDMI_device_session_init(session);
+  const auto malformedDiagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(malformedStatus, QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_THAT(
+      malformedDiagnostic,
+      testing::AllOf(testing::HasSubstr("[mqt-core] [error]"),
+                     testing::HasSubstr("Invalid SC device configuration from "
+                                        "inline session configuration"),
+                     testing::HasSubstr("invalid JSON")));
   ASSERT_EQ(MQT_SC_QDMI_device_session_set_parameter(
                 session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1,
                 std::strlen(CUSTOM_SC) + 1, CUSTOM_SC),
@@ -370,8 +378,16 @@ TEST(ScRuntimeConfiguration, SelectsEnvironmentAndExplicitFileSources) {
   MQT_SC_QDMI_Device_Session conflictingEnvironmentSession = nullptr;
   ASSERT_EQ(MQT_SC_QDMI_device_session_alloc(&conflictingEnvironmentSession),
             QDMI_SUCCESS);
-  EXPECT_EQ(MQT_SC_QDMI_device_session_init(conflictingEnvironmentSession),
-            QDMI_ERROR_INVALIDARGUMENT);
+  testing::internal::CaptureStderr();
+  const auto conflictingStatus =
+      MQT_SC_QDMI_device_session_init(conflictingEnvironmentSession);
+  const auto conflictingDiagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(conflictingStatus, QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_THAT(conflictingDiagnostic,
+              testing::AllOf(
+                  testing::HasSubstr("[mqt-core] [error]"),
+                  testing::HasSubstr("Both MQT_CORE_QDMI_SC_CONFIG_JSON and "
+                                     "MQT_CORE_QDMI_SC_CONFIG_FILE are set")));
   MQT_SC_QDMI_device_session_free(conflictingEnvironmentSession);
 }
 
@@ -384,7 +400,17 @@ TEST(ScRuntimeConfiguration, MapsMissingExplicitFileToNotFound) {
                 session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2, missing.size(),
                 missing.data()),
             QDMI_SUCCESS);
-  EXPECT_EQ(MQT_SC_QDMI_device_session_init(session), QDMI_ERROR_NOTFOUND);
+  testing::internal::CaptureStderr();
+  const auto status = MQT_SC_QDMI_device_session_init(session);
+  const auto diagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(status, QDMI_ERROR_NOTFOUND);
+  EXPECT_THAT(
+      diagnostic,
+      testing::AllOf(
+          testing::HasSubstr("[mqt-core] [error]"),
+          testing::HasSubstr("QDMI device configuration "
+                             "'missing-sc-device-configuration.json' does not "
+                             "exist")));
   MQT_SC_QDMI_device_session_free(session);
 }
 

--- a/test/qdmi/driver/CMakeLists.txt
+++ b/test/qdmi/driver/CMakeLists.txt
@@ -40,6 +40,21 @@ if(TARGET MQT::CoreQDMIDriver)
 
   package_add_test(${TARGET_NAME} MQT::CoreQDMIDriver test_driver.cpp)
   target_link_libraries(${TARGET_NAME} PRIVATE MQT::CoreFoMaC)
+
+  set(DIAGNOSTIC_TARGET_NAME mqt-core-qdmi-driver-diagnostic-test)
+  set(diagnostic_config_file
+      "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/diagnostic-configured-device.json")
+  file(
+    GENERATE
+    OUTPUT "${diagnostic_config_file}"
+    CONTENT
+      "{\n  \"schema-version\": 1,\n  \"qdmi\": {\n    \"devices\": [\n      {\"id\": \"broken.diagnostic\", \"library\": \"${CMAKE_CURRENT_BINARY_DIR}/missing-diagnostic-device-library\", \"prefix\": \"BROKEN\"}\n    ]\n  }\n}\n"
+  )
+  package_add_test(${DIAGNOSTIC_TARGET_NAME} MQT::CoreQDMIDriver test_driver_diagnostics.cpp)
+  target_compile_definitions(
+    ${DIAGNOSTIC_TARGET_NAME}
+    PRIVATE "MQT_CORE_QDMI_DIAGNOSTIC_CONFIG_FILE=\"${diagnostic_config_file}\"")
+
   set(config_file "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/configured-devices.json")
   file(
     GENERATE

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -1537,6 +1537,23 @@ TEST(DeviceSessionConfigTest, OpenWithBaseUrl) {
   }
 }
 
+TEST(DeviceSessionConfigTest, ReportsSkippedUnsupportedParameter) {
+  const auto [library, prefix] = TEST_DEVICE_LIBRARIES.front();
+  qdmi::DeviceSessionConfig config;
+  config.baseUrl = "http://localhost:8080";
+
+  testing::internal::CaptureStderr();
+  EXPECT_NO_THROW(
+      { static_cast<void>(openTestDevice(library, prefix, config)); });
+  const auto diagnostic = testing::internal::GetCapturedStderr();
+  EXPECT_THAT(
+      diagnostic,
+      testing::AllOf(
+          testing::HasSubstr("[mqt-core] [info]"),
+          testing::HasSubstr("Device session parameter BASE URL not supported "
+                             "by device (skipped)")));
+}
+
 TEST(DeviceSessionConfigTest, OpenWithCustomParameters) {
   qdmi::DeviceSessionConfig config;
   config.custom3 = "RESONANCE_COCOS_V1";

--- a/test/qdmi/driver/test_driver_diagnostics.cpp
+++ b/test/qdmi/driver/test_driver_diagnostics.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <qdmi/client.h>
+
+#include <cstdlib>
+
+namespace {
+
+TEST(DriverDiagnosticTest, ReportsSkippedConfiguredDevice) {
+#ifdef _WIN32
+  ASSERT_EQ(_putenv_s("MQT_CORE_QDMI_CONFIG_FILE",
+                      MQT_CORE_QDMI_DIAGNOSTIC_CONFIG_FILE),
+            0);
+#else
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  ASSERT_EQ(setenv("MQT_CORE_QDMI_CONFIG_FILE",
+                   MQT_CORE_QDMI_DIAGNOSTIC_CONFIG_FILE, 1),
+            0);
+#endif
+
+  testing::internal::CaptureStderr();
+  QDMI_Session session = nullptr;
+  const auto status = QDMI_session_alloc(&session);
+  const auto diagnostic = testing::internal::GetCapturedStderr();
+
+  ASSERT_EQ(status, QDMI_SUCCESS);
+  EXPECT_THAT(
+      diagnostic,
+      testing::AllOf(testing::HasSubstr("[mqt-core] [warning]"),
+                     testing::HasSubstr("Skipping configured QDMI device "
+                                        "'broken.diagnostic'"),
+                     testing::HasSubstr("missing-diagnostic-device-library")));
+  QDMI_session_free(session);
+}
+
+} // namespace


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Backports the following dependency cleanups to v3.x:

- https://github.com/munich-quantum-toolkit/core/pull/2138
- https://github.com/munich-quantum-toolkit/core/pull/2270

`nlohmann_json` becomes an implementation-only dependency, and `spdlog` is removed in favor of standard-library formatting and QDMI diagnostics.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
