### PR TITLE
🐛 Fix QC/QCO conversion and matrix contracts

### DIFF
--- a/.agent/audits/qc-qco-infrastructure.md
+++ b/.agent/audits/qc-qco-infrastructure.md
@@ -1,0 +1,57 @@
+# QC/QCO infrastructure audit
+
+Status: complete.
+
+## Scope and contract
+
+The audit covers QC/QCO dialect operations, modifier matrix queries, and the
+QC/QCO conversion boundary. The implementation baseline is
+`3be5ee96f3907659bd99fdd6d54cd74c4eea7da9` with LLVM/MLIR 23.1.0.
+
+QCO values carry linear state; QC values identify mutable references. A
+conversion that removes a quantum result must prove its correspondence to the
+replacement reference. QCO wire permutations remain valid IR, but reference
+conversion rejects permutations it cannot represent. QTensor slot updates remain
+real stores. Modifier matrices include every declared target in argument order.
+
+## Findings and disposition
+
+| Finding                                                                                                               | Owner and resolution                                                                                                                                                         | Surviving evidence                                                                                                 |
+| --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Positional conversion could silently change branch or loop wires, and changing `scf.while` quantum arity could assert | `QCOToQC.cpp` checks region terminators before rewriting and uses the same proven origins for function returns                                                               | Conversion regressions cover each region form, changing quantum arity, reset, classical state, and register stores |
+| QC unstructured control flow could assert                                                                             | Already fixed by [#2448](https://github.com/munich-quantum-toolkit/core/pull/2448); preserve the pass's SCF-only contract                                                    | Existing QC-to-QCO rejection tests                                                                                 |
+| Barrier input and result counts could differ                                                                          | The owning `BarrierOp` verifier requires one result per input                                                                                                                | `BarrierRejectsMismatchedQubitArity`                                                                               |
+| Single-operation modifier matrix shortcuts ignored idle targets and wire order                                        | All modifier queries use `composeBodyMatrix`; full-width operations retain direct matrix support, other supported operations are embedded; reordered yields return no matrix | Exact matrix tests for idle targets, full-width three-qubit operations, reordered yields, and total-width bounds   |
+| Allocation mode depended on function rewrite order                                                                    | Collect allocation roots before conversion and store an immutable module mode                                                                                                | `FindsAllocationModeBeforeConvertingCaller` and existing allocation tests                                          |
+| QTensor insertion scanned the cache before trying its exact key                                                       | Try the direct lookup first, then retain equivalent-index matching, result-number checks, stores, and cross-region invalidation                                              | Existing store-elision, dynamic slot-swap, and distinct-index-result tests                                         |
+| Sink order exposed DenseMap traversal                                                                                 | Track scalar references with MapVector                                                                                                                                       | `EmitsSinksInAllocationOrder`                                                                                      |
+| Thirty pattern classes only forwarded to shared helpers                                                               | Register the helpers with MLIR's native function-pattern overload; use short lambdas for optional boolean arguments                                                          | Existing gate canonicalization equivalence tests                                                                   |
+| Barrier merging used a dense map for contiguous positions and repeatedly searched inputs                              | Use positional output access and a replacement vector                                                                                                                        | Existing barrier equivalence tests                                                                                 |
+| QC/QCO headers retained obsolete reversed-operator warning suppression                                                | Remove the suppression and retain required interface includes                                                                                                                | Normal builds and full-file C++ lint                                                                               |
+| Duplicate gate helpers and unreachable branches obscured contracts                                                    | Reuse generic zero-target gate lowering and quantum-state predicates, use a constant-index set, and remove impossible absent-else branches                                   | Existing global-phase, register-alias, and branch-interface tests                                                  |
+
+The effect and modifier-verifier cleanup from
+[#2435](https://github.com/munich-quantum-toolkit/core/pull/2435) is already in
+the baseline. The conversion retains early delegation to the owning verifier
+rather than duplicating its body contract.
+
+## Performance evidence and limits
+
+The isolated exact-key cache change was measured on the original audit baseline
+`33dbc843e589d9e9166308084e825c9f8b2ff89d`. Five alternating paired runs of a
+32,000-slot extract/gate/insert workload reduced median conversion time from
+1,530.682 ms to 225.026 ms. This establishes the benefit on a synthetic wide
+register, not a general application speedup or a timing result for the complete
+patch. The 148-test conversion suite also passed with that isolated change.
+
+Dense modifier matrices are bounded to ten total qubits, including controls.
+Arbitrary-width subset embeddings, permutation transport, mixed allocation
+roots, and register-function support remain outside this change. Register-call
+contracts are tracked separately in
+[#2428](https://github.com/munich-quantum-toolkit/core/issues/2428).
+
+## Validation
+
+See the [implementation record](../plans/qc-qco-infrastructure.md) for the final
+checks. Behavioral regressions use the existing GoogleTest suites; no standalone
+probe or generated build artifact belongs to the implementation.

--- a/.agent/plans/qc-qco-infrastructure.md
+++ b/.agent/plans/qc-qco-infrastructure.md
@@ -1,0 +1,48 @@
+# QC/QCO infrastructure fixes
+
+Status: complete.
+
+## Outcome and decisions
+
+The [audit findings](../audits/qc-qco-infrastructure.md) are implemented or
+covered by upstream fixes. The conversion owns the proof that quantum region
+results can become in-place QC references. It rejects unproved permutations
+before rewriting; the QCO dialect continues to permit those permutations.
+Function-return validation uses the same proven origins rather than assuming
+positional loop results. QTensor slot updates remain stores where required.
+
+Allocation mode is an immutable result of module preflight, so factory and
+caller order does not affect deallocation. An ordered scalar map makes sink
+emission stable. The QTensor cache retains equivalent-index handling and
+invalidation, with a direct lookup before scanning.
+
+The shared modifier matrix composer owns width and wire order. Queries include
+idle targets, support ordered full-width operations, and return no matrix for
+unsupported embeddings or reordered yields. The ten-qubit dense-matrix bound
+includes controls. Barrier arity belongs to the operation verifier.
+
+Native MLIR function patterns replace forwarding classes. No new abstraction,
+cache, dependency, or register-function ABI is introduced. Register-function
+support remains a separate contract under #2428.
+
+## Validation
+
+All 1,978 tests passed in the corresponding release binaries:
+
+| Suite               | Tests |
+| ------------------- | ----: |
+| QCO-to-QC           |   153 |
+| QC-to-QCO           |   175 |
+| QC/QCO round trip   |     6 |
+| QC IR               |   348 |
+| QCO IR and matrices |   506 |
+| QCO utilities       |   185 |
+| Decomposition       |   238 |
+| Optimizations       |   196 |
+| Compiler            |   171 |
+
+The release build also includes `mqt-cc`. `uvx nox -s lint`,
+`cmake --build --preset release --target mlir-doc`, and `git diff --check`
+passed. The final full-file C++ lint comparison is pinned to the PR merge base,
+`3be5ee96f3907659bd99fdd6d54cd74c4eea7da9`, to exclude unrelated changes to
+main.

--- a/.agent/plans/qc-qco-infrastructure.md
+++ b/.agent/plans/qc-qco-infrastructure.md
@@ -27,7 +27,7 @@ support remains a separate contract under #2428.
 
 ## Validation
 
-All 1,978 tests passed in the corresponding release binaries:
+Before rebasing, all 1,978 tests passed in the corresponding release binaries:
 
 | Suite               | Tests |
 | ------------------- | ----: |
@@ -44,5 +44,30 @@ All 1,978 tests passed in the corresponding release binaries:
 The release build also includes `mqt-cc`. `uvx nox -s lint`,
 `cmake --build --preset release --target mlir-doc`, and `git diff --check`
 passed. The final full-file C++ lint comparison is pinned to the PR merge base,
-`3be5ee96f3907659bd99fdd6d54cd74c4eea7da9`, to exclude unrelated changes to
+`ec799daa09f855bd0edcbc5592a5fedd90836516`, to exclude unrelated changes to
 main.
+
+After rebasing on that main commit, all 505 conversion, round-trip, and compiler
+tests passed again, as did lint and full-file C++ lint. The complete strict
+`uvx nox --non-interactive -s docs` build, including notebook execution, passed
+after qualifying the inherited PennyLane capability reference with a local
+attribute docstring. This fixes the Read the Docs failure in PR #2464.
+
+## Linearity and modifier follow-up
+
+The development policy and MLIR agent guide state the exactly-one-use contract.
+Five redundant rewrite guards are removed; the boundary verifier, debug
+assertions, and classical/reference use checks remain. Native MLIR use-list
+iterators provide constant-time access without a new type interface or wrapper.
+Extract/insert cancellation uses a rewrite that deletes both operations,
+avoiding the temporary duplicate tensor use left by a root-only fold.
+
+DCX cancellation requires reversed target order. A lone controlled SWAP remains
+a conditional unitary; it cannot become an unconditional output permutation.
+Exact-matrix tests cover both DCX orientations and controlled SWAP behavior. The
+rebase on `11d983fa59831007a8ce7e8bf17b2f06f85b3a20` retains the upstream
+PennyLane documentation fix. The follow-up passed 880 tests: QCO IR (509),
+QTensor IR (37), QC-to-QCO (175), QCO-to-QC (153), and round trip (6). Strict
+Sphinx documentation, lint, and full-file C++ lint passed. Local release
+validation uses `ENABLE_IPO=OFF` to avoid a GCC/LTO duplicate symbol in the
+installed MLIR library; no source workaround is included.

--- a/docs/mlir/development.md
+++ b/docs/mlir/development.md
@@ -73,6 +73,26 @@ Use diagnostics for invalid input or unsupported behavior. Reserve assertions
 for internal invariants that valid input cannot violate. Diagnostics must state
 what failed and, when useful, which form is supported.
 
+## Linear quantum values
+
+Every `!qco.qubit` and one-dimensional qubit tensor or vector SSA value in valid
+QCO IR has exactly one use, including block arguments. `qco::verifyLinearity`
+owns this whole-IR check; ordinary MLIR operation verification alone does not
+establish it. Builders and transformations must preserve the invariant, and
+public QCO pipeline boundaries must validate it.
+
+Rewrites on valid QCO IR can use `*value.user_begin()` to obtain the sole
+consumer, or `*value.use_begin()` for its `OpOperand` and operand number. Do not
+repeat `hasOneUse()` guards in these rewrites. Keep linearity checks in the
+verifier and optional debug assertions at internal boundaries. This rule does
+not apply to QC references or classical SSA values, and does not permit assuming
+that results preserve wire order: linearity and wire correspondence are separate
+contracts.
+
+When forwarding a linear value requires deleting its producer, use a rewrite
+that removes both operations. A fold can only change its root; do not rely on
+later dead-code elimination to restore linearity before other rewrites run.
+
 ## Data structures and performance
 
 Use LLVM views and abstract range types at MLIR-facing boundaries. Prefer an

--- a/mlir/AGENTS.md
+++ b/mlir/AGENTS.md
@@ -18,6 +18,9 @@ normative. This file is its short, scoped routing layer.
   conversions and exporters check their supported subset. Diagnose unsupported
   valid IR instead of asserting, silently widening support, or emitting partial
   success. Failed rewrite matches must leave IR unchanged.
+- Treat QCO qubits and QTensors as exactly-one-use values in valid IR. Rely on
+  `qco::verifyLinearity` at boundaries; do not add redundant rewrite guards.
+  Linearity does not imply positional wire correspondence.
 - Preserve deterministic output; never expose pointer or unordered traversal
   order.
 - Search upstream MLIR before adding an MQT-specific operation, interface,

--- a/mlir/include/mlir/Conversion/QCOToQC/QCOToQC.td
+++ b/mlir/include/mlir/Conversion/QCOToQC/QCOToQC.td
@@ -12,8 +12,20 @@ def QCOToQC : Pass<"qco-to-qc", "mlir::ModuleOp"> {
   let summary = "Convert QCO dialect to QC dialect.";
 
   let description = [{
-    This pass converts all operations from the QCO dialect to their equivalent operations in the QC dialect.
-    It handles the transformation of qubit values in QCO to qubit references in QC, ensuring that the semantics of quantum operations are preserved during the conversion process.
+    Convert QCO qubit values to QC references and QTensor registers to memrefs.
+    Scalar function arguments become in-place references; each function must
+    return its qubit arguments as a positional suffix. Other results remain
+    explicit, including qubits created by a function.
+
+    Before rewriting, prove that quantum values yielded by modifiers, branches,
+    and loops correspond positionally to their region arguments. Reject wire
+    permutations and changes to quantum loop-state counts or types. Classical
+    loop state can change type in `scf.while`. QTensor insertions can update
+    register slots and become stores when the slot value changes.
+
+    Determine the module's allocation mode before converting any function.
+    Dynamic qubit sinks become deallocations; static qubit sinks are removed.
+    Mixing static and dynamic allocation roots is unsupported.
   }];
 
   let dependentDialects = ["mlir::memref::MemRefDialect",

--- a/mlir/include/mlir/Dialect/QC/IR/QCOps.h
+++ b/mlir/include/mlir/Dialect/QC/IR/QCOps.h
@@ -10,17 +10,6 @@
 
 #pragma once
 
-// Suppress warnings about ambiguous reversed operators in MLIR
-// (see https://github.com/llvm/llvm-project/issues/45853)
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wambiguous-reversed-operator"
-#endif
-#include <mlir/Interfaces/InferTypeOpInterface.h>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-
 #include "mlir/Dialect/QC/IR/QCDialect.h"
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 
@@ -28,6 +17,7 @@
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Interfaces/FunctionInterfaces.h>
+#include <mlir/Interfaces/InferTypeOpInterface.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 
 #include <variant>

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.h
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.h
@@ -10,17 +10,6 @@
 
 #pragma once
 
-// Suppress warnings about ambiguous reversed operators in MLIR
-// (see https://github.com/llvm/llvm-project/issues/45853)
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wambiguous-reversed-operator"
-#endif
-#include <mlir/Interfaces/InferTypeOpInterface.h>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
 
@@ -28,6 +17,7 @@
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/Interfaces/CallInterfaces.h>
 #include <mlir/Interfaces/ControlFlowInterfaces.h>
+#include <mlir/Interfaces/InferTypeOpInterface.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 
 #include <optional>

--- a/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mlir/Dialect/QCO/IR/QCOOps.td
@@ -1133,6 +1133,7 @@ def BarrierOp : QCOOp<"barrier", traits = [UnitaryOpInterface, Pure]> {
   let builders = [OpBuilder<(ins "ValueRange":$qubits)>];
 
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
 }
 
 def CallOp

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -60,8 +60,8 @@ inline bool checkDeadGate(Operation* op) {
 /// the entry block.
 [[nodiscard]] LogicalResult verifyLinearity(Operation* root);
 
-/// Maximum number of modifier targets supported by @ref
-/// composeBodyMatrix.
+/// Maximum dense modifier matrix width. Controlled matrices include controls
+/// in this bound; @ref composeBodyMatrix applies it to the target body.
 inline constexpr size_t kMaxModifierTargetQubits = 10;
 
 /**
@@ -70,7 +70,10 @@ inline constexpr size_t kMaxModifierTargetQubits = 10;
  *
  * @details Block arguments map to wire indices `0..numTargets-1` (MSB-first,
  * matching @ref Matrix2x2::embedInNqubit). Returns the composed unitary in
- * program order, or `std::nullopt` when the body cannot be composed.
+ * program order, including idle targets. Supports one- and two-qubit embeddings
+ * and full-width operations whose input order matches the modifier's wires.
+ * Returns `std::nullopt` for reordered yields, unsupported embeddings, unknown
+ * parameters, or widths above @ref kMaxModifierTargetQubits.
  */
 [[nodiscard]] std::optional<DynamicMatrix> composeBodyMatrix(Block& block,
                                                              size_t numTargets);

--- a/mlir/include/mlir/Dialect/QTensor/IR/QTensorOps.td
+++ b/mlir/include/mlir/Dialect/QTensor/IR/QTensorOps.td
@@ -165,7 +165,6 @@ def InsertOp
     }];
 
   let hasCanonicalizer = 1;
-  let hasFolder = 1;
   let hasVerifier = 1;
 }
 

--- a/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
+++ b/mlir/lib/Conversion/QCOToQC/QCOToQC.cpp
@@ -17,13 +17,11 @@
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
-#include "mlir/Dialect/QCO/Utils/FunctionUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/ScopeExit.h>
-#include <llvm/ADT/TypeSwitch.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -43,6 +41,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <utility>
 
 namespace mlir {
@@ -71,22 +70,10 @@ struct LoweringState {
   /// Original qubit argument positions, retained while signatures are
   /// rewritten.
   DenseMap<Operation*, SmallVector<unsigned>> qubitArguments;
-  /// The qubit allocation mode used in the module
-  AllocationMode allocationMode = AllocationMode::Unset;
+  /// Module-wide mode determined before rewriting any function.
+  const AllocationMode allocationMode;
 
-  /// Sets or validates the allocation mode, or emits an error if it conflicts.
-  [[nodiscard]] LogicalResult ensureAllocationMode(AllocationMode requestedMode,
-                                                   Operation* op) {
-    if (allocationMode == AllocationMode::Unset) {
-      allocationMode = requestedMode;
-      return success();
-    }
-    if (allocationMode == requestedMode) {
-      return success();
-    }
-    return op->emitOpError(
-        "cannot mix static and dynamic qubit allocation modes in QCO program");
-  }
+  explicit LoweringState(AllocationMode mode) : allocationMode(mode) {}
 };
 
 /// Base class for conversion patterns that need access to lowering state
@@ -109,6 +96,32 @@ private:
   LoweringState* state_;
 };
 } // namespace
+
+/// Determines allocation mode independently of conversion traversal order.
+[[nodiscard]] static FailureOr<AllocationMode>
+collectAllocationMode(ModuleOp moduleOp) {
+  auto mode = AllocationMode::Unset;
+  auto result = moduleOp.walk([&](Operation* op) {
+    const auto requested = isa<qco::StaticOp>(op) ? AllocationMode::Static
+                           : isa<qco::AllocOp, qtensor::AllocOp>(op)
+                               ? AllocationMode::Dynamic
+                               : AllocationMode::Unset;
+    if (requested == AllocationMode::Unset) {
+      return WalkResult::advance();
+    }
+    if (mode != AllocationMode::Unset && mode != requested) {
+      op->emitOpError("cannot mix static and dynamic qubit allocation modes "
+                      "in QCO program");
+      return WalkResult::interrupt();
+    }
+    mode = requested;
+    return WalkResult::advance();
+  });
+  if (result.wasInterrupted()) {
+    return failure();
+  }
+  return mode;
+}
 
 /// Moves the operations from one region into another.
 ///
@@ -248,8 +261,110 @@ public:
 
 } // namespace
 
+/// Proves the positional wire correspondence required by reference semantics.
+/// Region arguments are local roots; a region result is tied to its input only
+/// after both the region body and its terminator have been checked.
 [[nodiscard]] static LogicalResult
-collectFunctionQubitArguments(ModuleOp moduleOp, LoweringState& state) {
+collectWireOrigins(ModuleOp moduleOp, DenseMap<Value, Value>& origins) {
+  const auto origin = [&](Value value) {
+    auto known = origins.lookup(value);
+    return known ? known : value;
+  };
+  const auto quantum = [](ValueRange values) {
+    SmallVector<Value> result;
+    llvm::copy_if(values, std::back_inserter(result), [](Value value) {
+      return isQuantumStateType(value.getType());
+    });
+    return result;
+  };
+  const auto corresponds = [&](ValueRange inputs, ValueRange outputs) {
+    auto quantumInputs = quantum(inputs);
+    auto quantumOutputs = quantum(outputs);
+    if (quantumInputs.size() != quantumOutputs.size()) {
+      return false;
+    }
+    return llvm::all_of(llvm::zip_equal(quantumInputs, quantumOutputs),
+                        [&](auto pair) {
+                          auto [input, output] = pair;
+                          return input.getType() == output.getType() &&
+                                 origin(input) == origin(output);
+                        });
+  };
+  const auto tie = [&](ValueRange inputs, ValueRange outputs) {
+    auto quantumInputs = quantum(inputs);
+    auto quantumOutputs = quantum(outputs);
+    if (quantumInputs.size() != quantumOutputs.size()) {
+      return;
+    }
+    for (auto [input, output] :
+         llvm::zip_equal(quantumInputs, quantumOutputs)) {
+      origins[output] = origin(input);
+    }
+  };
+  auto result = moduleOp.walk<WalkOrder::PostOrder>([&](Operation* op) {
+    bool positional = true;
+    if (auto loop = dyn_cast<scf::ForOp>(op)) {
+      positional = corresponds(loop.getRegionIterArgs(),
+                               loop.getBody()->getTerminator()->getOperands());
+      tie(loop.getInitArgs(), loop.getResults());
+    } else if (auto loop = dyn_cast<scf::WhileOp>(op)) {
+      auto before = quantum(loop.getBeforeArguments());
+      auto after = quantum(loop.getAfterArguments());
+      positional =
+          before.size() == after.size() &&
+          llvm::equal(ValueRange(before).getTypes(),
+                      ValueRange(after).getTypes()) &&
+          corresponds(loop.getBeforeArguments(),
+                      loop.getConditionOp().getArgs()) &&
+          corresponds(loop.getAfterArguments(), loop.getYieldOp().getResults());
+      tie(loop.getInits(), loop.getResults());
+    } else if (isa<qco::IfOp, qco::IndexSwitchOp, qco::InvOp, qco::CtrlOp,
+                   qco::PowOp>(op)) {
+      for (auto& region : op->getRegions()) {
+        positional &=
+            region.hasOneBlock() &&
+            corresponds(region.front().getArguments(),
+                        region.front().getTerminator()->getOperands());
+      }
+      if (auto unitary = dyn_cast<qco::UnitaryOpInterface>(op)) {
+        tie(unitary.getInputQubits(), unitary.getOutputQubits());
+      } else {
+        tie(op->getOperands(), op->getResults());
+      }
+    } else if (auto unitary = dyn_cast<qco::UnitaryOpInterface>(op)) {
+      tie(unitary.getInputQubits(), unitary.getOutputQubits());
+    } else if (auto measure = dyn_cast<qco::MeasureOp>(op)) {
+      tie(ValueRange{measure.getQubitIn()}, ValueRange{measure.getQubitOut()});
+    } else if (auto reset = dyn_cast<qco::ResetOp>(op)) {
+      tie(ValueRange{reset.getQubitIn()}, ValueRange{reset.getQubitOut()});
+    } else if (auto extract = dyn_cast<qtensor::ExtractOp>(op)) {
+      origins[extract->getResult(0)] = origin(extract.getTensor());
+    } else if (auto insert = dyn_cast<qtensor::InsertOp>(op)) {
+      origins[insert.getResult()] = origin(insert.getDest());
+    } else if (auto call = dyn_cast<func::CallOp>(op)) {
+      SmallVector<Value> arguments;
+      for (auto operand : call.getOperands()) {
+        if (isa<qco::QubitType>(operand.getType())) {
+          arguments.push_back(operand);
+        }
+      }
+      if (call.getNumResults() >= arguments.size()) {
+        tie(arguments, call.getResults().take_back(arguments.size()));
+      }
+    }
+    if (!positional) {
+      op->emitOpError("QCO-to-QC requires positional quantum state "
+                      "correspondence through region terminators");
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return success(!result.wasInterrupted());
+}
+
+[[nodiscard]] static LogicalResult
+collectFunctionQubitArguments(ModuleOp moduleOp, LoweringState& state,
+                              const DenseMap<Value, Value>& origins) {
   for (auto function : moduleOp.getOps<func::FuncOp>()) {
     auto& qubitArguments = state.qubitArguments[function];
     for (auto [index, type] : llvm::enumerate(function.getArgumentTypes())) {
@@ -291,8 +406,8 @@ collectFunctionQubitArguments(ModuleOp moduleOp, LoweringState& state) {
         returnOp.getOperands().take_back(qubitArguments.size());
     for (auto [argument, value] :
          llvm::zip_equal(qubitArguments, returnedQubits)) {
-      auto origin = qco::traceQubitArgument(function, value);
-      if (failed(origin) || *origin != argument) {
+      auto origin = origins.lookup(value);
+      if ((origin ? origin : value) != function.getArgument(argument)) {
         return function.emitOpError()
                << "must return its qubit arguments positionally";
       }
@@ -439,17 +554,12 @@ struct ConvertQCOCallOp final : OpConversionPattern<qco::CallOp> {
 /// ```mlir
 /// %memref = memref.alloc(%c3) : memref<3x!qc.qubit>
 /// ```
-struct ConvertQTensorAllocOp final
-    : StatefulOpConversionPattern<qtensor::AllocOp> {
-  using StatefulOpConversionPattern::StatefulOpConversionPattern;
+struct ConvertQTensorAllocOp final : OpConversionPattern<qtensor::AllocOp> {
+  using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(qtensor::AllocOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
-    if (failed(getState().ensureAllocationMode(AllocationMode::Dynamic,
-                                               op.getOperation()))) {
-      return failure();
-    }
     auto qubitType = qc::QubitType::get(op.getContext());
     auto tensorType = op.getResult().getType();
     auto memrefType = MemRefType::get(tensorType.getShape(), qubitType);
@@ -528,7 +638,8 @@ struct ConvertQTensorInsertOp final
                  left, right, OperationEquivalence::exactValueMatch, nullptr,
                  OperationEquivalence::Flags::IgnoreLocations);
     };
-    if (llvm::any_of(qubitValues, [&](const auto& cached) {
+    if (qubitValues.lookup(adaptor.getIndex()) == adaptor.getScalar() ||
+        llvm::any_of(qubitValues, [&](const auto& cached) {
           return cached.second == adaptor.getScalar() &&
                  sameIndex(cached.first);
         })) {
@@ -596,7 +707,6 @@ struct ConvertQCOGateToQC final : OpConversionPattern<QCOOpType> {
   /// @see ConvertQCOGateToQC
   /// @see createGate
   /// @see matchAndRewrite
-  /// @see addGatePattern
   template <std::size_t... TargetIndices, std::size_t... ParamIndices>
   static void createGate(ConversionPatternRewriter& rewriter, Location loc,
                          ValueRange qcOperands,
@@ -638,14 +748,6 @@ struct ConvertQCOUnitaryOp final : OpConversionPattern<qco::UnitaryOp> {
 
 } // namespace
 
-template <typename QCOOp, typename QCOp, std::size_t Targets,
-          std::size_t Params>
-static void addGatePattern(RewritePatternSet& patterns,
-                           TypeConverter& typeConverter, MLIRContext* context) {
-  patterns.add<ConvertQCOGateToQC<QCOOp, QCOp, Targets, Params>>(typeConverter,
-                                                                 context);
-}
-
 namespace {
 
 /// Converts qco.alloc to qc.alloc
@@ -658,16 +760,12 @@ namespace {
 /// ```mlir
 /// %q = qc.alloc : !qc.qubit
 /// ```
-struct ConvertQCOAllocOp final : StatefulOpConversionPattern<qco::AllocOp> {
-  using StatefulOpConversionPattern::StatefulOpConversionPattern;
+struct ConvertQCOAllocOp final : OpConversionPattern<qco::AllocOp> {
+  using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(qco::AllocOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
-    if (failed(getState().ensureAllocationMode(AllocationMode::Dynamic,
-                                               op.getOperation()))) {
-      return failure();
-    }
 
     // Create qc.alloc
     rewriter.replaceOpWithNewOp<qc::AllocOp>(op);
@@ -726,16 +824,12 @@ struct ConvertQCOSinkOp final : StatefulOpConversionPattern<SinkOp> {
 /// // becomes:
 /// %q = qc.static 0 : !qc.qubit
 /// ```
-struct ConvertQCOStaticOp final : StatefulOpConversionPattern<qco::StaticOp> {
-  using StatefulOpConversionPattern::StatefulOpConversionPattern;
+struct ConvertQCOStaticOp final : OpConversionPattern<qco::StaticOp> {
+  using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(qco::StaticOp op, OpAdaptor /*adaptor*/,
                   ConversionPatternRewriter& rewriter) const override {
-    if (failed(getState().ensureAllocationMode(AllocationMode::Static,
-                                               op.getOperation()))) {
-      return failure();
-    }
 
     // Create qc.static with the same index
     rewriter.replaceOpWithNewOp<qc::StaticOp>(op, op.getIndex());
@@ -819,33 +913,6 @@ struct ConvertQCOResetOp final : OpConversionPattern<qco::ResetOp> {
     // Replace the output qubit with the same qc reference
     rewriter.replaceOp(op, qcQubit);
 
-    return success();
-  }
-};
-
-/// Converts a zero-target, one-parameter QCO gate to QC
-///
-/// @tparam QCOOpType The operation type of the QCO gate
-/// @tparam QCOpType The operation type of the QC gate
-///
-/// @par Example:
-/// ```mlir
-/// qco.gphase(%theta)
-/// ```
-/// is converted to
-/// ```mlir
-/// qc.gphase(%theta)
-/// ```
-template <typename QCOOpType, typename QCOpType>
-struct ConvertQCOZeroTargetOneParameterToQC final
-    : OpConversionPattern<QCOOpType> {
-  using OpConversionPattern<QCOOpType>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(QCOOpType op, QCOOpType::Adaptor /*adaptor*/,
-                  ConversionPatternRewriter& rewriter) const override {
-    QCOpType::create(rewriter, op.getLoc(), op.getParameter(0));
-    rewriter.eraseOp(op);
     return success();
   }
 };
@@ -1320,6 +1387,8 @@ struct ConvertQCOSCFConditionOp final : OpConversionPattern<scf::ConditionOp> {
 /// 2. Operation conversion: Each QCO op converted to its QC equivalent
 /// 3. Automatic operand mapping: OpAdaptors provide converted operands
 /// 4. Function/control-flow adaptation: Signatures updated to use QC types
+/// Quantum region correspondence and allocation mode are checked before
+/// rewriting.
 struct QCOToQC final : impl::QCOToQCBase<QCOToQC> {
   using QCOToQCBase::QCOToQCBase;
 
@@ -1328,11 +1397,19 @@ protected:
     MLIRContext* context = &getContext();
     auto moduleOp = getOperation();
 
-    // Create state object to track the qubit addressing mode
-    LoweringState state;
-    if (failed(collectFunctionQubitArguments(moduleOp, state))) {
+    const auto allocationMode = collectAllocationMode(moduleOp);
+    if (failed(allocationMode)) {
       signalPassFailure();
       return;
+    }
+    LoweringState state(*allocationMode);
+    {
+      DenseMap<Value, Value> origins;
+      if (failed(collectWireOrigins(moduleOp, origins)) ||
+          failed(collectFunctionQubitArguments(moduleOp, state, origins))) {
+        signalPassFailure();
+        return;
+      }
     }
 
     SmallVector<func::FuncOp> unitaryFunctions;
@@ -1358,33 +1435,21 @@ protected:
         .addLegalDialect<cbit::CBitDialect, QCDialect, memref::MemRefDialect>();
 
     target.addDynamicallyLegalDialect<scf::SCFDialect>([](Operation* op) {
-      // Some types are not converted yet so QC and QCO types have to be
-      // checked.
-      auto isQubitType = [](Type t) {
-        return TypeSwitch<Type, bool>(t)
-            .Case<qc::QubitType, qco::QubitType>([](auto) { return true; })
-            .Case([](MemRefType t) {
-              return isa<qc::QubitType>(t.getElementType());
-            })
-            .Case([](RankedTensorType t) {
-              return isa<qco::QubitType>(t.getElementType());
-            })
-            .Default([](auto) { return false; });
-      };
-
-      return !llvm::any_of(op->getOperandTypes(), isQubitType);
+      return !llvm::any_of(op->getOperandTypes(), isQuantumStateType) &&
+             !llvm::any_of(op->getResultTypes(), isQuantumStateType);
     });
 
     // Register operation conversion patterns that do not need state tracking
-    patterns
-        .add<ConvertQTensorDeallocOp, ConvertQCOMeasureOp, ConvertQCOResetOp,
-             ConvertQCOUnitaryOp,
-             ConvertQCOZeroTargetOneParameterToQC<qco::GPhaseOp, qc::GPhaseOp>>(
-            typeConverter, context);
+    patterns.add<ConvertQTensorDeallocOp, ConvertQCOMeasureOp,
+                 ConvertQCOResetOp, ConvertQCOUnitaryOp, ConvertQTensorAllocOp,
+                 ConvertQCOAllocOp, ConvertQCOStaticOp,
+                 ConvertQCOGateToQC<qco::GPhaseOp, qc::GPhaseOp, 0, 1>>(
+        typeConverter, context);
 
 #define MQT_GATE(KEY, NAME, GETTER, TARGETS, PARAMS, SUFFIX, CTL_SUFFIX)       \
-  addGatePattern<qco::KEY##Op, qc::KEY##Op, (TARGETS), (PARAMS)>(              \
-      patterns, typeConverter, context);
+  patterns.add<                                                                \
+      ConvertQCOGateToQC<qco::KEY##Op, qc::KEY##Op, (TARGETS), (PARAMS)>>(     \
+      typeConverter, context);
 #include "mlir/Conversion/GateTable.def"
 
     patterns.add<ConvertQCOBarrierOp, ConvertQCOCtrlOp, ConvertQCOInvOp,
@@ -1394,9 +1459,9 @@ protected:
                  ConvertQCOSCFForOp>(typeConverter, context);
 
     // Register operation conversion patterns that need state tracking
-    patterns.add<ConvertQTensorExtractOp, ConvertQTensorInsertOp,
-                 ConvertQTensorAllocOp, ConvertQCOAllocOp, ConvertQCOStaticOp,
-                 ConvertQCOSinkOp>(typeConverter, context, &state);
+    patterns
+        .add<ConvertQTensorExtractOp, ConvertQTensorInsertOp, ConvertQCOSinkOp>(
+            typeConverter, context, &state);
 
     // QCO qubit arguments are returned positionally and become in-place QC
     // references again.

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -78,7 +78,7 @@ struct RegisterAccess {
 
 /// Indices already used for one register by a quantum operation.
 struct SeenRegisterIndices {
-  DenseMap<int64_t, Value> constants;
+  DenseSet<int64_t> constants;
   llvm::SmallDenseSet<Value, 4> dynamicValues;
 };
 
@@ -127,7 +127,7 @@ struct LoweringState {
   ///
   /// Keys are `Operation::getParentRegion()` for ops being converted
   /// (typically a `func.func` body or a modifier region).
-  DenseMap<Region*, DenseMap<Value, Value>> qubitMap;
+  DenseMap<Region*, llvm::MapVector<Value, Value>> qubitMap;
 
   /// Per-region map from stable register identifiers to their latest QTensor
   /// SSA values.
@@ -220,10 +220,10 @@ private:
 /// Finds the nearest region-local map containing @p reference and
 /// returns the pair containing the map and a mutable reference to the value in
 /// the map.
-template <typename Key>
-[[nodiscard]] static std::pair<DenseMap<Key, Value>*, Value*>
-findRegionLocalMap(DenseMap<Region*, DenseMap<Key, Value>>& map,
-                   Operation* anchor, Key reference) {
+template <typename Map, typename Key>
+[[nodiscard]] static std::pair<Map*, Value*>
+findRegionLocalMap(DenseMap<Region*, Map>& map, Operation* anchor,
+                   Key reference) {
   for (auto* current = anchor->getParentRegion(); current != nullptr;
        current = current->getParentRegion()) {
     if (auto it = map.find(current); it != map.end()) {
@@ -638,10 +638,7 @@ collectRegisterAccesses(Operation* root, LoweringState& state) {
 
       auto& seen = registerIndices[access->second.reg];
       if (const auto constant = getConstantIntValue(access->second.index)) {
-        const auto [it, inserted] =
-            seen.constants.try_emplace(*constant, access->second.index);
-        if (!inserted &&
-            isEqualConstantIntOrValue(it->second, access->second.index)) {
+        if (!seen.constants.insert(*constant).second) {
           operation->emitOpError(
               "requires distinct qubit operands; register-backed operands "
               "have the same constant index");
@@ -751,7 +748,7 @@ struct ConvertFuncReturnOp final : StatefulOpConversionPattern<func::ReturnOp> {
     DenseSet<Value> liveQubits;
     for (auto [qcOperand, adaptorOperand] :
          llvm::zip_equal(op.getOperands(), adaptor.getOperands())) {
-      if (auto it = map.find(qcOperand); it != map.end()) {
+      if (auto* it = map.find(qcOperand); it != map.end()) {
         auto latest = it->second;
         returnValues.emplace_back(latest);
         liveQubits.insert(latest);
@@ -761,7 +758,7 @@ struct ConvertFuncReturnOp final : StatefulOpConversionPattern<func::ReturnOp> {
     }
     auto function = op->getParentOfType<func::FuncOp>();
     for (Value argument : state.functionQubitArguments[function]) {
-      const auto current = map.find(argument);
+      auto* const current = map.find(argument);
       if (current == map.end()) {
         return op.emitOpError(
             "cannot convert a function that consumes a qubit argument");

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -363,10 +363,8 @@ bool CtrlOp::hasCompileTimeKnownUnitaryMatrix() {
 }
 
 std::optional<DynamicMatrix> CtrlOp::getUnitaryMatrix() {
-  if (getNumControls() >= 32) {
-    llvm::reportFatalUsageError(
-        "Creating the unitary matrix for a CtrlOp with more than 31 controls "
-        "is not supported due to memory constraints.");
+  if (getNumQubits() > kMaxModifierTargetQubits) {
+    return std::nullopt;
   }
 
   const auto numControls = getNumControls();
@@ -382,18 +380,6 @@ std::optional<DynamicMatrix> CtrlOp::getUnitaryMatrix() {
     return matrix;
   };
 
-  // Single inner unitary (e.g. `ctrl { h }`, `ctrl { cx }`).
-  if (auto bodyUnitary =
-          mqt::getSoleBodyUnitary<UnitaryOpInterface>(*getBody())) {
-    if (const auto targetMatrix =
-            bodyUnitary.getUnitaryMatrix<DynamicMatrix>()) {
-      assert(targetMatrix->cols() == targetMatrix->rows());
-      return controlledMatrix(targetMatrix->cols(), *targetMatrix);
-    }
-    return std::nullopt;
-  }
-
-  // Composed body (e.g., `ctrl { h; x }` or `ctrl { swap; ry }`)
   if (const auto composed = composeBodyMatrix(*getBody(), getNumTargets())) {
     return controlledMatrix(composed->rows(), *composed);
   }

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
@@ -526,22 +526,6 @@ bool InvOp::hasCompileTimeKnownUnitaryMatrix() {
 }
 
 std::optional<DynamicMatrix> InvOp::getUnitaryMatrix() {
-  if (getNumBodyUnitaries() == 0) {
-    return DynamicMatrix::identity(
-        static_cast<int64_t>(uint64_t{1} << getNumTargets()));
-  }
-
-  // Single inner unitary (e.g. `inv { h }`, `inv { cx }`).
-  if (auto bodyUnitary =
-          mqt::getSoleBodyUnitary<UnitaryOpInterface>(*getBody())) {
-    if (const auto targetMatrix =
-            bodyUnitary.getUnitaryMatrix<DynamicMatrix>()) {
-      return targetMatrix->adjoint();
-    }
-    return std::nullopt;
-  }
-
-  // Composed body (e.g., `ctrl { h; x }` or `ctrl { swap; ry }`)
   if (const auto composed = composeBodyMatrix(*getBody(), getNumTargets())) {
     return composed->adjoint();
   }

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
@@ -64,7 +64,7 @@ SmallVector<size_t> getUsedQubitIndices(Block& body) {
   for (auto [index, arg, yielded] : llvm::enumerate(
            body.getArguments(), body.getTerminator()->getOperands())) {
     // A qubit that the body only yields back is not acted upon.
-    if (!arg.hasOneUse() || yielded != arg) {
+    if (yielded != arg) {
       used.push_back(index);
     }
   }

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
@@ -896,9 +896,7 @@ bool PowOp::hasCompileTimeKnownUnitaryMatrix() {
  * `V` is unitary and `V^{-1} = V^\dagger`; this is verified before use because
  * the eigensolver does not orthogonalize degenerate eigenspaces.
  *
- * The body matrix `U` comes either from a single inner unitary (e.g.
- * `pow(p) { h }`) or, for a composed body (e.g. `pow(p) { h; x }`), from
- * @ref composeBodyMatrix over all targets.
+ * The body matrix `U` comes from @ref composeBodyMatrix over all targets.
  *
  * @return `U^p`, or `std::nullopt` if the exponent is non-constant, the body is
  * not fully compile-time known, or `V` is not unitary.
@@ -951,17 +949,6 @@ std::optional<DynamicMatrix> PowOp::getUnitaryMatrix() {
     return v * powDiagonal * v.adjoint();
   };
 
-  // Single inner unitary (e.g. `pow(p) { h }`, `pow(p) { rz(theta) }`).
-  if (auto bodyUnitary =
-          mqt::getSoleBodyUnitary<UnitaryOpInterface>(*getBody())) {
-    if (const auto targetMatrix =
-            bodyUnitary.getUnitaryMatrix<DynamicMatrix>()) {
-      return raiseToPow(*targetMatrix);
-    }
-    return std::nullopt;
-  }
-
-  // Composed body (e.g., `pow(p) { h; x }`).
   if (const auto composed = composeBodyMatrix(*getBody(), getNumTargets())) {
     return raiseToPow(*composed);
   }

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
@@ -47,7 +47,7 @@ struct MergeSubsequentBarrier final : OpRewritePattern<BarrierOp> {
 
     for (size_t i = 0; i < qubitsIn.size(); ++i) {
       if (auto output = op.getQubitsOut()[i];
-          output.hasOneUse() && isa<BarrierOp>(*output.user_begin())) {
+          isa<BarrierOp>(*output.user_begin())) {
         anythingToMerge = true;
       } else {
         newQubitsIn.push_back(qubitsIn[i]);

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/BarrierOp.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Utils/Matrix.h"
 
-#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/ErrorHandling.h>
@@ -41,16 +40,15 @@ struct MergeSubsequentBarrier final : OpRewritePattern<BarrierOp> {
     auto qubitsIn = op.getQubitsIn();
 
     auto anythingToMerge = false;
-    DenseMap<size_t, Value> newQubitsOutMap;
+    SmallVector<Value> newQubitsOut(qubitsIn);
 
     SmallVector<Value> newQubitsIn;
     SmallVector<size_t> indicesToFill;
 
     for (size_t i = 0; i < qubitsIn.size(); ++i) {
-      if (isa<BarrierOp>(
-              *op.getOutputForInput(qubitsIn[i]).getUsers().begin())) {
+      if (auto output = op.getQubitsOut()[i];
+          output.hasOneUse() && isa<BarrierOp>(*output.user_begin())) {
         anythingToMerge = true;
-        newQubitsOutMap[i] = qubitsIn[i];
       } else {
         newQubitsIn.push_back(qubitsIn[i]);
         indicesToFill.push_back(i);
@@ -64,13 +62,7 @@ struct MergeSubsequentBarrier final : OpRewritePattern<BarrierOp> {
     auto newBarrier = BarrierOp::create(rewriter, op.getLoc(), newQubitsIn);
 
     for (size_t i = 0; i < indicesToFill.size(); ++i) {
-      newQubitsOutMap[indicesToFill[i]] = newBarrier.getQubitsOut()[i];
-    }
-
-    SmallVector<Value> newQubitsOut;
-    newQubitsOut.reserve(op.getQubitsIn().size());
-    for (size_t i = 0; i < op.getQubitsIn().size(); ++i) {
-      newQubitsOut.push_back(newQubitsOutMap[i]);
+      newQubitsOut[indicesToFill[i]] = newBarrier.getQubitsOut()[i];
     }
 
     rewriter.replaceOp(op, newQubitsOut);
@@ -79,6 +71,13 @@ struct MergeSubsequentBarrier final : OpRewritePattern<BarrierOp> {
 };
 
 } // namespace
+
+LogicalResult BarrierOp::verify() {
+  if (getQubitsIn().size() != getQubitsOut().size()) {
+    return emitOpError("requires one output qubit for each input qubit");
+  }
+  return success();
+}
 
 Value BarrierOp::getInputForOutput(Value output) {
   if (auto result = dyn_cast<OpResult>(output);

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/DCXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/DCXOp.cpp
@@ -20,27 +20,12 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove a DCX operation followed by a DCX operation with swapped
- *        targets.
- */
-struct RemoveInversePairDCX final : OpRewritePattern<DCXOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(DCXOp op,
-                                PatternRewriter& rewriter) const override {
+void DCXOp::getCanonicalizationPatterns(RewritePatternSet& results,
+                                        MLIRContext* /*context*/) {
+  results.add(+[](DCXOp op, PatternRewriter& rewriter) {
     return removeInversePairTwoTargetZeroParameter<DCXOp>(op, rewriter, false,
                                                           true);
-  }
-};
-
-} // namespace
-
-void DCXOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                        MLIRContext* context) {
-  results.add<RemoveInversePairDCX>(context);
+  });
 }
 
 Matrix4x4 DCXOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ECROp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ECROp.cpp
@@ -23,25 +23,11 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove subsequent ECR operations on the same qubits.
- */
-struct RemoveSubsequentECR final : OpRewritePattern<ECROp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ECROp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairTwoTargetZeroParameter<ECROp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void ECROp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                        MLIRContext* context) {
-  results.add<RemoveSubsequentECR>(context);
+                                        MLIRContext* /*context*/) {
+  results.add(+[](ECROp op, PatternRewriter& rewriter) {
+    return removeInversePairTwoTargetZeroParameter<ECROp>(op, rewriter);
+  });
 }
 
 Matrix4x4 ECROp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/HOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/HOp.cpp
@@ -22,25 +22,9 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove subsequent H operations on the same qubit.
- */
-struct RemoveSubsequentH final : OpRewritePattern<HOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(HOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<HOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void HOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                      MLIRContext* context) {
-  results.add<RemoveSubsequentH>(context);
+                                      MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<HOp, HOp>);
 }
 
 Matrix2x2 HOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/POp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/POp.cpp
@@ -29,23 +29,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent P operations on the same qubit by adding their
- * angles.
- */
-struct MergeSubsequentP final : OpRewritePattern<POp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(POp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetOneParameter(op, rewriter);
-  }
-};
-
-} // namespace
-
 void POp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                 const std::variant<double, Value>& theta) {
   auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
@@ -61,8 +44,8 @@ OpFoldResult POp::fold(FoldAdaptor /*adaptor*/) {
 }
 
 void POp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                      MLIRContext* context) {
-  results.add<MergeSubsequentP>(context);
+                                      MLIRContext* /*context*/) {
+  results.add(&mergeOneTargetOneParameter<POp>);
 }
 
 Matrix2x2 POp::unitaryMatrix(const double theta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RCCXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RCCXOp.cpp
@@ -20,25 +20,9 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove subsequent RCCX operations on the same qubits.
- */
-struct RemoveSubsequentRCCX final : OpRewritePattern<RCCXOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(RCCXOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairThreeTargetZeroParameter<RCCXOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void RCCXOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                         MLIRContext* context) {
-  results.add<RemoveSubsequentRCCX>(context);
+                                         MLIRContext* /*context*/) {
+  results.add(&removeInversePairThreeTargetZeroParameter<RCCXOp, RCCXOp>);
 }
 
 Matrix8x8 RCCXOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXOp.cpp
@@ -29,23 +29,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent RX operations on the same qubit by adding their
- * angles.
- */
-struct MergeSubsequentRX final : OpRewritePattern<RXOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(RXOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetOneParameter(op, rewriter);
-  }
-};
-
-} // namespace
-
 void RXOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& theta) {
   auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
@@ -61,8 +44,8 @@ OpFoldResult RXOp::fold(FoldAdaptor /*adaptor*/) {
 }
 
 void RXOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                       MLIRContext* context) {
-  results.add<MergeSubsequentRX>(context);
+                                       MLIRContext* /*context*/) {
+  results.add(&mergeOneTargetOneParameter<RXOp>);
 }
 
 Matrix2x2 RXOp::unitaryMatrix(const double theta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RXXOp.cpp
@@ -29,23 +29,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent RXX operations on the same qubits by adding their
- * angles.
- */
-struct MergeSubsequentRXX final : OpRewritePattern<RXXOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(RXXOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeTwoTargetOneParameter(op, rewriter, true);
-  }
-};
-
-} // namespace
-
 void RXXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                   Value qubit0In, Value qubit1In,
                   const std::variant<double, Value>& theta) {
@@ -65,8 +48,10 @@ LogicalResult RXXOp::fold(FoldAdaptor /*adaptor*/,
 }
 
 void RXXOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                        MLIRContext* context) {
-  results.add<MergeSubsequentRXX>(context);
+                                        MLIRContext* /*context*/) {
+  results.add(+[](RXXOp op, PatternRewriter& rewriter) {
+    return mergeTwoTargetOneParameter(op, rewriter, true);
+  });
 }
 
 Matrix4x4 RXXOp::unitaryMatrix(const double theta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYOp.cpp
@@ -28,23 +28,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent RY operations on the same qubit by adding their
- * angles.
- */
-struct MergeSubsequentRY final : OpRewritePattern<RYOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(RYOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetOneParameter(op, rewriter);
-  }
-};
-
-} // namespace
-
 void RYOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& theta) {
   auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
@@ -60,8 +43,8 @@ OpFoldResult RYOp::fold(FoldAdaptor /*adaptor*/) {
 }
 
 void RYOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                       MLIRContext* context) {
-  results.add<MergeSubsequentRY>(context);
+                                       MLIRContext* /*context*/) {
+  results.add(&mergeOneTargetOneParameter<RYOp>);
 }
 
 Matrix2x2 RYOp::unitaryMatrix(const double theta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RYYOp.cpp
@@ -29,23 +29,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent RYY operations on the same qubits by adding their
- * angles.
- */
-struct MergeSubsequentRYY final : OpRewritePattern<RYYOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(RYYOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeTwoTargetOneParameter(op, rewriter, true);
-  }
-};
-
-} // namespace
-
 void RYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                   Value qubit0In, Value qubit1In,
                   const std::variant<double, Value>& theta) {
@@ -65,8 +48,10 @@ LogicalResult RYYOp::fold(FoldAdaptor /*adaptor*/,
 }
 
 void RYYOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                        MLIRContext* context) {
-  results.add<MergeSubsequentRYY>(context);
+                                        MLIRContext* /*context*/) {
+  results.add(+[](RYYOp op, PatternRewriter& rewriter) {
+    return mergeTwoTargetOneParameter(op, rewriter, true);
+  });
 }
 
 Matrix4x4 RYYOp::unitaryMatrix(const double theta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZOp.cpp
@@ -29,23 +29,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent RZ operations on the same qubit by adding their
- * angles.
- */
-struct MergeSubsequentRZ final : OpRewritePattern<RZOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(RZOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetOneParameter(op, rewriter);
-  }
-};
-
-} // namespace
-
 void RZOp::build(OpBuilder& odsBuilder, OperationState& odsState, Value qubitIn,
                  const std::variant<double, Value>& theta) {
   auto thetaOperand = variantToValue(odsBuilder, odsState.location, theta);
@@ -61,8 +44,8 @@ OpFoldResult RZOp::fold(FoldAdaptor /*adaptor*/) {
 }
 
 void RZOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                       MLIRContext* context) {
-  results.add<MergeSubsequentRZ>(context);
+                                       MLIRContext* /*context*/) {
+  results.add(&mergeOneTargetOneParameter<RZOp>);
 }
 
 Matrix2x2 RZOp::unitaryMatrix(const double theta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZXOp.cpp
@@ -29,23 +29,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent RZX operations on the same qubits by adding their
- * angles.
- */
-struct MergeSubsequentRZX final : OpRewritePattern<RZXOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(RZXOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeTwoTargetOneParameter(op, rewriter);
-  }
-};
-
-} // namespace
-
 void RZXOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                   Value qubit0In, Value qubit1In,
                   const std::variant<double, Value>& theta) {
@@ -65,8 +48,10 @@ LogicalResult RZXOp::fold(FoldAdaptor /*adaptor*/,
 }
 
 void RZXOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                        MLIRContext* context) {
-  results.add<MergeSubsequentRZX>(context);
+                                        MLIRContext* /*context*/) {
+  results.add(+[](RZXOp op, PatternRewriter& rewriter) {
+    return mergeTwoTargetOneParameter(op, rewriter);
+  });
 }
 
 Matrix4x4 RZXOp::unitaryMatrix(const double theta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/RZZOp.cpp
@@ -29,23 +29,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent RZZ operations on the same qubits by adding their
- * angles.
- */
-struct MergeSubsequentRZZ final : OpRewritePattern<RZZOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(RZZOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeTwoTargetOneParameter(op, rewriter, true);
-  }
-};
-
-} // namespace
-
 void RZZOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                   Value qubit0In, Value qubit1In,
                   const std::variant<double, Value>& theta) {
@@ -65,8 +48,10 @@ LogicalResult RZZOp::fold(FoldAdaptor /*adaptor*/,
 }
 
 void RZZOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                        MLIRContext* context) {
-  results.add<MergeSubsequentRZZ>(context);
+                                        MLIRContext* /*context*/) {
+  results.add(+[](RZZOp op, PatternRewriter& rewriter) {
+    return mergeTwoTargetOneParameter(op, rewriter, true);
+  });
 }
 
 Matrix4x4 RZZOp::unitaryMatrix(const double theta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SOp.cpp
@@ -22,37 +22,10 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove S operations that immediately follow Sdg operations.
- */
-struct RemoveSAfterSdg final : OpRewritePattern<SOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<SdgOp>(op, rewriter);
-  }
-};
-
-/**
- * @brief Merge subsequent S operations on the same qubit into a Z operation.
- */
-struct MergeSubsequentS final : OpRewritePattern<SOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetZeroParameter<ZOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void SOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                      MLIRContext* context) {
-  results.add<RemoveSAfterSdg, MergeSubsequentS>(context);
+                                      MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<SdgOp, SOp>);
+  results.add(&mergeOneTargetZeroParameter<ZOp, SOp>);
 }
 
 Matrix2x2 SOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SWAPOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SWAPOp.cpp
@@ -20,25 +20,11 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove subsequent SWAP operations on the same qubits.
- */
-struct RemoveSubsequentSWAP final : OpRewritePattern<SWAPOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SWAPOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairTwoTargetZeroParameter<SWAPOp>(op, rewriter, true);
-  }
-};
-
-} // namespace
-
 void SWAPOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                         MLIRContext* context) {
-  results.add<RemoveSubsequentSWAP>(context);
+                                         MLIRContext* /*context*/) {
+  results.add(+[](SWAPOp op, PatternRewriter& rewriter) {
+    return removeInversePairTwoTargetZeroParameter<SWAPOp>(op, rewriter, true);
+  });
 }
 
 Matrix4x4 SWAPOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SXOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SXOp.cpp
@@ -22,37 +22,10 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove SX operations that immediately follow SXdg operations.
- */
-struct RemoveSXAfterSXdg final : OpRewritePattern<SXOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SXOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<SXdgOp>(op, rewriter);
-  }
-};
-
-/**
- * @brief Merge subsequent SX operations on the same qubit into an X operation.
- */
-struct MergeSubsequentSX final : OpRewritePattern<SXOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SXOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetZeroParameter<XOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void SXOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                       MLIRContext* context) {
-  results.add<RemoveSXAfterSXdg, MergeSubsequentSX>(context);
+                                       MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<SXdgOp, SXOp>);
+  results.add(&mergeOneTargetZeroParameter<XOp, SXOp>);
 }
 
 Matrix2x2 SXOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SXdgOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SXdgOp.cpp
@@ -22,38 +22,10 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove SXdg operations that immediately follow SX operations.
- */
-struct RemoveSXdgAfterSX final : OpRewritePattern<SXdgOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SXdgOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<SXOp>(op, rewriter);
-  }
-};
-
-/**
- * @brief Merge subsequent SXdg operations on the same qubit into an X
- * operation.
- */
-struct MergeSubsequentSXdg final : OpRewritePattern<SXdgOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SXdgOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetZeroParameter<XOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void SXdgOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                         MLIRContext* context) {
-  results.add<RemoveSXdgAfterSX, MergeSubsequentSXdg>(context);
+                                         MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<SXOp, SXdgOp>);
+  results.add(&mergeOneTargetZeroParameter<XOp, SXdgOp>);
 }
 
 Matrix2x2 SXdgOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SdgOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/SdgOp.cpp
@@ -22,37 +22,10 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove Sdg operations that immediately follow S operations.
- */
-struct RemoveSdgAfterS final : OpRewritePattern<SdgOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SdgOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<SOp>(op, rewriter);
-  }
-};
-
-/**
- * @brief Merge subsequent Sdg operations on the same qubit into a Z operation.
- */
-struct MergeSubsequentSdg final : OpRewritePattern<SdgOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SdgOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetZeroParameter<ZOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void SdgOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                        MLIRContext* context) {
-  results.add<RemoveSdgAfterS, MergeSubsequentSdg>(context);
+                                        MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<SOp, SdgOp>);
+  results.add(&mergeOneTargetZeroParameter<ZOp, SdgOp>);
 }
 
 Matrix2x2 SdgOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/TOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/TOp.cpp
@@ -23,37 +23,10 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove T operations that immediately follow Tdg operations.
- */
-struct RemoveTAfterTdg final : OpRewritePattern<TOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(TOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<TdgOp>(op, rewriter);
-  }
-};
-
-/**
- * @brief Merge subsequent T operations on the same qubit into an S operation.
- */
-struct MergeSubsequentT final : OpRewritePattern<TOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(TOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetZeroParameter<SOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void TOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                      MLIRContext* context) {
-  results.add<RemoveTAfterTdg, MergeSubsequentT>(context);
+                                      MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<TdgOp, TOp>);
+  results.add(&mergeOneTargetZeroParameter<SOp, TOp>);
 }
 
 Matrix2x2 TOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/TdgOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/TdgOp.cpp
@@ -23,38 +23,10 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove Tdg operations that immediately follow T operations.
- */
-struct RemoveTdgAfterT final : OpRewritePattern<TdgOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(TdgOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<TOp>(op, rewriter);
-  }
-};
-
-/**
- * @brief Merge subsequent Tdg operations on the same qubit into an Sdg
- * operation.
- */
-struct MergeSubsequentTdg final : OpRewritePattern<TdgOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(TdgOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeOneTargetZeroParameter<SdgOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void TdgOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                        MLIRContext* context) {
-  results.add<RemoveTdgAfterT, MergeSubsequentTdg>(context);
+                                        MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<TOp, TdgOp>);
+  results.add(&mergeOneTargetZeroParameter<SdgOp, TdgOp>);
 }
 
 Matrix2x2 TdgOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XOp.cpp
@@ -20,25 +20,9 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove subsequent X operations on the same qubit.
- */
-struct RemoveSubsequentX final : OpRewritePattern<XOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(XOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<XOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void XOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                      MLIRContext* context) {
-  results.add<RemoveSubsequentX>(context);
+                                      MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<XOp, XOp>);
 }
 
 Matrix2x2 XOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXMinusYYOp.cpp
@@ -30,23 +30,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent XXMinusYY operations on the same qubits by adding
- * their thetas.
- */
-struct MergeSubsequentXXMinusYY final : OpRewritePattern<XXMinusYYOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(XXMinusYYOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeXXPlusMinusYY(op, rewriter);
-  }
-};
-
-} // namespace
-
 void XXMinusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                         Value qubit0In, Value qubit1In,
                         const std::variant<double, Value>& theta,
@@ -68,8 +51,8 @@ LogicalResult XXMinusYYOp::fold(FoldAdaptor /*adaptor*/,
 }
 
 void XXMinusYYOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                              MLIRContext* context) {
-  results.add<MergeSubsequentXXMinusYY>(context);
+                                              MLIRContext* /*context*/) {
+  results.add(&mergeXXPlusMinusYY<XXMinusYYOp>);
 }
 
 Matrix4x4 XXMinusYYOp::unitaryMatrix(const double theta, const double beta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/XXPlusYYOp.cpp
@@ -30,23 +30,6 @@ using namespace mlir;
 using namespace mlir::qco;
 using namespace mlir::mqt;
 
-namespace {
-
-/**
- * @brief Merge subsequent XXPlusYY operations on the same qubits by adding
- * their thetas.
- */
-struct MergeSubsequentXXPlusYY final : OpRewritePattern<XXPlusYYOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(XXPlusYYOp op,
-                                PatternRewriter& rewriter) const override {
-    return mergeXXPlusMinusYY(op, rewriter);
-  }
-};
-
-} // namespace
-
 void XXPlusYYOp::build(OpBuilder& odsBuilder, OperationState& odsState,
                        Value qubit0In, Value qubit1In,
                        const std::variant<double, Value>& theta,
@@ -68,8 +51,8 @@ LogicalResult XXPlusYYOp::fold(FoldAdaptor /*adaptor*/,
 }
 
 void XXPlusYYOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                             MLIRContext* context) {
-  results.add<MergeSubsequentXXPlusYY>(context);
+                                             MLIRContext* /*context*/) {
+  results.add(&mergeXXPlusMinusYY<XXPlusYYOp>);
 }
 
 Matrix4x4 XXPlusYYOp::unitaryMatrix(const double theta, const double beta) {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/YOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/YOp.cpp
@@ -22,25 +22,9 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove subsequent Y operations on the same qubit.
- */
-struct RemoveSubsequentY final : OpRewritePattern<YOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(YOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<YOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void YOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                      MLIRContext* context) {
-  results.add<RemoveSubsequentY>(context);
+                                      MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<YOp, YOp>);
 }
 
 Matrix2x2 YOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ZOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ZOp.cpp
@@ -20,25 +20,9 @@
 using namespace mlir;
 using namespace mlir::qco;
 
-namespace {
-
-/**
- * @brief Remove subsequent Z operations on the same qubit.
- */
-struct RemoveSubsequentZ final : OpRewritePattern<ZOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ZOp op,
-                                PatternRewriter& rewriter) const override {
-    return removeInversePairOneTargetZeroParameter<ZOp>(op, rewriter);
-  }
-};
-
-} // namespace
-
 void ZOp::getCanonicalizationPatterns(RewritePatternSet& results,
-                                      MLIRContext* context) {
-  results.add<RemoveSubsequentZ>(context);
+                                      MLIRContext* /*context*/) {
+  results.add(&removeInversePairOneTargetZeroParameter<ZOp, ZOp>);
 }
 
 Matrix2x2 ZOp::getUnitaryMatrix() {

--- a/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
@@ -117,6 +117,12 @@ static void propagateWireIds(UnitaryOpInterface unitary,
 embedUnitaryInBody(UnitaryOpInterface unitary, size_t numTargets,
                    const DenseMap<Value, size_t>& wireIds) {
   const auto numOpQubits = unitary.getNumQubits();
+  if (numOpQubits == numTargets &&
+      llvm::all_of(llvm::enumerate(unitary.getInputQubits()), [&](auto entry) {
+        return lookupWireId(wireIds, entry.value()) == entry.index();
+      })) {
+    return unitary.getUnitaryMatrix<DynamicMatrix>();
+  }
   if (numOpQubits == 0 || numOpQubits > 2) {
     return std::nullopt;
   }
@@ -147,14 +153,13 @@ embedUnitaryInBody(UnitaryOpInterface unitary, size_t numTargets,
 
 std::optional<DynamicMatrix> composeBodyMatrix(Block& block,
                                                size_t numTargets) {
-  if (numTargets == 0 || numTargets > kMaxModifierTargetQubits ||
+  if (numTargets > kMaxModifierTargetQubits ||
       block.getNumArguments() != numTargets) {
     return std::nullopt;
   }
 
   std::optional<DynamicMatrix> acc;
   Complex global{1.0, 0.0};
-  bool found = false;
 
   DenseMap<Value, size_t> wireIds;
   for (size_t i = 0; i < numTargets; ++i) {
@@ -174,7 +179,6 @@ std::optional<DynamicMatrix> composeBodyMatrix(Block& block,
                 return false;
               }
               global *= matrix->value;
-              found = true;
               return true;
             })
             .Case([&](UnitaryOpInterface unitary) {
@@ -187,7 +191,6 @@ std::optional<DynamicMatrix> composeBodyMatrix(Block& block,
               } else {
                 acc->premultiplyBy(*embedded);
               }
-              found = true;
               propagateWireIds(unitary, wireIds);
               return true;
             })
@@ -204,7 +207,11 @@ std::optional<DynamicMatrix> composeBodyMatrix(Block& block,
     }
   }
 
-  if (!found) {
+  auto yield = dyn_cast<YieldOp>(block.getTerminator());
+  if (!yield || yield.getTargets().size() != numTargets ||
+      !llvm::all_of(llvm::enumerate(yield.getTargets()), [&](auto entry) {
+        return lookupWireId(wireIds, entry.value()) == entry.index();
+      })) {
     return std::nullopt;
   }
   if (!acc.has_value()) {

--- a/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/SCF/IfOp.cpp
@@ -104,13 +104,7 @@ void IfOp::getSuccessorRegions(RegionBranchPoint point,
 
   regions.push_back(RegionSuccessor(&getThenRegion()));
 
-  // If the else region is empty, execution continues after the parent op.
-  Region* elseRegion = &getElseRegion();
-  if (elseRegion->empty()) {
-    regions.push_back(RegionSuccessor(getOperation()));
-  } else {
-    regions.push_back(RegionSuccessor(elseRegion));
-  }
+  regions.push_back(RegionSuccessor(&getElseRegion()));
 }
 
 void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
@@ -121,13 +115,8 @@ void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
     regions.push_back(RegionSuccessor(&getThenRegion()));
   }
 
-  // If the else region is empty, execution continues after the parent op.
   if (!boolAttr || !boolAttr.getValue()) {
-    if (!getElseRegion().empty()) {
-      regions.push_back(RegionSuccessor(&getElseRegion()));
-    } else {
-      regions.push_back(RegionSuccessor(getOperation()));
-    }
+    regions.push_back(RegionSuccessor(&getElseRegion()));
   }
 }
 

--- a/mlir/lib/Dialect/QTensor/IR/Operations/DeallocOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/DeallocOp.cpp
@@ -32,7 +32,7 @@ struct RemoveAllocDeallocPair final : OpRewritePattern<DeallocOp> {
     // qtensor::AllocOp.
     auto tensor = op.getTensor();
     auto allocOp = tensor.getDefiningOp<AllocOp>();
-    if (!allocOp || !allocOp->hasOneUse()) {
+    if (!allocOp) {
       return failure();
     }
 

--- a/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/ExtractOp.cpp
@@ -84,7 +84,7 @@ struct FoldExtractAfterInsertPattern final : OpRewritePattern<ExtractOp> {
   LogicalResult matchAndRewrite(ExtractOp extract,
                                 PatternRewriter& rewriter) const override {
     auto insert = extract.getTensor().getDefiningOp<InsertOp>();
-    if (!insert || !insert->hasOneUse() ||
+    if (!insert ||
         !isEqualConstantIntOrValue(insert.getIndex(), extract.getIndex())) {
       return failure();
     }

--- a/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
@@ -22,36 +22,24 @@
 using namespace mlir;
 using namespace mlir::qtensor;
 
-/**
- * @brief Checks whether removing an extract-insert pair is linearity-safe.
- */
-static bool isRemovableExtractInsertPair(InsertOp insert, ExtractOp extract) {
-  return insert.getScalar() == extract.getResult() &&
-         isEqualConstantIntOrValue(insert.getIndex(), extract.getIndex());
-}
-
-/**
- * @brief Folds an insert operation after a matching extract operation into the
- * original tensor.
- */
-static Value foldInsertAfterExtract(InsertOp insert) {
-  auto extract = insert.getScalar().getDefiningOp<ExtractOp>();
-  if (!extract) {
-    return nullptr;
-  }
-
-  if (insert.getDest() != extract.getOutTensor()) {
-    return nullptr;
-  }
-
-  if (!isRemovableExtractInsertPair(insert, extract)) {
-    return nullptr;
-  }
-
-  return extract.getTensor();
-}
-
 namespace {
+/// Remove both operations so forwarding the tensor preserves linearity.
+struct FoldInsertAfterExtract final : OpRewritePattern<InsertOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(InsertOp insert,
+                                PatternRewriter& rewriter) const override {
+    auto extract = insert.getScalar().getDefiningOp<ExtractOp>();
+    if (!extract || insert.getDest() != extract.getOutTensor() ||
+        !isEqualConstantIntOrValue(insert.getIndex(), extract.getIndex())) {
+      return failure();
+    }
+    rewriter.replaceOp(insert, extract.getTensor());
+    rewriter.eraseOp(extract);
+    return success();
+  }
+};
+
 /**
  * @brief Commutes a directly chained insert and extract at provably distinct
  * constant indices.
@@ -61,9 +49,6 @@ struct CommuteAdjacentInsertExtractPattern final : OpRewritePattern<InsertOp> {
 
   LogicalResult matchAndRewrite(InsertOp insert,
                                 PatternRewriter& rewriter) const override {
-    if (!insert.getResult().hasOneUse()) {
-      return failure();
-    }
     auto extract = dyn_cast<ExtractOp>(*insert.getResult().getUsers().begin());
     if (!extract || insert->getBlock() != extract->getBlock()) {
       return failure();
@@ -114,14 +99,8 @@ LogicalResult InsertOp::verify() {
   return success();
 }
 
-OpFoldResult InsertOp::fold(FoldAdaptor /*adaptor*/) {
-  if (auto result = foldInsertAfterExtract(*this)) {
-    return result;
-  }
-  return {};
-}
-
 void InsertOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                            MLIRContext* context) {
-  results.add<CommuteAdjacentInsertExtractPattern>(context);
+  results.add<FoldInsertAfterExtract, CommuteAdjacentInsertExtractPattern>(
+      context);
 }

--- a/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
+++ b/mlir/unittests/Conversion/QCOToQC/test_qco_to_qc.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Support/Passes.h"
 #include "qc_programs.h"
@@ -90,6 +91,151 @@ static LogicalResult runQCOToQCConversion(ModuleOp moduleOp) {
   PassManager pm(moduleOp.getContext());
   pm.addPass(createQCOToQC());
   return pm.run(moduleOp);
+}
+
+TEST(QCOToQCRegressionTest, RejectsBranchWirePermutation) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, arith::ArithDialect,
+                  func::FuncDialect, scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(module {
+ func.func @main(%c: i1) -> i1 attributes {mqt.entry_point} {
+  %a = qco.alloc : !qco.qubit
+  %b = qco.alloc : !qco.qubit
+  %x = qco.x %a : !qco.qubit -> !qco.qubit
+  %r:2 = qco.if %c args(%u = %x, %v = %b) -> (!qco.qubit, !qco.qubit) {
+   qco.yield %v, %u : !qco.qubit, !qco.qubit
+  } else args(%u = %x, %v = %b) {
+   qco.yield %u, %v : !qco.qubit, !qco.qubit
+  }
+  %q, %m = qco.measure %r#0 : !qco.qubit
+  qco.sink %q : !qco.qubit
+  qco.sink %r#1 : !qco.qubit
+  return %m : i1
+ }
+}
+)mlir",
+                                              &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+  std::string diagnostics;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    diagnostics += diagnostic.str();
+    return success();
+  });
+  EXPECT_TRUE(failed(runQCOToQCConversion(*moduleOp)));
+  EXPECT_NE(diagnostics.find("positional quantum state correspondence"),
+            std::string::npos);
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+}
+
+TEST(QCOToQCRegressionTest, RejectsLoopWirePermutation) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, arith::ArithDialect,
+                  func::FuncDialect, scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(module {
+ func.func @main(%n: index) -> i1 attributes {mqt.entry_point} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %a = qco.alloc : !qco.qubit
+  %b = qco.alloc : !qco.qubit
+  %x = qco.x %a : !qco.qubit -> !qco.qubit
+  %r:2 = scf.for %iv = %c0 to %n step %c1 iter_args(%u = %x, %v = %b) -> (!qco.qubit, !qco.qubit) {
+   scf.yield %v, %u : !qco.qubit, !qco.qubit
+  }
+  %q, %m = qco.measure %r#0 : !qco.qubit
+  qco.sink %q : !qco.qubit
+  qco.sink %r#1 : !qco.qubit
+  return %m : i1
+ }
+}
+)mlir",
+                                              &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+  std::string diagnostics;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    diagnostics += diagnostic.str();
+    return success();
+  });
+  EXPECT_TRUE(failed(runQCOToQCConversion(*moduleOp)));
+  EXPECT_NE(diagnostics.find("positional quantum state correspondence"),
+            std::string::npos);
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+}
+
+TEST(QCOToQCRegressionTest, RejectsChangingQuantumWhileArity) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, arith::ArithDialect,
+                  func::FuncDialect, scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(module {
+ func.func @main() attributes {mqt.entry_point} {
+  %false = arith.constant false
+  %q = qco.alloc : !qco.qubit
+  %r:2 = scf.while (%u = %q) : (!qco.qubit) -> (!qco.qubit, !qco.qubit) {
+   %extra = qco.alloc : !qco.qubit
+   scf.condition(%false) %u, %extra : !qco.qubit, !qco.qubit
+  } do {
+  ^bb0(%a: !qco.qubit, %b: !qco.qubit):
+   qco.sink %b : !qco.qubit
+   scf.yield %a : !qco.qubit
+  }
+  qco.sink %r#0 : !qco.qubit
+  qco.sink %r#1 : !qco.qubit
+  return
+ }
+}
+)mlir",
+                                              &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+  std::string diagnostics;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+    diagnostics += diagnostic.str();
+    return success();
+  });
+  EXPECT_TRUE(failed(runQCOToQCConversion(*moduleOp)));
+  EXPECT_NE(diagnostics.find("positional quantum state correspondence"),
+            std::string::npos);
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+}
+
+TEST(QCOToQCRegressionTest, FindsAllocationModeBeforeConvertingCaller) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, func::FuncDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(module {
+ func.func @main() attributes {mqt.entry_point} {
+  %q = func.call @make() : () -> !qco.qubit
+  qco.sink %q : !qco.qubit
+  return
+ }
+ func.func private @make() -> !qco.qubit {
+  %q = qco.alloc : !qco.qubit
+  return %q : !qco.qubit
+ }
+}
+)mlir",
+                                              &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(runQCOToQCConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto caller = moduleOp->lookupSymbol<func::FuncOp>("main");
+  auto call = *caller.getOps<func::CallOp>().begin();
+  auto dealloc = *caller.getOps<qc::DeallocOp>().begin();
+  EXPECT_EQ(dealloc.getQubit(), call.getResult(0));
 }
 
 TEST(QCOToQCRegressionTest, StripsPositionalQubitResultsFromUnitaryCalls) {
@@ -1343,3 +1489,82 @@ INSTANTIATE_TEST_SUITE_P(
             MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithExtractedQubit),
             MQT_NAMED_BUILDER(
                 aliasSafeNestedForLoopCtrlOpWithExtractedQubit)}));
+
+TEST(QCOToQCRegressionTest, RejectsPermutationsInEveryRegionForm) {
+  DialectRegistry registry;
+  registry.insert<qc::QCDialect, qco::QCODialect, arith::ArithDialect,
+                  func::FuncDialect, scf::SCFDialect>();
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  const std::array bodies = {
+      R"mlir(
+      %r:2 = qco.index_switch %index -> (!qco.qubit, !qco.qubit)
+      case 0 args(%u = %a, %v = %b) {
+        qco.yield %v, %u : !qco.qubit, !qco.qubit
+      }
+      default args(%u = %a, %v = %b) {
+        qco.yield %u, %v : !qco.qubit, !qco.qubit
+      }
+    )mlir",
+      R"mlir(
+      %r:2 = scf.while (%u = %a, %v = %b)
+          : (!qco.qubit, !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        scf.condition(%flag) %v, %u : !qco.qubit, !qco.qubit
+      } do {
+      ^bb0(%u: !qco.qubit, %v: !qco.qubit):
+        scf.yield %u, %v : !qco.qubit, !qco.qubit
+      }
+    )mlir",
+      R"mlir(
+      %r:2 = scf.while (%u = %a, %v = %b)
+          : (!qco.qubit, !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        scf.condition(%flag) %u, %v : !qco.qubit, !qco.qubit
+      } do {
+      ^bb0(%u: !qco.qubit, %v: !qco.qubit):
+        scf.yield %v, %u : !qco.qubit, !qco.qubit
+      }
+    )mlir",
+      R"mlir(
+      %r:2 = qco.inv (%u = %a, %v = %b) {
+        qco.yield %v, %u : !qco.qubit, !qco.qubit
+      } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+    )mlir",
+      R"mlir(
+      %p = arith.constant 2.0 : f64
+      %r:2 = qco.pow(%p) (%u = %a, %v = %b) {
+        qco.yield %v, %u : !qco.qubit, !qco.qubit
+      } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+    )mlir",
+      R"mlir(
+      %c = qco.alloc : !qco.qubit
+      %control, %r:2 = qco.ctrl(%c) targets(%u = %a, %v = %b) {
+        qco.yield %v, %u : !qco.qubit, !qco.qubit
+      } : ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+          -> ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+      qco.sink %control : !qco.qubit
+    )mlir",
+  };
+  for (const auto* body : bodies) {
+    SCOPED_TRACE(body);
+    const std::string source = std::string(R"mlir(
+      func.func @test(%flag: i1, %index: index,
+                      %a: !qco.qubit, %b: !qco.qubit)
+          -> (!qco.qubit, !qco.qubit) {
+    )mlir") + body + R"mlir(
+        return %r#0, %r#1 : !qco.qubit, !qco.qubit
+      }
+    )mlir";
+    auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+    std::string diagnostics;
+    ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+      diagnostics += diagnostic.str();
+      return success();
+    });
+    EXPECT_TRUE(failed(runQCOToQCConversion(*moduleOp)));
+    EXPECT_NE(diagnostics.find("positional quantum state correspondence"),
+              std::string::npos);
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  }
+}

