### PR TITLE
🐛 Validate QDMI jobs and SDK execution

### DIFF
--- a/.agent/audits/qdmi-plugin-contracts-2026-09-07.md
+++ b/.agent/audits/qdmi-plugin-contracts-2026-09-07.md
@@ -1,8 +1,9 @@
 # Contract audit: QDMI jobs and Python plugins
 
-Status: findings 1, 2, and 5 fixed locally; findings 3 and 4 declined by the user.
-PennyLane specialist findings and Qiskit native preflight are implemented. Audit baseline:
-`1bf02dd7694d511abe19032b5d80a649ab5f8d20` (merged PR #2454). Date: 2026-09-07.
+Status: findings 1, 2, and 5 fixed locally; findings 3 and 4 declined by the
+user. PennyLane specialist findings and Qiskit native preflight are implemented.
+Audit baseline: `1bf02dd7694d511abe19032b5d80a649ab5f8d20` (merged PR #2454).
+Date: 2026-09-07.
 
 Scope: native job creation/retrieval, Qiskit target and submission behavior,
 PennyLane conversion and sampled execution. This is a bounded follow-up, not a
@@ -120,8 +121,8 @@ the replaceable driver and staging; they are not prerequisites for these fixes.
 
 PR #2373 and issues #2363/#2364 cover native multi-program batching; do not
 duplicate them. PR #2233 removes obsolete calibration/pulse metadata, so a
-separate duration-query cache optimization would need coordination. No additional compiler/DD changes
-are justified by this investigation.
+separate duration-query cache optimization would need coordination. No
+additional compiler/DD changes are justified by this investigation.
 
 ### Validation and limits
 
@@ -136,7 +137,6 @@ are justified by this investigation.
   Python process through `register_device` and `open_device`.
 - These audit probes preceded the fixes below. Windows and real hardware were
   not used. No new commit or remote write was made.
-
 
 ## Resolution
 
@@ -170,11 +170,12 @@ at the review date. All four specialist findings are addressed:
    format-specific supported operation names. QASM2 and QASM3 regressions verify
    the resulting operation matrix and serialization. Placement checks remain
    authoritative; graph support does not imply routing or hardware costs. See
-   the [plugin guide](https://docs.pennylane.ai/en/stable/development/plugins.html#custom-device-decompositions).
+   the
+   [plugin guide](https://docs.pennylane.ai/en/stable/development/plugins.html#custom-device-decompositions).
 3. **Shot API:** remove device-level shots, the implicit 1024-shot default, and
    the private `_shots` assignment. QNodes and tapes must specify finite shots;
-   `qp.set_shots` can override a QNode's budget. Omission fails before submission.
-   Examples and tests use the modern APIs. See
+   `qp.set_shots` can override a QNode's budget. Omission fails before
+   submission. Examples and tests use the modern APIs. See
    [deprecations](https://docs.pennylane.ai/en/stable/development/deprecations.html).
 4. **Tracking:** use standard `Tracker.update/record` for batches, tape counts,
    accepted jobs, and shots. Shot-vector copies count individually; jobs that
@@ -189,7 +190,8 @@ result decoding remain in #2226. Native batching remains with #2364/#2373.
 
 ## Final validation
 
-- `uv run --no-sync pytest -n0 test/python/qdmi test/python/plugins`: 500 passed.
+- `uv run --no-sync pytest -n0 test/python/qdmi test/python/plugins`: 500
+  passed.
 - Full repository lint passes, including Ruff and ty.
 - The unchanged native fix passes 104 driver tests and the warning-provider
   binding probe for both job entry points.
@@ -197,9 +199,10 @@ result decoding remain in #2226. Native batching remains with #2364/#2373.
   checked six C++ files with zero findings. The older base selects both changed
   driver files through the preceding PR's diff; lint inspects current contents
   with `--lines-changed-only=false`.
-- The two previously failing MLIR binaries pass 500 QCO IR and 47 target-synthesis
-  tests. Running formatting hooks alongside the build likely exposed partially
-  rewritten headers; sequential checks pass without unrelated source changes.
+- The two previously failing MLIR binaries pass 500 QCO IR and 47
+  target-synthesis tests. Running formatting hooks alongside the build likely
+  exposed partially rewritten headers; sequential checks pass without unrelated
+  source changes.
 - No hosted CI, Windows, or real hardware execution was performed.
 
 See [the v4 decision record](../plans/qdmi-v4-plugin-validation.md).

--- a/.agent/audits/qdmi-plugin-contracts-2026-09-07.md
+++ b/.agent/audits/qdmi-plugin-contracts-2026-09-07.md
@@ -1,0 +1,205 @@
+# Contract audit: QDMI jobs and Python plugins
+
+Status: findings 1, 2, and 5 fixed locally; findings 3 and 4 declined by the user.
+PennyLane specialist findings and Qiskit native preflight are implemented. Audit baseline:
+`1bf02dd7694d511abe19032b5d80a649ab5f8d20` (merged PR #2454). Date: 2026-09-07.
+
+Scope: native job creation/retrieval, Qiskit target and submission behavior,
+PennyLane conversion and sampled execution. This is a bounded follow-up, not a
+whole-repository audit. All probes used local test doubles or the SC metadata
+provider; no external hardware was used.
+
+## Confirmed findings
+
+### 1. Retain job handles returned with a warning
+
+`QDMI_Device_impl_d::createJob` and `retrieveJobById` in
+`src/qdmi/driver/Driver.cpp` return immediately for any status other than
+`QDMI_SUCCESS`. A provider returning `QDMI_WARN_GENERAL` with an allocated job
+therefore leaves the client output null and loses ownership of the native job.
+`qdmi::throwIfError` explicitly accepts warnings, so `Device::submitJobImpl`
+continues to set parameters on a null handle; retrieval returns an unusable
+`Job`. Both SDK plugins use this shared submission path.
+
+A scratch copy of `test/qdmi/driver/session_device.cpp`, changing the two
+successful job-allocation returns from `QDMI_SUCCESS` to `QDMI_WARN_GENERAL`,
+reproduced both failures through the Python bindings:
+
+- `submit_job(...)`: `ValueError: Setting program format: Invalid argument.`
+- `retrieve_job_by_id("session-job").check()`:
+  `ValueError: Checking job status: Invalid argument.`
+
+Accept success and warnings before wrapping the handle, preserve the warning
+status, and reject a null handle reported as successful. Test both entry points.
+Keep the separate allocation-failure work in #2271 out of this fix.
+
+### 2. Share PennyLane validation across both formats and all fixed arities
+
+`_ProgramConverter._convert_qasm2` checks only advertised gate spellings. It
+bypasses shape, finite-parameter, and placement validation performed by the
+QASM3 path. `_validate_qdmi_contract` also returns immediately for gates on more
+than two wires, even when explicit site tuples are present.
+
+Normal QNode execution with the existing `StubDevice` reproduced:
+
+- QASM2: advertise CX only on `(0, 1)`; CNOT on `(1, 0)` is submitted.
+- QASM2: RX with `nan` is submitted as `rx(nan) q[0];`.
+- QASM3: advertise CCX only on `(0, 1, 2)`; Toffoli on `(1, 2, 3)` is submitted.
+
+Use one validation path before either serializer, retaining their distinct gate
+spelling rules. Validate complete ordered tuples for every fixed arity. Preserve
+the existing treatment of unspecified placements and finite-shot preprocessing.
+These probes demonstrate invalid submissions, not incorrect hardware results.
+
+### 3. Do not infer unrestricted MCX support from its Qiskit class
+
+`QDMIBackend._add_operation_to_target` computes explicit placements, then
+ignores them whenever the mapped gate is a class. A real SC configuration with
+`{"name": "mcx", "numParameters": 0, "numQubits": 3, "sites": [[0, 1, 2]]}` on
+four qubits produced a Target accepting both `(1, 2, 3)` and `(0, 1, 2, 3)`. The
+latter also violates the advertised arity.
+
+Reserve unrestricted class instructions for providers that advertise genuinely
+variable arity and unrestricted placement. Represent a known fixed-arity gate as
+an instance with its placements, or reject the unsupported representation. Do
+not assume arbitrary classes in `_EXTRA_GATES` have a common constructor.
+
+### 4. Preserve placements from equivalent Qiskit aliases
+
+`_add_operation_to_target` returns when `gate_name` is already in
+`seen_gate_names`. A real SC model advertising `cx` on `(0, 1)` and `cnot` on
+`(1, 2)` produced a Target containing only `(0, 1)`. Both operation names are
+valid, unique SC entries and map to the same canonical Qiskit gate.
+
+Merge disjoint placements and their calibration into the existing instruction.
+Keep a deliberate rule for overlapping aliases with conflicting calibration; do
+not silently broaden explicit placements to global support. Retain alias
+semantics through serialization and subclass overrides.
+
+### 5. Cache PennyLane placement metadata, rather than successful gate uses
+
+The converter caches successful `(operation.name, indices)` validations, but
+each new tuple reads and reconstructs the operation's entire supported-site set.
+For one operation advertised on N sites and used once on each site, validation
+performs N full site-list queries and N-squared index reads.
+
+The existing boundary doubles measured:
+
+| Distinct sites used | Full site-list queries | Site-index reads |
+| ------------------- | ---------------------- | ---------------- |
+| 10                  | 10                     | 100              |
+| 20                  | 20                     | 400              |
+
+Cache normalized capability metadata once per operation/session and use set
+membership for each gate. This can replace `_validated_loci` and complement the
+shared validation in finding 2. Continue validating each gate's parameters and
+wire arguments. Counts prove redundant work; no end-to-end speedup is claimed.
+
+## Additional preflight hardening
+
+`QDMIBackend.run` checks operation names but not circuit width or operation
+placements. A backend whose Target rejects CX on `(1, 0)` still submitted that
+circuit successfully to a test double.
+
+Rejecting known-invalid native placements before submission would give earlier,
+more useful errors. However, a blanket check against the public Target is not
+safe: `_preprocess_circuit` can expand logical circuits to hidden device sites,
+and custom serializers can perform additional translation. Validate the native
+operation contract at the appropriate boundary while preserving those hooks.
+This is a proposed tightening of preflight behavior, distinct from the confirmed
+Target construction defects above; real providers may already reject the job.
+
+## Overlap with open work
+
+Refreshed open issues and PRs during the audit. #2226 changes payload selection,
+serializer registration, and control-flow support in both plugins, but its patch
+does not fix these placement or finite-parameter validation paths. Coordinate
+shared converter edits with it. #2230's warning handling concerns provider and
+session setup, not the two job-handle entry points above. #2229 and #2231 cover
+the replaceable driver and staging; they are not prerequisites for these fixes.
+
+PR #2373 and issues #2363/#2364 cover native multi-program batching; do not
+duplicate them. PR #2233 removes obsolete calibration/pulse metadata, so a
+separate duration-query cache optimization would need coordination. No additional compiler/DD changes
+are justified by this investigation.
+
+### Validation and limits
+
+- `uv run --no-sync pytest -n0 test/python/qdmi test/python/plugins -q`: 468
+  tests passed in 5.72 seconds. The existing suite does not cover the failing
+  combinations above.
+- `/tmp/qdmi-plugin-audit/probe.py` exercises ordinary PennyLane QNodes, real SC
+  Target construction, and Qiskit submission to a boundary double.
+- `/tmp/qdmi-plugin-audit/metadata.py` counts full-list queries and index reads.
+- The warning provider was compiled from the existing session fixture with only
+  its two successful job-allocation statuses changed, then opened in a separate
+  Python process through `register_device` and `open_device`.
+- These audit probes preceded the fixes below. Windows and real hardware were
+  not used. No new commit or remote write was made.
+
+
+## Resolution
+
+- Finding 1: preserve warning-status native jobs in both entry points and reject
+  null handles before wrapping them. The regression verifies status, ownership,
+  and exactly one native free for both entry points.
+- Findings 2 and 5: share preparation between QASM2 and QASM3, validate finite
+  parameters and fixed-arity placements, and normalize metadata once per
+  converter session. At 10/20 distinct loci, the probe now makes one site-list
+  query and 10/20 index reads, compared with 10/20 queries and 100/400 reads.
+- Findings 3 and 4: no changes to MCX or alias Target construction.
+- Qiskit preflight: built-in QASM serializers validate native width and ordered
+  placements after preprocessing. A bad circuit rejects its entire batch before
+  submission. Native metadata is cached; the public Target cannot substitute for
+  it because extensions can hide sites or expose fictional pairs. Custom
+  serializers retain compilation control. Control-flow bodies use their parent
+  qubit mapping and require explicit support in the extension's Target.
+
+## PennyLane specialist resolution
+
+Reviewed against PennyLane 0.45.1, both installed and
+[latest stable](https://api.github.com/repos/PennyLaneAI/pennylane/releases/latest)
+at the review date. All four specialist findings are addressed:
+
+1. **Named-wire deferral:** map used wires to contiguous indices, defer using
+   PennyLane's existing transform, then restore device labels. This supports
+   reset and feedback with named/nonconsecutive wires and rejects insufficient
+   spare-wire capacity. Real DDSIM tests cover both spare-last and spare-middle
+   device wires.
+2. **Graph decomposition:** derive `target_gates` from the converter's existing
+   format-specific supported operation names. QASM2 and QASM3 regressions verify
+   the resulting operation matrix and serialization. Placement checks remain
+   authoritative; graph support does not imply routing or hardware costs. See
+   the [plugin guide](https://docs.pennylane.ai/en/stable/development/plugins.html#custom-device-decompositions).
+3. **Shot API:** remove device-level shots, the implicit 1024-shot default, and
+   the private `_shots` assignment. QNodes and tapes must specify finite shots;
+   `qp.set_shots` can override a QNode's budget. Omission fails before submission.
+   Examples and tests use the modern APIs. See
+   [deprecations](https://docs.pennylane.ai/en/stable/development/deprecations.html).
+4. **Tracking:** use standard `Tracker.update/record` for batches, tape counts,
+   accepted jobs, and shots. Shot-vector copies count individually; jobs that
+   subsequently fail remain counted. See
+   [Tracker](https://docs.pennylane.ai/en/stable/code/api/pennylane.Tracker.html).
+
+The independent #2226 extraction declares deferred-only PennyLane capabilities,
+so explicit one-shot/tree-traversal requests fail instead of silently changing
+methods. Qiskit nested-operation validation also needs no new QDMI API. Exact
+payload descriptors, feature inference, native one-shot execution, and opaque
+result decoding remain in #2226. Native batching remains with #2364/#2373.
+
+## Final validation
+
+- `uv run --no-sync pytest -n0 test/python/qdmi test/python/plugins`: 500 passed.
+- Full repository lint passes, including Ruff and ty.
+- The unchanged native fix passes 104 driver tests and the warning-provider
+  binding probe for both job entry points.
+- `uvx nox -s cpp-lint -- e90db8be2` completed the full configured build and
+  checked six C++ files with zero findings. The older base selects both changed
+  driver files through the preceding PR's diff; lint inspects current contents
+  with `--lines-changed-only=false`.
+- The two previously failing MLIR binaries pass 500 QCO IR and 47 target-synthesis
+  tests. Running formatting hooks alongside the build likely exposed partially
+  rewritten headers; sequential checks pass without unrelated source changes.
+- No hosted CI, Windows, or real hardware execution was performed.
+
+See [the v4 decision record](../plans/qdmi-v4-plugin-validation.md).

--- a/.agent/plans/qdmi-v4-plugin-validation.md
+++ b/.agent/plans/qdmi-v4-plugin-validation.md
@@ -4,28 +4,30 @@ Status: complete.
 
 ## Scope and ownership
 
-The warning-job ownership and PennyLane conversion fixes are retained.
-Both SDK plugins now validate supported behavior using released QDMI APIs:
+The warning-job ownership and PennyLane conversion fixes are retained. Both SDK
+plugins now validate supported behavior using released QDMI APIs:
 
 - PennyLane: named-wire deferred measurements, graph decomposition target gates,
   standard tracking, modern shot examples, and explicit deferred-only MCM
   capabilities. QNodes or tapes must specify shots; device-level shots and the
   implicit 1024-shot default are removed.
-- Qiskit: native width and placement validation in the built-in QASM serializers,
-  after preprocessing; validate nested operations when a backend extension
-  explicitly enables control flow. Custom serializers retain compilation control.
+- Qiskit: native width and placement validation in the built-in QASM
+  serializers, after preprocessing; validate nested operations when a backend
+  extension explicitly enables control flow. Custom serializers retain
+  compilation control.
 
 The native operation metadata owns placement support. The public Qiskit Target
-may hide native sites or expose fictional pairs, so it cannot validate the output
-of preprocessing. Reuse the backend's existing native placement decoder and cache
-normalized metadata for its fixed device session. Do not change the previously
-reviewed variable-arity or alias Target construction behavior.
+may hide native sites or expose fictional pairs, so it cannot validate the
+output of preprocessing. Reuse the backend's existing native placement decoder
+and cache normalized metadata for its fixed device session. Do not change the
+previously reviewed variable-arity or alias Target construction behavior.
 
-PR #2226 at `29d17ced47b8c5cd33d8d19c39c662bf82708d68` supplies useful independent
-execution-configuration and nested-validation patterns. Exact payload descriptors,
-optional feature inference, native one-shot execution, and opaque result decoding
-remain dependent on the proposed QDMI contract. Retain the existing serializer
-registry and current result APIs. Native batching remains separate.
+PR #2226 at `29d17ced47b8c5cd33d8d19c39c662bf82708d68` supplies useful
+independent execution-configuration and nested-validation patterns. Exact
+payload descriptors, optional feature inference, native one-shot execution, and
+opaque result decoding remain dependent on the proposed QDMI contract. Retain
+the existing serializer registry and current result APIs. Native batching
+remains separate.
 
 ## Validation and remaining limits
 
@@ -37,6 +39,6 @@ Full repository lint passes. The unchanged native fix passes 104 driver tests
 and full C++ lint; the configured C++ build and both affected MLIR binaries also
 pass. The final diff contains no QDMI dependency or generated-stub changes.
 
-No native one-shot or new payload contract is inferred. The Qiskit Target changes
-excluded from this scope remain separate. Hosted CI and publication have not
-been performed.
+No native one-shot or new payload contract is inferred. The Qiskit Target
+changes excluded from this scope remain separate. Hosted CI and publication have
+not been performed.

--- a/.agent/plans/qdmi-v4-plugin-validation.md
+++ b/.agent/plans/qdmi-v4-plugin-validation.md
@@ -1,0 +1,42 @@
+# QDMI plugin validation for v4
+
+Status: complete.
+
+## Scope and ownership
+
+The warning-job ownership and PennyLane conversion fixes are retained.
+Both SDK plugins now validate supported behavior using released QDMI APIs:
+
+- PennyLane: named-wire deferred measurements, graph decomposition target gates,
+  standard tracking, modern shot examples, and explicit deferred-only MCM
+  capabilities. QNodes or tapes must specify shots; device-level shots and the
+  implicit 1024-shot default are removed.
+- Qiskit: native width and placement validation in the built-in QASM serializers,
+  after preprocessing; validate nested operations when a backend extension
+  explicitly enables control flow. Custom serializers retain compilation control.
+
+The native operation metadata owns placement support. The public Qiskit Target
+may hide native sites or expose fictional pairs, so it cannot validate the output
+of preprocessing. Reuse the backend's existing native placement decoder and cache
+normalized metadata for its fixed device session. Do not change the previously
+reviewed variable-arity or alias Target construction behavior.
+
+PR #2226 at `29d17ced47b8c5cd33d8d19c39c662bf82708d68` supplies useful independent
+execution-configuration and nested-validation patterns. Exact payload descriptors,
+optional feature inference, native one-shot execution, and opaque result decoding
+remain dependent on the proposed QDMI contract. Retain the existing serializer
+registry and current result APIs. Native batching remains separate.
+
+## Validation and remaining limits
+
+`uv run --no-sync pytest -n0 test/python/qdmi test/python/plugins` passes all
+500 tests. Regressions cover QASM2/QASM3 placements, whole-batch rejection,
+preprocessing to hidden sites, mapped control-flow operands, named-wire reset
+and feedback, graph decomposition, explicit shots, and tracking through failure.
+Full repository lint passes. The unchanged native fix passes 104 driver tests
+and full C++ lint; the configured C++ build and both affected MLIR binaries also
+pass. The final diff contains no QDMI dependency or generated-stub changes.
+
+No native one-shot or new payload contract is inferred. The Qiskit Target changes
+excluded from this scope remain separate. Hosted CI and publication have not
+been performed.

--- a/docs/qdmi/pennylane_device.md
+++ b/docs/qdmi/pennylane_device.md
@@ -36,10 +36,10 @@ conversion, execution, and finite-shot result reconstruction.
 ```{code-cell} ipython3
 import pennylane as qp
 
-bell_device = qp.device("mqt.ddsim.default", wires=2, shots=1000)
+bell_device = qp.device("mqt.ddsim.default", wires=2)
 
 
-@qp.qnode(bell_device)
+@qp.qnode(bell_device, shots=1000)
 def bell_state():
     qp.Hadamard(0)
     qp.CNOT(wires=[0, 1])
@@ -152,16 +152,16 @@ def ansatz(parameters):
     qp.qaoa.mixer_layer(parameters[1], mixer_hamiltonian)
 
 
-qaoa_device = qp.device("mqt.ddsim.default", wires=4, shots=1000)
+qaoa_device = qp.device("mqt.ddsim.default", wires=4)
 
 
-@qp.qnode(qaoa_device, diff_method="parameter-shift")
+@qp.qnode(qaoa_device, shots=1000, diff_method="parameter-shift")
 def cost(parameters):
     ansatz(parameters)
     return qp.expval(cost_hamiltonian)
 
 
-@qp.qnode(qaoa_device)
+@qp.qnode(qaoa_device, shots=1000)
 def sample(parameters):
     ansatz(parameters)
     return qp.sample(wires=range(4))
@@ -306,7 +306,6 @@ device_id = "stable ID returned by the QDMI device registration"
 device = QDMIDevice(
     device_id=device_id,
     wires=["a", "b", "c", "d"],
-    shots=[(100, 2), 500],
     session_parameters={
         "base_url": "device endpoint or selector",
         "token": "...",
@@ -327,16 +326,30 @@ from mqt.core.qdmi import slurm
 
 device = QDMIDevice(
     device=slurm.open_device_from_license(),
-    shots=1000,
 )
 ```
 
 Arbitrary PennyLane wire labels map deterministically to contiguous QASM
-indices. The converter validates the one- and two-qubit loci advertised through
-QDMI but does not route circuits. A topology-incompatible program therefore
-fails before submission. Shot vectors, batches, and parameter-shift tapes are
-submitted in order before their results are collected in the same order. The
-PennyLane call remains synchronous, and every execution requires finite shots.
+indices. The converter validates fixed-arity loci and finite parameters for both
+OpenQASM formats against the QDMI capabilities but does not route circuits. A
+topology-incompatible program therefore fails before submission. Shot vectors,
+batches, and parameter-shift tapes are submitted in order before their results
+are collected in the same order. The PennyLane call remains synchronous, and
+every execution requires finite shots. Set shots on the QNode or use
+`qp.set_shots` to override them. Devices do not accept a `shots` argument or
+provide a default shot count. Omitting finite shots fails before submission.
+
+Use `with qp.Tracker(device) as tracker:` to record submitted jobs
+(`executions`), requested shots, batches, and the number of tapes in each batch
+(`batch_len`). Shot-vector copies count as separate jobs. Tracking records
+accepted submissions, including jobs whose execution subsequently fails.
+
+Mid-circuit measurements use PennyLane's deferred-measurement transform. Reset
+and feedback may require unused device wires; custom wire labels are supported.
+The plugin rejects programs requiring more wires than are available and rejects
+postselection. Explicit `one-shot` and `tree-traversal` requests are
+unsupported; the plugin does not infer native dynamic-circuit support from gate
+names.
 
 ## Supported gate-level scope
 
@@ -344,7 +357,11 @@ The OpenQASM 3 path covers identity and Pauli gates; H, S, T, SX and supported
 adjoints; RX, RY, RZ, and phase shift; controlled Pauli and phase gates;
 Toffoli, SWAP, and CSWAP; ISWAP, PSWAP, and ECR; and Ising XX, XY, YY, and ZZ
 rotations. PennyLane decomposes higher-level operations when their
-decompositions reach operations advertised by the QDMI device.
+decompositions reach operations advertised by the QDMI device. Enabling
+`qp.decomposition.enable_graph()` also lets PennyLane choose registered graph
+decompositions targeting those operations. The target set reflects the selected
+OpenQASM serializer and advertised operation names; it does not imply native
+hardware gates or provide routing.
 
 The interface does not implement pulse programming, device-specific non-gate
 properties, routing, analytic execution, or QDMI batch jobs.

--- a/docs/qdmi/qdmi_backend.md
+++ b/docs/qdmi/qdmi_backend.md
@@ -415,6 +415,17 @@ When you run a circuit, the backend:
 3. Submits the program to the QDMI device via `device.submit_job()`
 4. Returns a {py:class}`~mqt.core.plugins.qiskit.job.QDMIJob`
 
+The built-in OpenQASM serializers validate circuit width and ordered operation
+placements against native QDMI metadata after preprocessing. They reject an
+invalid circuit before any job in its batch is submitted. This check uses the
+native device sites because a backend extension may hide sites from its public
+Target or use preprocessing to address them. It does not route circuits.
+
+Control-flow instructions require explicit support in the backend's Target;
+their bodies are checked recursively using the enclosing circuit's qubits.
+Advertising OpenQASM 3 alone does not enable control flow. Custom serializers
+retain responsibility for validating the native programs they produce.
+
 ### Program Serializers
 
 A _program serializer_ turns one circuit into one program in one program format.

--- a/python/mqt/core/plugins/pennylane/converter.py
+++ b/python/mqt/core/plugins/pennylane/converter.py
@@ -195,10 +195,19 @@ class _ProgramConverter:
         self._device_wires = device_wires
         self._program_format = program_format
         self._advertised = {operation.name().lower(): operation for operation in device.operations()}
+        self.target_gates = (
+            {
+                name
+                for name, spec in _QASM3_OPERATIONS.items()
+                if any(alias in self._advertised for alias in spec.aliases)
+            }
+            if program_format == ProgramFormat.QASM3
+            else {name for name, spelling in _QASM2_OPERATIONS.items() if spelling in self._advertised}
+        )
         self._wire_map: Mapping[Hashable, int] = MappingProxyType({
             wire: index for index, wire in enumerate(device_wires)
         })
-        self._validated_loci: set[tuple[str, tuple[int, ...]]] = set()
+        self._operation_contracts: dict[tuple[str, int], tuple[int | None, int, frozenset[tuple[int, ...]] | None]] = {}
 
     def supports(self, operation: Operator) -> bool:
         """Return whether an operation can stop PennyLane decomposition.
@@ -210,10 +219,7 @@ class _ProgramConverter:
         Returns:
             Whether the device runs the operation without further decomposition.
         """
-        if self._program_format == ProgramFormat.QASM3:
-            return _resolve_qasm3_operation(operation, self._advertised) is not None
-        spelling = _QASM2_OPERATIONS.get(operation.name)
-        return spelling is not None and spelling in self._advertised
+        return operation.name in self.target_gates
 
     def convert(self, tape: QuantumScript) -> _ConvertedProgram:
         """Convert one preprocessed tape to the selected program format.
@@ -266,46 +272,98 @@ class _ProgramConverter:
         Raises:
             PennyLaneValidationError: If arity, parameters, or topology do not match.
         """
-        qdmi_wires = qdmi_operation.qubits_num()
+        key = (qdmi_operation.name(), spec.wires)
+        if key not in self._operation_contracts:
+            self._operation_contracts[key] = (
+                qdmi_operation.qubits_num(),
+                qdmi_operation.parameters_num(),
+                self._operation_sites(qdmi_operation, spec.wires),
+            )
+        qdmi_wires, qdmi_parameters, sites = self._operation_contracts[key]
         if qdmi_wires is not None and qdmi_wires != spec.wires:
             msg = (
                 f"QDMI operation '{qdmi_operation.name()}' advertises {qdmi_wires} wires, "
                 f"but '{operation.name}' requires {spec.wires}."
             )
             raise ValidationError(msg)
-        if qdmi_operation.parameters_num() != spec.parameters:
+        if qdmi_parameters != spec.parameters:
             msg = (
-                f"QDMI operation '{qdmi_operation.name()}' advertises "
-                f"{qdmi_operation.parameters_num()} parameters, but '{operation.name}' "
-                f"requires {spec.parameters}."
+                f"QDMI operation '{qdmi_operation.name()}' advertises {qdmi_parameters} parameters, "
+                f"but '{operation.name}' requires {spec.parameters}."
             )
             raise ValidationError(msg)
-
-        if spec.wires == 1:
-            sites = qdmi_operation.sites()
-            if sites is not None and indices[0] not in {site.index() for site in sites}:
-                msg = f"Operation '{operation.name}' is not advertised on device wire {indices[0]}."
-                raise ValidationError(msg)
-            return
-
-        if spec.wires != 2:
-            return
-
-        site_pairs = qdmi_operation.site_pairs()
-        if site_pairs is not None:
-            advertised_pairs = {(first.index(), second.index()) for first, second in site_pairs}
-            if indices not in advertised_pairs:
-                msg = f"Operation '{operation.name}' is not advertised on device wires {indices}."
-                raise ValidationError(msg)
-            return
-
-        coupling_map = self._device.coupling_map()
-        if coupling_map is None:
-            return
-        edges = {(first.index(), second.index()) for first, second in coupling_map}
-        if indices not in edges and tuple(reversed(indices)) not in edges:
-            msg = f"Device topology does not connect wires {indices} for operation '{operation.name}'."
+        if sites is not None and indices not in sites:
+            locus = f"wire {indices[0]}" if spec.wires == 1 else f"wires {indices}"
+            msg = f"Operation '{operation.name}' is not advertised on device {locus}."
             raise ValidationError(msg)
+
+    def _operation_sites(self, operation: QDMIDevice.Operation, arity: int) -> frozenset[tuple[int, ...]] | None:
+        """Read the operation's supported placements once per session.
+
+        Returns:
+            Ordered placements, or None when placements are unspecified.
+
+        Raises:
+            PennyLaneValidationError: If an explicit site tuple is incomplete.
+        """
+        if arity == 2:
+            pairs = operation.site_pairs()
+            if pairs is not None:
+                return frozenset((first.index(), second.index()) for first, second in pairs)
+            coupling_map = self._device.coupling_map()
+            if coupling_map is None:
+                return None
+            edges = {(first.index(), second.index()) for first, second in coupling_map}
+            return frozenset(edges | {(second, first) for first, second in edges})
+        sites = operation.sites()
+        if sites is None:
+            return None
+        if len(sites) % arity:
+            msg = f"QDMI operation '{operation.name()}' has an incomplete {arity}-wire site tuple."
+            raise ValidationError(msg)
+        indices = [site.index() for site in sites]
+        return frozenset(tuple(indices[i : i + arity]) for i in range(0, len(indices), arity))
+
+    def _prepare_operation(self, operation: Operator) -> tuple[str, tuple[int, ...], tuple[float, ...]]:
+        """Resolve and validate one bound operation for either serializer.
+
+        Returns:
+            The advertised spelling, device indices, and finite parameters.
+
+        Raises:
+            PennyLaneUnsupportedOperationError: If no supported spelling exists.
+            PennyLaneValidationError: If shape, parameters, wires, or placement are invalid.
+        """
+        if self._program_format == ProgramFormat.QASM3:
+            resolved = _resolve_qasm3_operation(operation, self._advertised)
+        else:
+            spelling = _QASM2_OPERATIONS.get(operation.name)
+            resolved = (
+                (
+                    spelling,
+                    _OperationSpec((spelling,), operation.num_wires or len(operation.wires), operation.num_params),
+                    self._advertised[spelling],
+                )
+                if spelling is not None and spelling in self._advertised
+                else None
+            )
+        if resolved is None:
+            msg = (
+                f"Operation '{operation.name}' has no supported OpenQASM "
+                f"{3 if self._program_format == ProgramFormat.QASM3 else 2} spelling "
+                f"on QDMI device '{self._device.name()}'."
+            )
+            raise UnsupportedOperationError(msg)
+        spelling, spec, qdmi_operation = resolved
+        _validate_operation_shape(operation, spec)
+        try:
+            indices = tuple(self._wire_map[wire] for wire in operation.wires)
+        except KeyError as exc:
+            msg = f"Operation '{operation.name}' uses wire {exc.args[0]!r}, which is not a device wire."
+            raise ValidationError(msg) from exc
+        parameters = tuple(_finite_parameter(parameter, operation.name) for parameter in operation.parameters)
+        self._validate_qdmi_contract(operation, spec, qdmi_operation, indices)
+        return spelling, indices, parameters
 
     def _convert_qasm3(self, tape: QuantumScript) -> _ConvertedProgram:
         """Emit a minimal capability-driven OpenQASM 3 program.
@@ -313,9 +371,6 @@ class _ProgramConverter:
         Returns:
             The converted QDMI program.
 
-        Raises:
-            PennyLaneUnsupportedOperationError: If no advertised spelling exists.
-            PennyLaneValidationError: If parameters, wires, or topology are invalid.
         """
         lines = [
             "OPENQASM 3.0;",
@@ -324,31 +379,9 @@ class _ProgramConverter:
         ]
 
         for operation in tape.operations:
-            resolved = _resolve_qasm3_operation(operation, self._advertised)
-            if resolved is None:
-                msg = (
-                    f"Operation '{operation.name}' has no supported OpenQASM 3 spelling "
-                    f"on QDMI device '{self._device.name()}'."
-                )
-                raise UnsupportedOperationError(msg)
-            spelling, spec, qdmi_operation = resolved
-            _validate_operation_shape(operation, spec)
-            try:
-                indices = tuple(self._wire_map[wire] for wire in operation.wires)
-            except KeyError as exc:
-                msg = f"Operation '{operation.name}' uses wire {exc.args[0]!r}, which is not a device wire."
-                raise ValidationError(msg) from exc
-            # Capabilities are fixed for this converter's device session. Only
-            # cache successful metadata checks; validate each gate's inputs above.
-            locus = (operation.name, indices)
-            if locus not in self._validated_loci:
-                self._validate_qdmi_contract(operation, spec, qdmi_operation, indices)
-                self._validated_loci.add(locus)
-
+            spelling, indices, values = self._prepare_operation(operation)
             # repr gives the shortest literal that reads back as the same double.
-            parameters = ",".join(
-                repr(_finite_parameter(parameter, operation.name)) for parameter in operation.parameters
-            )
+            parameters = ",".join(map(repr, values))
             parameter_list = f"({parameters})" if parameters else ""
             operands = ",".join(f"q[{index}]" for index in indices)
             lines.append(f"{spelling}{parameter_list} {operands};")
@@ -363,19 +396,10 @@ class _ProgramConverter:
             The converted QDMI program.
 
         Raises:
-            PennyLaneUnsupportedOperationError: If the serializer/device intersection is empty.
             PennyLaneTranslationError: If PennyLane cannot serialize the program.
         """
-        # PennyLane's serializer emits whatever it knows, so the intersection
-        # with the advertised gate set has to be checked before serializing.
         for operation in tape.operations:
-            spelling = _QASM2_OPERATIONS.get(operation.name)
-            if spelling is None or spelling not in self._advertised:
-                msg = (
-                    f"Operation '{operation.name}' cannot be serialized to an "
-                    f"OpenQASM 2 gate advertised by QDMI device '{self._device.name()}'."
-                )
-                raise UnsupportedOperationError(msg)
+            self._prepare_operation(operation)
 
         try:
             payload = qp.to_openqasm(

--- a/python/mqt/core/plugins/pennylane/device.py
+++ b/python/mqt/core/plugins/pennylane/device.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pennylane as qp
-from pennylane.devices import Device, ExecutionConfig
+from pennylane.devices import Device, DeviceCapabilities, ExecutionConfig
 from pennylane.devices.preprocess import (
     decompose,
     measurements_from_samples,
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
 
     from pennylane.tape import QuantumScript, QuantumScriptOrBatch
     from pennylane.typing import Result, ResultBatch
+    from pennylane.wires import Wires
 
     from mqt.core.typing import QDMIJobParameters, QDMISessionParameters
 
@@ -107,6 +108,29 @@ def _validate_finite_shots(tape: QuantumScript) -> tuple[tuple[QuantumScript], A
     return (tape,), operator.itemgetter(0)
 
 
+@qp.transform
+def _defer_on_device_wires(tape: QuantumScript, wires: Wires) -> tuple[tuple[QuantumScript], Any]:
+    """Defer measurements using unused device wires, including custom labels.
+
+    Returns:
+        The transformed tape and PennyLane's result postprocessor.
+
+    Raises:
+        PennyLaneValidationError: If deferral requires more wires than the device exposes.
+    """
+    if not any(isinstance(operation, qp.ops.MidMeasure) for operation in tape.operations):
+        return (tape,), operator.itemgetter(0)
+    ordered_wires = [*tape.wires, *(wire for wire in wires if wire not in tape.wires)]
+    wire_map = {wire: index for index, wire in enumerate(ordered_wires)}
+    (mapped,), _ = qp.map_wires(tape, wire_map)
+    (deferred,), postprocess = defer_measurements(mapped, allow_postselect=False)
+    if any(wire >= len(wires) for wire in deferred.wires):
+        msg = "Deferred measurements require more wires than the QDMI device exposes."
+        raise ValidationError(msg)
+    (restored,), _ = qp.map_wires(deferred, dict(enumerate(ordered_wires)))
+    return (restored,), postprocess
+
+
 class QDMIDevice(Device):
     """Execute PennyLane programs on a gate-based QDMI device.
 
@@ -115,18 +139,18 @@ class QDMIDevice(Device):
             argument or ``device``.
         wires: PennyLane wire labels or number of wires. By default all QDMI
             qubits are exposed as consecutive integer wires.
-        shots: Finite default shot configuration.
         device: An already-open QDMI device. Use this for a session selected by
             an integration such as Slurm.
         session_parameters: QDMI device-session keyword arguments.
         job_parameters: QDMI custom job keyword arguments.
     """
 
+    capabilities = DeviceCapabilities(supported_mcm_methods=[])
+
     def __init__(
         self,
         device_id: str | None = None,
         wires: int | Sequence[Hashable] | None = None,
-        shots: int | Sequence[int | tuple[int, int]] | Shots | None = 1024,
         *,
         device: QDMIDeviceHandle | None = None,
         session_parameters: QDMISessionParameters | None = None,
@@ -173,12 +197,7 @@ class QDMIDevice(Device):
             )
             raise ConfigurationError(msg)
 
-        # PennyLane deprecates passing device-level shots to Device.__init__,
-        # but still reads Device.shots as the default. Set the validated value
-        # after initializing the base class to preserve the finite default
-        # without emitting a deprecation warning for every plugin instance.
-        super().__init__(wires=resolved_wires, shots=None)
-        self._shots = Shots(shots)
+        super().__init__(wires=resolved_wires)
         self._program_format = self._select_program_format()
         self._converter = _ProgramConverter(self._qdmi_device, self.wires, self._program_format)
         self._submitted_jobs = 0
@@ -230,8 +249,8 @@ class QDMIDevice(Device):
         del execution_config
         pipeline = CompilePipeline()
         pipeline.add_transform(_validate_finite_shots)
-        pipeline.add_transform(defer_measurements, allow_postselect=False, num_wires=len(self.wires))
         pipeline.add_transform(validate_device_wires, self.wires, name=self.name)
+        pipeline.add_transform(_defer_on_device_wires, self.wires)
         pipeline.add_transform(
             validate_measurements,
             analytic_measurements=lambda _measurement: False,
@@ -243,7 +262,7 @@ class QDMIDevice(Device):
         pipeline.add_transform(
             decompose,
             stopping_condition=self._converter.supports,
-            stopping_condition_shots=self._converter.supports,
+            target_gates=self._converter.target_gates,
             skip_initial_state_prep=False,
             device_wires=self.wires,
             name=self.name,
@@ -387,13 +406,21 @@ class QDMIDevice(Device):
         if not prepared:
             return cast("ResultBatch", ())
 
+        if self.tracker.active:
+            self.tracker.update(batches=1, batch_len=len(tapes))
+            self.tracker.record()
+
         submitted: list[tuple[int, _ConvertedProgram, int, QDMIJobHandle]] = []
+        tape_results: list[list[np.ndarray]] = [[] for _ in tapes]
         started = monotonic()
         try:
             for index, (converted, shot_copies) in enumerate(prepared):
-                submitted.extend((index, converted, shots, self._submit(converted, shots)) for shots in shot_copies)
+                for shots in shot_copies:
+                    submitted.append((index, converted, shots, self._submit(converted, shots)))
+                    if self.tracker.active:
+                        self.tracker.update(executions=1, shots=shots)
+                        self.tracker.record()
 
-            tape_results: list[list[np.ndarray]] = [[] for _ in tapes]
             for index, converted, shots, job in submitted:
                 tape_results[index].append(self._result(job, converted, shots))
         except BaseException:
@@ -419,7 +446,6 @@ class DDSIMDevice(QDMIDevice):
     def __init__(
         self,
         wires: int | Sequence[Hashable] | None = None,
-        shots: int | Sequence[int | tuple[int, int]] | Shots | None = 1024,
         *,
         session_parameters: QDMISessionParameters | None = None,
         job_parameters: QDMIJobParameters | None = None,
@@ -428,7 +454,6 @@ class DDSIMDevice(QDMIDevice):
         super().__init__(
             "mqt.ddsim.default",
             wires=wires,
-            shots=shots,
             session_parameters=session_parameters,
             job_parameters=job_parameters,
         )

--- a/python/mqt/core/plugins/qiskit/backend.py
+++ b/python/mqt/core/plugins/qiskit/backend.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 
 import inspect
 import warnings
+from functools import cached_property
 from math import isfinite
 from numbers import Integral
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from qiskit import qasm2, qasm3
-from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import ControlFlowOp, QuantumCircuit
 from qiskit.circuit.library import (
     MCPhaseGate,
     MCXGate,
@@ -123,6 +124,7 @@ def _serialize_to_qasm3(circuit: QuantumCircuit, backend: QDMIBackend) -> str:
     Returns:
         The OpenQASM 3 program.
     """
+    backend._validate_circuit(circuit, native=True)  # ruff: ignore[private-member-access] Built-in serializer.
     # Qiskit classical bits start at zero, while OpenQASM 3 bits are
     # uninitialized. Preserve Qiskit's semantics and make every output valid
     # even when the circuit measures only part of a register.
@@ -188,17 +190,17 @@ def _serialize_to_qasm3(circuit: QuantumCircuit, backend: QDMIBackend) -> str:
     return qasm3.dumps(circuit, basis_gates=basis_gates)
 
 
-def _serialize_to_qasm2(circuit: QuantumCircuit, backend: QDMIBackend) -> str:  # ruff:ignore[unused-function-argument]
+def _serialize_to_qasm2(circuit: QuantumCircuit, backend: QDMIBackend) -> str:
     """Serialize a circuit into an OpenQASM 2 program.
 
     Args:
         circuit: The circuit to serialize.
-        backend: The backend that runs the circuit. Qiskit's OpenQASM 2 exporter
-            takes no information from it.
+        backend: The backend whose native placements constrain the circuit.
 
     Returns:
         The OpenQASM 2 program.
     """
+    backend._validate_circuit(circuit, native=True)  # ruff: ignore[private-member-access] Built-in serializer.
     return qasm2.dumps(circuit)
 
 
@@ -621,6 +623,59 @@ class QDMIBackend(BackendV2):
             raise UnsupportedOperationError(msg)
         return [None]
 
+    @cached_property
+    def _native_operation_loci(self) -> dict[str, tuple[int | None, frozenset[tuple[int, ...] | None]]]:
+        """Normalize native placements once for the opened device session.
+
+        Returns:
+            Native arity and placements by QDMI operation name.
+        """
+        return {
+            operation.name().lower(): (operation.qubits_num(), frozenset(self._get_operation_qargs(operation)))
+            for operation in self._device.operations()
+        }
+
+    def _validate_circuit(self, circuit: QuantumCircuit, *, native: bool = False) -> None:
+        """Check supported operations, including operations inside control flow.
+
+        Built-in QASM serializers also check native width and placements after
+        preprocessing. Custom serializers can perform further compilation and
+        therefore retain responsibility for validating their output placements.
+
+        Raises:
+            CircuitValidationError: If the circuit exceeds the native device width.
+            UnsupportedOperationError: If an operation or placement is unsupported.
+        """
+        if native and circuit.num_qubits > self._device.qubits_num():
+            msg = f"Circuit has {circuit.num_qubits} qubits, but the native device has {self._device.qubits_num()}."
+            raise CircuitValidationError(msg)
+        device_ops = {operation.name().lower() for operation in self._device.operations()}
+
+        pending = [(circuit, tuple(range(circuit.num_qubits)))]
+        while pending:
+            block, indices = pending.pop()
+            for instruction in block.data:
+                operation = instruction.operation
+                qargs = tuple(indices[block.find_bit(bit).index] for bit in instruction.qubits)
+                if isinstance(operation, ControlFlowOp):
+                    if operation.name not in self._target.operation_names:
+                        msg = f"Unsupported control flow operation: '{operation.name}'"
+                        raise UnsupportedOperationError(msg)
+                    pending.extend((body, qargs) for body in reversed(operation.blocks))
+                    continue
+                if operation.name == "barrier":
+                    continue
+                names = self._map_qiskit_gate_to_operation_names(operation.name) & device_ops
+                if not names:
+                    msg = f"Unsupported operation: '{operation.name}'"
+                    raise UnsupportedOperationError(msg)
+                if native and not any(
+                    arity in {None, len(qargs)} and (None in loci or qargs in loci)
+                    for arity, loci in (self._native_operation_loci[name] for name in names)
+                ):
+                    msg = f"Operation '{operation.name}' is not advertised on native device qubits {qargs}."
+                    raise UnsupportedOperationError(msg)
+
     def _preprocess_circuit(self, circuit: QuantumCircuit) -> QuantumCircuit:  # ruff:ignore[no-self-use]
         """Rewrite a bound circuit before validation and conversion.
 
@@ -659,6 +714,7 @@ class QDMIBackend(BackendV2):
             text format and bytes for a binary format.
 
         Raises:
+            CircuitValidationError: If native circuit validation fails.
             UnsupportedFormatError: If the device reports no program format that
                 has a serializer.
             UnsupportedOperationError: If the circuit contains an operation the
@@ -676,7 +732,7 @@ class QDMIBackend(BackendV2):
                 continue
             try:
                 program = serializer(circuit, self)
-            except UnsupportedOperationError:
+            except (CircuitValidationError, UnsupportedOperationError):
                 # A circuit the chosen format cannot express must fail loudly
                 # rather than arrive at the device in a weaker format.
                 raise
@@ -733,7 +789,7 @@ class QDMIBackend(BackendV2):
             >>> qc2.ry(theta, 0)
             >>> qc2.measure_all()
             >>> job = backend.run([qc1, qc2], parameter_values=[{theta: 0.5}, {theta: 1.5}])
-        """
+        """  # ruff:ignore[docstring-extraneous-exception] The validation helper raises operation errors.
         # Normalize input to a list of circuits
         circuits = [run_input] if isinstance(run_input, QuantumCircuit) else run_input
 
@@ -770,8 +826,6 @@ class QDMIBackend(BackendV2):
             msg = f"Invalid 'memory' value: {memory!r}"
             raise CircuitValidationError(msg)
 
-        # Build set of all supported QDMI operation names once
-        device_ops = {op.name().lower() for op in self._device.operations()}
         supported_formats = self._device.supported_program_formats()
 
         # Process each circuit
@@ -803,16 +857,7 @@ class QDMIBackend(BackendV2):
                 msg = "Classical registers must partition circuit.clbits in register order."
                 raise CircuitValidationError(msg)
 
-            # Validate operations are supported
-            for instruction in bound_circuit.data:
-                op_name = instruction.operation.name
-                # Map the Qiskit gate name to possible QDMI operation names and check if any match
-                possible_qdmi_names = self._map_qiskit_gate_to_operation_names(op_name)
-                # Check if any of the possible QDMI names are supported by the device
-                # Also always allow 'barrier' as it's a directive, not an operation
-                if op_name != "barrier" and not any(qdmi_name in device_ops for qdmi_name in possible_qdmi_names):
-                    msg = f"Unsupported operation: '{op_name}'"
-                    raise UnsupportedOperationError(msg)
+            self._validate_circuit(bound_circuit)
 
             # Serialize the circuit into a program format the device accepts
             serialized_circuits.append(self._serialize_circuit(bound_circuit, supported_formats))

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -326,11 +326,15 @@ auto QDMI_Device_impl_d::createJob(QDMI_Job* job) -> int {
   if (job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
+  *job = nullptr;
   QDMI_Device_Job deviceJob = nullptr;
   auto const result =
       library_->device_session_create_device_job(deviceSession_, &deviceJob);
-  if (result != QDMI_SUCCESS) {
+  if (result != QDMI_SUCCESS && result != QDMI_WARN_GENERAL) {
     return result;
+  }
+  if (deviceJob == nullptr) {
+    return QDMI_ERROR_FATAL;
   }
   auto uniqueJob = std::make_unique<QDMI_Job_impl_d>(deviceJob, this);
   auto* const jobHandle = uniqueJob.get();
@@ -339,7 +343,7 @@ auto QDMI_Device_impl_d::createJob(QDMI_Job* job) -> int {
     jobs_.emplace(jobHandle, std::move(uniqueJob));
   }
   *job = jobHandle;
-  return QDMI_SUCCESS;
+  return result;
 }
 
 auto QDMI_Device_impl_d::retrieveJobById(const char* const jobId,
@@ -350,11 +354,15 @@ auto QDMI_Device_impl_d::retrieveJobById(const char* const jobId,
   if (library_->device_session_retrieve_device_job_by_id == nullptr) {
     return QDMI_ERROR_NOTSUPPORTED;
   }
+  *job = nullptr;
   QDMI_Device_Job deviceJob = nullptr;
   const auto result = library_->device_session_retrieve_device_job_by_id(
       deviceSession_, jobId, &deviceJob);
-  if (result != QDMI_SUCCESS) {
+  if (result != QDMI_SUCCESS && result != QDMI_WARN_GENERAL) {
     return result;
+  }
+  if (deviceJob == nullptr) {
+    return QDMI_ERROR_FATAL;
   }
   auto uniqueJob = std::make_unique<QDMI_Job_impl_d>(deviceJob, this);
   auto* const jobHandle = uniqueJob.get();
@@ -363,7 +371,7 @@ auto QDMI_Device_impl_d::retrieveJobById(const char* const jobId,
     jobs_.emplace(jobHandle, std::move(uniqueJob));
   }
   *job = jobHandle;
-  return QDMI_SUCCESS;
+  return result;
 }
 
 auto QDMI_Device_impl_d::freeJob(QDMI_Job job) -> void {

--- a/test/python/plugins/qdmi_pennylane/test_converter.py
+++ b/test/python/plugins/qdmi_pennylane/test_converter.py
@@ -47,9 +47,9 @@ def test_qasm3_prefers_and_resolves_braket_spellings(monkeypatch: pytest.MonkeyP
         result_factory=lambda _program, shots: ["10"] * shots,
     )
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=["left", "right"], shots=10)
+    device = QDMIDevice("fake.qdmi", wires=["left", "right"])
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=10)
     def circuit():
         qp.Hadamard("left")
         qp.CNOT(wires=["left", "right"])
@@ -97,9 +97,9 @@ def test_qasm3_resolves_ddsim_aliases_and_inverse_gates(monkeypatch: pytest.Monk
         [ProgramFormat.QASM3],
     )
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=5)
+    device = QDMIDevice("fake.qdmi", wires=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=5)
     def circuit():
         qp.CNOT(wires=[0, 1])
         qp.PhaseShift(-0.125, wires=1)
@@ -132,7 +132,7 @@ def test_qasm3_failure_does_not_fall_back_to_qasm2(monkeypatch: pytest.MonkeyPat
     # OpenQASM 3 operation table has no U3 row, so the QASM3 path must fail.
     qdmi = StubDevice([operation("u3", 1, 3)], [ProgramFormat.QASM3, ProgramFormat.QASM2])
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=1, shots=4)
+    device = QDMIDevice("fake.qdmi", wires=1)
     tape = qp.tape.QuantumScript([qp.U3(0.1, 0.2, 0.3, wires=0)], [qp.sample(wires=0)], shots=4)
     qasm2_called = False
 
@@ -143,7 +143,7 @@ def test_qasm3_failure_does_not_fall_back_to_qasm2(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(qp, "to_openqasm", fail_if_called)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=4)
     def circuit():
         qp.U3(0.1, 0.2, 0.3, wires=0)
         return qp.sample(wires=0)
@@ -165,9 +165,9 @@ def test_qasm2_fallback_uses_pennylane_serializer(monkeypatch: pytest.MonkeyPatc
         [ProgramFormat.QASM2],
     )
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=10)
+    device = QDMIDevice("fake.qdmi", wires=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=10)
     def circuit():
         qp.Hadamard(0)
         qp.CNOT(wires=[0, 1])
@@ -195,10 +195,10 @@ def test_qasm2_rejects_non_intersection_operation(monkeypatch: pytest.MonkeyPatc
     """Reject an operation the serializer knows when the QDMI device does not."""
     qdmi = StubDevice([operation("h", 1)], [ProgramFormat.QASM2])
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=2)
     tape = qp.tape.QuantumScript([qp.CNOT(wires=[0, 1])], [qp.sample(wires=[0, 1])], shots=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=2)
     def circuit():
         qp.CNOT(wires=[0, 1])
         return qp.sample(wires=[0, 1])
@@ -217,7 +217,7 @@ def test_qasm2_wraps_serializer_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """Expose serializer failures as focused translation errors."""
     qdmi = StubDevice([operation("h", 1)], [ProgramFormat.QASM2])
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=1, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=1)
 
     def fail(*_args: object, **_kwargs: object) -> str:
         msg = "serializer failed"
@@ -225,7 +225,7 @@ def test_qasm2_wraps_serializer_errors(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(qp, "to_openqasm", fail)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=2)
     def circuit():
         qp.Hadamard(0)
         return qp.sample(wires=0)
@@ -235,13 +235,16 @@ def test_qasm2_wraps_serializer_errors(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.parametrize("parameter", [np.nan, np.inf, -np.inf])
-def test_rejects_non_finite_parameters(monkeypatch: pytest.MonkeyPatch, parameter: float) -> None:
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_rejects_non_finite_parameters(
+    monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat, parameter: float
+) -> None:
     """Reject non-finite bound parameters before submission."""
-    qdmi = StubDevice([operation("rx", 1, 1)], [ProgramFormat.QASM3])
+    qdmi = StubDevice([operation("rx", 1, 1)], [program_format])
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=1, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=1)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=2)
     def circuit():
         qp.RX(parameter, 0)
         return qp.sample(wires=0)
@@ -251,17 +254,18 @@ def test_rejects_non_finite_parameters(monkeypatch: pytest.MonkeyPatch, paramete
     assert not qdmi.submissions
 
 
-def test_validates_operation_topology(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_validates_operation_topology(monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat) -> None:
     """Honor operation-specific QDMI site pairs."""
     qdmi = StubDevice(
         [operation("cx", 2, site_pairs=[(0, 1)])],
-        [ProgramFormat.QASM3],
+        [program_format],
         qubits=3,
     )
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=3, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=3)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=2)
     def circuit():
         qp.CNOT(wires=[1, 0])
         return qp.sample(wires=[0, 1])
@@ -271,12 +275,15 @@ def test_validates_operation_topology(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not qdmi.submissions
 
 
-def test_reuses_session_contract_checks_without_skipping_input_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_reuses_session_contract_checks_without_skipping_input_validation(
+    monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat
+) -> None:
     """Reuse valid gate locations across tapes, not inputs or other sessions."""
     rx = operation("rx", 1, 1, sites=[0])
-    qdmi = StubDevice([rx], [ProgramFormat.QASM3])
+    qdmi = StubDevice([rx], [program_format])
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=2)
     query_sites = Mock(wraps=rx.sites)
     monkeypatch.setattr(rx, "sites", query_sites)
 
@@ -294,17 +301,20 @@ def test_reuses_session_contract_checks_without_skipping_input_validation(monkey
     assert len(qdmi.submissions) == 3
 
     query_sites.reset_mock()
-    QDMIDevice("fake.qdmi", wires=2, shots=2).execute(tape(0.5))
+    QDMIDevice("fake.qdmi", wires=2).execute(tape(0.5))
     query_sites.assert_called_once()
 
 
-def test_rejects_operation_on_an_unadvertised_site(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_rejects_operation_on_an_unadvertised_site(
+    monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat
+) -> None:
     """Honor the single-qubit sites a QDMI operation advertises."""
-    qdmi = StubDevice([operation("h", 1, sites=[0])], [ProgramFormat.QASM3])
+    qdmi = StubDevice([operation("h", 1, sites=[0])], [program_format])
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=2)
     def circuit():
         qp.Hadamard(0)
         qp.Hadamard(1)
@@ -315,24 +325,25 @@ def test_rejects_operation_on_an_unadvertised_site(monkeypatch: pytest.MonkeyPat
     assert not qdmi.submissions
 
 
-def test_falls_back_to_the_device_coupling_map(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_falls_back_to_the_device_coupling_map(monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat) -> None:
     """Use the device topology when an operation advertises no site pairs."""
     qdmi = StubDevice(
         [operation("h", 1), operation("cx", 2)],
-        [ProgramFormat.QASM3],
+        [program_format],
         qubits=3,
         coupling_map=[(0, 1)],
         result_factory=lambda _program, shots: ["000"] * shots,
     )
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=3, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=3)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=2)
     def connected():
         qp.CNOT(wires=[1, 0])
         return qp.sample(wires=[0, 1])
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=2)
     def disconnected():
         qp.CNOT(wires=[0, 2])
         return qp.sample(wires=[0, 2])
@@ -340,23 +351,26 @@ def test_falls_back_to_the_device_coupling_map(monkeypatch: pytest.MonkeyPatch) 
     # The coupling map is undirected, so the reversed edge is connected too.
     connected()
     assert len(qdmi.submissions) == 1
-    with pytest.raises(PennyLaneValidationError, match=r"does not connect wires \(0, 2\)"):
+    with pytest.raises(PennyLaneValidationError, match=r"not advertised on device wires \(0, 2\)"):
         disconnected()
     assert len(qdmi.submissions) == 1
 
 
-def test_accepts_advertised_site_pairs_and_wider_operations(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Accept an advertised site pair, and skip loci checks above two wires."""
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_accepts_advertised_site_pairs_and_wider_operations(
+    monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat
+) -> None:
+    """Accept advertised pairs and three-qubit placements."""
     qdmi = StubDevice(
-        [operation("h", 1), operation("cx", 2, site_pairs=[(0, 1)]), operation("ccx", 3)],
-        [ProgramFormat.QASM3],
+        [operation("h", 1), operation("cx", 2, site_pairs=[(0, 1)]), operation("ccx", 3, sites=[0, 1, 2])],
+        [program_format],
         qubits=3,
         result_factory=lambda _program, shots: ["000"] * shots,
     )
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=3, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=3)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=2)
     def circuit():
         qp.CNOT(wires=[0, 1])
         qp.Toffoli(wires=[0, 1, 2])
@@ -376,15 +390,16 @@ def test_accepts_advertised_site_pairs_and_wider_operations(monkeypatch: pytest.
         (operation("rx", 1, 0), "advertises 0 parameters"),
     ],
 )
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
 def test_rejects_contradictory_qdmi_metadata(
-    monkeypatch: pytest.MonkeyPatch, advertised: object, expected: str
+    monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat, advertised: object, expected: str
 ) -> None:
     """Reject a QDMI operation whose arity contradicts the operation table."""
-    qdmi = StubDevice([advertised], [ProgramFormat.QASM3])  # ty: ignore[invalid-argument-type]
+    qdmi = StubDevice([advertised], [program_format])  # ty: ignore[invalid-argument-type]
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=1, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=1)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=2)
     def circuit():
         qp.RX(0.5, 0)
         return qp.sample(wires=0)
@@ -402,9 +417,9 @@ def test_measurement_without_wires_samples_every_device_wire(monkeypatch: pytest
         result_factory=lambda _program, shots: ["10"] * shots,
     )
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=4)
+    device = QDMIDevice("fake.qdmi", wires=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=4)
     def circuit():
         qp.PauliX(1)
         return qp.sample()
@@ -423,7 +438,7 @@ def test_converts_an_unpreprocessed_tape(monkeypatch: pytest.MonkeyPatch) -> Non
         result_factory=lambda _program, shots: ["00"] * shots,
     )
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=2)
+    device = QDMIDevice("fake.qdmi", wires=2)
 
     # Preprocessing always names the measured wires. A tape that skips it may
     # carry no measurement, or one that names none; both sample every wire.
@@ -433,3 +448,62 @@ def test_converts_an_unpreprocessed_tape(monkeypatch: pytest.MonkeyPatch) -> Non
 
     with pytest.raises(PennyLaneValidationError, match="not a device wire"):
         device.execute(qp.tape.QuantumScript([qp.Hadamard(5)], [qp.sample(wires=0)], shots=2))
+
+
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+@pytest.mark.parametrize("sites", [[0, 1, 2], [0, 1]])
+def test_rejects_unsupported_or_incomplete_three_qubit_placements(
+    program_format: ProgramFormat,
+    sites: list[int],
+) -> None:
+    """Reject invalid fixed-arity metadata and placements before submitting."""
+    qdmi = StubDevice([operation("ccx", 3, sites=sites)], [program_format], qubits=4)
+    device = QDMIDevice(device=qdmi, wires=4)  # ty: ignore[invalid-argument-type] Device boundary double.
+
+    @qp.qnode(device, shots=2)
+    def circuit():
+        qp.Toffoli(wires=[1, 2, 3])
+        return qp.sample(wires=range(4))
+
+    with pytest.raises(PennyLaneValidationError, match=r"not advertised|incomplete"):
+        circuit()
+    assert not qdmi.submissions
+
+
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_reads_placement_metadata_once_for_distinct_loci(
+    monkeypatch: pytest.MonkeyPatch,
+    program_format: ProgramFormat,
+) -> None:
+    """Read the complete site set once, even when every gate uses a new locus."""
+    x = operation("x", 1, sites=list(range(8)))
+    query_sites = Mock(wraps=x.sites)
+    monkeypatch.setattr(x, "sites", query_sites)
+    qdmi = StubDevice([x], [program_format], qubits=8, result_factory=lambda _program, shots: ["0" * 8] * shots)
+    device = QDMIDevice(device=qdmi, wires=8)  # ty: ignore[invalid-argument-type] Device boundary double.
+    tape = qp.tape.QuantumScript([qp.PauliX(i) for i in range(8)], [qp.sample(wires=range(8))], shots=2)
+    device.execute(tape)
+    query_sites.assert_called_once()
+
+
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_graph_decomposition_targets_advertised_gates(
+    monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat
+) -> None:
+    """Use registered graph decompositions to reach the advertised serializer gates."""
+    qdmi = StubDevice([operation("h", 1), operation("cz", 2)], [program_format])
+    patch_open_device(monkeypatch, qdmi)
+    device = QDMIDevice("fake.qdmi", wires=2)
+    tape = qp.tape.QuantumScript([qp.CNOT(wires=[0, 1])], [qp.sample(wires=[0, 1])], shots=5)
+
+    with qp.decomposition.toggle_graph_ctx(new_state=True):
+        (decomposed,), _ = device.preprocess_transforms()((tape,))
+
+    assert qp.math.allclose(
+        qp.matrix(qp.prod(*reversed(decomposed.operations)), wire_order=[0, 1]),
+        qp.matrix(qp.CNOT([0, 1])),
+        atol=1e-14,
+    )
+    device.execute((decomposed,))
+    payload = qdmi.submissions[0][0]
+    assert "cz " in payload

--- a/test/python/plugins/qdmi_pennylane/test_ddsim.py
+++ b/test/python/plugins/qdmi_pennylane/test_ddsim.py
@@ -22,16 +22,16 @@ except ImportError:
 
 import networkx as nx
 
-from mqt.core.plugins.pennylane import DDSIMDevice
+from mqt.core.plugins.pennylane import DDSIMDevice, PennyLaneValidationError
 
 GRAPH_EDGES = ((0, 1), (0, 2), (1, 2), (2, 3))
 
 
 def test_stable_entry_point_and_wire_order() -> None:
     """Discover the stable device ID and map QDMI bit strings to PennyLane wires."""
-    device = qp.device("mqt.ddsim.default", wires=["first", "second"], shots=20)
+    device = qp.device("mqt.ddsim.default", wires=["first", "second"])
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=20)
     def circuit():
         qp.PauliX("first")
         return qp.counts(wires=["first", "second"])
@@ -43,9 +43,9 @@ def test_stable_entry_point_and_wire_order() -> None:
 
 def test_bell_results_and_shot_vector() -> None:
     """Execute probabilities, samples, and shot-vector partitions end to end."""
-    device = qp.device("mqt.ddsim.default", wires=2, shots=[(1000, 2), 2000])
+    device = qp.device("mqt.ddsim.default", wires=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=[(1000, 2), 2000])
     def circuit():
         qp.Hadamard(0)
         qp.CNOT(wires=[0, 1])
@@ -62,9 +62,9 @@ def test_bell_results_and_shot_vector() -> None:
 
 def test_parameter_shift_gradient() -> None:
     """Compute a finite sampled parameter-shift gradient through QDMI."""
-    device = qp.device("mqt.ddsim.default", wires=1, shots=10_000)
+    device = qp.device("mqt.ddsim.default", wires=1)
 
-    @qp.qnode(device, diff_method="parameter-shift")
+    @qp.qnode(device, shots=10_000, diff_method="parameter-shift")
     def circuit(angle: float):
         qp.RY(angle, 0)
         return qp.expval(qp.PauliZ(0))
@@ -96,7 +96,7 @@ def test_parameter_shift_gradient() -> None:
 )
 def test_gate_semantics_against_pennylane_reference(operations: list[qp.operation.Operator]) -> None:
     """Match phase, inverse, parameter, and wire-order semantics."""
