### PR TITLE
🐛 Adopt recoverable jeff deserialization errors

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -22,11 +22,11 @@ if(BUILD_MQT_CORE_BINDINGS)
 endif()
 
 if(BUILD_MQT_CORE_MLIR)
-  # Fetch jeff-mlir
+  # Restore the upstream URL after unitaryfoundation/jeff-mlir#56 is merged.
   FetchContent_Declare(
     jeff-mlir
-    GIT_REPOSITORY https://github.com/unitaryfoundation/jeff-mlir.git
-    GIT_TAG ea09a8b46ec77ff4be8fd54ea72d781a644106c6
+    GIT_REPOSITORY https://github.com/simon1hofmann/jeff-mlir.git
+    GIT_TAG 650973fa9fafe246918a89506b94fef1424e4ce9
     EXCLUDE_FROM_ALL)
   block()
   # Cap'n Proto, which is fetched transitively by jeff-mlir, uses the generic BUILD_TESTING option

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -22,11 +22,10 @@ if(BUILD_MQT_CORE_BINDINGS)
 endif()
 
 if(BUILD_MQT_CORE_MLIR)
-  # Restore the upstream URL after unitaryfoundation/jeff-mlir#56 is merged.
   FetchContent_Declare(
     jeff-mlir
-    GIT_REPOSITORY https://github.com/simon1hofmann/jeff-mlir.git
-    GIT_TAG 650973fa9fafe246918a89506b94fef1424e4ce9
+    GIT_REPOSITORY https://github.com/unitaryfoundation/jeff-mlir.git
+    GIT_TAG 316eab7fab26d80a38278c8bf2ac2d249bda81a1
     EXCLUDE_FROM_ALL)
   block()
   # Cap'n Proto, which is fetched transitively by jeff-mlir, uses the generic BUILD_TESTING option

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -22,6 +22,7 @@ if(BUILD_MQT_CORE_BINDINGS)
 endif()
 
 if(BUILD_MQT_CORE_MLIR)
+  # Fetch jeff-mlir
   FetchContent_Declare(
     jeff-mlir
     GIT_REPOSITORY https://github.com/unitaryfoundation/jeff-mlir.git

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -26,7 +26,7 @@ if(BUILD_MQT_CORE_MLIR)
   FetchContent_Declare(
     jeff-mlir
     GIT_REPOSITORY https://github.com/unitaryfoundation/jeff-mlir.git
-    GIT_TAG 4732c4f12047e8cbf1890c79e90e30110e6588e2
+    GIT_TAG ea09a8b46ec77ff4be8fd54ea72d781a644106c6
     EXCLUDE_FROM_ALL)
   block()
   # Cap'n Proto, which is fetched transitively by jeff-mlir, uses the generic BUILD_TESTING option

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -130,8 +130,6 @@ class CompilerPipelineTest
 protected:
   std::unique_ptr<MLIRContext> context;
 
-  // GoogleTest requires this override name.
-  // NOLINTNEXTLINE(readability-identifier-naming)
   void SetUp() override {
     DialectRegistry registry;
     registry.insert<cbit::CBitDialect, QCDialect, QCODialect,

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -31,7 +31,10 @@
 #include "qco_programs.h"
 #include "qir_programs.h"
 
+#include <capnp/message.h>
+#include <capnp/serialize.h>
 #include <gtest/gtest.h>
+#include <jeff.capnp.h>
 #include <jeff/IR/JeffDialect.h>
 #include <jeff/IR/JeffOps.h>
 #include <llvm/ADT/APFloat.h>
@@ -75,6 +78,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <variant>
@@ -86,6 +90,8 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::qco;
 using namespace mlir::qir;
+
+namespace jeff = mlir::jeff;
 
 using QCProgramBuilderFn = NamedMLIRBuilder<QCProgramBuilder>;
 using QIRProgramBuilderFn = NamedMLIRBuilder<QIRProgramBuilder>;
@@ -124,6 +130,8 @@ class CompilerPipelineTest
 protected:
   std::unique_ptr<MLIRContext> context;
 
+  // GoogleTest requires this override name.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void SetUp() override {
     DialectRegistry registry;
     registry.insert<cbit::CBitDialect, QCDialect, QCODialect,
@@ -1479,6 +1487,14 @@ TEST_F(CompilerPipelineTest, JeffRejectsMutableClassicalHelperArguments) {
   })mlir");
   ASSERT_TRUE(qco);
   EXPECT_FALSE(std::move(*qco).intoJeff());
+}
+
+TEST_F(CompilerPipelineTest, RejectsJeffModuleWithoutFunctions) {
+  capnp::MallocMessageBuilder message;
+  message.initRoot<::jeff::Module>().setVersionMinor(3);
+  auto words = capnp::messageToFlatArray(message);
+  EXPECT_FALSE(JeffProgram::fromBytes(
+      std::as_bytes(std::span(words.begin(), words.size()))));
 }
 
 // Test: jeff programs round-trip through their binary APIs.


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Update jeff-mlir from `4732c4f` to upstream commit `316eab7fab26d80a38278c8bf2ac2d249bda81a1`, adopting the merged [deserializer fix (#55)](https://github.com/unitaryfoundation/jeff-mlir/pull/55) and [Windows build fix (#56)](https://github.com/unitaryfoundation/jeff-mlir/pull/56). The dependency uses the official `unitaryfoundation/jeff-mlir` repository.

Core already handles a null deserialization result. With the updated dependency, the previously fatal missing-functions input returns an import error instead of terminating the process. Add one in-process regression through `JeffProgram::fromBytes` using a serialized module without functions. Error handling stays upstream; no Core parser guards or exception-policy changes are added.

The deserializer requires exception support in KJ. The Windows fix enables `/EHsc` within the fetched Cap'n Proto dependency's CMake scope, including KJ and parser frames. The setting does not change Core's compiler flags.

Remove the unnecessary `SetUp` naming suppression. Its local warning came from incomplete SDK/header configuration; the override needs no source workaround.

Addresses the [jeff import-abort finding in #2287](https://github.com/munich-quantum-toolkit/core/pull/2287#discussion_r3950360654). This PR is independent of the other audit fixes and is based on `main` at `d52b3028c`.

## Validation

- Current upstream-pin update: `uvx nox -s lint` passed. A clean CMake FetchContent download from the official repository checked out the exact merged commit.
- The merged dependency tree matches the final #56 head exactly. Compared with the previously tested pin `650973f`, only the Windows workflow/preset relocation differs; runtime sources, tests, and the scoped exception fix are unchanged.
- At the previous Core revision `eb654ca23`, all 165 compiler tests and 151 jeff round-trip tests passed with LLVM/MLIR 23.1.0, including the missing-functions regression and successful imports. These tests were not rerun for the URL/tag-only update.
- Full changed-file `uvx nox -s cpp-lint` passed at `eb654ca23` with local clang-tidy 23.0.0git and the installed macOS SDK headers configured. No C++ files changed in the upstream-pin update.
- Hosted CI at `eb654ca23`: Windows x64 and ARM64 C++ tests, Windows Python tests, and C++ lint with clang-tidy 23.1.1 passed. CI for the upstream-pin update remains pending.

GPT-6 via Codex assisted the dependency update, regression test, validation, and PR text.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] Documentation changes are not required: the public API is unchanged and the deserializer contract is documented upstream.
- [x] Changelog entries are not required for this unreleased v4 functionality.
- [x] Migration instructions are not required for this unreleased v4 functionality.
- [x] Local style and full changed-file C++ lint checks passed; hosted Windows tests and C++ lint also passed.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