--- a/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
+++ b/mlir/unittests/Conversion/QCToQCO/test_qc_to_qco.cpp
@@ -2390,3 +2390,31 @@ INSTANTIATE_TEST_SUITE_P(
             MQT_NAMED_BUILDER(qc::nestedForLoopCtrlOpWithExtractedQubit),
             MQT_NAMED_BUILDER(qco::nestedForLoopCtrlOpWithExtractedQubit),
             true}));
+
+TEST_F(QCToQCOTest, EmitsSinksInAllocationOrder) {
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(
+    func.func @main() {
+      %q0 = qc.alloc : !qc.qubit
+      %q1 = qc.alloc : !qc.qubit
+      %q2 = qc.alloc : !qc.qubit
+      %q3 = qc.alloc : !qc.qubit
+      qc.x %q2 : !qc.qubit
+      qc.h %q0 : !qc.qubit
+      return
+    }
+  )mlir",
+                                              context.get());
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(runQCToQCOConversion(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("main");
+  auto allocations = llvm::to_vector(function.getOps<qco::AllocOp>());
+  auto sinks = llvm::to_vector(function.getOps<qco::SinkOp>());
+  ASSERT_EQ(sinks.size(), 4U);
+  EXPECT_EQ(sinks[0].getQubit(),
+            (*function.getOps<qco::HOp>().begin()).getResult());
+  EXPECT_EQ(sinks[1].getQubit(), allocations[1].getResult());
+  EXPECT_EQ(sinks[2].getQubit(),
+            (*function.getOps<qco::XOp>().begin()).getResult());
+  EXPECT_EQ(sinks[3].getQubit(), allocations[3].getResult());
+}

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -3565,3 +3565,21 @@ TEST_F(QCOTest, UnrollModifiersLeavesNonIntegerPowUntouched) {
   expectUnrollsTo(context.get(), powHalfDisjoint, powHalfDisjoint,
                   checkPreservedPowStructure);
 }
+
+TEST_F(QCOTest, BarrierRejectsMismatchedQubitArity) {
+  std::string diagnostics;
+  ScopedDiagnosticHandler handler(context.get(), [&](Diagnostic& diagnostic) {
+    diagnostics += diagnostic.str();
+    return success();
+  });
+  auto program = parseSourceString<ModuleOp>(R"mlir(
+    func.func @test(%q: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+      %out:2 = qco.barrier %q : !qco.qubit -> !qco.qubit, !qco.qubit
+      return %out#0, %out#1 : !qco.qubit, !qco.qubit
+    }
+  )mlir",
+                                             context.get());
+  EXPECT_FALSE(program);
+  EXPECT_NE(diagnostics.find("one output qubit for each input qubit"),
+            std::string::npos);
+}

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
@@ -88,7 +88,7 @@ static void makePowBodyParameterDynamic(ModuleOp module) {
   firstPowOp(module).getBodyUnitary(0)->setOperand(1, funcOp.getArgument(0));
 }
 