-    qdmi_device = qp.device("mqt.ddsim.default", wires=2, shots=20_000)
+    qdmi_device = qp.device("mqt.ddsim.default", wires=2)
     reference_device = qp.device("default.qubit", wires=2)
     sampled_tape = qp.tape.QuantumScript(operations, [qp.probs(wires=[0, 1])], shots=20_000)
     analytic_tape = qp.tape.QuantumScript(operations, [qp.probs(wires=[0, 1])])
@@ -111,7 +111,7 @@ def test_qaoa_application() -> None:
     """Optimize one finite-shot MaxCut QAOA step through the real QDMI device."""
     graph = nx.Graph(GRAPH_EDGES)
     cost_hamiltonian, mixer_hamiltonian = qp.qaoa.maxcut(graph)
-    device = qp.device("mqt.ddsim.default", wires=4, shots=200)
+    device = qp.device("mqt.ddsim.default", wires=4)
 
     def ansatz(parameters: np.ndarray) -> None:
         for wire in graph.nodes:
@@ -119,12 +119,12 @@ def test_qaoa_application() -> None:
         qp.qaoa.cost_layer(parameters[0], cost_hamiltonian)
         qp.qaoa.mixer_layer(parameters[1], mixer_hamiltonian)
 
-    @qp.qnode(device, diff_method="parameter-shift")
+    @qp.qnode(device, shots=200, diff_method="parameter-shift")
     def cost(parameters: np.ndarray):
         ansatz(parameters)
         return qp.expval(cost_hamiltonian)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=200)
     def sample(parameters: np.ndarray):
         ansatz(parameters)
         return qp.sample(wires=range(4))
