### PR TITLE
⚡️ Optimize QDMI driver session opening

### DIFF
--- a/.agent/audits/qdmi-driver-performance-2026-09-08.md
+++ b/.agent/audits/qdmi-driver-performance-2026-09-08.md
@@ -1,0 +1,103 @@
+# QDMI driver performance audit
+
+Status: both confirmed findings implemented and locally validated. Date:
+2026-09-08. Audit baseline: `e37fc41a49176c772ef855a12cfeadcccb471440`,
+initially clean. Driver source matched `origin/main` at
+`3be5ee96f3907659bd99fdd6d54cd74c4eea7da9`, the implementation base. Dependency:
+QDMI v1.3.3. Measurements: ARM64 DGX Spark, Clang 23.
+
+## Result
+
+Two confirmed opportunities in session opening were implemented. They do not
+establish faster quantum execution or higher remote-job throughput.
+
+### 1. Provider initialization no longer holds the global cache mutex
+
+`getDynamicDeviceLibrary` in `src/qdmi/driver/Driver.cpp` held a process-wide
+mutex across loading, symbol resolution, and the provider's `device_initialize`
+callback. A slow first open blocked fresh opens of unrelated cached providers.
+Public `Session::openDevice`, Python `open_device`, and compiler device opening
+reach this path; an already-open `Driver::open` device bypasses it.
+
+The global mutex now protects only the module map. Each loaded module has a
+mutex protecting initialization and its prefix-to-provider map. This preserves
+serialization for providers sharing module state, alias identity, one successful
+initialization, failure cleanup/retry, and process-lifetime retention. Module
+entries are never erased and an opener owns a loader reference while waiting.
+
+A gated initializer blocked an unrelated cached provider for the full 200 ms
+observation interval in four baseline runs (200.206–200.867 ms). With the fix,
+the unrelated open completed before release in all four runs (0.050–0.060 ms).
+The test shared object was preloaded to isolate the provider callback from OS
+loader initialization. This is a controlled concurrency demonstration, not a
+measurement of real provider startup. OS loader serialization can remain.
+
+Durable regression:
+`DynamicDeviceLibraryDeathTest.InitializesUnrelatedModulesWhileRetryingConcurrentAliases`.
+It gates the first initialization, queues an alias, opens a cached unrelated
+provider, then makes the first initialization fail. The alias retries, and a
+later open shares its successfully initialized provider. Existing alias/lifetime
+coverage checks process-lifetime retention and lack of premature finalization.
+
+### 2. Inline configuration avoids two redundant payload copies
+
+`Driver::openFresh` copied the registered definition, `mergeSessionConfig`
+copied its configuration again, and parameter forwarding implicitly converted
+inline JSON into an owning `optional<string>`. The last copy repeated for each
+child. Raw `custom1`, already optional, avoided the last conversion.
+
+The merge helper now takes defaults by value. Fresh opening moves its owned
+snapshot into the helper; registry callers passing lvalues retain copy
+semantics. The setter borrows existing NUL-terminated strings through optional
+string views. The registry snapshot, explicit empty overrides, absent
+parameters, NUL-inclusive lengths, conflict checks, and synchronous provider
+call remain intact.
+
+A no-op provider and allocations of at least 1 MiB isolated a 16 MiB synthetic
+payload. Snapshot/merge/construction allocated three payload-sized buffers for
+typed inline configuration before the fix and one after it. One hundred isolated
+constructors allocated 100 such buffers before and zero after. Constructor time
+was 42.613–63.504 ms before and 0.012–0.017 ms after across four runs each.
+These synthetic results exclude JSON parsing, provider copies, Python
+conversion, networking, and whole-device opening. The payload is opaque
+synthetic text, not a simulator configuration benchmark; allocation counts are
+the useful result.
+
+Durable regression: `DeviceSessionConfigTest.MovesAndBorrowsInlineConfiguration`
+checks buffer identity through the merge and the parent plus two child sessions.
+Existing tests cover configuration contents, overrides, errors, and ownership.
+
+## Candidates not promoted to findings
+
+- Linear registry lookup and quadratic repeated registration: no representative
+  catalog measurement establishes a practical bottleneck. Preserve public order.
+- Per-client copies of the immutable handle catalog: savings depend on catalog
+  size and session churn; no workload justifies changing ownership here.
+- Eager catalog and child-session initialization: laziness changes error timing
+  and lifetime behavior, so it is not part of these optimizations.
+- Repeated OS-loader calls on warm fresh opens: no measured cost justifies an
+  additional cache and its identity/invalidation obligations.
+
+Property/site/operation queries and job submit/check/wait/results already avoid
+bulk copies and global driver locks. Job creation/free holds the per-device
+mutex only for ownership bookkeeping; provider creation/free run outside it. No
+evidence supports a job pool, custom allocator, lock-free registry, or
+driver-wide metadata cache.
+
+## Related work and validation
+
+REST metadata and changed files were checked on 2026-09-08. PR #2229
+(`d76d6681`) changes the Client ABI; #2230 (`1f544f1a`) changes default-driver
+configuration and still holds the cache mutex during construction in its older
+path-based cache. PR #2373 (`c8b4ac3d`) changes batch/job forwarding, separate
+from these opening costs. Pending branches were not performance-tested.
+
+The optimized probe compiled `Driver.cpp` with `clang++-23 -std=c++20 -O2` and
+linked existing Debug Client/registry/common support; registry startup was
+outside timing. The rebuilt native driver binary passed 106 tests. Repository
+lint passed. Changed-file C++ lint passed with zero findings, including all
+three changed C++ translation units. The full QDMI CTest tree passed 478 tests
+with one existing skip (`ScQDMIJobSpecificationTest.QueryJobId`). Both new tests
+fail when linked against the original driver translation unit and pass with the
+fixed driver. The permanent tests replace the temporary benchmark's
+implementation-specific assertions as the regression checks.

