### PR TITLE
🐛 Enforce unitary effect contracts

### DIFF
--- a/mlir/include/mlir/Dialect/MQT/IR/MQTDialect.td
+++ b/mlir/include/mlir/Dialect/MQT/IR/MQTDialect.td
@@ -35,9 +35,15 @@ def MQTDialect : Dialect {
     `mqt.entry_point` marks the single public, defined `func.func` program entry
     in a module.
     `mqt.unitary` marks a private function that defines a unitary operation.
-    Its body admits unitary operations and pure, region-free classical
-    computation, matching the quantum modifier-body contract. Unitary
-    operations may retain effects such as a scoped global-phase contribution.
+    Its body admits unitary operations and memory-effect-free, region-free
+    classical computation, matching the quantum modifier-body contract. Parameter
+    computation is evaluated eagerly when the invocation is reached; it need not
+    be speculatable. The quantum action is unitary on the computation's defined
+    input domain. Modifiers transform that action, not the parameter computation:
+    inverse does not reverse it, control does not conditionally evaluate it, and
+    power does not repeat it, including at exponent zero. Undefined inputs do not
+    guarantee traps. Unitary operations may retain effects such as a scoped
+    global-phase contribution.
     `#mqt.compilation_target` records compiler-target facts as typed IR.
   }];
 

--- a/mlir/include/mlir/Dialect/MQT/IR/MQTDialect.td
+++ b/mlir/include/mlir/Dialect/MQT/IR/MQTDialect.td
@@ -35,6 +35,9 @@ def MQTDialect : Dialect {
     `mqt.entry_point` marks the single public, defined `func.func` program entry
     in a module.
     `mqt.unitary` marks a private function that defines a unitary operation.
+    Its body admits unitary operations and pure, region-free classical
+    computation, matching the quantum modifier-body contract. Unitary
+    operations may retain effects such as a scoped global-phase contribution.
     `#mqt.compilation_target` records compiler-target facts as typed IR.
   }];
 

--- a/mlir/include/mlir/Dialect/QC/IR/QCOps.td
+++ b/mlir/include/mlir/Dialect/QC/IR/QCOps.td
@@ -1043,7 +1043,8 @@ def CtrlOp
         Note that control qubits are logically unmodified by this operation in that their quantum state remains unchanged.
         However, the `controls` argument is marked with `MemWrite` to ensure correct dependency tracking in MLIR.
 
