### PR TITLE
🐛 Synthesize one-qubit gates without entanglers

### DIFF
--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -393,13 +393,13 @@ sampleQCO(const mlir::QCOProgram& program, size_t shots, uint64_t seed) {
     throw nb::value_error("dense unitary dimensions exceed addressable memory");
   }
   auto dataPtr = std::make_unique<dd::CVec>(dim * dim);
+  auto* const data = dataPtr->data();
   matrix.traverseMatrix(
       std::complex<dd::fp>{1., 0.}, 0ULL, 0ULL,
-      [&dataPtr, dim](size_t i, size_t j, const std::complex<dd::fp>& value) {
-        (*dataPtr)[(i * dim) + j] = value;
+      [data, dim](size_t i, size_t j, const std::complex<dd::fp>& value) {
+        data[i * dim + j] = value;
       },
       numQubits);
-  auto* const data = dataPtr->data();
   const nb::capsule owner(dataPtr.get(), [](void* ptr) noexcept {
     delete static_cast<dd::CVec*>(ptr);
   });
@@ -696,7 +696,7 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
               &mlir::CompilerTarget::SynthesisBasis::singleQubit,
               "The single-qubit synthesis basis.")
       .def_ro("entangler", &mlir::CompilerTarget::SynthesisBasis::entangler,
-              "The two-qubit entangler.");
+              "The two-qubit entangler, or None when none is usable.");
 
   nb::enum_<mlir::CompilerTarget::Connectivity::Kind>(
       compilerTarget, "ConnectivityKind", "The target connectivity model.")