@@ -145,3 +145,33 @@ def test_qaoa_application() -> None:
     assert all(len(bitstring) == 4 and set(bitstring) <= {"0", "1"} for bitstring in bitstrings)
     assert all(0 <= cut <= len(GRAPH_EDGES) for cut in cuts)
     assert device.submitted_jobs > 1
+
+
+@pytest.mark.parametrize("wires", [["control", "spare", "target"], [7, 3, 9], [0, 1, 2]])
+def test_deferred_measurements_reuse_spare_device_wires(wires: list[str] | list[int]) -> None:
+    """Keep reset and feedback semantics when an unused wire is not last."""
+    device = qp.device("mqt.ddsim.default", wires=wires)
+    control, _, target = wires
+
+    @qp.qnode(device, shots=5)
+    def circuit():
+        qp.X(control)
+        measured = qp.measure(control, reset=True)
+        qp.cond(measured, qp.X)(target)
+        return qp.counts(wires=[target, control])
+
+    assert circuit() == {"10": 5}
+
+
+def test_device_requires_qnode_shots() -> None:
+    """Do not submit a DDSIM job when a QNode omits its shot budget."""
+    device = qp.device("mqt.ddsim.default", wires=1)
+
+    @qp.qnode(device)
+    def circuit():
+        return qp.expval(qp.Z(0))
+
+    with pytest.raises(PennyLaneValidationError, match="finite number of shots"):
+        circuit()
+    assert device.submitted_jobs == 0
+    assert qp.set_shots(circuit, shots=5)() == pytest.approx(1.0)

