### PR TITLE
📝 Add project authors and expand project keywords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,16 @@ requires = [
 name = "mqt-core"
 description = "The Backbone of the Munich Quantum Toolkit"
 readme = "README.md"
-keywords = [ "decision-diagrams", "design-automation", "MQT", "quantum-computing" ]
+keywords = [
+  "decision-diagrams",
+  "design-automation",
+  "HPCQC",
+  "MQT",
+  "OpenQASM",
+  "QDMI",
+  "Qiskit",
+  "quantum-computing"
+]
 license = "MIT"
 license-files = [ "LICENSE" ]
 requires-python = ">=3.11"
@@ -53,6 +62,34 @@ dependencies = [
 [[project.authors]]
 name = "Lukas Burgholzer"
 email = "burgholzer@me.com"
+
+[[project.authors]]
+name = "Daniel Haag"
+email = "daniel@mq.sc"
+
+[[project.authors]]
+name = "Simon Hofmann"
+email = "simon@mq.sc"
+
+[[project.authors]]
+name = "Yannick Stade"
+email = "yannick.stade@tum.de"
+
+[[project.authors]]
+name = "Damian Rovara"
+email = "damian.rovara@tum.de"
+
+[[project.authors]]
+name = "Matthias Reumann"
+email = "matthias.reumann@tum.de"
+
+[[project.authors]]
+name = "Patrick Hopf"
+email = "patrick.hopf@tum.de"
+
+[[project.authors]]
+name = "Marcel Walter"
+email = "marcel@mq.sc"
 
 [project.optional-dependencies]
 pennylane = [


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Add the same project authors as `main` and expand the project keywords to match the features supported by v3.x.

Retain `HPCQC`, `OpenQASM`, `QDMI`, and `Qiskit`. Omit `compilation`, `MLIR`, and `QIR`, which apply to the v4 compiler stack.

This PR is stacked on #2416.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