@@ -910,7 +910,8 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
           },
           "Recognized native gates supported by the target.")
       .def_prop_ro("synthesis_basis", &mlir::CompilerTarget::synthesisBasis,
-                   "A complete target-wide synthesis basis, if available.")
+                   "A target-wide single-qubit basis with an optional "
+                   "entangler, or None when no single-qubit basis is usable.")
       .def(
           "supports_operation",
           [](const mlir::CompilerTarget& target, const std::string_view name,

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -81,8 +81,10 @@ directions. Target compilation requires a known static physical site for each
 qubit. Structured branch exits must agree on sites, and loop backedges must
 preserve the entry sites. Unsupported or inconsistent site transfers are
 diagnosed, including after all-to-all placement. A synthesis basis must provide
-the same one-qubit gate family on every site and an entangler on every routing
-edge in at least one direction.
+the same one-qubit gate family on every site. Its entangler is optional:
+one-qubit synthesis does not need one. Two-qubit synthesis requires an entangler
+on every routing edge in at least one direction. A native operation does not
+need a synthesis basis.
 
 Target synthesis preserves a native `gphase`. If the target does not support
 `gphase`, target synthesis preserves relative phase effects and removes only the

--- a/mlir/include/mlir/Compiler/Target.h
+++ b/mlir/include/mlir/Compiler/Target.h
@@ -297,10 +297,10 @@ public:
     ZXZ,  ///< `RZ(phi) * RX(theta) * RZ(lambda)`.
   };
 
-  /// One single-qubit basis and entangler usable across the target.
+  /// One single-qubit basis and optional entangler usable across the target.
   struct SynthesisBasis {
     SingleQubitBasis singleQubit;
-    GateKind entangler;
+    std::optional<GateKind> entangler;
 
     friend bool operator==(const SynthesisBasis&,
                            const SynthesisBasis&) = default;
@@ -413,7 +413,7 @@ public:
   /// Return the recognized gates supported by the target.
   [[nodiscard]] llvm::ArrayRef<GateKind> supportedGates() const noexcept;
 
-  /// Return one complete globally usable synthesis basis, if available.
+  /// Return a globally usable single-qubit basis with an optional entangler.
   [[nodiscard]] std::optional<SynthesisBasis> synthesisBasis() const noexcept;
 
   /// Materialize the source target facts as a typed MLIR attribute.

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Decomposition/Weyl.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Decomposition/Weyl.h
@@ -358,10 +358,8 @@ struct SynthesizedUnitary2Q {
 decomposeUnitary2QWeyl(const Matrix4x4& target,
                        CompilerTarget::GateKind entangler);
 
-/**
- * @brief Emits a prepared two-qubit decomposition in the selected target
- * @p basis.
- */
+/// Emits a prepared two-qubit decomposition in the selected target basis.
+/// The basis must contain an entangler.
 [[nodiscard]] SynthesizedUnitary2Q
 emitUnitary2QWeyl(OpBuilder& builder, Location loc, Value qubit0, Value qubit1,
                   const TwoQubitNativeDecomposition& decomposition,

--- a/mlir/lib/Compiler/Target.cpp
+++ b/mlir/lib/Compiler/Target.cpp
@@ -799,10 +799,15 @@ CompilerTarget::Storage::resolveSynthesisBasis() const {
   /// NOLINTNEXTLINE(readability-qualified-auto): portable iterator type.
   const auto entangler =
       std::ranges::find_if(entanglerPreference, supportsOnEveryCoupling);
-  if (!singleQubit || entangler == entanglerPreference.end()) {
+  if (!singleQubit) {
     return std::nullopt;
   }
-  return SynthesisBasis{.singleQubit = *singleQubit, .entangler = *entangler};
+  return SynthesisBasis{
+      .singleQubit = *singleQubit,
+      .entangler = entangler == entanglerPreference.end()
+                       ? std::nullopt
+                       : std::optional{*entangler},
+  };
 }
 
 llvm::Expected<CompilerTarget>

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/Weyl.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/Weyl.cpp
@@ -215,7 +215,8 @@ diagonalizeComplexSymmetric(const Matrix4x4& m,
     const Matrix4x4 p = Matrix4x4::fromRealRowMajor(m2Real)
                             .symmetricEigenDecomposition()
                             .eigenvectors;
-    const std::array<Complex, 4> d = (p.transpose() * m * p).diagonal();
+    const auto diagonalized = p.transpose() * m * p;
+    const std::array<Complex, 4> d = diagonalized.diagonal();
 
     const auto compare = p * Matrix4x4::fromDiagonal(d) * p.transpose();
     double err = 0.0;
@@ -253,7 +254,7 @@ decomposeTwoQubitProductGate(const Matrix4x4& specialUnitary) {
     llvm::reportFatalInternalError(
         "decomposeTwoQubitProductGate: unable to decompose: det_r < 0.1");
   }
-  r *= (1.0 / std::sqrt(detR));
+  r *= 1.0 / std::sqrt(detR);
   const Matrix2x2 rTConj = r.adjoint();
 
   const Matrix4x4 temp =
@@ -266,7 +267,7 @@ decomposeTwoQubitProductGate(const Matrix4x4& specialUnitary) {
     llvm::reportFatalInternalError(
         "decomposeTwoQubitProductGate: unable to decompose: detL < 0.9");
   }
-  l *= (1.0 / std::sqrt(detL));
+  l *= 1.0 / std::sqrt(detL);
   const auto phase = std::arg(detL) / 2.;
 
   return {l, r, phase};
@@ -747,6 +748,10 @@ SynthesizedUnitary2Q
 emitUnitary2QWeyl(OpBuilder& builder, Location loc, Value qubit0, Value qubit1,
                   const TwoQubitNativeDecomposition& decomposition,
                   const CompilerTarget::SynthesisBasis basis) {
+  if (!basis.entangler) {
+    llvm::reportFatalInternalError(
+        "two-qubit emission requires a synthesis-basis entangler");
+  }
   double globalPhase = decomposition.globalPhase;
 
   Value wire0 = qubit0;

--- a/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
@@ -269,7 +269,7 @@ static bool fuseTwoQubitGateRun(IRRewriter& rewriter, UnitaryOpInterface head,
     return false;
   }
 
-  const auto native = decomposeUnitary2QWeyl(run.composed, basis.entangler);
+  const auto native = decomposeUnitary2QWeyl(run.composed, *basis.entangler);
   if (native.numBasisUses >= run.numTwoQ) {
     return false;
   }
@@ -502,13 +502,16 @@ static LogicalResult synthesizeTargetOperation(
     return success();
   }
 
+  if (!basis->entangler) {
+    return unsupported("the target has no usable two-qubit entangler");
+  }
   Matrix4x4 matrix;
   if (!assignTwoQubitOpMatrix(op, matrix)) {
     return unsupported("its unitary matrix is not available at compile time");
   }
-  const bool reverseEntangler = !target.supports(basis->entangler, sites);
+  const bool reverseEntangler = !target.supports(*basis->entangler, sites);
   if (reverseEntangler &&
-      !target.supports(basis->entangler, std::array{sites[1], sites[0]})) {
+      !target.supports(*basis->entangler, std::array{sites[1], sites[0]})) {
     return operation->emitError()
            << "no supported synthesis-basis placement is known for its "
               "static sites";
@@ -520,7 +523,7 @@ static LogicalResult synthesizeTargetOperation(
     matrix = matrix.reorderForQubits(1, 0);
     std::swap(input0, input1);
   }
-  const auto native = decomposeUnitary2QWeyl(matrix, basis->entangler);
+  const auto native = decomposeUnitary2QWeyl(matrix, *basis->entangler);
   const auto synthesized = emitUnitary2QWeyl(rewriter, operation->getLoc(),
                                              input0, input1, native, *basis);
   decomposition::emitGPhaseIfNeeded(rewriter, operation->getLoc(),

--- a/mlir/unittests/Compiler/test_compiler_target.cpp
+++ b/mlir/unittests/Compiler/test_compiler_target.cpp
@@ -576,6 +576,24 @@ TEST(CompilerTargetTest, EnforcesExactOrderedOperationApplicability) {
       target.supportsOperation("device.operation", 3, 0, {30, 20, 10}));
 }
 
+TEST(CompilerTargetTest, ResolvesSingleQubitBasisWithoutEntangler) {
+  for (size_t numSites : {1U, 2U}) {
+    SCOPED_TRACE(numSites);
+    const auto target =
+        valid(Target::create(numSites, Connectivity::allToAll(),
+                             NativeOperations::fromOperations({
+                                 valid(Operation::create("sx", 1, 0)),
+                                 valid(Operation::create("x", 1, 0)),
+                                 valid(Operation::create("rz", 1, 1)),
+                             })));
+
+    ASSERT_TRUE(target.synthesisBasis());
+    EXPECT_EQ(target.synthesisBasis()->singleQubit,
+              Target::SingleQubitBasis::ZSXX);
+    EXPECT_FALSE(target.synthesisBasis()->entangler);
+  }
+}
+
 TEST(CompilerTargetTest, ClassifiesEveryEntangler) {
   using Entangler = std::tuple<GateKind, std::string_view, size_t>;
   const std::array entanglers{

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_weyl_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_weyl_decomposition.cpp
@@ -64,7 +64,8 @@ static const Matrix4x4 TWO_QUBIT_CONTROLLED_Z =
 
 [[nodiscard]] static bool
 isUnitaryMatrix(const auto& matrix, const double tolerance = MATRIX_TOLERANCE) {
-  return (matrix.adjoint() * matrix).isIdentity(tolerance);
+  const auto product = matrix.adjoint() * matrix;
+  return product.isIdentity(tolerance);
 }
 
 static Matrix4x4 randomUnitary4x4(std::mt19937& rng) {
@@ -475,7 +476,7 @@ synthesize2QMatrix(MLIRContext* ctx, const Matrix4x4& target,
   auto* entry = func.addEntryBlock();
 
   builder.setInsertionPointToStart(entry);
-  const auto decomposition = decomposeUnitary2QWeyl(target, basis.entangler);
+  const auto decomposition = decomposeUnitary2QWeyl(target, *basis.entangler);
   const auto synthesized =
       emitUnitary2QWeyl(builder, loc, entry->getArgument(0),
                         entry->getArgument(1), decomposition, basis);

--- a/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
@@ -879,6 +879,80 @@ TEST_F(TargetSynthesisTest,
       runPass(*moduleOp, mlir::qco::createVerifyTargetConformance(target))));
 }
 
+TEST_F(TargetSynthesisTest, SingleQubitSynthesisNeedsNoEntangler) {
+  const auto rotation = [](QCOProgramBuilder& builder) {
+    auto qubit = builder.staticQubit(0);
+    qubit = builder.ry(0.123, qubit);
+    builder.gphase(0.25);
+    return builder.intConstant(0);
+  };
+  auto expected = build(rotation);
+  auto synthesized = build(rotation);
+  const auto target =
+      valid(Target::create(1, Connectivity::allToAll(),
+                           NativeOperations::fromOperations({
+                               valid(Operation::create("sx", 1, 0)),
+                               valid(Operation::create("x", 1, 0)),
+                               valid(Operation::create("rz", 1, 1)),
+                               valid(Operation::create("gphase", 0, 1)),
+                           })));
+
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*synthesized)));
+  ASSERT_TRUE(mlir::succeeded(
+      runPass(*synthesized, mlir::qco::createTargetNativeSynthesis(target))));
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*synthesized)));
+  ASSERT_TRUE(mlir::succeeded(
+      runPass(*synthesized, mlir::qco::createVerifyTargetConformance(target))));
+  expectEquivalent(expected, synthesized);
+}
+
+TEST_F(TargetSynthesisTest, RuntimeSingleQubitSynthesisNeedsNoEntangler) {
+  auto moduleOp = mlir::parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @main(%theta: f64) -> !qco.qubit {
+        %q0 = qco.static 0 : !qco.qubit
+        %q1 = qco.ry(%theta) %q0 : !qco.qubit -> !qco.qubit
+        return %q1 : !qco.qubit
+      }
+    }
+  )mlir",
+                                                    context.get());
+  ASSERT_TRUE(moduleOp);
+  const auto target = valid(Target::create(
+      1, Connectivity::allToAll(),
+      NativeOperations::fromOperations({valid(Operation::create("u", 1, 3))})));
+
+  ASSERT_TRUE(mlir::succeeded(
+      runPass(*moduleOp, mlir::qco::createTargetNativeSynthesis(target))));
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*moduleOp)));
+  EXPECT_EQ(countOps<RYOp>(*moduleOp), 0U);
+  ASSERT_TRUE(mlir::succeeded(
+      runPass(*moduleOp, mlir::qco::createVerifyTargetConformance(target))));
+}
+
+TEST_F(TargetSynthesisTest, TwoQubitSynthesisRequiresEntangler) {
+  auto moduleOp = build([](QCOProgramBuilder& builder) {
+    auto input0 = builder.staticQubit(0);
+    auto input1 = builder.staticQubit(1);
+    [[maybe_unused]] auto [q0, q1] = builder.cx(input0, input1);
+    return builder.intConstant(0);
+  });
+  const auto target = valid(Target::create(
+      2, Connectivity::allToAll(),
+      NativeOperations::fromOperations({valid(Operation::create("u", 1, 3))})));
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*moduleOp)));
+  const auto before = printModule(*moduleOp);
+
+  const auto diagnostics =
+      expectFailure(*moduleOp, mlir::qco::createTargetNativeSynthesis(target));
+
+  EXPECT_NE(diagnostics.find("no usable two-qubit entangler"),
+            std::string::npos)
+      << diagnostics;
+  EXPECT_EQ(printModule(*moduleOp), before);
+  EXPECT_TRUE(mlir::succeeded(mlir::verify(*moduleOp)));
+}
+
 TEST_F(TargetSynthesisTest, DenseUnitaryHasAsymmetricTwoQubitDDSemantics) {
   const auto denseCx = [](QCOProgramBuilder& builder) {
     auto q0 = builder.staticQubit(0);

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -284,8 +284,8 @@ class CompilerTarget:
             """The single-qubit synthesis basis."""
 
         @property
-        def entangler(self) -> CompilerTarget.GateKind:
-            """The two-qubit entangler."""
+        def entangler(self) -> CompilerTarget.GateKind | None:
+            """The two-qubit entangler, or None when none is usable."""
 
     class ConnectivityKind(enum.Enum):
         """The target connectivity model."""
@@ -383,7 +383,7 @@ class CompilerTarget:
 
     @property
     def synthesis_basis(self) -> CompilerTarget.SynthesisBasis | None:
-        """A complete target-wide synthesis basis, if available."""
+        """A target-wide single-qubit basis with an optional entangler, or None when no single-qubit basis is usable."""
 
     def supports_operation(
         self, name: str, arity: int, num_parameters: int | None = None, sites: Sequence[int] | None = None

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -417,6 +417,36 @@ def test_qco_program_compiles_for_direct_sparse_target() -> None:
 
 
 @requires_qiskit_translation
+@pytest.mark.parametrize("num_sites", [1, 2])
+def test_target_compiles_single_qubit_gates_without_entangler(num_sites: int) -> None:
+    """Compile a non-native rotation without inventing a two-qubit capability."""
+    target = CompilerTarget(
+        num_sites,
+        connectivity=CompilerTarget.Connectivity.all_to_all(),
+        native_operations=CompilerTarget.NativeOperations([
+            CompilerTarget.Operation("sx", 1, 0),
+            CompilerTarget.Operation("x", 1, 0),
+            CompilerTarget.Operation("rz", 1, 1),
+            CompilerTarget.Operation("gphase", 0, 1),
+        ]),
+    )
+    assert target.synthesis_basis is not None
+    assert target.synthesis_basis.single_qubit == CompilerTarget.SingleQubitBasis.ZSXX
+    assert target.synthesis_basis.entangler is None
+    source = QuantumCircuit(num_sites)
+    for site in range(num_sites):
+        source.ry(0.123, site)
+    program = QCProgram.from_qiskit(source).to_qco()
+
+    program.compile_for_target(target)
+
+    assert program.is_valid
+    result = program.to_qc().to_qiskit(target=target)
+    assert set(result.count_ops()) <= {"sx", "x", "rz"}
+    assert np.allclose(Operator(result).data, Operator(source).data)
+
+
+@requires_qiskit_translation
 def test_target_compilation_exports_canonical_physical_qiskit_circuit() -> None:
     """Export a mapped program with the complete compiler target."""
     target = CompilerTarget(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Keep a usable single-qubit synthesis basis when the compiler target has no two-qubit entangler. A one-site `sx/x/rz` target can then compile a non-native `ry(0.123)` without declaring an impossible two-qubit capability. The same applies to independent one-qubit work on multi-site targets.

`SynthesisBasis.entangler` is optional in C++ and Python. Native operations retain their fast path. Non-native two-qubit lowering reports a missing-entangler diagnostic. The two-qubit emitter still requires a complete basis.

This fixes a gap found in the Benchpress integration. It is independent of the empty-program round-trip fix. The change updates unreleased v4 functionality; no standalone changelog or upgrade entry is added under the repository policy.

## Validation

- The new Python regression fails on unmodified main `f4093cbdc`, for both one- and two-site targets.
- Native synthesis: 47 tests passed, including phase-sensitive equivalence, runtime one-qubit lowering, and two-qubit rejection.
- Decomposition: 238 tests passed.
- Compiler: 164 tests passed.
- Python MLIR bindings: 53 tests passed, with the built SC device registered for QDMI fixtures.
- The real Benchpress adapter compiles `ry(0.123)` plus a nonzero global phase on a one-site `sx/x/rz` target; native Qiskit export preserves the full matrix (maximum absolute error `2.78e-16`).
- `uvx nox -s stubs` and `uvx nox -s lint` passed.
- `uvx nox -s cpp-lint -- f4093cbdc435254d08c544e5a033d464a2635d15` passed the complete changed files with zero findings.

C++ tests ran in the Debug lint build. The reused wheel-oriented Release build could not complete test discovery because of its build-tree shared-library search paths; no build-policy change is included.

Full-file C++ lint also required small expression/parenthesis cleanups in the touched binding and Weyl files; those are covered by the Python and decomposition tests.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

Codex assisted with implementation, tests, and review. Human review is still required before acceptance or merge.