--- a/test/python/plugins/qdmi_pennylane/test_device.py
+++ b/test/python/plugins/qdmi_pennylane/test_device.py
@@ -46,7 +46,7 @@ def test_uses_already_open_qdmi_device(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda *_args, **_kwargs: pytest.fail("The adapter reopened the QDMI device."),
     )
 
-    device = QDMIDevice(device=cast("QDMIDeviceHandle", qdmi), wires=2, shots=10)
+    device = QDMIDevice(device=cast("QDMIDeviceHandle", qdmi), wires=2)
 
     assert device.qdmi_device is qdmi
     assert device.device_id is None
@@ -56,9 +56,9 @@ def test_samples_counts_probabilities_expectations_and_variances(monkeypatch: py
     """Reconstruct common PennyLane result types from raw QDMI samples."""
     qdmi = stub_device()
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=["left", "right"], shots=100)
+    device = QDMIDevice("fake.qdmi", wires=["left", "right"])
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=100)
     def circuit() -> tuple[object, ...]:
         return (
             qp.sample(wires=["left", "right"]),
@@ -83,9 +83,9 @@ def test_histogram_only_device_reconstructs_samples(monkeypatch: pytest.MonkeyPa
     """Reconstruct raw samples when a QDMI implementation exposes only counts."""
     qdmi = stub_device(expose_shots=False)
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=8)
+    device = QDMIDevice("fake.qdmi", wires=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=8)
     def circuit():
         return qp.sample(wires=[0, 1])
 
@@ -101,9 +101,9 @@ def test_execution_time_accumulates_batch_wall_time(monkeypatch: pytest.MonkeyPa
     patch_open_device(monkeypatch, qdmi)
     readings = iter([0.0, 1.5, 10.0, 12.25])
     monkeypatch.setattr("mqt.core.plugins.pennylane.device.monotonic", lambda: next(readings))
-    device = QDMIDevice("fake.qdmi", wires=2, shots=[(5, 2), 7])
+    device = QDMIDevice("fake.qdmi", wires=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=[(5, 2), 7])
     def circuit():
         return qp.probs(wires=[0, 1])
 
@@ -118,9 +118,9 @@ def test_shot_vectors_submit_before_waiting(monkeypatch: pytest.MonkeyPatch) -> 
     """Submit every shot-vector copy before waiting for the first job."""
     qdmi = stub_device()
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=[(5, 2), 7])
+    device = QDMIDevice("fake.qdmi", wires=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=[(5, 2), 7])
     def circuit():
         return qp.probs(wires=[0, 1])
 
@@ -142,7 +142,7 @@ def test_batches_execute_in_input_order(monkeypatch: pytest.MonkeyPatch) -> None
 
     qdmi = stub_device(result_factory=basis_state_results)
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=6)
+    device = QDMIDevice("fake.qdmi", wires=2)
     tapes = (
         qp.tape.QuantumScript([qp.PauliX(0)], [qp.probs(wires=[0, 1])], shots=6),
         qp.tape.QuantumScript([qp.PauliX(1)], [qp.probs(wires=[0, 1])], shots=6),
@@ -190,11 +190,13 @@ def test_execution_failure_cancels_submitted_jobs(
 
     monkeypatch.setattr(qdmi, "submit_job", submit)
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=[2, 3, 4])
+    device = QDMIDevice("fake.qdmi", wires=2)
     tape = qp.tape.QuantumScript([], [qp.sample(wires=[0, 1])], shots=[2, 3, 4])
 
-    with pytest.raises(PennyLaneExecutionError, match="wait failed"):
+    with qp.Tracker(device) as tracker, pytest.raises(PennyLaneExecutionError, match="wait failed"):
         device.execute(tape)
+
+    assert tracker.totals == {"batches": 1, "batch_len": 1, "executions": 3, "shots": 9}
 
     assert qdmi.events == [
         "submit:1",
@@ -211,9 +213,9 @@ def test_parameter_shift_gradient_uses_multiple_qdmi_jobs(monkeypatch: pytest.Mo
     """Differentiate sampled execution through PennyLane's parameter-shift rule."""
     qdmi = stub_device(qubits=1, result_factory=rotation_results)
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=["theta"], shots=4000)
+    device = QDMIDevice("fake.qdmi", wires=["theta"])
 
-    @qp.qnode(device, diff_method="parameter-shift")
+    @qp.qnode(device, shots=4000, diff_method="parameter-shift")
     def circuit(angle: float):
         qp.RY(angle, wires="theta")
         return qp.expval(qp.PauliZ("theta"))
@@ -232,10 +234,10 @@ def test_hamiltonian_and_non_commuting_measurements_split(monkeypatch: pytest.Mo
     """Let PennyLane split and aggregate Hamiltonian and non-commuting terms."""
     qdmi = stub_device()
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=100)
+    device = QDMIDevice("fake.qdmi", wires=2)
     hamiltonian = 0.5 * qp.PauliZ(0) + 0.5 * qp.PauliZ(1)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=100)
     def circuit():
         return qp.expval(hamiltonian), qp.expval(qp.PauliX(0))
 
@@ -250,9 +252,9 @@ def test_qasm2_diagonalizes_observable_once(monkeypatch: pytest.MonkeyPatch) -> 
     """Do not duplicate the X-basis rotation in PennyLane's QASM2 serializer."""
     qdmi = stub_device(program_format=ProgramFormat.QASM2)
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=10)
+    device = QDMIDevice("fake.qdmi", wires=2)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=10)
     def circuit():
         return qp.expval(qp.PauliX(0))
 
