### PR TITLE
🐛 Export measurements across quantum operations

### DIFF
--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -2025,8 +2025,11 @@ static void validateControlFlowDepth(const size_t controlFlowDepth) {
   }
   for (auto* operation = measure->getNextNode(); operation != store;
        operation = operation->getNextNode()) {
+    // Fusion writes the destination at the measurement. Quantum gates and
+    // resets cannot observe that earlier classical write and stay in place.
     if (operation == nullptr ||
-        !llvm::isa<mlir::arith::ConstantOp>(operation)) {
+        !llvm::isa<mlir::arith::ConstantOp, mlir::qc::UnitaryOpInterface,
+                   mlir::qc::ResetOp>(operation)) {
       return false;
     }
   }

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -287,13 +287,15 @@ satisfy the existing snapshot checks.
 
 Each exported measurement must write to one static public CBit in the same
 block. Destinations may be reused; later measurements overwrite earlier values
-in program order. A measurement's destination store must follow it directly,
-apart from constant operations. A conditional or otherwise delayed destination
-store is rejected because Qiskit cannot preserve it as one measurement
-instruction. The measurement result may feed supported classical expressions
-after that store. General scalar control flow saves live measurement results in
-native variables before later writes. Deferred measurement expressions require
-an unchanged destination CBit.
+in program order. Constants, unitary quantum operations (including barriers),
+and resets may separate a measurement from its destination store. The exporter
+keeps the measurement at its original position and writes the destination there.
+Other intervening operations, including classical accesses and control flow, are
+rejected because this earlier write may change the program's meaning. The
+measurement result may feed supported classical expressions after that store.
+General scalar control flow saves live measurement results in native variables
+before later writes. Deferred measurement expressions require an unchanged
+destination CBit.
 
 Dense numeric unitaries remain explicit matrix operations during import and
 export. Target compilation synthesizes supported one- and two-qubit matrices to

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -2405,6 +2405,75 @@ def test_measurement_snapshot_rejects_overwritten_destination(overwrite: str) ->
         program.to_qiskit()
 
 
+@pytest.mark.parametrize("via_qco", [False, True], ids=["qc", "qco"])
+@pytest.mark.parametrize("gate", ["x", "swap", "reset", "barrier"])
+def test_delayed_measurement_store_across_quantum_operations(gate: str, *, via_qco: bool) -> None:
+    """Keep measurements before quantum operations without extra classical bits."""
+    instruction = f"qc.{gate} %q0 : !qc.qubit"
+    if gate in {"swap", "barrier"}:
+        instruction = f"qc.{gate} %q0, %q1 : !qc.qubit, !qc.qubit"
+    program = QCProgram.from_mlir_str(
+        f"""module {{
+  func.func @main() -> !cbit.reg<1> attributes {{mqt.entry_point}} {{
+    %q0 = qc.alloc : !qc.qubit
+    %q1 = qc.alloc : !qc.qubit
+    %classical = cbit.alloc(#cbit.init<zero>) {{mqt.register_name = "c"}} : !cbit.reg<1>
+    %zero = arith.constant 0 : index
+    qc.x %q0 : !qc.qubit
+    %measured = qc.measure %q0 : !qc.qubit -> i1
+    {instruction}
+    cbit.store %measured, %classical[%zero] : !cbit.reg<1>
+    qc.dealloc %q0 : !qc.qubit
+    qc.dealloc %q1 : !qc.qubit
+    return %classical : !cbit.reg<1>
+  }}
+}}
+"""
+    )
+    if via_qco:
+        program = program.to_qco().to_qc()
+
+    restored = program.to_qiskit()
+
+    assert restored.num_qubits == 2
+    assert restored.num_clbits == 1
+    assert [
+        (
+            item.operation.name,
+            [restored.find_bit(qubit).index for qubit in item.qubits],
+            [restored.find_bit(bit).index for bit in item.clbits],
+        )
+        for item in restored.data
+    ] == [("x", [0], []), ("measure", [0], [0]), (gate, [0, 1] if gate in {"swap", "barrier"} else [0], [])]
+    assert QCProgram.from_qiskit(restored).to_qco().sample(shots=1, seed=1) == {"1": 1}
+
+
+@pytest.mark.parametrize(
+    "write",
+    [
+        "cbit.store %false, %classical[%zero] : !cbit.reg<1>",
+        "cbit.write %false, %classical : i1, !cbit.reg<1>",
+    ],
+    ids=["bit-store", "register-write"],
+)
+def test_delayed_measurement_store_rejects_intervening_write(write: str) -> None:
+    """Do not fuse a measurement across a write that would overwrite its result."""
+    program = _single_qubit_program(
+        [
+            '%classical = cbit.alloc(#cbit.init<zero>) {mqt.register_name = "c"} : !cbit.reg<1>',
+            "%zero = arith.constant 0 : index",
+            "%false = arith.constant false",
+            "qc.x %q : !qc.qubit",
+            "%measured = qc.measure %q : !qc.qubit -> i1",
+            write,
+            "cbit.store %measured, %classical[%zero] : !cbit.reg<1>",
+        ],
+        returns_classical=True,
+    )
+    with pytest.raises(RuntimeError, match="destination must follow the measurement"):
+        program.to_qiskit()
+
+
 def test_delayed_measurement_store_is_rejected() -> None:
     """Reject a delayed write that would change a captured bit snapshot."""
     program = QCProgram.from_mlir_str(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

The native Qiskit exporter rejects valid programs when a SWAP or another quantum
operation separates a measurement from the store of its result. Allow constants,
unitary operations (including barriers), and resets between them. Keep the
measurement at its original position and use its existing classical destination,
without adding classical bits.

Continue rejecting intervening classical accesses and control flow: fusing the
store into the measurement writes the destination earlier and may otherwise
change the program's meaning. Update the documented export contract.

This addresses the exporter restriction discussed in #2351 independently of the
mapping fixes and the sorter changes in #2436. Neither PR is a dependency.

No standalone changelog entry or migration instructions are needed for this
correction to unreleased v4 functionality.

## Validation

- Merged main at `6b9385280`, including #2435 and #2444, and rebuilt the MLIR
  bindings at `db22ece60`.
- All 306 Qiskit translation tests passed with Python 3.13 and Qiskit 2.5.2.
- All 13 focused delayed-measurement tests passed. Ten positive cases cover X,
  SWAP, reset, barrier, and inverse modifiers through QC and QCO conversion.
  They check operation order, wire and destination identity, classical-bit
  count, and measured value.
- Intervening bit and whole-register writes and the deferred classical-snapshot
  case remain rejected. The existing control-flow checks still pass.
- `uvx nox -s lint` and `git diff --check` passed.
- `uvx nox -s stubs` passed and produced no tracked stub changes.
- `uvx nox -s cpp-lint -- upstream/main` passed with zero clang-format or
  clang-tidy findings, checking the full changed C++ file with clang-tidy 23.

Implementation, tests, documentation, and this description were prepared with
AI assistance via Codex. CI and human-review confirmations remain open for the
updated revision.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
