### PR TITLE
🐛 Keep deferred Qiskit `Store` instructions free of bit operands

### DIFF
--- a/bindings/mlir/qiskit/Qiskit2_5.cpp
+++ b/bindings/mlir/qiskit/Qiskit2_5.cpp
@@ -2474,7 +2474,8 @@ private:
       data[pending.instructionIndex] =
           pythonAttribute(placeholder, "replace",
                           "Qiskit Store placeholder cannot be replaced")(
-              nb::arg("operation") = operation);
+              nb::arg("operation") = operation, nb::arg("qubits") = nb::tuple(),
+              nb::arg("clbits") = nb::tuple());
     }
   }
 

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -525,6 +525,8 @@ def test_flat_export_preserves_classical_store_order(late_value: str) -> None:
     restored = program.to_qiskit()
 
     assert [instruction.operation.name for instruction in restored.data] == ["store", "x", "store"]
+    stores = (restored.data[0], restored.data[2])
+    assert all(not instruction.qubits and not instruction.clbits for instruction in stores)
     assert not restored.data[0].operation.rvalue.value
     assert bool(restored.data[2].operation.rvalue.value) is (late_value == "true")
 

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -1027,6 +1027,19 @@ def test_qiskit_store_rejects_stale_dynamic_index() -> None:
         program.to_qiskit()
 
 
+def test_qiskit_custom_gate_named_store_remains_a_gate() -> None:
+    """Use the Store type, not its public name, to classify assignments."""
+    definition = QuantumCircuit(1)
+    definition.x(0)
+    gate = Gate("mqt_store_test", 1, [])
+    gate.definition = definition
+    circuit = QuantumCircuit(1)
+    circuit.append(gate, [0])
+    circuit.data[0].operation.name = "store"
+
+    assert "qc.x" in QCProgram.from_qiskit(circuit).ir
+
+
 def test_openqasm_short_circuit_expression_exports_to_qiskit() -> None:
     """Export nested OpenQASM short-circuit logic through canonical scf.if."""
     program = QCProgram.from_qasm_str(

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -1027,19 +1027,6 @@ def test_qiskit_store_rejects_stale_dynamic_index() -> None:
         program.to_qiskit()
 
 
-def test_qiskit_custom_gate_named_store_remains_a_gate() -> None:
-    """Use the Store type, not its public name, to classify assignments."""
-    definition = QuantumCircuit(1)
-    definition.x(0)
-    gate = Gate("mqt_store_test", 1, [])
-    gate.definition = definition
-    circuit = QuantumCircuit(1)
-    circuit.append(gate, [0])
-    circuit.data[0].operation.name = "store"
-
-    assert "qc.x" in QCProgram.from_qiskit(circuit).ir
-
-
 def test_openqasm_short_circuit_expression_exports_to_qiskit() -> None:
     """Export nested OpenQASM short-circuit logic through canonical scf.if."""
     program = QCProgram.from_qasm_str(

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -1031,10 +1031,11 @@ def test_qiskit_custom_gate_named_store_remains_a_gate() -> None:
     """Use the Store type, not its public name, to classify assignments."""
     definition = QuantumCircuit(1)
     definition.x(0)
-    gate = Gate("store", 1, [])
+    gate = Gate("mqt_store_test", 1, [])
     gate.definition = definition
     circuit = QuantumCircuit(1)
     circuit.append(gate, [0])
+    circuit.data[0].operation.name = "store"
 
     assert "qc.x" in QCProgram.from_qiskit(circuit).ir
 


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Pass explicit empty qubit and classical-bit tuples when replacing deferred Qiskit `Store` placeholders. Qiskit commit https://github.com/Qiskit/qiskit/commit/ef5d926f7d4079de5b4fabe7e3f2ca91e05ecf0b defines a null qubit pointer passed to `qk_circuit_barrier` as a full-width barrier. Retaining those placeholder operands assigns qubits to a zero-qubit `Store` and raises `CircuitError`.

Extend the existing Store-order test to require exported `Store` instructions to have no qubit or classical-bit operands.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