@@ -265,7 +267,7 @@ def test_rejects_analytic_execution_before_submission(monkeypatch: pytest.Monkey
     """Reject analytic tapes before a QDMI job is created."""
     qdmi = stub_device()
     patch_open_device(monkeypatch, qdmi)
-    device = QDMIDevice("fake.qdmi", wires=2, shots=None)
+    device = QDMIDevice("fake.qdmi", wires=2)
 
     @qp.qnode(device)
     def circuit():
@@ -319,13 +321,63 @@ def test_forwards_job_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
     device = QDMIDevice(
         "fake.qdmi",
         wires=2,
-        shots=4,
         job_parameters={"custom1": "bucket", "custom2": "prefix"},
     )
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=4)
     def circuit():
         return qp.sample(wires=[0, 1])
 
     circuit()
     assert qdmi.submissions[0][3] == {"custom1": "bucket", "custom2": "prefix"}
+
+
+@pytest.mark.parametrize("method", ["one-shot", "tree-traversal"])
+def test_rejects_unsupported_mid_circuit_methods(method: str) -> None:
+    """Do not silently replace a requested native MCM method with deferral."""
+    qdmi = stub_device()
+    device = QDMIDevice(device=cast("QDMIDeviceHandle", qdmi), wires=2)
+
+    @qp.qnode(device, shots=5, mcm_method=method)
+    def circuit():
+        return qp.sample(wires=0)
+
+    with pytest.raises(qp.exceptions.QuantumFunctionError, match="unsupported by the device"):
+        circuit()
+    assert not qdmi.submissions
+
+
+def test_rejects_deferred_measurement_without_spare_wire() -> None:
+    """Fail before submission when resetting a measured wire needs an ancilla."""
+    qdmi = stub_device()
+    device = QDMIDevice(device=cast("QDMIDeviceHandle", qdmi), wires=["a", "b"])
+
+    @qp.qnode(device, shots=5)
+    def circuit():
+        measured = qp.measure("a", reset=True)
+        qp.cond(measured, qp.X)("b")
+        return qp.sample(wires=["b", "a"])
+
+    with pytest.raises(PennyLaneValidationError, match="require more wires"):
+        circuit()
+    assert not qdmi.submissions
+
+
+def test_qnode_shots_and_tracker() -> None:
+    """Track actual jobs and shot copies while QNode shots specify execution budgets."""
+    qdmi = stub_device()
+    device = QDMIDevice(device=cast("QDMIDeviceHandle", qdmi), wires=2)
+
+    @qp.qnode(device, shots=7)
+    def circuit():
+        return qp.sample(wires=[0, 1])
+
+    with qp.Tracker(device) as tracker:
+        assert circuit().shape == (7, 2)
+        results = qp.set_shots(circuit, shots=[(3, 2), 5])()
+    assert [result.shape for result in results] == [(3, 2), (3, 2), (5, 2)]
+    assert tracker.totals == {"batches": 2, "batch_len": 2, "executions": 4, "shots": 18}
+    assert device.submitted_jobs == 4
+    assert device.shots.total_shots is None
+    circuit()
+    assert tracker.totals["executions"] == 4

