### PR TITLE
🐛 Reload empty QC and QCO programs

### DIFF
--- a/mlir/include/mlir/Compiler/Programs.h
+++ b/mlir/include/mlir/Compiler/Programs.h
@@ -163,10 +163,8 @@ public:
   /// Take ownership of an MLIR module that contains a QC program.
   ///
   /// The context must own every dialect referenced by the module and must
-  /// remain the module's context. The factory verifies the module and requires
-  /// at least one QC operation, or only single-block functions with scalar
-  /// integer, index, or float parameters, constants, and returns for an empty
-  /// program.
+  /// remain the module's context. The factory verifies the module and rejects
+  /// QCO and QTensor operations. QC operations are not required.
   [[nodiscard]] static std::optional<QCProgram>
   fromModule(std::shared_ptr<MLIRContext> context,
              OwningOpRef<ModuleOp> moduleOp);
@@ -238,9 +236,7 @@ public:
   ///
   /// The context must own every dialect referenced by the module and must
   /// remain the module's context. The factory verifies the module and QCO
-  /// linearity. It requires at least one QCO operation, or only single-block
-  /// functions with scalar integer, index, or float parameters, constants,
-  /// and returns for an empty program.
+  /// linearity and rejects QC operations. QCO operations are not required.
   [[nodiscard]] static std::optional<QCOProgram>
   fromModule(std::shared_ptr<MLIRContext> context,
              OwningOpRef<ModuleOp> moduleOp);

--- a/mlir/include/mlir/Compiler/Programs.h
+++ b/mlir/include/mlir/Compiler/Programs.h
@@ -160,13 +160,13 @@ public:
   [[nodiscard]] static std::optional<QCProgram>
   fromQASMFile(const std::filesystem::path& path);
 
-  /**
-   * @brief Take ownership of an MLIR module that contains a QC program.
-   *
-   * @details The context must own every dialect referenced by the module and
-   * must remain the module's context. The factory verifies the module and
-   * requires at least one operation from the QC dialect.
-   */
+  /// Take ownership of an MLIR module that contains a QC program.
+  ///
+  /// The context must own every dialect referenced by the module and must
+  /// remain the module's context. The factory verifies the module and requires
+  /// at least one QC operation, or only single-block functions with scalar
+  /// integer, index, or float parameters, constants, and returns for an empty
+  /// program.
   [[nodiscard]] static std::optional<QCProgram>
   fromModule(std::shared_ptr<MLIRContext> context,
              OwningOpRef<ModuleOp> moduleOp);
@@ -234,13 +234,13 @@ public:
   [[nodiscard]] static std::optional<QCOProgram>
   fromMLIRFile(const std::filesystem::path& path);
 
-  /**
-   * @brief Take ownership of an MLIR module that contains a QCO program.
-   *
-   * @details The context must own every dialect referenced by the module and
-   * must remain the module's context. The factory verifies the module, requires
-   * at least one operation from the QCO dialect, and verifies QCO linearity.
-   */
+  /// Take ownership of an MLIR module that contains a QCO program.
+  ///
+  /// The context must own every dialect referenced by the module and must
+  /// remain the module's context. The factory verifies the module and QCO
+  /// linearity. It requires at least one QCO operation, or only single-block
+  /// functions with scalar integer, index, or float parameters, constants,
+  /// and returns for an empty program.
   [[nodiscard]] static std::optional<QCOProgram>
   fromModule(std::shared_ptr<MLIRContext> context,
              OwningOpRef<ModuleOp> moduleOp);

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -22,7 +22,6 @@
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 
 #include <jeff/IR/JeffDialect.h>
-#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/FileSystem.h>
@@ -38,7 +37,6 @@
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
-#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/Location.h>
@@ -138,29 +136,6 @@ parseMLIRFile(MLIRContext* context, const std::filesystem::path& path) {
                    : WalkResult::advance();
       })
       .wasInterrupted();
