### PR TITLE
🐛 Diagnose unsupported QC control flow

### DIFF
--- a/mlir/include/mlir/Conversion/QCToQCO/QCToQCO.td
+++ b/mlir/include/mlir/Conversion/QCToQCO/QCToQCO.td
@@ -14,6 +14,9 @@ def QCToQCO : Pass<"qc-to-qco", "mlir::ModuleOp"> {
   let description = [{
     This pass converts all operations from the QC dialect to their equivalent operations in the QCO dialect.
     It handles the transformation of qubit references in QC to qubit values in QCO, ensuring that the semantics of quantum operations are preserved during the conversion process.
+    Control flow must use structured SCF operations. Operations with block
+    successors, including `cf.br`, `cf.cond_br`, and `cf.switch`, are diagnosed
+    before conversion.
   }];
 
   let dependentDialects = ["mlir::arith::ArithDialect", "mlir::qco::QCODialect",

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -27,7 +27,6 @@
 #include <llvm/ADT/ScopeExit.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
-#include <mlir/Dialect/Func/Transforms/FuncConversions.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/Dialect/Utils/StaticValueUtils.h>
@@ -461,9 +460,8 @@ static void commitQubits(LoweringState& state, Operation* anchor,
   return success();
 }
 
-/// Rejects quantum SSA sources unsupported by the lowering state.
-[[nodiscard]] static LogicalResult
-validateQuantumValueSources(Operation* root) {
+/// Rejects input unsupported by the lowering state.
+[[nodiscard]] static LogicalResult validateSupportedInput(Operation* root) {
   const auto result = root->walk([&](Operation* operation) {
     if (operation->getNumSuccessors() != 0) {
       operation->emitOpError(
@@ -2026,7 +2024,7 @@ protected:
 
     LoweringState preflightState;
     if (failed(validateModifierBodies(moduleOp)) ||
-        failed(validateQuantumValueSources(moduleOp)) ||
+        failed(validateSupportedInput(moduleOp)) ||
         failed(collectRegisterAccesses(moduleOp, preflightState))) {
       signalPassFailure();
       return;
@@ -2133,9 +2131,6 @@ protected:
     patterns.add<ConvertFuncCallOp>(typeConverter, context, &state);
     target.addDynamicallyLegalOp<func::CallOp>(
         [&](func::CallOp op) { return typeConverter.isLegal(op); });
-
-    // Conversion of qc types in control-flow ops (e.g., cf.br, cf.cond_br)
-    populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
 
     // Convert structured parents and their contents first.
     if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -465,6 +465,12 @@ static void commitQubits(LoweringState& state, Operation* anchor,
 [[nodiscard]] static LogicalResult
 validateQuantumValueSources(Operation* root) {
   const auto result = root->walk([&](Operation* operation) {
+    if (operation->getNumSuccessors() != 0) {
+      operation->emitOpError(
+          "QC-to-QCO does not support unstructured control flow; use SCF "
+          "operations");
+      return WalkResult::interrupt();
+    }
     if (auto returnOp = dyn_cast<func::ReturnOp>(operation)) {
       auto function = returnOp->getParentOfType<func::FuncOp>();
       llvm::SmallDenseSet<Value, 4> returnedQubits;

--- a/mlir/unittests/Conversion/QCToQCO/CMakeLists.txt
+++ b/mlir/unittests/Conversion/QCToQCO/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${target_name} test_qc_to_qco.cpp)
 target_link_libraries(
   ${target_name}
   PRIVATE MLIRParser
+          MLIRControlFlowDialect
           MLIRSupportMQT
           GTest::gtest_main
           MLIRQCProgramBuilder

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -95,8 +95,6 @@ class QCToQCOTest : public testing::TestWithParam<QCToQCOTestCase> {
 protected:
   std::unique_ptr<MLIRContext> context;
 
-  // GoogleTest requires this override name.
-  // NOLINTNEXTLINE(readability-identifier-naming)
   void SetUp() override {
     // Register all necessary dialects
     DialectRegistry registry;

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -39,6 +39,7 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
@@ -806,6 +807,39 @@ module {
   EXPECT_TRUE(call.getOperand(1).getDefiningOp<qtensor::ExtractOp>());
   ASSERT_TRUE(call.getResult(1).hasOneUse());
   EXPECT_TRUE(isa<qtensor::InsertOp>(*call.getResult(1).getUsers().begin()));
+}
+
+TEST_F(QCToQCORegressionTest, RejectsUnstructuredControlFlow) {
+  context.getOrLoadDialect<cf::ControlFlowDialect>();
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(
+module {
+  func.func @main() attributes {mqt.entry_point} {
+    %q = qc.static 0 : !qc.qubit
+    %c = arith.constant true
+    cf.cond_br %c, ^then, ^else
+  ^then:
+    qc.x %q : !qc.qubit
+    return
+  ^else:
+    qc.z %q : !qc.qubit
+    return
+  }
+}
+)mlir",
+                                              &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    sawExpectedDiagnostic |=
+        StringRef(diagnostic.str())
+            .contains("QC-to-QCO does not support unstructured control flow");
+    return success();
+  });
+
+  EXPECT_TRUE(failed(runQCToQCOConversion(*moduleOp)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
 }
 
 TEST_F(QCToQCORegressionTest, PreflightRejectsNonOneDimensionalQubitRegisters) {

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -95,6 +95,8 @@ class QCToQCOTest : public testing::TestWithParam<QCToQCOTestCase> {
 protected:
   std::unique_ptr<MLIRContext> context;
 
+  // GoogleTest requires this override name.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void SetUp() override {
     // Register all necessary dialects
     DialectRegistry registry;


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

QC-to-QCO could accept unstructured branches even though its qubit state mapping requires structured control flow. The conversion now diagnoses operations with block successors, including `cf.br`, `cf.cond_br`, and `cf.switch`, before state mapping and directs callers to SCF operations.

Addresses [the unstructured-control-flow finding in #2287](https://github.com/munich-quantum-toolkit/core/pull/2287#discussion_r3950356783). This PR is independent of the other audit fixes and starts from `main` at `5f6a8cfa2`. No new dependencies.

Validation: all 175 QC-to-QCO tests passed on the combined validation branch containing the four audit fixes, including the new branch regression and existing SCF coverage. `uvx nox -s lint` and `uvx nox -s cpp-lint` passed; the latter checks every line of each changed C++ file.

GPT-6 via Codex assisted the implementation, tests, and PR text.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] Changelog entries are not required for this unreleased v4 functionality.
- [x] Migration instructions are not required for this unreleased v4 functionality.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
