### PR TITLE
🔧 Clean up project configuration and links

### DIFF
--- a/.github/workflow_inputs/release_drafter_categories.json
+++ b/.github/workflow_inputs/release_drafter_categories.json
@@ -4,7 +4,6 @@
   "🐉 MQT Core MLIR": ["MLIR"],
   "🐲 MQT Core QIR": ["QIR"],
   "🔌 MQT Core QDMI": ["QDMI"],
-  "🏼 MQT Core NA Package": ["NA"],
   "🚀 Features and Enhancements": [
     "enhancement",
     "feature",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,10 +136,11 @@ releases may include breaking changes.
 - 💥 Remove the `spdlog` dependency from MQT Core source builds, installed CMake
   packages, and Python wheels. QDMI diagnostics continue to be written to
   standard error ([#2270]) ([**@denialhaag**])
-- 💥 Remove `CircuitOptimizer`. Move equivalence-checking transformations to MQT
-  QCEC and mapping transformations to MQT QMAP. Move single-qubit gate fusion to
-  both downstream packages. Remove the public circuit dependency graph and
-  transformations without production consumers ([#2262]) ([**@simon1hofmann**])
+- 💥 Remove `CircuitOptimizer`. Move equivalence-checking transformations to
+  [MQT QCEC] and mapping transformations to [MQT QMAP]. Move single-qubit gate
+  fusion to both downstream packages. Remove the public circuit dependency graph
+  and transformations without production consumers ([#2262])
+  ([**@simon1hofmann**])
 - 💥 Remove test-only DD state generators, recursive functionality construction,
   and DD-specific named-gate helpers from MQT Core ([#2257], [#2335])
   ([**@simon1hofmann**])
@@ -1348,3 +1349,5 @@ for previous changelogs._
 [PEP 735]: https://peps.python.org/pep-0735/
 [CMake presets]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
 [munich-quantum-toolkit/workflows]: https://github.com/munich-quantum-toolkit/workflows
+[MQT QMAP]: https://github.com/munich-quantum-toolkit/qmap
+[MQT QCEC]: https://github.com/munich-quantum-toolkit/qcec

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -990,8 +990,8 @@ It also requires the `uv` library version 0.5.20 or higher.
 
 <!-- Other links -->
 
-[MQT DDSIM]: https://github.com/cda-tum/mqt-ddsim
-[MQT QMAP]: https://github.com/cda-tum/mqt-qmap
-[MQT QCEC]: https://github.com/cda-tum/mqt-qcec
-[MQT SyReC]: https://github.com/cda-tum/mqt-syrec
+[MQT DDSIM]: https://github.com/munich-quantum-toolkit/ddsim
+[MQT QMAP]: https://github.com/munich-quantum-toolkit/qmap
+[MQT QCEC]: https://github.com/munich-quantum-toolkit/qcec
+[MQT SyReC]: https://github.com/munich-quantum-toolkit/syrec
 [CMake presets]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,6 +382,5 @@ test = [
 dev = [
   {include-group = "build"},
   {include-group = "test"},
-  "lit>=18.1.8",
   "nox>=2025.11.12"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1305,15 +1305,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lit"
-version = "23.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/37/be14bf2cabacc40557a03cf4789d9a3335bf515b0ec3a655fdc84cae4779/lit-23.1.0.tar.gz", hash = "sha256:6fd50e0ca6fac61f4a672e9f30154edcab3d17c98aeb8202ac709bc353fe331f", size = 199907, upload-time = "2026-08-25T19:24:32.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/67/27b6051432c4cc016e50d4b5acb82116b608dd0132de1dd1d6967263588e/lit-23.1.0-py3-none-any.whl", hash = "sha256:6361af7f311092f23f874a45d2db001f3f07dcbf438275809c2fc29d1c1196cc", size = 111215, upload-time = "2026-08-25T19:24:31.022Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1546,7 +1537,6 @@ cpp-lint = [
 ]
 dev = [
     { name = "cmake" },
-    { name = "lit" },
     { name = "nanobind" },
     { name = "nox" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -1622,7 +1612,6 @@ cpp-lint = [
 ]
 dev = [
     { name = "cmake", specifier = ">=4.4.1" },
-    { name = "lit", specifier = ">=18.1.8" },
     { name = "nanobind", specifier = "~=3.0.1" },
     { name = "nox", specifier = ">=2025.11.12" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

These are all small cleanup items I noticed while working on the backports to `v3.x`:

- Remove the unused `lit` development dependency.
- Remove the obsolete NA package Release Drafter category.
- Update MQT project links to use the current GitHub organization.
- Define the MQT QCEC and MQT QMAP link references used by existing changelog entries.

## AI notice

This PR was created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