-        The body region may contain unitary operations and pure classical operations without regions.
+        The body region may contain unitary operations and memory-effect-free classical operations without regions.
+        Parameter computation is eager, as specified by the `mqt.unitary` contract; it need not be speculatable.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
@@ -1107,7 +1108,8 @@ def InvOp : QCOp<"inv",
   let description = [{
         A modifier operation that inverts the gates defined in its body region.
 
-        The body region may contain unitary operations and pure classical operations without regions.
+        The body region may contain unitary operations and memory-effect-free classical operations without regions.
+        Parameter computation is eager, as specified by the `mqt.unitary` contract; it need not be speculatable.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
@@ -1171,7 +1173,8 @@ def PowOp : QCOp<"pow",
           - r = 0: identity (no-op).
           - r < 0: equivalent to inv @ pow(-r) @ g.
 
-          The body region may contain unitary operations and pure classical operations without regions.
+        The body region may contain unitary operations and memory-effect-free classical operations without regions.
+        Parameter computation is eager, as specified by the `mqt.unitary` contract; it need not be speculatable.
           Classical SSA values may be captured from above, but every qubit used
           in the body must be passed through a modifier operand and accessed via
           its aliased block argument.

--- a/mlir/include/mlir/Dialect/QC/IR/QCOps.td
+++ b/mlir/include/mlir/Dialect/QC/IR/QCOps.td
@@ -1043,11 +1043,11 @@ def CtrlOp
         Note that control qubits are logically unmodified by this operation in that their quantum state remains unchanged.
         However, the `controls` argument is marked with `MemWrite` to ensure correct dependency tracking in MLIR.
 
-        The body region may contain an arbitrary amount of unitary and classical operations.
+        The body region may contain unitary operations and pure classical operations without regions.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Non-unitary operations, such as `AllocOp` and `MeasureOp`, are not allowed.
+        Operations with memory effects and non-unitary region operations are not allowed.
 
         Example:
         ```mlir
@@ -1106,11 +1106,11 @@ def InvOp : QCOp<"inv",
   let description = [{
         A modifier operation that inverts the gates defined in its body region.
 
-        The body region may contain an arbitrary amount of unitary and classical operations.
+        The body region may contain unitary operations and pure classical operations without regions.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Non-unitary operations, such as `AllocOp` and `MeasureOp`, are not allowed.
+        Operations with memory effects and non-unitary region operations are not allowed.
 
         Example:
         ```mlir
@@ -1169,11 +1169,11 @@ def PowOp : QCOp<"pow",
           - r = 0: identity (no-op).
           - r < 0: equivalent to inv @ pow(-r) @ g.
 
-          The body region may contain an arbitrary amount of unitary and classical operations.
+          The body region may contain unitary operations and pure classical operations without regions.
           Classical SSA values may be captured from above, but every qubit used
           in the body must be passed through a modifier operand and accessed via
           its aliased block argument.
-          Non-unitary operations, such as `AllocOp` and `MeasureOp`, are not allowed.
+          Operations with memory effects and non-unitary region operations are not allowed.
 
           Example:
           ```mlir

--- a/mlir/include/mlir/Dialect/QC/IR/QCOps.td
+++ b/mlir/include/mlir/Dialect/QC/IR/QCOps.td
@@ -1047,7 +1047,8 @@ def CtrlOp
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Operations with memory effects and non-unitary region operations are not allowed.
+        Classical memory access and non-unitary region operations are not allowed.
+        Unitary operations retain their required effects, including global phase.
 
         Example:
         ```mlir
@@ -1110,7 +1111,8 @@ def InvOp : QCOp<"inv",
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Operations with memory effects and non-unitary region operations are not allowed.
+        Classical memory access and non-unitary region operations are not allowed.
+        Unitary operations retain their required effects, including global phase.
 
         Example:
         ```mlir
@@ -1173,7 +1175,8 @@ def PowOp : QCOp<"pow",
           Classical SSA values may be captured from above, but every qubit used
           in the body must be passed through a modifier operand and accessed via
           its aliased block argument.
-          Operations with memory effects and non-unitary region operations are not allowed.
+          Classical memory access and non-unitary region operations are not allowed.
+          Unitary operations retain their required effects, including global phase.
 
           Example:
           ```mlir

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1254,7 +1254,8 @@ def CtrlOp : QCOOp<"ctrl",
         The operation takes a variadic number of control and target qubits as inputs and produces corresponding output qubits.
         Control qubits are not modified by the operation and simply pass through to the outputs.
 
-        The body region may contain unitary operations and pure classical operations without regions.
+        The body region may contain unitary operations and memory-effect-free classical operations without regions.
+        Parameter computation is eager, as specified by the `mqt.unitary` contract; it need not be speculatable.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
@@ -1341,7 +1342,8 @@ def InvOp
 
         The operation takes a variadic number of qubits as inputs and produces corresponding output qubits.
 
-        The body region may contain unitary operations and pure classical operations without regions.
+        The body region may contain unitary operations and memory-effect-free classical operations without regions.
+        Parameter computation is eager, as specified by the `mqt.unitary` contract; it need not be speculatable.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
@@ -1425,7 +1427,8 @@ def PowOp
         - r = 0: identity (no-op).
         - r < 0: equivalent to inv @ pow(-r) @ g.
 
-        The body region may contain unitary operations and pure classical operations without regions.
+        The body region may contain unitary operations and memory-effect-free classical operations without regions.
+        Parameter computation is eager, as specified by the `mqt.unitary` contract; it need not be speculatable.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1136,17 +1136,16 @@ def BarrierOp : QCOOp<"barrier", traits = [UnitaryOpInterface, Pure]> {
 }
 
 def CallOp
-    : QCOOp<"call",
-            traits = [CallOpInterface, UnitaryOpInterface,
-                      DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-                      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+    : QCOOp<"call", traits = [CallOpInterface, UnitaryOpInterface,
+                              DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+                              MemoryEffects<[MemWrite]>]> {
   let summary = "Call a unitary QCO function";
   let description = [{
     Calls a private `func.func` marked with `mqt.unitary`. Parameters precede
     qubit operands. Each qubit result continues the corresponding qubit input.
-    Calls are memory-effect-free when their transitive callees are
-    memory-effect-free. Otherwise, they conservatively carry a write effect,
-    including when a callee contains a global phase. Calls are not speculatable.
+    Calls conservatively carry a write effect and are not speculatable.
+    Module-level analyses may prove more precise effects for individual
+    optimizations. Generic effect queries do not inspect other function bodies.
 
     Example:
     ```mlir

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1136,15 +1136,17 @@ def BarrierOp : QCOOp<"barrier", traits = [UnitaryOpInterface, Pure]> {
 }
 
 def CallOp
-    : QCOOp<"call", traits = [CallOpInterface, UnitaryOpInterface,
-                              DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-                              MemoryEffects<[MemWrite]>]> {
+    : QCOOp<"call",
+            traits = [CallOpInterface, UnitaryOpInterface,
+                      DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+                      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Call a unitary QCO function";
   let description = [{
     Calls a private `func.func` marked with `mqt.unitary`. Parameters precede
     qubit operands. Each qubit result continues the corresponding qubit input.
-    Calls conservatively carry a write effect because the callee may contain a
-    global phase.
+    Calls are memory-effect-free when their transitive callees are
+    memory-effect-free. Otherwise, they conservatively carry a write effect,
+    including when a callee contains a global phase. Calls are not speculatable.
 
     Example:
     ```mlir
@@ -1257,7 +1259,8 @@ def CtrlOp : QCOOp<"ctrl",
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Operations with memory effects and non-unitary region operations are not allowed.
+        Classical memory access and non-unitary region operations are not allowed.
+        Unitary operations retain their required effects, including global phase.
 
         Example:
         ```mlir
@@ -1343,7 +1346,8 @@ def InvOp
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Operations with memory effects and non-unitary region operations are not allowed.
+        Classical memory access and non-unitary region operations are not allowed.
+        Unitary operations retain their required effects, including global phase.
 
         Example:
         ```mlir
@@ -1426,7 +1430,8 @@ def PowOp
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Operations with memory effects and non-unitary region operations are not allowed.
+        Classical memory access and non-unitary region operations are not allowed.
+        Unitary operations retain their required effects, including global phase.
 
         Example:
         ```mlir

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1136,13 +1136,15 @@ def BarrierOp : QCOOp<"barrier", traits = [UnitaryOpInterface, Pure]> {
 }
 
 def CallOp
-    : QCOOp<"call",
-            traits = [CallOpInterface, UnitaryOpInterface,
-                      DeclareOpInterfaceMethods<SymbolUserOpInterface>, Pure]> {
+    : QCOOp<"call", traits = [CallOpInterface, UnitaryOpInterface,
+                              DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+                              MemoryEffects<[MemWrite]>]> {
   let summary = "Call a unitary QCO function";
   let description = [{
     Calls a private `func.func` marked with `mqt.unitary`. Parameters precede
     qubit operands. Each qubit result continues the corresponding qubit input.
+    Calls conservatively carry a write effect because the callee may contain a
+    global phase.
 
     Example:
     ```mlir
@@ -1241,8 +1243,8 @@ def CtrlOp : QCOOp<"ctrl",
                    traits = [UnitaryOpInterface, AttrSizedOperandSegments,
                              AttrSizedResultSegments, SameOperandsAndResultType,
                              SameOperandsAndResultShape,
-                             SingleBlockImplicitTerminator<"YieldOp">, Pure,
-                             RecursiveMemoryEffects]> {
+                             SingleBlockImplicitTerminator<"YieldOp">,
+                             RecursivelySpeculatable, RecursiveMemoryEffects]> {
   let summary = "Apply a control modifier to a collection of gates";
   let description = [{
         A modifier operation that adds control qubits to the gates defined in its body region.
@@ -1251,11 +1253,11 @@ def CtrlOp : QCOOp<"ctrl",
         The operation takes a variadic number of control and target qubits as inputs and produces corresponding output qubits.
         Control qubits are not modified by the operation and simply pass through to the outputs.
 
-        The body region may contain an arbitrary amount of unitary and classical operations.
+        The body region may contain unitary operations and pure classical operations without regions.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Non-unitary operations, such as `AllocOp` and `MeasureOp`, are not allowed.
+        Operations with memory effects and non-unitary region operations are not allowed.
 
         Example:
         ```mlir
@@ -1326,9 +1328,10 @@ def CtrlOp : QCOOp<"ctrl",
   let hasVerifier = 1;
 }
 
-def InvOp : QCOOp<"inv", traits = [UnitaryOpInterface,
-                                   SingleBlockImplicitTerminator<"YieldOp">,
-                                   Pure, RecursiveMemoryEffects]> {
+def InvOp
+    : QCOOp<"inv", traits = [UnitaryOpInterface,
+                             SingleBlockImplicitTerminator<"YieldOp">,
+                             RecursivelySpeculatable, RecursiveMemoryEffects]> {
   let summary =
       "Apply an inverse (i.e., adjoint) modifier to a collection of gates";
   let description = [{
@@ -1336,11 +1339,11 @@ def InvOp : QCOOp<"inv", traits = [UnitaryOpInterface,
 
         The operation takes a variadic number of qubits as inputs and produces corresponding output qubits.
 
-        The body region may contain an arbitrary amount of unitary and classical operations.
+        The body region may contain unitary operations and pure classical operations without regions.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Non-unitary operations, such as `AllocOp` and `MeasureOp`, are not allowed.
+        Operations with memory effects and non-unitary region operations are not allowed.
 
         Example:
         ```mlir
@@ -1406,7 +1409,7 @@ def PowOp
     : QCOOp<"pow",
             traits = [UnitaryOpInterface,
                       SingleBlockImplicitTerminator<"::mlir::qco::YieldOp">,
-                      RecursiveMemoryEffects]> {
+                      RecursivelySpeculatable, RecursiveMemoryEffects]> {
   let summary = "Raise a unitary operation to a power";
   let description = [{
         A modifier operation that raises the gates defined in its body region to a given power.
@@ -1419,11 +1422,11 @@ def PowOp
         - r = 0: identity (no-op).
         - r < 0: equivalent to inv @ pow(-r) @ g.
 
-        The body region may contain an arbitrary amount of unitary and classical operations.
+        The body region may contain unitary operations and pure classical operations without regions.
         Classical SSA values may be captured from above, but every qubit used
         in the body must be passed through a modifier operand and accessed via
         its aliased block argument.
-        Non-unitary operations, such as `AllocOp` and `MeasureOp`, are not allowed.
+        Operations with memory effects and non-unitary region operations are not allowed.
 
         Example:
         ```mlir
@@ -1505,8 +1508,9 @@ def IfOp
                                                   "getRegionInvocationBounds",
                                                   "getEntrySuccessorRegions",
                                                   "getEntrySuccessorOperands"]>,
-                    SingleBlock, SingleBlockImplicitTerminator<"YieldOp">, Pure,
-                    RecursiveMemoryEffects, AttrSizedResultSegments]> {
+                    SingleBlock, SingleBlockImplicitTerminator<"YieldOp">,
+                    RecursivelySpeculatable, RecursiveMemoryEffects,
+                    AttrSizedResultSegments]> {
 
   let summary = "If-then-else operation with classical and linear results";
   let description = [{
@@ -1644,8 +1648,9 @@ def IndexSwitchOp
                         RegionBranchOpInterface, ["getRegionInvocationBounds",
                                                   "getEntrySuccessorRegions",
                                                   "getEntrySuccessorOperands"]>,
-                    SingleBlockImplicitTerminator<"YieldOp">, Pure,
-                    RecursiveMemoryEffects, AttrSizedResultSegments]> {
+                    SingleBlockImplicitTerminator<"YieldOp">,
+                    RecursivelySpeculatable, RecursiveMemoryEffects,
+                    AttrSizedResultSegments]> {
 
   let summary =
       "Index-based switch operation with classical and linear results";

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -327,6 +327,12 @@ def ReuseQubits : Pass<"reuse-qubits", "mlir::ModuleOp"> {
     `measurement-lifting` and `replace-classical-controls` passes, which can reduce the number of qubits required for a quantum program significantly.
     Only single-qubit allocations are considered for reuse, no `qtensor` allocations.
 
+    Before rewriting non-unitary functions, the pass summarizes the memory effects
+    of unitary helpers and their transitive callees. Proven effect-free calls
+    permit reuse; scoped global phases and unknown effects remain barriers.
+    Unitary helpers are not rewritten, and summaries are discarded after each
+    pass invocation.
+
     Use the `mqt-qubit-reuse` pipeline to run the preparation passes followed by this pass.
   }];
 }

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -25,6 +25,7 @@
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/ScopeExit.h>
+#include <llvm/ADT/TypeSwitch.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
@@ -661,41 +662,12 @@ collectRegisterAccesses(Operation* root, LoweringState& state) {
 /// Rejects unsupported operations and qubit captures in QC modifiers.
 [[nodiscard]] static LogicalResult validateModifierBodies(Operation* root) {
   const auto result = root->walk([&](Operation* operation) {
-    if (!isa<qc::InvOp, qc::CtrlOp, qc::PowOp>(operation)) {
-      return WalkResult::advance();
-    }
-
-    SetVector<Value> captures;
-    getUsedValuesDefinedAbove(operation->getRegions(), captures);
-    if (llvm::any_of(captures, [](Value value) {
-          return isa<qc::QubitType>(value.getType());
-        })) {
-      operation->emitOpError(
-          "body must not capture qubits from above; use only its aliased "
-          "block arguments");
-      return WalkResult::interrupt();
-    }
-
-    auto& body = operation->getRegion(0).front();
-    const auto hasNonUnitaryOperation =
-        llvm::any_of(body.without_terminator(), [](Operation& nested) {
-          if (isa<qc::UnitaryOpInterface>(nested)) {
-            return false;
-          }
-          const auto isQubit = [](Type type) {
-            return isa<qc::QubitType>(type);
-          };
-          return nested.getNumRegions() != 0 || !isPure(&nested) ||
-                 llvm::any_of(nested.getOperandTypes(), isQubit) ||
-                 llvm::any_of(nested.getResultTypes(), isQubit);
-        });
-    if (hasNonUnitaryOperation) {
-      operation->emitOpError(
-          "body must contain only unitary operations and pure classical "
-          "operations without regions");
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
+    return llvm::TypeSwitch<Operation*, WalkResult>(operation)
+        .Case<qc::InvOp, qc::CtrlOp, qc::PowOp>([](auto modifier) {
+          return failed(modifier.verify()) ? WalkResult::interrupt()
+                                           : WalkResult::advance();
+        })
+        .Default(WalkResult::advance());
   });
   return success(!result.wasInterrupted());
 }

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -661,33 +661,38 @@ collectRegisterAccesses(Operation* root, LoweringState& state) {
 /// Rejects unsupported operations and qubit captures in QC modifiers.
 [[nodiscard]] static LogicalResult validateModifierBodies(Operation* root) {
   const auto result = root->walk([&](Operation* operation) {
-    if (isa<qc::InvOp, qc::CtrlOp, qc::PowOp>(operation)) {
-      SetVector<Value> captures;
-      getUsedValuesDefinedAbove(operation->getRegions(), captures);
-      if (llvm::any_of(captures, [](Value value) {
-            return isa<qc::QubitType>(value.getType());
-          })) {
-        operation->emitOpError(
-            "body must not capture qubits from above; use only its aliased "
-            "block arguments");
-        return WalkResult::interrupt();
-      }
-    }
-
-    if (operation->getName().getDialectNamespace() !=
-            cbit::CBitDialect::getDialectNamespace() &&
-        !isa<qc::AllocOp, qc::DeallocOp, qc::MeasureOp, qc::ResetOp,
-             memref::LoadOp, memref::StoreOp>(operation)) {
+    if (!isa<qc::InvOp, qc::CtrlOp, qc::PowOp>(operation)) {
       return WalkResult::advance();
     }
 
-    for (auto* parent = operation->getParentOp(); parent != nullptr;
-         parent = parent->getParentOp()) {
-      if (!isa<qc::InvOp, qc::CtrlOp, qc::PowOp>(parent)) {
-        continue;
-      }
-      parent->emitOpError(
-          "body must not contain non-unitary operations or access registers");
+    SetVector<Value> captures;
+    getUsedValuesDefinedAbove(operation->getRegions(), captures);
+    if (llvm::any_of(captures, [](Value value) {
+          return isa<qc::QubitType>(value.getType());
+        })) {
+      operation->emitOpError(
+          "body must not capture qubits from above; use only its aliased "
+          "block arguments");
+      return WalkResult::interrupt();
+    }
+
+    auto& body = operation->getRegion(0).front();
+    const auto hasNonUnitaryOperation =
+        llvm::any_of(body.without_terminator(), [](Operation& nested) {
+          if (isa<qc::UnitaryOpInterface>(nested)) {
+            return false;
+          }
+          const auto isQubit = [](Type type) {
+            return isa<qc::QubitType>(type);
+          };
+          return nested.getNumRegions() != 0 || !isPure(&nested) ||
+                 llvm::any_of(nested.getOperandTypes(), isQubit) ||
+                 llvm::any_of(nested.getResultTypes(), isQubit);
+        });
+    if (hasNonUnitaryOperation) {
+      operation->emitOpError(
+          "body must contain only unitary operations and pure classical "
+          "operations without regions");
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
@@ -727,27 +732,6 @@ static void collectStructuredCaptures(Operation* root, LoweringState& state) {
   });
 }
 
-/// Canonicalizes preserved SCF capture keys after signature conversion.
-static void remapStructuredCaptures(Operation* root, LoweringState& state) {
-  root->walk([&](Operation* operation) {
-    if (!isa<scf::ForOp, scf::WhileOp, scf::IfOp, scf::IndexSwitchOp>(
-            operation)) {
-      return;
-    }
-
-    const auto captures = state.regionQubitMap.find(operation);
-    if (captures == state.regionQubitMap.end()) {
-      return;
-    }
-
-    SetVector<Value> remapped;
-    for (auto qubit : captures->second) {
-      remapped.insert(canonicalQubitKey(state, qubit));
-    }
-    captures->second = std::move(remapped);
-  });
-}
-
 /// Seeds region-owned modifier state after signature conversion.
 static void initializeModifierRegionState(Operation* modifier,
                                           ValueRange sourceArguments,
@@ -762,11 +746,6 @@ static void initializeModifierRegionState(Operation* modifier,
       SmallVector<Value>(convertedArguments.begin(), convertedArguments.end());
   seedRegionMappings(state, region, convertedArguments, {}, convertedArguments,
                      {});
-
-  // Signature conversion replaces modifier block arguments. Refresh nested
-  // structured captures so they refer to the converted arguments owned by the
-  // moved region rather than source conversion keys.
-  remapStructuredCaptures(modifier, state);
 }
 
 namespace {

--- a/mlir/lib/Dialect/MQT/IR/MQTDialect.cpp
+++ b/mlir/lib/Dialect/MQT/IR/MQTDialect.cpp
@@ -358,7 +358,7 @@ verifyNoUnitaryRecursion(func::FuncOp function) {
       return;
     }
     valid =
-        nested->getNumRegions() == 0 && isPure(nested) &&
+        nested->getNumRegions() == 0 && isMemoryEffectFree(nested) &&
         llvm::none_of(nested->getOperandTypes(),
                       llvm::IsaPred<qc::QubitType>) &&
         llvm::none_of(nested->getResultTypes(), llvm::IsaPred<qc::QubitType>);
@@ -382,7 +382,7 @@ verifyNoUnitaryRecursion(func::FuncOp function) {
       return;
     }
     valid =
-        nested->getNumRegions() == 0 && isPure(nested) &&
+        nested->getNumRegions() == 0 && isMemoryEffectFree(nested) &&
         llvm::none_of(nested->getOperandTypes(),
                       llvm::IsaPred<qco::QubitType>) &&
         llvm::none_of(nested->getResultTypes(), llvm::IsaPred<qco::QubitType>);

--- a/mlir/lib/Dialect/MQT/IR/MQTDialect.cpp
+++ b/mlir/lib/Dialect/MQT/IR/MQTDialect.cpp
@@ -358,7 +358,7 @@ verifyNoUnitaryRecursion(func::FuncOp function) {
       return;
     }
     valid =
-        nested->getNumRegions() == 0 && isMemoryEffectFree(nested) &&
+        nested->getNumRegions() == 0 && isPure(nested) &&
         llvm::none_of(nested->getOperandTypes(),
                       llvm::IsaPred<qc::QubitType>) &&
         llvm::none_of(nested->getResultTypes(), llvm::IsaPred<qc::QubitType>);
@@ -382,7 +382,7 @@ verifyNoUnitaryRecursion(func::FuncOp function) {
       return;
     }
     valid =
-        nested->getNumRegions() == 0 && isMemoryEffectFree(nested) &&
+        nested->getNumRegions() == 0 && isPure(nested) &&
         llvm::none_of(nested->getOperandTypes(),
                       llvm::IsaPred<qco::QubitType>) &&
         llvm::none_of(nested->getResultTypes(), llvm::IsaPred<qco::QubitType>);

--- a/mlir/lib/Dialect/MQT/Transforms/NormalizeGlobalPhases.cpp
+++ b/mlir/lib/Dialect/MQT/Transforms/NormalizeGlobalPhases.cpp
@@ -200,7 +200,8 @@ struct PhaseContribution final {
 
 } // namespace
 
-/// Collect a pure, body-local dependency slice in topological order.
+/// Collect a memory-effect-free, body-local dependency slice in order.
+/// Extraction crosses only eager quantum modifiers, never classical branches.
 static bool collectHoistableSlice(Value value, Block& body,
                                   SmallPtrSetImpl<Operation*>& visiting,
                                   SmallPtrSetImpl<Operation*>& collected,
@@ -217,7 +218,7 @@ static bool collectHoistableSlice(Value value, Block& body,
     return true;
   }
   if (!visiting.insert(definingOp).second || definingOp->getNumRegions() != 0 ||
-      !isPure(definingOp) || !isSpeculatable(definingOp)) {
+      !isMemoryEffectFree(definingOp)) {
     return false;
   }
   for (auto operand : definingOp->getOperands()) {

--- a/mlir/lib/Dialect/MQT/Transforms/UnrollModifiers.cpp
+++ b/mlir/lib/Dialect/MQT/Transforms/UnrollModifiers.cpp
@@ -49,12 +49,8 @@ namespace mlir::mqt {
 #define GEN_PASS_DEF_UNROLLMODIFIERS
 #include "mlir/Dialect/MQT/Transforms/Passes.h.inc"
 
-/**
- *@brief Move the classical operations of @p body in front of @p modifier.
- *
- * @details Fails if a classical operation is impure or depends on values
- * defined in @p body.
- */
+/// Move eager, memory-effect-free parameter computation before the modifier.
+/// Keep dependency order and reject dependencies on the body's qubits.
 template <typename UnitaryOpInterface>
 static LogicalResult hoistClassicalOps(Block& body, Operation* modifier,
                                        RewriterBase& rewriter) {
@@ -64,9 +60,12 @@ static LogicalResult hoistClassicalOps(Block& body, Operation* modifier,
   };
   for (auto& op : body) {
     if (isClassical(op) &&
-        (!isPure(&op) || llvm::any_of(op.getOperands(), [&](Value operand) {
-          return operand.getParentBlock() == &body;
-        }))) {
+        (op.getNumRegions() != 0 || !isMemoryEffectFree(&op) ||
+         llvm::any_of(op.getOperands(), [&](Value operand) {
+           return operand.getParentBlock() == &body &&
+                  (!operand.getDefiningOp() ||
+                   !isClassical(*operand.getDefiningOp()));
+         }))) {
       return failure();
     }
   }

--- a/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
@@ -67,6 +67,8 @@ struct MoveCtrlOutsideInv final : OpRewritePattern<InvOp> {
           return mqt::getValueFromBlockArgument(t, outerQubits);
         });
 
+    mqt::hoistSupportingOpsBefore(*op.getBody(), innerCtrlOp, op, rewriter);
+
     rewriter.replaceOpWithNewOp<CtrlOp>(
         op, controls, targets, [&](ValueRange targetArgs) {
           InvOp::create(rewriter, op.getLoc(), targetArgs,
@@ -315,6 +317,8 @@ struct CancelNestedInv final : OpRewritePattern<InvOp> {
     if (!mqt::getSoleBodyUnitary<UnitaryOpInterface>(*innerInvOp.getBody())) {
       return failure();
     }
+
+    mqt::hoistSupportingOpsBefore(*op.getBody(), innerInvOp, op, rewriter);
 
     // inv(inv(x)) == x: inline the doubly-nested body directly onto the outer
     // qubits. The inner body's block arguments alias the inner modifier's

--- a/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.cpp
@@ -10,21 +10,18 @@
 
 #include "ModifierUtils.h"
 
-#include "mlir/Dialect/CBit/IR/CBitDialect.h"
 #include "mlir/Dialect/MQT/Utils/Modifiers.h"
-#include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVectorExtras.h>
-#include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
-#include <mlir/Support/WalkResult.h>
 #include <mlir/Transforms/RegionUtils.h>
 
 #include <cstddef>
@@ -32,21 +29,6 @@
 namespace mlir::qc::detail {
 
 LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
-  const auto hasNonUnitaryOperation =
-      body.walk([](Operation* operation) {
-            return operation->getName().getDialectNamespace() ==
-                               cbit::CBitDialect::getDialectNamespace() ||
-                           isa<AllocOp, DeallocOp, StaticOp, MeasureOp, ResetOp,
-                               memref::LoadOp, memref::StoreOp>(operation)
-                       ? WalkResult::interrupt()
-                       : WalkResult::advance();
-          })
-          .wasInterrupted();
-  if (hasNonUnitaryOperation) {
-    return modifierOp->emitOpError(
-        "body must not contain non-unitary operations or access registers");
-  }
-
   SetVector<Value> captures;
   getUsedValuesDefinedAbove(modifierOp->getRegions(), captures);
   if (llvm::any_of(captures, [](Value value) {
@@ -55,6 +37,22 @@ LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
     return modifierOp->emitOpError(
         "body must not capture qubits from above; use only its aliased block "
         "arguments");
+  }
+
+  const auto hasNonUnitaryOperation =
+      llvm::any_of(body.without_terminator(), [](Operation& operation) {
+        if (isa<UnitaryOpInterface>(operation)) {
+          return false;
+        }
+        const auto isQubit = [](Type type) { return isa<QubitType>(type); };
+        return operation.getNumRegions() != 0 || !isPure(&operation) ||
+               llvm::any_of(operation.getOperandTypes(), isQubit) ||
+               llvm::any_of(operation.getResultTypes(), isQubit);
+      });
+  if (hasNonUnitaryOperation) {
+    return modifierOp->emitOpError(
+        "body must contain only unitary operations and pure classical "
+        "operations without regions");
   }
 
   return success();

--- a/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/ModifierUtils.cpp
@@ -45,14 +45,15 @@ LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
           return false;
         }
         const auto isQubit = [](Type type) { return isa<QubitType>(type); };
-        return operation.getNumRegions() != 0 || !isPure(&operation) ||
+        return operation.getNumRegions() != 0 ||
+               !isMemoryEffectFree(&operation) ||
                llvm::any_of(operation.getOperandTypes(), isQubit) ||
                llvm::any_of(operation.getResultTypes(), isQubit);
       });
   if (hasNonUnitaryOperation) {
-    return modifierOp->emitOpError(
-        "body must contain only unitary operations and pure classical "
-        "operations without regions");
+    return modifierOp->emitOpError("body must contain only unitary operations "
+                                   "and memory-effect-free classical "
+                                   "operations without regions");
   }
 
   return success();

--- a/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
@@ -246,6 +246,8 @@ struct MoveCtrlOutsidePow final : OpRewritePattern<PowOp> {
           return mqt::getValueFromBlockArgument(t, outerQubits);
         });
 
+    mqt::hoistSupportingOpsBefore(*op.getBody(), innerCtrlOp, op, rewriter);
+
     rewriter.replaceOpWithNewOp<CtrlOp>(
         op, controls, targets, [&](ValueRange targetArgs) {
           PowOp::create(rewriter, op.getLoc(), op.getExponent(), targetArgs,

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
@@ -81,6 +81,8 @@ struct MoveCtrlOutsideInv final : OpRewritePattern<InvOp> {
           return mqt::getValueFromBlockArgument(t, outerQubits);
         });
 
+    mqt::hoistSupportingOpsBefore(*op.getBody(), innerCtrlOp, op, rewriter);
+
     auto newCtrl =
         CtrlOp::create(rewriter, op.getLoc(), controls, targets,
                        [&](ValueRange targetArgs) -> SmallVector<Value> {
@@ -369,6 +371,8 @@ struct CancelNestedInv final : OpRewritePattern<InvOp> {
     if (!mqt::getSoleBodyUnitary<UnitaryOpInterface>(*innerInvOp.getBody())) {
       return failure();
     }
+
+    mqt::hoistSupportingOpsBefore(*op.getBody(), innerInvOp, op, rewriter);
 
     // inv(inv(x)) == x: inline the doubly-nested body directly onto the outer
     // input qubits. The inner body's block arguments alias the inner modifier's

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
@@ -10,9 +10,7 @@
 
 #include "ModifierUtils.h"
 
-#include "mlir/Dialect/CBit/IR/CBitDialect.h"
 #include "mlir/Dialect/MQT/Utils/Modifiers.h"
-#include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
 #include <llvm/ADT/STLExtras.h>
@@ -21,9 +19,9 @@
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
-#include <mlir/Support/WalkResult.h>
 #include <mlir/Transforms/RegionUtils.h>
 
 #include <cstddef>
@@ -31,21 +29,6 @@
 namespace mlir::qco::detail {
 
 LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
-  const auto hasNonUnitaryOperation =
-      body.walk([](Operation* operation) {
-            return operation->getName().getDialectNamespace() ==
-                               cbit::CBitDialect::getDialectNamespace() ||
-                           isa<AllocOp, SinkOp, StaticOp, MeasureOp, ResetOp>(
-                               operation)
-                       ? WalkResult::interrupt()
-                       : WalkResult::advance();
-          })
-          .wasInterrupted();
-  if (hasNonUnitaryOperation) {
-    return modifierOp->emitOpError(
-        "body must not contain non-unitary operations or access registers");
-  }
-
   SetVector<Value> captures;
   getUsedValuesDefinedAbove(modifierOp->getRegions(), captures);
   if (llvm::any_of(captures, [](Value value) {
@@ -54,6 +37,22 @@ LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
     return modifierOp->emitOpError(
         "body must not capture qubits from above; use only its aliased block "
         "arguments");
+  }
+
+  const auto hasNonUnitaryOperation =
+      llvm::any_of(body.without_terminator(), [](Operation& operation) {
+        if (isa<UnitaryOpInterface>(operation)) {
+          return false;
+        }
+        const auto isQubit = [](Type type) { return isa<QubitType>(type); };
+        return operation.getNumRegions() != 0 || !isPure(&operation) ||
+               llvm::any_of(operation.getOperandTypes(), isQubit) ||
+               llvm::any_of(operation.getResultTypes(), isQubit);
+      });
+  if (hasNonUnitaryOperation) {
+    return modifierOp->emitOpError(
+        "body must contain only unitary operations and pure classical "
+        "operations without regions");
   }
 
   return success();

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
@@ -45,14 +45,15 @@ LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
           return false;
         }
         const auto isQubit = [](Type type) { return isa<QubitType>(type); };
-        return operation.getNumRegions() != 0 || !isPure(&operation) ||
+        return operation.getNumRegions() != 0 ||
+               !isMemoryEffectFree(&operation) ||
                llvm::any_of(operation.getOperandTypes(), isQubit) ||
                llvm::any_of(operation.getResultTypes(), isQubit);
       });
   if (hasNonUnitaryOperation) {
-    return modifierOp->emitOpError(
-        "body must contain only unitary operations and pure classical "
-        "operations without regions");
+    return modifierOp->emitOpError("body must contain only unitary operations "
+                                   "and memory-effect-free classical "
+                                   "operations without regions");
   }
 
   return success();

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
@@ -298,6 +298,8 @@ struct MoveCtrlOutsidePow final : OpRewritePattern<PowOp> {
           return mqt::getValueFromBlockArgument(t, outerQubits);
         });
 
+    mqt::hoistSupportingOpsBefore(*op.getBody(), innerCtrlOp, op, rewriter);
+
     auto newCtrl = CtrlOp::create(
         rewriter, op.getLoc(), controls, targets,
         [&](ValueRange targetArgs) -> SmallVector<Value> {

--- a/mlir/lib/Dialect/QCO/IR/Operations/CallOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/CallOp.cpp
@@ -12,90 +12,16 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/SmallPtrSet.h>
-#include <llvm/ADT/SmallVector.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
-#include <mlir/IR/Block.h>
-#include <mlir/IR/Operation.h>
-#include <mlir/IR/Region.h>
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/IR/ValueRange.h>
-#include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <iterator>
-#include <utility>
 
 using namespace mlir;
 using namespace mlir::qco;
-
-/// Query local effects and follow calls without recursively querying
-/// containers. Summaries live only for this query: rewrites may change a
-/// callee's effects.
-static bool hasEffectFreeCallees(CallOp root) {
-  SymbolTableCollection symbols;
-  SmallPtrSet<Operation*, 8> active;
-  SmallPtrSet<Operation*, 8> completed;
-  SmallVector<std::pair<Operation*, bool>> worklist{{root, false}};
-  while (!worklist.empty()) {
-    auto [operation, leaving] = worklist.pop_back_val();
-    if (leaving) {
-      active.erase(operation);
-      completed.insert(operation);
-      continue;
-    }
-    if (auto call = dyn_cast<CallOp>(operation)) {
-      auto symbol = call->getAttrOfType<FlatSymbolRefAttr>("callee");
-      auto callee =
-          symbol ? symbols.lookupNearestSymbolFrom<func::FuncOp>(call, symbol)
-                 : func::FuncOp{};
-      if (!callee || !mqt::isUnitaryFunction(callee) ||
-          !callee.getBody().hasOneBlock() ||
-          callee.getArgumentTypes() != call.getOperandTypes() ||
-          callee.getResultTypes() != call.getResultTypes()) {
-        return false;
-      }
-      if (completed.contains(callee)) {
-        continue;
-      }
-      if (!active.insert(callee).second) {
-        return false;
-      }
-      worklist.emplace_back(callee, true);
-      for (Operation& nested : callee.getBody().front()) {
-        worklist.emplace_back(&nested, false);
-      }
-      continue;
-    }
-    const bool recursive =
-        operation->hasTrait<OpTrait::HasRecursiveMemoryEffects>();
-    if (auto effects = dyn_cast<MemoryEffectOpInterface>(operation)) {
-      if (!effects.hasNoEffect()) {
-        return false;
-      }
-    } else if (!recursive) {
-      return false;
-    }
-    if (recursive) {
-      for (Region& region : operation->getRegions()) {
-        for (Block& block : region) {
-          for (Operation& nested : block) {
-            worklist.emplace_back(&nested, false);
-          }
-        }
-      }
-    }
-  }
-  return true;
-}
-
-void CallOp::getEffects(
-    SmallVectorImpl<MemoryEffects::EffectInstance>& effects) {
-  if (!hasEffectFreeCallees(*this)) {
-    effects.emplace_back(MemoryEffects::Write::get());
-  }
-}
 
 void CallOp::build(OpBuilder&, OperationState& state, FlatSymbolRefAttr callee,
                    ValueRange operands) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/CallOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/CallOp.cpp
@@ -12,16 +12,90 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallPtrSet.h>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/Block.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/Region.h>
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Support/LLVM.h>
 
 #include <cstddef>
 #include <iterator>
+#include <utility>
 
 using namespace mlir;
 using namespace mlir::qco;
+
+/// Query local effects and follow calls without recursively querying
+/// containers. Summaries live only for this query: rewrites may change a
+/// callee's effects.
+static bool hasEffectFreeCallees(CallOp root) {
+  SymbolTableCollection symbols;
+  SmallPtrSet<Operation*, 8> active;
+  SmallPtrSet<Operation*, 8> completed;
+  SmallVector<std::pair<Operation*, bool>> worklist{{root, false}};
+  while (!worklist.empty()) {
+    auto [operation, leaving] = worklist.pop_back_val();
+    if (leaving) {
+      active.erase(operation);
+      completed.insert(operation);
+      continue;
+    }
+    if (auto call = dyn_cast<CallOp>(operation)) {
+      auto symbol = call->getAttrOfType<FlatSymbolRefAttr>("callee");
+      auto callee =
+          symbol ? symbols.lookupNearestSymbolFrom<func::FuncOp>(call, symbol)
+                 : func::FuncOp{};
+      if (!callee || !mqt::isUnitaryFunction(callee) ||
+          !callee.getBody().hasOneBlock() ||
+          callee.getArgumentTypes() != call.getOperandTypes() ||
+          callee.getResultTypes() != call.getResultTypes()) {
+        return false;
+      }
+      if (completed.contains(callee)) {
+        continue;
+      }
+      if (!active.insert(callee).second) {
+        return false;
+      }
+      worklist.emplace_back(callee, true);
+      for (Operation& nested : callee.getBody().front()) {
+        worklist.emplace_back(&nested, false);
+      }
+      continue;
+    }
+    const bool recursive =
+        operation->hasTrait<OpTrait::HasRecursiveMemoryEffects>();
+    if (auto effects = dyn_cast<MemoryEffectOpInterface>(operation)) {
+      if (!effects.hasNoEffect()) {
+        return false;
+      }
+    } else if (!recursive) {
+      return false;
+    }
+    if (recursive) {
+      for (Region& region : operation->getRegions()) {
+        for (Block& block : region) {
+          for (Operation& nested : block) {
+            worklist.emplace_back(&nested, false);
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
+void CallOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance>& effects) {
+  if (!hasEffectFreeCallees(*this)) {
+    effects.emplace_back(MemoryEffects::Write::get());
+  }
+}
 
 void CallOp::build(OpBuilder&, OperationState& state, FlatSymbolRefAttr callee,
                    ValueRange operands) {

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/ReuseQubits.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/ReuseQubits.cpp
@@ -8,18 +8,29 @@
  * Licensed under the MIT License
  */
 
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/Analysis/SliceAnalysis.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/Block.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Region.h>
+#include <mlir/IR/SymbolTable.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 #include <cassert>
+#include <cstddef>
 #include <optional>
 #include <utility>
 
@@ -28,10 +39,100 @@ namespace mlir::qco {
 #define GEN_PASS_DEF_REUSEQUBITS
 #include "mlir/Dialect/QCO/Transforms/Passes.h.inc"
 
+/// Check an operation's own effects; recursive containers also need their
+/// bodies.
+static bool hasNoLocalEffects(Operation* op) {
+  if (auto effects = dyn_cast<MemoryEffectOpInterface>(op)) {
+    return effects.hasNoEffect();
+  }
+  return op->hasTrait<OpTrait::HasRecursiveMemoryEffects>();
+}
+
+/// Summarize each helper once, completing callers only after all callees.
+/// Unknown targets and cycles never become proven effect-free.
+static DenseSet<Operation*>
+collectEffectFreeFunctions(ModuleOp moduleOp, SymbolTableCollection& symbols) {
+  DenseMap<Operation*, size_t> pending;
+  DenseMap<Operation*, SmallVector<Operation*>> callers;
+  DenseSet<Operation*> blocked;
+  moduleOp.walk([&](func::FuncOp function) {
+    if (mqt::isUnitaryFunction(function) && !function.isExternal()) {
+      pending.try_emplace(function, 0);
+    }
+  });
+  for (auto& [function, count] : pending) {
+    function->walk([&](Operation* op) {
+      if (op == function) {
+        return;
+      }
+      if (auto call = dyn_cast<CallOp>(op)) {
+        auto callee = symbols.lookupNearestSymbolFrom<func::FuncOp>(
+            call, call.getCalleeAttr());
+        if (!callee || !pending.contains(callee)) {
+          blocked.insert(function);
+          return;
+        }
+        ++count;
+        callers[callee].push_back(function);
+      } else if (!hasNoLocalEffects(op)) {
+        blocked.insert(function);
+      }
+    });
+  }
+  SmallVector<Operation*> ready;
+  for (auto [function, count] : pending) {
+    if (count == 0 && !blocked.contains(function)) {
+      ready.push_back(function);
+    }
+  }
+  DenseSet<Operation*> effectFree;
+  while (!ready.empty()) {
+    auto* function = ready.pop_back_val();
+    effectFree.insert(function);
+    for (auto* caller : callers[function]) {
+      if (--pending[caller] == 0 && !blocked.contains(caller)) {
+        ready.push_back(caller);
+      }
+    }
+  }
+  return effectFree;
+}
+
+static bool
+isEffectFreeForReuse(Operation* root,
+                     const DenseSet<Operation*>& effectFreeFunctions,
+                     SymbolTableCollection& symbols) {
+  SmallVector<Operation*> worklist{root};
+  while (!worklist.empty()) {
+    auto* op = worklist.pop_back_val();
+    if (auto call = dyn_cast<CallOp>(op)) {
+      auto callee = symbols.lookupNearestSymbolFrom<func::FuncOp>(
+          call, call.getCalleeAttr());
+      if (!callee || !effectFreeFunctions.contains(callee)) {
+        return false;
+      }
+    } else if (!hasNoLocalEffects(op)) {
+      return false;
+    }
+    if (op->hasTrait<OpTrait::HasRecursiveMemoryEffects>()) {
+      for (auto& region : op->getRegions()) {
+        for (auto& block : region) {
+          for (auto& nested : block) {
+            worklist.push_back(&nested);
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
 namespace {
 class ReuseAnalysis {
 public:
-  [[nodiscard]] static std::optional<ReuseAnalysis> analyze(AllocOp alloc) {
+  [[nodiscard]] static std::optional<ReuseAnalysis>
+  analyze(AllocOp alloc, const DenseSet<Operation*>& effectFreeFunctions,
+          SymbolTableCollection& symbols) {
     ReuseAnalysis analysis(alloc->getBlock());
     getForwardSlice(alloc.getResult(), &analysis.forwardSlice);
 
@@ -45,7 +146,7 @@ public:
 
     for (auto& operation : *analysis.block) {
       if (!analysis.users.contains(&operation) || isa<SinkOp>(operation) ||
-          isMemoryEffectFree(&operation)) {
+          isEffectFreeForReuse(&operation, effectFreeFunctions, symbols)) {
         continue;
       }
       analysis.firstEffectfulUser = &operation;
@@ -94,7 +195,11 @@ private:
  * @brief This is the main qubit reuse pattern.
  */
 struct ReuseQubitsPattern final : OpRewritePattern<AllocOp> {
-  using OpRewritePattern::OpRewritePattern;
+  ReuseQubitsPattern(MLIRContext* context,
+                     const DenseSet<Operation*>& effectFreeFunctions,
+                     SymbolTableCollection& symbols)
+      : OpRewritePattern(context), effectFreeFunctions_(effectFreeFunctions),
+        symbols_(symbols) {}
 
   /**
    * @brief Rewrites the given `AllocOp` and `SinkOp` to reuse the
@@ -122,7 +227,8 @@ struct ReuseQubitsPattern final : OpRewritePattern<AllocOp> {
     // if any of them are disjoint from the qubit being allocated, indicating
     // potential for reuse.
 
-    const auto analysis = ReuseAnalysis::analyze(op);
+    const auto analysis =
+        ReuseAnalysis::analyze(op, effectFreeFunctions_, symbols_);
     if (!analysis) {
       return failure();
     }
@@ -141,6 +247,10 @@ struct ReuseQubitsPattern final : OpRewritePattern<AllocOp> {
     rewriteForReuse(op, *reusableSink, *analysis, rewriter);
     return success();
   }
+
+private:
+  const DenseSet<Operation*>& effectFreeFunctions_;
+  SymbolTableCollection& symbols_;
 };
 
 /**
@@ -156,12 +266,33 @@ protected:
     auto op = getOperation();
     auto* ctx = &getContext();
 
-    // Define the set of patterns to use.
-    RewritePatternSet patterns(ctx);
-    patterns.add<ReuseQubitsPattern>(patterns.getContext());
+    SymbolTableCollection symbols;
+    const auto effectFreeFunctions = collectEffectFreeFunctions(op, symbols);
 
-    // Apply patterns in an iterative and greedy manner.
-    if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
+    /// Keep summarized helper bodies unchanged for this pass invocation.
+    RewritePatternSet patterns(ctx);
+    patterns.add<ReuseQubitsPattern>(ctx, effectFreeFunctions, symbols);
+    const FrozenRewritePatternSet frozenPatterns(std::move(patterns));
+    auto result = op.walk<WalkOrder::PreOrder>([&](func::FuncOp function) {
+      if (mqt::isUnitaryFunction(function) || function.isExternal()) {
+        return WalkResult::skip();
+      }
+      /// Rewrite nested functions separately, without folding their helpers
+      /// through an enclosing function's greedy driver.
+      if (function
+              .walk([&](func::FuncOp nested) {
+                return nested == function ? WalkResult::advance()
+                                          : WalkResult::interrupt();
+              })
+              .wasInterrupted()) {
+        return WalkResult::advance();
+      }
+      if (failed(applyPatternsGreedily(function, frozenPatterns))) {
+        return WalkResult::interrupt();
+      }
+      return WalkResult::skip();
+    });
+    if (result.wasInterrupted()) {
       signalPassFailure();
     }
   }

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -1308,8 +1308,9 @@ TEST_P(NestedModifierConversionTest, RejectsStructuredOperation) {
     ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
       sawExpectedDiagnostic |=
           StringRef(diagnostic.str())
-              .contains("body must contain only unitary operations and pure "
-                        "classical operations without regions");
+              .contains(
+                  "body must contain only unitary operations and "
+                  "memory-effect-free classical operations without regions");
       return success();
     });
 
@@ -1377,8 +1378,9 @@ TEST_F(QCToQCORegressionTest, PreflightRejectsRegisterLoadsInEveryModifier) {
     ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
       sawExpectedDiagnostic |=
           StringRef(diagnostic.str())
-              .contains("body must contain only unitary operations and pure "
-                        "classical operations without regions");
+              .contains(
+                  "body must contain only unitary operations and "
+                  "memory-effect-free classical operations without regions");
       return success();
     });
 
@@ -1485,8 +1487,9 @@ TEST_F(QCToQCORegressionTest,
       ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
         sawExpectedDiagnostic |=
             StringRef(diagnostic.str())
-                .contains("body must contain only unitary operations and pure "
-                          "classical operations without regions");
+                .contains(
+                    "body must contain only unitary operations and "
+                    "memory-effect-free classical operations without regions");
         return success();
       });
 

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -1297,53 +1297,27 @@ class NestedModifierConversionTest
 
 } // namespace
 
-TEST_P(NestedModifierConversionTest, CarriesQubitThroughStructuredOperation) {
+TEST_P(NestedModifierConversionTest, RejectsStructuredOperation) {
   for (const bool registerBacked : {false, true}) {
     SCOPED_TRACE(testing::Message() << "register_backed=" << registerBacked);
     auto moduleOp =
         buildNestedModifierProgram(&context, GetParam(), registerBacked);
     ASSERT_TRUE(moduleOp);
-    ASSERT_TRUE(succeeded(verify(*moduleOp)));
-    ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
-    ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
-    qco::YieldOp modifierYield;
-    moduleOp->walk([&](qco::YieldOp yield) {
-      if (isa<qco::InvOp, qco::CtrlOp, qco::PowOp>(yield->getParentOp())) {
-        modifierYield = yield;
-      }
+    bool sawExpectedDiagnostic = false;
+    ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+      sawExpectedDiagnostic |=
+          StringRef(diagnostic.str())
+              .contains("body must contain only unitary operations and pure "
+                        "classical operations without regions");
+      return success();
     });
-    ASSERT_TRUE(modifierYield);
-    ASSERT_EQ(modifierYield.getNumOperands(), 1);
 
-    Value structuredResult;
-    switch (GetParam().structured) {
-    case StructuredKind::For:
-      moduleOp->walk(
-          [&](scf::ForOp op) { structuredResult = op.getResults().back(); });
-      break;
-    case StructuredKind::While:
-      moduleOp->walk(
-          [&](scf::WhileOp op) { structuredResult = op.getResults().back(); });
-      break;
-    case StructuredKind::If:
-      moduleOp->walk([&](qco::IfOp op) {
-        structuredResult = op.getLinearResults().back();
-      });
-      break;
-    case StructuredKind::IndexSwitch:
-      moduleOp->walk([&](qco::IndexSwitchOp op) {
-        structuredResult = op.getLinearResults().back();
-      });
-      break;
-    }
-
-    ASSERT_TRUE(structuredResult);
-    EXPECT_EQ(modifierYield.getOperand(0), structuredResult);
-    if (registerBacked) {
-      expectOperationLocalRegisterAccesses(*moduleOp);
-    }
-    expectNoQCOperations(*moduleOp);
+    PassManager pm(&context);
+    pm.enableVerifier(false);
+    pm.addPass(createQCToQCO());
+    EXPECT_TRUE(failed(pm.run(*moduleOp)));
+    EXPECT_TRUE(sawExpectedDiagnostic);
   }
 }
 
@@ -1360,18 +1334,16 @@ static StringRef modifierName(const ModifierKind modifier) {
 }
 
 static OwningOpRef<ModuleOp>
-buildInvalidNestedRegisterLoadProgram(MLIRContext* context,
-                                      const ModifierKind modifier) {
+buildInvalidRegisterLoadProgram(MLIRContext* context,
+                                const ModifierKind modifier) {
   qc::QCProgramBuilder builder(context);
   builder.initialize();
   auto target = builder.allocQubit();
   auto reg = builder.allocQubitRegisterStorage(1);
   auto index = arith::ConstantIndexOp::create(builder, 0);
   const auto body = [&](Value) {
-    builder.scfIf(true, [&] {
-      auto loaded = builder.loadQubit(reg, index.getResult());
-      builder.x(loaded);
-    });
+    auto loaded = builder.loadQubit(reg, index.getResult());
+    builder.x(loaded);
   };
 
   switch (modifier) {
@@ -1388,8 +1360,7 @@ buildInvalidNestedRegisterLoadProgram(MLIRContext* context,
   return builder.finalize();
 }
 
-TEST_F(QCToQCORegressionTest,
-       PreflightRejectsNestedRegisterLoadsInEveryModifier) {
+TEST_F(QCToQCORegressionTest, PreflightRejectsRegisterLoadsInEveryModifier) {
   constexpr std::array modifiers{
       ModifierKind::Inv,
       ModifierKind::Ctrl,
@@ -1399,15 +1370,15 @@ TEST_F(QCToQCORegressionTest,
   for (const auto modifier : modifiers) {
     SCOPED_TRACE(testing::Message()
                  << "modifier=" << modifierName(modifier).str());
-    auto moduleOp = buildInvalidNestedRegisterLoadProgram(&context, modifier);
+    auto moduleOp = buildInvalidRegisterLoadProgram(&context, modifier);
     ASSERT_TRUE(moduleOp);
 
     bool sawExpectedDiagnostic = false;
     ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
       sawExpectedDiagnostic |=
           StringRef(diagnostic.str())
-              .contains("body must not contain non-unitary operations or "
-                        "access registers");
+              .contains("body must contain only unitary operations and pure "
+                        "classical operations without regions");
       return success();
     });
 
@@ -1448,31 +1419,29 @@ buildInvalidCBitModifierProgram(MLIRContext* context,
   auto index = arith::ConstantIndexOp::create(builder, 0);
   auto bit = builder.boolConstant(false);
   const auto body = [&](Value) {
-    builder.scfIf(true, [&] {
-      switch (cbitOperation) {
-      case CBitModifierBodyOp::Alloc:
-        cbit::AllocOp::create(builder,
-                              cbit::RegisterType::get(builder.getContext(), 1),
-                              cbit::Initialization::Zero);
-        break;
-      case CBitModifierBodyOp::Compare:
-        arith::CmpIOp::create(
-            builder, arith::CmpIPredicate::eq,
-            cbit::ReadOp::create(
-                builder,
-                builder.getIntegerAttr(builder.getI1Type(), 0).getType(), reg),
-            arith::ConstantOp::create(
-                builder, builder.getIntegerAttr(builder.getI1Type(), 0)));
-        break;
-      case CBitModifierBodyOp::Load:
-        cbit::LoadOp::create(builder, builder.getI1Type(), reg,
-                             index.getResult());
-        break;
-      case CBitModifierBodyOp::Store:
-        cbit::StoreOp::create(builder, bit, reg, index.getResult());
-        break;
-      }
-    });
+    switch (cbitOperation) {
+    case CBitModifierBodyOp::Alloc:
+      cbit::AllocOp::create(builder,
+                            cbit::RegisterType::get(builder.getContext(), 1),
+                            cbit::Initialization::Zero);
+      break;
+    case CBitModifierBodyOp::Compare:
+      arith::CmpIOp::create(
+          builder, arith::CmpIPredicate::eq,
+          cbit::ReadOp::create(
+              builder, builder.getIntegerAttr(builder.getI1Type(), 0).getType(),
+              reg),
+          arith::ConstantOp::create(
+              builder, builder.getIntegerAttr(builder.getI1Type(), 0)));
+      break;
+    case CBitModifierBodyOp::Load:
+      cbit::LoadOp::create(builder, builder.getI1Type(), reg,
+                           index.getResult());
+      break;
+    case CBitModifierBodyOp::Store:
+      cbit::StoreOp::create(builder, bit, reg, index.getResult());
+      break;
+    }
   };
 
   switch (modifier) {
@@ -1516,8 +1485,8 @@ TEST_F(QCToQCORegressionTest,
       ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
         sawExpectedDiagnostic |=
             StringRef(diagnostic.str())
-                .contains("body must not contain non-unitary operations or "
-                          "access registers");
+                .contains("body must contain only unitary operations and pure "
+                          "classical operations without regions");
         return success();
       });
 
@@ -1651,42 +1620,6 @@ TEST_F(QCToQCORegressionTest, ModifiersPermitClassicalCaptures) {
     EXPECT_TRUE(succeeded(verify(*moduleOp)));
     expectNoQCOperations(*moduleOp);
   }
-}
-
-TEST_F(QCToQCORegressionTest,
-       NestedModifiersCarryTheStructuredOperationResultByRegion) {
-  qc::QCProgramBuilder builder(&context);
-  builder.initialize();
-  auto target = builder.allocQubit();
-  builder.inv(target, [&](Value outerArgument) {
-    builder.pow(2.0, outerArgument, [&](Value innerArgument) {
-      builder.scfFor(0, 1, 1, [&](Value) { builder.x(innerArgument); });
-    });
-  });
-
-  auto moduleOp = builder.finalize();
-  ASSERT_TRUE(moduleOp);
-  ASSERT_TRUE(succeeded(verify(*moduleOp)));
-  ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
-  ASSERT_TRUE(succeeded(verify(*moduleOp)));
-
-  qco::InvOp inv;
-  qco::PowOp pow;
-  scf::ForOp loop;
-  moduleOp->walk([&](qco::InvOp op) { inv = op; });
-  moduleOp->walk([&](qco::PowOp op) { pow = op; });
-  moduleOp->walk([&](scf::ForOp op) { loop = op; });
-  ASSERT_TRUE(inv);
-  ASSERT_TRUE(pow);
-  ASSERT_TRUE(loop);
-
-  auto invYield = cast<qco::YieldOp>(inv.getBody()->getTerminator());
-  auto powYield = cast<qco::YieldOp>(pow.getBody()->getTerminator());
-  ASSERT_EQ(invYield.getNumOperands(), 1);
-  ASSERT_EQ(powYield.getNumOperands(), 1);
-  EXPECT_EQ(invYield.getOperand(0), pow.getQubitsOut().front());
-  EXPECT_EQ(powYield.getOperand(0), loop.getResults().back());
-  expectNoQCOperations(*moduleOp);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
@@ -120,42 +120,6 @@ TEST(QCToQIRAdaptiveNativeTest,
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
 }
 
-TEST(QCToQIRAdaptiveNativeTest, RejectsControlledPhaseWithNonHoistableAngle) {
-  MLIRContext context;
-  context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
-                      LLVM::LLVMDialect>();
-  qc::QCProgramBuilder builder(&context);
-  builder.initialize();
-  auto control = builder.allocQubit();
-  auto target = builder.allocQubit();
-  builder.ctrl(control, target, [&](Value /*targetArg*/) {
-    auto angle = func::CallOp::create(builder, builder.getLoc(), "angle",
-                                      builder.getF64Type(), ValueRange{});
-    builder.gphase(angle.getResult(0));
-  });
-  auto moduleOp = builder.finalize();
-  ASSERT_TRUE(moduleOp);
-  OpBuilder moduleBuilder(&context);
-  moduleBuilder.setInsertionPointToStart(moduleOp->getBody());
-  auto angleFunction = func::FuncOp::create(
-      moduleBuilder, moduleOp->getLoc(), "angle",
-      moduleBuilder.getFunctionType({}, {moduleBuilder.getF64Type()}));
-  angleFunction.setPrivate();
-  ASSERT_TRUE(succeeded(verify(*moduleOp)));
-
-  bool sawExpectedDiagnostic = false;
-  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
-    std::string message;
-    llvm::raw_string_ostream stream(message);
-    diagnostic.print(stream);
-    sawExpectedDiagnostic |= StringRef(message).contains(
-        "Controlled GPhaseOps cannot be converted to QIR");
-    return success();
-  });
-  EXPECT_TRUE(failed(runQCToQIRAdaptiveConversion(*moduleOp)));
-  EXPECT_TRUE(sawExpectedDiagnostic);
-}
-
 TEST(QCToQIRAdaptiveNativeTest, LowersControlFlowAssertions) {
   MLIRContext context;
   context

--- a/mlir/unittests/Dialect/MQT/IR/test_mqt_ir.cpp
+++ b/mlir/unittests/Dialect/MQT/IR/test_mqt_ir.cpp
@@ -410,7 +410,7 @@ TEST_F(MQTIRTest, RejectsMutuallyRecursiveUnitaryFunctions) {
   }
 }
 
-TEST_F(MQTIRTest, UnitaryFunctionsRejectNonSpeculatableClassicalComputation) {
+TEST_F(MQTIRTest, UnitaryFunctionsAllowNonSpeculatableParameterComputation) {
   for (StringRef source : {
            R"mlir(
              func.func private @rotate(%theta: f64, %q: !qc.qubit)
@@ -436,21 +436,7 @@ TEST_F(MQTIRTest, UnitaryFunctionsRejectNonSpeculatableClassicalComputation) {
            )mlir",
        }) {
     SCOPED_TRACE(source.str());
-    bool rejectedBody = false;
-    ScopedDiagnosticHandler handler(context.get(), [&](Diagnostic& diagnostic) {
-      rejectedBody |= StringRef(diagnostic.str())
-                          .contains("body contains a non-unitary operation");
-      return success();
-    });
-    EXPECT_FALSE(parse(source));
-    EXPECT_TRUE(rejectedBody);
-
-    auto safe = source.str();
-    const auto divisor = safe.find("arith.divsi %one, %n");
-    ASSERT_NE(divisor, std::string::npos);
-    safe.replace(divisor, StringRef("arith.divsi %one, %n").size(),
-                 "arith.divsi %one, %one");
-    EXPECT_TRUE(parse(safe));
+    EXPECT_TRUE(parse(source));
   }
 }
 

--- a/mlir/unittests/Dialect/MQT/IR/test_mqt_ir.cpp
+++ b/mlir/unittests/Dialect/MQT/IR/test_mqt_ir.cpp
@@ -410,6 +410,50 @@ TEST_F(MQTIRTest, RejectsMutuallyRecursiveUnitaryFunctions) {
   }
 }
 
+TEST_F(MQTIRTest, UnitaryFunctionsRejectNonSpeculatableClassicalComputation) {
+  for (StringRef source : {
+           R"mlir(
+             func.func private @rotate(%theta: f64, %q: !qc.qubit)
+                 attributes {mqt.unitary} {
+               %n = arith.fptosi %theta : f64 to i64
+               %one = arith.constant 1 : i64
+               %d = arith.divsi %one, %n : i64
+               %angle = arith.sitofp %d : i64 to f64
+               qc.rx(%angle) %q : !qc.qubit
+               return
+             }
+           )mlir",
+           R"mlir(
+             func.func private @rotate(%theta: f64, %q: !qco.qubit)
+                 -> !qco.qubit attributes {mqt.unitary} {
+               %n = arith.fptosi %theta : f64 to i64
+               %one = arith.constant 1 : i64
+               %d = arith.divsi %one, %n : i64
+               %angle = arith.sitofp %d : i64 to f64
+               %out = qco.rx(%angle) %q : !qco.qubit -> !qco.qubit
+               return %out : !qco.qubit
+             }
+           )mlir",
+       }) {
+    SCOPED_TRACE(source.str());
+    bool rejectedBody = false;
+    ScopedDiagnosticHandler handler(context.get(), [&](Diagnostic& diagnostic) {
+      rejectedBody |= StringRef(diagnostic.str())
+                          .contains("body contains a non-unitary operation");
+      return success();
+    });
+    EXPECT_FALSE(parse(source));
+    EXPECT_TRUE(rejectedBody);
+
+    auto safe = source.str();
+    const auto divisor = safe.find("arith.divsi %one, %n");
+    ASSERT_NE(divisor, std::string::npos);
+    safe.replace(divisor, StringRef("arith.divsi %one, %n").size(),
+                 "arith.divsi %one, %one");
+    EXPECT_TRUE(parse(safe));
+  }
+}
+
 TEST_F(MQTIRTest, RejectsEmptyUnitaryBodies) {
   for (StringRef source : {
            R"mlir(

--- a/mlir/unittests/Dialect/MQT/Transforms/test_global_phase_normalization.cpp
+++ b/mlir/unittests/Dialect/MQT/Transforms/test_global_phase_normalization.cpp
@@ -10,7 +10,9 @@
 
 #include "ExactUnitaryTest.h"
 #include "mlir/Conversion/QCToQCO/QCToQCO.h"
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/MQT/Transforms/GlobalPhaseNormalization.h"
+#include "mlir/Dialect/MQT/Transforms/Passes.h"
 #include "mlir/Dialect/MQT/Utils/Angles.h"
 #include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
 #include "mlir/Dialect/MQT/Utils/Parameters.h"
@@ -36,9 +38,11 @@
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
+#include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Transforms/Passes.h>
 
 #include <cmath>
 #include <cstddef>
@@ -58,9 +62,10 @@ protected:
 
   void SetUp() override {
     DialectRegistry registry;
-    registry.insert<arith::ArithDialect, cf::ControlFlowDialect,
-                    func::FuncDialect, memref::MemRefDialect,
-                    mlir::qc::QCDialect, qco::QCODialect, scf::SCFDialect>();
+    registry
+        .insert<arith::ArithDialect, cf::ControlFlowDialect, func::FuncDialect,
+                memref::MemRefDialect, mlir::mqt::MQTDialect,
+                mlir::qc::QCDialect, qco::QCODialect, scf::SCFDialect>();
     context = std::make_unique<MLIRContext>();
     context->appendDialectRegistry(registry);
     context->loadAllAvailableDialects();
@@ -105,6 +110,165 @@ protected:
 };
 
 } // namespace
+
+TEST_F(GlobalPhaseNormalizationTest,
+       UnrollsEagerParameterChainsWithoutCrossingClassicalControl) {
+  for (bool convertToQCO : {false, true}) {
+    for (StringRef modifier :
+         {"qc.inv", "qc.ctrl(%c) targets", "qc.pow(%two)"}) {
+      SCOPED_TRACE(modifier.str());
+      SCOPED_TRACE(convertToQCO);
+      const auto source = std::string(R"mlir(
+        func.func @test(%cond: i1, %theta: f64, %q: !qc.qubit,
+                        %r: !qc.qubit, %c: !qc.qubit) {
+          %two = arith.constant 2.0 : f64
+          scf.if %cond {
+      )mlir") + modifier.str() +
+                          R"mlir( (%a = %q, %b = %r) {
+            %n = arith.fptosi %theta : f64 to i64
+            %one = arith.constant 1 : i64
+            %d = arith.divsi %one, %n : i64
+            %angle = arith.sitofp %d : i64 to f64
+            qc.rx(%angle) %a : !qc.qubit
+            qc.ry(%angle) %b : !qc.qubit
+            qc.yield
+          } : )mlir" +
+                          (modifier.starts_with("qc.ctrl")
+                               ? "{!qc.qubit}, {!qc.qubit, !qc.qubit}"
+                               : "!qc.qubit, !qc.qubit") +
+                          R"mlir(
+          }
+          return
+        }
+      )mlir";
+      auto moduleOp = parse(source);
+      ASSERT_TRUE(moduleOp);
+      PassManager pm(context.get());
+      if (convertToQCO) {
+        pm.addPass(createQCToQCO());
+      }
+      pm.addPass(mlir::mqt::createUnrollModifiers());
+      ASSERT_TRUE(succeeded(pm.run(*moduleOp)));
+      ASSERT_TRUE(succeeded(verify(*moduleOp)));
+      size_t divisions = 0;
+      size_t modifiers = 0;
+      moduleOp->walk([&](arith::DivSIOp div) {
+        ++divisions;
+        EXPECT_TRUE((isa<scf::IfOp, qco::IfOp>(div->getParentOp())));
+        EXPECT_FALSE(isSpeculatable(div));
+      });
+      moduleOp->walk([&](Operation* op) {
+        if (isa<qc::InvOp, qc::CtrlOp, qc::PowOp, qco::InvOp, qco::CtrlOp,
+                qco::PowOp>(op)) {
+          ++modifiers;
+          EXPECT_EQ(op->getRegion(0).front().getOperations().size(), 2);
+        }
+      });
+      EXPECT_EQ(divisions, 1);
+      EXPECT_EQ(modifiers, 2);
+    }
+  }
+}
+
+TEST_F(GlobalPhaseNormalizationTest,
+       ExtractsEagerPhaseParameterWithoutCrossingClassicalControl) {
+  for (bool convertToQCO : {false, true}) {
+    auto moduleOp = parse(R"mlir(
+      func.func @test(%cond: i1, %theta: f64, %q: !qc.qubit) {
+        scf.if %cond {
+          qc.inv (%a = %q) {
+            %n = arith.fptosi %theta : f64 to i64
+            %one = arith.constant 1 : i64
+            %d = arith.divsi %one, %n : i64
+            %angle = arith.sitofp %d : i64 to f64
+            qc.gphase(%angle)
+            qc.x %a : !qc.qubit
+            qc.yield
+          } : !qc.qubit
+        }
+        return
+      }
+    )mlir");
+    ASSERT_TRUE(moduleOp);
+    if (convertToQCO) {
+      PassManager pm(context.get());
+      pm.addPass(createQCToQCO());
+      ASSERT_TRUE(succeeded(pm.run(*moduleOp)));
+    }
+    ASSERT_TRUE(succeeded(mlir::mqt::normalizeGlobalPhases(*moduleOp)));
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    size_t phases = 0;
+    size_t divisions = 0;
+    moduleOp->walk([&](arith::DivSIOp div) {
+      ++divisions;
+      EXPECT_TRUE((isa<scf::IfOp, qco::IfOp>(div->getParentOp())));
+    });
+    moduleOp->walk([&](Operation* op) {
+      if (isa<qc::GPhaseOp, qco::GPhaseOp>(op)) {
+        ++phases;
+        EXPECT_TRUE((isa<scf::IfOp, qco::IfOp>(op->getParentOp())));
+        EXPECT_TRUE(op->getOperand(0).getDefiningOp<arith::NegFOp>());
+      }
+    });
+    EXPECT_EQ(phases, 1);
+    EXPECT_EQ(divisions, 1);
+  }
+}
+
+TEST_F(GlobalPhaseNormalizationTest,
+       NestedModifierRewritesPreserveParameterProducers) {
+  for (bool convertToQCO : {false, true}) {
+    for (int variant : {0, 1, 2}) {
+      SCOPED_TRACE(convertToQCO);
+      SCOPED_TRACE(variant);
+      const auto* const outer = variant == 2 ? "qc.pow(%power)" : "qc.inv";
+      const auto* const inner = variant == 0 ? "qc.inv" : "qc.ctrl(%a) targets";
+      const auto* const innerTypes =
+          variant == 0 ? "!qc.qubit" : "{!qc.qubit}, {!qc.qubit}";
+      const auto source = std::string(R"mlir(
+        func.func private @rotate(%angle: f64, %q: !qc.qubit)
+            attributes {mqt.unitary, no_inline} {
+          qc.rx(%angle) %q : !qc.qubit
+          return
+        }
+        func.func @test(%cond: i1, %theta: f64, %power: f64,
+                        %q: !qc.qubit, %r: !qc.qubit) {
+          scf.if %cond {
+      )mlir") + outer + R"mlir( (%a = %q, %b = %r) {
+            %n = arith.fptosi %theta : f64 to i64
+            %one = arith.constant 1 : i64
+            %d = arith.divsi %one, %n : i64
+            %angle = arith.sitofp %d : i64 to f64
+      )mlir" + inner + R"mlir( (%t = %b) {
+              qc.call @rotate(%angle, %t) : f64, !qc.qubit
+              qc.yield
+            } : )mlir" + innerTypes +
+                          R"mlir(
+            qc.yield
+          } : !qc.qubit, !qc.qubit
+          }
+          return
+        }
+      )mlir";
+      auto moduleOp = parse(source);
+      ASSERT_TRUE(moduleOp);
+      PassManager pm(context.get());
+      if (convertToQCO) {
+        pm.addPass(createQCToQCO());
+      }
+      pm.addPass(createCanonicalizerPass());
+      ASSERT_TRUE(succeeded(pm.run(*moduleOp)));
+      ASSERT_TRUE(succeeded(verify(*moduleOp)));
+      size_t divisions = 0;
+      moduleOp->walk([&](arith::DivSIOp div) {
+        ++divisions;
+        EXPECT_TRUE((isa<scf::IfOp, qco::IfOp>(div->getParentOp())));
+        EXPECT_FALSE(div->use_empty());
+      });
+      EXPECT_EQ(divisions, 1);
+    }
+  }
+}
 
 TEST_F(GlobalPhaseNormalizationTest, CombinesQCOConstantsAtBlockExit) {
   auto moduleOp = parse(R"mlir(

--- a/mlir/unittests/Dialect/MQT/Transforms/test_global_phase_normalization.cpp
+++ b/mlir/unittests/Dialect/MQT/Transforms/test_global_phase_normalization.cpp
@@ -713,14 +713,14 @@ TEST_F(GlobalPhaseNormalizationTest, ZeroControlsReleaseAnUnchangedPhase) {
 }
 
 TEST_F(GlobalPhaseNormalizationTest,
-       MemoryDependentAngleRemainsInsideModifier) {
+       MemoryDependentAngleCapturedByModifierMovesOutsideModifier) {
   auto moduleOp = parse(R"mlir(
     module {
       func.func @test(%q: !qco.qubit, %angles: memref<1xf64>)
           -> !qco.qubit {
         %c0 = arith.constant 0 : index
+        %phase = memref.load %angles[%c0] : memref<1xf64>
         %out = qco.inv (%arg = %q) {
-          %phase = memref.load %angles[%c0] : memref<1xf64>
           %x = qco.x %arg : !qco.qubit -> !qco.qubit
           qco.gphase(%phase)
           qco.yield %x : !qco.qubit
@@ -735,8 +735,8 @@ TEST_F(GlobalPhaseNormalizationTest,
 
   auto func = *moduleOp->getOps<func::FuncOp>().begin();
   auto inv = *func.getBody().getOps<qco::InvOp>().begin();
-  EXPECT_EQ(llvm::range_size(inv.getBody()->getOps<qco::GPhaseOp>()), 1);
-  EXPECT_TRUE(func.getBody().getOps<qco::GPhaseOp>().empty());
+  EXPECT_TRUE(inv.getBody()->getOps<qco::GPhaseOp>().empty());
+  EXPECT_EQ(llvm::range_size(func.getBody().getOps<qco::GPhaseOp>()), 1);
 }
 
 TEST_F(GlobalPhaseNormalizationTest, CFGBlocksRemainIndependentScopes) {

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -1105,14 +1105,15 @@ TEST_F(QCTest, ModifiersRecursivelyRejectEveryForbiddenOperation) {
       ASSERT_TRUE(moduleOp);
 
       bool sawExpectedDiagnostic = false;
-      ScopedDiagnosticHandler handler(
-          context.get(), [&](Diagnostic& diagnostic) {
-            sawExpectedDiagnostic |=
-                StringRef(diagnostic.str())
-                    .contains("body must contain only unitary operations and "
-                              "pure classical operations without regions");
-            return success();
-          });
+      ScopedDiagnosticHandler handler(context.get(), [&](Diagnostic&
+                                                             diagnostic) {
+        sawExpectedDiagnostic |=
+            StringRef(diagnostic.str())
+                .contains(
+                    "body must contain only unitary operations and "
+                    "memory-effect-free classical operations without regions");
+        return success();
+      });
       EXPECT_TRUE(failed(verify(*moduleOp)));
       EXPECT_TRUE(sawExpectedDiagnostic);
     }

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -932,6 +932,9 @@ enum class ForbiddenModifierBodyOp : std::uint8_t {
   CBitRead,
   CBitLoad,
   CBitStore,
+  MemoryLoad,
+  MemoryStore,
+  StructuredControlFlow,
 };
 
 } // namespace
@@ -970,6 +973,12 @@ static StringRef forbiddenOperationName(ForbiddenModifierBodyOp kind) {
     return "cbit.load";
   case ForbiddenModifierBodyOp::CBitStore:
     return "cbit.store";
+  case ForbiddenModifierBodyOp::MemoryLoad:
+    return "memref.load";
+  case ForbiddenModifierBodyOp::MemoryStore:
+    return "memref.store";
+  case ForbiddenModifierBodyOp::StructuredControlFlow:
+    return "scf.if";
   }
   llvm_unreachable("unknown forbidden modifier operation");
 }
@@ -977,8 +986,9 @@ static StringRef forbiddenOperationName(ForbiddenModifierBodyOp kind) {
 static void emitForbiddenModifierBodyOperation(QCProgramBuilder& builder,
                                                ForbiddenModifierBodyOp kind,
                                                Value argument, Value qubitReg,
-                                               Value cbitReg, Value index,
-                                               Value bit) {
+                                               Value cbitReg, Value buffer,
+                                               Value index, Value bit,
+                                               Value value) {
   switch (kind) {
   case ForbiddenModifierBodyOp::Alloc:
     AllocOp::create(builder);
@@ -1012,6 +1022,15 @@ static void emitForbiddenModifierBodyOperation(QCProgramBuilder& builder,
   case ForbiddenModifierBodyOp::CBitStore:
     cbit::StoreOp::create(builder, bit, cbitReg, index);
     return;
+  case ForbiddenModifierBodyOp::MemoryLoad:
+    memref::LoadOp::create(builder, buffer, index);
+    return;
+  case ForbiddenModifierBodyOp::MemoryStore:
+    memref::StoreOp::create(builder, value, buffer, index);
+    return;
+  case ForbiddenModifierBodyOp::StructuredControlFlow:
+    builder.scfIf(true, [] {});
+    return;
   }
   llvm_unreachable("unknown forbidden modifier operation");
 }
@@ -1028,11 +1047,14 @@ buildInvalidNestedModifierProgram(MLIRContext* context,
   auto cbitReg = builder.allocClassicalBitRegister(1);
   auto bit = builder.boolConstant(false);
   auto index = arith::ConstantIndexOp::create(builder, 0);
+  auto value = arith::ConstantIntOp::create(builder, builder.getI32Type(), 1);
+  auto buffer = memref::AllocOp::create(
+      builder, MemRefType::get({1}, builder.getI32Type()));
   const auto modifierBody = [&](Value argument) {
-    builder.scfIf(true, [&] {
-      emitForbiddenModifierBodyOperation(builder, forbiddenOperation, argument,
-                                         qubitReg, cbitReg, index.getResult(),
-                                         bit);
+    builder.inv(argument, [&](Value nestedArgument) {
+      emitForbiddenModifierBodyOperation(builder, forbiddenOperation,
+                                         nestedArgument, qubitReg, cbitReg,
+                                         buffer, index.getResult(), bit, value);
     });
   };
 
@@ -1067,6 +1089,9 @@ TEST_F(QCTest, ModifiersRecursivelyRejectEveryForbiddenOperation) {
       ForbiddenModifierBodyOp::CBitRead,
       ForbiddenModifierBodyOp::CBitLoad,
       ForbiddenModifierBodyOp::CBitStore,
+      ForbiddenModifierBodyOp::MemoryLoad,
+      ForbiddenModifierBodyOp::MemoryStore,
+      ForbiddenModifierBodyOp::StructuredControlFlow,
   };
 
   for (auto modifier : modifiers) {
@@ -1084,8 +1109,8 @@ TEST_F(QCTest, ModifiersRecursivelyRejectEveryForbiddenOperation) {
           context.get(), [&](Diagnostic& diagnostic) {
             sawExpectedDiagnostic |=
                 StringRef(diagnostic.str())
-                    .contains("body must not contain non-unitary operations or "
-                              "access registers");
+                    .contains("body must contain only unitary operations and "
+                              "pure classical operations without regions");
             return success();
           });
       EXPECT_TRUE(failed(verify(*moduleOp)));

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -47,6 +47,7 @@
 #include <mlir/IR/Value.h>
 #include <mlir/IR/Verifier.h>
 #include <mlir/Interfaces/ControlFlowInterfaces.h>
+#include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
@@ -658,6 +659,9 @@ enum class ForbiddenModifierBodyOp : uint8_t {
   CBitRead,
   CBitLoad,
   CBitStore,
+  MemoryLoad,
+  MemoryStore,
+  StructuredControlFlow,
 };
 
 } // namespace
@@ -686,6 +690,12 @@ static StringRef forbiddenOperationName(ForbiddenModifierBodyOp kind) {
     return "cbit.load";
   case ForbiddenModifierBodyOp::CBitStore:
     return "cbit.store";
+  case ForbiddenModifierBodyOp::MemoryLoad:
+    return "memref.load";
+  case ForbiddenModifierBodyOp::MemoryStore:
+    return "memref.store";
+  case ForbiddenModifierBodyOp::StructuredControlFlow:
+    return "scf.if";
   }
   llvm_unreachable("unknown forbidden modifier operation");
 }
@@ -733,32 +743,50 @@ buildInvalidNestedModifierBody(QCOProgramBuilder& builder,
   auto condition = builder.boolConstant(true);
   auto cbitReg = builder.allocClassicalBitRegister(1);
   auto index = arith::ConstantIndexOp::create(builder, 0);
+  auto value = arith::ConstantIntOp::create(builder, builder.getI32Type(), 1);
+  auto buffer = memref::AllocOp::create(
+      builder, MemRefType::get({1}, builder.getI32Type()));
   const auto modifierBody = [&](Value argument) -> Value {
-    auto ifOp = IfOp::create(
-        builder, condition, argument, [&](Value nestedArgument) -> Value {
-          switch (forbiddenOperation) {
-          case ForbiddenModifierBodyOp::Measure:
-            return MeasureOp::create(builder, nestedArgument).getQubitOut();
-          case ForbiddenModifierBodyOp::CBitAlloc:
-            cbit::AllocOp::create(
-                builder, cbit::RegisterType::get(builder.getContext(), 1),
-                cbit::Initialization::Zero);
-            break;
-          case ForbiddenModifierBodyOp::CBitRead:
-            cbit::ReadOp::create(builder, builder.getI1Type(), cbitReg);
-            break;
-          case ForbiddenModifierBodyOp::CBitLoad:
-            cbit::LoadOp::create(builder, builder.getI1Type(), cbitReg,
-                                 index.getResult());
-            break;
-          case ForbiddenModifierBodyOp::CBitStore:
-            cbit::StoreOp::create(builder, condition, cbitReg,
-                                  index.getResult());
-            break;
-          }
-          return nestedArgument;
-        });
-    return ifOp.getResult(0);
+    return InvOp::create(
+               builder, argument,
+               [&](Value nestedArgument) -> Value {
+                 switch (forbiddenOperation) {
+                 case ForbiddenModifierBodyOp::Measure:
+                   return MeasureOp::create(builder, nestedArgument)
+                       .getQubitOut();
+                 case ForbiddenModifierBodyOp::CBitAlloc:
+                   cbit::AllocOp::create(
+                       builder,
+                       cbit::RegisterType::get(builder.getContext(), 1),
+                       cbit::Initialization::Zero);
+                   break;
+                 case ForbiddenModifierBodyOp::CBitRead:
+                   cbit::ReadOp::create(builder, builder.getI1Type(), cbitReg);
+                   break;
+                 case ForbiddenModifierBodyOp::CBitLoad:
+                   cbit::LoadOp::create(builder, builder.getI1Type(), cbitReg,
+                                        index.getResult());
+                   break;
+                 case ForbiddenModifierBodyOp::CBitStore:
+                   cbit::StoreOp::create(builder, condition, cbitReg,
+                                         index.getResult());
+                   break;
+                 case ForbiddenModifierBodyOp::MemoryLoad:
+                   memref::LoadOp::create(builder, buffer.getResult(),
+                                          ValueRange{index.getResult()});
+                   break;
+                 case ForbiddenModifierBodyOp::MemoryStore:
+                   memref::StoreOp::create(builder, value.getResult(),
+                                           buffer.getResult(),
+                                           ValueRange{index.getResult()});
+                   break;
+                 case ForbiddenModifierBodyOp::StructuredControlFlow:
+                   scf::IfOp::create(builder, TypeRange{}, condition, false);
+                   break;
+                 }
+                 return nestedArgument;
+               })
+        .getOutputTarget(0);
   };
 
   switch (modifier) {
@@ -780,9 +808,14 @@ TEST_F(QCOTest, ModifiersRecursivelyRejectNonUnitaryOperations) {
       VerifierModifierKind::Pow,
   };
   constexpr std::array forbiddenOperations{
-      ForbiddenModifierBodyOp::Measure,   ForbiddenModifierBodyOp::CBitAlloc,
-      ForbiddenModifierBodyOp::CBitRead,  ForbiddenModifierBodyOp::CBitLoad,
+      ForbiddenModifierBodyOp::Measure,
+      ForbiddenModifierBodyOp::CBitAlloc,
+      ForbiddenModifierBodyOp::CBitRead,
+      ForbiddenModifierBodyOp::CBitLoad,
       ForbiddenModifierBodyOp::CBitStore,
+      ForbiddenModifierBodyOp::MemoryLoad,
+      ForbiddenModifierBodyOp::MemoryStore,
+      ForbiddenModifierBodyOp::StructuredControlFlow,
   };
 
   for (const auto modifier : modifiers) {
@@ -800,8 +833,8 @@ TEST_F(QCOTest, ModifiersRecursivelyRejectNonUnitaryOperations) {
           context.get(), [&](Diagnostic& diagnostic) {
             sawExpectedDiagnostic |=
                 StringRef(diagnostic.str())
-                    .contains("body must not contain non-unitary operations or "
-                              "access registers");
+                    .contains("body must contain only unitary operations and "
+                              "pure classical operations without regions");
             return success();
           });
       EXPECT_TRUE(failed(verify(modifierOp)));
@@ -838,6 +871,98 @@ TEST_F(QCOTest, ModifiersRejectDirectAndNestedQubitCaptures) {
       EXPECT_TRUE(sawExpectedDiagnostic);
     }
   }
+}
+
+TEST_F(QCOTest, RegionOperationEffectTraitsMatchTheirSemantics) {
+  EXPECT_FALSE(CtrlOp::hasTrait<OpTrait::AlwaysSpeculatableImplTrait>());
+  EXPECT_FALSE(InvOp::hasTrait<OpTrait::AlwaysSpeculatableImplTrait>());
+  EXPECT_FALSE(PowOp::hasTrait<OpTrait::AlwaysSpeculatableImplTrait>());
+  EXPECT_FALSE(IfOp::hasTrait<OpTrait::AlwaysSpeculatableImplTrait>());
+  EXPECT_FALSE(IndexSwitchOp::hasTrait<OpTrait::AlwaysSpeculatableImplTrait>());
+
+  EXPECT_TRUE(CtrlOp::hasTrait<OpTrait::RecursivelySpeculatableImplTrait>());
+  EXPECT_TRUE(InvOp::hasTrait<OpTrait::RecursivelySpeculatableImplTrait>());
+  EXPECT_TRUE(PowOp::hasTrait<OpTrait::RecursivelySpeculatableImplTrait>());
+  EXPECT_TRUE(IfOp::hasTrait<OpTrait::RecursivelySpeculatableImplTrait>());
+  EXPECT_TRUE(
+      IndexSwitchOp::hasTrait<OpTrait::RecursivelySpeculatableImplTrait>());
+
+  EXPECT_TRUE(CtrlOp::hasTrait<OpTrait::HasRecursiveMemoryEffects>());
+  EXPECT_TRUE(InvOp::hasTrait<OpTrait::HasRecursiveMemoryEffects>());
+  EXPECT_TRUE(PowOp::hasTrait<OpTrait::HasRecursiveMemoryEffects>());
+  EXPECT_TRUE(IfOp::hasTrait<OpTrait::HasRecursiveMemoryEffects>());
+  EXPECT_TRUE(IndexSwitchOp::hasTrait<OpTrait::HasRecursiveMemoryEffects>());
+}
+
+TEST_F(QCOTest, GlobalPhaseMakesModifiersEffectfulAndNonSpeculatable) {
+  constexpr std::array modifiers{
+      VerifierModifierKind::Inv,
+      VerifierModifierKind::Ctrl,
+      VerifierModifierKind::Pow,
+  };
+
+  for (const auto modifier : modifiers) {
+    SCOPED_TRACE(testing::Message()
+                 << "modifier=" << modifierName(modifier).str());
+    QCOProgramBuilder builder(context.get());
+    builder.initialize();
+    const auto target = builder.allocQubit();
+    const auto control = builder.allocQubit();
+    const auto body = [&](Value argument) -> Value {
+      builder.gphase(0.25);
+      return argument;
+    };
+
+    Operation* modifierOp = nullptr;
+    switch (modifier) {
+    case VerifierModifierKind::Inv:
+      modifierOp = InvOp::create(builder, target, body);
+      break;
+    case VerifierModifierKind::Ctrl:
+      modifierOp = CtrlOp::create(builder, control, target, body);
+      break;
+    case VerifierModifierKind::Pow:
+      modifierOp = PowOp::create(builder, target, 2.0, body);
+      break;
+    }
+
+    EXPECT_FALSE(isMemoryEffectFree(modifierOp));
+    EXPECT_FALSE(isSpeculatable(modifierOp));
+  }
+}
+
+TEST_F(QCOTest, GlobalPhaseEffectsPropagateAcrossUnitaryCalls) {
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func private @phase(%q: !qco.qubit) -> !qco.qubit
+          attributes {mqt.unitary} {
+        %theta = arith.constant 0.25 : f64
+        qco.gphase(%theta)
+        return %q : !qco.qubit
+      }
+      func.func @main(%q: !qco.qubit) -> !qco.qubit {
+        %out = qco.inv (%arg = %q) {
+          %called = qco.call @phase(%arg)
+              : (!qco.qubit) -> !qco.qubit
+          qco.yield %called : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %out : !qco.qubit
+      }
+    }
+  )mlir",
+                                              context.get());
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  CallOp call;
+  InvOp inv;
+  moduleOp->walk([&](CallOp op) { call = op; });
+  moduleOp->walk([&](InvOp op) { inv = op; });
+  ASSERT_TRUE(call && inv);
+  EXPECT_FALSE(isMemoryEffectFree(call));
+  EXPECT_FALSE(isSpeculatable(call));
+  EXPECT_FALSE(isMemoryEffectFree(inv));
+  EXPECT_FALSE(isSpeculatable(inv));
 }
 
 TEST_F(QCOTest, DirectIfBuilder) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -965,7 +965,7 @@ TEST_F(QCOTest, GlobalPhaseEffectsPropagateAcrossUnitaryCalls) {
   EXPECT_FALSE(isSpeculatable(inv));
 }
 
-TEST_F(QCOTest, UnitaryCallEffectsFollowTransitiveCalleeChanges) {
+TEST_F(QCOTest, UnitaryCallEffectsRemainConservativeAcrossCalleeChanges) {
   auto moduleOp = parseSourceString<ModuleOp>(R"mlir(
     module {
       func.func private @leaf(%q: !qco.qubit) -> !qco.qubit
@@ -1000,24 +1000,24 @@ TEST_F(QCOTest, UnitaryCallEffectsFollowTransitiveCalleeChanges) {
   )mlir",
                                               context.get());
   ASSERT_TRUE(moduleOp);
-  const auto checkCalls = [&](bool effectFree) {
+  const auto checkCalls = [&] {
     EXPECT_TRUE(succeeded(verify(*moduleOp)));
     moduleOp->walk([&](CallOp call) {
-      EXPECT_EQ(isMemoryEffectFree(call), effectFree);
+      EXPECT_FALSE(isMemoryEffectFree(call));
       EXPECT_FALSE(isSpeculatable(call));
     });
     moduleOp->walk([&](InvOp inv) {
-      EXPECT_EQ(isMemoryEffectFree(inv), effectFree);
+      EXPECT_FALSE(isMemoryEffectFree(inv));
       EXPECT_FALSE(isSpeculatable(inv));
     });
   };
-  checkCalls(true);
+  checkCalls();
   auto leaf = moduleOp->lookupSymbol<func::FuncOp>("leaf");
   OpBuilder builder(leaf.getBody().front().getTerminator());
   auto phase = GPhaseOp::create(builder, leaf.getLoc(), 0.25);
-  checkCalls(false);
+  checkCalls();
   phase.erase();
-  checkCalls(true);
+  checkCalls();
 }
 
 TEST_F(QCOTest, UnitaryCallEffectsConservativelyHandleInvalidCallees) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -829,14 +829,15 @@ TEST_F(QCOTest, ModifiersRecursivelyRejectNonUnitaryOperations) {
           buildInvalidNestedModifierBody(builder, modifier, forbiddenOperation);
 
       bool sawExpectedDiagnostic = false;
-      ScopedDiagnosticHandler handler(
-          context.get(), [&](Diagnostic& diagnostic) {
-            sawExpectedDiagnostic |=
-                StringRef(diagnostic.str())
-                    .contains("body must contain only unitary operations and "
-                              "pure classical operations without regions");
-            return success();
-          });
+      ScopedDiagnosticHandler handler(context.get(), [&](Diagnostic&
+                                                             diagnostic) {
+        sawExpectedDiagnostic |=
+            StringRef(diagnostic.str())
+                .contains(
+                    "body must contain only unitary operations and "
+                    "memory-effect-free classical operations without regions");
+        return success();
+      });
       EXPECT_TRUE(failed(verify(modifierOp)));
       EXPECT_TRUE(sawExpectedDiagnostic);
     }

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -965,6 +965,88 @@ TEST_F(QCOTest, GlobalPhaseEffectsPropagateAcrossUnitaryCalls) {
   EXPECT_FALSE(isSpeculatable(inv));
 }
 
+TEST_F(QCOTest, UnitaryCallEffectsFollowTransitiveCalleeChanges) {
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func private @leaf(%q: !qco.qubit) -> !qco.qubit
+          attributes {mqt.unitary} {
+        %out = qco.x %q : !qco.qubit -> !qco.qubit
+        return %out : !qco.qubit
+      }
+      func.func private @left(%q: !qco.qubit) -> !qco.qubit
+          attributes {mqt.unitary} {
+        %out = qco.inv (%arg = %q) {
+          %called = qco.call @leaf(%arg) : (!qco.qubit) -> !qco.qubit
+          qco.yield %called : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %out : !qco.qubit
+      }
+      func.func private @right(%q: !qco.qubit) -> !qco.qubit
+          attributes {mqt.unitary} {
+        %out = qco.call @leaf(%q) : (!qco.qubit) -> !qco.qubit
+        return %out : !qco.qubit
+      }
+      func.func private @diamond(%q: !qco.qubit) -> !qco.qubit
+          attributes {mqt.unitary} {
+        %left = qco.call @left(%q) : (!qco.qubit) -> !qco.qubit
+        %out = qco.call @right(%left) : (!qco.qubit) -> !qco.qubit
+        return %out : !qco.qubit
+      }
+      func.func @main(%q: !qco.qubit) -> !qco.qubit {
+        %out = qco.call @diamond(%q) : (!qco.qubit) -> !qco.qubit
+        return %out : !qco.qubit
+      }
+    }
+  )mlir",
+                                              context.get());
+  ASSERT_TRUE(moduleOp);
+  const auto checkCalls = [&](bool effectFree) {
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    moduleOp->walk([&](CallOp call) {
+      EXPECT_EQ(isMemoryEffectFree(call), effectFree);
+      EXPECT_FALSE(isSpeculatable(call));
+    });
+    moduleOp->walk([&](InvOp inv) {
+      EXPECT_EQ(isMemoryEffectFree(inv), effectFree);
+      EXPECT_FALSE(isSpeculatable(inv));
+    });
+  };
+  checkCalls(true);
+  auto leaf = moduleOp->lookupSymbol<func::FuncOp>("leaf");
+  OpBuilder builder(leaf.getBody().front().getTerminator());
+  auto phase = GPhaseOp::create(builder, leaf.getLoc(), 0.25);
+  checkCalls(false);
+  phase.erase();
+  checkCalls(true);
+}
+
+TEST_F(QCOTest, UnitaryCallEffectsConservativelyHandleInvalidCallees) {
+  auto moduleOp =
+      parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func private @external(!qco.qubit) -> !qco.qubit
+          attributes {mqt.unitary}
+      func.func private @cycle(%q: !qco.qubit) -> !qco.qubit
+          attributes {mqt.unitary} {
+        %out = qco.call @cycle(%q) : (!qco.qubit) -> !qco.qubit
+        return %out : !qco.qubit
+      }
+      func.func @main(%q: !qco.qubit) -> !qco.qubit {
+        %a = qco.call @external(%q) : (!qco.qubit) -> !qco.qubit
+        %b = qco.call @missing(%a) : (!qco.qubit) -> !qco.qubit
+        %out = qco.call @cycle(%b) : (!qco.qubit) -> !qco.qubit
+        return %out : !qco.qubit
+      }
+    }
+  )mlir",
+                                  ParserConfig(context.get(), false));
+  ASSERT_TRUE(moduleOp);
+  moduleOp->walk([&](CallOp call) {
+    EXPECT_FALSE(isMemoryEffectFree(call));
+    EXPECT_FALSE(isSpeculatable(call));
+  });
+}
+
 TEST_F(QCOTest, DirectIfBuilder) {
   QCOProgramBuilder builder(context.get());
   auto cbitType = cbit::RegisterType::get(context.get(), 1);

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_reuse_qubits.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_reuse_qubits.cpp
@@ -15,13 +15,16 @@
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/Verifier.h>
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
@@ -226,6 +229,52 @@ TEST_F(QCOQubitReuseTest, preserveEffectfulUserOrder) {
   ASSERT_EQ(callees.size(), 2);
   EXPECT_EQ(callees[0], "record1");
   EXPECT_EQ(callees[1], "record0");
+}
+
+TEST_F(QCOQubitReuseTest, ReuseAcrossPhaseFreeUnitaryCalls) {
+  for (const bool hasPhase : {false, true}) {
+    SCOPED_TRACE(hasPhase);
+    module = parseSourceString<ModuleOp>(R"mlir(
+      module {
+        func.func private @record0(i1)
+        func.func private @record1(i1)
+        func.func private @flip(%q: !qco.qubit) -> !qco.qubit
+            attributes {mqt.unitary, no_inline} {
+          %out = qco.x %q : !qco.qubit -> !qco.qubit
+          return %out : !qco.qubit
+        }
+        func.func @main() attributes {mqt.entry_point} {
+          %q0 = qco.alloc : !qco.qubit
+          %h = qco.h %q0 : !qco.qubit -> !qco.qubit
+          %q1 = qco.alloc : !qco.qubit
+          %x = qco.call @flip(%q1) : (!qco.qubit) -> !qco.qubit
+          %m0, %b0 = qco.measure %h : !qco.qubit
+          func.call @record0(%b0) : (i1) -> ()
+          qco.sink %m0 : !qco.qubit
+          %m1, %b1 = qco.measure %x : !qco.qubit
+          func.call @record1(%b1) : (i1) -> ()
+          qco.sink %m1 : !qco.qubit
+          return
+        }
+      }
+    )mlir",
+                                         &context);
+    ASSERT_TRUE(module);
+    if (hasPhase) {
+      auto flip = module->lookupSymbol<func::FuncOp>("flip");
+      OpBuilder builder(flip.getBody().front().getTerminator());
+      GPhaseOp::create(builder, flip.getLoc(), 0.25);
+    }
+    ASSERT_TRUE(succeeded(verify(*module)));
+    PassManager pm(&context);
+    pm.addPass(createReuseQubits());
+    ASSERT_TRUE(succeeded(pm.run(*module)));
+    ASSERT_TRUE(succeeded(verify(*module)));
+    auto main = module->lookupSymbol<func::FuncOp>("main");
+    EXPECT_EQ(llvm::range_size(main.getOps<AllocOp>()), hasPhase ? 2 : 1);
+    EXPECT_EQ(llvm::range_size(main.getOps<ResetOp>()), hasPhase ? 0 : 1);
+    EXPECT_EQ(llvm::range_size(main.getOps<CallOp>()), 1);
+  }
 }
 
 /**

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_reuse_qubits.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_reuse_qubits.cpp
@@ -231,7 +231,41 @@ TEST_F(QCOQubitReuseTest, preserveEffectfulUserOrder) {
   EXPECT_EQ(callees[1], "record0");
 }
 
-TEST_F(QCOQubitReuseTest, ReuseAcrossPhaseFreeUnitaryCalls) {
+TEST_F(QCOQubitReuseTest, PreservesHelpersInsideNestedSymbolTables) {
+  module = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @outer() {
+        builtin.module {
+          func.func private @helper(%q: !qco.qubit) -> !qco.qubit
+              attributes {mqt.unitary} {
+            %unused = arith.constant 0.25 : f64
+            %out = qco.x %q : !qco.qubit -> !qco.qubit
+            return %out : !qco.qubit
+          }
+          func.func @inner() {
+            %q = qco.alloc : !qco.qubit
+            qco.sink %q : !qco.qubit
+            return
+          }
+        }
+        return
+      }
+    }
+  )mlir",
+                                       &context);
+  ASSERT_TRUE(module);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  PassManager pm(&context);
+  pm.addPass(createReuseQubits());
+  ASSERT_TRUE(succeeded(pm.run(*module)));
+  ASSERT_TRUE(succeeded(verify(*module)));
+  size_t constants = 0;
+  module->walk([&](arith::ConstantOp) { ++constants; });
+  /// Even unused classical operations in summarized helpers stay unchanged.
+  EXPECT_EQ(constants, 1);
+}
+
+TEST_F(QCOQubitReuseTest, ReuseAcrossTransitivePhaseFreeUnitaryCalls) {
   for (const bool hasPhase : {false, true}) {
     SCOPED_TRACE(hasPhase);
     module = parseSourceString<ModuleOp>(R"mlir(
@@ -243,11 +277,25 @@ TEST_F(QCOQubitReuseTest, ReuseAcrossPhaseFreeUnitaryCalls) {
           %out = qco.x %q : !qco.qubit -> !qco.qubit
           return %out : !qco.qubit
         }
+        func.func private @left(%q: !qco.qubit) -> !qco.qubit
+            attributes {mqt.unitary, no_inline} {
+          %out = qco.inv (%arg = %q) {
+            %called = qco.call @flip(%arg) : (!qco.qubit) -> !qco.qubit
+            qco.yield %called : !qco.qubit
+          } : {!qco.qubit} -> {!qco.qubit}
+          return %out : !qco.qubit
+        }
+        func.func private @diamond(%q: !qco.qubit) -> !qco.qubit
+            attributes {mqt.unitary, no_inline} {
+          %left = qco.call @left(%q) : (!qco.qubit) -> !qco.qubit
+          %out = qco.call @flip(%left) : (!qco.qubit) -> !qco.qubit
+          return %out : !qco.qubit
+        }
         func.func @main() attributes {mqt.entry_point} {
           %q0 = qco.alloc : !qco.qubit
           %h = qco.h %q0 : !qco.qubit -> !qco.qubit
           %q1 = qco.alloc : !qco.qubit
-          %x = qco.call @flip(%q1) : (!qco.qubit) -> !qco.qubit
+          %x = qco.call @diamond(%q1) : (!qco.qubit) -> !qco.qubit
           %m0, %b0 = qco.measure %h : !qco.qubit
           func.call @record0(%b0) : (i1) -> ()
           qco.sink %m0 : !qco.qubit
@@ -274,6 +322,16 @@ TEST_F(QCOQubitReuseTest, ReuseAcrossPhaseFreeUnitaryCalls) {
     EXPECT_EQ(llvm::range_size(main.getOps<AllocOp>()), hasPhase ? 2 : 1);
     EXPECT_EQ(llvm::range_size(main.getOps<ResetOp>()), hasPhase ? 0 : 1);
     EXPECT_EQ(llvm::range_size(main.getOps<CallOp>()), 1);
+    if (hasPhase) {
+      auto flip = module->lookupSymbol<func::FuncOp>("flip");
+      auto phases = flip.getOps<GPhaseOp>();
+      ASSERT_EQ(llvm::range_size(phases), 1);
+      (*phases.begin()).erase();
+      ASSERT_TRUE(succeeded(pm.run(*module)));
+      ASSERT_TRUE(succeeded(verify(*module)));
+      EXPECT_EQ(llvm::range_size(main.getOps<AllocOp>()), 1);
+      EXPECT_EQ(llvm::range_size(main.getOps<ResetOp>()), 1);
+    }
   }
 }
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Model `qco.ctrl`, `qco.inv`, `qco.pow`, `qco.if`, and `qco.index_switch` with both `RecursivelySpeculatable` and `RecursiveMemoryEffects`. Their own region-container behavior has no direct effect, but both properties depend on the nested operations. In particular, a nested `qco.gphase` carries `MemWrite`, so its enclosing modifier is neither memory-effect-free nor speculatable and cannot be erased or speculated as pure.

Keep generic `qco.call` effects conservatively at `MemWrite`, with calls non-speculatable. Generic effect queries never inspect sibling function bodies, so they respect MLIR's function-pass isolation.

Compute more precise effects once inside the module-level qubit-reuse pass. Bottom-up summaries share work across transitive callees and call sites; unknown effects and cyclic dependencies never become proven effect-free. The pass keeps unitary helper bodies unchanged while rewriting callers and discards all summaries afterward. This preserves reuse across phase-free calls without persistent cache invalidation.

Strengthen the QC and QCO modifier and `mqt.unitary` function verifiers to admit only operations implementing the dialect `UnitaryOpInterface` plus memory-effect-free classical operations that have no regions and carry no qubits. Parameter computation is eager when the invocation is reached and need not be speculatable. Modifiers transform the quantum action on the computation's defined input domain, not the parameter computation. Classical SSA values may still be captured from above. Memory access, classical-bit register access, and non-unitary region operations such as SCF are rejected.

Reuse the QC modifier verifiers in the QC-to-QCO preflight and remove modifier-specific structured-control-flow remapping that is no longer valid. General structured control flow outside modifiers remains supported.

Controlled global phases retain their quantum semantics: global-phase normalization converts a phase inside `qco.ctrl` into the corresponding phase operation on its controls instead of extracting it as an unconditional global phase.

Preserve dependent parameter chains when unrolling modifiers and extracting global phases. These moves cross only eager modifier boundaries, never surrounding classical conditions. Nested modifier canonicalizers retain parameter producers before erasing their former scopes.

Regression tests cover non-speculatable classical computation in unitary helpers and all QC/QCO modifiers, classical conditional boundaries, nested canonicalization, transitive callee effects, callee mutations between pass invocations, unresolved and recursive calls, helper preservation in nested symbol tables, and qubit reuse across phase-free calls. A callee with a global phase remains an effect barrier.

No new dependencies.

Fixes #2434

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.