### PR TITLE
🐛 Support V gates in the Qiskit exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Export V and V† gates to Qiskit ([#2433]) ([**@burgholzer**])
+
 ## [3.10.0] - 2026-09-05
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#3100)._
@@ -823,6 +827,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2433]: https://github.com/munich-quantum-toolkit/core/pull/2433
 [#2399]: https://github.com/munich-quantum-toolkit/core/pull/2399
 [#2368]: https://github.com/munich-quantum-toolkit/core/pull/2368
 [#2358]: https://github.com/munich-quantum-toolkit/core/pull/2358

--- a/python/mqt/core/plugins/qiskit/mqt_to_qiskit.py
+++ b/python/mqt/core/plugins/qiskit/mqt_to_qiskit.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+from math import pi
 from typing import TYPE_CHECKING
 
 from qiskit.circuit import (
@@ -67,8 +68,7 @@ from ...ir.operations import (
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
-    from qiskit.circuit import Clbit, Qubit
-    from qiskit.circuit.singleton import SingletonGate
+    from qiskit.circuit import Clbit, Gate, Qubit
 
     from ...ir import QuantumComputation
     from ...ir.operations import Operation
@@ -132,7 +132,7 @@ def _add_standard_operation(circ: QuantumCircuit, op: StandardOperation, qubit_m
 
     controls, ctrl_state = _translate_controls(op.controls, qubit_map)
 
-    gate_map_singleton: dict[OpType, SingletonGate] = {
+    gate_map_no_param: dict[OpType, Gate] = {
         OpType.i: IGate(),
         OpType.x: XGate(),
         OpType.y: YGate(),
@@ -142,6 +142,8 @@ def _add_standard_operation(circ: QuantumCircuit, op: StandardOperation, qubit_m
         OpType.sdg: SdgGate(),
         OpType.t: TGate(),
         OpType.tdg: TdgGate(),
+        OpType.v: RXGate(pi / 2),
+        OpType.vdg: RXGate(-pi / 2),
         OpType.sx: SXGate(),
         OpType.sxdg: SXdgGate(),
         OpType.dcx: DCXGate(),
@@ -151,8 +153,8 @@ def _add_standard_operation(circ: QuantumCircuit, op: StandardOperation, qubit_m
         OpType.rccx: RCCXGate(),
     }
 
-    if op.type_ in gate_map_singleton:
-        gate = gate_map_singleton[op.type_]
+    if op.type_ in gate_map_no_param:
+        gate = gate_map_no_param[op.type_]
         if len(controls) == 0:
             circ.append(gate, targets)
         else:

--- a/test/python/plugins/test_qiskit.py
+++ b/test/python/plugins/test_qiskit.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+from math import pi
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -30,6 +31,7 @@ from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.qasm3 import dumps
 from qiskit.quantum_info import Operator
 
+from mqt.core.ir import QuantumComputation
 from mqt.core.ir.operations import (
     ComparisonKind,
     CompoundOperation,
@@ -417,6 +419,23 @@ def test_operations() -> None:
     print(qiskit_qc)
     assert qiskit_qc.num_qubits == 3
     assert len(qiskit_qc) == len(qc)
+
+
+def test_v_gates() -> None:
+    """Test export of V gates."""
+    qc = QuantumComputation(2)
+    qc.v(0)
+    qc.cv(0, 1)
+    qc.vdg(0)
+    qc.cvdg(0, 1)
+
+    expected = QuantumCircuit(2)
+    expected.rx(pi / 2, 0)
+    expected.crx(pi / 2, 0, 1)
+    expected.rx(-pi / 2, 0)
+    expected.crx(-pi / 2, 0, 1)
+
+    assert mqt_to_qiskit(qc) == expected
 
 
 @pytest.mark.parametrize("ctrl_state", ["0", "1"])


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Export MQT V and Vdg operations as Qiskit RX gates with fixed angles of π/2 and -π/2. This representation preserves the exact matrix and remains correct for controlled operations.

Codex traced the exporter dispatch and gate semantics, implemented the change and regression test, and ran the validation listed below.

Fixes #2432

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the projects style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.