### PR TITLE
👷 Share Ninja presets and validate shared sccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
             compiler: msvc
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@8f8bcd976732d8d481221bcf5e16a31036337022
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@cca0e668ce3cfa6621b40889c4f163ac54ea06c0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@8f8bcd976732d8d481221bcf5e16a31036337022
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@cca0e668ce3cfa6621b40889c4f163ac54ea06c0
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true
@@ -208,7 +208,7 @@ jobs:
             windows-2025,
             windows-11-arm,
           ]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@8f8bcd976732d8d481221bcf5e16a31036337022
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@cca0e668ce3cfa6621b40889c4f163ac54ea06c0
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
             preset: release
             run-on-draft: false
             setup-mlir: true
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@9d0a300a990563b5d70b6cd5e7549c3e678d3cf7
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -73,7 +73,7 @@ jobs:
             compiler: clang
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@9d0a300a990563b5d70b6cd5e7549c3e678d3cf7
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -100,7 +100,7 @@ jobs:
             compiler: msvc
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@9d0a300a990563b5d70b6cd5e7549c3e678d3cf7
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -115,7 +115,7 @@ jobs:
     name: 🇨 Coverage
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-coverage.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-coverage.yml@9d0a300a990563b5d70b6cd5e7549c3e678d3cf7
     with:
       setup-mlir: true
       llvm-version: 23.1.0
@@ -127,7 +127,7 @@ jobs:
     name: 🇨 Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@9d0a300a990563b5d70b6cd5e7549c3e678d3cf7
     with:
       clang-version: 23
       build-project: true
@@ -152,7 +152,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@9d0a300a990563b5d70b6cd5e7549c3e678d3cf7
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
             compiler: msvc
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@4e1a050439717695ca078f11a41ce066144df257
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@ad19ac42882422b7cedb632ffea5c09d89e87f7f
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@4e1a050439717695ca078f11a41ce066144df257
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@ad19ac42882422b7cedb632ffea5c09d89e87f7f
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true
@@ -208,7 +208,7 @@ jobs:
             windows-2025,
             windows-11-arm,
           ]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@4e1a050439717695ca078f11a41ce066144df257
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@ad19ac42882422b7cedb632ffea5c09d89e87f7f
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
             preset: release
             run-on-draft: false
             setup-mlir: true
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@ae4c1005796fedc123c3c70cdba94ce643c9fcae # v2.3.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -73,7 +73,7 @@ jobs:
             compiler: clang
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@ae4c1005796fedc123c3c70cdba94ce643c9fcae # v2.3.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -100,7 +100,7 @@ jobs:
             compiler: msvc
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@cf0244e0f8acb3a43b325b7556ded20939d8b465
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -108,7 +108,6 @@ jobs:
       llvm-version: 23.1.0
       preset-name: ${{ matrix.preset }}
       run-on-draft: ${{ matrix.run-on-draft }}
-      use-sccache-gha: true
     permissions:
       contents: read
 
@@ -116,7 +115,7 @@ jobs:
     name: 🇨 Coverage
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-coverage.yml@ae4c1005796fedc123c3c70cdba94ce643c9fcae # v2.3.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-coverage.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
     with:
       setup-mlir: true
       llvm-version: 23.1.0
@@ -128,7 +127,7 @@ jobs:
     name: 🇨 Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@ae4c1005796fedc123c3c70cdba94ce643c9fcae # v2.3.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
     with:
       clang-version: 23
       build-project: true
@@ -153,12 +152,11 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@cf0244e0f8acb3a43b325b7556ded20939d8b465
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true
       llvm-version: 23.1.0
-      use-sccache-gha: ${{ startsWith(matrix.runs-on, 'windows') }}
     permissions:
       contents: read
 
@@ -208,12 +206,11 @@ jobs:
             windows-2025,
             windows-11-arm,
           ]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@cf0244e0f8acb3a43b325b7556ded20939d8b465
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true
       llvm-version: 23.1.0
-      use-sccache-gha: ${{ startsWith(matrix.runs-on, 'windows') }}
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
             preset: release
             run-on-draft: false
             setup-mlir: true
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -73,7 +73,7 @@ jobs:
             compiler: clang
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -100,7 +100,7 @@ jobs:
             compiler: msvc
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -115,7 +115,7 @@ jobs:
     name: 🇨 Coverage
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-coverage.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-coverage.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
     with:
       setup-mlir: true
       llvm-version: 23.1.0
@@ -127,7 +127,7 @@ jobs:
     name: 🇨 Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
     with:
       clang-version: 23
       build-project: true
@@ -152,7 +152,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@bf4d4cbc9d96f38e9b0f100a9947870c59c3c318
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true
@@ -206,7 +206,7 @@ jobs:
             windows-2025,
             windows-11-arm,
           ]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@cd511e0c450670c36cf22a501c82316f8a3b71d7
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@ae4c1005796fedc123c3c70cdba94ce643c9fcae # v2.3.1
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
             compiler: msvc
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@ad19ac42882422b7cedb632ffea5c09d89e87f7f
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@8f8bcd976732d8d481221bcf5e16a31036337022
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@ad19ac42882422b7cedb632ffea5c09d89e87f7f
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@8f8bcd976732d8d481221bcf5e16a31036337022
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true
@@ -208,7 +208,7 @@ jobs:
             windows-2025,
             windows-11-arm,
           ]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@ad19ac42882422b7cedb632ffea5c09d89e87f7f
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@8f8bcd976732d8d481221bcf5e16a31036337022
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,13 +94,13 @@ jobs:
         include:
           - runs-on: windows-2025
             compiler: msvc