-static Value powUnsupportedThreeQubitBody(QCOProgramBuilder& b) {
+static Value powThreeQubitBody(QCOProgramBuilder& b) {
   auto q = b.allocQubitRegister(3);
   auto powOut = b.pow(2.0, q.qubits, [&](ValueRange args) {
     auto [q0, q1, q2] = b.rccx(args[0], args[1], args[2]);
@@ -147,15 +147,6 @@ static void assertInvBodyAdjoint(MLIRContext* ctx, Builder&& build,
   const auto matrix = invMatrix(*moduleOp);
   ASSERT_TRUE(matrix);
   ASSERT_TRUE(matrix->isApprox(body.adjoint()));
-}
-
-template <typename Builder>
-static void expectComposeNTargetFails(MLIRContext* ctx, Builder&& build,
-                                      size_t numTargets) {
-  auto moduleOp = QCOProgramBuilder::build(ctx, std::forward<Builder>(build));
-  ASSERT_TRUE(moduleOp);
-  EXPECT_FALSE(composeBodyMatrix(*firstInvOp(*moduleOp).getBody(), numTargets)
-                   .has_value());
 }
 
 namespace {
@@ -508,8 +499,10 @@ TEST_F(QCOMatrixTest, ComposeNTargetRejectsExcessiveTargets) {
                    .has_value());
 }
 
-TEST_F(QCOMatrixTest, ComposeNTargetRejectsThreeQubitOp) {
-  expectComposeNTargetFails(context.get(), inverseWithThreeQubitOpInBody, 3);
+TEST_F(QCOMatrixTest, ComposeNTargetSupportsFullWidthThreeQubitOp) {
+  auto expected = DynamicMatrix::identity(8);
+  expected.setBottomRightCorner(XOp::getUnitaryMatrix());
+  assertInvBodyAdjoint(context.get(), inverseWithThreeQubitOpInBody, expected);
 }
 
 TEST_F(QCOMatrixTest, ComposeNTargetRejectsRuntimeGphase) {
@@ -602,14 +595,17 @@ TEST_F(QCOMatrixTest, PowMatrixAvailabilityContract) {
   ASSERT_TRUE(emptyModule);
   auto empty = firstPowOp(*emptyModule);
   EXPECT_TRUE(empty.hasCompileTimeKnownUnitaryMatrix());
-  EXPECT_FALSE(empty.getUnitaryMatrix().has_value());
+  ASSERT_TRUE(empty.getUnitaryMatrix());
+  EXPECT_TRUE(empty.getUnitaryMatrix()->isApprox(DynamicMatrix::identity(4)));
 
-  auto unsupportedModule =
-      QCOProgramBuilder::build(context.get(), powUnsupportedThreeQubitBody);
-  ASSERT_TRUE(unsupportedModule);
-  auto unsupported = firstPowOp(*unsupportedModule);
-  EXPECT_TRUE(unsupported.hasCompileTimeKnownUnitaryMatrix());
-  EXPECT_FALSE(unsupported.getUnitaryMatrix().has_value());
+  auto threeQubitModule =
+      QCOProgramBuilder::build(context.get(), powThreeQubitBody);
+  ASSERT_TRUE(threeQubitModule);
+  auto threeQubit = firstPowOp(*threeQubitModule);
+  EXPECT_TRUE(threeQubit.hasCompileTimeKnownUnitaryMatrix());
+  ASSERT_TRUE(threeQubit.getUnitaryMatrix());
+  EXPECT_TRUE(
+      threeQubit.getUnitaryMatrix()->isApprox(DynamicMatrix::identity(8)));
 
   auto dynamicBodyModule = QCOProgramBuilder::build(context.get(), powRxScaled);
   ASSERT_TRUE(dynamicBodyModule);
@@ -940,7 +936,8 @@ TEST_F(QCOMatrixTest, InverseTwoBarriersInInvOpMatrix) {
   auto moduleOp =
       QCOProgramBuilder::build(context.get(), inverseTwoBarriersInInv);
   ASSERT_TRUE(moduleOp);
-  EXPECT_FALSE(invMatrix(*moduleOp).has_value());
+  ASSERT_TRUE(invMatrix(*moduleOp));
+  EXPECT_TRUE(invMatrix(*moduleOp)->isApprox(DynamicMatrix::identity(2)));
 }
 
 TEST_F(QCOMatrixTest, InvTwoOpMatrix) {
@@ -1518,3 +1515,93 @@ TEST_F(QCOMatrixTest, ZOpMatrix) {
   ASSERT_TRUE(matrix.isApprox(expected));
 }
 /// @}
+
+TEST_F(QCOMatrixTest, ModifierMatricesIncludeIdleTargets) {
+  auto moduleOp =
+      QCOProgramBuilder::build(context.get(), [](QCOProgramBuilder& b) {
+        auto q = b.allocQubitRegister(3);
+        auto subset = [&](ValueRange args) {
+          return SmallVector<Value>{args[0], b.x(args[1])};
+        };
+        auto inv = b.inv({q[1], q[2]}, subset);
+        auto pow = b.pow(1.0, inv, subset);
+        auto [controls, targets] = b.ctrl({q[0]}, pow, subset);
+        return b.measure(targets[0]).second;
+      });
+  ASSERT_TRUE(moduleOp);
+  const auto targetMatrix = XOp::getUnitaryMatrix().embedInNqubit(2, 1);
+  auto inv = firstInvOp(*moduleOp).getUnitaryMatrix();
+  auto pow = firstPowOp(*moduleOp).getUnitaryMatrix();
+  ASSERT_TRUE(inv);
+  ASSERT_TRUE(pow);
+  EXPECT_TRUE(inv->isApprox(targetMatrix));
+  EXPECT_TRUE(pow->isApprox(targetMatrix));
+  auto expected = DynamicMatrix::identity(8);
+  expected.setBottomRightCorner(targetMatrix);
+  moduleOp->walk([&](CtrlOp op) {
+    const auto matrix = op.getUnitaryMatrix();
+    ASSERT_TRUE(matrix);
+    EXPECT_TRUE(matrix->isApprox(expected));
+  });
+}
+
+TEST_F(QCOMatrixTest, ModifierMatrixRejectsReorderedYield) {
+  auto moduleOp =
+      QCOProgramBuilder::build(context.get(), [](QCOProgramBuilder& b) {
+        auto q = b.allocQubitRegister(2);
+        auto out = b.inv(q.qubits, [&](ValueRange args) {
+          return SmallVector<Value>{b.x(args[1]), args[0]};
+        });
+        return b.measure(out[0]).second;
+      });
+  ASSERT_TRUE(moduleOp);
+  EXPECT_FALSE(firstInvOp(*moduleOp).getUnitaryMatrix());
+}
+
+TEST_F(QCOMatrixTest, ModifierMatricesRespectTotalWidthLimit) {
+  auto moduleOp =
+      QCOProgramBuilder::build(context.get(), [](QCOProgramBuilder& b) {
+        auto q = b.allocQubitRegister(kMaxModifierTargetQubits + 1);
+        auto out = b.inv(q.qubits, [](ValueRange args) { return args; });
+        auto powered = b.pow(0.0, out, [](ValueRange args) { return args; });
+        auto [controls, targets] =
+            b.ctrl(powered.drop_back(), powered.back(),
+                   [&](Value target) { return b.x(target); });
+        return b.measure(targets).second;
+      });
+  ASSERT_TRUE(moduleOp);
+  EXPECT_FALSE(firstInvOp(*moduleOp).getUnitaryMatrix());
+  EXPECT_FALSE(firstPowOp(*moduleOp).getUnitaryMatrix());
+  moduleOp->walk([](CtrlOp op) { EXPECT_FALSE(op.getUnitaryMatrix()); });
+}
+
+TEST_F(QCOMatrixTest, ModifierMatrixEmbedsReversedGateInputs) {
+  auto moduleOp =
+      QCOProgramBuilder::build(context.get(), [](QCOProgramBuilder& b) {
+        auto q = b.allocQubitRegister(2);
+        auto out = b.inv(q.qubits, [&](ValueRange args) {
+          auto [second, first] = b.rzx(0.42, args[1], args[0]);
+          return SmallVector<Value>{first, second};
+        });
+        return b.measure(out[0]).second;
+      });
+  ASSERT_TRUE(moduleOp);
+  const auto matrix = firstInvOp(*moduleOp).getUnitaryMatrix();
+  ASSERT_TRUE(matrix);
+  EXPECT_TRUE(matrix->isApprox(
+      RZXOp::unitaryMatrix(0.42).embedInNqubit(2, 1, 0).adjoint()));
+}
+
+TEST_F(QCOMatrixTest, ModifierMatrixRejectsUnsupportedSubsetEmbedding) {
+  auto moduleOp =
+      QCOProgramBuilder::build(context.get(), [](QCOProgramBuilder& b) {
+        auto q = b.allocQubitRegister(4);
+        auto out = b.inv(q.qubits, [&](ValueRange args) {
+          auto [first, second, third] = b.rccx(args[0], args[1], args[2]);
+          return SmallVector<Value>{first, second, third, args[3]};
+        });
+        return b.measure(out[0]).second;
+      });
+  ASSERT_TRUE(moduleOp);
+  EXPECT_FALSE(firstInvOp(*moduleOp).getUnitaryMatrix());
+}

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
@@ -976,6 +976,66 @@ TEST_F(QCOMatrixTest, InverseDynamicRzXOpMatrix) {
 
 /// \name QCO/Operations/StandardGates/DcxOp.cpp
 /// @{
+TEST_F(QCOMatrixTest, DcxInverseReversesTargets) {
+  const auto forward = DCXOp::getUnitaryMatrix().embedInNqubit(2, 0, 1);
+  const auto reverse = DCXOp::getUnitaryMatrix().embedInNqubit(2, 1, 0);
+  EXPECT_TRUE(reverse.isApprox(forward.adjoint()));
+  EXPECT_TRUE((reverse * forward).isApprox(DynamicMatrix::identity(4)));
+  EXPECT_FALSE((forward * forward).isApprox(DynamicMatrix::identity(4)));
+}
+
+TEST_F(QCOMatrixTest, DcxCancellationPreservesOrderedOutputs) {
+  for (const bool reversed : {false, true}) {
+    SCOPED_TRACE(reversed);
+    auto program = QCOProgramBuilder::build(context.get(), [&](auto& builder) {
+      auto in0 = builder.staticQubit(0);
+      auto in1 = builder.staticQubit(1);
+      auto [q0, q1] = builder.dcx(in0, in1);
+      if (reversed) {
+        std::tie(q1, q0) = builder.dcx(q1, q0);
+      } else {
+        std::tie(q0, q1) = builder.dcx(q0, q1);
+      }
+      return SmallVector<Value>{q0, q1};
+    });
+    ASSERT_TRUE(program);
+    OwningOpRef<ModuleOp> expected(cast<ModuleOp>((*program)->clone()));
+    ASSERT_TRUE(succeeded(runQCOCleanupPipeline(*program)));
+    ASSERT_TRUE(succeeded(verifyLinearity(*program)));
+    ::mqt::test::expectFullUnitaryEqual(*expected, *program, 2);
+    auto function = *program->getOps<func::FuncOp>().begin();
+    EXPECT_EQ(llvm::range_size(function.getBody().getOps<DCXOp>()),
+              reversed ? 0 : 2);
+  }
+}
+
+TEST_F(QCOMatrixTest, ControlledSwapRemainsConditional) {
+  auto program = QCOProgramBuilder::build(context.get(), [&](auto& builder) {
+    auto control = builder.staticQubit(0);
+    auto q0 = builder.staticQubit(1);
+    auto q1 = builder.staticQubit(2);
+    auto [controls, targets] =
+        builder.ctrl({control}, {q0, q1}, [&](ValueRange args) {
+          auto [out0, out1] = builder.swap(args[0], args[1]);
+          return SmallVector<Value>{out0, out1};
+        });
+    return SmallVector<Value>{controls[0], targets[0], targets[1]};
+  });
+  ASSERT_TRUE(program);
+  ASSERT_TRUE(succeeded(runQCOCleanupPipeline(*program)));
+  ASSERT_TRUE(succeeded(verifyLinearity(*program)));
+  auto function = *program->getOps<func::FuncOp>().begin();
+  auto controls = llvm::to_vector(function.getBody().getOps<CtrlOp>());
+  ASSERT_EQ(controls.size(), 1U);
+  const auto matrix = controls.front().getUnitaryMatrix();
+  ASSERT_TRUE(matrix);
+  auto expected = DynamicMatrix::identity(8);
+  expected.setBottomRightCorner(SWAPOp::getUnitaryMatrix());
+  EXPECT_TRUE(matrix->isApprox(expected));
+  EXPECT_FALSE(
+      matrix->isApprox(SWAPOp::getUnitaryMatrix().embedInNqubit(3, 1, 2)));
+}
+
 TEST_F(QCOMatrixTest, DCXOpMatrix) {
   const auto matrix = DCXOp::getUnitaryMatrix();
   const auto expected = Matrix4x4::fromElements(1, 0, 0, 0,  // row 0

--- a/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
+++ b/mlir/unittests/Dialect/QTensor/IR/test_qtensor_ir.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mlir/Dialect/QTensor/IR/QTensorOps.h"
 #include "mlir/Dialect/QTensor/IR/QTensorUtils.h"
@@ -479,15 +480,19 @@ TEST_F(QTensorTest, AdjacentInsertExtractKeepsPotentialDynamicAlias) {
 TEST_F(QTensorTest, InsertChainCanonicalizationRemainsLocal) {
   auto program = buildTwoQubitInsertChainProgram(context.get(), false, false);
   ASSERT_TRUE(program);
-  EXPECT_TRUE(verify(*program).succeeded());
+  ASSERT_TRUE(verify(*program).succeeded());
+  ASSERT_TRUE(succeeded(qco::verifyLinearity(*program)));
   EXPECT_TRUE(runQCOCleanupPipeline(program.get()).succeeded());
-  EXPECT_TRUE(verify(*program).succeeded());
+  ASSERT_TRUE(verify(*program).succeeded());
+  ASSERT_TRUE(succeeded(qco::verifyLinearity(*program)));
 
   auto reference = buildTwoQubitInsertChainProgram(context.get(), true, false);
   ASSERT_TRUE(reference);
-  EXPECT_TRUE(verify(*reference).succeeded());
+  ASSERT_TRUE(verify(*reference).succeeded());
+  ASSERT_TRUE(succeeded(qco::verifyLinearity(*reference)));
   EXPECT_TRUE(runQCOCleanupPipeline(reference.get()).succeeded());
-  EXPECT_TRUE(verify(*reference).succeeded());
+  ASSERT_TRUE(verify(*reference).succeeded());
+  ASSERT_TRUE(succeeded(qco::verifyLinearity(*reference)));
 
   EXPECT_EQ(countOps<InsertOp>(*program), 2U);
   EXPECT_EQ(countOps<InsertOp>(*reference), 0U);


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

QCO-to-QC could silently replace permuted branch or loop results with the wrong
references, and changing quantum `scf.while` state could assert. The pass now
proves positional correspondence through region terminators before rewriting,
uses those origins for function returns, and determines allocation mode before
converting any function. QCO permutations remain valid IR; this lowering
reports unsupported transport. Classical loop state and QTensor slot stores are
preserved.

Barrier verification now requires matching input and output counts. Modifier
matrix queries compose all declared targets in wire order, including idle
wires, and bound dense matrices to ten total qubits, including controls.

The cleanup uses direct QTensor cache lookups, stable sink order, positional
barrier vectors, and MLIR function patterns for 30 forwarding classes. It also
removes duplicate conversion helpers, unreachable else-region handling, and
obsolete warning suppressions. No new dependencies.

The development policy now makes the exactly-one-use QCO/QTensor invariant
explicit. Rewrites use native MLIR use-list access and omit five redundant
single-use guards. Extract/insert cancellation removes both operations in one
rewrite, avoiding a temporary linearity violation from folding only the insert.
Exact-matrix regressions cover DCX target order and controlled SWAP semantics.

Validation: the original implementation passed 1,978 tests. After rebasing onto
main at `11d983fa`, all 880 QCO IR, QTensor IR, conversion, and round-trip tests
passed. Lint, full-file C++ lint, and the complete strict Sphinx documentation
build passed. Local release tests used `ENABLE_IPO=OFF` because GCC/LTO hit a
duplicate symbol in the installed MLIR library. Main already contains the
PennyLane documentation reference fix. Hosted checks for the updated commit
are pending. Changelog and upgrade entries are not applicable to this unreleased
v4 functionality.

AI assistance: Codex implemented and checked this change under explicit
maintainer authorization.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

