### PR TITLE
🐛 Enforce terminal measurements in Base QIR

### DIFF
--- a/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
@@ -23,6 +23,11 @@ def QCToQIRBase : Pass<"qc-to-qir-base", "mlir::ModuleOp"> {
     - The input entry function must consist of a single block.
       Multi-block input functions are currently not supported.
     - The program must have straight-line control flow (i.e., Base Profile QIR).
+    - A gate must not act on a qubit after it has been measured. The pass
+      rejects this order because moving the measurement after the gate can
+      change the result. Gates on independent qubits may follow measurements.
+      Dynamic register indices must be provably independent of measured
+      register elements.
 
     Behavior:
 

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
@@ -26,8 +26,6 @@ def QCToQIRBase : Pass<"qc-to-qir-base", "mlir::ModuleOp"> {
     - A gate must not act on a qubit after it has been measured. The pass
       rejects this order because moving the measurement after the gate can
       change the result. Gates on independent qubits may follow measurements.
-      Dynamic register indices must be provably independent of measured
-      register elements.
 
     Behavior:
 

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
@@ -23,13 +23,18 @@ def QCToQIRBase : Pass<"qc-to-qir-base", "mlir::ModuleOp"> {
     - The input entry function must consist of a single block.
       Multi-block input functions are currently not supported.
     - The program must have straight-line control flow (i.e., Base Profile QIR).
-    - A gate must not act on a qubit after it has been measured. The pass
-      rejects this order because moving the measurement after the gate can
-      change the result. Gates on independent qubits may follow measurements.
+    - A measured qubit must not be used by another quantum instruction,
+      including another measurement. Gates on independent qubits may follow
+      measurements in the input.
+    - Explicit static qubit IDs cannot be mixed with qubit allocations.
+    - Qubit-register loads require constant, in-bounds indices into statically
+      sized allocations. Register aliases must be resolved before conversion.
 
     Behavior:
 
-    - Each QC quantum operation is replaced by a call to the corresponding QIR function in the LLVM dialect.
+    - Each QC quantum operation is replaced in place by its QIR call. After
+      validating qubit usage in instruction order, the pass moves terminal
+      measurements to the irreversible operations block.
     - Required QIR module flags are attached as attributes to the entry function.
     - The pass transforms the single-block entry function into four blocks to satisfy QIR Base Profile constraints:
       0. Initialization block: Sets up the execution environment and performs required runtime initialization.

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRCommon/QIRCommon.h
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRCommon/QIRCommon.h
@@ -12,6 +12,7 @@
 
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/Support/Allocator.h>
 #include <llvm/Support/StringSaver.h>
@@ -45,6 +46,9 @@ struct LoweringState {
 
   /// Cache static qubit pointers for reuse
   DenseMap<int64_t, Value> staticQubits;
+
+  /// Canonical Base-profile pointers for constant qubit-register elements.
+  DenseMap<std::pair<Value, int64_t>, Value> staticRegisterQubits;
 
   /// Cache qubit register sizes for reuse
   DenseMap<Value, Value> qregSizes;

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -16,10 +16,12 @@
 #include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/MQT/Transforms/GlobalPhaseNormalization.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QIR/QIRDefinitions.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
+#include <llvm/ADT/DenseSet.h>
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
 #include <mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h>
 #include <mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h>
@@ -40,6 +42,7 @@
 #include <mlir/IR/OpDefinition.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Region.h>
+#include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
@@ -86,6 +89,51 @@ static FailureOr<Value> resolveRegisterMeasurement(LoweringState& state,
 }
 
 namespace {
+
+/// Checks that moving measurements after all gates preserves qubit order.
+static LogicalResult checkMeasurementOrder(func::FuncOp entryPoint) {
+  // Static indices and register elements can have multiple SSA references.
+  const auto qubitKey = [](Value qubit) -> std::pair<Value, int64_t> {
+    if (auto staticQubit = qubit.getDefiningOp<StaticOp>()) {
+      return {Value{}, static_cast<int64_t>(staticQubit.getIndex())};
+    }
+    if (auto load = qubit.getDefiningOp<memref::LoadOp>()) {
+      // A dynamic index can refer to any element of its register.
+      const auto index =
+          load.getIndices().size() == 1
+              ? getConstantIntValue(load.getIndices().front()).value_or(-1)
+              : -1;
+      return {load.getMemref(), index};
+    }
+    return {qubit, 0};
+  };
+
+  DenseSet<std::pair<Value, int64_t>> measuredQubits;
+  DenseSet<Value> measuredRegisters;
+  for (auto& operation : entryPoint.front()) {
+    if (auto measurement = dyn_cast<MeasureOp>(operation)) {
+      const auto key = qubitKey(measurement.getQubit());
+      measuredQubits.insert(key);
+      measuredRegisters.insert(key.first);
+      continue;
+    }
+    auto unitary = dyn_cast<UnitaryOpInterface>(operation);
+    if (!unitary || isa<BarrierOp, IdOp>(operation)) {
+      continue;
+    }
+    for (auto qubit : unitary.getQubits()) {
+      const auto key = qubitKey(qubit);
+      if (measuredQubits.contains(key) ||
+          measuredQubits.contains({key.first, -1}) ||
+          (key.second == -1 && measuredRegisters.contains(key.first))) {
+        return operation.emitError(
+            "QIR Base Profile requires gates to precede measurements on "
+            "the same qubit");
+      }
+    }
+  }
+  return success();
+}
 
 /**
  * @brief Converts `cbit.alloc` to static result
@@ -490,6 +538,10 @@ protected:
     if (!entryPoint.getBody().hasOneBlock()) {
       entryPoint.emitError(
           "QIR Base Profile requires a single-block entry function");
+      signalPassFailure();
+      return;
+    }
+    if (failed(checkMeasurementOrder(entryPoint))) {
       signalPassFailure();
       return;
     }

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -88,8 +88,6 @@ static FailureOr<Value> resolveRegisterMeasurement(LoweringState& state,
   return results[static_cast<size_t>(*indexValue)];
 }
 
-namespace {
-
 /// Checks that moving measurements after all gates preserves qubit order.
 static LogicalResult checkMeasurementOrder(func::FuncOp entryPoint) {
   // Static indices and register elements can have multiple SSA references.
@@ -134,6 +132,8 @@ static LogicalResult checkMeasurementOrder(func::FuncOp entryPoint) {
   }
   return success();
 }
+
+namespace {
 
 /**
  * @brief Converts `cbit.alloc` to static result

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -16,7 +16,6 @@
 #include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/MQT/Transforms/GlobalPhaseNormalization.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
-#include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QIR/QIRDefinitions.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
@@ -52,6 +51,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <utility>
 #include <variant>
 
@@ -88,39 +88,35 @@ static FailureOr<Value> resolveRegisterMeasurement(LoweringState& state,
   return results[static_cast<size_t>(*indexValue)];
 }
 
-/// Checks that moving measurements after all gates preserves qubit order.
-static LogicalResult checkMeasurementOrder(func::FuncOp entryPoint) {
-  // Static qubit IDs and constant register indices can have SSA aliases.
-  const auto qubitKey = [](Value qubit) -> std::pair<Value, int64_t> {
-    if (auto staticQubit = qubit.getDefiningOp<StaticOp>()) {
-      return {Value{}, static_cast<int64_t>(staticQubit.getIndex())};
-    }
-    if (auto load = qubit.getDefiningOp<memref::LoadOp>();
-        load && load.getIndices().size() == 1) {
-      if (const auto index = getConstantIntValue(load.getIndices().front())) {
-        return {load.getMemref(), *index};
-      }
-    }
-    return {qubit, 0};
-  };
-
-  DenseSet<std::pair<Value, int64_t>> measuredQubits;
-  for (auto& operation : entryPoint.front()) {
-    if (auto measurement = dyn_cast<MeasureOp>(operation)) {
-      measuredQubits.insert(qubitKey(measurement.getQubit()));
+/// Validates canonical qubit pointers before moving measurements out of order.
+static LogicalResult moveTerminalMeasurements(Block& body,
+                                              Block& measurements) {
+  DenseSet<Value> measuredQubits;
+  SmallVector<LLVM::CallOp> measurementCalls;
+  for (auto call : body.getOps<LLVM::CallOp>()) {
+    if (!call.getCallee() ||
+        !call.getCallee()->starts_with("__quantum__qis__")) {
       continue;
     }
-    auto unitary = dyn_cast<UnitaryOpInterface>(operation);
-    if (!unitary || isa<BarrierOp, IdOp>(operation)) {
-      continue;
+    const bool isMeasurement = call.getCallee() == QIR_MEASURE;
+    /// Measurement's second pointer identifies a result, not a qubit.
+    auto operands = call.getOperands();
+    if (isMeasurement) {
+      operands = operands.take_front(1);
     }
-    for (auto qubit : unitary.getQubits()) {
-      if (measuredQubits.contains(qubitKey(qubit))) {
-        return operation.emitError(
-            "QIR Base Profile requires gates to precede measurements on "
-            "the same qubit");
+    for (auto operand : operands) {
+      if (measuredQubits.contains(operand)) {
+        return call.emitError(
+            "QIR Base Profile forbids using a qubit after measurement");
       }
     }
+    if (isMeasurement) {
+      measuredQubits.insert(call.getOperand(0));
+      measurementCalls.push_back(call);
+    }
+  }
+  for (auto call : measurementCalls) {
+    call->moveBefore(measurements.getTerminator());
   }
   return success();
 }
@@ -211,6 +207,9 @@ struct ConvertMemRefAllocOp final
   LogicalResult
   matchAndRewrite(memref::AllocOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
+    if (failed(getState().ensureAllocationMode(AllocationMode::Dynamic, op))) {
+      return failure();
+    }
     rewriter.eraseOp(op);
     return success();
   }
@@ -246,16 +245,23 @@ struct ConvertMemRefLoadOp final : StatefulOpConversionPattern<memref::LoadOp> {
       return rewriter.notifyMatchFailure(
           op, "Only one-dimensional registers are supported");
     }
-    // Save current insertion point
-    const OpBuilder::InsertionGuard guard(rewriter);
-
-    // Switch to entry block
-    rewriter.setInsertionPoint(state.entryBlock->getTerminator());
-
-    auto nqubits = state.staticQubits.size();
-    auto qubit = createPointerFromIndex(rewriter, op.getLoc(),
-                                        static_cast<int64_t>(nqubits));
-    state.staticQubits.try_emplace(static_cast<int64_t>(nqubits), qubit);
+    const auto index = getConstantIntValue(op.getIndices().front());
+    if (!index || ShapedType::isDynamic(shape.front()) ||
+        !op.getMemref().getDefiningOp<memref::AllocOp>()) {
+      return op.emitError("QIR Base Profile requires constant indices into "
+                          "statically allocated qubit registers");
+    }
+    if (*index < 0 || *index >= shape.front()) {
+      return op.emitError("qubit-register index is out of bounds");
+    }
+    auto& qubit = state.staticRegisterQubits[{op.getMemref(), *index}];
+    if (!qubit) {
+      const OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPoint(state.entryBlock->getTerminator());
+      const auto id = static_cast<int64_t>(state.staticQubits.size());
+      qubit = createPointerFromIndex(rewriter, op.getLoc(), id);
+      state.staticQubits.try_emplace(id, qubit);
+    }
     rewriter.replaceOp(op, qubit);
 
     return success();
@@ -302,6 +308,9 @@ struct ConvertQCAllocOp final : StatefulOpConversionPattern<AllocOp> {
   matchAndRewrite(AllocOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
     auto& state = getState();
+    if (failed(state.ensureAllocationMode(AllocationMode::Dynamic, op))) {
+      return failure();
+    }
 
     const OpBuilder::InsertionGuard guard(rewriter);
 
@@ -371,8 +380,8 @@ struct ConvertQCMeasureOp final : StatefulOpConversionPattern<MeasureOp> {
       result = getResultPtr(state, op.getOperation(), rewriter);
     }
 
-    // Emit the measurement in the measurements block
-    rewriter.setInsertionPoint(state.measurementsBlock->getTerminator());
+    /// Preserve instruction order until terminal measurements are verified.
+    rewriter.setInsertionPoint(op);
     auto fnSig = LLVM::LLVMFunctionType::get(voidType, {ptrType, ptrType});
     auto fnDec =
         getOrCreateFunctionDeclaration(rewriter, op, QIR_MEASURE, fnSig);
@@ -508,8 +517,8 @@ protected:
    * Insert the `__quantum__rt__initialize` call.
    *
    * **Stage 4: QC to LLVM**
-   * Convert QC dialect operations to QIR calls and add output recording to the
-   * output block.
+   * Convert QC dialect operations in place, validate and move terminal
+   * measurements, and add output recording to the output block.
    *
    * **Stage 5: Standard dialects to LLVM**
    * Convert arith and control flow dialects to LLVM (for index arithmetic and
@@ -530,10 +539,6 @@ protected:
     if (!entryPoint.getBody().hasOneBlock()) {
       entryPoint.emitError(
           "QIR Base Profile requires a single-block entry function");
-      signalPassFailure();
-      return;
-    }
-    if (failed(checkMeasurementOrder(entryPoint))) {
       signalPassFailure();
       return;
     }
@@ -598,6 +603,11 @@ protected:
         return;
       }
 
+      auto& body = *std::next(main.getBody().begin());
+      if (failed(moveTerminalMeasurements(body, *state.measurementsBlock))) {
+        signalPassFailure();
+        return;
+      }
       addOutputRecording(main, ctx, state);
     }
 

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -90,29 +90,24 @@ static FailureOr<Value> resolveRegisterMeasurement(LoweringState& state,
 
 /// Checks that moving measurements after all gates preserves qubit order.
 static LogicalResult checkMeasurementOrder(func::FuncOp entryPoint) {
-  // Static indices and register elements can have multiple SSA references.
+  // Static qubit IDs and constant register indices can have SSA aliases.
   const auto qubitKey = [](Value qubit) -> std::pair<Value, int64_t> {
     if (auto staticQubit = qubit.getDefiningOp<StaticOp>()) {
       return {Value{}, static_cast<int64_t>(staticQubit.getIndex())};
     }
-    if (auto load = qubit.getDefiningOp<memref::LoadOp>()) {
-      // A dynamic index can refer to any element of its register.
-      const auto index =
-          load.getIndices().size() == 1
-              ? getConstantIntValue(load.getIndices().front()).value_or(-1)
-              : -1;
-      return {load.getMemref(), index};
+    if (auto load = qubit.getDefiningOp<memref::LoadOp>();
+        load && load.getIndices().size() == 1) {
+      if (const auto index = getConstantIntValue(load.getIndices().front())) {
+        return {load.getMemref(), *index};
+      }
     }
     return {qubit, 0};
   };
 
   DenseSet<std::pair<Value, int64_t>> measuredQubits;
-  DenseSet<Value> measuredRegisters;
   for (auto& operation : entryPoint.front()) {
     if (auto measurement = dyn_cast<MeasureOp>(operation)) {
-      const auto key = qubitKey(measurement.getQubit());
-      measuredQubits.insert(key);
-      measuredRegisters.insert(key.first);
+      measuredQubits.insert(qubitKey(measurement.getQubit()));
       continue;
     }
     auto unitary = dyn_cast<UnitaryOpInterface>(operation);
@@ -120,10 +115,7 @@ static LogicalResult checkMeasurementOrder(func::FuncOp entryPoint) {
       continue;
     }
     for (auto qubit : unitary.getQubits()) {
-      const auto key = qubitKey(qubit);
-      if (measuredQubits.contains(key) ||
-          measuredQubits.contains({key.first, -1}) ||
-          (key.second == -1 && measuredRegisters.contains(key.first))) {
+      if (measuredQubits.contains(qubitKey(qubit))) {
         return operation.emitError(
             "QIR Base Profile requires gates to precede measurements on "
             "the same qubit");

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -834,6 +834,30 @@ if (flag) {
   EXPECT_TRUE(qir->llvmIR().has_value());
 }
 
+TEST_F(CompilerPipelineTest, BaseMeasurementMayBeInsertedIntoFreedQTensor) {
+  auto qco = QCOProgram::fromMLIRString(R"mlir(module {
+    func.func @main() -> i1 attributes {mqt.entry_point} {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %reg = qtensor.alloc(%c1) : tensor<1x!qco.qubit>
+      %rest, %qubit = qtensor.extract %reg[%c0] : tensor<1x!qco.qubit>
+      %out, %result = qco.measure %qubit : !qco.qubit
+      %final = qtensor.insert %out into %rest[%c0] : tensor<1x!qco.qubit>
+      qtensor.dealloc %final : tensor<1x!qco.qubit>
+      return %result : i1
+    }
+  })mlir");
+  ASSERT_TRUE(qco);
+  auto qc = std::move(*qco).intoQC();
+  ASSERT_TRUE(qc);
+  auto qir = std::move(*qc).intoQIR(QIRProfile::Base);
+  ASSERT_TRUE(qir);
+  const auto llvmIR = qir->llvmIR();
+  ASSERT_TRUE(llvmIR);
+  EXPECT_NE(llvmIR->find("call void @__quantum__qis__mz__body"),
+            std::string::npos);
+}
+
 TEST_F(CompilerPipelineTest, EmitsQIR21ProfileModuleFlags) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.0;

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
@@ -74,6 +74,8 @@ class QCToQIRBaseTest : public testing::TestWithParam<QCToQIRBaseTestCase> {
 protected:
   std::unique_ptr<MLIRContext> context;
 
+  // GoogleTest requires this override name.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void SetUp() override {
     DialectRegistry registry;
     registry.insert<qc::QCDialect, LLVM::LLVMDialect, arith::ArithDialect,

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/MQT/Transforms/Passes.h"
 #include "mlir/Dialect/QC/Builder/QCProgramBuilder.h"
 #include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QIR/Builder/QIRProgramBuilder.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 #include "mlir/Support/Passes.h"
@@ -157,6 +158,119 @@ TEST(QCToQIRBaseNativeTest, RejectsMultiBlockEntryFunctionWithoutMutation) {
   EXPECT_TRUE(failed(runQCToQIRBaseConversion(*moduleOp)));
   EXPECT_TRUE(sawExpectedDiagnostic);
   EXPECT_EQ(entryPoint.getBlocks().size(), 2);
+}
+
+static void expectMeasurementOrderRejected(
+    function_ref<Value(qc::QCProgramBuilder&)> buildProgram) {
+  MLIRContext context;
+  context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
+                      LLVM::LLVMDialect, memref::MemRefDialect>();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  auto result = buildProgram(builder);
+  builder.retype(result.getType());
+  auto moduleOp = builder.finalize(result);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  bool sawExpectedDiagnostic = false;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    std::string message;
+    llvm::raw_string_ostream stream(message);
+    diagnostic.print(stream);
+    sawExpectedDiagnostic |= StringRef(message).contains(
+        "QIR Base Profile requires gates to precede measurements on the "
+        "same qubit");
+    return success();
+  });
+  EXPECT_TRUE(failed(runQCToQIRBaseConversion(*moduleOp)));
+  EXPECT_TRUE(sawExpectedDiagnostic);
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsGateAfterMeasurementOnSameQubit) {
+  expectMeasurementOrderRejected([](qc::QCProgramBuilder& builder) {
+    auto qubit = builder.allocQubit();
+    auto result = builder.measure(qubit);
+    builder.x(qubit);
+    return result;
+  });
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsGateWithMeasuredControl) {
+  expectMeasurementOrderRejected([](qc::QCProgramBuilder& builder) {
+    auto control = builder.allocQubit();
+    auto target = builder.allocQubit();
+    auto result = builder.measure(control);
+    builder.cx(control, target);
+    return result;
+  });
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsGateOnMeasuredStaticAlias) {
+  expectMeasurementOrderRejected([](qc::QCProgramBuilder& builder) {
+    auto qubit = builder.staticQubit(0);
+    auto result = builder.measure(qubit);
+    auto alias = qc::StaticOp::create(builder, 0).getQubit();
+    builder.x(alias);
+    return result;
+  });
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsGateOnMeasuredRegisterElement) {
+  expectMeasurementOrderRejected([](qc::QCProgramBuilder& builder) {
+    auto qubits = builder.allocQubitRegister(2);
+    auto result = builder.measure(qubits[0]);
+    auto alias = builder.loadQubit(qubits.value, builder.indexConstant(0));
+    builder.x(alias);
+    return result;
+  });
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsPossiblyMeasuredRegisterElement) {
+  for (const auto dynamicMeasurement : {false, true}) {
+    SCOPED_TRACE(dynamicMeasurement);
+    expectMeasurementOrderRejected([&](qc::QCProgramBuilder& builder) {
+      auto qubits = builder.allocQubitRegister(2);
+      auto condition = LLVM::UndefOp::create(builder, builder.getI1Type());
+      auto index =
+          arith::SelectOp::create(builder, condition, builder.indexConstant(0),
+                                  builder.indexConstant(1));
+      auto dynamicQubit = builder.loadQubit(qubits.value, index);
+      auto result =
+          builder.measure(dynamicMeasurement ? dynamicQubit : qubits[0]);
+      builder.x(dynamicMeasurement ? qubits[0] : dynamicQubit);
+      return result;
+    });
+  }
+}
+
+TEST(QCToQIRBaseNativeTest, AllowsGateAfterMeasurementOnIndependentQubit) {
+  MLIRContext context;
+  context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
+                      LLVM::LLVMDialect, memref::MemRefDialect>();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  auto qubits = builder.allocQubitRegister(2);
+  auto result = builder.measure(qubits[0]);
+  builder.x(qubits[1]);
+  builder.retype(result.getType());
+  auto moduleOp = builder.finalize(result);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCToQIRBaseConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+
+  SmallVector<LLVM::CallOp> quantumCalls;
+  moduleOp->walk([&](LLVM::CallOp call) {
+    if (call.getCallee() == qir::QIR_X ||
+        call.getCallee() == qir::QIR_MEASURE) {
+      quantumCalls.push_back(call);
+    }
+  });
+  ASSERT_EQ(quantumCalls.size(), 2);
+  EXPECT_EQ(quantumCalls[0].getCallee(), qir::QIR_X);
+  EXPECT_EQ(quantumCalls[1].getCallee(), qir::QIR_MEASURE);
+  EXPECT_NE(quantumCalls[0].getOperand(0), quantumCalls[1].getOperand(0));
 }
 
 TEST(QCToQIRBaseNativeTest, ControlledBarrierDoesNotControlFollowingGate) {

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
@@ -161,7 +161,9 @@ TEST(QCToQIRBaseNativeTest, RejectsMultiBlockEntryFunctionWithoutMutation) {
 }
 
 static void expectMeasurementOrderRejected(
-    function_ref<Value(qc::QCProgramBuilder&)> buildProgram) {
+    function_ref<Value(qc::QCProgramBuilder&)> buildProgram,
+    StringRef expectedDiagnostic =
+        "QIR Base Profile forbids using a qubit after measurement") {
   MLIRContext context;
   context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
                       LLVM::LLVMDialect, memref::MemRefDialect>();
@@ -178,9 +180,7 @@ static void expectMeasurementOrderRejected(
     std::string message;
     llvm::raw_string_ostream stream(message);
     diagnostic.print(stream);
-    sawExpectedDiagnostic |= StringRef(message).contains(
-        "QIR Base Profile requires gates to precede measurements on the "
-        "same qubit");
+    sawExpectedDiagnostic |= StringRef(message).contains(expectedDiagnostic);
     return success();
   });
   EXPECT_TRUE(failed(runQCToQIRBaseConversion(*moduleOp)));
@@ -224,6 +224,105 @@ TEST(QCToQIRBaseNativeTest, RejectsGateOnMeasuredRegisterElement) {
     builder.x(alias);
     return result;
   });
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsRepeatedMeasurement) {
+  expectMeasurementOrderRejected([](qc::QCProgramBuilder& builder) {
+    auto qubit = builder.allocQubit();
+    builder.measure(qubit);
+    return builder.measure(qubit);
+  });
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsRepeatedMeasurementToSameBit) {
+  expectMeasurementOrderRejected(qc::repeatedMeasurementToSameBit);
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsRepeatedMeasurementToDifferentBits) {
+  expectMeasurementOrderRejected([](qc::QCProgramBuilder& builder) {
+    return qc::repeatedMeasurementToDifferentBits(builder).front();
+  });
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsMixedQubitAllocationModes) {
+  for (const bool registerAllocation : {false, true}) {
+    SCOPED_TRACE(registerAllocation);
+    expectMeasurementOrderRejected(
+        [registerAllocation](qc::QCProgramBuilder& builder) {
+          auto qubit = builder.staticQubit(5);
+          if (registerAllocation) {
+            memref::AllocOp::create(builder,
+                                    MemRefType::get({1}, qubit.getType()));
+          } else {
+            qc::AllocOp::create(builder);
+          }
+          return builder.measure(qubit);
+        },
+        "cannot mix static and dynamic qubit allocation modes");
+  }
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsRuntimeQubitRegisterIndex) {
+  expectMeasurementOrderRejected(
+      [](qc::QCProgramBuilder& builder) {
+        auto qubits = builder.allocQubitRegister(2);
+        auto unknown = LLVM::UndefOp::create(builder, builder.getI64Type());
+        auto index = arith::IndexCastOp::create(builder, builder.getIndexType(),
+                                                unknown);
+        return builder.measure(builder.loadQubit(qubits.value, index));
+      },
+      "QIR Base Profile requires constant indices");
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsOutOfBoundsQubitRegisterIndex) {
+  for (const auto index : {-1, 2}) {
+    SCOPED_TRACE(index);
+    expectMeasurementOrderRejected(
+        [index](qc::QCProgramBuilder& builder) {
+          auto qubits = builder.allocQubitRegister(2);
+          return builder.measure(
+              builder.loadQubit(qubits.value, builder.indexConstant(index)));
+        },
+        "qubit-register index is out of bounds");
+  }
+}
+
+TEST(QCToQIRBaseNativeTest, RejectsRepeatedMeasurementThroughRegisterAlias) {
+  expectMeasurementOrderRejected([](qc::QCProgramBuilder& builder) {
+    auto qubits = builder.allocQubitRegister(1);
+    builder.measure(qubits[0]);
+    return builder.measure(
+        builder.loadQubit(qubits.value, builder.indexConstant(0)));
+  });
+}
+
+TEST(QCToQIRBaseNativeTest, RegisterLoadsPreserveQubitIdentity) {
+  MLIRContext context;
+  context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
+                      LLVM::LLVMDialect, memref::MemRefDialect>();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  auto qubits = builder.allocQubitRegister(1);
+  builder.x(qubits[0]);
+  auto result = builder.measure(
+      builder.loadQubit(qubits.value, builder.indexConstant(0)));
+  builder.retype(result.getType());
+  auto moduleOp = builder.finalize(result);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCToQIRBaseConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  Value gateQubit;
+  Value measuredQubit;
+  moduleOp->walk([&](LLVM::CallOp call) {
+    if (call.getCallee() == qir::QIR_X) {
+      gateQubit = call.getOperand(0);
+    } else if (call.getCallee() == qir::QIR_MEASURE) {
+      measuredQubit = call.getOperand(0);
+    }
+  });
+  ASSERT_TRUE(gateQubit);
+  EXPECT_EQ(gateQubit, measuredQubit);
 }
 
 TEST(QCToQIRBaseNativeTest, AllowsGateAfterMeasurementOnIndependentQubit) {
@@ -1043,14 +1142,6 @@ INSTANTIATE_TEST_SUITE_P(
             "SingleMeasurementToSingleBit",
             MQT_NAMED_BUILDER(qc::singleMeasurementToSingleBit),
             MQT_NAMED_BUILDER(qir::singleMeasurementToSingleBit)},
-        QCToQIRBaseTestCase{
-            "RepeatedMeasurementToSameBit",
-            MQT_NAMED_BUILDER(qc::repeatedMeasurementToSameBit),
-            MQT_NAMED_BUILDER(qir::repeatedMeasurementToSameBit)},
-        QCToQIRBaseTestCase{
-            "RepeatedMeasurementToDifferentBits",
-            MQT_NAMED_BUILDER(qc::repeatedMeasurementToDifferentBits),
-            MQT_NAMED_BUILDER(qir::repeatedMeasurementToDifferentBits)},
         QCToQIRBaseTestCase{
             "MultipleClassicalRegistersAndMeasurements",
             MQT_NAMED_BUILDER(qc::multipleClassicalRegistersAndMeasurements),

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
@@ -74,8 +74,6 @@ class QCToQIRBaseTest : public testing::TestWithParam<QCToQIRBaseTestCase> {
 protected:
   std::unique_ptr<MLIRContext> context;
 
-  // GoogleTest requires this override name.
-  // NOLINTNEXTLINE(readability-identifier-naming)
   void SetUp() override {
     DialectRegistry registry;
     registry.insert<qc::QCDialect, LLVM::LLVMDialect, arith::ArithDialect,

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRBase/test_qc_to_qir_base.cpp
@@ -228,24 +228,6 @@ TEST(QCToQIRBaseNativeTest, RejectsGateOnMeasuredRegisterElement) {
   });
 }
 
-TEST(QCToQIRBaseNativeTest, RejectsPossiblyMeasuredRegisterElement) {
-  for (const auto dynamicMeasurement : {false, true}) {
-    SCOPED_TRACE(dynamicMeasurement);
-    expectMeasurementOrderRejected([&](qc::QCProgramBuilder& builder) {
-      auto qubits = builder.allocQubitRegister(2);
-      auto condition = LLVM::UndefOp::create(builder, builder.getI1Type());
-      auto index =
-          arith::SelectOp::create(builder, condition, builder.indexConstant(0),
-                                  builder.indexConstant(1));
-      auto dynamicQubit = builder.loadQubit(qubits.value, index);
-      auto result =
-          builder.measure(dynamicMeasurement ? dynamicQubit : qubits[0]);
-      builder.x(dynamicMeasurement ? qubits[0] : dynamicQubit);
-      return result;
-    });
-  }
-}
-
 TEST(QCToQIRBaseNativeTest, AllowsGateAfterMeasurementOnIndependentQubit) {
   MLIRContext context;
   context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Base QIR lowering moved measurements behind all gates, so `measure q; x q;` became `x q; measure q;`. Lowering now preserves instruction order, checks canonical qubit pointers in one forward scan, and moves measurements only after validation succeeds. It rejects gates, measured controls, and repeated measurements on an already measured qubit, as required by the [Base profile](https://github.com/qir-alliance/qir-spec/blob/main/specification/profiles/Base_Profile.md#qubit-and-result-usage). Gates on independent qubits remain supported.

Repeated loads of a constant register element reuse the same qubit pointer. Unresolved register references, runtime or out-of-bounds indices, and mixed static/allocation modes are rejected during resource lowering. QC and QCO use the same validation path; a measured QCO qubit can be inserted into a QTensor and then freed. Adaptive measurement behavior is unchanged.

Addresses [the Base-profile ordering finding in #2287](https://github.com/munich-quantum-toolkit/core/pull/2287#discussion_r3950340983).

Local validation: 136 Base conversion tests, 152 Adaptive conversion tests, and 165 compiler tests passed with LLVM/MLIR 23.1.0. `uvx nox -s lint` and `uvx nox -s cpp-lint -- 80abe20f444d231e91e06df3deba5ff665ab3f55` passed; the C++ check covers every line of all three changed C++ source/test files with clang-tidy 23.1.1. Hosted CI must validate the new head.

GPT-6 via Codex assisted the implementation, tests, and PR text.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] Changelog entries are not required for this unreleased v4 functionality.
- [x] Migration instructions are not required for this unreleased v4 functionality.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
