### PR TITLE
⬆️ Require CMake 3.28

### DIFF
--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -31,7 +31,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write # Needed to push the templating branch
           permission-pull-requests: write # Needed to open the templating pull request
-      - uses: munich-quantum-toolkit/templates@8caeb0bd8d0e2ebf906e7c3a826c06f72844a83b # v1.5.0
+      - uses: munich-quantum-toolkit/templates@26c7cb8534daf355596bf0a31379ba84d097c768 # v1.5.1
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: Core

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ MQT Core. The project-wide policy for AI-assisted contributions is
 
 ## Build and Test
 
+Use CMake 3.28 or newer for all C++ builds.
+
 ### C++
 
 - Configure a release build with `cmake --preset release`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@ releases may include breaking changes.
 
 ### Changed
 
+- 💥 Require CMake 3.28 or newer for source builds and embedded projects, use
+  native dependency exclusions and system include handling, and disable unused
+  C++ module scanning ([#2421]) ([**@burgholzer**])
 - ⬆️ Update clang-tidy to version 23 and adapt the C++ sources to its
   diagnostics ([#2328]) ([**@simon1hofmann**])
 - 💥 Update QIR execution for QIR 2.1, isolated runtimes, deterministic QDMI
@@ -923,6 +926,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2421]: https://github.com/munich-quantum-toolkit/core/pull/2421
 [#2399]: https://github.com/munich-quantum-toolkit/core/pull/2399
 [#2380]: https://github.com/munich-quantum-toolkit/core/pull/2380
 [#2368]: https://github.com/munich-quantum-toolkit/core/pull/2368

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Licensed under the MIT License
 
 # set required cmake version
-cmake_minimum_required(VERSION 3.24...4.4)
+cmake_minimum_required(VERSION 3.28...4.4)
 
 project(
   mqt-core

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ print(job.get_counts())
 ## System Requirements
 
 Building the project requires a C++ compiler with support for C++20 and CMake
-3.24 or newer. For details on how to build the project, please refer to the
+3.28 or newer. For details on how to build the project, please refer to the
 [documentation](https://mqt.readthedocs.io/projects/core). Building (and
 running) is continuously tested under Linux, macOS, and Windows using the
 [latest available system versions for GitHub Actions](https://github.com/actions/runner-images).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,11 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### CMake 3.28 minimum
+
+MQT Core now requires CMake 3.28 or newer. Upgrade CMake before configuring a
+source build or embedding MQT Core with `FetchContent`.
+
 ### Removal of the classic circuit representation
 
 MQT Core 4 removes the complete classic circuit surface. This includes the C++

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -26,28 +26,25 @@ if(BUILD_MQT_CORE_MLIR)
   FetchContent_Declare(
     jeff-mlir
     GIT_REPOSITORY https://github.com/unitaryfoundation/jeff-mlir.git
-    GIT_TAG d214dc5c1c18c48b197c122f06f12cf44f49831a)
-  function(_mqt_core_make_jeff_available)
-    # Cap'n Proto, which is fetched transitively by jeff-mlir, uses the generic BUILD_TESTING option
-    # and defines a global `check` target when it is enabled. Do not let an embedding project's test
-    # setting leak into this third-party dependency.
-    set(BUILD_TESTING OFF)
-    # jeff's transitive Cap'n Proto dependency contains source files that cannot share a unity
-    # translation unit. Keep the complete dependency subtree out of unity builds.
-    set(CMAKE_UNITY_BUILD OFF)
-    FetchContent_MakeAvailable(jeff-mlir)
-  endfunction()
-  _mqt_core_make_jeff_available()
+    GIT_TAG 4732c4f12047e8cbf1890c79e90e30110e6588e2
+    EXCLUDE_FROM_ALL)
+  block()
+  # Cap'n Proto, which is fetched transitively by jeff-mlir, uses the generic BUILD_TESTING option
+  # and defines a global `check` target when it is enabled. Do not let an embedding project's test
+  # setting leak into this third-party dependency.
+  set(BUILD_TESTING OFF)
+  # jeff's transitive Cap'n Proto dependency contains source files that cannot share a unity
+  # translation unit. Keep the complete dependency subtree out of unity builds.
+  set(CMAKE_UNITY_BUILD OFF)
+  FetchContent_MakeAvailable(jeff-mlir)
+  endblock()
 endif()
 
 set(JSON_VERSION
     3.12.0
     CACHE STRING "nlohmann_json version")
 set(JSON_URL https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}/json.tar.xz)
-set(JSON_SystemInclude
-    ON
-    CACHE INTERNAL "Treat the library headers like system headers")
-FetchContent_Declare(nlohmann_json URL ${JSON_URL} FIND_PACKAGE_ARGS ${JSON_VERSION})
+FetchContent_Declare(nlohmann_json URL ${JSON_URL} SYSTEM FIND_PACKAGE_ARGS ${JSON_VERSION})
 list(APPEND FETCH_PACKAGES nlohmann_json)
 
 if(BUILD_MQT_CORE_TESTS)

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -88,14 +88,4 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
     ON
     CACHE BOOL "Export all symbols on Windows")
 
-# on macOS with GCC, disable module scanning
-# https://www.reddit.com/r/cpp_questions/comments/1kwlkom/comment/ni5angh/
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")
-    set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
-  else()
-    message(WARNING "CMake 3.28+ is required to disable C++ module scanning on macOS with GCC. "
-                    "Current version: ${CMAKE_VERSION}. "
-                    "Consider upgrading CMake to avoid potential build issues.")
-  endif()
-endif()
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -194,7 +194,7 @@ instructions on how to set up your development environment.
 
 Building the project requires a C++20-capable
 [C++ compiler](https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers)
-and [CMake](https://cmake.org/) 3.24 or newer. As of August 2025, our CI
+and [CMake](https://cmake.org/) 3.28 or newer. As of August 2025, our CI
 pipeline on GitHub continuously tests the library across the following matrix of
 systems and compilers:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -107,7 +107,7 @@ pip install mqt.core --no-binary mqt.core
 
 This requires a C++20-capable
 [C++ compiler](https://en.wikipedia.org/wiki/List_of_compilers#C++_compilers)
-and [CMake](https://cmake.org/) 3.24 or newer.
+and [CMake](https://cmake.org/) 3.28 or newer.
 
 ## Integrating MQT Core into Your Project
 

--- a/test/qdmi/driver/imported_device/CMakeLists.txt
+++ b/test/qdmi/driver/imported_device/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 # Licensed under the MIT License
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.28)
 project(mqt-core-qdmi-imported-device-test LANGUAGES CXX)
 
 if(NOT MQT_CORE_QDMI_DEVICE_TARGETS OR NOT MQT_CORE_QDMI_HELPER)

--- a/test/qdmi/driver/runtime_file_device/CMakeLists.txt
+++ b/test/qdmi/driver/runtime_file_device/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 # Licensed under the MIT License
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.28)
 project(mqt-core-qdmi-runtime-file-device-test LANGUAGES CXX)
 
 if(NOT MQT_CORE_QDMI_HELPER OR NOT MQT_CORE_QDMI_TEST_SOURCE_DIR)


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Require CMake 3.28 across MQT Core and its standalone QDMI fixture projects. Use the guaranteed CMake features to disable unused C++ module scanning, mark fetched nlohmann/json as a system dependency, exclude unrelated fetched jeff-mlir targets, and replace the temporary dependency-scoping function with `block()`.

Pin jeff-mlir to merged commit `4732c4f12047e8cbf1890c79e90e30110e6588e2` from unitaryfoundation/jeff-mlir#54. Pin the templating workflow to MQT Templates v1.5.1 commit `26c7cb8534daf355596bf0a31379ba84d097c768` so post-merge synchronization preserves the CMake 3.28 guidance.

This PR contains only the Core CMake migration. Reusable-workflow and Core CI caller changes remain in the later workflow stage.

AI assistance: Codex implemented, reviewed, and locally validated the scoped changes under explicit authorization.

## Validation

- CMake 3.28.4: release configure/build, 3,740 configured tests, and install passed
- CMake 4.4.2: release configure/build, 3,740 configured tests, and install passed
- CMake 3.27.9 rejects configuration as expected
- `uvx nox -s lint` passed after the Templates pin update

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.