-}
-
-/// Accept empty functions after cleanup removes all quantum operations.
-[[nodiscard]] static bool isEmptyProgram(ModuleOp moduleOp) {
-  return !moduleOp
-              .walk([](Operation* operation) {
-                if (auto function = dyn_cast<func::FuncOp>(operation)) {
-                  return function.getBody().hasOneBlock() &&
-                                 llvm::all_of(
-                                     function.getArgumentTypes(),
-                                     [](Type type) {
-                                       return isa<IntegerType, IndexType,
-                                                  FloatType>(type);
-                                     })
-                             ? WalkResult::advance()
-                             : WalkResult::interrupt();
-                }
-                return isa<ModuleOp, arith::ConstantOp, func::ReturnOp>(
-                           operation)
-                           ? WalkResult::advance()
-                           : WalkResult::interrupt();
-              })
-              .wasInterrupted();
 }
 
 template <class ProgramType, class Parse>
@@ -310,8 +285,10 @@ QCProgram::fromModule(std::shared_ptr<MLIRContext> context,
   if (failed(verify(*storage.mod))) {
     return std::nullopt;
   }
-  if (!moduleUsesDialect(*storage.mod, "qc") && !isEmptyProgram(*storage.mod)) {
-    storage.mod->emitError("expected a module using the 'qc' dialect");
+  if (moduleUsesDialect(*storage.mod, "qco") ||
+      moduleUsesDialect(*storage.mod, "qtensor")) {
+    storage.mod->emitError(
+        "QC programs must not contain QCO or QTensor operations");
     return std::nullopt;
   }
   return QCProgram(std::move(storage));
@@ -403,9 +380,8 @@ QCOProgram::fromModule(std::shared_ptr<MLIRContext> context,
   if (failed(verify(*storage.mod))) {
     return std::nullopt;
   }
-  if (!moduleUsesDialect(*storage.mod, "qco") &&
-      !isEmptyProgram(*storage.mod)) {
-    storage.mod->emitError("expected a module using the 'qco' dialect");
+  if (moduleUsesDialect(*storage.mod, "qc")) {
+    storage.mod->emitError("QCO programs must not contain QC operations");
     return std::nullopt;
   }
   if (failed(qco::verifyLinearity(*storage.mod))) {

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 
 #include <jeff/IR/JeffDialect.h>
+#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/FileSystem.h>
@@ -37,6 +38,7 @@
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/DialectRegistry.h>
 #include <mlir/IR/Location.h>
@@ -136,6 +138,29 @@ parseMLIRFile(MLIRContext* context, const std::filesystem::path& path) {
                    : WalkResult::advance();
       })
       .wasInterrupted();
+}
+
+/// Accept empty functions after cleanup removes all quantum operations.
+[[nodiscard]] static bool isEmptyProgram(ModuleOp moduleOp) {
+  return !moduleOp
+              .walk([](Operation* operation) {
+                if (auto function = dyn_cast<func::FuncOp>(operation)) {
+                  return function.getBody().hasOneBlock() &&
+                                 llvm::all_of(
+                                     function.getArgumentTypes(),
+                                     [](Type type) {
+                                       return isa<IntegerType, IndexType,
+                                                  FloatType>(type);
+                                     })
+                             ? WalkResult::advance()
+                             : WalkResult::interrupt();
+                }
+                return isa<ModuleOp, arith::ConstantOp, func::ReturnOp>(
+                           operation)
+                           ? WalkResult::advance()
+                           : WalkResult::interrupt();
+              })
+              .wasInterrupted();
 }
 
 template <class ProgramType, class Parse>
@@ -285,7 +310,7 @@ QCProgram::fromModule(std::shared_ptr<MLIRContext> context,
   if (failed(verify(*storage.mod))) {
     return std::nullopt;
   }
-  if (!moduleUsesDialect(*storage.mod, "qc")) {
+  if (!moduleUsesDialect(*storage.mod, "qc") && !isEmptyProgram(*storage.mod)) {
     storage.mod->emitError("expected a module using the 'qc' dialect");
     return std::nullopt;
   }
@@ -378,7 +403,8 @@ QCOProgram::fromModule(std::shared_ptr<MLIRContext> context,
   if (failed(verify(*storage.mod))) {
     return std::nullopt;
   }
-  if (!moduleUsesDialect(*storage.mod, "qco")) {
+  if (!moduleUsesDialect(*storage.mod, "qco") &&
+      !isEmptyProgram(*storage.mod)) {
     storage.mod->emitError("expected a module using the 'qco' dialect");
     return std::nullopt;
   }

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -37,8 +37,11 @@
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/Support/Error.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/FileUtilities.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
@@ -303,7 +306,7 @@ TEST(CompilerProgramOwnershipTest, ValidatesAndOwnsExistingQCModules) {
   QCProgramBuilder emptyBuilder(context.get());
   emptyBuilder.initialize();
   auto emptyModule = emptyBuilder.finalize();
-  EXPECT_FALSE(QCProgram::fromModule(context, std::move(emptyModule)));
+  EXPECT_TRUE(QCProgram::fromModule(context, std::move(emptyModule)));
 
   QCProgramBuilder mismatchedBuilder(context.get());
   mismatchedBuilder.initialize();
@@ -1050,6 +1053,90 @@ h q;
   ASSERT_TRUE(qcoFromQC);
   EXPECT_FALSE(QCProgram::fromMLIRString(qcoFromQC->str()));
   EXPECT_FALSE(QCOProgram::fromMLIRString(mlir));
+}
+
+TEST_F(CompilerPipelineTest, EmptyCompiledProgramsRoundTrip) {
+  for (const std::string parameters : {"", "%angle: f64"}) {
+    SCOPED_TRACE(parameters);
+    auto qc =
+        QCProgram::fromMLIRString("module { func.func @main(" + parameters +
+                                  R"mlir() attributes {mqt.entry_point} {
+      %phase = arith.constant 0.0 : f64
+      qc.gphase(%phase)
+      return
+    }
+  })mlir");
+    ASSERT_TRUE(qc);
+    auto qco = std::move(*qc).intoQCO();
+    ASSERT_TRUE(qco);
+    ASSERT_TRUE(qco->compileForTarget(makeCZTarget({{"sx", 0}, {"rz", 1}})));
+    ASSERT_TRUE(succeeded(verify(qco->module())));
+    qco->module().walk([](Operation* operation) {
+      const auto dialect = operation->getName().getDialectNamespace();
+      EXPECT_NE(dialect, "qc");
+      EXPECT_NE(dialect, "qco");
+    });
+
+    SmallString<128> filename;
+    ASSERT_FALSE(llvm::sys::fs::createTemporaryFile("empty-compiled-program",
+                                                    "mlir", filename));
+    const llvm::FileRemover cleanup(filename);
+    const auto path = std::filesystem::path(filename.str().str());
+    std::ofstream(path) << qco->str();
+    auto qcoFromString = QCOProgram::fromMLIRString(qco->str());
+    auto qcoFromFile = QCOProgram::fromMLIRFile(path);
+    ASSERT_TRUE(qcoFromString);
+    ASSERT_TRUE(qcoFromFile);
+    EXPECT_EQ(qcoFromString->str(), qco->str());
+    EXPECT_EQ(qcoFromFile->str(), qco->str());
+
+    auto restoredQC = std::move(*qcoFromString).intoQC();
+    ASSERT_TRUE(restoredQC);
+    EXPECT_EQ(restoredQC->numGates(), 0U);
+    std::ofstream(path) << restoredQC->str();
+    auto qcFromString = QCProgram::fromMLIRString(restoredQC->str());
+    auto qcFromFile = QCProgram::fromMLIRFile(path);
+    ASSERT_TRUE(qcFromString);
+    ASSERT_TRUE(qcFromFile);
+    EXPECT_EQ(qcFromString->str(), restoredQC->str());
+    EXPECT_EQ(qcFromFile->str(), restoredQC->str());
+  }
+}
+
+TEST_F(CompilerPipelineTest, EmptyProgramImportsRejectForeignTypes) {
+  EXPECT_FALSE(QCProgram::fromMLIRString(R"mlir(module {
+    func.func @identity(%q: !qco.qubit) -> !qco.qubit {
+      return %q : !qco.qubit
+    }
+  })mlir"));
+  EXPECT_FALSE(QCOProgram::fromMLIRString(R"mlir(module {
+    func.func @identity(%q: !qc.qubit) -> !qc.qubit {
+      return %q : !qc.qubit
+    }
+  })mlir"));
+  constexpr llvm::StringLiteral declaration = R"mlir(module {
+    func.func private @get_qubit() -> !qc.qubit
+  })mlir";
+  EXPECT_FALSE(QCOProgram::fromMLIRString(declaration));
+  EXPECT_FALSE(QCProgram::fromMLIRString(R"mlir(module {
+    func.func @identity(%q: tensor<1x!qco.qubit>) -> tensor<1x!qco.qubit> {
+      return %q : tensor<1x!qco.qubit>
+    }
+  })mlir"));
+  EXPECT_FALSE(QCProgram::fromMLIRString(R"mlir(module {
+    func.func @main() {
+      return
+    ^bb1(%foreign: !qco.qubit):
+      return
+    }
+  })mlir"));
+  EXPECT_FALSE(QCOProgram::fromMLIRString(R"mlir(module {
+    func.func @main() {
+      return
+    ^bb1(%foreign: !qc.qubit):
+      return
+    }
+  })mlir"));
 }
 
 // Test: QCO imports require each linear value to have one use.

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -127,6 +127,8 @@ class CompilerPipelineTest
 protected:
   std::unique_ptr<MLIRContext> context;
 
+  // GoogleTest requires this override name.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void SetUp() override {
     DialectRegistry registry;
     registry.insert<cbit::CBitDialect, QCDialect, QCODialect,
@@ -1103,40 +1105,39 @@ TEST_F(CompilerPipelineTest, EmptyCompiledProgramsRoundTrip) {
   }
 }
 
-TEST_F(CompilerPipelineTest, EmptyProgramImportsRejectForeignTypes) {
-  EXPECT_FALSE(QCProgram::fromMLIRString(R"mlir(module {
-    func.func @identity(%q: !qco.qubit) -> !qco.qubit {
-      return %q : !qco.qubit
+TEST_F(CompilerPipelineTest, ProgramImportsRejectMixedQuantumDialects) {
+  const std::string source = R"mlir(module {
+    func.func @main() {
+      %reference = qc.alloc : !qc.qubit
+      qc.dealloc %reference : !qc.qubit
+      %value = qco.alloc : !qco.qubit
+      qco.sink %value : !qco.qubit
+      return
     }
-  })mlir"));
-  EXPECT_FALSE(QCOProgram::fromMLIRString(R"mlir(module {
-    func.func @identity(%q: !qc.qubit) -> !qc.qubit {
-      return %q : !qc.qubit
-    }
-  })mlir"));
-  constexpr llvm::StringLiteral declaration = R"mlir(module {
-    func.func private @get_qubit() -> !qc.qubit
   })mlir";
-  EXPECT_FALSE(QCOProgram::fromMLIRString(declaration));
-  EXPECT_FALSE(QCProgram::fromMLIRString(R"mlir(module {
-    func.func @identity(%q: tensor<1x!qco.qubit>) -> tensor<1x!qco.qubit> {
-      return %q : tensor<1x!qco.qubit>
-    }
-  })mlir"));
-  EXPECT_FALSE(QCProgram::fromMLIRString(R"mlir(module {
+  auto moduleOp = parseRecordedModule(source);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  EXPECT_FALSE(QCProgram::fromMLIRString(source));
+  EXPECT_FALSE(QCOProgram::fromMLIRString(source));
+}
+
+TEST_F(CompilerPipelineTest, ProgramImportsRecognizeQTensorOnlyModules) {
+  const std::string source = R"mlir(module {
     func.func @main() {
-      return
-    ^bb1(%foreign: !qco.qubit):
-      return
-    }
-  })mlir"));
-  EXPECT_FALSE(QCOProgram::fromMLIRString(R"mlir(module {
-    func.func @main() {
-      return
-    ^bb1(%foreign: !qc.qubit):
+      %c1 = arith.constant 1 : index
+      %register = qtensor.alloc(%c1) : tensor<1x!qco.qubit>
+      qtensor.dealloc %register : tensor<1x!qco.qubit>
       return
     }
-  })mlir"));
+  })mlir";
+  auto moduleOp = parseRecordedModule(source);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  EXPECT_TRUE(QCOProgram::fromMLIRString(source));
+  EXPECT_FALSE(QCProgram::fromMLIRString(source));
 }
 
 // Test: QCO imports require each linear value to have one use.

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -127,8 +127,6 @@ class CompilerPipelineTest
 protected:
   std::unique_ptr<MLIRContext> context;
 