-            preset: release-windows
+            preset: release
             run-on-draft: true
           - runs-on: windows-11-arm
             compiler: msvc
-            preset: release-windows
+            preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@ae4c1005796fedc123c3c70cdba94ce643c9fcae # v2.3.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@4e1a050439717695ca078f11a41ce066144df257
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -108,6 +108,7 @@ jobs:
       llvm-version: 23.1.0
       preset-name: ${{ matrix.preset }}
       run-on-draft: ${{ matrix.run-on-draft }}
+      use-sccache-gha: true
     permissions:
       contents: read
 
@@ -152,11 +153,12 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@ae4c1005796fedc123c3c70cdba94ce643c9fcae # v2.3.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@4e1a050439717695ca078f11a41ce066144df257
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true
       llvm-version: 23.1.0
+      use-sccache-gha: ${{ startsWith(matrix.runs-on, 'windows') }}
     permissions:
       contents: read
 
@@ -206,11 +208,12 @@ jobs:
             windows-2025,
             windows-11-arm,
           ]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@ae4c1005796fedc123c3c70cdba94ce643c9fcae # v2.3.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@4e1a050439717695ca078f11a41ce066144df257
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true
       llvm-version: 23.1.0
+      use-sccache-gha: ${{ startsWith(matrix.runs-on, 'windows') }}
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
             compiler: msvc
             preset: release
             run-on-draft: false
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@cca0e668ce3cfa6621b40889c4f163ac54ea06c0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@cf0244e0f8acb3a43b325b7556ded20939d8b465
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@cca0e668ce3cfa6621b40889c4f163ac54ea06c0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@cf0244e0f8acb3a43b325b7556ded20939d8b465
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true
@@ -208,7 +208,7 @@ jobs:
             windows-2025,
             windows-11-arm,
           ]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@cca0e668ce3cfa6621b40889c4f163ac54ea06c0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@cf0244e0f8acb3a43b325b7556ded20939d8b465
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-mlir: true

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,6 +5,8 @@
       "name": "base",
       "hidden": true,
       "binaryDir": "${sourceDir}/build/${presetName}",
+      "description": "Default configuration. Uses the Ninja generator",
+      "generator": "Ninja",
       "cacheVariables": {
         "MLIR_DIR": "$env{MLIR_DIR}",
         "CMAKE_UNITY_BUILD": "ON"
@@ -20,41 +22,8 @@
       }
     },
     {
-      "name": "base-unix",
-      "hidden": true,
-      "inherits": "base",
-      "condition": {
-        "type": "inList",
-        "string": "${hostSystemName}",
-        "list": ["Linux", "Darwin"]
-      },
-      "description": "Default configuration for Linux and macOS builds. Uses the Ninja generator",
-      "generator": "Ninja"
-    },
-    {
-      "name": "base-unix-no-mlir",
-      "hidden": true,
-      "inherits": ["base-unix", "base-no-mlir"]
-    },
-    {
-      "name": "base-windows",
-      "hidden": true,
-      "inherits": "base",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      },
-      "description": "Default configuration for Windows builds. Uses the default generator"
-    },
-    {
-      "name": "base-windows-no-mlir",
-      "hidden": true,
-      "inherits": ["base-windows", "base-no-mlir"]
-    },
-    {
       "name": "debug",
-      "inherits": "base-unix",
+      "inherits": "base",
       "displayName": "Debug config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -63,7 +32,7 @@
     },
     {
       "name": "debug-no-mlir",
-      "inherits": "base-unix-no-mlir",
+      "inherits": "base-no-mlir",
       "displayName": "Debug config without MLIR",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
@@ -71,7 +40,7 @@
     },
     {
       "name": "release",
-      "inherits": "base-unix",
+      "inherits": "base",
       "displayName": "Release config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
@@ -79,7 +48,7 @@
     },
     {
       "name": "release-no-mlir",
-      "inherits": "base-unix-no-mlir",
+      "inherits": "base-no-mlir",
       "displayName": "Release config without MLIR",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
@@ -87,7 +56,7 @@
     },
     {
       "name": "coverage",
-      "inherits": "base-unix",
+      "inherits": "base",
       "displayName": "Coverage config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -96,46 +65,13 @@
     },
     {
       "name": "lint",
-      "inherits": "base-unix",
+      "inherits": "base",
       "displayName": "Lint config",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "BUILD_MQT_CORE_BINDINGS": "ON",
         "CMAKE_UNITY_BUILD": "OFF",
         "CMAKE_VERIFY_INTERFACE_HEADER_SETS": "ON"
-      }
-    },
-    {
-      "name": "debug-windows",
-      "inherits": "base-windows",
-      "displayName": "Windows Debug config",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "LLVM_ENABLE_ASSERTIONS": "ON"
-      }
-    },
-    {
-      "name": "debug-windows-no-mlir",
-      "inherits": "base-windows-no-mlir",
-      "displayName": "Windows Debug config without MLIR",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "name": "release-windows",
-      "inherits": "base-windows",
-      "displayName": "Windows Release config",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
-    },
-    {
-      "name": "release-windows-no-mlir",
-      "inherits": "base-windows-no-mlir",
-      "displayName": "Windows Release config without MLIR",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
       }
     }
   ],