--- a/.agent/plans/qdmi-driver-opening-performance.md
+++ b/.agent/plans/qdmi-driver-opening-performance.md
@@ -1,0 +1,35 @@
+# QDMI driver opening performance
+
+Status: complete. Both confirmed findings are implemented and validated.
+
+## Scope and decisions
+
+The default driver owns provider initialization and configuration forwarding.
+Keep the existing process-lifetime provider cache and its loader-handle/prefix
+identity. A module now owns its initialization mutex and provider map. The
+global mutex protects only module lookup/insertion. Map entries are never
+erased, so references remain stable after releasing that mutex. Each opener
+holds a loader reference while waiting; failed initialization can be retried
+without exposing a partial provider. Providers in the same module remain
+serialized because they may share internal state.
+
+Fresh opening still snapshots the registered definition while holding the
+registry mutex. Move that owned session configuration into the by-value merge
+helper. Parameter forwarding borrows NUL-terminated strings through optional
+string views; all calls remain synchronous and path temporaries survive the
+call. Preserve empty overrides, validation, and parent/child ownership.
+
+The audit's unpromoted candidates remain deferred. No registry index, lazy
+catalog/child opening, job pool, metadata cache, or additional loader cache is
+part of this change. Related PRs #2229/#2230 alter the client/default-driver
+boundary; these fixes apply to the current default driver independently.
+
+## Validation
+
+Both new regressions and the complete native driver binary pass: 106 tests. The
+full QDMI CTest tree passed 478 tests with one existing skip. Repository lint
+and changed-file C++ lint passed with zero findings. Focused probes confirm
+unrelated opening completes before a gated initializer is released, and the
+typed configuration path allocates one payload-sized snapshot instead of three.
+See the [audit](../audits/qdmi-driver-performance-2026-09-08.md) for scope and
+evidence.

--- a/docs/qdmi/driver.md
+++ b/docs/qdmi/driver.md
@@ -26,6 +26,8 @@ registered through
 The driver shares a loaded provider across path aliases with the same symbol
 prefix and retains it for the process lifetime. Closing a device session frees
 that session without finalizing the provider while another session may use it.
+Initialization is serialized within each loaded module. A slow provider
+initializer does not hold the driver cache lock while other modules are opened.
 
 ## Building the Bundled Devices
 

