### PR TITLE
♻️ Simplify QDMI implementation and tests

### DIFF
--- a/.agent/plans/qdmi-simplification.md
+++ b/.agent/plans/qdmi-simplification.md
@@ -14,7 +14,8 @@ fields as fresh-session overrides, including explicitly empty values. The test
 environment guard supports unsetting and fails loudly if restoration fails.
 
 Validation: the QDMI C++ suite passes in release and Clang builds (465 passed,
-one expected skip). `uv run --no-sync pytest test/python/qdmi test/python/plugins
--q` passes all 463 tests. Both `uvx nox -s lint` and `uvx nox -s cpp-lint` pass.
-No dependencies or public wrapper API changes require migration instructions.
-Hosted CI remains a separate check; Windows behavior was not executed locally.
+one expected skip).
+`uv run --no-sync pytest test/python/qdmi test/python/plugins -q` passes all 463
+tests. Both `uvx nox -s lint` and `uvx nox -s cpp-lint` pass. No dependencies or
+public wrapper API changes require migration instructions. Hosted CI remains a
+separate check; Windows behavior was not executed locally.

--- a/.agent/plans/qdmi-simplification.md
+++ b/.agent/plans/qdmi-simplification.md
@@ -1,0 +1,20 @@
+# QDMI implementation simplification
+
+Status: complete.
+
+QDMI shares platform lookup, standard property decoding, sparse-result decoding,
+and session override handling. The test suite reuses one environment guard and
+constructs mock devices directly. The unused internal session constructor is
+removed. Each change has a separate commit.
+
+Module lookup retains caller-supplied anchors so providers and the driver locate
+their own libraries. Shared decoders retain optional support, buffer checks,
+query diagnostics, and session ownership. Registry patches use the same optional
+fields as fresh-session overrides, including explicitly empty values. The test
+environment guard supports unsetting and fails loudly if restoration fails.
+
+Validation: the QDMI C++ suite passes in release and Clang builds (465 passed,
+one expected skip). `uv run --no-sync pytest test/python/qdmi test/python/plugins
+-q` passes all 463 tests. Both `uvx nox -s lint` and `uvx nox -s cpp-lint` pass.
+No dependencies or public wrapper API changes require migration instructions.
+Hosted CI remains a separate check; Windows behavior was not executed locally.

--- a/include/mqt-core/qdmi/Client.hpp
+++ b/include/mqt-core/qdmi/Client.hpp
@@ -382,6 +382,59 @@ template <typename T>
 concept maybe_optional_value_or_string_or_vector =
     value_or_string_or_vector<remove_optional_t<T>>;
 