@@ -163,26 +99,6 @@
     {
       "name": "lint",
       "configurePreset": "lint"
-    },
-    {
-      "name": "debug-windows",
-      "configurePreset": "debug-windows",
-      "configuration": "Debug"
-    },
-    {
-      "name": "debug-windows-no-mlir",
-      "configurePreset": "debug-windows-no-mlir",
-      "configuration": "Debug"
-    },
-    {
-      "name": "release-windows",
-      "configurePreset": "release-windows",
-      "configuration": "Release"
-    },
-    {
-      "name": "release-windows-no-mlir",
-      "configurePreset": "release-windows-no-mlir",
-      "configuration": "Release"
     }
   ],
   "testPresets": [
@@ -216,30 +132,6 @@
       "name": "coverage",
       "inherits": "base",
       "configurePreset": "coverage"
-    },
-    {
-      "name": "debug-windows",
-      "inherits": "base",
-      "configurePreset": "debug-windows",
-      "configuration": "Debug"
-    },
-    {
-      "name": "debug-windows-no-mlir",
-      "inherits": "base",
-      "configurePreset": "debug-windows-no-mlir",
-      "configuration": "Debug"
-    },
-    {
-      "name": "release-windows",
-      "inherits": "base",
-      "configurePreset": "release-windows",
-      "configuration": "Release"
-    },
-    {
-      "name": "release-windows-no-mlir",
-      "inherits": "base",
-      "configurePreset": "release-windows-no-mlir",
-      "configuration": "Release"
     }
   ]
 }


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Share the standard Ninja-backed CMake configure, build, and test presets across Linux, macOS, and Windows instead of maintaining separate Windows presets.

Pin the Workflows `main` revision that contains merged munich-quantum-toolkit/workflows#460 and exercise its default GitHub-backed sccache integration across the C++ test, C++ linter, C++ coverage, and ordinary Python test paths. The cibuildwheel and CD paths remain pinned to the released v2.3.1 workflows and are unchanged.

Workflows revision: merged munich-quantum-toolkit/workflows#460 (`9d0a300a990563b5d70b6cd5e7549c3e678d3cf7`).

### Experiment results

| C++ job | Cold | Final warm | Reduction |
| --- | ---: | ---: | ---: |
| Windows x64 | 17m52s | 3m34s | 80% |
| Windows ARM64 | 13m30s | 4m16s | 68% |
| Ubuntu ARM64 | 8m27s | 1m42s | 80% |
| Linter | 14m02s | 2m21s | 83% |
| Coverage | 10m37s | 4m15s | 60% |

| Python test job | Cold | Final warm | Reduction |
| --- | ---: | ---: | ---: |
| Ubuntu x64 | 18m52s | 12m34s | 34% |
| Ubuntu ARM64 | 14m59s | 11m51s | 21% |
| macOS | 15m21s | 13m02s | 15% |
| Windows x64 | 27m05s | 15m45s | 42% |

The final exact-head run served every C++ compiler request from cache: 159/159 in each full C++ build and coverage job, 350/350 in the linter, and 23/23 in the no-MLIR build. Python tests recorded 135 Ubuntu x64, 134 Ubuntu ARM64, 134 macOS, and 110 Windows hits, with zero misses and zero cache read/write errors on every platform.

The initial concurrent cold run encountered non-fatal GitHub cache write-rate errors. The reusable workflows therefore let only `main` write while pull requests and other branches read the default-branch cache.

An LLD comparison found no meaningful improvement and was removed from the final workflows: x64 C++ build steps measured 60.2s with LLD versus 62.0–74.3s without it, while ARM64 measured 62.2s versus 61.5–64.8s.

The obsolete timestamped linter and coverage ccache archives were deleted separately. The verified post-cleanup snapshot contains no `c++-lint_*` or `c++-coverage_*` cache entries; active runs using the old workflow can recreate them until the rollout reaches `main`.

AI assistance: GPT-5.6 via Codex implemented and validated the preset/workflow changes and drafted this description.

### Validation

- `uvx nox -s lint`
- shared `release-no-mlir` preset configure and build
- C++ tests (375 passed)
- manual cold full-matrix run [34111068554](https://github.com/munich-quantum-toolkit/core/actions/runs/34111068554) (passed)
- exact-head PR run [34122741185](https://github.com/munich-quantum-toolkit/core/actions/runs/34122741185) (passed)
- final full-matrix run [34122770074](https://github.com/munich-quantum-toolkit/core/actions/runs/34122770074) at `d4f77a06e876637fc5ee134d423ec223bd539cb1` (passed)

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