--- a/include/mqt-core/qdmi/driver/SessionConfig.hpp
+++ b/include/mqt-core/qdmi/driver/SessionConfig.hpp
@@ -35,10 +35,9 @@ inline void applyOverride(std::optional<T>& value,
 
 /// Apply present overrides, including explicitly empty values.
 [[nodiscard]] inline auto
-mergeSessionConfig(const DeviceSessionConfig& defaults,
+mergeSessionConfig(DeviceSessionConfig merged,
                    const DeviceSessionConfig& overrides)
     -> DeviceSessionConfig {
-  auto merged = defaults;
   applyOverride(merged.baseUrl, overrides.baseUrl);
   applyOverride(merged.token, overrides.token);
   applyOverride(merged.authFile, overrides.authFile);

--- a/src/qdmi/driver/Driver.cpp
+++ b/src/qdmi/driver/Driver.cpp
@@ -164,9 +164,12 @@ DynamicDeviceLibrary::~DynamicDeviceLibrary() {
 
 namespace {
 struct DynamicLibraryCache {
+  struct Module {
+    std::mutex mutex;
+    std::map<std::string, std::shared_ptr<DynamicDeviceLibrary>> providers;
+  };
   std::mutex mutex;
-  std::map<void*, std::map<std::string, std::shared_ptr<DynamicDeviceLibrary>>>
-      libraries;
+  std::map<void*, Module> libraries;
 };
 
 [[nodiscard]] auto dynamicLibraryCache() -> DynamicLibraryCache& {
@@ -181,14 +184,20 @@ struct DynamicLibraryCache {
                                            const std::string& prefix)
     -> std::shared_ptr<DynamicDeviceLibrary> {
   auto& cache = dynamicLibraryCache();
-  const std::scoped_lock lock(cache.mutex);
   const auto closeLibrary = [](void* handle) { DL_CLOSE(handle); };
   std::unique_ptr<void, decltype(closeLibrary)> handle(DL_OPEN(libName.c_str()),
                                                        closeLibrary);
   if (!handle) {
     throw std::runtime_error("Couldn't open the device library: " + libName);
   }
-  auto& providers = cache.libraries[handle.get()];
+  auto& module = [&]() -> auto& {
+    const std::scoped_lock lock(cache.mutex);
+    return cache.libraries[handle.get()];
+  }();
+  /// Modules may contain providers that share initialization state. Keep their
+  /// initialization serialized without blocking unrelated modules.
+  const std::scoped_lock lock(module.mutex);
+  auto& providers = module.providers;
   if (const auto found = providers.find(prefix); found != providers.end()) {
     return found->second;
   }
@@ -223,13 +232,14 @@ QDMI_Device_impl_d::QDMI_Device_impl_d(
     throw std::runtime_error("Device returned a null session handle");
   }
   try {
-    const auto setParameter = [&](const std::optional<std::string>& value,
+    /// All views borrow NUL-terminated strings for this synchronous call.
+    const auto setParameter = [&](const std::optional<std::string_view> value,
                                   const QDMI_Device_Session_Parameter param) {
       if (!value || library_->device_session_set_parameter == nullptr) {
         return;
       }
       const auto status = library_->device_session_set_parameter(
-          deviceSession_, param, value->size() + 1, value->c_str());
+          deviceSession_, param, value->size() + 1, value->data());
       if (status == QDMI_ERROR_NOTSUPPORTED) {
         qdmi::diagnostics::info(
             "Device session parameter {} not supported by device (skipped)",
@@ -755,7 +765,7 @@ auto Driver::openFresh(const std::string_view id,
   }
   return std::make_shared<QDMI_Device_impl_d>(
       getDynamicDeviceLibrary(definition.library.string(), definition.prefix),
-      detail::mergeSessionConfig(definition.session, overrides));
+      detail::mergeSessionConfig(std::move(definition.session), overrides));
 }
 
 void Driver::materializeClientCatalog() {

--- a/test/qdmi/driver/session_device.cpp
+++ b/test/qdmi/driver/session_device.cpp
@@ -44,6 +44,13 @@ namespace {
   return count;
 }
 
+using InitializeCallback = int (*)();
+
+auto initializeCallback() -> std::atomic<InitializeCallback>& {
+  static std::atomic<InitializeCallback> callback = nullptr;
+  return callback;
+}
+
 [[nodiscard]] auto finalizations() -> std::atomic_size_t& {
   static std::atomic_size_t count = 0;
   return count;
@@ -163,7 +170,17 @@ auto queryValue(const T& result, const size_t size, void* value,
 // NOLINTBEGIN(readability-identifier-naming)
 extern "C" int TEST_SESSION_QDMI_device_initialize() {
   ++initializations();
+  if (const auto callback = initializeCallback().load()) {
+    return callback();
+  }
   return QDMI_SUCCESS;
+}
+
+/// Tests install a callback before opening sessions to coordinate
+/// initialization.
+extern "C" void
+TEST_SESSION_set_initialize_callback(InitializeCallback callback) {
+  initializeCallback() = callback;
 }
 
 extern "C" int TEST_SESSION_QDMI_device_finalize() {

--- a/test/qdmi/driver/test_driver.cpp
+++ b/test/qdmi/driver/test_driver.cpp
@@ -10,6 +10,7 @@
 
 #include "qdmi/Client.hpp"
 #include "qdmi/driver/Driver.hpp"
+#include "qdmi/driver/SessionConfig.hpp"
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
@@ -18,13 +19,16 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <barrier>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -140,6 +144,7 @@ class ChildDeviceLibrary final : public qdmi::DeviceLibrary {
     }
     auto* const fakeSession = asSession(session);
     if (parameter == QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1) {
+      fakeSession->library->custom1Data.emplace_back(value);
       return fakeSession->library->successStatus;
     }
     if (parameter != QDMI_DEVICE_SESSION_PARAMETER_CHILDDEVICE) {
@@ -246,6 +251,7 @@ public:
   bool childDevicesNotSupported = false;
   bool childDeviceQueryFails = false;
   std::vector<QDMI_Child_Device> selectedChildren;
+  std::vector<const void*> custom1Data;
 
   ChildDeviceLibrary() {
     activeLibrary = this;
@@ -1680,6 +1686,27 @@ TEST(DeviceRegistrationTest, RuntimeRegistrationsStayOutOfClientCatalog) {
   QDMI_session_free(existingSession);
 }
 
+TEST(DeviceSessionConfigTest, MovesAndBorrowsInlineConfiguration) {
+  const auto library = std::make_shared<ChildDeviceLibrary>();
+  qdmi::DeviceSessionConfig config{
+      .deviceConfiguration =
+          qdmi::InlineDeviceConfiguration{
+              .json = std::string(4096, ' '),
+          },
+  };
+  const auto* const data =
+      std::get<qdmi::InlineDeviceConfiguration>(*config.deviceConfiguration)
+          .json.data();
+  const auto merged = qdmi::detail::mergeSessionConfig(std::move(config), {});
+  EXPECT_EQ(
+      std::get<qdmi::InlineDeviceConfiguration>(*merged.deviceConfiguration)
+          .json.data(),
+      data);
+  const QDMI_Device_impl_d device(library, merged);
+  /// The parent and both children borrow the same configuration buffer.
+  EXPECT_THAT(library->custom1Data, testing::ElementsAre(data, data, data));
+}
+
 TEST(DeviceSessionConfigTest, OpenWithBaseUrl) {
   qdmi::DeviceSessionConfig config;
   config.baseUrl = "http://localhost:8080";
@@ -1825,6 +1852,90 @@ TEST(DeviceSessionConfigTest, IdempotentLoadingWithDifferentConfigs) {
       EXPECT_NO_THROW(static_cast<void>(openTestDevice(lib, prefix, config)););
     }
   }
+}
+
+TEST(DynamicDeviceLibraryDeathTest,
+     InitializesUnrelatedModulesWhileRetryingConcurrentAliases) {
+  const auto probe = [] {
+#ifdef _WIN32
+    auto* handle = LoadLibraryW(
+        std::filesystem::path(MQT_CORE_QDMI_SESSION_DEVICE).c_str());
+    const auto setCallback =
+        handle == nullptr
+            ? nullptr
+            : reinterpret_cast<void (*)(int (*)())>(GetProcAddress(
+                  handle, "TEST_SESSION_set_initialize_callback"));
+#else
+    auto* handle = dlopen(MQT_CORE_QDMI_SESSION_DEVICE, RTLD_NOW | RTLD_LOCAL);
+    const auto setCallback =
+        handle == nullptr
+            ? nullptr
+            : reinterpret_cast<void (*)(int (*)())>(
+                  dlsym(handle, "TEST_SESSION_set_initialize_callback"));
+#endif
+    if (setCallback == nullptr) {
+      std::_Exit(1);
+    }
+    static std::promise<void> entered;
+    static std::promise<void> release;
+    static const auto RELEASED = release.get_future().share();
+    static std::atomic_size_t attempts = 0;
+    setCallback([]() -> int {
+      if (++attempts == 1) {
+        entered.set_value();
+        RELEASED.wait();
+        return QDMI_ERROR_FATAL;
+      }
+      return QDMI_SUCCESS;
+    });
+
+    auto& driver = qdmi::Driver::get();
+    driver.registerDevice({
+        .id = "cache.slow",
+        .library = MQT_CORE_QDMI_SESSION_DEVICE,
+        .prefix = "TEST_SESSION",
+    });
+    driver.registerDevice({
+        .id = "cache.alias",
+        .library =
+            std::filesystem::path(MQT_CORE_QDMI_SESSION_DEVICE).filename(),
+        .prefix = "TEST_SESSION",
+    });
+    const auto warm = qdmi::Session::openDevice("mqt.sc.default");
+    auto first = std::async(std::launch::async, [] {
+      try {
+        static_cast<void>(qdmi::Session::openDevice("cache.slow"));
+        return false;
+      } catch (const std::runtime_error&) {
+        return true;
+      }
+    });
+    if (entered.get_future().wait_for(std::chrono::seconds(5)) !=
+        std::future_status::ready) {
+      std::_Exit(2);
+    }
+    auto alias = std::async(std::launch::async, [] {
+      return qdmi::Session::openDevice("cache.alias");
+    });
+    auto unrelated = std::async(std::launch::async, [] {
+      return qdmi::Session::openDevice("mqt.sc.default");
+    });
+    const auto aliasWaited = alias.wait_for(std::chrono::milliseconds(50)) ==
+                             std::future_status::timeout;
+    const auto unrelatedReady = unrelated.wait_for(std::chrono::seconds(5)) ==
+                                std::future_status::ready;
+    release.set_value();
+    const auto failed = first.get();
+    const auto retried = alias.get();
+    static_cast<void>(unrelated.get());
+    const auto later = qdmi::Session::openDevice("cache.slow");
+    const auto shared = &static_cast<QDMI_Device>(retried)->getLibrary() ==
+                        &static_cast<QDMI_Device>(later)->getLibrary();
+    std::_Exit(
+        failed && aliasWaited && unrelatedReady && shared && attempts == 2 ? 0
+                                                                           : 3);
+  };
+  EXPECT_EXIT(probe(), testing::ExitedWithCode(0), "");
 }
 
 TEST(DynamicDeviceLibraryDeathTest,


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

A slow provider initializer currently blocks fresh sessions for unrelated cached providers. Serialize initialization per loaded module and keep the global cache mutex limited to lookup/insertion, while preserving module aliases, failure retry, and process-lifetime provider ownership.

Remove two redundant inline-configuration copies by moving the owned session snapshot into merging and borrowing strings during synchronous parameter forwarding. A 16 MiB synthetic payload now needs one payload allocation in the snapshot/merge/construction path instead of three; parent and child sessions share the forwarded buffer.

Add regressions for concurrent alias retry during failed initialization, unrelated opening during that wait, and configuration buffer reuse. Both new regressions fail against the original driver. This change is independent of the pending Client/default-driver work in #2229 and #2230 and does not change the QDMI API.

Local validation: 478 QDMI C++ tests passed, with one existing skip (including all 106 native driver tests); repository lint and changed-file C++ lint passed. In the gated initializer probe, the unrelated open completed before release instead of waiting for the full 200 ms observation interval. These are driver-only measurements, not quantum execution or remote throughput claims.

AI assistance is recorded in the signed commit. Human review remains required.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