+namespace detail {
+/// Decode a standard property while preserving optional support and
+/// diagnostics.
+template <maybe_optional_value_or_string_or_vector T, typename Query>
+[[nodiscard]] T queryProperty(Query query, const std::string& msg,
+                              const std::string& sizeMsg) {
+  if constexpr (string_or_optional_string<T>) {
+    size_t size = 0;
+    auto result = query(0, nullptr, &size);
+
+    if constexpr (is_optional<T>) {
+      if (result == QDMI_ERROR_NOTSUPPORTED) {
+        return std::nullopt;
+      }
+    }
+
+    qdmi::throwIfError(result, sizeMsg);
+    std::string value(size - 1, '\0');
+    result = query(size, value.data(), nullptr);
+    qdmi::throwIfError(result, msg);
+    return value;
+  } else if constexpr (maybe_optional_size_constructible_contiguous_range<T>) {
+    size_t size = 0;
+    auto result = query(0, nullptr, &size);
+
+    if constexpr (is_optional<T>) {
+      if (result == QDMI_ERROR_NOTSUPPORTED) {
+        return std::nullopt;
+      }
+    }
+
+    qdmi::throwIfError(result, sizeMsg);
+    remove_optional_t<T> value(
+        size / sizeof(typename remove_optional_t<T>::value_type));
+    result = query(size, value.data(), nullptr);
+    qdmi::throwIfError(result, msg);
+    return value;
+  } else {
+    remove_optional_t<T> value{};
+    const auto result = query(sizeof(remove_optional_t<T>), &value, nullptr);
+
+    if constexpr (is_optional<T>) {
+      if (result == QDMI_ERROR_NOTSUPPORTED) {
+        return std::nullopt;
+      }
+    }
+
+    qdmi::throwIfError(result, msg);
+    return value;
+  }
+}
+} // namespace detail
+
 /**
  * @brief Configuration structure for session authentication parameters.
  * @details All parameters are optional. Only set the parameters needed for
@@ -738,59 +791,13 @@ private:
   /// Query a device property.
   template <maybe_optional_value_or_string_or_vector T>
   [[nodiscard]] T queryProperty(const QDMI_Device_Property prop) const {
-    std::string msg = "Querying ";
-    msg += qdmi::toString(prop);
-
-    if constexpr (string_or_optional_string<T>) {
-      size_t size = 0;
-      auto result = QDMI_device_query_device_property(device_.get(), prop, 0,
-                                                      nullptr, &size);
-
-      if constexpr (is_optional<T>) {
-        if (result == QDMI_ERROR_NOTSUPPORTED) {
-          return std::nullopt;
-        }
-      }
-
-      qdmi::throwIfError(result, msg);
-      std::string value(size - 1, '\0');
-      result = QDMI_device_query_device_property(device_.get(), prop, size,
-                                                 value.data(), nullptr);
-      qdmi::throwIfError(result, msg);
-      return value;
-    } else if constexpr (maybe_optional_size_constructible_contiguous_range<
-                             T>) {
-      size_t size = 0;
-      auto result = QDMI_device_query_device_property(device_.get(), prop, 0,
-                                                      nullptr, &size);
-
-      if constexpr (is_optional<T>) {
-        if (result == QDMI_ERROR_NOTSUPPORTED) {
-          return std::nullopt;
-        }
-      }
-
-      qdmi::throwIfError(result, msg);
-      remove_optional_t<T> value(
-          size / sizeof(typename remove_optional_t<T>::value_type));
-      result = QDMI_device_query_device_property(device_.get(), prop, size,
-                                                 value.data(), nullptr);
-      qdmi::throwIfError(result, msg);
-      return value;
-    } else {
-      remove_optional_t<T> value{};
-      const auto result = QDMI_device_query_device_property(
-          device_.get(), prop, sizeof(remove_optional_t<T>), &value, nullptr);
-
-      if constexpr (is_optional<T>) {
-        if (result == QDMI_ERROR_NOTSUPPORTED) {
-          return std::nullopt;
-        }
-      }
-
-      qdmi::throwIfError(result, msg);
-      return value;
-    }
+    const std::string msg = std::string("Querying ") + qdmi::toString(prop);
+    return detail::queryProperty<T>(
+        [&](const size_t size, void* value, size_t* sizeRet) {
+          return QDMI_device_query_device_property(device_.get(), prop, size,
+                                                   value, sizeRet);
+        },
+        msg, msg);
   }
 
   [[nodiscard]] Job
@@ -1075,37 +1082,13 @@ private:
   /// Query a site property.
   template <maybe_optional_value_or_string T>
   [[nodiscard]] T queryProperty(const QDMI_Site_Property prop) const {
-    if constexpr (string_or_optional_string<T>) {
-      size_t size = 0;
-      const auto result = QDMI_device_query_site_property(
-          device_.get(), site_, prop, 0, nullptr, &size);
-      if constexpr (is_optional<T>) {
-        if (result == QDMI_ERROR_NOTSUPPORTED) {
-          return std::nullopt;
-        }
-      }
-      qdmi::throwIfError(result,
-                         std::string("Querying size") + qdmi::toString(prop));
-      std::string value(size - 1, '\0');
-      qdmi::throwIfError(QDMI_device_query_site_property(device_.get(), site_,
-                                                         prop, size,
-                                                         value.data(), nullptr),
-                         std::string("Querying ") + qdmi::toString(prop));
-      return value;
-    } else {
-      remove_optional_t<T> value{};
-      const auto result = QDMI_device_query_site_property(
-          device_.get(), site_, prop, sizeof(remove_optional_t<T>), &value,
-          nullptr);
-      if constexpr (is_optional<T>) {
-        if (result == QDMI_ERROR_NOTSUPPORTED) {
-          return std::nullopt;
-        }
-      }
-      qdmi::throwIfError(result,
-                         std::string("Querying ") + qdmi::toString(prop));
-      return value;
-    }
+    const std::string msg = std::string("Querying ") + qdmi::toString(prop);
+    return detail::queryProperty<T>(
+        [&](const size_t size, void* value, size_t* sizeRet) {
+          return QDMI_device_query_site_property(device_.get(), site_, prop,
+                                                 size, value, sizeRet);
+        },
+        msg, std::string("Querying size") + qdmi::toString(prop));
   }
 
   /// @brief The QDMI device handle that owns the site.
@@ -1246,62 +1229,18 @@ private:
   [[nodiscard]] T queryProperty(const QDMI_Operation_Property prop,
                                 const std::vector<Site>& sites,
                                 const std::vector<double>& params) const {
-    std::string msg = "Querying ";
-    msg += qdmi::toString(prop);
+    const std::string msg = std::string("Querying ") + qdmi::toString(prop);
     std::vector<QDMI_Site> qdmiSites;
     qdmiSites.reserve(sites.size());
     std::ranges::transform(sites, std::back_inserter(qdmiSites),
                            [](const Site& site) -> QDMI_Site { return site; });
-    if constexpr (string_or_optional_string<T>) {
-      size_t size = 0;
-      auto result = QDMI_device_query_operation_property(
-          device_.get(), operation_, sites.size(), qdmiSites.data(),
-          params.size(), params.data(), prop, 0, nullptr, &size);
-      if constexpr (is_optional<T>) {
-        if (result == QDMI_ERROR_NOTSUPPORTED) {
-          return std::nullopt;
-        }
-      }
-      qdmi::throwIfError(result, msg);
-      std::string value(size - 1, '\0');
-      result = QDMI_device_query_operation_property(
-          device_.get(), operation_, sites.size(), qdmiSites.data(),
-          params.size(), params.data(), prop, size, value.data(), nullptr);
-      qdmi::throwIfError(result, msg);
-      return value;
-    } else if constexpr (maybe_optional_size_constructible_contiguous_range<
-                             T>) {
-      size_t size = 0;
-      auto result = QDMI_device_query_operation_property(
-          device_.get(), operation_, sites.size(), qdmiSites.data(),
-          params.size(), params.data(), prop, 0, nullptr, &size);
-      if constexpr (is_optional<T>) {
-        if (result == QDMI_ERROR_NOTSUPPORTED) {
-          return std::nullopt;
-        }
-      }
-      qdmi::throwIfError(result, msg);
-      remove_optional_t<T> value(
-          size / sizeof(typename remove_optional_t<T>::value_type));
-      result = QDMI_device_query_operation_property(
-          device_.get(), operation_, sites.size(), qdmiSites.data(),
-          params.size(), params.data(), prop, size, value.data(), nullptr);
-      qdmi::throwIfError(result, msg);
-      return value;
-    } else {
-      remove_optional_t<T> value{};
-      const auto result = QDMI_device_query_operation_property(
-          device_.get(), operation_, sites.size(), qdmiSites.data(),
-          params.size(), params.data(), prop, sizeof(remove_optional_t<T>),
-          &value, nullptr);
-      if constexpr (is_optional<T>) {
-        if (result == QDMI_ERROR_NOTSUPPORTED) {
-          return std::nullopt;
-        }
-      }
-      qdmi::throwIfError(result, msg);
-      return value;
-    }
+    return detail::queryProperty<T>(
+        [&](const size_t size, void* value, size_t* sizeRet) {
+          return QDMI_device_query_operation_property(
+              device_.get(), operation_, sites.size(), qdmiSites.data(),
+              params.size(), params.data(), prop, size, value, sizeRet);
+        },
+        msg, msg);
   }
 
   /// @brief The QDMI device handle that owns the operation.

--- a/include/mqt-core/qdmi/common/DeviceConfiguration.hpp
+++ b/include/mqt-core/qdmi/common/DeviceConfiguration.hpp
@@ -19,6 +19,12 @@
 
 namespace qdmi::detail {
 
+/// Returns a non-empty environment value, or nullopt when absent or empty.
+[[nodiscard]] std::optional<std::string> environment(std::string_view name);
+
+/// Returns the directory of the loaded module containing the caller's anchor.
+[[nodiscard]] std::filesystem::path moduleDirectory(const void* anchor);
+
 /// JSON text selected for a provider session together with a safe source label.
 struct LoadedDeviceConfiguration {
   std::string json;

--- a/include/mqt-core/qdmi/driver/Driver.hpp
+++ b/include/mqt-core/qdmi/driver/Driver.hpp
@@ -406,10 +406,6 @@ private:
   std::vector<QDMI_Device> devices_;
 
 public:
-  /// @brief Constructor for the QDMI session.
-  explicit QDMI_Session_impl_d(
-      const std::vector<std::unique_ptr<QDMI_Device_impl_d>>& devices);
-
   /// @brief Constructor from an explicit device-handle snapshot.
   explicit QDMI_Session_impl_d(const std::vector<QDMI_Device>& devices);
 

--- a/include/mqt-core/qdmi/driver/SessionConfig.hpp
+++ b/include/mqt-core/qdmi/driver/SessionConfig.hpp
@@ -24,6 +24,37 @@
 
 namespace qdmi {
 
+namespace detail {
+template <class T>
+inline void applyOverride(std::optional<T>& value,
+                          const std::optional<T>& overrideValue) {
+  if (overrideValue) {
+    value = overrideValue;
+  }
+}
+
+/// Apply present overrides, including explicitly empty values.
+[[nodiscard]] inline auto
+mergeSessionConfig(const DeviceSessionConfig& defaults,
+                   const DeviceSessionConfig& overrides)
+    -> DeviceSessionConfig {
+  auto merged = defaults;
+  applyOverride(merged.baseUrl, overrides.baseUrl);
+  applyOverride(merged.token, overrides.token);
+  applyOverride(merged.authFile, overrides.authFile);
+  applyOverride(merged.authUrl, overrides.authUrl);
+  applyOverride(merged.username, overrides.username);
+  applyOverride(merged.password, overrides.password);
+  applyOverride(merged.deviceConfiguration, overrides.deviceConfiguration);
+  applyOverride(merged.custom1, overrides.custom1);
+  applyOverride(merged.custom2, overrides.custom2);
+  applyOverride(merged.custom3, overrides.custom3);
+  applyOverride(merged.custom4, overrides.custom4);
+  applyOverride(merged.custom5, overrides.custom5);
+  return merged;
+}
+} // namespace detail
+
 /**
  * @brief Construct a device session configuration from individual parameters.
  * @throws std::invalid_argument If both an inline device configuration and a

--- a/src/qdmi/Client.cpp
+++ b/src/qdmi/Client.cpp
@@ -54,6 +54,64 @@ void rejectUnsupportedProgramFormat(const QDMI_Program_Format format) {
         "trigger a calibration run");
   }
 }
+template <typename T>
+std::map<std::string, T>
+getSparseResult(QDMI_Job job, const QDMI_Job_Result keysResult,
+                const QDMI_Job_Result valuesResult,
+                const std::string& description, const std::string& valueType,
+                const std::string& mismatch) {
+  size_t keysSize = 0;
+  qdmi::throwIfError(
+      QDMI_job_get_results(job, keysResult, 0, nullptr, &keysSize),
+      "Querying " + description + " keys size");
+
+  if (keysSize == 0) {
+    return {};
+  }
+
+  std::string keys(keysSize, '\0');
+  qdmi::throwIfError(
+      QDMI_job_get_results(job, keysResult, keysSize, keys.data(), nullptr),
+      "Querying " + description + " keys");
+  keys.pop_back();
+
+  size_t valuesSize = 0;
+  qdmi::throwIfError(
+      QDMI_job_get_results(job, valuesResult, 0, nullptr, &valuesSize),
+      "Querying " + description + " values size");
+
+  if (valuesSize % sizeof(T) != 0) {
+    throw std::runtime_error("Invalid " + description +
+                             " values size: not a multiple of " + valueType);
+  }
+
+  std::vector<T> values(valuesSize / sizeof(T));
+  qdmi::throwIfError(QDMI_job_get_results(job, valuesResult, valuesSize,
+                                          values.data(), nullptr),
+                     "Querying " + description + " values");
+
+  /// Parse the comma-separated keys.
+  std::map<std::string, T> result;
+  if (keys.empty() && values.size() == 1) {
+    result[""] = values.front();
+    return result;
+  }
+  std::istringstream keysStream(keys);
+  std::string key;
+  size_t idx = 0;
+  while (std::getline(keysStream, key, ',')) {
+    if (idx >= values.size()) {
+      throw std::runtime_error(mismatch);
+    }
+    result[key] = values[idx];
+    ++idx;
+  }
+
+  if (idx != values.size()) {
+    throw std::runtime_error(mismatch);
+  }
+  return result;
+}
 } // namespace
 
 size_t Site::getIndex() const {
@@ -757,122 +815,17 @@ std::vector<double> Job::getDenseProbabilities() const {
 }
 
 std::map<std::string, std::complex<double>> Job::getSparseStateVector() const {
-  size_t keysSize = 0;
-  qdmi::throwIfError(
-      QDMI_job_get_results(job_.get(), QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS,
-                           0, nullptr, &keysSize),
-      "Querying sparse state vector keys size");
-
-  if (keysSize == 0) {
-    return {}; // Empty state vector
-  }
-
-  std::string keys(keysSize, '\0');
-  qdmi::throwIfError(
-      QDMI_job_get_results(job_.get(), QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS,
-                           keysSize, keys.data(), nullptr),
-      "Querying sparse state vector keys");
-  keys.pop_back();
-
-  size_t valuesSize = 0;
-  qdmi::throwIfError(QDMI_job_get_results(
-                         job_.get(), QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES,
-                         0, nullptr, &valuesSize),
-                     "Querying sparse state vector values size");
-
-  if (valuesSize % sizeof(std::complex<double>) != 0) {
-    throw std::runtime_error(
-        "Invalid sparse state vector values size: not a multiple of "
-        "complex<double>");
-  }
-
-  std::vector<std::complex<double>> values(valuesSize /
-                                           sizeof(std::complex<double>));
-  qdmi::throwIfError(QDMI_job_get_results(
-                         job_.get(), QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES,
-                         valuesSize, values.data(), nullptr),
-                     "Querying sparse state vector values");
-
-  // Parse the keys (comma-separated)
-  std::map<std::string, std::complex<double>> stateVector;
-  if (keys.empty() && values.size() == 1) {
-    stateVector[""] = values.front();
-    return stateVector;
-  }
-  std::istringstream keysStream(keys);
-  std::string key;
-  size_t idx = 0;
-  while (std::getline(keysStream, key, ',')) {
-    if (idx >= values.size()) {
-      throw std::runtime_error("Sparse state vector key/value count mismatch");
-    }
-    stateVector[key] = values[idx];
-    ++idx;
-  }
-
-  if (idx != values.size()) {
-    throw std::runtime_error("Sparse state vector key/value count mismatch");
-  }
-  return stateVector;
+  return getSparseResult<std::complex<double>>(
+      job_.get(), QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS,
+      QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES, "sparse state vector",
+      "complex<double>", "Sparse state vector key/value count mismatch");
 }
 
 std::map<std::string, double> Job::getSparseProbabilities() const {
-  size_t keysSize = 0;
-  qdmi::throwIfError(QDMI_job_get_results(
-                         job_.get(), QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
-                         0, nullptr, &keysSize),
-                     "Querying sparse probabilities keys size");
-
-  if (keysSize == 0) {
-    return {}; // Empty probabilities
-  }
-
-  std::string keys(keysSize, '\0');
-  qdmi::throwIfError(QDMI_job_get_results(
-                         job_.get(), QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
-                         keysSize, keys.data(), nullptr),
-                     "Querying sparse probabilities keys");
-  keys.pop_back();
-
-  size_t valuesSize = 0;
-  qdmi::throwIfError(
-      QDMI_job_get_results(job_.get(),
-                           QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES, 0,
-                           nullptr, &valuesSize),
-      "Querying sparse probabilities values size");
-
-  if (valuesSize % sizeof(double) != 0) {
-    throw std::runtime_error(
-        "Invalid sparse probabilities values size: not a multiple of double");
-  }
-
-  std::vector<double> values(valuesSize / sizeof(double));
-  qdmi::throwIfError(
-      QDMI_job_get_results(job_.get(),
-                           QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES,
-                           valuesSize, values.data(), nullptr),
-      "Querying sparse probabilities values");
-
-  // Parse the keys (comma-separated)
-  std::map<std::string, double> probabilities;
-  if (keys.empty() && values.size() == 1) {
-    probabilities[""] = values.front();
-    return probabilities;
-  }
-  std::istringstream keysStream(keys);
-  std::string key;
-  size_t idx = 0;
-  while (std::getline(keysStream, key, ',')) {
-    if (idx >= values.size()) {
-      throw std::runtime_error("Sparse probabilities key/value count mismatch");
-    }
-    probabilities[key] = values[idx];
-    ++idx;
-  }
-  if (idx != values.size()) {
-    throw std::runtime_error("Sparse probabilities key/value count mismatch");
-  }
-  return probabilities;
+  return getSparseResult<double>(
+      job_.get(), QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
+      QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES, "sparse probabilities",
+      "double", "Sparse probabilities key/value count mismatch");
 }
 
 Device Session::createSessionlessDevice(QDMI_Device device) {

--- a/src/qdmi/common/DeviceConfiguration.cpp
+++ b/src/qdmi/common/DeviceConfiguration.cpp
@@ -38,7 +38,6 @@
 #endif
 
 namespace qdmi::detail {
-namespace {
 [[nodiscard]] std::optional<std::string>
 environment(const std::string_view name) {
 #ifdef _WIN32
@@ -93,6 +92,7 @@ environment(const std::string_view name) {
 #endif
 }
 
+namespace {
 template <class Reporter>
 void reportPath(const std::filesystem::path& path,
                 const std::format_string<> fallback,

--- a/src/qdmi/driver/DeviceRegistry.cpp
+++ b/src/qdmi/driver/DeviceRegistry.cpp
@@ -10,6 +10,7 @@
 
 #include "DeviceRegistry.hpp"
 
+#include "qdmi/common/DeviceConfiguration.hpp"
 #include "qdmi/driver/Driver.hpp"
 
 #include <nlohmann/json.hpp> // NOLINT(misc-include-cleaner)
@@ -28,12 +29,6 @@
 #include <system_error>
 #include <utility>
 #include <vector>
-
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <dlfcn.h>
-#endif
 
 namespace qdmi::detail {
 namespace {
@@ -307,59 +302,6 @@ void mergePatch(DefinitionPatch& target, const DefinitionPatch& source) {
   target.source = source.source;
 }
 
-[[nodiscard]] auto moduleDirectory() -> std::filesystem::path {
-#ifdef _WIN32
-  HMODULE module = nullptr;
-  if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                             GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                         reinterpret_cast<LPCWSTR>(&moduleDirectory),
-                         &module) == 0) {
-    return {};
-  }
-  std::wstring buffer(MAX_PATH, L'\0');
-  while (true) {
-    const auto size = GetModuleFileNameW(module, buffer.data(),
-                                         static_cast<DWORD>(buffer.size()));
-    if (size == 0) {
-      return {};
-    }
-    if (size < buffer.size()) {
-      buffer.resize(size);
-      return std::filesystem::path(buffer).parent_path();
-    }
-    buffer.resize(buffer.size() * 2);
-  }
-#else
-  Dl_info info{};
-  if (dladdr(reinterpret_cast<const void*>(&moduleDirectory), &info) == 0 ||
-      info.dli_fname == nullptr) {
-    return {};
-  }
-  return std::filesystem::path(info.dli_fname).parent_path();
-#endif
-}
-
-[[nodiscard]] auto environment(const char* name) -> std::optional<std::string> {
-#ifdef _WIN32
-  char* raw = nullptr;
-  size_t size = 0;
-  if (_dupenv_s(&raw, &size, name) != 0 || raw == nullptr) {
-    return std::nullopt;
-  }
-  const std::unique_ptr<char, decltype(&std::free)> value(raw, &std::free);
-  if (*value == '\0') {
-    return std::nullopt;
-  }
-  return std::string(value.get());
-#else
-  if (const auto* value = std::getenv(name);
-      value != nullptr && *value != '\0') {
-    return std::string(value);
-  }
-  return std::nullopt;
-#endif
-}
-
 void appendIfFile(std::vector<std::filesystem::path>& files,
                   const std::filesystem::path& path) {
   const auto absolute = absolutePath(path);
@@ -411,7 +353,8 @@ void appendFragments(std::vector<std::filesystem::path>& files,
 
 [[nodiscard]] auto discoverFiles() -> std::vector<std::filesystem::path> {
   std::vector<std::filesystem::path> files;
-  const auto root = moduleDirectory();
+  const auto root =
+      moduleDirectory(reinterpret_cast<const void*>(&discoverFiles));
   appendFragments(files, root);
   appendFragments(files, root / "bin");
   appendFragments(files, root / "lib");

--- a/src/qdmi/driver/DeviceRegistry.cpp
+++ b/src/qdmi/driver/DeviceRegistry.cpp
@@ -12,6 +12,7 @@
 
 #include "qdmi/common/DeviceConfiguration.hpp"
 #include "qdmi/driver/Driver.hpp"
+#include "qdmi/driver/SessionConfig.hpp"
 
 #include <nlohmann/json.hpp> // NOLINT(misc-include-cleaner)
 
@@ -34,27 +35,12 @@ namespace qdmi::detail {
 namespace {
 using Json = nlohmann::json; // NOLINT(misc-include-cleaner)
 
-struct SessionPatch {
-  std::optional<std::string> baseUrl;
-  std::optional<std::string> token;
-  std::optional<std::filesystem::path> authFile;
-  std::optional<std::string> authUrl;
-  std::optional<std::string> username;
-  std::optional<std::string> password;
-  std::optional<DeviceConfigurationSource> deviceConfiguration;
-  std::optional<std::string> custom1;
-  std::optional<std::string> custom2;
-  std::optional<std::string> custom3;
-  std::optional<std::string> custom4;
-  std::optional<std::string> custom5;
-};
-
 struct DefinitionPatch {
   std::string id;
   std::optional<std::filesystem::path> library;
   std::optional<std::string> prefix;
   std::optional<bool> enabled;
-  SessionPatch session;
+  DeviceSessionConfig session;
   std::filesystem::path source;
 };
 
@@ -120,7 +106,7 @@ void rejectUnknownKeys(const Json& value,
 [[nodiscard]] auto
 parseSessionPatch(const Json& value, const std::filesystem::path& source,
                   const std::string& path, const std::filesystem::path& base)
-    -> SessionPatch {
+    -> DeviceSessionConfig {
   requireObject(value, source, path);
   rejectUnknownKeys(value,
                     {
@@ -138,7 +124,7 @@ parseSessionPatch(const Json& value, const std::filesystem::path& source,
                         "device-config",
                     },
                     source, path);
-  SessionPatch patch;
+  DeviceSessionConfig patch;
   patch.baseUrl = optionalString(value, "base-url", source, path);
   patch.token = optionalString(value, "token", source, path);
   patch.authUrl = optionalString(value, "auth-url", source, path);
@@ -272,33 +258,11 @@ parseDevicePatch(const Json& value, const std::filesystem::path& source,
   }
 }
 
-template <class T>
-void mergeOptional(std::optional<T>& target, const std::optional<T>& source) {
-  if (source) {
-    target = source;
-  }
-}
-
-void mergeSession(SessionPatch& target, const SessionPatch& source) {
-  mergeOptional(target.baseUrl, source.baseUrl);
-  mergeOptional(target.token, source.token);
-  mergeOptional(target.authFile, source.authFile);
-  mergeOptional(target.authUrl, source.authUrl);
-  mergeOptional(target.username, source.username);
-  mergeOptional(target.password, source.password);
-  mergeOptional(target.deviceConfiguration, source.deviceConfiguration);
-  mergeOptional(target.custom1, source.custom1);
-  mergeOptional(target.custom2, source.custom2);
-  mergeOptional(target.custom3, source.custom3);
-  mergeOptional(target.custom4, source.custom4);
-  mergeOptional(target.custom5, source.custom5);
-}
-
 void mergePatch(DefinitionPatch& target, const DefinitionPatch& source) {
-  mergeOptional(target.library, source.library);
-  mergeOptional(target.prefix, source.prefix);
-  mergeOptional(target.enabled, source.enabled);
-  mergeSession(target.session, source.session);
+  applyOverride(target.library, source.library);
+  applyOverride(target.prefix, source.prefix);
+  applyOverride(target.enabled, source.enabled);
+  target.session = mergeSessionConfig(target.session, source.session);
   target.source = source.source;
 }
 
@@ -419,20 +383,7 @@ void appendFragments(std::vector<std::filesystem::path>& files,
   definition.id = patch.id;
   definition.library = *patch.library;
   definition.prefix = *patch.prefix;
-  definition.session.baseUrl = patch.session.baseUrl;
-  definition.session.token = patch.session.token;
-  if (patch.session.authFile) {
-    definition.session.authFile = patch.session.authFile;
-  }
-  definition.session.authUrl = patch.session.authUrl;
-  definition.session.username = patch.session.username;
-  definition.session.password = patch.session.password;
-  definition.session.deviceConfiguration = patch.session.deviceConfiguration;
-  definition.session.custom1 = patch.session.custom1;
-  definition.session.custom2 = patch.session.custom2;
-  definition.session.custom3 = patch.session.custom3;
-  definition.session.custom4 = patch.session.custom4;
-  definition.session.custom5 = patch.session.custom5;
+  definition.session = patch.session;
   return definition;
 }
 

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -13,6 +13,7 @@
 #include "DeviceRegistry.hpp"
 #include "qdmi/common/Common.hpp"
 #include "qdmi/common/Diagnostics.hpp"
+#include "qdmi/driver/SessionConfig.hpp"
 
 #include <qdmi/client.h>
 #include <qdmi/device.h>
@@ -190,32 +191,6 @@ struct DynamicLibraryCache {
   return library;
 }
 
-template <class T>
-void applyOverride(std::optional<T>& value,
-                   const std::optional<T>& overrideValue) {
-  if (overrideValue) {
-    value = overrideValue;
-  }
-}
-
-[[nodiscard]] auto mergeSessionConfig(const DeviceSessionConfig& defaults,
-                                      const DeviceSessionConfig& overrides)
-    -> DeviceSessionConfig {
-  auto merged = defaults;
-  applyOverride(merged.baseUrl, overrides.baseUrl);
-  applyOverride(merged.token, overrides.token);
-  applyOverride(merged.authFile, overrides.authFile);
-  applyOverride(merged.authUrl, overrides.authUrl);
-  applyOverride(merged.username, overrides.username);
-  applyOverride(merged.password, overrides.password);
-  applyOverride(merged.deviceConfiguration, overrides.deviceConfiguration);
-  applyOverride(merged.custom1, overrides.custom1);
-  applyOverride(merged.custom2, overrides.custom2);
-  applyOverride(merged.custom3, overrides.custom3);
-  applyOverride(merged.custom4, overrides.custom4);
-  applyOverride(merged.custom5, overrides.custom5);
-  return merged;
-}
 } // namespace
 
 #undef DL_OPEN
@@ -798,7 +773,7 @@ auto Driver::openFresh(const std::string_view id,
   }
   return std::make_shared<QDMI_Device_impl_d>(
       getDynamicDeviceLibrary(definition.library.string(), definition.prefix),
-      mergeSessionConfig(definition.session, overrides));
+      detail::mergeSessionConfig(definition.session, overrides));
 }
 
 void Driver::materializeClientCatalog() {

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -468,13 +468,6 @@ namespace {
 } // namespace
 
 QDMI_Session_impl_d::QDMI_Session_impl_d(
-    const std::vector<std::unique_ptr<QDMI_Device_impl_d>>& devices) {
-  devices_.reserve(devices.size());
-  std::ranges::transform(devices, std::back_inserter(devices_),
-                         [](const auto& device) { return device.get(); });
-}
-
-QDMI_Session_impl_d::QDMI_Session_impl_d(
     const std::vector<QDMI_Device>& devices)
     : devices_(devices) {}
 

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -40,6 +40,8 @@
 #include <vector>
 
 #ifdef _WIN32
+#include "qdmi/common/DeviceConfiguration.hpp"
+
 #include <windows.h>
 #else
 #include <dlfcn.h>
@@ -48,34 +50,6 @@
 namespace qdmi {
 #ifdef _WIN32
 namespace {
-/// Returns the directory of the currently loaded driver library.
-[[nodiscard]] auto getDriverDirectory() -> std::filesystem::path {
-  HMODULE module = nullptr;
-  if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                             GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                         reinterpret_cast<LPCWSTR>(&getDriverDirectory),
-                         &module) == 0) {
-    return {};
-  }
-
-  std::wstring buffer(MAX_PATH, L'\0');
-  DWORD size = 0;
-  while (true) {
-    size = GetModuleFileNameW(module, buffer.data(),
-                              static_cast<DWORD>(buffer.size()));
-    if (size == 0) {
-      return {};
-    }
-    if (size < buffer.size()) {
-      buffer.resize(size);
-      break;
-    }
-    buffer.resize(buffer.size() * 2);
-  }
-
-  return std::filesystem::path(buffer).parent_path();
-}
-
 /// Loads the device library with the given name, searching in the driver
 /// directory if no path is specified.
 [[nodiscard]] auto loadDeviceLibrary(const std::string& libName) -> HMODULE {
@@ -84,7 +58,9 @@ namespace {
   // already absolute or relative to their declaring file.
   const auto path = requested.has_parent_path()
                         ? requested
-                        : getDriverDirectory() / requested;
+                        : detail::moduleDirectory(reinterpret_cast<const void*>(
+                              &loadDeviceLibrary)) /
+                              requested;
   // Search beside the device DLL for its dependencies. This is required for
   // device implementations such as DDSIM in an installed Python wheel.
   return LoadLibraryExW(path.wstring().c_str(), nullptr,

--- a/test/python/plugins/qiskit/test_mock_backend.py
+++ b/test/python/plugins/qiskit/test_mock_backend.py
@@ -305,28 +305,6 @@ class MockQDMIDevice:
         return self.MockJob(num_clbits=num_clbits, shots=num_shots)
 
 
-@pytest.fixture
-def mock_qdmi_device_factory() -> type[MockQDMIDevice]:
-    """Factory fixture for creating custom MockQDMIDevice instances.
-
-    Returns:
-        The MockQDMIDevice class that can be called to create instances.
-
-    Note:
-        Use this fixture when you need to create custom mock device instances
-        with specific configurations (operations, coupling maps, etc.) for testing.
-
-    Example:
-        def test_custom_device(mock_qdmi_device_factory):
-            device = mock_qdmi_device_factory(
-                name="Custom Device",
-                num_qubits=2,
-                operations=["h", "cx"]
-            )
-    """
-    return MockQDMIDevice
-
-
 def _patch_registered_devices(monkeypatch: pytest.MonkeyPatch, devices: list[MockQDMIDevice]) -> None:
     """Make the driver functions expose the given mock devices."""
     device_ids = [f"test.device.{index}" for index in range(len(devices))]
@@ -339,11 +317,11 @@ def _patch_registered_devices(monkeypatch: pytest.MonkeyPatch, devices: list[Moc
 
 
 def test_backend_warns_on_unmappable_operation(
-    monkeypatch: pytest.MonkeyPatch, mock_qdmi_device_factory: type[MockQDMIDevice]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Backend should warn when device operation cannot be mapped to a Qiskit gate."""
     # Create mock device with an unmappable operation
-    mock_device = mock_qdmi_device_factory(
+    mock_device = MockQDMIDevice(
         name="Test Device",
         num_qubits=2,
         operations=["cz", "custom_unmappable_gate", "measure"],
@@ -368,11 +346,11 @@ def test_backend_warns_on_unmappable_operation(
 
 
 def test_backend_warns_on_missing_measurement_operation(
-    monkeypatch: pytest.MonkeyPatch, mock_qdmi_device_factory: type[MockQDMIDevice]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Backend should warn when device does not define a measurement operation."""
     # Create mock device without measure operation
-    mock_device = mock_qdmi_device_factory(
+    mock_device = MockQDMIDevice(
         name="Test Device",
         num_qubits=2,
         operations=["cz"],  # No measure operation
@@ -396,9 +374,9 @@ def test_backend_warns_on_missing_measurement_operation(
         )
 
 
-def test_backend_warns_on_device_native_operation(mock_qdmi_device_factory: type[MockQDMIDevice]) -> None:
+def test_backend_warns_on_device_native_operation() -> None:
     """Backend skips a device operation that no Qiskit gate represents."""
-    mock_device = mock_qdmi_device_factory(
+    mock_device = MockQDMIDevice(
         name="Test Device with a device-native operation",
         num_qubits=2,
         operations=["hop", "cz", "measure"],
@@ -410,7 +388,7 @@ def test_backend_warns_on_device_native_operation(mock_qdmi_device_factory: type
     assert "hop" not in backend.target.operation_names
 
 
-def test_subclass_extra_gates_appear_in_target(mock_qdmi_device_factory: type[MockQDMIDevice]) -> None:
+def test_subclass_extra_gates_appear_in_target() -> None:
     """A subclass represents a device-native operation through _EXTRA_GATES."""
 
     class HopGate(Gate):
@@ -424,7 +402,7 @@ def test_subclass_extra_gates_appear_in_target(mock_qdmi_device_factory: type[Mo
 
         _EXTRA_GATES: ClassVar[dict[str, Instruction | type[Instruction]]] = {"hop": HopGate()}
 
-    mock_device = mock_qdmi_device_factory(
+    mock_device = MockQDMIDevice(
         name="Test Device with a device-native operation",
         num_qubits=2,
         operations=["hop", "cz", "measure"],
@@ -460,27 +438,27 @@ def _record_submissions(device: MockQDMIDevice) -> list[tuple[str | bytes, Progr
     return submissions
 
 
-def test_backend_serialization_without_supported_formats(mock_qdmi_device_factory: type[MockQDMIDevice]) -> None:
+def test_backend_serialization_without_supported_formats() -> None:
     """Backend should raise UnsupportedFormatError when the device reports no program format."""
     qc = QuantumCircuit(2)
     qc.cz(0, 1)
     qc.measure_all()
 
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["cz", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["cz", "measure"])
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(UnsupportedFormatError, match="reports no supported program formats"):
         backend._serialize_circuit(qc, [])  # ruff:ignore[private-member-access]
 
 
-def test_backend_qasm3_serialization_success(mock_qdmi_device_factory: type[MockQDMIDevice]) -> None:
+def test_backend_qasm3_serialization_success() -> None:
     """Backend should successfully serialize a circuit into OpenQASM 3."""
     qc = QuantumCircuit(2)
     qc.h(0)
     qc.cx(0, 1)
     qc.measure_all()
 
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["h", "cx", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["h", "cx", "measure"])
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
 
     program, fmt = backend._serialize_circuit(qc, [ProgramFormat.QASM3])  # ruff:ignore[private-member-access]
@@ -492,14 +470,12 @@ def test_backend_qasm3_serialization_success(mock_qdmi_device_factory: type[Mock
     assert "cx q[0], q[1]" in program
 
 
-def test_backend_qasm3_zero_initializes_classical_bits(
-    mock_qdmi_device_factory: type[MockQDMIDevice],
-) -> None:
+def test_backend_qasm3_zero_initializes_classical_bits() -> None:
     """Initialize every QASM 3 classical bit before measurement."""
     qc = QuantumCircuit(2, 2)
     qc.measure(0, 0)
 
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["measure"])
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
 
     program, fmt = backend._serialize_circuit(qc, [ProgramFormat.QASM3])  # ruff:ignore[private-member-access]
@@ -511,14 +487,14 @@ def test_backend_qasm3_zero_initializes_classical_bits(
     assert program.index("c[0] = false;") < program.index("c[0] = measure q[0];")
 
 
-def test_backend_qasm2_serialization_success(mock_qdmi_device_factory: type[MockQDMIDevice]) -> None:
+def test_backend_qasm2_serialization_success() -> None:
     """Backend should successfully serialize a circuit into OpenQASM 2."""
     qc = QuantumCircuit(2)
     qc.h(0)
     qc.cx(0, 1)
     qc.measure_all()
 
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["h", "cx", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["h", "cx", "measure"])
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
 
     program, fmt = backend._serialize_circuit(qc, [ProgramFormat.QASM2])  # ruff:ignore[private-member-access]
@@ -530,13 +506,13 @@ def test_backend_qasm2_serialization_success(mock_qdmi_device_factory: type[Mock
     assert "cx q[0],q[1]" in program
 
 
-def test_backend_respects_format_preference(mock_qdmi_device_factory: type[MockQDMIDevice]) -> None:
+def test_backend_respects_format_preference() -> None:
     """The preference order decides the format, not the order the device reports."""
     qc = QuantumCircuit(2)
     qc.h(0)
     qc.measure_all()
 
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["h", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["h", "measure"])
     # The device reports OpenQASM 2 first, but OpenQASM 3 outranks it.
     device.supported_program_formats = lambda: [ProgramFormat.QASM2, ProgramFormat.QASM3]  # ty: ignore[invalid-assignment]
     submissions = _record_submissions(device)
@@ -567,11 +543,9 @@ def registered_serializer() -> Iterator[ProgramFormat]:
     unregister_program_serializer(ProgramFormat.CUSTOM1)
 
 
-def test_backend_uses_registered_serializer(
-    mock_qdmi_device_factory: type[MockQDMIDevice], registered_serializer: ProgramFormat
-) -> None:
+def test_backend_uses_registered_serializer(registered_serializer: ProgramFormat) -> None:
     """Backend serializes through a registered serializer when the device supports its format."""
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["r", "cz", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["r", "cz", "measure"])
     device.supported_program_formats = lambda: [registered_serializer, ProgramFormat.QASM3]  # ty: ignore[invalid-assignment]
     submissions = _record_submissions(device)
 
@@ -585,11 +559,9 @@ def test_backend_uses_registered_serializer(
     assert submissions == [("CUSTOM1 program for bell", registered_serializer)]
 
 
-def test_backend_prefers_registered_serializer_over_qasm(
-    mock_qdmi_device_factory: type[MockQDMIDevice], registered_serializer: ProgramFormat
-) -> None:
+def test_backend_prefers_registered_serializer_over_qasm(registered_serializer: ProgramFormat) -> None:
     """A registered serializer takes priority over the built-in OpenQASM serializers."""
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["r", "cz", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["r", "cz", "measure"])
     device.supported_program_formats = lambda: [ProgramFormat.QASM2, ProgramFormat.QASM3, registered_serializer]  # ty: ignore[invalid-assignment]
     submissions = _record_submissions(device)
 
@@ -622,12 +594,10 @@ def registered_binary_serializer() -> Iterator[tuple[ProgramFormat, bytes]]:
     unregister_program_serializer(ProgramFormat.QPY)
 
 
-def test_backend_submits_binary_payload(
-    mock_qdmi_device_factory: type[MockQDMIDevice], registered_binary_serializer: tuple[ProgramFormat, bytes]
-) -> None:
+def test_backend_submits_binary_payload(registered_binary_serializer: tuple[ProgramFormat, bytes]) -> None:
     """A binary format reaches the device as the exact bytes the serializer returned."""
     fmt, payload = registered_binary_serializer
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["h", "cz", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["h", "cz", "measure"])
     device.supported_program_formats = lambda: [fmt, ProgramFormat.QASM3]  # ty: ignore[invalid-assignment]
     submissions = _record_submissions(device)
 
@@ -658,15 +628,13 @@ def mistyped_serializer() -> Iterator[ProgramFormat]:
     unregister_program_serializer(ProgramFormat.CUSTOM2)
 
 
-def test_backend_rejects_wrong_payload_type(
-    mock_qdmi_device_factory: type[MockQDMIDevice], mistyped_serializer: ProgramFormat
-) -> None:
+def test_backend_rejects_wrong_payload_type(mistyped_serializer: ProgramFormat) -> None:
     """A serializer that returns the wrong payload type for its format fails."""
     qc = QuantumCircuit(2)
     qc.h(0)
     qc.measure_all()
 
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["h", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["h", "measure"])
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(TranslationError, match="returned bytes, but CUSTOM2 requires str"):
@@ -692,11 +660,9 @@ def replaced_qasm3_serializer() -> Iterator[str]:
     register_program_serializer(ProgramFormat.QASM3, original, replace=True)
 
 
-def test_backend_uses_replaced_qasm3_serializer(
-    mock_qdmi_device_factory: type[MockQDMIDevice], replaced_qasm3_serializer: str
-) -> None:
+def test_backend_uses_replaced_qasm3_serializer(replaced_qasm3_serializer: str) -> None:
     """Replacing the built-in OpenQASM 3 serializer changes what the backend submits."""
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["h", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["h", "measure"])
     submissions = _record_submissions(device)
 
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
@@ -709,13 +675,13 @@ def test_backend_uses_replaced_qasm3_serializer(
     assert submissions == [(replaced_qasm3_serializer, ProgramFormat.QASM3)]
 
 
-def test_backend_rejects_device_without_program_payload(mock_qdmi_device_factory: type[MockQDMIDevice]) -> None:
+def test_backend_rejects_device_without_program_payload() -> None:
     """A device that only accepts CALIBRATION has no format a circuit can go into."""
     qc = QuantumCircuit(2)
     qc.h(0)
     qc.measure_all()
 
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["h", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["h", "measure"])
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(UnsupportedFormatError, match="No program serializer for any format the device supports"):
@@ -733,7 +699,6 @@ def test_backend_qasm_serialization_failure(
     monkeypatch: pytest.MonkeyPatch,
     qasm_module_name: str,
     program_format: ProgramFormat,
-    mock_qdmi_device_factory: type[MockQDMIDevice],
 ) -> None:
     """Backend should raise TranslationError when OpenQASM serialization fails."""
     qasm_module = qasm3 if qasm_module_name == "qasm3" else qasm2
@@ -749,20 +714,20 @@ def test_backend_qasm_serialization_failure(
     qc.cz(0, 1)
     qc.measure_all()
 
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["cz", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["cz", "measure"])
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(TranslationError, match=f"Failed to serialize the circuit to {qasm_module_name.upper()}"):
         backend._serialize_circuit(qc, [program_format])  # ruff:ignore[private-member-access]
 
 
-def test_backend_unsupported_format_error(mock_qdmi_device_factory: type[MockQDMIDevice]) -> None:
+def test_backend_unsupported_format_error() -> None:
     """Backend should raise UnsupportedFormatError when no supported format has a serializer."""
     qc = QuantumCircuit(2)
     qc.cz(0, 1)
     qc.measure_all()
 
-    device = mock_qdmi_device_factory(num_qubits=2, operations=["cz", "measure"])
+    device = MockQDMIDevice(num_qubits=2, operations=["cz", "measure"])
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
 
     # MQT Core ships no QPY serializer, and no package registered one
@@ -816,11 +781,11 @@ def test_map_qiskit_gate_to_operation_names() -> None:
 
 
 def test_backend_validation_uses_inverse_mapping(
-    monkeypatch: pytest.MonkeyPatch, mock_qdmi_device_factory: type[MockQDMIDevice]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Backend validation correctly uses inverse mapping to handle device-specific naming."""
     # Create a mock device that uses 'prx' instead of 'r' (like IQM devices)
-    mock_device = mock_qdmi_device_factory(
+    mock_device = MockQDMIDevice(
         name="Test Device with PRX",
         num_qubits=2,
         operations=["prx", "cz", "measure"],  # Uses 'prx' instead of 'r'

--- a/test/qdmi/TestUtils.hpp
+++ b/test/qdmi/TestUtils.hpp
@@ -22,10 +22,11 @@
 
 namespace mqt::test {
 
-/// Temporarily sets an environment variable and restores its previous value.
+/// Temporarily sets or unsets an environment variable and restores its value.
 class ScopedEnvironmentVariable {
 public:
-  ScopedEnvironmentVariable(std::string name, const std::string& value)
+  ScopedEnvironmentVariable(std::string name,
+                            const std::optional<std::string>& value)
       : name_(std::move(name)) {
     if (const auto* previous = std::getenv(name_.c_str());
         previous != nullptr) {
@@ -35,15 +36,8 @@ public:
   }
 
   ~ScopedEnvironmentVariable() {
-    if (previous_) {
-      static_cast<void>(setWithoutChecking(*previous_));
-    } else {
-#ifdef _WIN32
-      static_cast<void>(_putenv_s(name_.c_str(), ""));
-#else
-      // NOLINTNEXTLINE(misc-include-cleaner)
-      static_cast<void>(unsetenv(name_.c_str()));
-#endif
+    if (!setWithoutChecking(previous_)) {
+      std::abort();
     }
   }
 
@@ -54,18 +48,20 @@ public:
   ScopedEnvironmentVariable& operator=(ScopedEnvironmentVariable&&) = delete;
 
 private:
-  void set(const std::string& value) const {
+  void set(const std::optional<std::string>& value) const {
     if (!setWithoutChecking(value)) {
       throw std::runtime_error("Failed to set environment variable " + name_);
     }
   }
 
-  [[nodiscard]] bool setWithoutChecking(const std::string& value) const {
+  [[nodiscard]] bool
+  setWithoutChecking(const std::optional<std::string>& value) const {
 #ifdef _WIN32
-    return _putenv_s(name_.c_str(), value.c_str()) == 0;
+    return _putenv_s(name_.c_str(), value.value_or("").c_str()) == 0;
 #else
-    // NOLINTNEXTLINE(misc-include-cleaner)
-    return setenv(name_.c_str(), value.c_str(), 1) == 0;
+    const auto* const name = name_.c_str();
+    /// NOLINTNEXTLINE(misc-include-cleaner): POSIX environment functions.
+    return (value ? setenv(name, value->c_str(), 1) : unsetenv(name)) == 0;
 #endif
   }
 

--- a/test/qdmi/test_client.cpp
+++ b/test/qdmi/test_client.cpp
@@ -190,6 +190,36 @@ TEST(CustomPropertyTest, RejectsInvalidSelector) {
                std::invalid_argument);
 }
 
+TEST(StandardPropertyTest, PreservesValuesAndOptionalSupport) {
+  const auto bytes = bytesOf(size_t{42});
+  const auto query = queryBytes(bytes);
+  EXPECT_EQ(detail::queryProperty<size_t>(query, "value", "size"), 42);
+  EXPECT_EQ(
+      detail::queryProperty<std::optional<size_t>>(query, "value", "size"), 42);
+  EXPECT_EQ(detail::queryProperty<std::vector<size_t>>(query, "value", "size"),
+            std::vector<size_t>{42});
+  const std::vector<std::byte> text{std::byte{'x'}, std::byte{0}};
+  EXPECT_EQ(
+      detail::queryProperty<std::string>(queryBytes(text), "value", "size"),
+      "x");
+
+  const auto unsupported = [](size_t, void*, size_t*) {
+    return QDMI_ERROR_NOTSUPPORTED;
+  };
+  EXPECT_EQ(detail::queryProperty<std::optional<size_t>>(unsupported, "value",
+                                                         "size"),
+            std::nullopt);
+  EXPECT_EQ(detail::queryProperty<std::optional<std::string>>(unsupported,
+                                                              "value", "size"),
+            std::nullopt);
+  EXPECT_EQ(detail::queryProperty<std::optional<std::vector<size_t>>>(
+                unsupported, "value", "size"),
+            std::nullopt);
+  EXPECT_THROW(std::ignore =
+                   detail::queryProperty<size_t>(unsupported, "value", "size"),
+               std::runtime_error);
+}
+
 TEST(CustomPropertyTest, DecodesSupportedTypes) {
   const std::vector<std::byte> stringBytes{
       std::byte{'v'}, std::byte{'a'}, std::byte{'l'},

--- a/test/qdmi/test_slurm.cpp
+++ b/test/qdmi/test_slurm.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "TestUtils.hpp"
 #include "qdmi/Slurm.hpp"
 #include "qdmi/driver/Driver.hpp"
 
@@ -16,7 +17,6 @@
 #include <qdmi/constants.h>
 
 #include <array>
-#include <cstdlib>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -25,50 +25,7 @@
 namespace qdmi::slurm {
 namespace {
 
-class ScopedSlurmLicenses {
-public:
-  explicit ScopedSlurmLicenses(const std::optional<std::string>& value)
-      : originalValue(getValue()) {
-    setValue(value);
-  }
-
-  ~ScopedSlurmLicenses() { setValue(originalValue); }
-
-  ScopedSlurmLicenses(const ScopedSlurmLicenses&) = delete;
-  ScopedSlurmLicenses& operator=(const ScopedSlurmLicenses&) = delete;
-  ScopedSlurmLicenses(ScopedSlurmLicenses&&) = delete;
-  ScopedSlurmLicenses& operator=(ScopedSlurmLicenses&&) = delete;
-
-private:
-  [[nodiscard]] static auto getValue() -> std::optional<std::string> {
-    if (const auto* const value = std::getenv("SLURM_JOB_LICENSES")) {
-      return value;
-    }
-    return std::nullopt;
-  }
-
-  static void setValue(const std::optional<std::string>& value) {
-#ifdef _WIN32
-    if (_putenv_s("SLURM_JOB_LICENSES", value.value_or("").c_str()) != 0) {
-      std::abort();
-    }
-#else
-    int result = 0;
-    if (value.has_value()) {
-      // NOLINTNEXTLINE(misc-include-cleaner)
-      result = setenv("SLURM_JOB_LICENSES", value->c_str(), 1);
-    } else {
-      // NOLINTNEXTLINE(misc-include-cleaner)
-      result = unsetenv("SLURM_JOB_LICENSES");
-    }
-    if (result != 0) {
-      std::abort();
-    }
-#endif
-  }
-
-  std::optional<std::string> originalValue;
-};
+using mqt::test::ScopedEnvironmentVariable;
 
 void registerStatusDevice(const std::string& id,
                           const std::string& configuredStatus) {
@@ -85,14 +42,15 @@ void registerStatusDevice(const std::string& id,
 TEST(SlurmAdapterTest, AcceptsImplicitAndExplicitUnitCounts) {
   registerStatusDevice("test.slurm.idle", "idle");
   for (const auto* const value : {"test.slurm.idle", "test.slurm.idle:1"}) {
-    const ScopedSlurmLicenses licenses(value);
+    const ScopedEnvironmentVariable licenses("SLURM_JOB_LICENSES", value);
     EXPECT_EQ(openDeviceFromLicense().getStatus(), QDMI_DEVICE_STATUS_IDLE);
   }
 }
 
 TEST(SlurmAdapterTest, AcceptsBusyDevice) {
   registerStatusDevice("test.slurm.busy", "busy");
-  const ScopedSlurmLicenses licenses("test.slurm.busy");
+  const ScopedEnvironmentVariable licenses("SLURM_JOB_LICENSES",
+                                           "test.slurm.busy");
   EXPECT_EQ(openDeviceFromLicense().getStatus(), QDMI_DEVICE_STATUS_BUSY);
 }
 
@@ -115,7 +73,7 @@ TEST(SlurmAdapterTest, RejectsMissingAndMalformedValues) {
   };
 
   for (const auto& value : invalidValues) {
-    const ScopedSlurmLicenses licenses(value);
+    const ScopedEnvironmentVariable licenses("SLURM_JOB_LICENSES", value);
     EXPECT_THROW(static_cast<void>(openDeviceFromLicense()), std::runtime_error)
         << "value: " << value.value_or("<unset>");
   }
@@ -130,7 +88,7 @@ TEST(SlurmAdapterTest, RejectsUnknownRemoteAndCompoundLicenses) {
   };
 
   for (const auto* const value : invalidValues) {
-    const ScopedSlurmLicenses licenses(value);
+    const ScopedEnvironmentVariable licenses("SLURM_JOB_LICENSES", value);
     EXPECT_THROW(static_cast<void>(openDeviceFromLicense()), std::runtime_error)
         << "value: " << value;
   }
@@ -148,7 +106,7 @@ TEST(SlurmAdapterTest, RejectsUnavailableDeviceWithIdAndStatus) {
   for (const auto& [configuredStatus, reportedStatus] : rejectedStates) {
     const auto id = std::string{"test.slurm."} + configuredStatus;
     registerStatusDevice(id, configuredStatus);
-    const ScopedSlurmLicenses licenses(id);
+    const ScopedEnvironmentVariable licenses("SLURM_JOB_LICENSES", id);
     EXPECT_THAT(
         [] { return openDeviceFromLicense(); },
         testing::ThrowsMessage<std::runtime_error>(testing::AllOf(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

QDMI maintained duplicate platform lookup, property/result decoding, and session override implementations. Share those implementations while preserving the public wrapper APIs, query diagnostics, validation, and device/session ownership. Remove redundant test scaffolding and the unused internal session constructor.

The changes are split into seven commits:

1. Share module-directory and environment lookup, retaining caller-provided module anchors.
2. Share standard property decoding across devices, sites, and operations.
3. Share sparse statevector and probability result decoding.
4. Reuse `DeviceSessionConfig` and its override handling in the registry.
5. Reuse the environment test guard, including explicit unsetting and checked restoration.
6. Construct mock QDMI devices directly instead of using a class-only fixture.
7. Remove the unused session constructor.

No dependencies are added. This is internal refactoring, so no changelog entry or migration instructions are needed. Codex implemented and reviewed the changes under explicit user authorization; human review remains required.

Validation:

- QDMI C++ tests: 465 passed, one expected skip, in both release and Clang builds.
- `uv run --no-sync pytest test/python/qdmi test/python/plugins -q`: 463 passed.
- `uvx nox -s lint`: passed.
- `uvx nox -s cpp-lint`: passed with zero findings.
- All commits are signed and verified. Hosted CI is pending.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