-  // GoogleTest requires this override name.
-  // NOLINTNEXTLINE(readability-identifier-naming)
   void SetUp() override {
     DialectRegistry registry;
     registry.insert<cbit::CBitDialect, QCDialect, QCODialect,

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -355,6 +355,27 @@ def test_compile_program_exposes_raw_and_optimized_qco() -> None:
     assert raw.ir != optimized.ir
 
 
+@requires_qiskit_translation
+def test_empty_compiled_program_round_trips_through_mlir() -> None:
+    """Reload empty compiled IR through both typed program APIs."""
+    circuit = QuantumCircuit(0)
+    program = QCProgram.from_qiskit(circuit).to_qco()
+    target = CompilerTarget(
+        1,
+        connectivity=CompilerTarget.Connectivity.all_to_all(),
+        native_operations=CompilerTarget.NativeOperations.unrestricted(),
+    )
+    program.compile_for_target(target)
+    assert "qco." not in program.ir
+
+    qc = QCOProgram.from_mlir_str(program.ir).to_qc()
+    restored = QCProgram.from_mlir_str(qc.ir).to_qiskit()
+
+    assert restored.num_qubits == 0
+    assert restored.num_clbits == 0
+    assert Operator(restored) == Operator(circuit)
+
+
 @pytest.fixture(scope="module")
 def garnet_target() -> CompilerTarget:
     """Snapshot the bundled IQM Garnet device.


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Allow explicitly typed QC/QCO loaders to reload empty compiler output. Removing a zero global phase can leave a valid program with no QC or QCO operation; the loaders previously rejected that program's own printed IR.

The loaders exclude the opposite quantum dialect operations: QC programs may not contain QCO or QTensor operations, and QCO programs may not contain QC operations. Neither loader requires its own dialect to appear, so empty and classical-only programs need no special fallback. Module verification, context ownership, and QCO linearity checks remain unchanged.

The change updates unreleased v4 functionality; no standalone changelog or upgrade entry is added under repository policy.

## Validation

Validated at `a46c29947`:

- Compiler: 166 tests passed; QC-to-QCO: 174; QCO-to-QC: 148; QC/QCO round-trip: 6 (494 total).
- Regressions cover empty compiled QC/QCO string/file round-trips, retained scalar parameters, ownership, mixed-dialect rejection, and QTensor-only acceptance as QCO.
- Python MLIR bindings: 51 tests passed, including the empty-program Qiskit round-trip, using this revision's built extension and Qiskit 2.5.2.
- One Python test, `test_compiler_target_from_device_id_preserves_open_and_conversion_errors`, fails in the local build: an unknown QDMI device ID produces `SystemError` instead of `IndexError`. The same failure was reproduced on the original PR revision `e89f715c3`; no QDMI code changed.
- `uvx nox -s lint` and `uvx nox -s cpp-lint -- f4093cbdc435254d08c544e5a033d464a2635d15` passed. C++ lint covered both changed C++ implementation/test files in full with local clang-tidy 23.0.0git.
- CI confirmation of this revision is pending.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

Codex assisted with implementation, tests, and review. Human review is still required before acceptance or merge.