--- a/test/python/plugins/qiskit/test_mock_backend.py
+++ b/test/python/plugins/qiskit/test_mock_backend.py
@@ -18,9 +18,11 @@ from typing import TYPE_CHECKING, ClassVar, NoReturn
 
 import pytest
 from qiskit import qasm2, qasm3
-from qiskit.circuit import Gate, Parameter, QuantumCircuit
+from qiskit.circuit import Gate, IfElseOp, Parameter, QuantumCircuit
+from qiskit.transpiler import Target
 
 from mqt.core.plugins.qiskit import (
+    CircuitValidationError,
     QDMIBackend,
     QDMIProvider,
     TranslationError,
@@ -662,8 +664,8 @@ def replaced_qasm3_serializer() -> Iterator[str]:
 
 
 def test_backend_uses_replaced_qasm3_serializer(replaced_qasm3_serializer: str) -> None:
-    """Replacing the built-in OpenQASM 3 serializer changes what the backend submits."""
-    device = MockQDMIDevice(num_qubits=2, operations=["h", "measure"])
+    """A custom serializer retains control over compilation to native width."""
+    device = MockQDMIDevice(num_qubits=1, operations=["h", "measure"])
     submissions = _record_submissions(device)
 
     backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type]
@@ -674,6 +676,99 @@ def test_backend_uses_replaced_qasm3_serializer(replaced_qasm3_serializer: str) 
     backend.run(qc, shots=100)
 
     assert submissions == [(replaced_qasm3_serializer, ProgramFormat.QASM3)]
