### PR TITLE
💥 Prune CoreIR APIs and remove RNG state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ releases may include breaking changes.
   neutral-atom QDMI device and its configuration, the `mqt.core.na` Python
   module, `AodOperation`, and the `Move`, `Bridge`, `AodActivate`,
   `AodDeactivate`, and `AodMove` operation kinds ([#2137]) ([**@denialhaag**])
+- 💥 Remove the random-number generator, seed, and `getGenerator()` method from
+  `QuantumComputation`; randomized algorithms now own generators initialized
+  from their seed arguments ([#2111]) ([**@simon1hofmann**])
 - 💥 Remove the ZX-calculus library, including the `mqt-core-zx` target,
   `MQT::CoreZX` alias, `zx` headers and namespace, and its Boost.Multiprecision
   and GMP build support. Equivalence-checking users should use [MQT QCEC]; its
@@ -802,6 +805,7 @@ for previous changelogs._
 [#2116]: https://github.com/munich-quantum-toolkit/core/pull/2116
 [#2114]: https://github.com/munich-quantum-toolkit/core/pull/2114
 [#2112]: https://github.com/munich-quantum-toolkit/core/pull/2112
+[#2111]: https://github.com/munich-quantum-toolkit/core/pull/2111
 [#2106]: https://github.com/munich-quantum-toolkit/core/pull/2106
 [#2108]: https://github.com/munich-quantum-toolkit/core/pull/2108
 [#2084]: https://github.com/munich-quantum-toolkit/core/pull/2084

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ releases may include breaking changes.
   ([**@burgholzer**])
 - 🐛 Protect process-wide DD, IR, and QDMI state for free-threaded Python
   ([#2209]) ([**@burgholzer**])
+- 💥 Prune dead and misleading CoreIR APIs, including renaming the non-garbage
+  logical output count to `getNoutputQubits()` and `num_output_qubits` ([#2112])
+  ([**@simon1hofmann**])
 
 ### Removed
 
@@ -798,6 +801,7 @@ for previous changelogs._
 [#2124]: https://github.com/munich-quantum-toolkit/core/pull/2124
 [#2116]: https://github.com/munich-quantum-toolkit/core/pull/2116
 [#2114]: https://github.com/munich-quantum-toolkit/core/pull/2114
+[#2112]: https://github.com/munich-quantum-toolkit/core/pull/2112
 [#2106]: https://github.com/munich-quantum-toolkit/core/pull/2106
 [#2108]: https://github.com/munich-quantum-toolkit/core/pull/2108
 [#2084]: https://github.com/munich-quantum-toolkit/core/pull/2084

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -127,6 +127,14 @@ The CoreIR API cleanup requires the following migrations:
 The register lookup helpers `getQubitRegister()`, `getPhysicalQubitIndex()`, and
 `physicalQubitIsAncillary()` are now private implementation details.
 
+### QuantumComputation random-number generator
+
+`QuantumComputation` no longer stores a random-number generator or seed. Remove
+the third `seed` argument from C++ and Python constructor calls. C++ callers
+that used `QuantumComputation::getGenerator()` must create and own a
+random-number generator instead. Randomized circuit generators continue to
+accept a seed and now own a separate generator for each call.
+
 ### Removal of the `datastructures` (sub)library
 
 MQT Core no longer provides the `datastructures` (`ds`) sublibrary. [MQT QMAP]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -110,6 +110,23 @@ algorithm had no production owner in the MQT ecosystem. Remove uses of the
 `dd/Approximation.hpp` header, the `dd::ApproximationMetadata` type, and the
 `dd::approximate` function. MQT Core does not provide a replacement.
 
+### CoreIR API cleanup
+
+The CoreIR API cleanup requires the following migrations:
+
+- Replace `getNmeasuredQubits()` and `num_measured_qubits` with
+  `getNoutputQubits()` and `num_output_qubits`, respectively.
+- Replace permutation-aware `Operation::equals()` and `getUsedQubitsPermuted()`
+  calls by applying the permutation to cloned operations before comparing them.
+- Replace `getHighestLogicalQubitIndex()`, `printStatistics()`, and
+  `printPermutation()` with `initialLayout.maxValue()`, the individual count
+  accessors, and direct `Permutation` iteration, respectively.
+- Construct output-permutation measurements explicitly instead of calling
+  `appendMeasurementsAccordingToOutputPermutation()`.
+
+The register lookup helpers `getQubitRegister()`, `getPhysicalQubitIndex()`, and
+`physicalQubitIsAncillary()` are now private implementation details.
+
 ### Removal of the `datastructures` (sub)library
 
 MQT Core no longer provides the `datastructures` (`ds`) sublibrary. [MQT QMAP]

--- a/bindings/ir/register_quantum_computation.cpp
+++ b/bindings/ir/register_quantum_computation.cpp
@@ -121,10 +121,10 @@ Note:
     Garbage qubits are qubits whose final state is not relevant for the computation.)pb");
 
   qc.def_prop_ro(
-      "num_measured_qubits", &qc::QuantumComputation::getNmeasuredQubits,
-      R"pb(The number of qubits that are measured in the quantum computation.
+      "num_output_qubits", &qc::QuantumComputation::getNoutputQubits,
+      R"pb(The number of logical output qubits in the quantum computation.
 
-Computed as :math:`| \text{qubits} | - | \text{garbage} |`.)pb");
+Output qubits are the qubits that are not marked as garbage.)pb");
 
   qc.def_prop_ro("num_data_qubits",
                  &qc::QuantumComputation::getNqubitsWithoutAncillae,

--- a/bindings/ir/register_quantum_computation.cpp
+++ b/bindings/ir/register_quantum_computation.cpp
@@ -68,14 +68,12 @@ Acts as mutable sequence of :class:`~mqt.core.ir.operations.Operation` objects, 
 
 Args:
     nq: The number of qubits in the quantum computation.
-    nc: The number of classical bits in the quantum computation.
-    seed: The seed to use for the internal random number generator.)pb");
+    nc: The number of classical bits in the quantum computation.)pb");
 
   ///---------------------------------------------------------------------------
   ///                           \n Constructors \n
   ///---------------------------------------------------------------------------
-  qc.def(nb::init<std::size_t, std::size_t, std::size_t>(), "nq"_a = 0U,
-         "nc"_a = 0U, "seed"_a = 0U);
+  qc.def(nb::init<std::size_t, std::size_t>(), "nq"_a = 0U, "nc"_a = 0U);
 
   // expose the static constructor from qasm strings or files
   qc.def_static("from_qasm_str", &qasm3::Importer::imports, "qasm"_a,

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -23,9 +23,9 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <random>
 #include <string>
 #include <unordered_map>
@@ -134,7 +134,8 @@ public:
     return occurringVariables;
   }
 
-  [[nodiscard]] std::size_t getNmeasuredQubits() const noexcept;
+  /// Returns the number of logical output qubits that are not marked garbage.
+  [[nodiscard]] std::size_t getNoutputQubits() const noexcept;
   [[nodiscard]] std::size_t getNgarbageQubits() const;
 
   void setName(const std::string& n) noexcept { name = n; }
@@ -143,23 +144,9 @@ public:
   [[nodiscard]] std::size_t getNsingleQubitOps() const;
   [[nodiscard]] std::size_t getDepth() const;
 
-  [[nodiscard]] QuantumRegister& getQubitRegister(Qubit physicalQubitIndex);
-  /// Returns the highest qubit index used as a value in the initial layout
-  [[nodiscard]] Qubit getHighestLogicalQubitIndex() const;
   /// Returns the highest qubit index used as a key in the initial layout
   [[nodiscard]] Qubit getHighestPhysicalQubitIndex() const;
-  /**
-   * @brief Returns the physical qubit index of the given logical qubit index
-   * @details Iterates over the initial layout dictionary and returns the key
-   * corresponding to the given value.
-   * @param logicalQubitIndex The logical qubit index to look for
-   * @return The physical qubit index of the given logical qubit index
-   */
-  [[nodiscard]] Qubit getPhysicalQubitIndex(Qubit logicalQubitIndex) const;
   [[nodiscard]] bool isIdleQubit(Qubit physicalQubit) const;
-  [[nodiscard]] bool isLastOperationOnQubit(const const_iterator& opIt,
-                                            const const_iterator& end) const;
-  [[nodiscard]] bool physicalQubitIsAncillary(Qubit physicalQubitIndex) const;
   [[nodiscard]] bool
   logicalQubitIsAncillary(const Qubit logicalQubitIndex) const {
     return ancillary[logicalQubitIndex];
@@ -387,10 +374,6 @@ public:
    * non-empty output permutation.
    */
   void initializeIOMapping();
-  // append measurements to the end of the circuit according to the tracked
-  // output permutation
-  void appendMeasurementsAccordingToOutputPermutation(
-      const std::string& registerName = "c");
 
   // this function augments a given circuit by additional registers
   const QuantumRegister& addQubitRegister(std::size_t nq,
@@ -459,11 +442,6 @@ public:
     return qc.print(os);
   }
 
-  std::ostream& printStatistics(std::ostream& os) const;
-
-  static std::ostream& printPermutation(const Permutation& permutation,
-                                        std::ostream& os = std::cout);
-
   void dump(const std::string& filename,
             Format format = Format::OpenQASM3) const;
 
@@ -527,10 +505,13 @@ protected:
     }
     return garbage.size();
   }
-  [[nodiscard]] bool isLastOperationOnQubit(const const_iterator& opIt) const {
-    const auto end = ops.cend();
-    return isLastOperationOnQubit(opIt, end);
-  }
+
+private:
+  [[nodiscard]] QuantumRegister& getQubitRegister(Qubit physicalQubitIndex);
+  [[nodiscard]] Qubit getPhysicalQubitIndex(Qubit logicalQubitIndex) const;
+  [[nodiscard]] bool physicalQubitIsAncillary(Qubit physicalQubitIndex) const;
+
+protected:
   void checkQubitRange(Qubit qubit) const;
   void checkQubitRange(Qubit qubit, const Controls& controls) const;
   void checkQubitRange(Qubit qubit0, Qubit qubit1,

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -26,7 +26,6 @@
 #include <memory>
 #include <optional>
 #include <ostream>
-#include <random>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -61,16 +60,12 @@ protected:
   std::vector<bool> ancillary;
   std::vector<bool> garbage;
 
-  std::mt19937_64 mt;
-  std::size_t seed = 0;
-
   fp globalPhase = 0.;
 
   std::unordered_set<sym::Variable> occurringVariables;
 
 public:
-  explicit QuantumComputation(std::size_t nq = 0, std::size_t nc = 0U,
-                              std::size_t s = 0);
+  explicit QuantumComputation(std::size_t nq = 0, std::size_t nc = 0U);
   QuantumComputation(QuantumComputation&& qc) noexcept = default;
   QuantumComputation& operator=(QuantumComputation&& qc) noexcept = default;
   QuantumComputation(const QuantumComputation& qc);
@@ -122,8 +117,6 @@ public:
   [[nodiscard]] const auto& getAncillaRegisters() const noexcept {
     return ancillaRegisters;
   }
-  [[nodiscard]] decltype(mt)& getGenerator() noexcept { return mt; }
-
   [[nodiscard]] fp getGlobalPhase() const noexcept { return globalPhase; }
   [[nodiscard]] bool hasGlobalPhase() const noexcept {
     return std::abs(getGlobalPhase()) > 0;

--- a/include/mqt-core/ir/operations/CompoundOperation.hpp
+++ b/include/mqt-core/ir/operations/CompoundOperation.hpp
@@ -70,8 +70,6 @@ public:
 
   Controls::iterator removeControl(Controls::iterator it) override;
 
-  [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
-                            const Permutation& perm2) const override;
   [[nodiscard]] bool equals(const Operation& operation) const override;
 
   std::ostream& print(std::ostream& os, const Permutation& permutation,
@@ -94,8 +92,7 @@ public:
     return ops;
   }
 
-  [[nodiscard]] auto getUsedQubitsPermuted(const Permutation& perm) const
-      -> std::set<Qubit> override;
+  [[nodiscard]] auto getUsedQubits() const -> std::set<Qubit> override;
 
   [[nodiscard]] auto commutesAtQubit(const Operation& other,
                                      const Qubit& qubit) const -> bool override;

--- a/include/mqt-core/ir/operations/IfElseOperation.hpp
+++ b/include/mqt-core/ir/operations/IfElseOperation.hpp
@@ -90,11 +90,7 @@ public:
     return comparisonKind_;
   }
 
-  [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
-                            const Permutation& perm2) const override;
-  [[nodiscard]] bool equals(const Operation& op) const override {
-    return equals(op, {}, {});
-  }
+  [[nodiscard]] bool equals(const Operation& op) const override;
 
   virtual std::ostream& print(std::ostream& os, const Permutation& permutation,
                               std::size_t prefixWidth,

--- a/include/mqt-core/ir/operations/NonUnitaryOperation.hpp
+++ b/include/mqt-core/ir/operations/NonUnitaryOperation.hpp
@@ -70,11 +70,7 @@ public:
         "Cannot remove controls from non-unitary operation.");
   }
 
-  [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
-                            const Permutation& perm2) const override;
-  [[nodiscard]] bool equals(const Operation& operation) const override {
-    return equals(operation, {}, {});
-  }
+  [[nodiscard]] bool equals(const Operation& operation) const override;
 
   std::ostream& print(std::ostream& os, const Permutation& permutation,
                       std::size_t prefixWidth,

--- a/include/mqt-core/ir/operations/Operation.hpp
+++ b/include/mqt-core/ir/operations/Operation.hpp
@@ -80,10 +80,7 @@ public:
   [[nodiscard]] const std::string& getName() const { return name; }
   [[nodiscard]] virtual OpType getType() const { return type; }
 
-  [[nodiscard]] virtual auto
-  getUsedQubitsPermuted(const Permutation& perm) const -> std::set<Qubit>;
-
-  [[nodiscard]] auto getUsedQubits() const -> std::set<Qubit>;
+  [[nodiscard]] virtual auto getUsedQubits() const -> std::set<Qubit>;
 
   [[nodiscard]] std::unique_ptr<Operation> getInverted() const {
     auto op = clone();
@@ -181,12 +178,7 @@ public:
 
   virtual void addDepthContribution(std::vector<std::size_t>& depths) const;
 
-  [[nodiscard]] virtual bool equals(const Operation& op,
-                                    const Permutation& perm1,
-                                    const Permutation& perm2) const;
-  [[nodiscard]] virtual bool equals(const Operation& op) const {
-    return equals(op, {}, {});
-  }
+  [[nodiscard]] virtual bool equals(const Operation& op) const;
 
   virtual std::ostream& printParameters(std::ostream& os) const;
   std::ostream& print(std::ostream& os, const std::size_t nqubits) const {

--- a/include/mqt-core/ir/operations/StandardOperation.hpp
+++ b/include/mqt-core/ir/operations/StandardOperation.hpp
@@ -108,14 +108,6 @@ public:
     return controls.erase(it);
   }
 
-  [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
-                            const Permutation& perm2) const override {
-    return Operation::equals(op, perm1, perm2);
-  }
-  [[nodiscard]] bool equals(const Operation& operation) const override {
-    return equals(operation, {}, {});
-  }
-
   void dumpOpenQASM(std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
                     const BitIndexToRegisterMap& bitMap, size_t indent,
                     bool openQASM3) const override;

--- a/include/mqt-core/ir/operations/SymbolicOperation.hpp
+++ b/include/mqt-core/ir/operations/SymbolicOperation.hpp
@@ -67,11 +67,7 @@ public:
 
   [[nodiscard]] bool isStandardOperation() const override;
 
-  [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
-                            const Permutation& perm2) const override;
-  [[nodiscard]] bool equals(const Operation& op) const override {
-    return equals(op, {}, {});
-  }
+  [[nodiscard]] bool equals(const Operation& op) const override;
 
   [[noreturn]] void dumpOpenQASM(std::ostream& of,
                                  const QubitIndexToRegisterMap& qubitMap,

--- a/python/mqt/core/ir/__init__.pyi
+++ b/python/mqt/core/ir/__init__.pyi
@@ -149,10 +149,10 @@ class QuantumComputation(MutableSequence[operations.Operation]):
         """
 
     @property
-    def num_measured_qubits(self) -> int:
-        """The number of qubits that are measured in the quantum computation.
+    def num_output_qubits(self) -> int:
+        """The number of logical output qubits in the quantum computation.
 
-        Computed as :math:`| \\text{qubits} | - | \\text{garbage} |`.
+        Output qubits are the qubits that are not marked as garbage.
         """
 
     @property

--- a/python/mqt/core/ir/__init__.pyi
+++ b/python/mqt/core/ir/__init__.pyi
@@ -96,10 +96,9 @@ class QuantumComputation(MutableSequence[operations.Operation]):
     Args:
         nq: The number of qubits in the quantum computation.
         nc: The number of classical bits in the quantum computation.
-        seed: The seed to use for the internal random number generator.
     """
 
-    def __init__(self, nq: int = 0, nc: int = 0, seed: int = 0) -> None: ...
+    def __init__(self, nq: int = 0, nc: int = 0) -> None: ...
     @staticmethod
     def from_qasm_str(qasm: str) -> QuantumComputation:
         """Create a QuantumComputation object from an OpenQASM string.

--- a/src/algorithms/BernsteinVazirani.cpp
+++ b/src/algorithms/BernsteinVazirani.cpp
@@ -105,8 +105,9 @@ auto createBernsteinVazirani(const BVBitString& hiddenString)
 
 auto createBernsteinVazirani(const Qubit nq, const std::size_t seed)
     -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto hiddenString = generateBitstring(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto hiddenString = generateBitstring(nq, generator);
+  auto qc = QuantumComputation();
   constructBernsteinVaziraniCircuit(qc, hiddenString, nq);
   return qc;
 }
@@ -169,8 +170,9 @@ auto createIterativeBernsteinVazirani(const BVBitString& hiddenString)
 
 auto createIterativeBernsteinVazirani(const Qubit nq, const std::size_t seed)
     -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto hiddenString = generateBitstring(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto hiddenString = generateBitstring(nq, generator);
+  auto qc = QuantumComputation();
   constructIterativeBernsteinVaziraniCircuit(qc, hiddenString, nq);
   return qc;
 }

--- a/src/algorithms/Grover.cpp
+++ b/src/algorithms/Grover.cpp
@@ -128,8 +128,9 @@ auto constructGroverCircuit(QuantumComputation& qc, const Qubit nq,
 
 auto createGrover(const Qubit nq, const std::size_t seed)
     -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto targetValue = generateTargetValue(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto targetValue = generateTargetValue(nq, generator);
+  auto qc = QuantumComputation();
   constructGroverCircuit(qc, nq, targetValue);
   return qc;
 }

--- a/src/algorithms/QPE.cpp
+++ b/src/algorithms/QPE.cpp
@@ -129,9 +129,10 @@ auto constructQPECircuit(QuantumComputation& qc, const fp lambda,
 
 auto createQPE(const Qubit nq, const bool exact, const std::size_t seed)
     -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto lambda = exact ? createExactPhase(nq, qc.getGenerator())
-                            : createInexactPhase(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto lambda = exact ? createExactPhase(nq, generator)
+                            : createInexactPhase(nq, generator);
+  auto qc = QuantumComputation();
   constructQPECircuit(qc, lambda, nq);
   return qc;
 }
@@ -194,9 +195,10 @@ auto constructIterativeQPECircuit(QuantumComputation& qc, const fp lambda,
 
 auto createIterativeQPE(const Qubit nq, const bool exact,
                         const std::size_t seed) -> QuantumComputation {
-  auto qc = QuantumComputation(0, 0, seed);
-  const auto lambda = exact ? createExactPhase(nq, qc.getGenerator())
-                            : createInexactPhase(nq, qc.getGenerator());
+  auto generator = std::mt19937_64(seed);
+  const auto lambda = exact ? createExactPhase(nq, generator)
+                            : createInexactPhase(nq, generator);
+  auto qc = QuantumComputation();
   constructIterativeQPECircuit(qc, lambda, nq);
   return qc;
 }

--- a/src/algorithms/RandomCliffordCircuit.cpp
+++ b/src/algorithms/RandomCliffordCircuit.cpp
@@ -206,12 +206,13 @@ auto append2QClifford(QuantumComputation& circ, const std::uint16_t idx,
 
 auto createRandomCliffordCircuit(const Qubit nq, const std::size_t depth,
                                  const std::size_t seed) -> QuantumComputation {
-  auto qc = QuantumComputation(nq, nq, seed);
+  auto qc = QuantumComputation(nq, nq);
   qc.setName("random_clifford_" + std::to_string(nq) + "_" +
              std::to_string(depth) + "_" + std::to_string(seed));
 
   std::uniform_int_distribution<std::uint16_t> distribution(0, 11520);
-  auto cliffordGenerator = [&]() { return distribution(qc.getGenerator()); };
+  auto generator = std::mt19937_64(seed);
+  auto cliffordGenerator = [&]() { return distribution(generator); };
 
   for (std::size_t l = 0; l < depth; ++l) {
     if (nq == 1) {

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -642,15 +642,6 @@ std::ostream& QuantumComputation::print(std::ostream& os) const {
   return os;
 }
 
-std::ostream& QuantumComputation::printStatistics(std::ostream& os) const {
-  os << "QC Statistics:";
-  os << "\n\tn: " << static_cast<std::size_t>(nqubits);
-  os << "\n\tanc: " << static_cast<std::size_t>(nancillae);
-  os << "\n\tm: " << ops.size();
-  os << "\n--------------\n";
-  return os;
-}
-
 void QuantumComputation::dumpOpenQASM(std::ostream& of, bool openQASM3) const {
   // dump initial layout and output permutation
 
@@ -843,19 +834,6 @@ Qubit QuantumComputation::getPhysicalQubitIndex(
                            " not found in initial layout");
 }
 
-std::ostream&
-QuantumComputation::printPermutation(const Permutation& permutation,
-                                     std::ostream& os) {
-  for (const auto& [physical, logical] : permutation) {
-    os << "\t" << physical << ": " << logical << "\n";
-  }
-  return os;
-}
-
-Qubit QuantumComputation::getHighestLogicalQubitIndex() const {
-  return initialLayout.maxValue();
-}
-
 Qubit QuantumComputation::getHighestPhysicalQubitIndex() const {
   return initialLayout.maxKey();
 }
@@ -919,35 +897,6 @@ QuantumComputation::containsLogicalQubit(const Qubit logicalQubitIndex) const {
   return {false, std::nullopt};
 }
 
-bool QuantumComputation::isLastOperationOnQubit(
-    const const_iterator& opIt, const const_iterator& end) const {
-  if (opIt == end) {
-    return true;
-  }
-
-  // determine which qubits the gate acts on
-  std::vector<bool> actson(nqubits + nancillae);
-  for (std::size_t i = 0; i < actson.size(); ++i) {
-    if ((*opIt)->actsOn(static_cast<Qubit>(i))) {
-      actson[i] = true;
-    }
-  }
-
-  // iterate over remaining gates and check if any act on qubits overlapping
-  // with the target gate
-  auto atEnd = opIt;
-  std::advance(atEnd, 1);
-  while (atEnd != end) {
-    for (std::size_t i = 0; i < actson.size(); ++i) {
-      if (actson[i] && (*atEnd)->actsOn(static_cast<Qubit>(i))) {
-        return false;
-      }
-    }
-    ++atEnd;
-  }
-  return true;
-}
-
 const QuantumRegister&
 QuantumComputation::unifyQuantumRegisters(const std::string& regName) {
   ancillaRegisters.clear();
@@ -956,27 +905,6 @@ QuantumComputation::unifyQuantumRegisters(const std::string& regName) {
   nancillae = 0;
   quantumRegisters.try_emplace(regName, 0, nqubits, regName);
   return quantumRegisters.at(regName);
-}
-
-void QuantumComputation::appendMeasurementsAccordingToOutputPermutation(
-    const std::string& registerName) {
-  // ensure that the circuit contains enough classical registers
-  if (classicalRegisters.empty()) {
-    // in case there are no registers, create a new one
-    addClassicalRegister(outputPermutation.size(), registerName);
-  } else if (nclassics < outputPermutation.size()) {
-    if (classicalRegisters.contains(registerName)) {
-      throw std::runtime_error(
-          "[appendMeasurementsAccordingToOutputPermutation] Register " +
-          registerName + " already exists but is too small");
-    }
-    addClassicalRegister(outputPermutation.size() - nclassics, registerName);
-  }
-  barrier();
-  // append measurements according to output permutation
-  for (const auto& [qubit, clbit] : outputPermutation) {
-    measure(qubit, clbit);
-  }
 }
 
 void QuantumComputation::checkQubitRange(const Qubit qubit) const {
@@ -1313,7 +1241,7 @@ QuantumComputation::fromCompoundOperation(const CompoundOperation& op) {
   return qc;
 }
 
-std::size_t QuantumComputation::getNmeasuredQubits() const noexcept {
+std::size_t QuantumComputation::getNoutputQubits() const noexcept {
   return getNqubits() - getNgarbageQubits();
 }
 std::size_t QuantumComputation::getNgarbageQubits() const {

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -22,7 +22,6 @@
 #include "ir/operations/SymbolicOperation.hpp"
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
@@ -37,7 +36,6 @@
 #include <numeric>
 #include <optional>
 #include <ostream>
-#include <random>
 #include <ranges>
 #include <set>
 #include <sstream>
@@ -589,7 +587,7 @@ bool QuantumComputation::operator==(const QuantumComputation& rhs) const {
       initialLayout != rhs.initialLayout ||
       outputPermutation != rhs.outputPermutation ||
       ancillary != rhs.ancillary || garbage != rhs.garbage ||
-      seed != rhs.seed || globalPhase != rhs.globalPhase ||
+      globalPhase != rhs.globalPhase ||
       occurringVariables != rhs.occurringVariables) {
     return false;
   }
@@ -970,25 +968,12 @@ void QuantumComputation::checkClassicalRegister(
 void QuantumComputation::reverse() { std::ranges::reverse(ops); }
 
 QuantumComputation::QuantumComputation(const std::size_t nq,
-                                       const std::size_t nc,
-                                       const std::size_t s)
-    : seed(s) {
+                                       const std::size_t nc) {
   if (nq > 0) {
     addQubitRegister(nq);
   }
   if (nc > 0) {
     addClassicalRegister(nc);
-  }
-  if (seed != 0) {
-    mt.seed(seed);
-  } else {
-    // create and properly seed rng
-    std::array<std::mt19937_64::result_type, std::mt19937_64::state_size>
-        randomData{};
-    std::random_device rd;
-    std::ranges::generate(randomData, [&rd]() { return rd(); });
-    std::seed_seq seeds(std::begin(randomData), std::end(randomData));
-    mt.seed(seeds);
   }
 }
 
@@ -997,8 +982,8 @@ QuantumComputation::QuantumComputation(const QuantumComputation& qc)
       name(qc.name), quantumRegisters(qc.quantumRegisters),
       classicalRegisters(qc.classicalRegisters),
       ancillaRegisters(qc.ancillaRegisters), ancillary(qc.ancillary),
-      garbage(qc.garbage), mt(qc.mt), seed(qc.seed),
-      globalPhase(qc.globalPhase), occurringVariables(qc.occurringVariables),
+      garbage(qc.garbage), globalPhase(qc.globalPhase),
+      occurringVariables(qc.occurringVariables),
       initialLayout(qc.initialLayout), outputPermutation(qc.outputPermutation) {
   ops.reserve(qc.ops.size());
   for (const auto& op : qc.ops) {
@@ -1015,8 +1000,6 @@ QuantumComputation::operator=(const QuantumComputation& qc) {
     quantumRegisters = qc.quantumRegisters;
     classicalRegisters = qc.classicalRegisters;
     ancillaRegisters = qc.ancillaRegisters;
-    mt = qc.mt;
-    seed = qc.seed;
     globalPhase = qc.globalPhase;
     occurringVariables = qc.occurringVariables;
     initialLayout = qc.initialLayout;

--- a/src/ir/operations/CompoundOperation.cpp
+++ b/src/ir/operations/CompoundOperation.cpp
@@ -138,16 +138,15 @@ CompoundOperation::removeControl(const Controls::iterator it) {
 
   return controls.erase(it);
 }
-bool CompoundOperation::equals(const Operation& op, const Permutation& perm1,
-                               const Permutation& perm2) const {
-  if (const auto* comp = dynamic_cast<const CompoundOperation*>(&op)) {
+bool CompoundOperation::equals(const Operation& operation) const {
+  if (const auto* comp = dynamic_cast<const CompoundOperation*>(&operation)) {
     if (comp->ops.size() != ops.size()) {
       return false;
     }
 
     auto it = comp->ops.cbegin();
-    for (const auto& operation : ops) {
-      if (!operation->equals(**it, perm1, perm2)) {
+    for (const auto& op : ops) {
+      if (!op->equals(**it)) {
         return false;
       }
       ++it;
@@ -155,10 +154,6 @@ bool CompoundOperation::equals(const Operation& op, const Permutation& perm1,
     return true;
   }
   return false;
-}
-
-bool CompoundOperation::equals(const Operation& operation) const {
-  return equals(operation, {}, {});
 }
 
 std::ostream& CompoundOperation::print(std::ostream& os,
@@ -198,11 +193,10 @@ void CompoundOperation::dumpOpenQASM(std::ostream& of,
   }
 }
 
-auto CompoundOperation::getUsedQubitsPermuted(const Permutation& perm) const
-    -> std::set<Qubit> {
+auto CompoundOperation::getUsedQubits() const -> std::set<Qubit> {
   std::set<Qubit> usedQubits{};
   for (const auto& op : ops) {
-    usedQubits.merge(op->getUsedQubitsPermuted(perm));
+    usedQubits.merge(op->getUsedQubits());
   }
   return usedQubits;
 }

--- a/src/ir/operations/IfElseOperation.cpp
+++ b/src/ir/operations/IfElseOperation.cpp
@@ -126,9 +126,7 @@ void IfElseOperation::apply(const Permutation& permutation) {
   }
 }
 
-bool IfElseOperation::equals(const Operation& operation,
-                             const Permutation& perm1,
-                             const Permutation& perm2) const {
+bool IfElseOperation::equals(const Operation& operation) const {
   if (const auto* other = dynamic_cast<const IfElseOperation*>(&operation)) {
     if (controlRegister_ != other->controlRegister_) {
       return false;
@@ -146,14 +144,14 @@ bool IfElseOperation::equals(const Operation& operation,
       return false;
     }
     if (thenOp_ && other->thenOp_) {
-      if (!thenOp_->equals(*other->thenOp_, perm1, perm2)) {
+      if (!thenOp_->equals(*other->thenOp_)) {
         return false;
       }
     } else if (thenOp_ || other->thenOp_) {
       return false;
     }
     if (elseOp_ && other->elseOp_) {
-      if (!elseOp_->equals(*other->elseOp_, perm1, perm2)) {
+      if (!elseOp_->equals(*other->elseOp_)) {
         return false;
       }
     } else if (elseOp_ || other->elseOp_) {

--- a/src/ir/operations/NonUnitaryOperation.cpp
+++ b/src/ir/operations/NonUnitaryOperation.cpp
@@ -125,8 +125,7 @@ void NonUnitaryOperation::dumpOpenQASM(std::ostream& of,
   }
 }
 
-bool NonUnitaryOperation::equals(const Operation& op, const Permutation& perm1,
-                                 const Permutation& perm2) const {
+bool NonUnitaryOperation::equals(const Operation& op) const {
   if (const auto* nonunitary = dynamic_cast<const NonUnitaryOperation*>(&op)) {
     if (getType() != nonunitary->getType()) {
       return false;
@@ -148,11 +147,7 @@ bool NonUnitaryOperation::equals(const Operation& op, const Permutation& perm1,
       auto qubitIt1 = targets.cbegin();
       auto classicIt1 = classics.cbegin();
       while (qubitIt1 != targets.cend()) {
-        if (perm1.empty()) {
-          measurements1.emplace(*qubitIt1, *classicIt1);
-        } else {
-          measurements1.emplace(perm1.at(*qubitIt1), *classicIt1);
-        }
+        measurements1.emplace(*qubitIt1, *classicIt1);
         ++qubitIt1;
         ++classicIt1;
       }
@@ -161,18 +156,14 @@ bool NonUnitaryOperation::equals(const Operation& op, const Permutation& perm1,
       auto qubitIt2 = nonunitary->targets.cbegin();
       auto classicIt2 = nonunitary->classics.cbegin();
       while (qubitIt2 != nonunitary->targets.cend()) {
-        if (perm2.empty()) {
-          measurements2.emplace(*qubitIt2, *classicIt2);
-        } else {
-          measurements2.emplace(perm2.at(*qubitIt2), *classicIt2);
-        }
+        measurements2.emplace(*qubitIt2, *classicIt2);
         ++qubitIt2;
         ++classicIt2;
       }
 
       return measurements1 == measurements2;
     }
-    return Operation::equals(op, perm1, perm2);
+    return Operation::equals(op);
   }
   return false;
 }

--- a/src/ir/operations/Operation.cpp
+++ b/src/ir/operations/Operation.cpp
@@ -98,8 +98,7 @@ std::ostream& Operation::print(std::ostream& os, const Permutation& permutation,
   return os;
 }
 
-bool Operation::equals(const Operation& op, const Permutation& perm1,
-                       const Permutation& perm2) const {
+bool Operation::equals(const Operation& op) const {
   // check type
   if (getType() != op.getType()) {
     return false;
@@ -121,8 +120,8 @@ bool Operation::equals(const Operation& op, const Permutation& perm1,
 
   if (isDiagonalGate()) {
     // check pos. controls and targets together
-    const auto& usedQubits1 = getUsedQubitsPermuted(perm1);
-    const auto& usedQubits2 = op.getUsedQubitsPermuted(perm2);
+    const auto& usedQubits1 = getUsedQubits();
+    const auto& usedQubits2 = op.getUsedQubits();
     if (usedQubits1 != usedQubits2) {
       return false;
     }
@@ -130,24 +129,23 @@ bool Operation::equals(const Operation& op, const Permutation& perm1,
     std::set<Qubit> negControls1{};
     for (const auto& control : getControls()) {
       if (control.type == Control::Type::Neg) {
-        negControls1.emplace(perm1.apply(control.qubit));
+        negControls1.emplace(control.qubit);
       }
     }
     std::set<Qubit> negControls2{};
     for (const auto& control : op.getControls()) {
       if (control.type == Control::Type::Neg) {
-        negControls2.emplace(perm2.apply(control.qubit));
+        negControls2.emplace(control.qubit);
       }
     }
     return negControls1 == negControls2;
   }
   // check controls
-  if (nc1 != 0U &&
-      perm1.apply(getControls()) != perm2.apply(op.getControls())) {
+  if (nc1 != 0U && getControls() != op.getControls()) {
     return false;
   }
 
-  return perm1.apply(getTargets()) == perm2.apply(op.getTargets());
+  return getTargets() == op.getTargets();
 }
 
 void Operation::addDepthContribution(std::vector<std::size_t>& depths) const {
@@ -180,19 +178,14 @@ auto Operation::isInverseOf(const Operation& other) const -> bool {
   return operator==(*other.getInverted());
 }
 
-auto Operation::getUsedQubitsPermuted(const qc::Permutation& perm) const
-    -> std::set<Qubit> {
+auto Operation::getUsedQubits() const -> std::set<Qubit> {
   std::set<Qubit> usedQubits;
   for (const auto& target : getTargets()) {
-    usedQubits.emplace(perm.apply(target));
+    usedQubits.emplace(target);
   }
   for (const auto& control : getControls()) {
-    usedQubits.emplace(perm.apply(control.qubit));
+    usedQubits.emplace(control.qubit);
   }
   return usedQubits;
-}
-
-auto Operation::getUsedQubits() const -> std::set<Qubit> {
-  return getUsedQubitsPermuted({});
 }
 } // namespace qc

--- a/src/ir/operations/SymbolicOperation.cpp
+++ b/src/ir/operations/SymbolicOperation.cpp
@@ -11,7 +11,6 @@
 #include "ir/operations/SymbolicOperation.hpp"
 
 #include "ir/Definitions.hpp"
-#include "ir/Permutation.hpp"
 #include "ir/Register.hpp"
 #include "ir/operations/Control.hpp"
 #include "ir/operations/Expression.hpp"
@@ -329,12 +328,11 @@ bool SymbolicOperation::isStandardOperation() const {
                              [](const auto& sym) { return !sym.has_value(); });
 }
 
-bool SymbolicOperation::equals(const Operation& op, const Permutation& perm1,
-                               const Permutation& perm2) const {
+bool SymbolicOperation::equals(const Operation& op) const {
   if (!op.isSymbolicOperation() && !isStandardOperation()) {
     return false;
   }
-  if (isStandardOperation() && StandardOperation::equals(op, perm1, perm2)) {
+  if (isStandardOperation() && StandardOperation::equals(op)) {
     return true;
   }
 

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -19,7 +19,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <memory>
 #include <sstream>
 
@@ -55,7 +54,6 @@ TEST_P(BernsteinVazirani, FunctionTest) {
 
   // construct Bernstein Vazirani circuit
   const auto qc = qc::createBernsteinVazirani(s);
-  qc.printStatistics(std::cout);
 
   // simulate the circuit
   constexpr std::size_t shots = 1024;
@@ -74,7 +72,6 @@ TEST_P(BernsteinVazirani, FunctionTestDynamic) {
 
   // construct Bernstein Vazirani circuit
   const auto qc = qc::createIterativeBernsteinVazirani(s);
-  qc.printStatistics(std::cout);
 
   // simulate the circuit
   constexpr std::size_t shots = 1024;

--- a/test/algorithms/test_grover.cpp
+++ b/test/algorithms/test_grover.cpp
@@ -24,7 +24,6 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
-#include <iostream>
 #include <memory>
 #include <sstream>
 #include <tuple>
@@ -43,7 +42,6 @@ protected:
     std::tie(nqubits, seed) = GetParam();
     dd = std::make_unique<dd::Package>(nqubits + 1);
     qc = qc::createGrover(nqubits, seed);
-    qc.printStatistics(std::cout);
 
     // parse expected result from circuit name
     const auto& name = qc.getName();

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -87,7 +87,6 @@ TEST_P(QFT, Functionality) {
   // there should be no error building the functionality
   ASSERT_NO_THROW({ func = buildFunctionality(qc, *dd); });
 
-  qc.printStatistics(std::cout);
   // QFT DD should consist of 2^n nodes
   ASSERT_EQ(func.size(), 1ULL << nqubits);
 
@@ -130,7 +129,6 @@ TEST_P(QFT, FunctionalityRecursive) {
   // there should be no error building the functionality
   ASSERT_NO_THROW({ func = buildFunctionalityRecursive(qc, *dd); });
 
-  qc.printStatistics(std::cout);
   // QFT DD should consist of 2^n nodes
   ASSERT_EQ(func.size(), 1ULL << nqubits);
 
@@ -175,7 +173,6 @@ TEST_P(QFT, Simulation) {
     auto in = makeZeroState(nqubits, *dd);
     sim = simulate(qc, in, *dd);
   });
-  qc.printStatistics(std::cout);
 
   // QFT DD |0...0> sim should consist of n nodes
   ASSERT_EQ(sim.size(), nqubits + 1);

--- a/test/algorithms/test_qpe.cpp
+++ b/test/algorithms/test_qpe.cpp
@@ -137,7 +137,6 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(QPE, QPETest) {
   auto dd = std::make_unique<dd::Package>(precision + 1);
   auto qc = qc::createQPE(lambda, precision);
-  qc.printStatistics(std::cout);
   ASSERT_EQ(qc.getNqubits(), precision + 1);
   ASSERT_NO_THROW({ qc::CircuitOptimizer::removeFinalMeasurements(qc); });
 

--- a/test/algorithms/test_random_clifford.cpp
+++ b/test/algorithms/test_random_clifford.cpp
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
-#include <iostream>
 #include <memory>
 #include <sstream>
 
@@ -49,11 +48,10 @@ TEST_P(RandomClifford, simulate) {
 
   const auto dd = std::make_unique<dd::Package>(nq);
   for (size_t i = 0; i < numReps; ++i) {
-    auto qc =
+    const qc::QuantumComputation circuit =
         qc::createRandomCliffordCircuit(nq, static_cast<std::size_t>(nq) * nq);
     auto in = makeZeroState(nq, *dd);
-    ASSERT_NO_THROW({ dd::simulate(qc, in, *dd); });
-    qc.printStatistics(std::cout);
+    ASSERT_NO_THROW({ dd::simulate(circuit, in, *dd); });
   }
 }
 
@@ -61,8 +59,7 @@ TEST_P(RandomClifford, buildFunctionality) {
   const auto nq = GetParam();
 
   const auto dd = std::make_unique<dd::Package>(nq);
-  const auto qc = qc::createRandomCliffordCircuit(
+  const qc::QuantumComputation circuit = qc::createRandomCliffordCircuit(
       nq, static_cast<std::size_t>(nq) * nq, 12345);
-  ASSERT_NO_THROW({ dd::buildFunctionality(qc, *dd); });
-  qc.printStatistics(std::cout);
+  ASSERT_NO_THROW({ dd::buildFunctionality(circuit, *dd); });
 }

--- a/test/algorithms/test_randomized_algorithms.cpp
+++ b/test/algorithms/test_randomized_algorithms.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "algorithms/BernsteinVazirani.hpp"
+#include "algorithms/Grover.hpp"
+#include "algorithms/QPE.hpp"
+#include "algorithms/RandomCliffordCircuit.hpp"
+#include "ir/QuantumComputation.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+
+TEST(RandomizedAlgorithms, ReproducibleWithExplicitSeed) {
+  constexpr std::size_t seed = 17;
+
+  EXPECT_EQ(qc::createBernsteinVazirani(64, seed),
+            qc::createBernsteinVazirani(64, seed));
+  EXPECT_EQ(qc::createIterativeBernsteinVazirani(64, seed),
+            qc::createIterativeBernsteinVazirani(64, seed));
+  EXPECT_EQ(qc::createGrover(5, seed), qc::createGrover(5, seed));
+  EXPECT_EQ(qc::createQPE(8, true, seed), qc::createQPE(8, true, seed));
+  EXPECT_EQ(qc::createIterativeQPE(8, false, seed),
+            qc::createIterativeQPE(8, false, seed));
+  EXPECT_EQ(qc::createRandomCliffordCircuit(4, 8, seed),
+            qc::createRandomCliffordCircuit(4, 8, seed));
+}
+
+TEST(RandomizedAlgorithms, SeedsAreIndependentBetweenCalls) {
+  constexpr std::size_t seed = 23;
+  const qc::QuantumComputation expected = qc::createBernsteinVazirani(64, seed);
+
+  static_cast<void>(qc::createGrover(5, seed + 1));
+  static_cast<void>(qc::createQPE(8, true, seed + 2));
+  static_cast<void>(qc::createRandomCliffordCircuit(4, 8, seed + 3));
+
+  EXPECT_EQ(qc::createBernsteinVazirani(64, seed), expected);
+  EXPECT_NE(qc::createBernsteinVazirani(64, seed + 1), expected);
+}

--- a/test/ir/test_io.cpp
+++ b/test/ir/test_io.cpp
@@ -13,7 +13,6 @@
 #include "ir/operations/CompoundOperation.hpp"
 #include "ir/operations/Control.hpp"
 #include "ir/operations/IfElseOperation.hpp"
-#include "ir/operations/NonUnitaryOperation.hpp"
 #include "ir/operations/OpType.hpp"
 #include "ir/operations/StandardOperation.hpp"
 #include "qasm3/Exception.hpp"
@@ -440,62 +439,6 @@ TEST_F(IO, unifyRegisters) {
                   "qreg q[2];\n"
                   "x q[0];\n"
                   "x q[1];\n");
-}
-
-TEST_F(IO, appendMeasurementsAccordingToOutputPermutation) {
-  qc = qasm3::Importer::imports("// o 1\n"
-                                "qreg q[2];"
-                                "x q[1];");
-  qc.appendMeasurementsAccordingToOutputPermutation();
-  std::cout << qc << "\n";
-  const auto& op = qc.back();
-  ASSERT_EQ(op->getType(), qc::OpType::Measure);
-  const auto& meas = dynamic_cast<const qc::NonUnitaryOperation*>(op.get());
-  ASSERT_NE(meas, nullptr);
-  EXPECT_EQ(meas->getTargets().size(), 1U);
-  EXPECT_EQ(meas->getTargets().front(), 1U);
-  EXPECT_EQ(meas->getClassics().size(), 1U);
-  EXPECT_EQ(meas->getClassics().front(), 0U);
-}
-
-TEST_F(IO, appendMeasurementsAccordingToOutputPermutationAddRegister) {
-  qc = qasm3::Importer::imports("// o 0 1\n"
-                                "qreg q[2];"
-                                "creg d[1];"
-                                "x q;");
-  qc.appendMeasurementsAccordingToOutputPermutation();
-  std::cout << qc << "\n";
-  EXPECT_EQ(qc.getNcbits(), 2U);
-  const auto& op = qc.back();
-  ASSERT_EQ(op->getType(), qc::OpType::Measure);
-  const auto& meas = dynamic_cast<const qc::NonUnitaryOperation*>(op.get());
-  ASSERT_NE(meas, nullptr);
-  EXPECT_EQ(meas->getTargets().size(), 1U);
-  EXPECT_EQ(meas->getTargets().front(), 1U);
-  EXPECT_EQ(meas->getClassics().size(), 1U);
-  EXPECT_EQ(meas->getClassics().front(), 1U);
-  const auto& op2 = *(++qc.rbegin());
-  ASSERT_EQ(op2->getType(), qc::OpType::Measure);
-  const auto& meas2 = dynamic_cast<const qc::NonUnitaryOperation*>(op2.get());
-  ASSERT_NE(meas2, nullptr);
-  EXPECT_EQ(meas2->getTargets().size(), 1U);
-  EXPECT_EQ(meas2->getTargets().front(), 0U);
-  EXPECT_EQ(meas2->getClassics().size(), 1U);
-  EXPECT_EQ(meas2->getClassics().front(), 0U);
-  const auto qasm = qc.toQASM(false);
-  std::cout << qasm << "\n";
-  EXPECT_EQ(qasm, "// i 0 1\n"
-                  "// o 0 1\n"
-                  "OPENQASM 2.0;\n"
-                  "include \"qelib1.inc\";\n"
-                  "qreg q[2];\n"
-                  "creg d[1];\n"
-                  "creg c[1];\n"
-                  "x q[0];\n"
-                  "x q[1];\n"
-                  "barrier q;\n"
-                  "measure q[0] -> d[0];\n"
-                  "measure q[1] -> c[0];\n");
 }
 
 TEST_F(IO, NativeTwoQubitGateImportAndExport) {

--- a/test/ir/test_operation.cpp
+++ b/test/ir/test_operation.cpp
@@ -9,7 +9,6 @@
  */
 
 #include "ir/Definitions.hpp"
-#include "ir/Permutation.hpp"
 #include "ir/QuantumComputation.hpp"
 #include "ir/operations/CompoundOperation.hpp"
 #include "ir/operations/Control.hpp"
@@ -155,6 +154,15 @@ TEST(NonStandardOperation, CommutesAtQubit) {
           .commutesAtQubit(op, 0));
 }
 
+TEST(NonUnitaryOperation, ResetEquality) {
+  const qc::NonUnitaryOperation reset0(qc::Targets{0});
+  const qc::NonUnitaryOperation equalReset(qc::Targets{0});
+  const qc::NonUnitaryOperation differentReset(qc::Targets{1});
+
+  EXPECT_EQ(reset0, equalReset);
+  EXPECT_NE(reset0, differentReset);
+}
+
 TEST(Operation, IsIndividualGate) {
   const qc::StandardOperation op1(0, qc::X);
   EXPECT_TRUE(op1.isSingleQubitGate());
@@ -228,7 +236,7 @@ TEST(Operation, IsGlobalGate) {
                                "rz(pi/4) q[0];\n"
                                "ry(pi/2) q;\n";
   const auto qc = qasm3::Importer::imports(testfile);
-  EXPECT_EQ(qc.getHighestLogicalQubitIndex(), 2);
+  EXPECT_EQ(qc.getNqubits(), 3);
   EXPECT_FALSE(qc.at(0)->isGlobal(3));
   EXPECT_TRUE(qc.at(1)->isGlobal(3));
 }
@@ -242,13 +250,6 @@ TEST(Operation, Equality) {
   EXPECT_TRUE(op2 == op3);
   EXPECT_TRUE(op3 == op2);
   EXPECT_FALSE(op2 == op4);
-
-  EXPECT_TRUE(op2.equals(op3, qc::Permutation{{{0, 0}, {1, 2}}},
-                         qc::Permutation{{{0, 2}, {1, 0}}}));
-  EXPECT_FALSE(
-      op2.equals(op3, qc::Permutation{{{0, 0}, {1, 2}}}, qc::Permutation{}));
-  EXPECT_FALSE(op2.equals(op4, qc::Permutation{{{0, 0}, {1, 2}}},
-                          qc::Permutation{{{0, 2}, {1, 0}}}));
 }
 
 TEST(StandardOperation, Constructor) {

--- a/test/ir/test_qasm3_parser.cpp
+++ b/test/ir/test_qasm3_parser.cpp
@@ -624,12 +624,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3OutputPerm) {
                                "qubit[4] q;\n";
   const auto qc = qasm3::Importer::imports(testfile);
 
-  std::stringstream out{};
-  QuantumComputation::printPermutation(qc.outputPermutation, out);
-
-  const std::string expected = "\t0: 1\n"
-                               "\t3: 0\n";
-  EXPECT_EQ(out.str(), expected);
+  EXPECT_EQ(qc.outputPermutation, (Permutation{{0, 1}, {3, 0}}));
 }
 
 TEST_F(Qasm3ParserTest, ImportQasm3OutputPermDefault) {
@@ -637,14 +632,8 @@ TEST_F(Qasm3ParserTest, ImportQasm3OutputPermDefault) {
                                "qubit[4] q;\n";
   const auto qc = qasm3::Importer::imports(testfile);
 
-  std::stringstream out{};
-  QuantumComputation::printPermutation(qc.outputPermutation, out);
-
-  const std::string expected = "\t0: 0\n"
-                               "\t1: 1\n"
-                               "\t2: 2\n"
-                               "\t3: 3\n";
-  EXPECT_EQ(out.str(), expected);
+  EXPECT_EQ(qc.outputPermutation,
+            (Permutation{{0, 0}, {1, 1}, {2, 2}, {3, 3}}));
 }
 
 TEST_F(Qasm3ParserTest, ImportQasm3IfElseNoBlock) {

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -84,7 +84,6 @@ TEST_F(QFRFunctionality, removeTrailingIdleQubits) {
   qc.x(0);
   qc.x(2);
   std::cout << qc;
-  QuantumComputation::printPermutation(qc.outputPermutation);
   printRegisters(qc);
 
   qc.outputPermutation.erase(1);
@@ -93,13 +92,11 @@ TEST_F(QFRFunctionality, removeTrailingIdleQubits) {
   qc.stripIdleQubits();
   EXPECT_EQ(qc.getNqubits(), 2);
   std::cout << qc;
-  QuantumComputation::printPermutation(qc.outputPermutation);
   printRegisters(qc);
 
   qc.pop_back();
   qc.outputPermutation.erase(2);
   std::cout << qc;
-  QuantumComputation::printPermutation(qc.outputPermutation);
   printRegisters(qc);
 
   qc.stripIdleQubits();
@@ -153,7 +150,6 @@ TEST_F(QFRFunctionality, ancillaryQubitAtEnd) {
   EXPECT_EQ(qc.getNqubits(), 0);
   EXPECT_TRUE(qc.getQuantumRegisters().empty());
   printRegisters(qc);
-  qc.printStatistics(std::cout);
 }
 
 TEST_F(QFRFunctionality, ancillaryQubitRemoveMiddle) {
@@ -373,12 +369,6 @@ TEST_F(QFRFunctionality, OperationEquality) {
   const auto x1 = StandardOperation(1, X);
   EXPECT_FALSE(x0.equals(x1));
   EXPECT_NE(x0, x1);
-  Permutation perm0{};
-  perm0[0] = 1;
-  perm0[1] = 0;
-  EXPECT_TRUE(x0.equals(x1, perm0, {}));
-  EXPECT_TRUE(x0.equals(x1, {}, perm0));
-
   const auto cx01 = StandardOperation(0, 1, X);
   const auto cx10 = StandardOperation(1, 0, X);
   EXPECT_FALSE(cx01.equals(cx10));
@@ -402,8 +392,6 @@ TEST_F(QFRFunctionality, OperationEquality) {
   EXPECT_NE(measure0, measure1);
   EXPECT_FALSE(measure0.equals(measure2));
   EXPECT_NE(measure0, measure2);
-  EXPECT_TRUE(measure0.equals(measure2, perm0, {}));
-  EXPECT_TRUE(measure0.equals(measure2, {}, perm0));
 
   std::unique_ptr<Operation> xp0 = std::make_unique<StandardOperation>(0, X);
   std::unique_ptr<Operation> xp1 = std::make_unique<StandardOperation>(0, X);
@@ -1062,7 +1050,7 @@ TEST_F(QFRFunctionality, testSettingSetMultipleAncillariesAndGarbage) {
   ASSERT_EQ(qc.getNancillae(), 2U);
   qc.setLogicalQubitsGarbage(1U, 2U);
   ASSERT_EQ(qc.getNgarbageQubits(), 2U);
-  ASSERT_EQ(qc.getNmeasuredQubits(), 1U);
+  ASSERT_EQ(qc.getNoutputQubits(), 1U);
 }
 
 TEST_F(QFRFunctionality, StripIdleQubitsInMiddleOfCircuit) {
@@ -1486,10 +1474,11 @@ TEST_F(QFRFunctionality, TryAddingZeroSizeClassicalRegister) {
   EXPECT_THROW(qc.addClassicalRegister(0, "c"), std::runtime_error);
 }
 
-TEST_F(QFRFunctionality, TryGettingRegisterForQubitNotInRegister) {
+TEST_F(QFRFunctionality, RemoveQubitMissingRegisterThrows) {
   QuantumComputation qc{};
   qc.addQubitRegister(1, "q");
-  EXPECT_THROW(std::ignore = qc.getQubitRegister(2), std::runtime_error);
+  qc.initialLayout.emplace(2, 1);
+  EXPECT_THROW(std::ignore = qc.removeQubit(1), std::runtime_error);
 }
 
 TEST_F(QFRFunctionality, stripIdleQubits) {
@@ -1528,15 +1517,9 @@ TEST_F(QFRFunctionality, failOnAddingNonConsecutiveQubit) {
   EXPECT_THROW(qc.addQubit(2, 2, 2);, std::runtime_error);
 }
 
-TEST_F(QFRFunctionality, failOnGettingIndexOfNonExistingQubit) {
-  const QuantumComputation qc(1);
-  EXPECT_THROW(std::ignore = qc.getPhysicalQubitIndex(1);, std::runtime_error);
+TEST_F(QFRFunctionality, RemoveQubitMissingLayoutThrows) {
+  QuantumComputation qc(1);
+  EXPECT_THROW(std::ignore = qc.removeQubit(1), std::runtime_error);
 }
 
-TEST_F(QFRFunctionality, failOnRegisterMisconfigurationWithMeasurements) {
-  QuantumComputation qc(2);
-  qc.addClassicalRegister(1, "c");
-  EXPECT_THROW(qc.appendMeasurementsAccordingToOutputPermutation("c");
-               , std::runtime_error);
-}
 } // namespace qc

--- a/test/python/ir/test_ir.py
+++ b/test/python/ir/test_ir.py
@@ -39,3 +39,12 @@ def test_bell_state_circuit() -> None:
     """
     # Remove all whitespace from both strings before comparison
     assert "".join(qasm.split()) == "".join(expected.split())
+
+
+def test_num_output_qubits_excludes_garbage() -> None:
+    """Test that the output count reflects the circuit's garbage metadata."""
+    qc = QuantumComputation(3)
+    assert qc.num_output_qubits == 3
+
+    qc.set_circuit_qubit_garbage(1)
+    assert qc.num_output_qubits == 2


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Backports the following CoreIR cleanups to v3.x:

- https://github.com/munich-quantum-toolkit/core/pull/2112
- https://github.com/munich-quantum-toolkit/core/pull/2111

The changes remove dead and misleading APIs, rename the output-qubit count, and make randomized algorithms own their random-number generators instead of `QuantumComputation`.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
