### PR TITLE
🐛 Include side-effect operation dependencies in `reorderTopologically`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ releases may include breaking changes.
 - ✨ Add a compiler-target-aware `place-and-route` pass ([#1537], [#1547],
   [#1568], [#1581], [#1583], [#1588], [#1600], [#1664], [#1709], [#1716],
   [#1748], [#1805], [#1870], [#1904], [#1911], [#1951], [#1956], [#1997],
-  [#2016], [#2060], [#2179], [#2184], [#2185], [#2205], [#2240])
+  [#2016], [#2060], [#2179], [#2184], [#2185], [#2205], [#2240], [#2436])
   ([**@MatthiasReumann**], [**@burgholzer**], [**@rturrado**],
   [**@simon1hofmann**])
 - ✨ Add modifier and global-phase normalization passes ([#1986], [#1995],
@@ -926,6 +926,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2436]: https://github.com/munich-quantum-toolkit/core/pull/2436
 [#2421]: https://github.com/munich-quantum-toolkit/core/pull/2421
 [#2399]: https://github.com/munich-quantum-toolkit/core/pull/2399
 [#2380]: https://github.com/munich-quantum-toolkit/core/pull/2380

--- a/mlir/include/mlir/Dialect/CBit/IR/CBitOps.td
+++ b/mlir/include/mlir/Dialect/CBit/IR/CBitOps.td
@@ -44,7 +44,7 @@ def CBit_RegisterType : TypeDef<CBitDialect, "Register"> {
 class CBitOp<string mnemonic, list<Trait> traits = []>
     : Op<CBitDialect, mnemonic, traits>;
 
-def AllocOp : CBitOp<"alloc", [MemoryEffects<[MemAlloc]>]> {
+def AllocOp : CBitOp<"alloc"> {
   let summary = "Allocate a classical-bit register";
   let description = [{
     Allocates a static classical-bit register. `zero` initialization defines
@@ -60,7 +60,7 @@ def AllocOp : CBitOp<"alloc", [MemoryEffects<[MemAlloc]>]> {
   }];
 
   let arguments = (ins CBit_InitializationAttr:$initialization);
-  let results = (outs CBit_RegisterType:$result);
+  let results = (outs Res<CBit_RegisterType, "register", [MemAlloc]>:$result);
   let assemblyFormat = [{
     `(` qualified($initialization) `)` attr-dict `:` qualified(type($result))
   }];

--- a/mlir/include/mlir/Dialect/QCO/Utils/Sorting.h
+++ b/mlir/include/mlir/Dialect/QCO/Utils/Sorting.h
@@ -18,5 +18,7 @@ namespace mlir::qco {
 /// topological order. Assumes that the block is acyclic. Historically this
 /// replaced MLIR's `sortTopologically` due to significant runtime overhead.
 /// Preserve deterministic discovery order for ready operations.
+/// Keep SSA dependencies and order effects on each SSA value. This does not
+/// perform alias analysis or order unknown and value-less effects.
 void reorderTopologically(Block& block, IRRewriter& rewriter);
 } // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Utils/Sorting.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/Sorting.cpp
@@ -13,7 +13,6 @@
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SetVector.h>
-#include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>

--- a/mlir/lib/Dialect/QCO/Utils/Sorting.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/Sorting.cpp
@@ -10,150 +10,107 @@
 
 #include "mlir/Dialect/QCO/Utils/Sorting.h"
 
-#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/SetVector.h>
+#include <llvm/ADT/SmallVector.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Support/LLVM.h>
 
-using namespace mlir;
-using namespace llvm;
-
-/// Find the nearest neighbour in a given block.
-static Operation* findParentInBlock(Operation* op, Block& block) {
-  Operation* parent = op->getParentOp();
-  while (parent != nullptr && parent->getBlock() != &block) {
-    parent = parent->getParentOp();
-  }
-  return parent;
-}
-
-/// Return the vector of locations for each block argument.
-static SmallVector<Location> getArgumentLocs(Block& block) {
-  return map_to_vector(block.getArguments(),
-                       [](BlockArgument& arg) { return arg.getLoc(); });
-}
+#include <cassert>
+#include <cstddef>
 
 namespace mlir::qco {
+
 void reorderTopologically(Block& block, IRRewriter& rewriter) {
   Operation* const terminator = block.getTerminator();
 
-  // Construct unresolved map: The dependencies of each operation.
-
-  SmallDenseSet<Value> valuesWithEffect;
-  DenseMap<Operation*, size_t> inDegree;
+  struct Dependencies {
+    size_t pending = 0;
+    SmallVector<Operation*, 2> successors;
+  };
+  const auto numOperations = llvm::range_size(block);
+  DenseMap<Operation*, Dependencies> dependencies;
+  dependencies.reserve(numOperations);
   DenseMap<Value, Operation*> lastEffect;
-  DenseMap<Operation*, SmallSetVector<Operation*, 16>> successors;
-  DenseMap<Operation*, SmallDenseSet<Operation*, 16>> predecessors;
 
+  /// Count repeated edges on both ends instead of maintaining deduplication
+  /// sets.
   const auto addDependency = [&](Operation* predecessor, Operation* successor) {
     assert(predecessor != successor);
-    if (!predecessors[successor].insert(predecessor).second) {
-      return;
-    }
-    ++inDegree[successor];
-    successors[predecessor].insert(successor);
+    ++dependencies[successor].pending;
+    dependencies[predecessor].successors.push_back(successor);
   };
 
   for (Operation& op : block) {
-    successors.try_emplace(&op);
-    predecessors.try_emplace(&op);
-    inDegree.try_emplace(&op, 0);
+    dependencies.try_emplace(&op);
 
-    // Collect the in-block dependencies of the current operation.
-
-    // First, process the side-effect dependencies. This includes all operations
-    // with memory effects. For example, classical register operations which
-    // don't fulfill linear typing.
-
+    /// Preserve the order of effects on each SSA value, including nested
+    /// effects.
     const auto effects = getEffectsRecursively(&op);
     if (effects) {
       for (const auto& effect : *effects) {
         auto value = effect.getValue();
-        if (!(value && valuesWithEffect.insert(value).second)) {
+        if (!value) {
           continue;
         }
-
-        if (Operation* last = lastEffect.lookup(value)) {
-          addDependency(last, &op);
+        auto [it, inserted] = lastEffect.try_emplace(value, &op);
+        if (!inserted && it->second != &op) {
+          addDependency(it->second, &op);
+          it->second = &op;
         }
-
-        lastEffect[value] = &op;
       }
     }
 
-    // Then, process the def-use dependencies, where each operand depends on its
-    // defining operation.
-
+    /// An effect edge need not lead back to the value's defining operation.
+    /// Always retain SSA dependencies, including those of effect-bearing
+    /// inputs.
     for (auto v : op.getOperands()) {
-      if (valuesWithEffect.contains(v)) {
-        continue;
-      }
-
       Operation* def = v.getDefiningOp();
       if (def != nullptr && v.getParentBlock() == &block) {
         addDependency(def, &op);
       }
     }
 
-    // Finally, for each user of the current operation that is *not* in the
-    // targeted block, find the nearest parent operation in the targeted block,
-    // and increase its pending count. Thus, this parent operation also depends
-    // on the release of the current operation.
-
+    /// A nested capture makes its enclosing operation depend on the producer.
     for (Operation* user : op.getUsers()) {
       if (user->getBlock() == &block) {
         continue;
       }
 
-      if (Operation* parent = findParentInBlock(user, block);
+      if (Operation* parent = block.findAncestorOpInBlock(*user);
           parent != nullptr) {
         addDependency(&op, parent);
       }
     }
-
-    valuesWithEffect.clear();
   }
 
-  assert((inDegree.size() == range_size(block)));
+  assert(dependencies.size() == numOperations);
 
   SmallVector<Operation*> worklist;
-  worklist.reserve(range_size(block));
+  worklist.reserve(numOperations);
   for (Operation& op : block) {
-    if (inDegree.lookup(&op) == 0) {
+    if (dependencies[&op].pending == 0) {
       worklist.emplace_back(&op);
     }
   }
 
-  Block* newBlock = rewriter.createBlock(&block, block.getArgumentTypes(),
-                                         getArgumentLocs(block));
-
   for (size_t cursor = 0; cursor < worklist.size(); ++cursor) {
     Operation* ready = worklist[cursor];
 
-    rewriter.moveOpBefore(ready, newBlock, newBlock->end());
+    rewriter.moveOpBefore(ready, &block, block.end());
 
-    for (Operation* user : successors[ready]) {
-      inDegree[user]--;
-      if (inDegree[user] == 0) {
+    for (Operation* user : dependencies[ready].successors) {
+      if (--dependencies[user].pending == 0) {
         worklist.push_back(user);
       }
     }
   }
 
-  assert(all_of(inDegree, [](const auto& kv) { return kv.second == 0; }));
+  assert(worklist.size() == numOperations && "cyclic operation dependencies");
 
-  // Finally replace the old block arguments with the new ones, move the
-  // terminator back at its place, and erase the old block.
-
-  for (size_t i = 0; i < block.getNumArguments(); ++i) {
-    rewriter.replaceAllUsesWith(block.getArgument(i), newBlock->getArgument(i));
-  }
-
-  rewriter.moveOpBefore(terminator, newBlock, newBlock->end());
-  rewriter.eraseBlock(&block);
+  rewriter.moveOpBefore(terminator, &block, block.end());
 }
 } // namespace mlir::qco

--- a/mlir/lib/Dialect/QCO/Utils/Sorting.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/Sorting.cpp
@@ -13,12 +13,15 @@
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SetVector.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/PatternMatch.h>
+#include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Support/LLVM.h>
 
 using namespace mlir;
+using namespace llvm;
 
 /// Find the nearest neighbour in a given block.
 static Operation* findParentInBlock(Operation* op, Block& block) {
@@ -41,54 +44,79 @@ void reorderTopologically(Block& block, IRRewriter& rewriter) {
 
   // Construct unresolved map: The dependencies of each operation.
 
+  SmallDenseSet<Value> effectedValues;
   DenseMap<Operation*, size_t> inDegree;
-  DenseMap<Operation*, llvm::SmallSetVector<Operation*, 16>> successors;
-  DenseMap<Operation*, llvm::SmallDenseSet<Operation*, 16>> predecessors;
+  DenseMap<Value, Operation*> lastEffect;
+  DenseMap<Operation*, SmallSetVector<Operation*, 16>> successors;
+  DenseMap<Operation*, SmallDenseSet<Operation*, 16>> predecessors;
+
+  const auto addDependency = [&](Operation* predecessor, Operation* successor) {
+    assert(predecessor != successor);
+    if (!predecessors[successor].insert(predecessor).second) {
+      return;
+    }
+    ++inDegree[successor];
+    successors[predecessor].insert(successor);
+  };
 
   for (Operation& op : block) {
+    successors.try_emplace(&op);
+    predecessors.try_emplace(&op);
+    inDegree.try_emplace(&op, 0);
 
     // Collect the in-block dependencies of the current operation.
 
-    auto& succs = successors[&op];
-    auto& pres = predecessors[&op];
-    inDegree.try_emplace(&op, 0);
+    // First, process the side-effect dependencies. This includes all operations
+    // with memory effects. For example, classical register operations which
+    // don't fulfill linear typing.
 
-    for (Value v : op.getOperands()) {
-      Operation* def = v.getDefiningOp();
-      if (def != nullptr && v.getParentBlock() == &block &&
-          !pres.contains(def)) {
-        pres.insert(def);
-        ++inDegree[&op];
+    const auto effects = getEffectsRecursively(&op);
+    if (effects) {
+      for (const auto& effect : *effects) {
+        auto value = effect.getValue();
+        if (!(value && effectedValues.insert(value).second)) {
+          continue;
+        }
+
+        if (Operation* last = lastEffect.lookup(value)) {
+          addDependency(last, &op);
+        }
+
+        lastEffect[value] = &op;
       }
     }
 
-    // For each user of the current operation that is *not* in the targeted
-    // block, find the nearest parent operation in the targeted block, and
-    // increase its pending count. Thus, this parent operation also depends on
-    // the release of the current operation.
+    // Then, process the def-use dependencies, where each operand depends on its
+    // defining operation.
+
+    for (auto v : op.getOperands()) {
+      if (effectedValues.contains(v)) {
+        continue;
+      }
+
+      Operation* def = v.getDefiningOp();
+      if (def != nullptr && v.getParentBlock() == &block) {
+        addDependency(def, &op);
+      }
+    }
+
+    // Finally, for each user of the current operation that is *not* in the
+    // targeted block, find the nearest parent operation in the targeted block,
+    // and increase its pending count. Thus, this parent operation also depends
+    // on the release of the current operation.
 
     for (Operation* user : op.getUsers()) {
       if (user->getBlock() == &block) {
-        if (!succs.contains(user)) {
-          succs.insert(user);
-        }
         continue;
       }
 
       if (Operation* parent = findParentInBlock(user, block);
           parent != nullptr) {
-
-        auto& parentPre = predecessors[parent];
-        if (!parentPre.contains(&op)) {
-          parentPre.insert(&op);
-          ++inDegree[parent];
-        }
-
-        if (!succs.contains(parent)) {
-          succs.insert(parent);
-        }
+        addDependency(&op, parent);
       }
     }
+
+    effectedValues.clear();
   }
 
   assert((inDegree.size() == range_size(block)));

--- a/mlir/lib/Dialect/QCO/Utils/Sorting.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/Sorting.cpp
@@ -43,7 +43,7 @@ void reorderTopologically(Block& block, IRRewriter& rewriter) {
 
   // Construct unresolved map: The dependencies of each operation.
 
-  SmallDenseSet<Value> effectedValues;
+  SmallDenseSet<Value> valuesWithEffect;
   DenseMap<Operation*, size_t> inDegree;
   DenseMap<Value, Operation*> lastEffect;
   DenseMap<Operation*, SmallSetVector<Operation*, 16>> successors;
@@ -73,7 +73,7 @@ void reorderTopologically(Block& block, IRRewriter& rewriter) {
     if (effects) {
       for (const auto& effect : *effects) {
         auto value = effect.getValue();
-        if (!(value && effectedValues.insert(value).second)) {
+        if (!(value && valuesWithEffect.insert(value).second)) {
           continue;
         }
 
@@ -89,7 +89,7 @@ void reorderTopologically(Block& block, IRRewriter& rewriter) {
     // defining operation.
 
     for (auto v : op.getOperands()) {
-      if (effectedValues.contains(v)) {
+      if (valuesWithEffect.contains(v)) {
         continue;
       }
 
@@ -115,7 +115,7 @@ void reorderTopologically(Block& block, IRRewriter& rewriter) {
       }
     }
 
-    effectedValues.clear();
+    valuesWithEffect.clear();
   }
 
   assert((inDegree.size() == range_size(block)));

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -666,13 +666,13 @@ TEST_F(MappingPassFixture, PreserveStoredRegisterControlDuringRouting) {
         %condition = arith.cmpi eq, %snapshot, %expected : i1
         %controlled1 = qco.if %condition args(%arg = %q1) -> (!qco.qubit) {
           %prev_bit = cbit.read %reg : !cbit.reg<1> -> i1
-          
+
           %flipped = qco.x %arg : !qco.qubit -> !qco.qubit
           %cond_meas, %next_bit = qco.measure %flipped : !qco.qubit
-          
+
           %changed = arith.xori %prev_bit, %next_bit : i1
           cbit.store %changed, %reg[%c0] : !cbit.reg<1>
-          
+
           qco.yield %cond_meas : !qco.qubit
         } else args(%arg = %q1) {
           qco.yield %arg : !qco.qubit

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -9,6 +9,8 @@
  */
 
 #include "mlir/Compiler/Target.h"
+#include "mlir/Dialect/CBit/IR/CBitDialect.h"
+#include "mlir/Dialect/CBit/IR/CBitOps.h"
 #include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
@@ -16,6 +18,7 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Transforms/Mapping/Mapping.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
+#include "mlir/Dialect/QCO/Utils/Sorting.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Support/Passes.h"
@@ -61,6 +64,8 @@
 
 using namespace mlir;
 using namespace mlir::qco;
+using namespace mlir::cbit;
+
 using mlir::mqt::getEntryPoint;
 using Connectivity = CompilerTarget::Connectivity;
 using NativeOperations = CompilerTarget::NativeOperations;
@@ -305,7 +310,8 @@ protected:
   void SetUp() override {
     DialectRegistry registry;
     registry.insert<mqt::MQTDialect, QCODialect, qtensor::QTensorDialect,
-                    scf::SCFDialect, arith::ArithDialect, func::FuncDialect>();
+                    CBitDialect, scf::SCFDialect, arith::ArithDialect,
+                    func::FuncDialect>();
     context = std::make_unique<MLIRContext>();
     context->appendDialectRegistry(registry);
     context->loadAllAvailableDialects();
@@ -498,7 +504,7 @@ TEST_F(MappingPassFixture, PlaceNoncontiguousTargetCompactly) {
   size_t numAllocations = 0;
   SmallVector<int64_t> staticSites;
   size_t numSinks = 0;
-  module->walk([&](AllocOp) { ++numAllocations; });
+  module->walk([&](qco::AllocOp) { ++numAllocations; });
   module->walk([&](StaticOp op) { staticSites.emplace_back(op.getIndex()); });
   module->walk([&](SinkOp) { ++numSinks; });
   EXPECT_EQ(numAllocations, 0);
@@ -642,6 +648,97 @@ TEST_F(MappingPassFixture, KeepWorkspaceSparseOnLargeTarget) {
   EXPECT_EQ(numSinks, numStatics);
 }
 
+TEST_F(MappingPassFixture, PreserveStoredRegisterControlDuringRouting) {
+  constexpr StringLiteral source = R"mlir(
+    module {
+      func.func @main() attributes {mqt.entry_point} {
+        %c0 = arith.constant 0 : index
+        %reg = cbit.alloc(#cbit.init<zero>) : !cbit.reg<1>
+        %q0 = qco.alloc : !qco.qubit
+        %q1 = qco.alloc : !qco.qubit
+        %q2 = qco.alloc : !qco.qubit
+        %measured, %bit = qco.measure %q0 : !qco.qubit
+        cbit.store %bit, %reg[%c0] : !cbit.reg<1>
+        %one = arith.constant 1 : i64
+        %two = arith.addi %one, %one : i64
+        %snapshot = cbit.read %reg : !cbit.reg<1> -> i1
+        %expected = arith.constant 1 : i1
+        %condition = arith.cmpi eq, %snapshot, %expected : i1
+        %controlled1 = qco.if %condition args(%arg = %q1) -> (!qco.qubit) {
+          %prev_bit = cbit.read %reg : !cbit.reg<1> -> i1
+          
+          %flipped = qco.x %arg : !qco.qubit -> !qco.qubit
+          %cond_meas, %next_bit = qco.measure %flipped : !qco.qubit
+          
+          %changed = arith.xori %prev_bit, %next_bit : i1
+          cbit.store %changed, %reg[%c0] : !cbit.reg<1>
+          
+          qco.yield %cond_meas : !qco.qubit
+        } else args(%arg = %q1) {
+          qco.yield %arg : !qco.qubit
+        }
+        %next1, %next2 = qco.swap %controlled1, %q2
+            : !qco.qubit, !qco.qubit -> !qco.qubit, !qco.qubit
+        qco.sink %measured : !qco.qubit
+        qco.sink %next1 : !qco.qubit
+        qco.sink %next2 : !qco.qubit
+        return
+      }
+    }
+  )mlir";
+
+  auto moduleOp = parseSourceString<ModuleOp>(source, context.get());
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  const auto target = llvm::cantFail(
+      CompilerTarget::create(3, Connectivity::fromCouplings({{0, 1}, {1, 2}}),
+                             NativeOperations::unrestricted()));
+  PassManager mappingPm(context.get());
+  mappingPm.addPass(
+      createMappingPass(target, MappingPassOptions{.ntrials = 1}));
+  ASSERT_TRUE(succeeded(mappingPm.run(moduleOp.get())));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_TRUE(isExecutable(getEntryPoint(moduleOp.get()), target));
+
+  auto func = mqt::getEntryPoint(*moduleOp);
+  auto alloc = *(func.getOps<cbit::AllocOp>().begin());
+  auto measure = *(func.getOps<MeasureOp>().begin());
+  auto store = *(func.getOps<StoreOp>().begin());
+  auto snapshot = *(func.getOps<ReadOp>().begin());
+  auto comparison = *(func.getOps<arith::CmpIOp>().begin());
+  auto conditional = *(func.getOps<IfOp>().begin());
+
+  Block* condBody = conditional.getBody();
+  auto condRead = *(condBody->getOps<ReadOp>().begin());
+  auto condMeasure = *(condBody->getOps<MeasureOp>().begin());
+  auto condXOR = *(condBody->getOps<arith::XOrIOp>().begin());
+  auto condStore = *(condBody->getOps<StoreOp>().begin());
+
+  ASSERT_TRUE(alloc);
+  ASSERT_TRUE(measure);
+  ASSERT_TRUE(store);
+  ASSERT_TRUE(snapshot);
+  ASSERT_TRUE(comparison);
+  ASSERT_TRUE(conditional);
+
+  ASSERT_TRUE(condRead);
+  ASSERT_TRUE(condMeasure);
+  ASSERT_TRUE(condXOR);
+  ASSERT_TRUE(condStore);
+
+  ASSERT_TRUE(alloc->isBeforeInBlock(measure));
+  ASSERT_TRUE(measure->isBeforeInBlock(store));
+  ASSERT_TRUE(store->isBeforeInBlock(snapshot));
+  ASSERT_TRUE(snapshot->isBeforeInBlock(comparison));
+  ASSERT_TRUE(comparison->isBeforeInBlock(conditional));
+
+  ASSERT_TRUE(condRead->isBeforeInBlock(condStore));
+  ASSERT_TRUE(condRead->isBeforeInBlock(condXOR));
+  ASSERT_TRUE(condMeasure->isBeforeInBlock(condXOR));
+  ASSERT_TRUE(condMeasure->isBeforeInBlock(condStore));
+}
+
 TEST_P(MappingPassTest, FailNoEntryPoint) {
   const auto& target = GetParam();
 
@@ -672,7 +769,7 @@ TEST_P(MappingPassTest, MapScalarAllocation) {
 
   size_t numAllocations = 0;
   size_t numStatics = 0;
-  m->walk([&](AllocOp) { ++numAllocations; });
+  m->walk([&](qco::AllocOp) { ++numAllocations; });
   m->walk([&](StaticOp) { ++numStatics; });
   EXPECT_EQ(numAllocations, 0);
   EXPECT_EQ(numStatics, 1);
@@ -747,7 +844,7 @@ TEST_P(MappingPassTest, MapMixedScalarAndTensorAllocations) {
 
   size_t numScalarAllocations = 0;
   size_t numTensorAllocations = 0;
-  m->walk([&](AllocOp) { ++numScalarAllocations; });
+  m->walk([&](qco::AllocOp) { ++numScalarAllocations; });
   m->walk([&](qtensor::AllocOp) { ++numTensorAllocations; });
   EXPECT_EQ(numScalarAllocations, 0);
   EXPECT_EQ(numTensorAllocations, 0);
@@ -899,7 +996,7 @@ TEST_P(MappingPassTest, FailNestedHigherArityUnitary) {
 
   size_t numAllocations = 0;
   size_t numStatics = 0;
-  m->walk([&](AllocOp) { ++numAllocations; });
+  m->walk([&](qco::AllocOp) { ++numAllocations; });
   m->walk([&](StaticOp) { ++numStatics; });
   EXPECT_EQ(numAllocations, 3);
   EXPECT_EQ(numStatics, 0);

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -702,18 +702,18 @@ TEST_F(MappingPassFixture, PreserveStoredRegisterControlDuringRouting) {
   EXPECT_TRUE(isExecutable(getEntryPoint(moduleOp.get()), target));
 
   auto func = mqt::getEntryPoint(*moduleOp);
-  auto alloc = *(func.getOps<cbit::AllocOp>().begin());
-  auto measure = *(func.getOps<MeasureOp>().begin());
-  auto store = *(func.getOps<StoreOp>().begin());
-  auto snapshot = *(func.getOps<ReadOp>().begin());
-  auto comparison = *(func.getOps<arith::CmpIOp>().begin());
-  auto conditional = *(func.getOps<IfOp>().begin());
+  auto alloc = *func.getOps<cbit::AllocOp>().begin();
+  auto measure = *func.getOps<MeasureOp>().begin();
+  auto store = *func.getOps<StoreOp>().begin();
+  auto snapshot = *func.getOps<ReadOp>().begin();
+  auto comparison = *func.getOps<arith::CmpIOp>().begin();
+  auto conditional = *func.getOps<IfOp>().begin();
 
   Block* condBody = conditional.getBody();
-  auto condRead = *(condBody->getOps<ReadOp>().begin());
-  auto condMeasure = *(condBody->getOps<MeasureOp>().begin());
-  auto condXOR = *(condBody->getOps<arith::XOrIOp>().begin());
-  auto condStore = *(condBody->getOps<StoreOp>().begin());
+  auto condRead = *condBody->getOps<ReadOp>().begin();
+  auto condMeasure = *condBody->getOps<MeasureOp>().begin();
+  auto condXOR = *condBody->getOps<arith::XOrIOp>().begin();
+  auto condStore = *condBody->getOps<StoreOp>().begin();
 
   ASSERT_TRUE(alloc);
   ASSERT_TRUE(measure);

--- a/mlir/unittests/Dialect/QCO/Utils/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Utils/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 set(qco_utils_target mqt-core-mlir-unittest-qco-utils)
 add_executable(${qco_utils_target} test_dd_functionality.cpp test_drivers.cpp test_layout.cpp
-                                   test_unitary_matrix.cpp test_wireiterator.cpp)
+                                   test_sorting.cpp test_unitary_matrix.cpp test_wireiterator.cpp)
 target_link_libraries(
   ${qco_utils_target}
   PRIVATE GTest::gtest_main

--- a/mlir/unittests/Dialect/QCO/Utils/test_sorting.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_sorting.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/CBit/IR/CBitDialect.h"
+#include "mlir/Dialect/CBit/IR/CBitOps.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/Utils/Sorting.h"
+
+#include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Support/LLVM.h>
+
+using namespace mlir;
+
+namespace {
+
+class TopologicalSortingTest : public testing::Test {
+protected:
+  MLIRContext context;
+
+  void SetUp() override {
+    context.loadDialect<arith::ArithDialect, cbit::CBitDialect,
+                        func::FuncDialect, qco::QCODialect, scf::SCFDialect>();
+  }
+
+  OwningOpRef<ModuleOp> parse(StringRef source) {
+    return parseSourceString<ModuleOp>(source, &context);
+  }
+
+  void sort(ModuleOp moduleOp) {
+    auto function = *moduleOp.getOps<func::FuncOp>().begin();
+    IRRewriter rewriter(&context);
+    qco::reorderTopologically(function.getBody().front(), rewriter);
+  }
+};
+
+} // namespace
+
+TEST_F(TopologicalSortingTest, RetainsSSAForEffectBearingQubits) {
+  auto moduleOp = parse(R"mlir(
+    func.func @test(%q: !qco.qubit, %power: f64) -> !qco.qubit {
+      %a = qco.x %q : !qco.qubit -> !qco.qubit
+      %b = qco.h %a : !qco.qubit -> !qco.qubit
+      %r = qco.pow(%power) (%t = %b) {
+        %u = qco.s %t : !qco.qubit -> !qco.qubit
+        qco.yield %u : !qco.qubit
+      } : {!qco.qubit} -> {!qco.qubit}
+      return %r : !qco.qubit
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  sort(*moduleOp);
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+}
+
+TEST_F(TopologicalSortingTest, RepairsDominanceWithoutReplacingBlockArguments) {
+  auto moduleOp = parse(R"mlir(
+    func.func @test(%x: i64) -> i64 {
+      %a = arith.addi %x, %x : i64
+      %b = arith.addi %a, %a : i64
+      return %b : i64
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto function = *moduleOp->getOps<func::FuncOp>().begin();
+  auto* block = &function.getBody().front();
+  auto argument = block->getArgument(0);
+  auto adds = llvm::to_vector(block->getOps<arith::AddIOp>());
+  adds[1]->moveBefore(adds[0]);
+  sort(*moduleOp);
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_EQ(&function.getBody().front(), block);
+  EXPECT_EQ(function.getArgument(0), argument);
+  EXPECT_TRUE(adds[0]->isBeforeInBlock(adds[1]));
+}
+
+TEST_F(TopologicalSortingTest, PreservesRepeatedNestedEffectsAndCaptures) {
+  auto moduleOp = parse(R"mlir(
+    func.func @test(%x: i1) -> i1 {
+      %reg = cbit.alloc(#cbit.init<zero>) : !cbit.reg<1>
+      %condition = arith.xori %x, %x : i1
+      scf.if %condition {
+        %before = cbit.read %reg : !cbit.reg<1> -> i1
+        %changed = arith.xori %before, %x : i1
+        cbit.write %changed, %reg : i1, !cbit.reg<1>
+        %again = cbit.read %reg : !cbit.reg<1> -> i1
+        %next = arith.xori %again, %x : i1
+        cbit.write %next, %reg : i1, !cbit.reg<1>
+      }
+      %result = cbit.read %reg : !cbit.reg<1> -> i1
+      return %result : i1
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  sort(*moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto function = *moduleOp->getOps<func::FuncOp>().begin();
+  auto alloc = *function.getOps<cbit::AllocOp>().begin();
+  auto conditional = *function.getOps<scf::IfOp>().begin();
+  auto read = *function.getOps<cbit::ReadOp>().begin();
+  EXPECT_TRUE(alloc->isBeforeInBlock(conditional));
+  EXPECT_TRUE(conditional->isBeforeInBlock(read));
+}
+
+TEST_F(TopologicalSortingTest, PreservesReadyOperationDiscoveryOrder) {
+  auto moduleOp = parse(R"mlir(
+    func.func @test(%x: i64) -> i64 {
+      %a = arith.addi %x, %x : i64
+      %b = arith.addi %a, %a : i64
+      %c = arith.muli %x, %x : i64
+      %d = arith.addi %b, %c : i64
+      return %d : i64
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto function = *moduleOp->getOps<func::FuncOp>().begin();
+  auto adds = llvm::to_vector(function.getOps<arith::AddIOp>());
+  auto mul = *function.getOps<arith::MulIOp>().begin();
+  sort(*moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_TRUE(adds[0]->isBeforeInBlock(mul));
+  EXPECT_TRUE(mul->isBeforeInBlock(adds[1]));
+  EXPECT_TRUE(adds[1]->isBeforeInBlock(adds[2]));
+}


### PR DESCRIPTION
## Description

(Extracted from #2351) The `reorderTopologically` function currently only respects def-use dependencies and thus fails to correctly order `cbit` register operations after mapping. This pull request updates the function to also consider dependencies with memory effects. 

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