+
+
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_qasm_rejects_invalid_native_placements_before_submitting_batch(
+    monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat
+) -> None:
+    """Validate the whole batch against ordered native pairs before submission."""
+    device = MockQDMIDevice(num_qubits=2, operations=["cx", "measure"])
+    operation = device.operations()[0]
+    monkeypatch.setattr(operation, "site_pairs", lambda: [(device.sites()[0], device.sites()[1])])
+    monkeypatch.setattr(device, "supported_program_formats", lambda: [program_format])
+    submissions = _record_submissions(device)
+    backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type] Device boundary double.
+    valid = QuantumCircuit(2)
+    valid.cx(0, 1)
+    valid.measure_all()
+    invalid = QuantumCircuit(2)
+    invalid.cx(1, 0)
+    invalid.measure_all()
+
+    with pytest.raises(UnsupportedOperationError, match=r"native device qubits \(1, 0\)"):
+        backend.run([valid, invalid], shots=2)
+    assert not submissions
+    backend.run(valid, shots=2)
+    assert len(submissions) == 1
+
+
+@pytest.mark.parametrize("program_format", [ProgramFormat.QASM2, ProgramFormat.QASM3])
+def test_qasm_rejects_excess_native_width(monkeypatch: pytest.MonkeyPatch, program_format: ProgramFormat) -> None:
+    """A QASM program cannot address qubits beyond the native device width."""
+    device = MockQDMIDevice(num_qubits=2, operations=["measure"])
+    monkeypatch.setattr(device, "supported_program_formats", lambda: [program_format])
+    submissions = _record_submissions(device)
+    backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type] Device boundary double.
+    circuit = QuantumCircuit(3)
+    circuit.measure_all()
+    with pytest.raises(CircuitValidationError, match="native device has 2"):
+        backend.run(circuit, shots=2)
+    assert not submissions
+
+
+def test_qasm_preflight_uses_native_sites_after_preprocessing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Preprocessing may widen a logical circuit to a site hidden from the Target."""
+
+    class WideningBackend(QDMIBackend):
+        """Expose a logical pair and lower it onto three native sites."""
+
+        def _build_target(self) -> Target:
+            return Target.from_configuration(basis_gates=["cx", "measure"], num_qubits=self.device.qubits_num() - 1)
+
+        def _preprocess_circuit(self, circuit: QuantumCircuit) -> QuantumCircuit:
+            widened = QuantumCircuit(self.device.qubits_num(), circuit.num_clbits)
+            widened.compose(circuit, qubits=[0, 2], inplace=True)
+            return widened
+
+    device = MockQDMIDevice(num_qubits=3, operations=["cx", "measure"])
+    monkeypatch.setattr(device.operations()[0], "site_pairs", lambda: [(device.sites()[0], device.sites()[2])])
+    submissions = _record_submissions(device)
+    backend = WideningBackend(device)  # ty: ignore[invalid-argument-type] Device boundary double.
+    circuit = QuantumCircuit(2)
+    circuit.cx(0, 1)
+    circuit.measure_all()
+    backend.run(circuit, shots=2)
+    assert backend.target.num_qubits == 2
+    assert len(submissions) == 1
+    program, _ = submissions[0]
+    assert isinstance(program, str)
+    assert "cx q[0], q[2];" in program
+
+
+def test_qasm_preflight_maps_control_flow_operands(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Validate block-local operands against their enclosing native qubits."""
+    device = MockQDMIDevice(num_qubits=3, operations=["cx", "measure"])
+    monkeypatch.setattr(device.operations()[0], "site_pairs", lambda: [(device.sites()[2], device.sites()[0])])
+    submissions = _record_submissions(device)
+    backend = QDMIBackend(device)  # ty: ignore[invalid-argument-type] Device boundary double.
+    body = QuantumCircuit(2)
+    body.cx(0, 1)
+    circuit = QuantumCircuit(3, 1)
+    circuit.if_else((circuit.clbits[0], True), body, QuantumCircuit(2), [2, 0], [])
+    with pytest.raises(UnsupportedOperationError, match="Unsupported control flow"):
+        backend.run(circuit, shots=2)
+    assert not submissions
+
+    backend.target.add_instruction(IfElseOp, name="if_else")
+    backend.run(circuit, shots=2)
+    assert len(submissions) == 1
+
+    invalid = QuantumCircuit(3, 1)
+    invalid.if_else((invalid.clbits[0], True), body, QuantumCircuit(2), [0, 2], [])
+    with pytest.raises(UnsupportedOperationError, match=r"native device qubits \(0, 2\)"):
+        backend.run(invalid, shots=2)
+    assert len(submissions) == 1
 
 
 def test_backend_rejects_device_without_program_payload() -> None:

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -236,6 +236,9 @@ public:
   size_t allocatedSessions = 0;
   size_t freedSessions = 0;
   int successStatus = QDMI_SUCCESS;
