### PR TITLE
⬆️ Update jeff-mlir and use native arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ releases may include breaking changes.
   [#2175], [#2176], [#2178], [#2342]) ([**@burgholzer**], [**@simon1hofmann**])
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637],
   [#1676], [#1706], [#1776], [#1836], [#1934], [#2000], [#2018], [#2105],
-  [#2339]) ([**@denialhaag**], [**@burgholzer**])
+  [#2339], [#2457]) ([**@denialhaag**], [**@burgholzer**])
 - ✨ Add QIR generation support to the MQT Compiler Collection ([#1264],
   [#1446], [#1513], [#1521], [#1548], [#1567], [#1569], [#1570], [#1572],
   [#1580], [#1620], [#1624], [#1626], [#1648], [#1710], [#1751], [#1755],
@@ -926,6 +926,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2457]: https://github.com/munich-quantum-toolkit/core/pull/2457
 [#2436]: https://github.com/munich-quantum-toolkit/core/pull/2436
 [#2421]: https://github.com/munich-quantum-toolkit/core/pull/2421
 [#2399]: https://github.com/munich-quantum-toolkit/core/pull/2399

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -26,7 +26,7 @@ if(BUILD_MQT_CORE_MLIR)
   FetchContent_Declare(
     jeff-mlir
     GIT_REPOSITORY https://github.com/unitaryfoundation/jeff-mlir.git
-    GIT_TAG 316eab7fab26d80a38278c8bf2ac2d249bda81a1
+    GIT_TAG eec13f1f41da0da03ad55090adce4c6b4afecd21
     EXCLUDE_FROM_ALL)
   block()
   # Cap'n Proto, which is fetched transitively by jeff-mlir, uses the generic BUILD_TESTING option

--- a/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
+++ b/mlir/lib/Conversion/JeffToQCO/JeffToQCO.cpp
@@ -1029,51 +1029,6 @@ struct ConvertJeffSwitchOpToQCO final : OpConversionPattern<jeff::SwitchOp> {
 
     auto inValues = adaptor.getInValues();
 
-    /// Pure selections are ordinary SSA values, not mutable register aliases.
-    const bool pureSelection =
-        llvm::all_of(op.getBranches(), [](Region& region) {
-          return llvm::all_of(
-              region.front().without_terminator(), [](Operation& nested) {
-                return isa<jeff::IntConst1Op, jeff::IntConst8Op,
-                           jeff::IntConst16Op, jeff::IntConst32Op,
-                           jeff::IntConst64Op, arith::ConstantOp>(nested);
-              });
-        });
-    if (pureSelection && llvm::all_of(op.getResultTypes(), [](Type type) {
-          return isa<IntegerType>(type);
-        })) {
-      SmallVector<Value> falseValues;
-      SmallVector<Value> trueValues;
-      for (auto [index, region] : llvm::enumerate(op.getBranches())) {
-        auto yield = cast<jeff::YieldOp>(region.front().getTerminator());
-        auto& values = index == 0 ? falseValues : trueValues;
-        for (auto value : yield.getOperands()) {
-          auto argument = dyn_cast<BlockArgument>(value);
-          if (argument && argument.getOwner() == &region.front()) {
-            values.push_back(inValues[argument.getArgNumber()]);
-          } else if (auto* constant = value.getDefiningOp();
-                     isa_and_nonnull<jeff::IntConst1Op, jeff::IntConst8Op,
-                                     jeff::IntConst16Op, jeff::IntConst32Op,
-                                     jeff::IntConst64Op, arith::ConstantOp>(
-                         constant)) {
-            values.push_back(rewriter.clone(*constant)->getResult(0));
-          } else {
-            return rewriter.notifyMatchFailure(
-                op, "selection must yield an input or integer constant");
-          }
-        }
-      }
-      SmallVector<Value> results;
-      for (auto [trueValue, falseValue] :
-           llvm::zip_equal(trueValues, falseValues)) {
-        results.push_back(arith::SelectOp::create(rewriter, op.getLoc(),
-                                                  adaptor.getSelection(),
-                                                  trueValue, falseValue));
-      }
-      rewriter.replaceOp(op, results);
-      return success();
-    }
-
     SmallVector<Value> qubits;
     for (auto [argument, adapted] : llvm::zip_equal(
              op.getBranches()[0].front().getArguments(), inValues)) {

--- a/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
+++ b/mlir/lib/Conversion/QCOToJeff/QCOToJeff.cpp
@@ -684,32 +684,6 @@ static Value integerConstant(OpBuilder& builder, Location loc, IntegerType type,
   }
 }
 
-static Value selectInteger(OpBuilder& builder, Location loc, Value condition,
-                           Value trueValue, Value falseValue) {
-  /// The current serializer infers result types from the input signature.
-  /// Carry one difference value and yield either that value or zero.
-  auto difference = jeff::IntBinaryOp::create(
-      builder, loc, trueValue, falseValue, jeff::IntBinaryOperation::_xor);
-  auto select =
-      jeff::SwitchOp::create(builder, loc, TypeRange{trueValue.getType()},
-                             condition, ValueRange{difference}, 2);
-  {
-    OpBuilder::InsertionGuard guard(builder);
-    for (auto& region : select->getRegions()) {
-      auto* block = builder.createBlock(&region, {},
-                                        TypeRange{trueValue.getType()}, {loc});
-      Value result = block->getArgument(0);
-      if (&region != &select.getBranches()[1]) {
-        auto type = cast<IntegerType>(trueValue.getType());
-        result = integerConstant(builder, loc, type, APInt(type.getWidth(), 0));
-      }
-      jeff::YieldOp::create(builder, loc, result);
-    }
-  }
-  return jeff::IntBinaryOp::create(builder, loc, select.getResult(0),
-                                   falseValue, jeff::IntBinaryOperation::_xor);
-}
-
 static Value maskInteger(OpBuilder& builder, Location loc, Value value,
                          unsigned width) {
   auto type = cast<IntegerType>(value.getType());
@@ -755,39 +729,24 @@ static Value joinBits(OpBuilder& builder, Location loc,
   return bits.front();
 }
 
-/// jeff has no integer cast: extract at most 64 bits into the target
-/// representation.
+/// Cast between native widths and preserve the original integer's sign and
+/// mask.
 static Value castInteger(OpBuilder& builder, Location loc, Value value,
                          unsigned sourceWidth, IntegerType targetType,
                          unsigned targetWidth, bool signExtend) {
   auto sourceType = cast<IntegerType>(value.getType());
   Value result = value;
-  if (sourceType != targetType) {
-    SmallVector<Value> bits;
-    auto zero = integerConstant(builder, loc, sourceType,
-                                APInt(sourceType.getWidth(), 0));
-    for (unsigned bit = 0; bit < std::min(sourceWidth, targetWidth); ++bit) {
-      auto mask =
-          integerConstant(builder, loc, sourceType,
-                          APInt::getOneBitSet(sourceType.getWidth(), bit));
-      auto masked = jeff::IntBinaryOp::create(builder, loc, value, mask,
-                                              jeff::IntBinaryOperation::_and);
-      auto isZero = jeff::IntComparisonOp::create(
-          builder, loc, masked, zero, jeff::IntComparisonOperation::_eq);
-      auto targetBit =
-          integerConstant(builder, loc, targetType,
-                          APInt::getOneBitSet(targetType.getWidth(), bit));
-      auto selected =
-          selectInteger(builder, loc, isZero,
-                        integerConstant(builder, loc, targetType,
-                                        APInt(targetType.getWidth(), 0)),
-                        targetBit);
-      bits.push_back(selected);
-    }
-    result = joinBits(builder, loc, std::move(bits));
-  }
   if (signExtend && targetWidth > sourceWidth) {
     result = signedInteger(builder, loc, result, sourceWidth);
+  }
+  if (sourceType.getWidth() < targetType.getWidth()) {
+    if (signExtend) {
+      result = jeff::IntExtSOp::create(builder, loc, targetType, result);
+    } else {
+      result = jeff::IntExtUOp::create(builder, loc, targetType, result);
+    }
+  } else if (sourceType.getWidth() > targetType.getWidth()) {
+    result = jeff::IntTruncOp::create(builder, loc, targetType, result);
   }
   return maskInteger(builder, loc, result, targetWidth);
 }
@@ -826,7 +785,8 @@ struct ConvertCBitReadOpToJeff final
       if (width != 1) {
         auto mask = integerConstant(rewriter, op.getLoc(), type,
                                     APInt::getOneBitSet(type.getWidth(), bit));
-        selected = selectInteger(rewriter, op.getLoc(), value, mask, zero);
+        selected = jeff::IntSelectOp::create(rewriter, op.getLoc(), type, value,
+                                             mask, zero);
       }
       bits.push_back(selected);
     }
@@ -881,16 +841,37 @@ struct ConvertCBitWriteOpToJeff final
   }
 };
 
-/// Override the dependency adapter for exact-width integer computations.
+/// Preserve promoted integer widths and cover gaps in native conversions.
 struct ConvertIntegerExpression final : ConversionPattern {
   ConvertIntegerExpression(TypeConverter& converter, MLIRContext* context)
       : ConversionPattern(converter, MatchAnyOpTypeTag(), 10, context) {}
   LogicalResult
   matchAndRewrite(Operation* op, ArrayRef<Value> operands,
                   ConversionPatternRewriter& rewriter) const override {
+    if (op->getName().getDialectNamespace() != "arith") {
+      return failure();
+    }
+    if (getTypeConverter()->isLegal(op) &&
+        !isa<arith::CmpIOp, arith::ShRUIOp, arith::ShRSIOp>(op)) {
+      return failure();
+    }
+    if (isa<arith::SIToFPOp>(op)) {
+      auto sourceType = dyn_cast<IntegerType>(op->getOperand(0).getType());
+      if (!sourceType) {
+        return failure();
+      }
+      const auto width = sourceType.getWidth();
+      if (width > 64) {
+        return op->emitError(
+            "jeff supports general integer expressions only up to 64 bits");
+      }
+      auto value = signedInteger(rewriter, op->getLoc(), operands[0], width);
+      rewriter.replaceOpWithNewOp<jeff::IntToFloatSOp>(
+          op, op->getResult(0).getType(), value);
+      return success();
+    }
     if (op->getNumResults() != 1 ||
-        !isa<IntegerType>(op->getResult(0).getType()) ||
-        op->getName().getDialectNamespace() != "arith") {
+        !isa<IntegerType>(op->getResult(0).getType())) {
       return failure();
     }
     auto originalType = cast<IntegerType>(op->getResult(0).getType());
@@ -910,26 +891,47 @@ struct ConvertIntegerExpression final : ConversionPattern {
       return success();
     }
     if (isa<arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp>(op)) {
-      rewriter.replaceOp(
-          op,
-          castInteger(rewriter, loc, operands[0],
-                      cast<IntegerType>(op->getOperand(0).getType()).getWidth(),
-                      type, width, isa<arith::ExtSIOp>(op)));
+      const auto sourceWidth =
+          cast<IntegerType>(op->getOperand(0).getType()).getWidth();
+      rewriter.replaceOp(op,
+                         castInteger(rewriter, loc, operands[0], sourceWidth,
+                                     type, width, isa<arith::ExtSIOp>(op)));
+      return success();
+    }
+    if (isa<arith::FPToSIOp, arith::FPToUIOp>(op)) {
+      Value result =
+          isa<arith::FPToSIOp>(op)
+              ? jeff::FloatToSIntOp::create(rewriter, loc, type, operands[0])
+                    .getResult()
+              : jeff::FloatToUIntOp::create(rewriter, loc, type, operands[0])
+                    .getResult();
+      rewriter.replaceOp(op, maskInteger(rewriter, loc, result, width));
       return success();
     }
     if (isa<arith::SelectOp>(op)) {
-      rewriter.replaceOp(op, selectInteger(rewriter, loc, operands[0],
-                                           operands[1], operands[2]));
+      rewriter.replaceOpWithNewOp<jeff::IntSelectOp>(op, type, operands[0],
+                                                     operands[1], operands[2]);
       return success();
     }
     if (auto comparison = dyn_cast<arith::CmpIOp>(op)) {
       auto lhs = operands[0];
       auto rhs = operands[1];
       auto predicate = comparison.getPredicate();
+      // Zero-extension preserves equality and unsigned ordering. Signed
+      // comparisons need adjustment only when the operands were promoted.
+      auto sourceType = dyn_cast<IntegerType>(comparison.getLhs().getType());
+      if (predicate == arith::CmpIPredicate::eq ||
+          predicate == arith::CmpIPredicate::ult ||
+          predicate == arith::CmpIPredicate::ule ||
+          ((predicate == arith::CmpIPredicate::slt ||
+            predicate == arith::CmpIPredicate::sle) &&
+           (!sourceType || nativeIntegerWidth(sourceType.getWidth()) ==
+                               sourceType.getWidth()))) {
+        return failure();
+      }
       const auto unsignedPredicate = mqt::unsignedPredicate(predicate);
       if (unsignedPredicate != predicate) {
         auto operandType = cast<IntegerType>(lhs.getType());
-        auto sourceType = dyn_cast<IntegerType>(comparison.getLhs().getType());
         auto sourceWidth =
             sourceType ? sourceType.getWidth() : operandType.getWidth();
         auto sign = integerConstant(
@@ -969,15 +971,10 @@ struct ConvertIntegerExpression final : ConversionPattern {
             .Case("arith.addi", jeff::IntBinaryOperation::_add)
             .Case("arith.subi", jeff::IntBinaryOperation::_sub)
             .Case("arith.muli", jeff::IntBinaryOperation::_mul)
-            .Case("arith.divui", jeff::IntBinaryOperation::_divU)
             .Case("arith.divsi", jeff::IntBinaryOperation::_divS)
-            .Case("arith.remui", jeff::IntBinaryOperation::_remU)
             .Case("arith.remsi", jeff::IntBinaryOperation::_remS)
             .Case("arith.minsi", jeff::IntBinaryOperation::_minS)
             .Case("arith.maxsi", jeff::IntBinaryOperation::_maxS)
-            .Case("arith.andi", jeff::IntBinaryOperation::_and)
-            .Case("arith.ori", jeff::IntBinaryOperation::_or)
-            .Case("arith.xori", jeff::IntBinaryOperation::_xor)
             .Case("arith.shli", jeff::IntBinaryOperation::_shl)
             .Cases({"arith.shrui", "arith.shrsi"},
                    jeff::IntBinaryOperation::_shr)
@@ -1009,7 +1006,8 @@ struct ConvertIntegerExpression final : ConversionPattern {
           rewriter, loc, ones, rhs, jeff::IntBinaryOperation::_shr);
       auto fill = jeff::IntBinaryOp::create(rewriter, loc, ones, shiftedMask,
                                             jeff::IntBinaryOperation::_xor);
-      auto selected = selectInteger(rewriter, loc, nonnegative, zero, fill);
+      auto selected = jeff::IntSelectOp::create(rewriter, loc, type,
+                                                nonnegative, zero, fill);
       result = jeff::IntBinaryOp::create(rewriter, loc, result, selected,
                                          jeff::IntBinaryOperation::_or);
     }

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -1503,12 +1503,6 @@ llvm::ArrayRef<OpenQASMProgram> jeffCompatiblePrograms() {
           .name = "affine-index-alias",
           .source = expressionDynamicIntIndex,
       },
-  };
-  return programs;
-}
-
-llvm::ArrayRef<OpenQASMProgram> jeffIncompatiblePrograms() {
-  static const std::array programs{
       OpenQASMProgram{
           .name = "integer-to-floating-gate-parameter",
           .source = bitVectorBuiltins,
@@ -1517,6 +1511,12 @@ llvm::ArrayRef<OpenQASMProgram> jeffIncompatiblePrograms() {
           .name = "checked-integer-state",
           .source = checkedIntegerState,
       },
+  };
+  return programs;
+}
+
+llvm::ArrayRef<OpenQASMProgram> jeffIncompatiblePrograms() {
+  static const std::array programs{
       OpenQASMProgram{.name = "dynamic-range", .source = dynamicRange},
   };
   return programs;


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Update `jeff-mlir` to eec13f1f41da0da03ad55090adce4c6b4afecd21 from https://github.com/unitaryfoundation/jeff-mlir/pull/44.

Delegate supported arithmetic to `jeff-mlir` in the conversions between QCO and `jeff`. Retain local handling for width promotion, missing comparison predicates, and right shifts. Replace the switch/XOR and bit reconstruction workarounds with native integer selections and casts. Update the existing compiler corpus for the newly supported programs.

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
