### PR TITLE
♻️ Simplify QIR lowering and metadata emission

### DIFF
--- a/.agent/plans/qir-lowering-cleanup.md
+++ b/.agent/plans/qir-lowering-cleanup.md
@@ -1,0 +1,38 @@
+# QIR lowering cleanup
+
+Status: complete.
+
+## Scope and decisions
+
+Preserve direct Base and Adaptive conversion passes and their supported input
+contracts. Share their final classical lowering and cast reconciliation in
+`QIRCommon`, while retaining profile-specific quantum lowering.
+
+Remove the obsolete cleanup metadata rewrite and unused allocator state. Emit
+computation-type lists as native LLVM module flags. LLVM 23 still requires the
+integer flag-width repair after translation; direct i1/i2 flags can assert in
+its integer translation path.
+
+Allocate result-pointer vectors only in Base and move returned register records
+into output emission in function-result order. Bind control operands to the
+specific body gate instead of relying on rewrite order.
+
+Use LLVM memset for local Adaptive register zero initialization at the original
+allocation location. Compute the byte extent through an LLVM GEP so target
+layout determines the i1 allocation stride.
+
+Keep dynamic size support in the shared QIR builder utility. Defer symbol lookup
+caching until profiling shows it matters. The broader resource, lifetime, and
+profile-validation findings are outside this cleanup.
+
+## Validation
+
+Local validation passes: 288 Base and Adaptive conversion tests, 121 QIR
+metadata/translation tests, 24 QIR JIT tests, and 171 compiler tests. The
+conversion regressions check constant-size zero initialization for an 8,192-bit
+register and initialization at a loop-local allocation site.
+
+Build the corresponding release test targets, run
+`ctest --preset release -R QCToQIR`, and run the QIR IR, QIR JIT, and compiler
+test binaries. Repository lint and full-file C++ lint pass. Hosted CI is
+separate from these local results.

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.td
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.td
@@ -13,8 +13,9 @@ def QCToQIRAdaptive : Pass<"qc-to-qir-adaptive", "mlir::ModuleOp"> {
                 "QIR Adaptive Profile 2.1";
 
   let description = [{
-    This pass lowers all operations from the QC dialect to their equivalent operations in the LLVM dialect, ensuring compliance with the QIR Adaptive Profile 2.1 standard.
-    It translates quantum operations and types from QC to their corresponding representations in QIR, facilitating interoperability with quantum computing frameworks that utilize the QIR standard.
+    Lower supported QC operations to QIR Adaptive Profile runtime calls and
+    LLVM dialect operations. Run `set-qir-attributes-and-metadata` separately
+    to attach QIR attributes and module flags.
 
     Requirements:
 
@@ -25,8 +26,6 @@ def QCToQIRAdaptive : Pass<"qc-to-qir-adaptive", "mlir::ModuleOp"> {
 
     - Each QC quantum operation is replaced by a call to the corresponding QIR function in the LLVM dialect.
     - Operations from the scf dialect are lowered into the cf dialect before they are lowered to the LLVM dialect.
-    - Required QIR module flags are attached to the MLIR module.
-    - Required attributes are attached to the entry function.
     - The pass extends the existing block structure of the entry function with an entry block and an epilogue block:
       0. Initialization block: Sets up the execution environment and performs required runtime initialization.
       1. Epilogue block: Records measurement results and returns from the entry function.

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRBase/QCToQIRBase.td
@@ -13,8 +13,9 @@ def QCToQIRBase : Pass<"qc-to-qir-base", "mlir::ModuleOp"> {
                 "QIR Base Profile 2.1";
 
   let description = [{
-    This pass lowers all operations from the QC dialect to their equivalent operations in the LLVM dialect, ensuring compliance with the QIR Base Profile 2.1 standard.
-    It translates quantum operations and types from QC to their corresponding representations in QIR, facilitating interoperability with quantum computing frameworks that utilize the QIR standard.
+    Lower supported QC operations to QIR Base Profile runtime calls and
+    LLVM dialect operations. Run `set-qir-attributes-and-metadata` separately
+    to attach QIR attributes and module flags.
 
     Requirements:
 
@@ -35,11 +36,10 @@ def QCToQIRBase : Pass<"qc-to-qir-base", "mlir::ModuleOp"> {
     - Each QC quantum operation is replaced in place by its QIR call. After
       validating qubit usage in instruction order, the pass moves terminal
       measurements to the irreversible operations block.
-    - Required QIR module flags are attached as attributes to the entry function.
     - The pass transforms the single-block entry function into four blocks to satisfy QIR Base Profile constraints:
       0. Initialization block: Sets up the execution environment and performs required runtime initialization.
       1. Reversible operations block: Contains only void-returning calls to reversible quantum operations.
-      2. Irreversible operations block: Contains only void-returning calls to operations marked irreversible (e.g., `__quantum__qis__mz__body` and `__quantum__qis__reset__body`).
+      2. Irreversible operations block: Contains terminal measurement calls (`__quantum__qis__mz__body`). Reset operations are not supported.
       3. Epilogue block: Records measurement results and returns from the entry function.
     - Blocks are connected via unconditional branches in the order listed above.
     - Non-quantum dialects are lowered via MLIR's built-in conversions.

--- a/mlir/include/mlir/Conversion/QCToQIR/QIRCommon/QIRCommon.h
+++ b/mlir/include/mlir/Conversion/QCToQIR/QIRCommon/QIRCommon.h
@@ -14,8 +14,6 @@
 
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/StringMap.h>
-#include <llvm/Support/Allocator.h>
-#include <llvm/Support/StringSaver.h>
 #include <mlir/Conversion/LLVMCommon/TypeConverter.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/IR/BuiltinTypes.h>
@@ -72,13 +70,8 @@ struct LoweringState {
   /// `qc::MeasureOp`
   DenseSet<Operation*> returnedStaticResults;
 
-  /// Modifier information
-  bool inCtrlOp = false;
-  SmallVector<Value> controls;
-
-  /// Allocator and StringSaver for stable StringRefs
-  llvm::BumpPtrAllocator allocator;
-  llvm::StringSaver stringSaver{allocator};
+  /// Converted controls associated with their specific body unitary.
+  DenseMap<Operation*, SmallVector<Value>> controlledGates;
 
   /// Block information
   Block* entryBlock{};
@@ -92,6 +85,11 @@ struct LoweringState {
   [[nodiscard]] LogicalResult ensureAllocationMode(AllocationMode requestedMode,
                                                    Operation* op);
 };
+
+/// Lower remaining classical dialects and reconcile casts for either profile.
+[[nodiscard]] LogicalResult
+finalizeQIRConversion(ModuleOp moduleOp, ConversionTarget& target,
+                      LLVMTypeConverter& typeConverter);
 
 struct QCToQIRTypeConverter final : LLVMTypeConverter {
   explicit QCToQIRTypeConverter(MLIRContext* ctx);
@@ -165,7 +163,7 @@ void populateQCToQIRPatterns(RewritePatternSet& patterns,
  *
  * @param main The main LLVM function
  * @param ctx The MLIR context
- * @param state The lowering state containing measurement information
+ * @param state The lowering state whose returned register records are consumed
  */
 void addOutputRecording(LLVM::LLVMFuncOp& main, MLIRContext* ctx,
                         LoweringState& state);

--- a/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
+++ b/mlir/include/mlir/Dialect/QIR/Utils/QIRUtils.h
@@ -45,12 +45,9 @@ namespace mlir::qir {
 /// Normalize QIR profile module flags after MLIR-to-LLVM translation.
 ///
 /// MLIR translates integer-valued `llvm.module_flags` attributes to i32
-/// metadata and only supports array-valued flags for LLVM's own CG profile.
-/// QIR instead requires i1/i2 capability flags and metadata tuples describing
-/// the integer and floating-point widths used by Adaptive Profile classical
-/// computations. This function repairs the scalar flag widths and serializes
-/// type metadata that the MLIR pipeline derived before translation.
-void normalizeQIRModuleFlags(llvm::Module& moduleOp, ModuleOp sourceModule);
+/// metadata. QIR requires i1/i2 capability flags, so translation callers
+/// must repair those scalar widths.
+void normalizeQIRModuleFlags(llvm::Module& moduleOp);
 
 // QIR function names
 

--- a/mlir/lib/Compiler/Pipeline.cpp
+++ b/mlir/lib/Compiler/Pipeline.cpp
@@ -359,7 +359,7 @@ translateToLLVM(ModuleOp mod, llvm::LLVMContext& context) {
     mod.emitError("failed to translate QIR MLIR to LLVM IR");
     return nullptr;
   }
-  qir::normalizeQIRModuleFlags(*llvmModule, mod);
+  qir::normalizeQIRModuleFlags(*llvmModule);
   return llvmModule;
 }
 

--- a/mlir/lib/Conversion/QCToQIR/QIRAdaptive/CMakeLists.txt
+++ b/mlir/lib/Conversion/QCToQIR/QIRAdaptive/CMakeLists.txt
@@ -25,9 +25,6 @@ add_mlir_conversion_library(
   MLIRTransforms
   MLIRFuncDialect
   MLIRFuncToLLVM
-  MLIRMathDialect
-  MLIRMathToLLVM
-  MLIRSCFToControlFlow
-  MLIRReconcileUnrealizedCasts)
+  MLIRSCFToControlFlow)
 
 mqt_mlir_target_use_project_options(MLIRQCToQIRAdaptive)

--- a/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
@@ -21,11 +21,7 @@
 #include "mlir/Dialect/QIR/QIRDefinitions.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
-#include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
-#include <mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h>
 #include <mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h>
-#include <mlir/Conversion/MathToLLVM/MathToLLVM.h>
-#include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
 #include <mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
@@ -41,7 +37,6 @@
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/IR/Region.h>
 #include <mlir/Interfaces/ControlFlowInterfaces.h>
-#include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/DialectConversion.h>
 #include <mlir/Transforms/WalkPatternRewriteDriver.h>
@@ -269,17 +264,15 @@ struct ConvertCBitAllocOp final : StatefulOpConversionPattern<cbit::AllocOp> {
           LLVM::AllocaOp::create(rewriter, loc, ptrType, i1Type, size)
               .getResult();
       if (op.getInitialization() == cbit::Initialization::Zero) {
-        auto zero = LLVM::ConstantOp::create(rewriter, loc, i1Type,
-                                             rewriter.getBoolAttr(false));
-        for (int64_t index = 0; index < op.getResult().getType().getWidth();
-             ++index) {
-          auto indexValue = LLVM::ConstantOp::create(
-              rewriter, loc, rewriter.getI64Type(), index);
-          auto element =
-              LLVM::GEPOp::create(rewriter, loc, ptrType, i1Type, storage,
-                                  ValueRange{indexValue.getResult()});
-          LLVM::StoreOp::create(rewriter, loc, zero, element);
-        }
+        rewriter.setInsertionPoint(op);
+        auto zero = LLVM::ConstantOp::create(rewriter, loc,
+                                             rewriter.getI8IntegerAttr(0));
+        auto null = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+        auto end = LLVM::GEPOp::create(rewriter, loc, ptrType, i1Type, null,
+                                       ValueRange{size});
+        auto bytes =
+            LLVM::PtrToIntOp::create(rewriter, loc, rewriter.getI64Type(), end);
+        LLVM::MemsetOp::create(rewriter, loc, storage, zero, bytes, false);
       }
       rewriter.replaceOp(op, storage);
       return success();
@@ -676,23 +669,8 @@ static void populateQCToQIRAdaptivePatterns(RewritePatternSet& patterns,
 
 namespace {
 
-/**
- * @brief Pass for converting QC dialect operations to QIR Adaptive Profile
- *
- * @details
- * Converts QC dialect quantum operations to QIR by lowering them to LLVM
- * dialect operations that call QIR runtime functions.
- *
- * Conversion stages:
- * 1. Convert scf dialect to cf
- * 2. Cpmvert func dialect to LLVM
- * 3. Ensure proper block structure for QIR Adaptive Profile
- * 4. Add QIR initialization call
- * 5. Convert QC and memref operations to QIR calls
- * 6. Set QIR metadata attributes
- * 7. Convert arith and cf dialects to LLVM
- * 8. Reconcile unrealized casts
- */
+/// Lower supported QC operations to QIR Adaptive runtime calls and LLVM IR.
+/// QIR attributes and module flags are attached by the separate metadata pass.
 struct QCToQIRAdaptive final : impl::QCToQIRAdaptiveBase<QCToQIRAdaptive> {
   using QCToQIRAdaptiveBase::QCToQIRAdaptiveBase;
 
@@ -777,38 +755,6 @@ struct QCToQIRAdaptive final : impl::QCToQIRAdaptiveBase<QCToQIRAdaptive> {
   }
 
 protected:
-  /**
-   * @brief Executes the QC to QIR conversion pass
-   *
-   * @details
-   * Performs the conversion in seven stages:
-   *
-   * **Stage 1: scf to cf**
-   * Convert scf dialect operation to cf dialect equivalents.
-   *
-   * **Stage 2: func to LLVM**
-   * Convert func dialect operations (main function) to LLVM dialect
-   * equivalents.
-   *
-   * **Stage 3: Block structure**
-   * Create proper block structure for QIR Adaptive Profile (entry,
-   * intermediate blocks, output).
-   *
-   * **Stage 4: Initialization**
-   * Insert the `__quantum__rt__initialize` call.
-   *
-   * **Stage 5: QC and memref to LLVM**
-   * Convert QC dialect operations and memref operations to QIR calls and add
-   * output recording to the output block.
-   *
-   * **Stage 6: Standard dialects to LLVM**
-   * Convert arith and control flow dialects to LLVM (for index arithmetic and
-   * function control flow).
-   *
-   * **Stage 7: Reconcile casts**
-   * Clean up any unrealized cast operations introduced during type
-   * conversion.
-   */
   void runOnOperation() override {
     MLIRContext* ctx = &getContext();
     auto moduleOp = getOperation();
@@ -906,30 +852,7 @@ protected:
       releaseResults(main, ctx, &state);
     }
 
-    // Stage 6: Convert standard dialects to LLVM
-    {
-      RewritePatternSet stdPatterns(ctx);
-      target.addIllegalDialect<arith::ArithDialect>();
-      target.addIllegalDialect<cf::ControlFlowDialect>();
-      target.addIllegalDialect<math::MathDialect>();
-
-      cf::populateControlFlowToLLVMConversionPatterns(typeConverter,
-                                                      stdPatterns);
-      cf::populateAssertToLLVMConversionPattern(typeConverter, stdPatterns);
-      arith::populateArithToLLVMConversionPatterns(typeConverter, stdPatterns);
-      populateMathToLLVMConversionPatterns(typeConverter, stdPatterns);
-
-      if (applyPartialConversion(moduleOp, target, std::move(stdPatterns))
-              .failed()) {
-        signalPassFailure();
-        return;
-      }
-    }
-
-    // Stage 7: Reconcile unrealized casts
-    PassManager passManager(ctx);
-    passManager.addPass(createReconcileUnrealizedCastsPass());
-    if (passManager.run(moduleOp).failed()) {
+    if (failed(finalizeQIRConversion(moduleOp, target, typeConverter))) {
       signalPassFailure();
     }
   }

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/CMakeLists.txt
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/CMakeLists.txt
@@ -24,9 +24,6 @@ add_mlir_conversion_library(
   MLIRArithDialect
   MLIRTransforms
   MLIRFuncDialect
-  MLIRFuncToLLVM
-  MLIRMathDialect
-  MLIRMathToLLVM
-  MLIRReconcileUnrealizedCasts)
+  MLIRFuncToLLVM)
 
 mqt_mlir_target_use_project_options(MLIRQCToQIRBase)

--- a/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRBase/QCToQIRBase.cpp
@@ -21,12 +21,8 @@
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 
 #include <llvm/ADT/DenseSet.h>
-#include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
-#include <mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h>
 #include <mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h>
 #include <mlir/Conversion/LLVMCommon/TypeConverter.h>
-#include <mlir/Conversion/MathToLLVM/MathToLLVM.h>
-#include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -43,7 +39,6 @@
 #include <mlir/IR/Region.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
-#include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/DialectConversion.h>
@@ -128,7 +123,7 @@ namespace {
  * pointers represented by `llvm.inttoptr` operations
  *
  * @details
- * Static qubit pointers are allocated during by `ConvertMemRefLoadOp`.
+ * Allocate static result pointers for each bit in a classical register.
  */
 struct ConvertCBitAllocOp final : StatefulOpConversionPattern<cbit::AllocOp> {
   using StatefulOpConversionPattern::StatefulOpConversionPattern;
@@ -152,11 +147,12 @@ struct ConvertCBitAllocOp final : StatefulOpConversionPattern<cbit::AllocOp> {
 
     OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(state.entryBlock->getTerminator());
+    reg.results.reserve(static_cast<size_t>(*size));
     const auto base = static_cast<int64_t>(state.staticResults.size());
     for (int64_t i = 0; i < *size; ++i) {
       const auto index = base + i;
       auto result = createPointerFromIndex(rewriter, op.getLoc(), index);
-      reg.results[i] = result;
+      reg.results.push_back(result);
       // The results are recorded as part of the register
       state.staticResults.try_emplace(
           index, qir::StaticResult{.pointer = result, .record = false});
@@ -411,28 +407,8 @@ static void populateQCToQIRBasePatterns(RewritePatternSet& patterns,
 }
 
 namespace {
-/**
- * @brief Pass for converting QC dialect operations to QIR
- *
- * @details
- * This pass converts QC dialect quantum operations to QIR (Quantum
- * Intermediate Representation) by lowering them to LLVM dialect operations
- * that call QIR runtime functions.
- *
- * Conversion stages:
- * 1. Convert func dialect to LLVM
- * 2. Ensure proper block structure for QIR base profile
- * 3. Add QIR initialization call
- * 4. Convert QC operations to QIR calls
- * 5. Set QIR metadata attributes
- * 6. Convert arith and cf dialects to LLVM
- * 7. Reconcile unrealized casts
- *
- * @pre
- * The input entry function must consist of a single block. The pass will
- * restructure it into four blocks. Multi-block input functions are
- * currently not supported.
- */
+/// Lower supported QC operations to QIR Base runtime calls and LLVM IR.
+/// QIR attributes and module flags are attached by the separate metadata pass.
 struct QCToQIRBase final : impl::QCToQIRBaseBase<QCToQIRBase> {
   using QCToQIRBaseBase::QCToQIRBaseBase;
 
@@ -499,34 +475,6 @@ struct QCToQIRBase final : impl::QCToQIRBaseBase<QCToQIRBase> {
   }
 
 protected:
-  /**
-   * @brief Executes the QC to QIR conversion pass
-   *
-   * @details
-   * Performs the conversion in six stages:
-   *
-   * **Stage 1: Func to LLVM**
-   * Convert func dialect operations (main function) to LLVM dialect
-   * equivalents.
-   *
-   * **Stage 2: Block structure**
-   * Create proper 4-block structure for QIR base profile (entry, main,
-   * irreversible, output).
-   *
-   * **Stage 3: Initialization**
-   * Insert the `__quantum__rt__initialize` call.
-   *
-   * **Stage 4: QC to LLVM**
-   * Convert QC dialect operations in place, validate and move terminal
-   * measurements, and add output recording to the output block.
-   *
-   * **Stage 5: Standard dialects to LLVM**
-   * Convert arith and control flow dialects to LLVM (for index arithmetic and
-   * function control flow).
-   *
-   * **Stage 6: Reconcile casts**
-   * Clean up any unrealized cast operations introduced during type conversion.
-   */
   void runOnOperation() override {
     MLIRContext* ctx = &getContext();
     auto moduleOp = getOperation();
@@ -611,30 +559,7 @@ protected:
       addOutputRecording(main, ctx, state);
     }
 
-    // Stage 5: Convert standard dialects to LLVM
-    {
-      RewritePatternSet stdPatterns(ctx);
-      target.addIllegalDialect<arith::ArithDialect>();
-      target.addIllegalDialect<cf::ControlFlowDialect>();
-      target.addIllegalDialect<math::MathDialect>();
-
-      cf::populateControlFlowToLLVMConversionPatterns(typeConverter,
-                                                      stdPatterns);
-      cf::populateAssertToLLVMConversionPattern(typeConverter, stdPatterns);
-      arith::populateArithToLLVMConversionPatterns(typeConverter, stdPatterns);
-      populateMathToLLVMConversionPatterns(typeConverter, stdPatterns);
-
-      if (applyPartialConversion(moduleOp, target, std::move(stdPatterns))
-              .failed()) {
-        signalPassFailure();
-        return;
-      }
-    }
-
-    // Stage 6: Reconcile unrealized casts
-    PassManager passManager(ctx);
-    passManager.addPass(createReconcileUnrealizedCastsPass());
-    if (passManager.run(moduleOp).failed()) {
+    if (failed(finalizeQIRConversion(moduleOp, target, typeConverter))) {
       signalPassFailure();
     }
   }

--- a/mlir/lib/Conversion/QCToQIR/QIRCommon/CMakeLists.txt
+++ b/mlir/lib/Conversion/QCToQIR/QIRCommon/CMakeLists.txt
@@ -20,8 +20,10 @@ add_mlir_library(
   MLIRTransforms
   MLIRLLVMDialect
   MLIRLLVMCommonConversion
-  MLIRFuncToLLVM
   MLIRControlFlowToLLVM
+  MLIRMathDialect
+  MLIRMathToLLVM
+  MLIRReconcileUnrealizedCasts
   MLIRArithToLLVM
   MLIRMemRefDialect
   MLIRMQTDialect

--- a/mlir/lib/Conversion/QCToQIR/QIRCommon/QIRCommon.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRCommon/QIRCommon.cpp
@@ -20,13 +20,15 @@
 #include <llvm/ADT/SmallVector.h>
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
 #include <mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h>
-#include <mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h>
 #include <mlir/Conversion/LLVMCommon/TypeConverter.h>
+#include <mlir/Conversion/MathToLLVM/MathToLLVM.h>
 #include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Dialect/LLVMIR/LLVMTypes.h>
+#include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
@@ -37,6 +39,7 @@
 #include <mlir/IR/Types.h>
 #include <mlir/IR/Value.h>
 #include <mlir/IR/ValueRange.h>
+#include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/DialectConversion.h>
@@ -64,6 +67,24 @@ LogicalResult LoweringState::ensureAllocationMode(AllocationMode requested,
       "cannot mix static and dynamic qubit allocation modes in conversion");
 }
 
+LogicalResult finalizeQIRConversion(ModuleOp moduleOp, ConversionTarget& target,
+                                    LLVMTypeConverter& typeConverter) {
+  auto* ctx = moduleOp.getContext();
+  RewritePatternSet patterns(ctx);
+  target.addIllegalDialect<arith::ArithDialect, cf::ControlFlowDialect,
+                           math::MathDialect>();
+  cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
+  cf::populateAssertToLLVMConversionPattern(typeConverter, patterns);
+  arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
+  populateMathToLLVMConversionPatterns(typeConverter, patterns);
+  if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
+    return failure();
+  }
+  PassManager manager(ctx);
+  manager.addPass(createReconcileUnrealizedCastsPass());
+  return manager.run(moduleOp);
+}
+
 QCToQIRTypeConverter::QCToQIRTypeConverter(MLIRContext* ctx)
     : LLVMTypeConverter(ctx) {
   addConversion([ctx](QubitType) { return LLVM::LLVMPointerType::get(ctx); });
@@ -85,7 +106,7 @@ QCToQIRTypeConverter::QCToQIRTypeConverter(MLIRContext* ctx)
  * @param op The QC operation instance to convert
  * @param adaptor The OpAdaptor of the QC operation
  * @param rewriter The pattern rewriter
- * @param state The lowering state
+ * @param controls Converted controls for this gate
  * @param fnName The name of the QIR function to call
  * @param numTargets The number of targets
  * @param numParams The number of parameters
@@ -94,22 +115,13 @@ QCToQIRTypeConverter::QCToQIRTypeConverter(MLIRContext* ctx)
 template <typename QCOpType, typename QCOpAdaptorType>
 static LogicalResult
 convertUnitaryToCallOp(QCOpType& op, QCOpAdaptorType& adaptor,
-                       ConversionPatternRewriter& rewriter,
-                       LoweringState& state, StringRef fnName,
-                       const size_t numTargets, const size_t numParams) {
-  // Query state for modifier information
-  const SmallVector<Value> controls =
-      state.inCtrlOp ? state.controls : SmallVector<Value>{};
+                       ConversionPatternRewriter& rewriter, ValueRange controls,
+                       StringRef fnName, const size_t numTargets,
+                       const size_t numParams) {
   auto convertedOperands = adaptor.getOperands();
   auto targets = convertedOperands.take_front(numTargets);
   auto parameters = convertedOperands.drop_front(numTargets);
   assert(parameters.size() == numParams && "unexpected gate parameter count");
-
-  // Clean up modifier information
-  if (state.inCtrlOp) {
-    state.inCtrlOp = false;
-    state.controls.clear();
-  }
 
   qir::emitQISCall(rewriter, op, op.getLoc(), parameters, controls, targets,
                    fnName);
@@ -214,10 +226,17 @@ struct ConvertQCUnitaryOpQIR : StatefulOpConversionPattern<OpType> {
   matchAndRewrite(OpType op, OpType::Adaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
     auto& state = this->getState();
-    const size_t numCtrls = state.inCtrlOp ? state.controls.size() : 0;
-    const auto fnName = GetFnName(numCtrls);
-    return convertUnitaryToCallOp(op, adaptor, rewriter, state, fnName,
-                                  NumTargets, NumParams);
+    const auto it = state.controlledGates.find(op);
+    ValueRange controls = it != state.controlledGates.end()
+                              ? ValueRange(it->second)
+                              : ValueRange{};
+    const auto fnName = GetFnName(controls.size());
+    auto result = convertUnitaryToCallOp(op, adaptor, rewriter, controls,
+                                         fnName, NumTargets, NumParams);
+    if (it != state.controlledGates.end()) {
+      state.controlledGates.erase(it);
+    }
+    return result;
   }
 };
 
@@ -296,11 +315,11 @@ struct ConvertQCGPhaseOp final : StatefulOpConversionPattern<GPhaseOp> {
   matchAndRewrite(GPhaseOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter& rewriter) const override {
     auto& state = getState();
-    if (state.inCtrlOp) {
+    if (state.controlledGates.contains(op)) {
       return op.emitError("Controlled GPhaseOps cannot be converted to QIR");
     }
-    return convertUnitaryToCallOp(op, adaptor, rewriter, state, QIR_GPHASE, 0,
-                                  1);
+    return convertUnitaryToCallOp(op, adaptor, rewriter, ValueRange{},
+                                  QIR_GPHASE, 0, 1);
   }
 };
 
@@ -331,7 +350,7 @@ struct ConvertQCCtrlOp final : StatefulOpConversionPattern<CtrlOp> {
                   ConversionPatternRewriter& rewriter) const override {
     auto& state = getState();
 
-    if (state.inCtrlOp) {
+    if (state.controlledGates.contains(op)) {
       return rewriter.notifyMatchFailure(op,
                                          "Nested CtrlOps are not supported");
     }
@@ -342,15 +361,11 @@ struct ConvertQCCtrlOp final : StatefulOpConversionPattern<CtrlOp> {
               "unroll-modifiers pass before the conversion");
     }
 
-    // Empty control bodies and controls around no-op unitaries do not need
-    // lowering state. In particular, barrier lowering erases the operation
-    // without consuming that state, which would otherwise control the next
-    // gate.
     auto bodyUnitary = op.getNumBodyUnitaries() == 1 ? op.getBodyUnitary(0)
                                                      : UnitaryOpInterface{};
     if (bodyUnitary && !isa<BarrierOp, IdOp>(bodyUnitary.getOperation())) {
-      state.inCtrlOp = true;
-      state.controls = llvm::to_vector(adaptor.getControls());
+      state.controlledGates.try_emplace(bodyUnitary.getOperation(),
+                                        llvm::to_vector(adaptor.getControls()));
     }
 
     // Inline block and remove operation
@@ -399,7 +414,7 @@ void addOutputRecording(LLVM::LLVMFuncOp& main, MLIRContext* ctx,
   SmallVector<qir::ClassicalRegister> returnedRegisters;
   returnedRegisters.reserve(state.returnedCregs.size());
   for (const auto registerIndex : state.returnedCregs) {
-    returnedRegisters.push_back(state.cregs[registerIndex]);
+    returnedRegisters.push_back(std::move(state.cregs[registerIndex]));
   }
   emitOutputRecording(builder, main, returnedRegisters, state.staticResults);
 }
@@ -482,7 +497,6 @@ LogicalResult prepareClassicalResults(Operation* moduleOp,
       }
       const auto size = allocOp.getResult().getType().getWidth();
       reg.size = size;
-      reg.results.assign(static_cast<size_t>(size), Value{});
     });
 
     const auto markRegisterForRecording = [&](const size_t registerIndex) {

--- a/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
@@ -206,15 +206,15 @@ private:
     const auto setTypes = [&](const StringRef name,
                               const llvm::SmallSet<std::string, 4>& types) {
       if (types.empty()) {
-        m->removeAttr(name);
         return;
       }
       SmallVector<StringRef> values(types.begin(), types.end());
       llvm::sort(values);
-      m->setAttr(name, rewriter.getStrArrayAttr(values));
+      flags.emplace_back(createFlag(LLVM::ModFlagBehavior::Append, name,
+                                    rewriter.getStrArrayAttr(values)));
     };
-    setTypes("qir.int_computations", metadata.integerTypes);
-    setTypes("qir.float_computations", metadata.floatingTypes);
+    setTypes("int_computations", metadata.integerTypes);
+    setTypes("float_computations", metadata.floatingTypes);
     LLVM::ModuleFlagsOp::create(rewriter, m.getLoc(),
                                 rewriter.getArrayAttr(flags));
   }

--- a/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/QIRCleanup.cpp
@@ -31,18 +31,6 @@ namespace mlir::qir {
 #define GEN_PASS_DEF_QIRCLEANUPPASS
 #include "mlir/Dialect/QIR/Transforms/Passes.h.inc"
 
-[[nodiscard]] static StringAttr getMetadataKey(const Attribute attr) {
-  auto pair = dyn_cast<ArrayAttr>(attr);
-  if (!pair || pair.size() != 2) {
-    return {};
-  }
-  auto key = dyn_cast<StringAttr>(pair[0]);
-  if (!key || !isa<StringAttr>(pair[1])) {
-    return {};
-  }
-  return key;
-}
-
 [[nodiscard]] static StringRef getCalleeName(LLVM::CallOp callOp) {
   auto calleeAttr = callOp.getCalleeAttr();
   auto flatRef = calleeAttr;
@@ -50,20 +38,6 @@ namespace mlir::qir {
     return {};
   }
   return flatRef.getValue();
-}
-
-[[nodiscard]] static bool moduleHasDynamicQubitRuntimeCalls(ModuleOp module) {
-  return llvm::any_of(module.getOps<LLVM::CallOp>(), [](LLVM::CallOp callOp) {
-    const auto callee = getCalleeName(callOp);
-    return callee == QIR_QUBIT_ALLOC || callee == QIR_QUBIT_ARRAY_ALLOC;
-  });
-}
-
-[[nodiscard]] static bool moduleHasDynamicResultRuntimeCalls(ModuleOp module) {
-  return llvm::any_of(module.getOps<LLVM::CallOp>(), [](LLVM::CallOp callOp) {
-    const auto callee = getCalleeName(callOp);
-    return callee == QIR_RESULT_ALLOC || callee == QIR_RESULT_ARRAY_ALLOC;
-  });
 }
 
 static void dropUnusedExternalDeclarations(ModuleOp module) {
@@ -77,67 +51,6 @@ static void dropUnusedExternalDeclarations(ModuleOp module) {
     }
     funcOp.erase();
   }
-}
-
-static void normalizeQIRMetadata(ModuleOp module) {
-  auto main = getMainFunction(module);
-  if (!main) {
-    return;
-  }
-
-  auto passthroughAttr = main->getAttrOfType<ArrayAttr>("passthrough");
-  if (!passthroughAttr) {
-    return;
-  }
-
-  const bool hasDynamicQubit = moduleHasDynamicQubitRuntimeCalls(module);
-  const bool hasDynamicResult = moduleHasDynamicResultRuntimeCalls(module);
-  if (hasDynamicQubit && hasDynamicResult) {
-    return;
-  }
-
-  ArrayAttr requiredNumQubitsAttr = nullptr;
-  ArrayAttr requiredNumResultsAttr = nullptr;
-  for (const auto attr : passthroughAttr) {
-    const auto key = getMetadataKey(attr);
-    if (!key) {
-      continue;
-    }
-    if (key.getValue() == "required_num_qubits") {
-      requiredNumQubitsAttr = cast<ArrayAttr>(attr);
-    } else if (key.getValue() == "required_num_results") {
-      requiredNumResultsAttr = cast<ArrayAttr>(attr);
-    }
-  }
-
-  OpBuilder builder(module.getContext());
-  SmallVector<Attribute> updatedMetadata;
-  updatedMetadata.reserve(passthroughAttr.size() + 2);
-
-  for (const auto attr : passthroughAttr) {
-    const auto key = getMetadataKey(attr);
-    if (!key) {
-      updatedMetadata.push_back(attr);
-      continue;
-    }
-
-    if (key.getValue() == "dynamic_qubit_management" && !hasDynamicQubit) {
-      if (requiredNumQubitsAttr) {
-        updatedMetadata.push_back(requiredNumQubitsAttr);
-      }
-      continue;
-    }
-    if (key.getValue() == "dynamic_result_management" && !hasDynamicResult) {
-      if (requiredNumResultsAttr) {
-        updatedMetadata.push_back(requiredNumResultsAttr);
-      }
-      continue;
-    }
-
-    updatedMetadata.push_back(attr);
-  }
-
-  main->setAttr("passthrough", builder.getArrayAttr(updatedMetadata));
 }
 
 namespace {
@@ -201,7 +114,7 @@ struct RemoveDeadQubitArrayPair final : OpRewritePattern<LLVM::CallOp> {
 /**
  * @brief Clean up QIR.
  * @details Removes dead allocation-release pairs of qubit arrays, drops unused
- * external declarations, and normalizes QIR metadata.
+ * external declarations.
  */
 struct QIRCleanupPass final : impl::QIRCleanupPassBase<QIRCleanupPass> {
 protected:
@@ -216,7 +129,6 @@ protected:
     }
 
     dropUnusedExternalDeclarations(module);
-    normalizeQIRMetadata(module);
   }
 };
 

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -62,7 +62,7 @@ static void setIntegerModuleFlag(llvm::Module& moduleOp,
       llvm::ConstantInt::get(llvm::IntegerType::get(context, bitWidth), value));
 }
 
-void normalizeQIRModuleFlags(llvm::Module& moduleOp, ModuleOp sourceModule) {
+void normalizeQIRModuleFlags(llvm::Module& moduleOp) {
   for (const auto* const key : {
            "dynamic_qubit_management",
            "dynamic_result_management",
@@ -81,23 +81,6 @@ void normalizeQIRModuleFlags(llvm::Module& moduleOp, ModuleOp sourceModule) {
         moduleOp, llvm::Module::Error, "backwards_branching", 2,
         moduleFlagIntegerValue(moduleOp, "backwards_branching"));
   }
-  const auto setTypes = [&](const StringRef flag, const StringRef attribute) {
-    const auto values = sourceModule->getAttrOfType<ArrayAttr>(attribute);
-    if (!values || values.empty()) {
-      return;
-    }
-    SmallVector<llvm::Metadata*> entries;
-    entries.reserve(values.size());
-    llvm::transform(values.getAsRange<StringAttr>(),
-                    std::back_inserter(entries), [&](const StringAttr value) {
-                      return llvm::MDString::get(moduleOp.getContext(),
-                                                 value.getValue());
-                    });
-    moduleOp.setModuleFlag(llvm::Module::Append, flag,
-                           llvm::MDTuple::get(moduleOp.getContext(), entries));
-  };
-  setTypes("int_computations", "qir.int_computations");
-  setTypes("float_computations", "qir.float_computations");
 }
 
 void emitQISCall(OpBuilder& builder, Operation* anchor, const Location loc,

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -637,7 +637,7 @@ static int runCompiler(int argc, char** argv) {
       llvm::errs() << "Failed to translate MLIR module to LLVM IR\n";
       return 1;
     }
-    qir::normalizeQIRModuleFlags(*llvmMod, *program.mod);
+    qir::normalizeQIRModuleFlags(*llvmMod);
     if (writeOutput<llvm::Module*>(llvmMod.get(), outputFilename).failed()) {
       return 1;
     }

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
@@ -534,7 +534,7 @@ TEST(QCToQIRAdaptiveNativeTest, LowersInternalZeroInitializedRegisterStorage) {
                       LLVM::LLVMDialect, memref::MemRefDialect>();
   qc::QCProgramBuilder builder(&context);
   builder.initialize();
-  auto c = builder.allocClassicalBitRegister(2);
+  auto c = builder.allocClassicalBitRegister(8192);
   auto first = builder.loadClassicalBit(c, 0);
   builder.storeClassicalBit(first, c, 1);
   auto module = builder.finalize();
@@ -551,7 +551,58 @@ TEST(QCToQIRAdaptiveNativeTest, LowersInternalZeroInitializedRegisterStorage) {
   module->walk([&](LLVM::StoreOp) { ++stores; });
   EXPECT_EQ(allocs, 1);
   EXPECT_EQ(loads, 1);
-  EXPECT_EQ(stores, 3);
+  EXPECT_EQ(stores, 1);
+  size_t zeroFills = 0;
+  module->walk([&](LLVM::MemsetOp fill) {
+    ++zeroFills;
+    auto value = fill.getVal().getDefiningOp<LLVM::ConstantOp>();
+    ASSERT_TRUE(value);
+    EXPECT_TRUE(cast<IntegerAttr>(value.getValue()).getValue().isZero());
+  });
+  EXPECT_EQ(zeroFills, 1);
+}
+
+TEST(QCToQIRAdaptiveNativeTest, InitializesLocalRegisterInsideLoop) {
+  MLIRContext context;
+  context.loadDialect<cbit::CBitDialect, qc::QCDialect, arith::ArithDialect,
+                      cf::ControlFlowDialect, func::FuncDialect,
+                      LLVM::LLVMDialect, scf::SCFDialect>();
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @main() -> i64 attributes {mqt.entry_point} {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %c2 = arith.constant 2 : index
+        %false = arith.constant false
+        %true = arith.constant true
+        %answer = scf.for %i = %c0 to %c2 step %c1
+            iter_args(%last = %false) -> i1 {
+          %r = cbit.alloc(#cbit.init<zero>) : !cbit.reg<1>
+          %v = cbit.load %r[%c0] : !cbit.reg<1>
+          cbit.store %true, %r[%c0] : !cbit.reg<1>
+          scf.yield %v : i1
+        }
+        %exit = arith.extui %answer : i1 to i64
+        return %exit : i64
+      }
+    }
+  )mlir",
+                                              &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCToQIRAdaptiveConversionSimple(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  LLVM::MemsetOp fill;
+  LLVM::LoadOp load;
+  moduleOp->walk([&](LLVM::MemsetOp op) { fill = op; });
+  moduleOp->walk([&](LLVM::LoadOp op) { load = op; });
+  ASSERT_TRUE(fill);
+  ASSERT_TRUE(load);
+  ASSERT_EQ(fill->getBlock(), load->getBlock());
+  EXPECT_TRUE(fill->isBeforeInBlock(load));
+  auto main = moduleOp->lookupSymbol<LLVM::LLVMFuncOp>("main");
+  ASSERT_TRUE(main);
+  EXPECT_NE(fill->getBlock(), &main.getBody().front());
 }
 
 TEST(QCToQIRAdaptiveNativeTest, SupportsDynamicInternalRegisterIndices) {

--- a/mlir/unittests/Dialect/QIR/IR/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QIR/IR/CMakeLists.txt
@@ -10,8 +10,16 @@ set(target_name mqt-core-mlir-unittest-qir-ir)
 add_executable(${target_name} test_qir_ir.cpp)
 
 target_link_libraries(
-  ${target_name} PRIVATE MLIRParser MLIRSupportMQT MLIRSCFDialect GTest::gtest_main
-                         MLIRQIRProgramBuilder MLIRQIRPrograms)
+  ${target_name}
+  PRIVATE MLIRParser
+          MLIRSupportMQT
+          MLIRSCFDialect
+          GTest::gtest_main
+          MLIRQIRProgramBuilder
+          MLIRQIRPrograms
+          MLIRBuiltinToLLVMIRTranslation
+          MLIRLLVMToLLVMIRTranslation
+          MLIRTargetLLVMIRExport)
 
 mqt_mlir_configure_unittest_target(${target_name})
 

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -40,6 +40,9 @@
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h>
+#include <mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h>
+#include <mlir/Target/LLVMIR/Export.h>
 
 #include <algorithm>
 #include <array>
@@ -540,14 +543,18 @@ TEST_F(QIRTest, DerivesAdaptiveClassicalCapabilities) {
   LLVM::ReturnOp::create(builder, location, doubled);
 
   ASSERT_TRUE(attachQIRMetadata(moduleOp, true).succeeded());
-  const auto integerTypes =
-      moduleOp->getAttrOfType<ArrayAttr>("qir.int_computations");
+  const auto integerFlag = findModuleFlag(moduleOp, "int_computations");
+  ASSERT_TRUE(integerFlag);
+  EXPECT_EQ(integerFlag.getBehavior(), LLVM::ModFlagBehavior::Append);
+  const auto integerTypes = cast<ArrayAttr>(integerFlag.getValue());
   ASSERT_TRUE(integerTypes);
   ASSERT_EQ(integerTypes.size(), 2U);
   EXPECT_EQ(cast<StringAttr>(integerTypes[0]).getValue(), "i32");
   EXPECT_EQ(cast<StringAttr>(integerTypes[1]).getValue(), "i8");
-  const auto floatingTypes =
-      moduleOp->getAttrOfType<ArrayAttr>("qir.float_computations");
+  const auto floatingFlag = findModuleFlag(moduleOp, "float_computations");
+  ASSERT_TRUE(floatingFlag);
+  EXPECT_EQ(floatingFlag.getBehavior(), LLVM::ModFlagBehavior::Append);
+  const auto floatingTypes = cast<ArrayAttr>(floatingFlag.getValue());
   ASSERT_TRUE(floatingTypes);
   ASSERT_EQ(floatingTypes.size(), 2U);
   EXPECT_EQ(cast<StringAttr>(floatingTypes[0]).getValue(), "double");
@@ -564,8 +571,8 @@ TEST_F(QIRTest, DerivesAdaptiveClassicalCapabilities) {
   }
 
   ASSERT_TRUE(attachQIRMetadata(moduleOp).succeeded());
-  EXPECT_FALSE(moduleOp->hasAttr("qir.int_computations"));
-  EXPECT_FALSE(moduleOp->hasAttr("qir.float_computations"));
+  EXPECT_FALSE(findModuleFlag(moduleOp, "int_computations"));
+  EXPECT_FALSE(findModuleFlag(moduleOp, "float_computations"));
   EXPECT_FALSE(findModuleFlag(moduleOp, "ir_functions"));
   EXPECT_FALSE(findModuleFlag(moduleOp, "multiple_target_branching"));
   EXPECT_FALSE(findModuleFlag(moduleOp, "multiple_return_points"));
@@ -573,19 +580,27 @@ TEST_F(QIRTest, DerivesAdaptiveClassicalCapabilities) {
 
 TEST(QIRModuleFlagsTest, RecordsAdaptiveClassicalCapabilities) {
   MLIRContext mlirContext;
-  OpBuilder builder(&mlirContext);
-  auto sourceModule = ModuleOp::create(builder.getUnknownLoc());
-  sourceModule->setAttr("qir.int_computations",
-                        builder.getStrArrayAttr({"i8"}));
-  sourceModule->setAttr("qir.float_computations",
-                        builder.getStrArrayAttr({"double"}));
-
+  mlirContext.loadDialect<LLVM::LLVMDialect>();
+  registerBuiltinDialectTranslation(mlirContext);
+  registerLLVMDialectTranslation(mlirContext);
+  auto sourceModule = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      llvm.module_flags [
+        #llvm.mlir.module_flag<append, "int_computations", ["i8"]>,
+        #llvm.mlir.module_flag<append, "float_computations", ["double"]>,
+        #llvm.mlir.module_flag<error, "ir_functions", 1 : i32>,
+        #llvm.mlir.module_flag<error, "multiple_target_branching", 1 : i32>,
+        #llvm.mlir.module_flag<error, "multiple_return_points", 1 : i32>
+      ]
+    }
+  )mlir",
+                                                  &mlirContext);
+  ASSERT_TRUE(sourceModule);
   llvm::LLVMContext llvmContext;
-  llvm::Module moduleOp("adaptive", llvmContext);
-  moduleOp.addModuleFlag(llvm::Module::Error, "ir_functions", 1U);
-  moduleOp.addModuleFlag(llvm::Module::Error, "multiple_target_branching", 1U);
-  moduleOp.addModuleFlag(llvm::Module::Error, "multiple_return_points", 1U);
-  normalizeQIRModuleFlags(moduleOp, sourceModule);
+  auto translated = translateModuleToLLVMIR(*sourceModule, llvmContext);
+  ASSERT_NE(translated, nullptr);
+  auto& moduleOp = *translated;
+  normalizeQIRModuleFlags(moduleOp);
 
   const auto* integerTypes =
       llvm::dyn_cast<llvm::MDNode>(moduleOp.getModuleFlag("int_computations"));

--- a/python/mqt/core/plugins/pennylane/device.py
+++ b/python/mqt/core/plugins/pennylane/device.py
@@ -146,6 +146,7 @@ class QDMIDevice(Device):
     """
 
     capabilities = DeviceCapabilities(supported_mcm_methods=[])
+    """Backend capabilities described by :class:`~pennylane.devices.capabilities.DeviceCapabilities`."""
 
     def __init__(
         self,


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Simplify the Base and Adaptive QIR conversion paths while preserving direct pass use. Computation-type lists now use native LLVM module flags, and obsolete cleanup metadata rewriting and unused allocator state are removed. The narrow integer flag-width repair remains necessary with LLVM 23.

Share final classical lowering and cast reconciliation, bind controls to their body gate, allocate result vectors only in Base, and move returned register records into output emission. Adaptive local registers now use a single bulk zero operation at the allocation site, so initialization remains inside loops and emitted initialization code no longer grows with register width. Correct stale pass descriptions.

Local validation passes: 288 conversion tests, 121 QIR metadata/translation tests, 24 QIR JIT tests, 171 compiler tests, repository lint, full-file C++ lint, and the strict documentation build (`uvx nox --non-interactive -s docs`). Hosted CI is pending. The new tests cover an 8,192-bit local register and initialization inside a loop. No new dependencies. Changelog and upgrade entries are omitted under the repository policy for unreleased v4 functionality.

The PennyLane capabilities docstring uses its public class target so strict documentation builds resolve the link without suppressing reference warnings.

AI assistance: Codex implemented, reviewed, and locally validated this change under explicit authorization. Human review remains required.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