+  int jobStatus = QDMI_SUCCESS;
+  bool nullJob = false;
+  size_t freedJobs = 0;
   bool nullSession = false;
   bool nullChild = false;
   bool rejectChildSelection = false;
@@ -251,6 +254,18 @@ public:
     device_session_set_parameter = setParameter;
     device_session_init = init;
     device_session_query_device_property = queryDeviceProperty;
+    device_session_create_device_job = [](QDMI_Device_Session session,
+                                          QDMI_Device_Job* job) {
+      *job = activeLibrary->nullJob
+                 ? nullptr
+                 : reinterpret_cast<QDMI_Device_Job>(session);
+      return activeLibrary->jobStatus;
+    };
+    device_session_retrieve_device_job_by_id =
+        [](QDMI_Device_Session session, const char*, QDMI_Device_Job* job) {
+          return activeLibrary->device_session_create_device_job(session, job);
+        };
+    device_job_free = [](QDMI_Device_Job) { ++activeLibrary->freedJobs; };
   }
 
   ~ChildDeviceLibrary() override { activeLibrary = nullptr; }
@@ -404,6 +419,33 @@ TEST(ChildDeviceTest, WrapsOpaqueHandlesInStableClientDevices) {
               QDMI_ERROR_NOTSUPPORTED);
   }
   EXPECT_EQ(library->freedSessions, 3);
+}
+
+TEST(ChildDeviceTest, PreservesWarningJobsAndRejectsNullHandles) {
+  const auto library = std::make_shared<ChildDeviceLibrary>();
+  library->childDevicesNotSupported = true;
+  QDMI_Device_impl_d device(library);
+  for (const auto status : {QDMI_SUCCESS, QDMI_WARN_GENERAL}) {
+    library->jobStatus = status;
+    for (const auto nullJob : {false, true}) {
+      library->nullJob = nullJob;
+      for (const auto retrieve : {false, true}) {
+        QDMI_Job job = nullptr;
+        const auto freedBefore = library->freedJobs;
+        const auto result =
+            retrieve ? QDMI_session_retrieve_job_by_id(&device, "job", &job)
+                     : QDMI_device_create_job(&device, &job);
+        EXPECT_EQ(result, nullJob ? QDMI_ERROR_FATAL : status);
+        if (nullJob) {
+          EXPECT_EQ(job, nullptr);
+        } else {
+          ASSERT_NE(job, nullptr);
+          QDMI_job_free(job);
+        }
+        EXPECT_EQ(library->freedJobs, freedBefore + (nullJob ? 0 : 1));
+      }
+    }
+  }
 }
 
 TEST(ChildDeviceTest, AcceptsWarningsDuringSessionSetup) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Preserve usable QDMI jobs when providers return a warning, and reject unsupported SDK programs before submission. These changes prepare the unreleased v4 plugins using the released QDMI API.

- Share PennyLane validation between QASM2 and QASM3, including finite parameters and fixed-arity placements, and normalize operation metadata once per session.
- Support named-wire deferred measurements, graph decomposition, and standard PennyLane tracking. Require explicit QNode or tape shots instead of the deprecated device-level argument and implicit 1024-shot default.
- Validate Qiskit native width and ordered placements after preprocessing. Reject invalid batches before submission, preserve custom serializers and hidden native sites, and validate operations inside explicitly supported control flow.

Extract the independent deferred-only capability declaration and nested-validation behavior from #2226. Exact payload descriptors, feature inference, and native one-shot execution remain there; no new QDMI dependency is introduced.

Validation: 500 Python QDMI/plugin tests and 104 native driver tests passed. Repository lint and full-file C++ lint passed. Hosted CI is pending. Documentation covers the shot API and validation behavior; no standalone changelog or upgrade entry is added for these unreleased v4 features, following repository guidance.

AI assistance was used for implementation, specialist review, tests, documentation, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
