### PR TITLE
📝 Frontport v3.10.0 changelog and upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,8 +90,8 @@ releases may include breaking changes.
 
 #### Other additions
 
-- ✨ Expose ordered shots from DDSIM QDMI OpenQASM and QIR jobs, with matching
-  histograms ([#2368]) ([**@burgholzer**])
+- ✨ Expose ordered shots from DDSIM QDMI QIR jobs, with matching histograms
+  ([#2368]) ([**@burgholzer**])
 - 🐳 Add dev container configuration for a consistent local development
   environment ([#1786]) ([**@denialhaag**])
 
@@ -99,29 +99,6 @@ releases may include breaking changes.
 
 - ⬆️ Update clang-tidy to version 23 and adapt the C++ sources to its
   diagnostics ([#2328]) ([**@simon1hofmann**])
-- ⚡ Run PennyLane QDMI jobs concurrently and release the GIL during waits and
-  result retrieval ([#2349]) ([**@burgholzer**])
-- 💥 Raise the minimum Qiskit version from 1.1.0 to 2.1.0 ([#2358])
-  ([**@burgholzer**])
-- 💥 Replace the QDMI-specific primitives with native Qiskit primitives and
-  typed backend factories. Sampler and `memory=True` require genuine QDMI
-  `SHOTS` ([#2358]) ([**@burgholzer**])
-- 💥 Drop support for x86 macOS and stop publishing the respective wheels
-  ([#2259]) ([**@denialhaag**])
-- ⬆️ Raise the macOS deployment target to 13.3 to enable `std::format` in libc++
-  ([#2259]) ([**@denialhaag**])
-- 💥 Require Python 3.11 or newer ([#2209]) ([**@denialhaag**],
-  [**@burgholzer**])
-- ⬆️ Update `nanobind` to version 3.0.1 ([#2209], [#2283]) ([**@denialhaag**],
-  [**@burgholzer**])
-- 📦 Publish one split-mode `cp311-abi3` wheel for GIL-enabled CPython 3.11 and
-  newer ([#2209]) ([**@denialhaag**], [**@burgholzer**])
-- 📦 Publish one `cp315-abi3t` wheel for free-threaded CPython 3.15 and newer
-  ([#2209]) ([**@denialhaag**], [**@burgholzer**])
-- ⚡ Remove an extra dense copy from `VectorDD.get_vector` ([#2209])
-  ([**@burgholzer**])
-- 🐛 Protect process-wide DD, IR, and QDMI state for free-threaded Python
-  ([#2209]) ([**@burgholzer**])
 - 💥 Update QIR execution for QIR 2.1, isolated runtimes, deterministic QDMI
   sampling, and safe statevector extraction ([#2035], [#2036], [#2246])
   ([**@burgholzer**], [**@denialhaag**])
@@ -135,39 +112,102 @@ releases may include breaking changes.
 - 💥 Remove `qc::QuantumComputation`, `MQT::CoreIR`, and `MQT::CoreQASM`. Use
   compiler-backed QC/QCO APIs in v4 or the MQT Core v3 release series for legacy
   code ([#2111], [#2112], [#2288]) ([**@burgholzer**], [**@simon1hofmann**])
-- 💥 Remove the `spdlog` dependency from MQT Core source builds, installed CMake
+- 💥 Remove the standalone QIR runner and make the QIR runtime and JIT internal
+  DDSIM implementation details ([#2246]) ([**@denialhaag**])
+
+## [3.10.0] - 2026-09-05
+
+_If you are upgrading: please see
+[`UPGRADING.md`](UPGRADING.md#3100)._
+
+### Added
+
+- ✨ Expose ordered shots from DDSIM QDMI OpenQASM jobs, with matching
+  histograms ([#2368]) ([**@burgholzer**])
+
+### Changed
+
+- ⚡ Run PennyLane QDMI jobs concurrently and release the GIL during waits and
+  result retrieval ([#2349]) ([**@burgholzer**])
+- 💥 Raise the minimum Qiskit version from 1.1.0 to 2.1.0 ([#2358])
+  ([**@burgholzer**])
+- 💥 Replace the QDMI-specific primitives with native Qiskit primitives and
+  typed backend factories. Sampler and `memory=True` require genuine QDMI
+  `SHOTS` ([#2358]) ([**@burgholzer**])
+- ⬆️ Update `nanobind` to version 3.0.1 ([#2209], [#2283]) ([**@denialhaag**],
+  [**@burgholzer**])
+- 💥 Move circuit IR OpenQASM serialization from operation subclasses to
+  `qasm3::Serializer` in `qasm3/Serializer.hpp` ([#2249]) ([**@simon1hofmann**])
+- 💥 Drop support for x86 macOS and stop publishing the respective wheels
+  ([#2259]) ([**@denialhaag**])
+- ⬆️ Raise the macOS deployment target to 13.3 to enable `std::format` in libc++
+  ([#2259]) ([**@denialhaag**])
+- 💥 Require Python 3.11 or newer ([#2209]) ([**@denialhaag**],
+  [**@burgholzer**])
+- 📦 Publish one split-mode `cp311-abi3` wheel for GIL-enabled CPython 3.11 and
+  newer ([#2209]) ([**@denialhaag**], [**@burgholzer**])
+- 📦 Publish one `cp315-abi3t` wheel for free-threaded CPython 3.15 and newer
+  ([#2209]) ([**@denialhaag**], [**@burgholzer**])
+- ⚡ Remove an extra dense copy from `VectorDD.get_vector` ([#2209])
+  ([**@burgholzer**])
+- 🐛 Protect process-wide DD, IR, and QDMI state for free-threaded Python
+  ([#2209]) ([**@burgholzer**])
+- 💥 Prune dead and misleading CoreIR APIs, including renaming the non-garbage
+  logical output count to `getNoutputQubits()` and `num_output_qubits` ([#2112])
+  ([**@simon1hofmann**])
+
+### Removed
+
+- 💥 Remove test-only DD state generators, recursive functionality construction,
+  and DD-specific named-gate helpers ([#2257], [#2335]) ([**@simon1hofmann**])
+- 💥 Remove the `spdlog` dependency from source builds, installed CMake
   packages, and Python wheels. QDMI diagnostics continue to be written to
   standard error ([#2270]) ([**@denialhaag**])
-- 💥 Remove `CircuitOptimizer`. Move equivalence-checking transformations to
-  [MQT QCEC] and mapping transformations to [MQT QMAP]. Move single-qubit gate
+- 💥 Remove `CircuitOptimizer`. Move circuit flattening and final-measurement
+  removal to `QuantumComputation`, equivalence-checking transformations to
+  [MQT QCEC], and mapping transformations to [MQT QMAP]. Move single-qubit gate
   fusion to both downstream packages. Remove the public circuit dependency graph
   and transformations without production consumers ([#2262])
   ([**@simon1hofmann**])
-- 💥 Remove test-only DD state generators, recursive functionality construction,
-  and DD-specific named-gate helpers from MQT Core ([#2257], [#2335])
-  ([**@simon1hofmann**])
-- 💥 Remove the standalone QIR runner and make the QIR runtime and JIT internal
-  DDSIM implementation details ([#2246]) ([**@denialhaag**])
 - 💥 Remove `MQT::CoreAlgorithms`, its fixed-circuit factories, and the legacy
   DD package evaluation. MQT Core provides no direct replacement ([#2214])
   ([**@burgholzer**])
-- 💥 Remove the unowned decision-diagram approximation algorithm and
-  density-matrix support from MQT Core ([#1466], [#2154]) ([**@burgholzer**])
-- 💥 Make `nlohmann_json` an implementation detail and replace JSON-typed
-  decision-diagram statistics APIs with strings and streams ([#2138])
-  ([**@denialhaag**])
-- 💥 Remove the neutral-atom stack from MQT Core and move it to [MQT QMAP]
-  ([#2137]) ([**@denialhaag**])
-- 💥 Remove the FoMaC compatibility names from the C++ and Python QDMI APIs
-  ([#2115]) ([**@burgholzer**])
-- 💥 Remove the ZX-calculus library and its Boost.Multiprecision and GMP
-  support. Equivalence-checking users should use [MQT QCEC] ([#2082])
+- 💥 Remove the unused decision-diagram approximation algorithm, including the
+  `dd/Approximation.hpp` header, `dd::ApproximationMetadata`, and
+  `dd::approximate`. No replacement is provided ([#2154]) ([**@burgholzer**])
+- 💥 Remove `nlohmann_json` from the public package contract. MQT Core no longer
+  installs or exports the library, no installed header exposes a `nlohmann`
+  type, and the decision-diagram statistics report through strings and streams
+  ([#2138]) ([**@denialhaag**])
+- 💥 Remove the neutral-atom stack, which moves to [MQT QMAP]. This drops the
+  neutral-atom computation model, the neutral-atom FoMaC device session, the
+  neutral-atom QDMI device and its configuration, the `mqt.core.na` Python
+  module, `AodOperation`, and the `Move`, `Bridge`, `AodActivate`,
+  `AodDeactivate`, and `AodMove` operation kinds ([#2137]) ([**@denialhaag**])
+- 💥 Remove the random-number generator, seed, and `getGenerator()` method from
+  `QuantumComputation`; randomized algorithms now own generators initialized
+  from their seed arguments ([#2111]) ([**@simon1hofmann**])
+- 💥 Remove the FoMaC compatibility name from the C++ and Python QDMI APIs. Use
+  the `qdmi` C++ namespace, headers, library, and CMake target; the
+  `mqt.core.qdmi` Python module; and module-level functions in
+  `mqt.core.qdmi.driver` ([#2115]) ([**@burgholzer**])
+- 💥 Remove the ZX-calculus library, including the `mqt-core-zx` target,
+  `MQT::CoreZX` alias, `zx` headers and namespace, and its Boost.Multiprecision
+  and GMP build support. Equivalence-checking users should use [MQT QCEC]; its
+  ZX implementation is internal and does not provide a replacement public API
+  ([#2082]) ([**@burgholzer**])
+- 🔥 Remove density matrix support from the DD package ([#1466])
   ([**@burgholzer**])
-- 🔥 Remove `datastructures` (`ds`) (sub)library from MQT Core ([#1458])
+- 🔥 Remove `datastructures` (`ds`) (sub)library ([#1458])
   ([**@burgholzer**])
 
 ### Fixed
 
+- 🐛 Initialize Qiskit classical bits before OpenQASM 3 serialization so
+  partially measured circuits preserve their zero values ([#2399])
+  ([**@burgholzer**])
+- 🐛 Handle empty DDSIM results and NUL-terminated QDMI result buffers ([#2288])
+  ([**@simon1hofmann**])
 - 🐛 Validate output permutations before I/O mapping initialization ([#2278])
   ([**@denialhaag**])
 
@@ -856,7 +896,8 @@ for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.2...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.10.0...HEAD
+[3.10.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.10.0
 [3.9.2]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.9.2
 [3.9.1]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.9.1
 [3.9.0]: https://github.com/munich-quantum-toolkit/core/releases/tag/v3.9.0
@@ -882,6 +923,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2399]: https://github.com/munich-quantum-toolkit/core/pull/2399
 [#2380]: https://github.com/munich-quantum-toolkit/core/pull/2380
 [#2368]: https://github.com/munich-quantum-toolkit/core/pull/2368
 [#2358]: https://github.com/munich-quantum-toolkit/core/pull/2358
@@ -905,6 +947,7 @@ for previous changelogs._
 [#2259]: https://github.com/munich-quantum-toolkit/core/pull/2259
 [#2258]: https://github.com/munich-quantum-toolkit/core/pull/2258
 [#2257]: https://github.com/munich-quantum-toolkit/core/pull/2257
+[#2249]: https://github.com/munich-quantum-toolkit/core/pull/2249
 [#2246]: https://github.com/munich-quantum-toolkit/core/pull/2246
 [#2240]: https://github.com/munich-quantum-toolkit/core/pull/2240
 [#2232]: https://github.com/munich-quantum-toolkit/core/pull/2232

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,212 +41,23 @@ stay on that release series. C++ consumers should likewise use a v3 release
 branch or a matching v3 version constraint. MQT Core v3 and v4 cannot provide
 their Python or CMake packages in the same environment.
 
-### Removal of the `spdlog` dependency
+### Typed benchmark library
 
-MQT Core no longer discovers, downloads, builds, installs, or exports `spdlog`.
-The installed CMake package no longer calls `find_dependency(spdlog)`, and the
-Python wheels no longer contain the `spdlog` headers or shared library. QDMI
-diagnostics continue to use standard error.
-
-Downstream projects that use `spdlog` must declare and package the dependency
-themselves. Stop passing `MQT_CORE_SPDLOG_INSTALL` or `SPDLOG_*` cache variables
-when configuring MQT Core. Configure the downstream project's own `spdlog`
-dependency instead.
-
-### CircuitOptimizer removal
-
-MQT Core no longer provides `qc::CircuitOptimizer`. MQT QCEC and MQT QMAP each
-own their single-qubit gate-fusion implementation. MQT Core provides no
-replacement for `flattenOperations`, `removeFinalMeasurements`, or
-`singleQubitGateFusion` outside packages that still use the classic circuit
-representation.
-
-MQT QCEC now owns the equivalence-checking transformations `swapReconstruction`,
-`removeDiagonalGatesBeforeMeasure`, `eliminateResets`, `deferMeasurements`,
-`backpropagateOutputPermutation`, and `elidePermutations`. Use MQT QCEC's
-equivalence-checking flow for this behavior, or keep a package-specific
-transformation with the consumer that needs it.
-
-MQT QMAP now owns the mapping transformations `decomposeSWAP`, `cancelCNOTs`,
-and `replaceMCXWithMCZ`. Replace calls to the corresponding
-`qc::CircuitOptimizer` methods with `qmap::decomposeSWAP`, `qmap::cancelCNOTs`,
-and `qmap::replaceMCXWithMCZ`, respectively. Include
-`datastructures/CircuitOptimizations.hpp` and link `MQT::QMapDS`.
-
-The public `constructDAG` function and the `DAG`, `DAGIterator`,
-`DAGReverseIterator`, `DAGIterators`, and `DAGReverseIterators` aliases have no
-Core replacement. Build the small traversal structure in the package that
-consumes it. MQT QMAP and MQT QuSAT demonstrate this migration.
-
-The public `removeIdentities`, `removeOperation`, `collectBlocks`, and
-`collectCliffordBlocks` functions have no replacement. Keep a package-specific
-implementation with a consumer that still needs one.
-
-The `MQT::CoreCircuitOptimizer` CMake target and the
-`circuit_optimizer/CircuitOptimizer.hpp` header are removed. The
-`circuit_optimizer/mqt_core_circuit_optimizer_export.h` header is no longer
-generated or installed.
-
-### Pruned DD helpers
-
-MQT Core no longer provides `dd::GenerationWireStrategy`,
-`dd::generateExponentialState`, or `dd::generateRandomState`. These APIs
-generated decision diagrams with selected shapes for tests and have no direct
-replacement.
-
-MQT Core also removed `dd::buildFunctionalityRecursive`. The Python
-`mqt.core.dd.sample`, `simulate_statevector`, `build_unitary`, `simulate`, and
-`build_functionality` functions were removed together with the classic circuit
-representation. Use the `mqt.core.mlir.sample`, `simulate`, or
-`build_functionality` function instead. Compile to a `mqt.core.mlir.QCOProgram`
-and call the corresponding method for custom initial states, DD results, or
-program reuse. Use MQT DDSIM's unitary simulator when recursive pairwise
-construction is required.
-
-MQT Core also removed `dd/GateMatrixDefinitions.hpp` and the named-gate dispatch
-from `dd/Operations.hpp`. This removes `dd::GateType`, the
-`dd::isSingleQubitGate`, `dd::isTwoQubitGate`, and `dd::isThreeQubitGate`
-classifiers, `dd::opToSingleQubitGateMatrix`, `dd::opToTwoQubitGateMatrix`,
-`dd::opToThreeQubitGateMatrix`, `dd::getGateDD`, and the `dd::MEAS_ZERO_MAT` and
-`dd::MEAS_ONE_MAT` constants. Low-level consumers must pass raw matrices to
-`dd::Package::makeGateDD`, `makeTwoQubitGateDD`, `makeThreeQubitGateDD`, or
-`makeDDFromMatrix`. Compiler-backed paths use QCO operations as the canonical
-source of named-gate matrices.
-
-The zero, basis, GHZ, W, dense-vector, dense-matrix, and raw gate-matrix DD
-constructors remain available.
-
-### macOS support
-
-MQT Core no longer supports x86 macOS. Use Apple silicon with macOS 13.3 or
-newer. The new deployment target enables `std::format` in libc++.
-
-### Removal of CoreAlgorithms
-
-MQT Core no longer installs `MQT::CoreAlgorithms` or the headers below
-`algorithms/`. MQT Core provides no direct replacement for the removed circuit
-factories. Move required implementations to the package that uses them. The
-`BUILD_MQT_CORE_BENCHMARKS` option and its legacy DD evaluation target were also
-removed.
-
-MQT Core now provides the separate `MQT::CoreBench` library and `mqt-core-bench`
+MQT Core 4 provides the separate `MQT::CoreBench` library and `mqt-core-bench`
 CLI for typed structured benchmarks. These interfaces are not drop-in
-replacements for the removed factories.
+replacements for the circuit factories removed in MQT Core 3.10.
 
-### Python 3.11 and split-mode wheels
+### QDMI names in compiler APIs
 
-MQT Core now requires Python 3.11 or newer. Upgrade the Python environment
-before installing this release.
+Replace `mlir/Compiler/FoMaCAdapter.h` and `MQTCompilerFoMaCAdapter` with
+`mlir/Compiler/QDMIAdapter.h` and `MQTCompilerQDMIAdapter`, respectively.
 
-MQT Core now uses nanobind 3 split mode. One `cp311-abi3` wheel supports
-GIL-enabled CPython 3.11 and newer. Free-threaded support starts with CPython
-3.15 and uses a separate `cp315-abi3t` wheel. MQT Core no longer publishes
-free-threaded CPython 3.13 or 3.14 wheels.
+### DD named-gate APIs
 
-nanobind 3 changes the nanobind ABI. Rebuild downstream native Python extensions
-that use MQT Core's nanobind-bound C++ types. Pure Python consumers do not need
-to recompile anything.
-
-The Python bindings depend on `nanobind-backend`, which supplies the
-interpreter-specific nanobind runtime. This dependency does not change the C++
-API or the Python import paths.
-
-### Removal of DD approximation and density-matrix support
-
-MQT Core no longer provides the decision-diagram approximation algorithm. The
-algorithm had no production owner in the MQT ecosystem. Remove uses of the
-`dd/Approximation.hpp` header, the `dd::ApproximationMetadata` type, and the
-`dd::approximate` function. MQT Core does not provide a replacement.
-
-MQT Core also no longer provides density-matrix decision diagrams or the noise
-operations that depended on them. Consumers must provide this functionality or
-use another implementation.
-
-### Private `nlohmann_json` dependency
-
-MQT Core uses `nlohmann_json` only inside its implementation. It no longer
-installs the library, exports it, or looks for it in its package configuration.
-Depend on `nlohmann_json` directly if your project uses it.
-
-No installed header includes a `nlohmann` header any more. The decision-diagram
-statistics report through strings and streams instead. MQT Core removed the
-following names:
-
-- `dd::Statistics::json`, `dd::MemoryManagerStatistics::json`,
-  `dd::TableStatistics::json`, and `dd::UniqueTableStatistics::json`. Use
-  `toString`, the stream operator, or the individual counters.
-- `dd::UniqueTable::getStatsJson`. Use `dd::getStatisticsString`.
-- `dd::getStatistics` and `dd::getDataStructureStatistics`. Use
-  `dd::getStatisticsString` and `dd::getDataStructureStatisticsString`, which
-  return the same report as a JSON-formatted string.
-- The `MQT_CORE_JSON_INSTALL` CMake option.
-
-`dd::getStatisticsString` takes the `includeIndividualTables` flag that
-`dd::getStatistics` used to take.
-
-### Removal of the neutral-atom stack
-
-MQT Core no longer contains any neutral-atom functionality. The complete stack
-moved to [MQT QMAP](https://github.com/munich-quantum-toolkit/qmap), which is
-now its sole owner. Depend on MQT QMAP to keep using it.
-
-MQT Core removed the following names:
-
-- The `MQT::CoreNA`, `MQT::CoreNAQDMI`, `MQT::CoreQDMINaDevice`, and
-  `MQT::CoreQDMINaDeviceConfig` CMake targets.
-- The `BUILD_MQT_CORE_QDMI_NA_DEVICE` CMake option.
-- The `na/NAComputation.hpp`, `na/entities/*.hpp`, `na/operations/*.hpp`,
-  `na/qdmi/Device.hpp`, `qdmi/devices/na/Configuration.hpp`, and
-  `ir/operations/AodOperation.hpp` headers.
-- The `na` C++ namespace.
-- The `mqt.core.na` Python module and its `mqt.core.na.qdmi` submodule.
-- The `Move`, `Bridge`, `AodActivate`, `AodDeactivate`, and `AodMove`
-  `qc::OpType` values, together with `QuantumComputation::move`,
-  `QuantumComputation::bridge`, and the OpenQASM names `move`, `bridge`,
-  `aod_activate`, `aod_deactivate`, and `aod_move`.
-- The bundled `mqt.na.default` QDMI device.
-
-### Removal of FoMaC compatibility APIs
-
-MQT Core 4 removes the deprecated FoMaC names that MQT Core 3.9 kept as
-compatibility aliases. Replace Python imports of QDMI entities from
-`mqt.core.fomac` with imports from `mqt.core.qdmi`. Import registry functions
-and `DeviceDefinition` from `mqt.core.qdmi.driver`.
-
-MQT Core 4 also removes `mqt.core.qdmi.driver.Session`. Use
-`registered_device_ids()` to discover devices and `open_device()` to open a
-fresh device session. Pass provider configuration overrides to `open_device()`
-when a device needs per-open configuration.
-
-Apply these replacements to C++ and MLIR code:
-
-- `fomac::` becomes `qdmi::`.
-- `fomac/FoMaC.hpp` becomes `qdmi/Client.hpp`.
-- `fomac/Slurm.hpp` becomes `qdmi/Slurm.hpp`.
-- `MQT::CoreFoMaC` becomes `MQT::CoreQDMI`.
-- `mlir/Compiler/FoMaCAdapter.h` and `MQTCompilerFoMaCAdapter` become
-  `mlir/Compiler/QDMIAdapter.h` and `MQTCompilerQDMIAdapter`.
-
-The class and function names do not change. For example:
-
-```cpp
-#include "qdmi/Client.hpp"
-
-auto device = qdmi::Session::openDevice("mqt.ddsim.default");
-```
-
-### Removal of the ZX-calculus library
-
-MQT Core no longer provides the `mqt-core-zx` library, the `MQT::CoreZX` CMake
-target, the `mqt-core/zx` headers, or the global `zx` namespace. Remove these
-from downstream includes and link dependencies. Equivalence-checking users
-should use [MQT QCEC]; QCEC's ZX implementation is internal and is not a
-replacement public API.
-
-The `MQT::Multiprecision` target and the `USE_SYSTEM_BOOST`,
-`MQT_CORE_WITH_GMP`, and `MQT_CORE_ZX_SYSTEM_BOOST` CMake options have also been
-removed. MQT Core no longer discovers, fetches, or exports configuration for
-Boost.Multiprecision or GMP.
+MQT Core 4 removes `dd::GateType`, `dd::isSingleQubitGate`,
+`dd::isTwoQubitGate`, `dd::isThreeQubitGate`, and `dd::getGateDD`.
+Compiler-backed paths use QCO operations as the canonical source of named-gate
+matrices.
 
 ### QIR execution
 
@@ -290,11 +101,297 @@ Known limitations when MLIR is enabled:
 - AppleClang 17+ is required to build the MLIR part of MQT Core due to some
   C++20 features that older versions do not support fully.
 
+## [3.10.0]
+
+### Shared-library ABI version
+
+The shared-library ABI version (`SOVERSION`) changes from `3.9` to `3.10`.
+Rebuild downstream C++ libraries against MQT Core 3.10.0. In `cibuildwheel`
+configurations that exclude bundled MQT Core libraries from wheel repair,
+replace each `libmqt-core-*.so.3.9` entry with the corresponding
+`libmqt-core-*.so.3.10` entry.
+
+### Removal of the `spdlog` dependency
+
+MQT Core no longer discovers, downloads, builds, installs, or exports `spdlog`.
+The installed CMake package no longer calls `find_dependency(spdlog)`, and the
+Python wheels no longer contain the `spdlog` headers or shared library. QDMI
+diagnostics continue to use standard error.
+
+Downstream projects that use `spdlog` must declare and package the dependency
+themselves. Stop passing `MQT_CORE_SPDLOG_INSTALL` or `SPDLOG_*` cache variables
+when configuring MQT Core. Configure the downstream project's own `spdlog`
+dependency instead.
+
+### CircuitOptimizer removal
+
+MQT Core no longer provides `qc::CircuitOptimizer`. Replace the two generic
+transformations with `QuantumComputation` member calls:
+
+- Replace `qc::CircuitOptimizer::flattenOperations(qc, customGatesOnly)` with
+  `qc.flattenOperations(customGatesOnly)`.
+- Replace `qc::CircuitOptimizer::removeFinalMeasurements(qc)` with
+  `qc.removeFinalMeasurements()`.
+
+Include `ir/QuantumComputation.hpp` and link `MQT::CoreIR`. MQT QCEC and MQT
+QMAP each own their single-qubit gate-fusion implementation. MQT Core provides
+no replacement for `singleQubitGateFusion` outside those packages.
+
+MQT QCEC now owns the equivalence-checking transformations `swapReconstruction`,
+`removeDiagonalGatesBeforeMeasure`, `eliminateResets`, `deferMeasurements`,
+`backpropagateOutputPermutation`, and `elidePermutations`. Use MQT QCEC's
+equivalence-checking flow for this behavior, or keep a package-specific
+transformation with the consumer that needs it.
+
+MQT QMAP now owns the mapping transformations `decomposeSWAP`, `cancelCNOTs`,
+and `replaceMCXWithMCZ`. Replace calls to the corresponding
+`qc::CircuitOptimizer` methods with `qmap::decomposeSWAP`, `qmap::cancelCNOTs`,
+and `qmap::replaceMCXWithMCZ`, respectively. Include
+`datastructures/CircuitOptimizations.hpp` and link `MQT::QMapDS`.
+
+The public `constructDAG` function and the `DAG`, `DAGIterator`,
+`DAGReverseIterator`, `DAGIterators`, and `DAGReverseIterators` aliases have no
+Core replacement. Build the small traversal structure in the package that
+consumes it. MQT QMAP and MQT QuSAT demonstrate this migration.
+
+The public `removeIdentities`, `removeOperation`, `collectBlocks`, and
+`collectCliffordBlocks` functions have no replacement. Erase operations through
+`QuantumComputation` where needed.
+
+The `MQT::CoreCircuitOptimizer` CMake target and the
+`circuit_optimizer/CircuitOptimizer.hpp` header are removed. The
+`circuit_optimizer/mqt_core_circuit_optimizer_export.h` header is no longer
+generated or installed.
+
+### Pruned DD construction helpers
+
+MQT Core no longer provides `dd::GenerationWireStrategy`,
+`dd::generateExponentialState`, or `dd::generateRandomState`. These APIs
+generated decision diagrams with selected shapes for tests and have no direct
+replacement.
+
+MQT Core also removed `dd::buildFunctionalityRecursive`. The Python
+`mqt.core.dd.build_unitary` and `mqt.core.dd.build_functionality` functions no
+longer accept the `recursive` argument and always use sequential construction.
+Use MQT DDSIM's unitary simulator when recursive pairwise construction is
+required.
+
+MQT Core also removed `dd/GateMatrixDefinitions.hpp`,
+`dd::opToSingleQubitGateMatrix`, `dd::opToTwoQubitGateMatrix`,
+`dd::opToThreeQubitGateMatrix`, `dd::getStandardOperationDD`,
+`dd::MEAS_ZERO_MAT`, and `dd::MEAS_ONE_MAT`. Low-level consumers must pass raw
+matrices to `dd::Package::makeGateDD`, `makeTwoQubitGateDD`,
+`makeThreeQubitGateDD`, or `makeDDFromMatrix`. Circuit-facing DD functions
+continue to translate CoreIR operations internally.
+
+The zero, basis, GHZ, W, dense-vector, dense-matrix, raw gate-matrix, and
+sequential circuit constructors remain available.
+
+### macOS support
+
+MQT Core no longer supports x86 macOS. Use Apple silicon with macOS 13.3 or
+newer. The new deployment target enables `std::format` in libc++.
+
+### Removal of CoreAlgorithms
+
+MQT Core no longer installs `MQT::CoreAlgorithms` or the headers below
+`algorithms/`. MQT Core provides no direct replacement for the removed circuit
+factories. Move required implementations to the package that uses them. The
+`BUILD_MQT_CORE_BENCHMARKS` option and its legacy DD evaluation target were also
+removed.
+
+### Removal of the FoMaC compatibility APIs
+
+MQT Core no longer provides `mqt.core.fomac` or `mqt.core.qdmi.driver.Session`.
+Import QDMI entities such as `Device`, `Job`, and `ProgramFormat` from
+`mqt.core.qdmi`. Import `DeviceDefinition` and the module-level registry
+functions from `mqt.core.qdmi.driver`. Use `registered_device_ids()` to discover
+devices and `open_device()` to open a fresh device session. Pass provider
+configuration overrides to `open_device()` when a device needs per-open
+configuration.
+
+MQT Core also removes the FoMaC name from its C++ API. Apply these replacements:
+
+- `fomac::` becomes `qdmi::`.
+- `fomac/FoMaC.hpp` becomes `qdmi/Client.hpp`.
+- `fomac/Slurm.hpp` becomes `qdmi/Slurm.hpp`.
+- `MQT::CoreFoMaC` becomes `MQT::CoreQDMI`.
+
+The class and function names do not change. For example:
+
+```cpp
+#include "qdmi/Client.hpp"
+
+auto device = qdmi::Session::openDevice("mqt.ddsim.default");
+```
+
+### Qiskit 2.1 minimum
+
+The minimum Qiskit version increases from **1.1.0 to 2.1.0**, dropping support
+for all Qiskit 1.x releases and Qiskit 2.0. Upgrade Qiskit to 2.1.0 or newer.
+
+### Native QDMI Qiskit primitives
+
+`QDMISampler` and `QDMIEstimator` are removed. Use Qiskit's `BackendSamplerV2`
+and `BackendEstimatorV2`, or the backend factories with native options:
+
+```python
+sampler = backend.sampler(default_shots=2048)
+estimator = backend.estimator(default_precision=0.01)
+```
+
+Estimator uses positive precision, not `default_shots`: its default is `1/64`
+(4096 shots). Grouping, metadata, broadcasting, and standard errors now follow
+Qiskit. Sampler requires genuine QDMI `SHOTS`, which DDSIM supports. Counts-only
+devices remain usable for Estimator but cannot run Sampler. No shot
+reconstruction is available.
+
+`backend.run(memory=True)` preserves shot order. Results include classical
+register boundaries; failed jobs and invalid results raise on collection, and
+unsupported execution options are rejected. See the
+[backend requirements](https://mqt.readthedocs.io/projects/core/en/latest/qdmi/qdmi_backend.html#backend-requirements).
+
+### Private `nlohmann_json` dependency
+
+MQT Core uses `nlohmann_json` only inside its implementation. It no longer
+installs the library, exports it, or looks for it in its package configuration.
+Depend on `nlohmann_json` directly if your project uses it.
+
+No installed header includes a `nlohmann` header any more. The decision-diagram
+statistics report through strings and streams instead. MQT Core removed the
+following names:
+
+- `dd::Statistics::json`, `dd::MemoryManagerStatistics::json`,
+  `dd::TableStatistics::json`, and `dd::UniqueTableStatistics::json`. Use
+  `toString`, the stream operator, or the individual counters.
+- `dd::UniqueTable::getStatsJson`. Use `dd::getStatisticsString`.
+- `dd::getStatistics` and `dd::getDataStructureStatistics`. Use
+  `dd::getStatisticsString` and `dd::getDataStructureStatisticsString`, which
+  return the same report as a JSON-formatted string.
+- The `MQT_CORE_JSON_INSTALL` CMake option.
+
+`dd::getStatisticsString` takes the `includeIndividualTables` flag that
+`dd::getStatistics` used to take.
+
+### Removal of the neutral-atom stack
+
+MQT Core no longer contains neutral-atom functionality. The complete stack moved
+to [MQT QMAP](https://github.com/munich-quantum-toolkit/qmap), which is now its
+sole owner. Depend on MQT QMAP to keep using this functionality.
+
+MQT Core removed the following names:
+
+- The `MQT::CoreNA`, `MQT::CoreNAFoMaC`, `MQT::CoreQDMINaDevice`, and
+  `MQT::CoreQDMINaDeviceConfig` CMake targets.
+- The `BUILD_MQT_CORE_QDMI_NA_DEVICE` CMake option.
+- The `na/NAComputation.hpp`, `na/entities/*.hpp`, `na/operations/*.hpp`,
+  `na/fomac/Device.hpp`, `qdmi/devices/na/Configuration.hpp`, and
+  `ir/operations/AodOperation.hpp` headers.
+- The `na` C++ namespace.
+- The `mqt.core.na` Python module and its `mqt.core.na.qdmi` and
+  `mqt.core.na.fomac` submodules.
+- The `Move`, `Bridge`, `AodActivate`, `AodDeactivate`, and `AodMove`
+  `qc::OpType` values, together with `QuantumComputation::move`,
+  `QuantumComputation::cmove`, `QuantumComputation::mcmove`,
+  `QuantumComputation::bridge`, and the OpenQASM names `move`, `bridge`,
+  `aod_activate`, `aod_deactivate`, and `aod_move`.
+- The bundled `mqt.na.default` QDMI device.
+
+### Removal of the ZX-calculus library
+
+MQT Core no longer provides the `mqt-core-zx` library, the `MQT::CoreZX` CMake
+target, the `mqt-core/zx` headers, or the global `zx` namespace. Remove these
+from downstream includes and link dependencies. Equivalence-checking users
+should use [MQT QCEC]; QCEC's ZX implementation is internal and is not a
+replacement public API.
+
+The build-tree `MQT::Multiprecision` alias, the installed `MQT::multiprecision`
+target, the `USE_SYSTEM_BOOST`, `MQT_CORE_WITH_GMP`, and
+`MQT_CORE_ZX_SYSTEM_BOOST` CMake options, and the `BOOST_MIN_VERSION` cache
+variable have also been removed. MQT Core no longer discovers, fetches, or
+exports configuration for Boost.Multiprecision or GMP.
+
+### Removal of density matrix support from the DD package
+
+MQT Core no longer provides density matrix decision diagrams or the related
+deterministic and stochastic noise functionality. [MQT DDSIM] 2.5.0 and newer
+provide this functionality in the `dd::ddsim` namespace. Downstream code that
+used the MQT Core APIs must migrate to MQT DDSIM or provide the functionality
+directly. The `ATrue`, `AFalse`, `MultiATrue`, and `MultiAFalse` operation types
+have also been removed.
+
+### Removal of DD approximation support
+
+MQT Core no longer provides the decision-diagram approximation algorithm. The
+algorithm had no production owner in the MQT ecosystem. Remove uses of the
+`dd/Approximation.hpp` header, the `dd::ApproximationMetadata` type, and the
+`dd::approximate` function. MQT Core does not provide a replacement.
+
+### CoreIR API cleanup
+
+The CoreIR API cleanup requires the following migrations:
+
+- Replace `getNmeasuredQubits()` and `num_measured_qubits` with
+  `getNoutputQubits()` and `num_output_qubits`, respectively.
+- Replace permutation-aware `Operation::equals()` and `getUsedQubitsPermuted()`
+  calls by applying the permutation to cloned operations before comparing them.
+- Replace `getHighestLogicalQubitIndex()`, `printStatistics()`, and
+  `printPermutation()` with `initialLayout.maxValue()`, the individual count
+  accessors, and direct `Permutation` iteration, respectively.
+- Construct output-permutation measurements explicitly instead of calling
+  `appendMeasurementsAccordingToOutputPermutation()`.
+- Replace direct `Operation::dumpOpenQASM2()`, `dumpOpenQASM3()`, or
+  `dumpOpenQASM()` calls with `qasm3::Serializer`. The register-map aliases
+  moved from `ir/Register.hpp` to `qasm3/Serializer.hpp`:
+
+  ```cpp
+  #include "qasm3/Serializer.hpp"
+
+  qasm3::Serializer(stream, qc::Format::OpenQASM2)
+      .serialize(operation, qubitMap, bitMap);
+  ```
+
+  Use `qc::Format::OpenQASM3` for OpenQASM 3 output. The relocated maps own
+  their register metadata instead of retaining references to the registers used
+  to construct them. Packages that define custom `Operation` subclasses must own
+  serialization for their extended syntax; in particular, MQT QMAP owns
+  neutral-atom OpenQASM serialization.
+
+The register lookup helpers `getQubitRegister()`, `getPhysicalQubitIndex()`, and
+`physicalQubitIsAncillary()` are now private implementation details.
+
+### QuantumComputation random-number generator
+
+`QuantumComputation` no longer stores a random-number generator or seed. Remove
+the third `seed` argument from C++ and Python constructor calls. C++ callers
+that used `QuantumComputation::getGenerator()` must create and own a
+random-number generator instead. Randomized circuit generators continue to
+accept a seed and now own a separate generator for each call.
+
 ### Removal of the `datastructures` (sub)library
 
-MQT Core no longer provides the `datastructures` (`ds`) sublibrary. MQT QMAP was
-its only consumer. Downstream users must depend on MQT QMAP or provide the
-required data structures directly.
+MQT Core no longer provides the `datastructures` (`ds`) sublibrary. [MQT QMAP]
+3.8.0 and newer provide the moved code under `datastructures/` through the
+`MQT::QMapDS` CMake target. Downstream users must depend on MQT QMAP or provide
+the required data structures directly.
+
+### Python 3.11 and Stable ABI wheels
+
+MQT Core now requires Python 3.11 or newer. Upgrade the Python environment
+before installing this release.
+
+MQT Core now publishes one `cp311-abi3` wheel for GIL-enabled CPython 3.11 and
+newer. Free-threaded support starts with CPython 3.15 in a separate
+`cp315-abi3t` wheel. MQT Core no longer publishes free-threaded CPython 3.13 or
+3.14 wheels.
+
+This release updates `nanobind` to 3.0.1, which changes the `nanobind` ABI.
+Rebuild downstream native Python extensions that use MQT Core's `nanobind`-bound
+C++ types. Pure Python consumers do not need to recompile anything.
+
+The Python bindings depend on `nanobind-backend`, which supplies the
+interpreter-specific `nanobind` runtime. This dependency does not change the C++
+API or the Python import paths.
 
 ## [3.9.2]
 
@@ -457,31 +554,20 @@ resolve against the file that declares them. `MQT_CORE_QDMI_CONFIG_FILE`,
 `MQT_CORE_QDMI_CONFIG_JSON`, the system and user files, and the packaged
 `*.qdmi.json` fragments do not change.
 
-### Qiskit 2.1 minimum
+### QDMI Qiskit primitive options
 
-The minimum Qiskit version increases from **1.1.0 to 2.1.0**, dropping support
-for all Qiskit 1.x releases and Qiskit 2.0. Upgrade Qiskit to 2.1.0 or newer.
-
-### Native QDMI Qiskit primitives
-
-`QDMISampler` and `QDMIEstimator` are removed. Use Qiskit's `BackendSamplerV2`
-and `BackendEstimatorV2`, or the backend factories with native options:
+`QDMISampler` and `QDMIEstimator` no longer accept the MQT-specific `options`
+mapping. Pass shot and precision defaults directly, preferably through the
+backend factories:
 
 ```python
 sampler = backend.sampler(default_shots=2048)
-estimator = backend.estimator(default_precision=0.01)
+estimator = backend.estimator(default_precision=0.01, default_shots=2048)
 ```
 
-Estimator uses positive precision, not `default_shots`: its default is `1/64`
-(4096 shots). Grouping, metadata, broadcasting, and standard errors now follow
-Qiskit. Sampler requires genuine QDMI `SHOTS`, which DDSIM supports. Counts-only
-devices remain usable for Estimator but cannot run Sampler. No shot
-reconstruction is available.
-
-`backend.run(memory=True)` preserves shot order. Results include classical
-register boundaries; failed jobs and invalid results raise on collection, and
-unsupported execution options are rejected. See the
-[backend requirements](https://mqt.readthedocs.io/projects/core/en/latest/qdmi/qdmi_backend.html#backend-requirements).
+Replace `QDMIEstimator(..., options={"default_shots": shots})` with
+`QDMIEstimator(..., default_shots=shots)`. The sampler ignored its former
+`options` mapping, so remove that argument without replacement.
 
 ### Runtime-configurable SC QDMI device
 
@@ -973,7 +1059,8 @@ It also requires the `uv` library version 0.5.20 or higher.
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.2...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/core/compare/v3.10.0...HEAD
+[3.10.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.2...v3.10.0
 [3.9.2]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.1...v3.9.2
 [3.9.1]: https://github.com/munich-quantum-toolkit/core/compare/v3.9.0...v3.9.1
 [3.9.0]: https://github.com/munich-quantum-toolkit/core/compare/v3.8.0...v3.9.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -47,11 +47,6 @@ MQT Core 4 provides the separate `MQT::CoreBench` library and `mqt-core-bench`
 CLI for typed structured benchmarks. These interfaces are not drop-in
 replacements for the circuit factories removed in MQT Core 3.10.
 
-### QDMI names in compiler APIs
-
-Replace `mlir/Compiler/FoMaCAdapter.h` and `MQTCompilerFoMaCAdapter` with
-`mlir/Compiler/QDMIAdapter.h` and `MQTCompilerQDMIAdapter`, respectively.
-
 ### DD named-gate APIs
 
 MQT Core 4 removes `dd::GateType`, `dd::isSingleQubitGate`,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -47,13 +47,6 @@ MQT Core 4 provides the separate `MQT::CoreBench` library and `mqt-core-bench`
 CLI for typed structured benchmarks. These interfaces are not drop-in
 replacements for the circuit factories removed in MQT Core 3.10.
 
-### DD named-gate APIs
-
-MQT Core 4 removes `dd::GateType`, `dd::isSingleQubitGate`,
-`dd::isTwoQubitGate`, `dd::isThreeQubitGate`, and `dd::getGateDD`.
-Compiler-backed paths use QCO operations as the canonical source of named-gate
-matrices.
-
 ### QIR execution
 
 Dynamic QIR inputs must use the current QIR 2.1 resource-management interface.


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Frontport the v3.10.0 changelog and upgrade guide to `main`, remove released changes from the Unreleased sections, and retain only distinct v4 work.

The 3.10.0 sections use the released v3 wording where the branches share behavior. They omit the v3-only QIR and LLVM/MLIR removal notes because `main` retains those stacks. The Unreleased sections keep the compiler, QIR, and classic-circuit changes intended for v4.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
