### PR TITLE
🐛 Correct OpenQASM import and export contracts

### DIFF
--- a/.agent/audits/openqasm-import-export.md
+++ b/.agent/audits/openqasm-import-export.md
@@ -1,447 +1,139 @@
 # Contract audit: OpenQASM import and export
 
-Status: complete; accepted findings implemented and locally validated. Audit
-baseline: `33dbc843e589d9e9166308084e825c9f8b2ff89d`, initially clean checkout.
-Date: 2026-09-08. Environment: native ARM64, release build, LLVM/MLIR 23.1.0.
-
-## Implementation disposition
-
-The implementation preserves affine quantum indexing. Static-only quantum
-indexing was rejected. The accepted changes are:
-
-- Bound affine reconstruction per proof and use set-based static distinctness.
-- Replace projected emission costs with actual insertion accounting and bounded
-  cancellation. Keep semantic target restrictions at their owning lowering.
-- Preserve ordered outputs and zero-valued data; use void for absent outputs and
-  diagnose repeated register outputs instead of silently dropping aliases.
-- Share frontend name validation; align floating inequality with unordered
-  semantics; avoid storage for unused measurement results.
-- Build syntax IDs directly, use one bit-vector comparison representation, and
-  materialize entry-function snapshots at their definition.
-- Require full-register initialization for dynamic reads. Static initialization
-  tracking and affine scalar generations remain.
-- Accept exact-width bit strings and float casts; use compact zero initializers.
-  Document the existing working-directory/include-directory lookup policy.
-- Lower catalog definitions through strict mode for matrix tests, including
-  controlled forms and exact global phase. These tests exposed native `qc.u` and
-  `qc.u2` export phase errors. One shared helper applies `gphase(-theta/2)`
-  before OpenQASM 3 `U`, retaining the native matrix under controls.
-
-Local parser measurements on 100,000 distinct declarations reduced peak RSS from
-about 137,600 KiB to 88,000 KiB. Three-run median wall time was 0.66 s versus
-0.45 s; other host workloads make timing noisy. A 20-assignment affine DAG took
-17.8 s before and 0.00072 s after under host contention. A 64,000-operand static
-control probe took 7.21 s before and 0.145 s after. These observations establish
-local scaling improvements, not cross-machine timing promises.
-
-The release build and all 3,215 MLIR CTests pass, including 190 OpenQASM target
-and 209 QC translation tests. Repository lint and full-file C++ lint pass.
-Hosted CI is separate from these local results.
-
-The sections below retain the original audit evidence and proposals, whose
-source line numbers refer to the audit baseline. The disposition above records
-which proposals were implemented.
-
-## Result
-
-The most useful work is to bound affine analysis, remove a stale emission-cost
-assumption, and repair exporter result and expression contracts. The larger
-deletions are possible only after choosing explicit internal representations.
-The current safety checks are not generally redundant.
-
-| Rank | Finding                                                         | Impact                                        | Confidence                                       |
-| ---- | --------------------------------------------------------------- | --------------------------------------------- | ------------------------------------------------ |
-| 1    | Repeated scalar assignments cause exponential affine analysis   | Small input can stall compilation             | Confirmed by timing and source                   |
-| 2    | Dynamic writes still pay for an obsolete register-wide lowering | Valid small programs fail the emission limit  | Confirmed reproducer                             |
-| 3    | Export loses output order, multiplicity, and zero-valued data   | Changes the result interface                  | Confirmed reproducers; status rule is documented |
-| 4    | Floating inequality uses inconsistent predicates                | Valid imported comparison cannot be exported  | Confirmed reproducer and predicate definitions   |
-| 5    | Exporter name validation duplicates an incomplete keyword list  | Successful export produces rejected source    | Confirmed reproducers                            |
-| 6    | Unused measurements allocate observable classical storage       | Reimport introduces an implicit output        | Confirmed reproducer                             |
-| 7    | Static gate-operand distinctness uses pairwise checks           | Quadratic analysis for large controlled gates | Confirmed timing and source                      |
-
-The source scope covers the lexer, parser, syntax storage, semantic analysis,
-typed frontend, QC emitter, QC builder, exporter, gate catalog, relevant driver
-entry points, documentation, and both OpenQASM/QC translation test targets. This
-is an investigation of the current implementation, not a claim of full OpenQASM
-language conformance or exhaustive downstream interoperability.
-
-## Confirmed findings
-
-### 1. Store affine facts without repeatedly expanding their expression DAG
-
-**Change and benefit.** In `mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp`,
-replace repeated recursive reconstruction in `buildAffineForm` (line 633) and
-`expandAffineScalarValues` (line 710) with bounded analysis of shared
-expressions. Prefer retaining normalized affine facts at assignment time. At
-minimum, avoid revisiting a shared expression within one proof and bound proof
-work.
-
-**Evidence.** Analyze `OPENQASM 3.1; int a = 1;` followed by N copies of
-`a = a + a;`. No quantum indexing is needed to trigger the cost.
-
-| N   | Typed expressions | Parse and analysis time |
-| --- | ----------------- | ----------------------- |
-| 8   | 33                | 0.00161 s               |
-| 12  | 49                | 0.01886 s               |
-| 16  | 65                | 0.29367 s               |
-| 20  | 81                | 2.339 s                 |
-| 24  | —                 | Exceeded a 5 s timeout  |
-
-These are local observations, not cross-machine performance promises. The
-expression arena grows modestly; recursively following both operands repeatedly
-revisits the same DAG. The parser's expression-depth bound does not bound this
-work across assignments.
-
-**Contract and limits.** Preserve proof of intermediate integer operations and
-overflow, induction domains, scope, and branch invalidation. A global cache
-keyed only by expression ID would be unsafe because the proof context changes.
-When an optional scalar fact exceeds a budget, forget the fact; reject a quantum
-index only when its required proof then fails. Do not reject ordinary classical
-arithmetic merely because an optional affine optimization is expensive.
-
-### 2. Remove the obsolete register-width charge for dynamic stores
-
-**Change and benefit.** In
-`mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp`, the
-projected-emission checks at lines 781–788 and 830–834 charge `9 + 3 * width`
-for a dynamic bit store. `assignBit` at line 2251 now emits a checked index and
-a native `cbit.store`. Correct both ordinary-assignment and measurement-target
-accounting.
-
-**Evidence.** This accepted-width source fails with the projected 10-million-op
-limit around line 35, although only 40 stores are requested:
-
-```python
-source = "OPENQASM 3.1;\nbit[99999] c;\noutput int i;\ni = 0;\n"
-source += "c[i] = false;\n" * 40
-```
-
-Using width 10 instead succeeds and emits 40 `cbit.store` operations. The
-explicit scalar output keeps the partially initialized register from becoming an
-implicit output, isolating the emission-budget problem.
-
-**Larger simplification.** The roughly 600-line predictive cost implementation
-duplicates lowering details while `EmissionBudget`, an `OpBuilder` listener,
-already counts actual emitted operations. This is a concrete maintenance cost:
-the two have drifted. Prefer one authoritative actual-emission budget if
-emission can abort promptly. Do not delete the preflight implementation
-unchanged: the listener currently marks exhaustion, and recursive expression
-construction and bulk statement paths need cancellation propagation. Preserve
-all resource bounds and rejection tests; replace predicted-count assertions with
-bounded-emission checks where the distinction is not public behavior.
-
-### 3. Represent outputs as ordered results, with explicit status semantics
-
-**Change and benefit.** In
-`mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp`,
-`collectProgramShape` (line 382) separates returned registers into a set and
-scalars into a vector. `emitDeclarations` (line 515) prints registers in
-allocation order before scalar outputs. That representation cannot preserve the
-entry function's ordered result list or repeated register results.
-
-**Evidence.** Direct import/export of:
-
-```qasm
-OPENQASM 3.1;
-output int a;
-output bit b;
-a = 1;
-b = false;
-```
-
-prints `output bit[1] b;` before `output int _mqt_out0;`. Reimport changes the
-ordered output types. A verified function returning `%c, %c` as two
-`!cbit.reg<1>` results exports only one output declaration. Independently,
-`output int answer; answer = 0;` loses its sole output through the CLI, while
-the same program with value 1 retains an output.
-
-The last behavior follows `isCanonicalStatus` (line 480), which recognizes any
-lone constant-zero `i64` result. `docs/mlir/OpenQASM.md` explicitly documents
-it; this is a brittle documented convention, not an undocumented regression.
-
-**Contract and limits.** Use an ordered result description and choose an
-explicit policy for aliases: preserve each result with a distinct output or
-reject repeated register results. Distinguish status from data through an
-explicit contract; `QCProgramBuilder` already has empty result-type/value
-overloads, but changing the default status ABI requires checking all builder and
-compiler consumers. A documented restriction on mixed or aliased outputs would
-be a smaller acceptable change than silently changing their shape. Scalar names
-and fixed-angle spelling are already documented as lossy and are separate from
-losing actual results.
-
-### 4. Align floating inequality with the imported predicate
-
-**Change and benefit.** The importer maps `!=` to `arith.cmpf UNE` in
-`OpenQASMToQCEmitter.cpp::emitComparison` (line 1919). The exporter maps `ONE`
-to `!=` and rejects `UNE` in `TranslateQCToOpenQASM3.cpp::floatPredicate` (line
-1227). Map `UNE` consistently; reject `ONE` unless its ordered semantics can be
-preserved or non-NaN operands are established.
-
-**Evidence.** Strict frontend analysis accepts this source, but direct
-import/export fails with an unsupported floating-comparison diagnostic:
-
-```qasm
-OPENQASM 3.1;
-float f = 1.0;
-output bool b;
-b = f != 2.0;
-```
-
-`ONE` and `UNE` differ for NaNs according to the
-[MLIR comparison definitions](https://mlir.llvm.org/docs/Dialects/ArithOps/#arithcmpf-arithcmpfop).
-Checking finite literals does not establish finite runtime computations. The
-existing `EmitsSignedAndFloatingComparisonFamilies` string check accepts the
-wrong `ONE` mapping. Replace that expectation with predicate-sensitive coverage.
-The finite-value roundtrip failure is reproduced; NaN behavior here is
-established from predicate semantics, not from a hardware execution experiment.
-
-### 5. Share source-name validation with the frontend
-
-**Change and benefit.** Exporter `isReserved` (line 111) duplicates only part of
-the lexer keyword and semantic builtin-constant policy. Centralize that policy
-for names that will be emitted as source. Keep exporter-specific
-generated-prefix and gate-collision rules separate.
-
-**Evidence.** Export succeeds for the following verified IR, but strict analysis
-of its output fails:
-
-```mlir
-module {
-  func.func @main() -> !cbit.reg<1> attributes {mqt.entry_point} {
-    %c = cbit.alloc(#cbit.init<zero>) {mqt.register_name = "void"}
-      : !cbit.reg<1>
-    return %c : !cbit.reg<1>
-  }
-}
-```
-
-The same happens for `im`, `pragma`, and `pi`. `sin` and `valid_name` pass,
-providing controls against an overly broad blacklist. Compare
-`OpenQASMLexer.cpp::keywordKind` and `OpenQASMSemantics.cpp::builtinConstant`.
-Preserve deterministic renaming and catalog collisions; accepting every Unicode
-source identifier is not necessary to fix this inconsistency.
-
-### 6. Emit unused measurements without a scratch bit
-
-**Change and benefit.** `TranslateQCToOpenQASM3.cpp::emitMeasurement` (line
-1315) allocates a scratch bit for an unfused measurement even when its classical
-result is unused. Emit `measure q;` for an unused result.
-
-**Evidence.** Direct import/export of `OPENQASM 3.1; qubit q; measure q;`
-produces `bit _mqt_b0;` and `_mqt_b0 = measure _mqt_q0;`. Reimport treats the
-new global bit as an implicit output. The original has no classical outputs. The
-quantum measurement and its position must survive; only its unused classical
-storage is removable. Keep scratch storage for values with consumers.
-
-### 7. Reuse static deduplication before affine distinctness proofs
-
-**Change and benefit.** `OpenQASMSemantics.cpp` gate-application validation
-(line 4955) compares every operand with every previous operand, including static
-indices. `analyzeBarrier` already demonstrates set-based static deduplication.
-Reuse that pattern, partitioned by reference kind and register identity; reserve
-pairwise affine proofs for cases that need them.
-
-**Evidence.** Analyze `qubit[N] q; ctrl(N-1) @ x q[0], ..., q[N-1];` after the
-version declaration. Median parse-and-analysis times over three local runs:
-
-| N      | Time       |
-| ------ | ---------- |
-| 8,000  | 0.028016 s |
-| 16,000 | 0.105600 s |
-| 32,000 | 0.705165 s |
-| 64,000 | 5.494332 s |
-
-The affine solver's comparison cap does not limit the cheap static pair count.
-Keep rejection of duplicate targets/controls, hardware-qubit identity, and
-uncertain affine overlap. No revised implementation was benchmarked.
-
-## Structural simplifications and explicit limits
-
-These are proposals, not measured line savings or applied changes.
-
-### Collapse the special register-comparison representation
-
-`ConditionKind::RegisterComparison` and `BitVectorComparison` now converge on
-whole-register reads, constants, and integer comparisons in `emitCondition`
-(lines 1970–1994). Convert register-versus-literal comparisons to the existing
-bit-vector expression representation during analysis, then remove the redundant
-typed fields, emitter branch, and cost-model branch.
-
-Preserve `OpenQASMSemantics.cpp` lines 4567–4630: comparisons against
-out-of-range literals can fold without truncation, and swapping literal/register
-sides changes relational predicates. Initialization diagnostics must also
-survive. The typed frontend is publicly declared, so no in-tree external user is
-insufficient to prove source compatibility. This is a narrow consolidation, not
-deletion of the comparison semantics.
-
-### Make the parser concrete; consider building syntax IDs directly
-
-`OpenQASMParser.h` defines a `QASMSink` concept and a large parser template, but
-`Frontend.cpp` instantiates it only with `SyntaxBuilder`. Removing that unused
-internal extension point would simplify the interface. A second, larger change
-could construct syntax expression IDs directly:
-`OpenQASMSyntax.cpp::copyExpression` (lines 83–122) currently traverses
-transient expression objects into an ID arena using a worklist and map while the
-transient allocator remains alive during parsing.
-
-Do not merge parsing with semantic analysis. Reusable `ParsedProgram` analysis,
-different gate policies, source-buffer lifetime, diagnostics, and iterative
-handling of long expression chains are useful contracts. Removing the transient
-tree needs a peak-memory and parse-time comparison before claiming a speedup.
-
-### Prefer explicit scalar snapshots to recursive exporter reconstruction
-
-The exporter tracks operation positions and writes to reject stale or
-cross-region classical snapshots, and caps recursive expression expansion at
-4,096 nodes and depth 256. These checks protect correctness and bounded output.
-A more explicit entry-function export normal form could materialize reads at
-their definition and shared scalar expressions once, using the existing
-`materialize` machinery.
-
-This could remove much of the need to reconstruct temporal safety and could
-export presently rejected programs. It is not safe to delete snapshot checks
-first. Preserve evaluation order, simultaneous SCF edge assignments, and loop
-semantics. Gate bodies have stricter allowed statements, and registers wider
-than 64 bits need a different snapshot representation. Start with entry-function
-scalar values. Replace stale-snapshot and expansion rejection tests only when
-semantic snapshot and bounded-output tests cover the new implementation.
-
-### State partial-initialization support before simplifying its analysis
-
-Dynamic bit facts, expression equivalence, dependencies, and generation tracking
-allow a partially initialized register to support `c[i] = ...; read c[i]`
-without requiring every bit to be initialized. Requiring full initialization
-before every dynamic read could delete substantial machinery, but would remove
-tested behavior. That is a product decision, not redundant-code cleanup. Keep
-the copy-on-write initialization state used across branches.
-
-Similarly, requiring constant quantum indices would remove affine analysis but
-also useful documented loops. The
-[OpenQASM type specification](https://openqasm.com/language/types.html) permits
-implementations to restrict nonconstant quantum indexing; permission to restrict
-it does not make this project's existing feature dispensable. Bound the current
-proof work before considering that larger reduction.
-
-### Compact zero initialization within the supported expression profile
-
-`emitDeclarations` writes one assignment per bit for zero-initialized registers.
-A width-10,000 probe produced 10,005 lines and 248,959 bytes. For widths up to
-64, the frontend accepts a whole-register assignment such as
-`c = bit[64](uint[64](0));`, which can replace the per-bit loop.
-
-Do not assume that an arbitrary-width bit string is an available replacement:
-`bit[3] c = "000";` fails in the current parser. Exact-width bit strings are
-described by the language and mentioned by the local documentation, but
-`parsePrimary` does not accept them. Supporting them is a separate frontend
-change. Keep wide-register initialization correct until that support exists.
-
-### Make the remaining syntax and include boundaries explicit
-
-The exporter can emit `float(int[64](1))`, while parser `parsePrimary` does not
-accept the float cast. This reproduces a reimport failure, but float/integer
-conversions are explicitly excluded from the documented roundtrip subset. Either
-close the parser gap through the existing cast representation or make the
-earlier broad statement that emitted expressions are accepted more precise.
-
-CLI relative include lookup depends on the process working directory rather than
-automatically using the source file's directory. A source beside `repeated.inc`
-failed to find it when invoked from another directory. `openSourceMgr` in the
-driver and `SourceMgr::OpenIncludeFile` in the frontend own this boundary.
-Document the search policy or provide the source directory explicitly. The
-[OpenQASM include rules](https://openqasm.com/language/comments.html) describe
-source inclusion; they do not by themselves establish a filesystem search order.
-This is a usability/contract choice, not a claimed language violation.
-
-## Test coverage and rejected deletions
-
-`EmitsCatalogHelpersUnderTheirNativeNames` in `test_openqasm3_emission.cpp`
-(around line 658) runs strict analysis, then translates through the default
-compatibility policy. Compatibility mode deliberately ignores a matching catalog
-definition body and emits the native operation. The test therefore does not
-prove that exported helper bodies implement those native operations.
-
-Add strict-policy lowering and compare helper unitaries, including controlled
-global phase. Reuse the existing matrix oracle in `test_qasm3_translation.cpp`
-where suitable. That oracle is independent reference behavior, not removable
-duplication of production lowering. No incorrect helper matrix was demonstrated
-by this audit.
-
-Other tempting deletions are rejected:
-
-- Exact fixed-angle quantization protects widths, wrapping, and ties-to-even;
-  ordinary floating rounding is not an equivalent replacement.
-- Runtime integer-power overflow checks protect a distinct documented contract;
-  modular addition semantics do not justify removing them.
-- Resource limits, snapshot checks, uncertain-alias rejection, and
-  initialization checks are necessary until an alternative representation
-  enforces the same guarantees.
-- Equal emitted strings or overlapping coverage do not prove tests redundant. No
-  broad test deletion is justified by this investigation.
-
-## Related work
-
-Live GitHub inspection found relevant boundaries in issues
-[#2414](https://github.com/munich-quantum-toolkit/core/issues/2414) (naming),
-[#2413](https://github.com/munich-quantum-toolkit/core/issues/2413) (gate
-bodies), and
-[#2427](https://github.com/munich-quantum-toolkit/core/issues/2427),
-[#2428](https://github.com/munich-quantum-toolkit/core/issues/2428), and
-[#2429](https://github.com/munich-quantum-toolkit/core/issues/2429) (register
-subroutines). Coordinate changes to naming or function/result contracts with
-that work. Runtime angles, general arrays, and slices remain separate feature
-scopes. No issues, pull requests, or remote branches were changed.
-
-## Validation and reproduction
-
-Built successfully, exit 0:
-
-```sh
-cmake --build --preset release --target \
-  mqt-core-mlir-unittest-openqasm-target \
-  mqt-core-mlir-unittest-qc-translation mqt-cc -j8
-```
-
-Ran both binaries directly and recorded their actual exit statuses:
-
-```sh
-build/release/mlir/unittests/Target/OpenQASM/mqt-core-mlir-unittest-openqasm-target
-build/release/mlir/unittests/Dialect/QC/Translation/mqt-core-mlir-unittest-qc-translation
-```
-
-Results: 185/185 and 199/199 passed, each exit 0. These baseline tests do not
-disprove the reproduced gaps. Logs are in `/tmp/openqasm-audit-target.log` and
-`/tmp/openqasm-audit-translation.log` for this session.
-
-`uvx nox -s lint` passed. The explicit report check,
-`uvx prek run --files .agent/audits/openqasm-import-export.md`, also passed.
-
-The temporary C++ probe and input files are under `/tmp/mqt-openqasm-audit`. The
-probe uses the built libraries and these API sequences:
-
-- `analyze` / `strict`: load a `SourceMgr`, call `parseOpenQASM`, then
-  `analyzeOpenQASM` with `MQTCompatibility` / `Strict`; report diagnostic
-  failure as exit 1 and success as exit 0. Timings include parsing and analysis.
-- `import`: call `translateQASM3ToQC` and print the resulting module.
-- `roundtrip`: call `translateQASM3ToQC`, then `translateQCToOpenQASM3`
-  directly, without cleanup passes that could fold away the tested operation.
-- `export`: parse the input MLIR and call `translateQCToOpenQASM3`.
-
-Example commands with the retained inputs:
-
-```sh
-/tmp/mqt-openqasm-audit/probe strict /tmp/mqt-openqasm-audit/float-ne-input.qasm
-/tmp/mqt-openqasm-audit/probe roundtrip /tmp/mqt-openqasm-audit/float-ne-input.qasm
-/tmp/mqt-openqasm-audit/probe export /tmp/mqt-openqasm-audit/name-void.mlir
-/tmp/mqt-openqasm-audit/probe analyze /tmp/mqt-openqasm-audit/affine-dag-20.qasm
-```
-
-The first command succeeds; the second fails; the third succeeds but produces
-source that strict analysis rejects; the fourth succeeds after excessive work.
-The source fragments and generators above preserve the essential reproductions
-without depending on temporary files surviving.
-
-No production mutation, full-project test run, downstream simulator execution,
-hosted CI run, or benchmark of a proposed replacement was performed. This report
-does not claim a measured net line reduction or dependency removal. Implement
-the small reproduced corrections first; evaluate the parser, budgeting, and
-snapshot representations as separate changes with their retained contracts.
+Status: complete; accepted findings implemented and locally validated. Original
+baseline: `33dbc843e589d9e9166308084e825c9f8b2ff89d`. Simplification baseline:
+`2a927489805c93e9931df65d6c6cf3e49e971324`. Date: 2026-09-08. Measurements used
+native ARM64 and LLVM/MLIR 23.1.0.
+
+## Scope and disposition
+
+The scope covers `mlir/lib/Target/OpenQASM`, QC OpenQASM translation,
+`bindings/mlir/qiskit`, their corresponding unit tests, and
+`test/python/test_mlir_qiskit_translation.py`. The supported language subset is
+in `docs/mlir/OpenQASM.md`; the Qiskit boundary is in
+`docs/mlir/python_compiler_collection.md`. This audit does not establish full
+OpenQASM conformance.
+
+### Bounded analysis and emission
+
+Affine reconstruction caches within one proof context and bounds its work.
+Optional facts may be forgotten; required quantum-index proofs must succeed.
+Intermediate overflow, induction domains, scope invalidation, and uncertain
+alias rejection remain checked. Static operand distinctness uses a set before
+pairwise affine proofs.
+
+The original affine reproducer is `OPENQASM 3.1; int a = 1;` followed by N
+copies of `a = a + a;`. With 20 assignments, analysis took 17.8 s before and
+0.00072 s after under host contention. The static-distinctness reproducer is
+`qubit[N] q; ctrl(N-1) @ x q[0], ..., q[N-1];`. At N = 64,000, analysis fell
+from 7.21 s to 0.145 s. These are local scaling observations, not timing
+promises.
+
+An `OpBuilder` listener counts inserted operations; cancellation bounds further
+construction. This replaces a predictive model that charged register-wide work
+for native dynamic stores. The reproducer declares `bit[99999] c; output int i;`
+with `i = 0;` and 40 copies of `c[i] = false;`. It must emit 40 stores within
+the ordinary budget. The explicit output isolates this check from
+initialization. Budget-boundary tests use the public importer and count actual
+insertions.
+
+### One syntax representation and explicit policies
+
+The parser builds persistent expression IDs directly. Operands, bit references,
+and modifiers have one shared representation. Gate-call arrays remain borrowed
+while parsing and owned in stored syntax. Parsing remains separate from analysis
+so source lifetimes, diagnostics, and reanalysis under different policies
+survive. `GatePolicy` is passed directly to analysis; `QASM3ImportOptions` owns
+a flat policy and emission limit.
+
+For 100,000 distinct declarations, the original syntax-ID change reduced peak
+RSS from about 137,600 KiB to 88,000 KiB. Three-run median parse time fell from
+0.66 s to 0.45 s. Removing duplicate leaf types has no separate speedup claim.
+
+### Ordered outputs and scalar snapshots
+
+The exporter preserves result order and integer zero as data. Absent outputs are
+void; repeated register results are rejected rather than silently merged. The
+original reproducer declares `output int a; output bit b;` and assigns
+`a = 1; b = false;`: reimport must retain this result-type order. A lone
+`output int answer; answer = 0;` must retain its result. Returning the same
+`!cbit.reg` twice exercises alias rejection.
+
+Entry-function scalar snapshots are materialized at their definition. Tests
+check updates across loop iterations and simultaneous SCF assignments. Gate
+bodies retain bounded expressions because OpenQASM gates cannot declare local
+classical storage. Dynamic reads require full-register initialization; static
+initialization facts and scalar generations remain supported.
+
+Unused measurements emit `measure q;` without introducing an implicit classical
+output. Used results retain storage. Zero-initialized registers use exact-width
+bit strings, including widths above 64. Register comparisons use the existing
+bit-vector representation while preserving out-of-range literal comparisons.
+
+### Source and matrix correctness
+
+Source-name validation shares the frontend keyword and builtin-constant policy.
+Names such as `void`, `im`, `pragma`, and `pi` are renamed deterministically;
+ordinary identifiers remain unchanged. Exporter-generated prefixes and gate
+collisions remain exporter-owned. Include lookup retains its documented working
+directory and explicit include-directory policy.
+
+Floating `!=` round-trips through `arith.cmpf UNE`, whose NaN behavior differs
+from `ONE`. The source reproducer is
+`float f = 1.0; output bool b; b = f != 2.0;`. Float casts and exact-width bit
+strings use the existing expression model.
+
+Strict-policy lowering tests the emitted catalog bodies themselves.
+Compatibility mode may replace a recognized body with its native operation, so
+that mode alone cannot prove a helper's matrix. Phase-sensitive matrices exposed
+native `u` and `u2` mismatches with OpenQASM `U`. A shared helper applies
+`gphase(-theta/2)` before `U`; controlled tests preserve relative phase as well
+as amplitudes.
+
+### Qiskit normalization and parameter identity
+
+Private gate formals are positional. Export generates local names directly;
+private spelling is not a round-trip promise. Public inputs retain name and
+parameter-vector validation. Calls bind the explicit formal list by position, so
+local renaming does not reorder actual arguments.
+
+Ordinary canonicalization does not require weakening the two float-castable
+symbol tests. On LLVM/MLIR 23.1, `theta - theta` remains an `arith.subf`, and
+the Qiskit-imported representation of `(theta - theta) + 2` retains `theta * 0`.
+Without fast-math assumptions these are not universally constant floating-point
+expressions. Canonicalization does fold literal arithmetic and integer-to-float
+casts, allowing removal of the exporter's special cast recognizer.
+
+Native folding is enabled in the existing integer-expansion rewrite driver,
+which runs on a clone. No separate pass or custom cast recognizer is needed.
+Identity tests cover explicit cleanup and several numeric bindings. Constant
+measurement-index and low-bit tests permit folding; rejection tests use dynamic
+operands and a non-foldable expression DAG.
+
+A full canonicalizer was tested and rejected for implicit export normalization:
+it removes unused standalone qubits and forwards CBit loads from measurements,
+which can require extra scratch bits and stores in Qiskit. Those transformations
+need separate resource and snapshot decisions. Native folding preserves the
+existing measurement, layout, and control-flow tests. Explicit `cleanup()`
+remains available to callers.
+
+## Retained limits and rejected deletions
+
+- Static-only quantum indexing was rejected; affine loops remain supported.
+- Resource bounds, fixed-angle quantization, integer-power overflow checks, and
+  uncertain-alias rejection protect distinct contracts and remain tested.
+- Snapshot and initialization checks can be removed only when another
+  representation enforces their guarantees.
+- General arrays, runtime angles, and register subroutines remain separate work.
+  Relevant original overlaps were issues #2413, #2414, and #2427–#2429.
+- Equal emitted strings or overlapping coverage do not justify deleting
+  independent matrix or semantic regression tests.
+
+## Validation
+
+The release build and `ctest --preset release` pass: 3,201 tests passed and one
+optional QDMI job-ID test skipped. `uv run --no-sync pytest test/python -q`
+passes all 1,156 tests, including 328 Qiskit translation tests. The 493
+OpenQASM-focused CTest cases also pass. Repository lint passes and regenerated
+stubs are unchanged. Full-file C++ lint of the exact PR diff passes with zero
+findings. Hosted CI is separate.

--- a/.agent/audits/openqasm-import-export.md
+++ b/.agent/audits/openqasm-import-export.md
@@ -1,0 +1,447 @@
+# Contract audit: OpenQASM import and export
+
+Status: complete; accepted findings implemented and locally validated. Audit
+baseline: `33dbc843e589d9e9166308084e825c9f8b2ff89d`, initially clean checkout.
+Date: 2026-09-08. Environment: native ARM64, release build, LLVM/MLIR 23.1.0.
+
+## Implementation disposition
+
+The implementation preserves affine quantum indexing. Static-only quantum
+indexing was rejected. The accepted changes are:
+
+- Bound affine reconstruction per proof and use set-based static distinctness.
+- Replace projected emission costs with actual insertion accounting and bounded
+  cancellation. Keep semantic target restrictions at their owning lowering.
+- Preserve ordered outputs and zero-valued data; use void for absent outputs and
+  diagnose repeated register outputs instead of silently dropping aliases.
+- Share frontend name validation; align floating inequality with unordered
+  semantics; avoid storage for unused measurement results.
+- Build syntax IDs directly, use one bit-vector comparison representation, and
+  materialize entry-function snapshots at their definition.
+- Require full-register initialization for dynamic reads. Static initialization
+  tracking and affine scalar generations remain.
+- Accept exact-width bit strings and float casts; use compact zero initializers.
+  Document the existing working-directory/include-directory lookup policy.
+- Lower catalog definitions through strict mode for matrix tests, including
+  controlled forms and exact global phase. These tests exposed native `qc.u` and
+  `qc.u2` export phase errors. One shared helper applies `gphase(-theta/2)`
+  before OpenQASM 3 `U`, retaining the native matrix under controls.
+
+Local parser measurements on 100,000 distinct declarations reduced peak RSS from
+about 137,600 KiB to 88,000 KiB. Three-run median wall time was 0.66 s versus
+0.45 s; other host workloads make timing noisy. A 20-assignment affine DAG took
+17.8 s before and 0.00072 s after under host contention. A 64,000-operand static
+control probe took 7.21 s before and 0.145 s after. These observations establish
+local scaling improvements, not cross-machine timing promises.
+
+The release build and all 3,215 MLIR CTests pass, including 190 OpenQASM target
+and 209 QC translation tests. Repository lint and full-file C++ lint pass.
+Hosted CI is separate from these local results.
+
+The sections below retain the original audit evidence and proposals, whose
+source line numbers refer to the audit baseline. The disposition above records
+which proposals were implemented.
+
+## Result
+
+The most useful work is to bound affine analysis, remove a stale emission-cost
+assumption, and repair exporter result and expression contracts. The larger
+deletions are possible only after choosing explicit internal representations.
+The current safety checks are not generally redundant.
+
+| Rank | Finding                                                         | Impact                                        | Confidence                                       |
+| ---- | --------------------------------------------------------------- | --------------------------------------------- | ------------------------------------------------ |
+| 1    | Repeated scalar assignments cause exponential affine analysis   | Small input can stall compilation             | Confirmed by timing and source                   |
+| 2    | Dynamic writes still pay for an obsolete register-wide lowering | Valid small programs fail the emission limit  | Confirmed reproducer                             |
+| 3    | Export loses output order, multiplicity, and zero-valued data   | Changes the result interface                  | Confirmed reproducers; status rule is documented |
+| 4    | Floating inequality uses inconsistent predicates                | Valid imported comparison cannot be exported  | Confirmed reproducer and predicate definitions   |
+| 5    | Exporter name validation duplicates an incomplete keyword list  | Successful export produces rejected source    | Confirmed reproducers                            |
+| 6    | Unused measurements allocate observable classical storage       | Reimport introduces an implicit output        | Confirmed reproducer                             |
+| 7    | Static gate-operand distinctness uses pairwise checks           | Quadratic analysis for large controlled gates | Confirmed timing and source                      |
+
+The source scope covers the lexer, parser, syntax storage, semantic analysis,
+typed frontend, QC emitter, QC builder, exporter, gate catalog, relevant driver
+entry points, documentation, and both OpenQASM/QC translation test targets. This
+is an investigation of the current implementation, not a claim of full OpenQASM
+language conformance or exhaustive downstream interoperability.
+
+## Confirmed findings
+
+### 1. Store affine facts without repeatedly expanding their expression DAG
+
+**Change and benefit.** In `mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp`,
+replace repeated recursive reconstruction in `buildAffineForm` (line 633) and
+`expandAffineScalarValues` (line 710) with bounded analysis of shared
+expressions. Prefer retaining normalized affine facts at assignment time. At
+minimum, avoid revisiting a shared expression within one proof and bound proof
+work.
+
+**Evidence.** Analyze `OPENQASM 3.1; int a = 1;` followed by N copies of
+`a = a + a;`. No quantum indexing is needed to trigger the cost.
+
+| N   | Typed expressions | Parse and analysis time |
+| --- | ----------------- | ----------------------- |
+| 8   | 33                | 0.00161 s               |
+| 12  | 49                | 0.01886 s               |
+| 16  | 65                | 0.29367 s               |
+| 20  | 81                | 2.339 s                 |
+| 24  | —                 | Exceeded a 5 s timeout  |
+
+These are local observations, not cross-machine performance promises. The
+expression arena grows modestly; recursively following both operands repeatedly
+revisits the same DAG. The parser's expression-depth bound does not bound this
+work across assignments.
+
+**Contract and limits.** Preserve proof of intermediate integer operations and
+overflow, induction domains, scope, and branch invalidation. A global cache
+keyed only by expression ID would be unsafe because the proof context changes.
+When an optional scalar fact exceeds a budget, forget the fact; reject a quantum
+index only when its required proof then fails. Do not reject ordinary classical
+arithmetic merely because an optional affine optimization is expensive.
+
+### 2. Remove the obsolete register-width charge for dynamic stores
+
+**Change and benefit.** In
+`mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp`, the
+projected-emission checks at lines 781–788 and 830–834 charge `9 + 3 * width`
+for a dynamic bit store. `assignBit` at line 2251 now emits a checked index and
+a native `cbit.store`. Correct both ordinary-assignment and measurement-target
+accounting.
+
+**Evidence.** This accepted-width source fails with the projected 10-million-op
+limit around line 35, although only 40 stores are requested:
+
+```python
+source = "OPENQASM 3.1;\nbit[99999] c;\noutput int i;\ni = 0;\n"
+source += "c[i] = false;\n" * 40
+```
+
+Using width 10 instead succeeds and emits 40 `cbit.store` operations. The
+explicit scalar output keeps the partially initialized register from becoming an
+implicit output, isolating the emission-budget problem.
+
+**Larger simplification.** The roughly 600-line predictive cost implementation
+duplicates lowering details while `EmissionBudget`, an `OpBuilder` listener,
+already counts actual emitted operations. This is a concrete maintenance cost:
+the two have drifted. Prefer one authoritative actual-emission budget if
+emission can abort promptly. Do not delete the preflight implementation
+unchanged: the listener currently marks exhaustion, and recursive expression
+construction and bulk statement paths need cancellation propagation. Preserve
+all resource bounds and rejection tests; replace predicted-count assertions with
+bounded-emission checks where the distinction is not public behavior.
+
+### 3. Represent outputs as ordered results, with explicit status semantics
+
+**Change and benefit.** In
+`mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp`,
+`collectProgramShape` (line 382) separates returned registers into a set and
+scalars into a vector. `emitDeclarations` (line 515) prints registers in
+allocation order before scalar outputs. That representation cannot preserve the
+entry function's ordered result list or repeated register results.
+
+**Evidence.** Direct import/export of:
+
+```qasm
+OPENQASM 3.1;
+output int a;
+output bit b;
+a = 1;
+b = false;
+```
+
+prints `output bit[1] b;` before `output int _mqt_out0;`. Reimport changes the
+ordered output types. A verified function returning `%c, %c` as two
+`!cbit.reg<1>` results exports only one output declaration. Independently,
+`output int answer; answer = 0;` loses its sole output through the CLI, while
+the same program with value 1 retains an output.
+
+The last behavior follows `isCanonicalStatus` (line 480), which recognizes any
+lone constant-zero `i64` result. `docs/mlir/OpenQASM.md` explicitly documents
+it; this is a brittle documented convention, not an undocumented regression.
+
+**Contract and limits.** Use an ordered result description and choose an
+explicit policy for aliases: preserve each result with a distinct output or
+reject repeated register results. Distinguish status from data through an
+explicit contract; `QCProgramBuilder` already has empty result-type/value
+overloads, but changing the default status ABI requires checking all builder and
+compiler consumers. A documented restriction on mixed or aliased outputs would
+be a smaller acceptable change than silently changing their shape. Scalar names
+and fixed-angle spelling are already documented as lossy and are separate from
+losing actual results.
+
+### 4. Align floating inequality with the imported predicate
+
+**Change and benefit.** The importer maps `!=` to `arith.cmpf UNE` in
+`OpenQASMToQCEmitter.cpp::emitComparison` (line 1919). The exporter maps `ONE`
+to `!=` and rejects `UNE` in `TranslateQCToOpenQASM3.cpp::floatPredicate` (line
+1227). Map `UNE` consistently; reject `ONE` unless its ordered semantics can be
+preserved or non-NaN operands are established.
+
+**Evidence.** Strict frontend analysis accepts this source, but direct
+import/export fails with an unsupported floating-comparison diagnostic:
+
+```qasm
+OPENQASM 3.1;
+float f = 1.0;
+output bool b;
+b = f != 2.0;
+```
+
+`ONE` and `UNE` differ for NaNs according to the
+[MLIR comparison definitions](https://mlir.llvm.org/docs/Dialects/ArithOps/#arithcmpf-arithcmpfop).
+Checking finite literals does not establish finite runtime computations. The
+existing `EmitsSignedAndFloatingComparisonFamilies` string check accepts the
+wrong `ONE` mapping. Replace that expectation with predicate-sensitive coverage.
+The finite-value roundtrip failure is reproduced; NaN behavior here is
+established from predicate semantics, not from a hardware execution experiment.
+
+### 5. Share source-name validation with the frontend
+
+**Change and benefit.** Exporter `isReserved` (line 111) duplicates only part of
+the lexer keyword and semantic builtin-constant policy. Centralize that policy
+for names that will be emitted as source. Keep exporter-specific
+generated-prefix and gate-collision rules separate.
+
+**Evidence.** Export succeeds for the following verified IR, but strict analysis
+of its output fails:
+
+```mlir
+module {
+  func.func @main() -> !cbit.reg<1> attributes {mqt.entry_point} {
+    %c = cbit.alloc(#cbit.init<zero>) {mqt.register_name = "void"}
+      : !cbit.reg<1>
+    return %c : !cbit.reg<1>
+  }
+}
+```
+
+The same happens for `im`, `pragma`, and `pi`. `sin` and `valid_name` pass,
+providing controls against an overly broad blacklist. Compare
+`OpenQASMLexer.cpp::keywordKind` and `OpenQASMSemantics.cpp::builtinConstant`.
+Preserve deterministic renaming and catalog collisions; accepting every Unicode
+source identifier is not necessary to fix this inconsistency.
+
+### 6. Emit unused measurements without a scratch bit
+
+**Change and benefit.** `TranslateQCToOpenQASM3.cpp::emitMeasurement` (line
+1315) allocates a scratch bit for an unfused measurement even when its classical
+result is unused. Emit `measure q;` for an unused result.
+
+**Evidence.** Direct import/export of `OPENQASM 3.1; qubit q; measure q;`
+produces `bit _mqt_b0;` and `_mqt_b0 = measure _mqt_q0;`. Reimport treats the
+new global bit as an implicit output. The original has no classical outputs. The
+quantum measurement and its position must survive; only its unused classical
+storage is removable. Keep scratch storage for values with consumers.
+
+### 7. Reuse static deduplication before affine distinctness proofs
+
+**Change and benefit.** `OpenQASMSemantics.cpp` gate-application validation
+(line 4955) compares every operand with every previous operand, including static
+indices. `analyzeBarrier` already demonstrates set-based static deduplication.
+Reuse that pattern, partitioned by reference kind and register identity; reserve
+pairwise affine proofs for cases that need them.
+
+**Evidence.** Analyze `qubit[N] q; ctrl(N-1) @ x q[0], ..., q[N-1];` after the
+version declaration. Median parse-and-analysis times over three local runs:
+
+| N      | Time       |
+| ------ | ---------- |
+| 8,000  | 0.028016 s |
+| 16,000 | 0.105600 s |
+| 32,000 | 0.705165 s |
+| 64,000 | 5.494332 s |
+
+The affine solver's comparison cap does not limit the cheap static pair count.
+Keep rejection of duplicate targets/controls, hardware-qubit identity, and
+uncertain affine overlap. No revised implementation was benchmarked.
+
+## Structural simplifications and explicit limits
+
+These are proposals, not measured line savings or applied changes.
+
+### Collapse the special register-comparison representation
+
+`ConditionKind::RegisterComparison` and `BitVectorComparison` now converge on
+whole-register reads, constants, and integer comparisons in `emitCondition`
+(lines 1970–1994). Convert register-versus-literal comparisons to the existing
+bit-vector expression representation during analysis, then remove the redundant
+typed fields, emitter branch, and cost-model branch.
+
+Preserve `OpenQASMSemantics.cpp` lines 4567–4630: comparisons against
+out-of-range literals can fold without truncation, and swapping literal/register
+sides changes relational predicates. Initialization diagnostics must also
+survive. The typed frontend is publicly declared, so no in-tree external user is
+insufficient to prove source compatibility. This is a narrow consolidation, not
+deletion of the comparison semantics.
+
+### Make the parser concrete; consider building syntax IDs directly
+
+`OpenQASMParser.h` defines a `QASMSink` concept and a large parser template, but
+`Frontend.cpp` instantiates it only with `SyntaxBuilder`. Removing that unused
+internal extension point would simplify the interface. A second, larger change
+could construct syntax expression IDs directly:
+`OpenQASMSyntax.cpp::copyExpression` (lines 83–122) currently traverses
+transient expression objects into an ID arena using a worklist and map while the
+transient allocator remains alive during parsing.
+
+Do not merge parsing with semantic analysis. Reusable `ParsedProgram` analysis,
+different gate policies, source-buffer lifetime, diagnostics, and iterative
+handling of long expression chains are useful contracts. Removing the transient
+tree needs a peak-memory and parse-time comparison before claiming a speedup.
+
+### Prefer explicit scalar snapshots to recursive exporter reconstruction
+
+The exporter tracks operation positions and writes to reject stale or
+cross-region classical snapshots, and caps recursive expression expansion at
+4,096 nodes and depth 256. These checks protect correctness and bounded output.
+A more explicit entry-function export normal form could materialize reads at
+their definition and shared scalar expressions once, using the existing
+`materialize` machinery.
+
+This could remove much of the need to reconstruct temporal safety and could
+export presently rejected programs. It is not safe to delete snapshot checks
+first. Preserve evaluation order, simultaneous SCF edge assignments, and loop
+semantics. Gate bodies have stricter allowed statements, and registers wider
+than 64 bits need a different snapshot representation. Start with entry-function
+scalar values. Replace stale-snapshot and expansion rejection tests only when
+semantic snapshot and bounded-output tests cover the new implementation.
+
+### State partial-initialization support before simplifying its analysis
+
+Dynamic bit facts, expression equivalence, dependencies, and generation tracking
+allow a partially initialized register to support `c[i] = ...; read c[i]`
+without requiring every bit to be initialized. Requiring full initialization
+before every dynamic read could delete substantial machinery, but would remove
+tested behavior. That is a product decision, not redundant-code cleanup. Keep
+the copy-on-write initialization state used across branches.
+
+Similarly, requiring constant quantum indices would remove affine analysis but
+also useful documented loops. The
+[OpenQASM type specification](https://openqasm.com/language/types.html) permits
+implementations to restrict nonconstant quantum indexing; permission to restrict
+it does not make this project's existing feature dispensable. Bound the current
+proof work before considering that larger reduction.
+
+### Compact zero initialization within the supported expression profile
+
+`emitDeclarations` writes one assignment per bit for zero-initialized registers.
+A width-10,000 probe produced 10,005 lines and 248,959 bytes. For widths up to
+64, the frontend accepts a whole-register assignment such as
+`c = bit[64](uint[64](0));`, which can replace the per-bit loop.
+
+Do not assume that an arbitrary-width bit string is an available replacement:
+`bit[3] c = "000";` fails in the current parser. Exact-width bit strings are
+described by the language and mentioned by the local documentation, but
+`parsePrimary` does not accept them. Supporting them is a separate frontend
+change. Keep wide-register initialization correct until that support exists.
+
+### Make the remaining syntax and include boundaries explicit
+
+The exporter can emit `float(int[64](1))`, while parser `parsePrimary` does not
+accept the float cast. This reproduces a reimport failure, but float/integer
+conversions are explicitly excluded from the documented roundtrip subset. Either
+close the parser gap through the existing cast representation or make the
+earlier broad statement that emitted expressions are accepted more precise.
+
+CLI relative include lookup depends on the process working directory rather than
+automatically using the source file's directory. A source beside `repeated.inc`
+failed to find it when invoked from another directory. `openSourceMgr` in the
+driver and `SourceMgr::OpenIncludeFile` in the frontend own this boundary.
+Document the search policy or provide the source directory explicitly. The
+[OpenQASM include rules](https://openqasm.com/language/comments.html) describe
+source inclusion; they do not by themselves establish a filesystem search order.
+This is a usability/contract choice, not a claimed language violation.
+
+## Test coverage and rejected deletions
+
+`EmitsCatalogHelpersUnderTheirNativeNames` in `test_openqasm3_emission.cpp`
+(around line 658) runs strict analysis, then translates through the default
+compatibility policy. Compatibility mode deliberately ignores a matching catalog
+definition body and emits the native operation. The test therefore does not
+prove that exported helper bodies implement those native operations.
+
+Add strict-policy lowering and compare helper unitaries, including controlled
+global phase. Reuse the existing matrix oracle in `test_qasm3_translation.cpp`
+where suitable. That oracle is independent reference behavior, not removable
+duplication of production lowering. No incorrect helper matrix was demonstrated
+by this audit.
+
+Other tempting deletions are rejected:
+
+- Exact fixed-angle quantization protects widths, wrapping, and ties-to-even;
+  ordinary floating rounding is not an equivalent replacement.
+- Runtime integer-power overflow checks protect a distinct documented contract;
+  modular addition semantics do not justify removing them.
+- Resource limits, snapshot checks, uncertain-alias rejection, and
+  initialization checks are necessary until an alternative representation
+  enforces the same guarantees.
+- Equal emitted strings or overlapping coverage do not prove tests redundant. No
+  broad test deletion is justified by this investigation.
+
+## Related work
+
+Live GitHub inspection found relevant boundaries in issues
+[#2414](https://github.com/munich-quantum-toolkit/core/issues/2414) (naming),
+[#2413](https://github.com/munich-quantum-toolkit/core/issues/2413) (gate
+bodies), and
+[#2427](https://github.com/munich-quantum-toolkit/core/issues/2427),
+[#2428](https://github.com/munich-quantum-toolkit/core/issues/2428), and
+[#2429](https://github.com/munich-quantum-toolkit/core/issues/2429) (register
+subroutines). Coordinate changes to naming or function/result contracts with
+that work. Runtime angles, general arrays, and slices remain separate feature
+scopes. No issues, pull requests, or remote branches were changed.
+
+## Validation and reproduction
+
+Built successfully, exit 0:
+
+```sh
+cmake --build --preset release --target \
+  mqt-core-mlir-unittest-openqasm-target \
+  mqt-core-mlir-unittest-qc-translation mqt-cc -j8
+```
+
+Ran both binaries directly and recorded their actual exit statuses:
+
+```sh
+build/release/mlir/unittests/Target/OpenQASM/mqt-core-mlir-unittest-openqasm-target
+build/release/mlir/unittests/Dialect/QC/Translation/mqt-core-mlir-unittest-qc-translation
+```
+
+Results: 185/185 and 199/199 passed, each exit 0. These baseline tests do not
+disprove the reproduced gaps. Logs are in `/tmp/openqasm-audit-target.log` and
+`/tmp/openqasm-audit-translation.log` for this session.
+
+`uvx nox -s lint` passed. The explicit report check,
+`uvx prek run --files .agent/audits/openqasm-import-export.md`, also passed.
+
+The temporary C++ probe and input files are under `/tmp/mqt-openqasm-audit`. The
+probe uses the built libraries and these API sequences:
+
+- `analyze` / `strict`: load a `SourceMgr`, call `parseOpenQASM`, then
+  `analyzeOpenQASM` with `MQTCompatibility` / `Strict`; report diagnostic
+  failure as exit 1 and success as exit 0. Timings include parsing and analysis.
+- `import`: call `translateQASM3ToQC` and print the resulting module.
+- `roundtrip`: call `translateQASM3ToQC`, then `translateQCToOpenQASM3`
+  directly, without cleanup passes that could fold away the tested operation.
+- `export`: parse the input MLIR and call `translateQCToOpenQASM3`.
+
+Example commands with the retained inputs:
+
+```sh
+/tmp/mqt-openqasm-audit/probe strict /tmp/mqt-openqasm-audit/float-ne-input.qasm
+/tmp/mqt-openqasm-audit/probe roundtrip /tmp/mqt-openqasm-audit/float-ne-input.qasm
+/tmp/mqt-openqasm-audit/probe export /tmp/mqt-openqasm-audit/name-void.mlir
+/tmp/mqt-openqasm-audit/probe analyze /tmp/mqt-openqasm-audit/affine-dag-20.qasm
+```
+
+The first command succeeds; the second fails; the third succeeds but produces
+source that strict analysis rejects; the fourth succeeds after excessive work.
+The source fragments and generators above preserve the essential reproductions
+without depending on temporary files surviving.
+
+No production mutation, full-project test run, downstream simulator execution,
+hosted CI run, or benchmark of a proposed replacement was performed. This report
+does not claim a measured net line reduction or dependency removal. Implement
+the small reproduced corrections first; evaluate the parser, budgeting, and
+snapshot representations as separate changes with their retained contracts.

--- a/.agent/plans/openqasm-audit-fixes.md
+++ b/.agent/plans/openqasm-audit-fixes.md
@@ -14,7 +14,8 @@ register results, and keeps absent outputs void. It materializes snapshots at
 their definition, shares frontend name validation, avoids unused measurement
 storage, and initializes registers with exact-width bit strings. Float casts and
 unordered floating inequality round-trip. A shared native-U helper preserves
-global phase, including under controls.
+global phase, including under controls. Loop-local bit storage does not carry
+global register-name metadata.
 
 The implementation lives in `mlir/lib/Target/OpenQASM` and
 `mlir/lib/Dialect/QC/Translation`, with headers under `mlir/include` and
@@ -37,11 +38,14 @@ accepted dispositions are in `../audits/openqasm-import-export.md`.
 
 ## Validation
 
-The release OpenQASM target suite passes 190 tests; QC translation passes 209,
-including strict-policy helper matrices with controlled global phase. Repository
-lint passes. The release build and all 3,215 MLIR CTests pass. Complete C++ lint
-on the PR diff passes with zero findings. Hosted CI is separate from these local
-results.
+The release build passes. The configured CTest suite has 3,166 passes and one
+optional QDMI job-ID test skipped, including 191 passing OpenQASM target tests.
+All 1,131 Python tests pass. Strict-policy helper matrices check controlled
+global phase; Python round trips use the native OpenQASM frontend before
+comparison with Qiskit matrices. Snapshot tests distinguish one loop iteration
+from two. An instrumented run covers 18 previously missed changed lines through
+the existing emission-budget boundary test. Repository lint and complete C++
+lint pass. Hosted CI is separate from these local results.
 
 The audit records baseline/revised parser memory and timing measurements and
 scaling checks for shared affine expressions and large controlled gates.

--- a/.agent/plans/openqasm-audit-fixes.md
+++ b/.agent/plans/openqasm-audit-fixes.md
@@ -1,0 +1,47 @@
+# OpenQASM import and export corrections
+
+Status: complete.
+
+## Outcome and scope
+
+The frontend builds persistent syntax IDs directly, bounds affine analysis per
+proof, and uses set-based static distinctness. Affine quantum indexing remains
+supported. Typed register comparisons use the existing bit-vector form. QC
+emission counts inserted operations instead of predicting lowering costs.
+
+The exporter preserves result order and zero-valued data, rejects repeated
+register results, and keeps absent outputs void. It materializes snapshots at
+their definition, shares frontend name validation, avoids unused measurement
+storage, and initializes registers with exact-width bit strings. Float casts and
+unordered floating inequality round-trip. A shared native-U helper preserves
+global phase, including under controls.
+
+The implementation lives in `mlir/lib/Target/OpenQASM` and
+`mlir/lib/Dialect/QC/Translation`, with headers under `mlir/include` and
+regression tests in the corresponding `mlir/unittests` directories. The source
+contract is documented in `docs/mlir/OpenQASM.md`. The audit evidence and
+accepted dispositions are in `../audits/openqasm-import-export.md`.
+
+## Decisions and limits
+
+- Keep affine quantum-index proofs, intermediate-overflow checks, and scope
+  invalidation. Cache only within one proof context.
+- Require full-register initialization before dynamic reads. Static bit facts
+  and scalar generations remain; dynamic partial-initialization facts do not.
+- Store entry-function snapshots explicitly. Gate bodies retain bounded inline
+  expressions because OpenQASM gates cannot declare local classical state.
+- Preserve ordered results; diagnose repeated register aliases rather than
+  changing their meaning. A returned integer zero is data.
+- Keep the existing include search order and document it. General arrays,
+  runtime angles, and static-only quantum indexing are outside this change.
+
+## Validation
+
+The release OpenQASM target suite passes 190 tests; QC translation passes 209,
+including strict-policy helper matrices with controlled global phase. Repository
+lint passes. The release build and all 3,215 MLIR CTests pass. Complete C++ lint
+on the PR diff passes with zero findings. Hosted CI is separate from these local
+results.
+
+The audit records baseline/revised parser memory and timing measurements and
+scaling checks for shared affine expressions and large controlled gates.

--- a/.agent/plans/openqasm-audit-fixes.md
+++ b/.agent/plans/openqasm-audit-fixes.md
@@ -17,6 +17,12 @@ unordered floating inequality round-trip. A shared native-U helper preserves
 global phase, including under controls. Loop-local bit storage does not carry
 global register-name metadata.
 
+The public importer accepts frontend policy and emission limits through
+`QASM3ImportOptions`; tests use this API without including private emitter
+headers. Direct Qiskit export assigns names to unnamed private gate parameters
+and folds constant integer-to-float casts. OpenQASM callers need no QCO
+conversion or manual pass pipeline for these cases.
+
 The implementation lives in `mlir/lib/Target/OpenQASM` and
 `mlir/lib/Dialect/QC/Translation`, with headers under `mlir/include` and
 regression tests in the corresponding `mlir/unittests` directories. The source
@@ -38,14 +44,17 @@ accepted dispositions are in `../audits/openqasm-import-export.md`.
 
 ## Validation
 
-The release build passes. The configured CTest suite has 3,166 passes and one
-optional QDMI job-ID test skipped, including 191 passing OpenQASM target tests.
-All 1,131 Python tests pass. Strict-policy helper matrices check controlled
-global phase; Python round trips use the native OpenQASM frontend before
-comparison with Qiskit matrices. Snapshot tests distinguish one loop iteration
-from two. An instrumented run covers 18 previously missed changed lines through
-the existing emission-budget boundary test. Repository lint and complete C++
-lint pass. Hosted CI is separate from these local results.
+The release build passes with `ENABLE_IPO=OFF`; GCC LTO encountered duplicate
+MLIR symbols in the local linker. The configured CTest suite has 3,201 passes
+and one optional QDMI job-ID test skipped, including 191 passing OpenQASM target
+tests. All 1,152 Python tests pass. Strict-policy helper matrices check
+controlled global phase; Python round trips use the native OpenQASM frontend and
+direct Qiskit export. Snapshot tests distinguish one loop iteration from two. An
+instrumented run covers 18 previously missed changed lines through the existing
+emission-budget boundary test. Repository lint and complete C++ lint pass. The
+documentation build passes with the PennyLane capability-link fix from upstream
+main. Generated Python stubs are unchanged. Hosted CI is separate from these
+local results.
 
 The audit records baseline/revised parser memory and timing measurements and
 scaling checks for shared affine expressions and large controlled gates.

--- a/.agent/plans/openqasm-audit-fixes.md
+++ b/.agent/plans/openqasm-audit-fixes.md
@@ -4,57 +4,40 @@ Status: complete.
 
 ## Outcome and scope
 
-The frontend builds persistent syntax IDs directly, bounds affine analysis per
-proof, and uses set-based static distinctness. Affine quantum indexing remains
-supported. Typed register comparisons use the existing bit-vector form. QC
-emission counts inserted operations instead of predicting lowering costs.
+The frontend builds syntax IDs directly, shares leaf types, bounds affine
+analysis per proof, and deduplicates static operands with sets. Typed register
+comparisons use bit vectors. QC emission counts actual inserted operations.
+Analysis accepts `GatePolicy` directly; `QASM3ImportOptions` owns the policy and
+emission limit.
 
-The exporter preserves result order and zero-valued data, rejects repeated
-register results, and keeps absent outputs void. It materializes snapshots at
-their definition, shares frontend name validation, avoids unused measurement
-storage, and initializes registers with exact-width bit strings. Float casts and
-unordered floating inequality round-trip. A shared native-U helper preserves
-global phase, including under controls. Loop-local bit storage does not carry
-global register-name metadata.
+OpenQASM export preserves ordered results and zero-valued data, rejects repeated
+register outputs, and keeps absent outputs void. It materializes scalar
+snapshots, shares source-name validation, avoids unused measurement storage, and
+emits exact-width bit strings. Float casts and unordered floating inequality
+round-trip. A shared native-U helper preserves phase, including under controls.
 
-The public importer accepts frontend policy and emission limits through
-`QASM3ImportOptions`; tests use this API without including private emitter
-headers. Direct Qiskit export assigns names to unnamed private gate parameters
-and folds constant integer-to-float casts. OpenQASM callers need no QCO
-conversion or manual pass pipeline for these cases.
-
-The implementation lives in `mlir/lib/Target/OpenQASM` and
-`mlir/lib/Dialect/QC/Translation`, with headers under `mlir/include` and
-regression tests in the corresponding `mlir/unittests` directories. The source
-contract is documented in `docs/mlir/OpenQASM.md`. The audit evidence and
-accepted dispositions are in `../audits/openqasm-import-export.md`.
+Private Qiskit gate formals are positional and receive generated local names.
+Export enables native folding on a clone before reconstructing Qiskit
+expressions. Public parameter names, vector metadata, and shared identities
+remain validated.
 
 ## Decisions and limits
 
-- Keep affine quantum-index proofs, intermediate-overflow checks, and scope
-  invalidation. Cache only within one proof context.
-- Require full-register initialization before dynamic reads. Static bit facts
-  and scalar generations remain; dynamic partial-initialization facts do not.
-- Store entry-function snapshots explicitly. Gate bodies retain bounded inline
-  expressions because OpenQASM gates cannot declare local classical state.
-- Preserve ordered results; diagnose repeated register aliases rather than
-  changing their meaning. A returned integer zero is data.
-- Keep the existing include search order and document it. General arrays,
-  runtime angles, and static-only quantum indexing are outside this change.
+Keep affine quantum indexing, intermediate-overflow checks, scope invalidation,
+and actual emission bounds. Dynamic reads require full-register initialization.
+Gate bodies retain bounded inline expressions; entry functions use snapshots.
+Include lookup retains its documented policy. General arrays, runtime angles,
+and register subroutines remain separate features.
+
+The audit at `../audits/openqasm-import-export.md` retains reproducers, measured
+scaling improvements, and the reasons for keeping semantic tests. Source
+contracts live in `docs/mlir/OpenQASM.md` and
+`docs/mlir/python_compiler_collection.md`.
 
 ## Validation
 
-The release build passes with `ENABLE_IPO=OFF`; GCC LTO encountered duplicate
-MLIR symbols in the local linker. The configured CTest suite has 3,201 passes
-and one optional QDMI job-ID test skipped, including 191 passing OpenQASM target
-tests. All 1,152 Python tests pass. Strict-policy helper matrices check
-controlled global phase; Python round trips use the native OpenQASM frontend and
-direct Qiskit export. Snapshot tests distinguish one loop iteration from two. An
-instrumented run covers 18 previously missed changed lines through the existing
-emission-budget boundary test. Repository lint and complete C++ lint pass. The
-documentation build passes with the PennyLane capability-link fix from upstream
-main. Generated Python stubs are unchanged. Hosted CI is separate from these
-local results.
-
-The audit records baseline/revised parser memory and timing measurements and
-scaling checks for shared affine expressions and large controlled gates.
+The release build and CTest suite pass: 3,201 passed and one optional QDMI
+job-ID test skipped. All 1,156 Python tests pass, including 328 Qiskit
+translation tests. Repository lint passes; regenerated stubs are unchanged.
+Full-file C++ lint of the exact PR diff passes with zero findings. Hosted CI is
+separate from these local results.

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -143,6 +143,11 @@ struct ExportedControlFlow {
                            "-level nesting depth");
 }
 
+[[nodiscard]] static bool isConstantIntegerToFloat(mlir::Operation& operation) {
+  return llvm::isa<mlir::arith::SIToFPOp, mlir::arith::UIToFPOp>(operation) &&
+         mlir::matchPattern(operation.getOperand(0), mlir::m_Constant());
+}
+
 [[nodiscard]] static Parameter
 exportParameterImpl(mlir::Value value, ExportedParameters& parameters,
                     const size_t depth, size_t& nodes) {
@@ -170,6 +175,13 @@ exportParameterImpl(mlir::Value value, ExportedParameters& parameters,
     throw std::runtime_error(
         "Qiskit runtime classical gate parameters are not supported; use a "
         "constant or symbolic gate parameter");
+  }
+  if (isConstantIntegerToFloat(*operation)) {
+    if (const auto number = mlir::mqt::valueToConstantDouble(value)) {
+      auto result = Parameter::number(*number);
+      parameters.try_emplace(value, result);
+      return result;
+    }
   }
   const auto unary = [&](const UnaryParameterKind kind) {
     if (operation->getNumOperands() != 1U) {
@@ -288,7 +300,8 @@ isParameterExpressionOperation(mlir::Operation& operation) {
                    mlir::arith::NegFOp, mlir::math::PowFOp, mlir::math::SinOp,
                    mlir::math::CosOp, mlir::math::TanOp, mlir::math::AsinOp,
                    mlir::math::AcosOp, mlir::math::AtanOp, mlir::math::ExpOp,
-                   mlir::math::LogOp, mlir::math::AbsFOp>(operation);
+                   mlir::math::LogOp, mlir::math::AbsFOp>(operation) ||
+         isConstantIntegerToFloat(operation);
 }
 
 [[nodiscard]] static uint32_t checkedIndex(const int64_t index,
@@ -2870,6 +2883,25 @@ collectGateFunctions(mlir::ModuleOp moduleOp, mlir::func::FuncOp entryPoint) {
 [[nodiscard]] static ExportedGateDefinition
 collectGateDefinition(mlir::func::FuncOp function) {
   const auto numParameters = gateParameterCount(function);
+  const auto nameAttribute =
+      mlir::mqt::MQTDialect::InputNameAttrHelper::getNameStr();
+  llvm::StringSet<> parameterNames;
+  for (size_t index = 0; index < numParameters; ++index) {
+    if (auto name =
+            function.getArgAttrOfType<mlir::StringAttr>(index, nameAttribute)) {
+      parameterNames.insert(name.getValue());
+    }
+  }
+  for (size_t index = 0; index < numParameters; ++index) {
+    if (!function.getArgAttr(index, nameAttribute)) {
+      auto name = "p" + std::to_string(index);
+      while (!parameterNames.insert(name).second) {
+        name += '_';
+      }
+      function.setArgAttr(index, nameAttribute,
+                          mlir::StringAttr::get(function.getContext(), name));
+    }
+  }
   ExportState state;
   collectParameters(function, state, numParameters);
   const auto numQubits = function.getNumArguments() - numParameters;

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -143,11 +143,6 @@ struct ExportedControlFlow {
                            "-level nesting depth");
 }
 
-[[nodiscard]] static bool isConstantIntegerToFloat(mlir::Operation& operation) {
-  return llvm::isa<mlir::arith::SIToFPOp, mlir::arith::UIToFPOp>(operation) &&
-         mlir::matchPattern(operation.getOperand(0), mlir::m_Constant());
-}
-
 [[nodiscard]] static Parameter
 exportParameterImpl(mlir::Value value, ExportedParameters& parameters,
                     const size_t depth, size_t& nodes) {
@@ -175,13 +170,6 @@ exportParameterImpl(mlir::Value value, ExportedParameters& parameters,
     throw std::runtime_error(
         "Qiskit runtime classical gate parameters are not supported; use a "
         "constant or symbolic gate parameter");
-  }
-  if (isConstantIntegerToFloat(*operation)) {
-    if (const auto number = mlir::mqt::valueToConstantDouble(value)) {
-      auto result = Parameter::number(*number);
-      parameters.try_emplace(value, result);
-      return result;
-    }
   }
   const auto unary = [&](const UnaryParameterKind kind) {
     if (operation->getNumOperands() != 1U) {
@@ -300,8 +288,7 @@ isParameterExpressionOperation(mlir::Operation& operation) {
                    mlir::arith::NegFOp, mlir::math::PowFOp, mlir::math::SinOp,
                    mlir::math::CosOp, mlir::math::TanOp, mlir::math::AsinOp,
                    mlir::math::AcosOp, mlir::math::AtanOp, mlir::math::ExpOp,
-                   mlir::math::LogOp, mlir::math::AbsFOp>(operation) ||
-         isConstantIntegerToFloat(operation);
+                   mlir::math::LogOp, mlir::math::AbsFOp>(operation);
 }
 
 [[nodiscard]] static uint32_t checkedIndex(const int64_t index,
@@ -2883,27 +2870,12 @@ collectGateFunctions(mlir::ModuleOp moduleOp, mlir::func::FuncOp entryPoint) {
 [[nodiscard]] static ExportedGateDefinition
 collectGateDefinition(mlir::func::FuncOp function) {
   const auto numParameters = gateParameterCount(function);
-  const auto nameAttribute =
-      mlir::mqt::MQTDialect::InputNameAttrHelper::getNameStr();
-  llvm::StringSet<> parameterNames;
-  for (size_t index = 0; index < numParameters; ++index) {
-    if (auto name =
-            function.getArgAttrOfType<mlir::StringAttr>(index, nameAttribute)) {
-      parameterNames.insert(name.getValue());
-    }
-  }
-  for (size_t index = 0; index < numParameters; ++index) {
-    if (!function.getArgAttr(index, nameAttribute)) {
-      auto name = "p" + std::to_string(index);
-      while (!parameterNames.insert(name).second) {
-        name += '_';
-      }
-      function.setArgAttr(index, nameAttribute,
-                          mlir::StringAttr::get(function.getContext(), name));
-    }
-  }
   ExportState state;
-  collectParameters(function, state, numParameters);
+  for (size_t index = 0; index < numParameters; ++index) {
+    auto parameter = Parameter::symbol("p" + std::to_string(index));
+    state.parameters[function.getArgument(index)] = parameter;
+    state.inputParameters.push_back(std::move(parameter));
+  }
   const auto numQubits = function.getNumArguments() - numParameters;
   state.numQubits = checkedIndex(static_cast<uint64_t>(numQubits), "qubit");
   for (auto [index, argument] :
@@ -2935,12 +2907,10 @@ nb::object exportCircuit(const mlir::QCProgram& program,
   auto moduleOp = *expanded;
   mlir::RewritePatternSet patterns(moduleOp.getContext());
   mlir::mqt::populateIntegerExpansionPatterns(patterns);
-  // Expand missing operations and eliminate dead expressions without folding
-  // unrelated control flow or changing the source program.
-  if (mlir::failed(mlir::applyPatternsGreedily(
-          moduleOp, std::move(patterns),
-          mlir::GreedyRewriteConfig().enableFolding(false)))) {
-    throw std::runtime_error("failed to expand integer operations for Qiskit");
+  /// Fold scalar expressions without applying resource or snapshot rewrites.
+  if (mlir::failed(
+          mlir::applyPatternsGreedily(moduleOp, std::move(patterns)))) {
+    throw std::runtime_error("failed to normalize arithmetic for Qiskit");
   }
   auto function = mlir::mqt::getEntryPoint(moduleOp);
   if (!function) {

--- a/bindings/mlir/qiskit/QiskitImport.cpp
+++ b/bindings/mlir/qiskit/QiskitImport.cpp
@@ -84,13 +84,9 @@ using ValidationParameters = llvm::StringMap<Parameter>;
 
 namespace {
 struct GateImportState {
-  explicit GateImportState(ParameterGroupRegistry& groups)
-      : parameterGroups(groups) {}
-
   llvm::DenseMap<uintptr_t, mlir::func::FuncOp> gates;
   llvm::StringSet<> functionNames;
   llvm::StringMap<size_t> nextFunctionSuffix;
-  ParameterGroupRegistry& parameterGroups;
 };
 } // namespace
 
@@ -1968,21 +1964,6 @@ void translateCircuit(mlir::qc::QCProgramBuilder& builder,
             mlir::mqt::MQTDialect::SourceNameAttrHelper::getNameStr(),
             builder.getStringAttr(instruction.name));
       }
-      for (const auto [parameterIndex, parameter] :
-           llvm::enumerate(definitionParameters)) {
-        const auto* symbol = parameter.getSymbol();
-        function.setArgAttr(
-            parameterIndex,
-            mlir::mqt::MQTDialect::InputNameAttrHelper::getNameStr(),
-            builder.getStringAttr(symbol->name));
-        if (symbol->group) {
-          gateState.parameterGroups.add(*symbol->group);
-          function.setArgAttr(
-              parameterIndex,
-              mlir::mqt::MQTDialect::ParameterGroupAttrHelper::getNameStr(),
-              parameterGroupAttribute(builder, *symbol->group));
-        }
-      }
       gateState.gates.insert({identity, function});
     }
 
@@ -2951,7 +2932,7 @@ mlir::QCProgram importCircuit(const nb::handle circuit) {
   std::iota(qubitMap.begin(), qubitMap.end(), 0U);
   std::iota(clbitMap.begin(), clbitMap.end(), 0U);
   ImportedVariables variables;
-  GateImportState gateState(parameterGroups);
+  GateImportState gateState;
   gateState.functionNames.insert(function.getName());
   translateCircuit(builder, *view, qubitMap, clbitMap, qubitMap, clbitMap,
                    qubits, classicalBits, {}, globalParameters, gateState, 0U,

--- a/docs/mlir/OpenQASM.md
+++ b/docs/mlir/OpenQASM.md
@@ -16,6 +16,11 @@ auto fromString = mlir::QCProgram::fromQASMString(source);
 auto fromFile = mlir::QCProgram::fromQASMFile("program.qasm");
 ```
 
+The lower-level `mlir::qc::translateQASM3ToQC` importer accepts
+`QASM3ImportOptions`. Its `frontend` field selects the gate policy, and
+`maxOperations` limits the number of inserted QC operations (10,000,000 by
+default). Exceeding the limit emits a diagnostic and returns no program.
+
 Python provides the corresponding constructors:
 
 ```python
@@ -23,6 +28,7 @@ from mqt.core.mlir import QCProgram
 
 from_string = QCProgram.from_qasm_str(source)
 from_file = QCProgram.from_qasm_file("program.qasm")
+qiskit_circuit = QCProgram.from_qasm_str(source).to_qiskit()
 ```
 
 `mqt-cc` recognizes `.qasm` files automatically. Use `--input-format=qasm` when

--- a/docs/mlir/OpenQASM.md
+++ b/docs/mlir/OpenQASM.md
@@ -52,6 +52,15 @@ register when the constant width is 1 through 64. Bit zero is the least
 significant bit. Signed casts use two's-complement representation, with bit
 `N - 1` as the sign bit.
 
+`float(value)` and `float[64](value)` accept numeric and Boolean values.
+Bit-string literals contain binary digits, optionally separated by underscores,
+and must match the destination register width.
+
+Textual includes use LLVM SourceMgr lookup: paths are tried relative to the
+process working directory, then in the include directories supplied to
+SourceMgr. They are not resolved relative to the including file. The built-in
+standard libraries do not require files on disk.
+
 Syntax and semantic diagnostics retain source locations and include stacks.
 Classical-index bounds and integer-power preconditions are represented
 explicitly in QC. Runtime integer arithmetic uses machine-width promotion and
@@ -111,20 +120,24 @@ Branch conditions do not add proof facts. Classical bit indexing and loops that
 do not index qubits keep their runtime behavior.
 
 Bit registers use `!cbit.reg<N>` in QC. OpenQASM 2 initializes each register to
-zero. OpenQASM 3 leaves each register undefined until a statement writes it.
-Whole-register reads and writes lower to `cbit.read` and `cbit.write`. Standard
-integer operations represent computation, including all comparisons: `cbit.read`
-produces the snapshot, `arith.constant` the comparison constant, and
-`arith.cmpi` determines signedness. CBit operations carry storage memory
-effects. jeff legalization preserves native widths and promotes other widths up
-to 64 to 8, 16, 32, or 64 bits, masking results to retain exact-width semantics.
-Wider register-versus-constant comparisons remain supported; wider general
-integer expressions are rejected. Integer-to-floating-point casts (for example,
-using a runtime population count as a rotation angle) remain outside the jeff
-subset. Explicit outputs and implicit global outputs are returned by the entry
-function; internal CBit allocations are not outputs. Other scalar outputs use
-builtin MLIR scalar types. A scalar `qubit` lowers to `qc.alloc`, while
-`qubit[1]` remains a one-element qubit register.
+zero. OpenQASM 3 leaves each register undefined until a statement writes it. A
+static read requires its bit to be initialized. A dynamic read requires the
+whole register to be initialized; writing one dynamic index does not prove that
+a later dynamic read accesses an initialized bit. Whole-register reads and
+writes lower to `cbit.read` and `cbit.write`. Standard integer operations
+represent computation, including all comparisons: `cbit.read` produces the
+snapshot, `arith.constant` the comparison constant, and `arith.cmpi` determines
+signedness. CBit operations carry storage memory effects. jeff legalization
+preserves native widths and promotes other widths up to 64 to 8, 16, 32, or 64
+bits, masking results to retain exact-width semantics. Wider
+register-versus-constant comparisons remain supported; wider general integer
+expressions are rejected. Integer-to-floating-point casts (for example, using a
+runtime population count as a rotation angle) remain outside the jeff subset.
+Explicit outputs and implicit global outputs are returned by the entry function;
+internal CBit allocations are not outputs. Other scalar outputs use builtin MLIR
+scalar types. Programs without classical outputs have a void entry function; a
+returned integer zero is ordinary output data. A scalar `qubit` lowers to
+`qc.alloc`, while `qubit[1]` remains a one-element qubit register.
 
 ## Export OpenQASM
 
@@ -185,15 +198,15 @@ bypasses that QCO optimization round trip.
 
 ### Export and round-trip support
 
-| QC or MLIR concept        | Export support                                                                                                                                                                                                               |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Qubits and classical bits | Logical and physical qubits, scalar qubit allocations, static rank-one qubit memrefs, and CBit registers. Qubit memory indices must resolve statically. CBit indices can be dynamic.                                         |
-| Quantum operations        | Measurement, reset, barrier, deallocation, global phase, and QC unitary operations. The exporter uses standard gates where available; for example, `sxdg` becomes `inv @ sx` and `u2` uses the standard compatibility alias. |
-| Reusable gates            | Private functions with leading `f64` parameters followed by scalar qubit arguments and no results. Straight-line `mqt.unitary` functions use `qc.call`; loop-containing gate functions use `func.call`.                      |
-| Gate modifiers            | Nested `ctrl`, `inv`, and `pow`. A multi-operation modifier body with target qubits becomes a private generated gate.                                                                                                        |
-| Scalar values             | Integers of widths 1–64, `f64`, and internal `index` values, including arithmetic, comparisons, Boolean operations, value-preserving casts, and supported math functions.                                                    |
-| Structured control        | `scf.if`, `scf.index_switch`, signed `scf.for` with positive constant steps, and general two-region `scf.while`, including scalar arguments and results. Index switches use native `switch`, `case`, and `default`.          |
-| Results                   | Multiple scalar and bit-register outputs using the canonical type and naming rules below.                                                                                                                                    |
+| QC or MLIR concept        | Export support                                                                                                                                                                                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Qubits and classical bits | Logical and physical qubits, scalar qubit allocations, static rank-one qubit memrefs, and CBit registers. Qubit memory indices must resolve statically. CBit indices can be dynamic.                                                                                |
+| Quantum operations        | Measurement, reset, barrier, deallocation, global phase, and QC unitary operations. The exporter uses standard gates where available; for example, `sxdg` becomes `inv @ sx` and `u` and `u2` use a shared helper that compensates the OpenQASM 3 `U` global phase. |
+| Reusable gates            | Private functions with leading `f64` parameters followed by scalar qubit arguments and no results. Straight-line `mqt.unitary` functions use `qc.call`; loop-containing gate functions use `func.call`.                                                             |
+| Gate modifiers            | Nested `ctrl`, `inv`, and `pow`. A multi-operation modifier body with target qubits becomes a private generated gate.                                                                                                                                               |
+| Scalar values             | Integers of widths 1–64, `f64`, and internal `index` values, including arithmetic, comparisons, Boolean operations, value-preserving casts, and supported math functions.                                                                                           |
+| Structured control        | `scf.if`, `scf.index_switch`, signed `scf.for` with positive constant steps, and general two-region `scf.while`, including scalar arguments and results. Index switches use native `switch`, `case`, and `default`.                                                 |
+| Results                   | Multiple scalar and bit-register outputs using the canonical type and naming rules below.                                                                                                                                                                           |
 
 For loops preserve their exclusive upper bound when exported to an inclusive
 OpenQASM range. Dynamic bounds are supported in the entry function and are
@@ -208,12 +221,13 @@ a final increment that wraps cannot cause another iteration. This supports round
 trips without restricting the signed range of the endpoints. Other range forms
 can still require wider arithmetic or runtime checks that the exporter rejects.
 
-Ordinary while loops retain `while (condition)` when the condition region can be
-expressed directly. Loops with executable statements before their condition use
-`while (true)` and a conditional `break`. The before and after regions may have
-different argument counts and types. Local variables preserve scalar state, exit
-values, and simultaneous updates such as swaps. The condition and its forwarded
-values are evaluated before any continuation updates.
+Entry-function while loops use `while (true)` and a conditional `break`, so
+condition-region expressions are evaluated once per iteration. Gate functions
+retain direct `while (condition)` syntax because they cannot declare local
+state. The before and after regions may have different argument counts and
+types. Local variables preserve scalar state, exit values, and simultaneous
+updates such as swaps. The condition and its forwarded values are evaluated
+before any continuation updates.
 
 For example, this terminating do-while form executes its body three times:
 
@@ -266,15 +280,20 @@ Output types follow a deliberately small canonical mapping:
 | Other integers of 2–63 bits       | `uint[N]`       |
 | `f64`                             | `float`         |
 
-A lone constant-zero `i64` result is treated as the frontend's status return and
-is not emitted. Import and export do not preserve `uint`, fixed-angle spelling
-or width, scalar-versus-one-element bit spelling, or scalar output names.
-Integer computations use explicit `int[N]`/`uint[N]` casts, so signedness is
-chosen by each MLIR operation rather than inferred from its source register.
-Truncation, sign/zero extension, arithmetic, bitwise operations, comparisons,
-shifts, and integer selection are supported. Selection uses a fixed-width bit
-mask and does not allocate a temporary register. The frontend accepts the casts
-and expressions emitted by the exporter, including Boolean/integer conversions.
+Outputs preserve function-result order, including mixed scalar and register
+results and constant-zero integers. Returning the same register more than once
+is diagnosed because OpenQASM outputs cannot preserve that aliasing. Programs
+without results keep generated classical temporaries in a local scope to avoid
+implicit outputs. Unused measurement results need no temporary.
+
+Import and export do not preserve `uint`, fixed-angle spelling or width,
+scalar-versus-one-element bit spelling, or scalar output names. Integer
+computations use explicit `int[N]`/`uint[N]` casts, so signedness is chosen by
+each MLIR operation rather than inferred from its source register. Truncation,
+sign/zero extension, arithmetic, bitwise operations, comparisons, shifts, and
+integer selection are supported. Selection uses a fixed-width bit mask and does
+not allocate a temporary register. The frontend accepts the casts and
+expressions emitted by the exporter, including Boolean/integer conversions.
 
 ### Export limitations
 
@@ -284,7 +303,8 @@ by scalar qubit arguments and no results. Gate functions may contain supported
 scalar expressions, quantum operations, calls, and loops. Measurement, reset,
 barrier, allocation, classical storage, conditionals, switches, and
 `arith.select` are rejected in gate functions. For-loop bounds in gate functions
-must remain constant.
+must remain constant. Gate while loops require a pure condition region and no
+loop-carried values.
 
 The exporter rejects arbitrary CFGs, multi-block SCF regions, recursive or
 unresolved calls, dynamic qubit indices, dynamic for-loop steps, unsigned
@@ -302,24 +322,31 @@ Rotation counts must be constant or represented by at most 64 bits, optionally
 zero-extended to the register width. Qiskit interoperability uses the common
 subset described in the Python compiler documentation.
 
-The exporter inlines a whole-register read only in the block that contains the
-read and only when no later write to that register precedes the expression use.
-It rejects stale and cross-region snapshots instead of reading newer register
-state. Shift interpretation is determined by the MLIR operation, not by the
-history of its operands. Arithmetic right shifts are encoded with unsigned
-bitwise operations and explicit sign-bit biasing.
+The exporter stores used scalar expressions and bit-register reads in local
+variables at their definition. These variables preserve snapshots across later
+writes and nested regions and prevent repeated expansion of shared expressions.
+Wide bit-vector expressions use local bit registers. Zero-initialized registers
+use one exact-width bit-string initializer. Shift interpretation is determined
+by the MLIR operation, not by the history of its operands. Arithmetic right
+shifts are encoded with unsigned bitwise operations and explicit sign-bit
+biasing.
 
-Export accepts an expression nesting depth of at most 256 and an expansion
-budget of 4,096 values per expression. The total width of classical registers is
-limited to 1,048,576 bits.
+Inline expressions, including those in gate functions, have a nesting limit of
+256 and an expansion budget of 4,096 values per expression. The total width of
+classical registers, including wide snapshots, is limited to 1,048,576 bits.
+Import limits affine proofs to 256 levels and 4,096 distinct expressions per
+proof and QC emission to 10,000,000 inserted operations.
 
 The exporter does not reconstruct the runtime checks created for dynamic indices
 or checked integer arithmetic. Surviving assertions, checked-index control flow,
 or live poison values cause an explicit diagnostic. Programs with static qubit
 and bit indices and supported integer/Boolean casts can be exported and parsed
-again through the strict frontend. Floating-point/integer conversions remain
-outside that round-trip subset. Programs that rely on the input safety machinery
-must continue through another output path such as QIR.
+again through the strict frontend. Integer-to-floating-point conversions support
+this round trip. Compile-time floating-point-to-integer conversions remain
+outside the input subset. Floating-point `!=` uses unordered-or-not-equal
+semantics, including NaNs; ordered-not-equal MLIR comparisons are rejected.
+Programs that rely on the input safety machinery must continue through another
+output path such as QIR.
 
 :::{important}
 The compiler removes dead code. A circuit that only prepares a state has no

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -202,10 +202,19 @@ containing circuit. This includes values used only by the condition or switch
 target and not by a control-flow block. External runtime inputs remain
 unsupported.
 
-Private gate parameters without name metadata receive local names during Qiskit
-export. Public program inputs still require explicit names. OpenQASM custom
-gates can therefore use `QCProgram.from_qasm_str(source).to_qiskit()` directly
-within the supported subset below.
+Private gate parameters bind by position and receive generated local names
+during Qiskit export; their original names and grouping are not preserved.
+Public program inputs still require explicit names. OpenQASM custom gates can
+therefore use `QCProgram.from_qasm_str(source).to_qiskit()` directly within the
+supported subset below.
+
+Export folds scalar expressions on a copy of the QC program. Constant
+arithmetic, casts, and idempotent expressions can therefore disappear;
+expression-tree shape is not preserved. Quantum-resource and classical-snapshot
+canonicalization patterns are not applied, because they can change circuit width
+or introduce scratch bits. Call `cleanup()` explicitly when those broader
+transformations are wanted. Live free parameters retain their identities; unused
+named program inputs remain unsupported.
 
 Free symbols become named {code}`f64` program inputs. Parameter-vector elements
 retain their grouping and index, preserving vector order and positional binding

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -202,6 +202,11 @@ containing circuit. This includes values used only by the condition or switch
 target and not by a control-flow block. External runtime inputs remain
 unsupported.
 
+Private gate parameters without name metadata receive local names during Qiskit
+export. Public program inputs still require explicit names. OpenQASM custom
+gates can therefore use `QCProgram.from_qasm_str(source).to_qiskit()` directly
+within the supported subset below.
+
 Free symbols become named {code}`f64` program inputs. Parameter-vector elements
 retain their grouping and index, preserving vector order and positional binding
 across a round trip; similarly named standalone parameters remain standalone.
@@ -211,7 +216,8 @@ combined declared size in one translated circuit are each limited to 65,536
 elements. Parameter-expression trees support at most 64 levels and 4,096 nodes.
 Import and export support real addition, subtraction, multiplication, division,
 power, negation, trigonometric and inverse trigonometric functions, exponential,
-logarithm, absolute value, and real conjugation. Other parameter-expression
+logarithm, absolute value, and real conjugation. Export also folds signed and
+unsigned integer-to-float casts of constants. Other parameter-expression
 functions are rejected. Lexically bound {code}`for`-loop induction parameters
 are supported and remain distinct from free symbols. Parameterized
 custom-instruction definitions are expanded after their symbols and expressions

--- a/mlir/include/mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h
+++ b/mlir/include/mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h
@@ -28,7 +28,8 @@ namespace qc {
 
 /// Controls source acceptance and the size of the emitted QC program.
 struct QASM3ImportOptions {
-  oq3::frontend::FrontendOptions frontend;
+  oq3::frontend::GatePolicy gatePolicy =
+      oq3::frontend::GatePolicy::MQTCompatibility;
   /// Maximum number of inserted operations, excluding the module itself.
   size_t maxOperations = 10'000'000;
 };

--- a/mlir/include/mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h
+++ b/mlir/include/mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h
@@ -10,9 +10,13 @@
 
 #pragma once
 
+#include "mlir/Target/OpenQASM/Frontend.h"
+
 #include <llvm/Support/SourceMgr.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/Support/LLVM.h>
+
+#include <cstddef>
 
 namespace mlir {
 
@@ -22,29 +26,36 @@ class ModuleOp;
 
 namespace qc {
 
-/**
- * @brief Translate an OpenQASM 3 program to a QC program.
- *
- * Frontend and lowering failures are reported through the diagnostic engine of
- * @p context and result in a null return value.
- *
- * @param sourceMgr Source manager containing the OpenQASM program.
- * @param context MLIRContext to create the module in.
- */
-[[nodiscard]] OwningOpRef<ModuleOp>
-translateQASM3ToQC(llvm::SourceMgr& sourceMgr, MLIRContext* context);
+/// Controls source acceptance and the size of the emitted QC program.
+struct QASM3ImportOptions {
+  oq3::frontend::FrontendOptions frontend;
+  /// Maximum number of inserted operations, excluding the module itself.
+  size_t maxOperations = 10'000'000;
+};
 
-/**
- * @brief Translate an OpenQASM 3 program to a QC program.
- *
- * Frontend and lowering failures are reported through the diagnostic engine of
- * @p context and result in a null return value.
- *
- * @param source String containing the OpenQASM program.
- * @param context MLIRContext to create the module in.
- */
-[[nodiscard]] OwningOpRef<ModuleOp> translateQASM3ToQC(StringRef source,
-                                                       MLIRContext* context);
+/// @brief Translate an OpenQASM 3 program to a QC program.
+///
+/// Frontend and lowering failures are reported through the diagnostic engine of
+/// @p context and result in a null return value.
+///
+/// @param sourceMgr Source manager containing the OpenQASM program.
+/// @param context MLIRContext to create the module in.
+/// @param options Frontend policy and emission resource limit.
+[[nodiscard]] OwningOpRef<ModuleOp>
+translateQASM3ToQC(llvm::SourceMgr& sourceMgr, MLIRContext* context,
+                   const QASM3ImportOptions& options = {});
+
+/// @brief Translate an OpenQASM 3 program to a QC program.
+///
+/// Frontend and lowering failures are reported through the diagnostic engine of
+/// @p context and result in a null return value.
+///
+/// @param source String containing the OpenQASM program.
+/// @param context MLIRContext to create the module in.
+/// @param options Frontend policy and emission resource limit.
+[[nodiscard]] OwningOpRef<ModuleOp>
+translateQASM3ToQC(StringRef source, MLIRContext* context,
+                   const QASM3ImportOptions& options = {});
 
 } // namespace qc
 

--- a/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMParser.h
+++ b/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMParser.h
@@ -407,7 +407,7 @@ private:
     }
     if (measureSource) {
       const BitReference target{
-          .loc = loc, .identifier = id, .index = std::nullopt};
+          .location = loc, .identifier = id, .index = std::nullopt};
       return sink.measure(loc, &target, *measureSource);
     }
     return success();
@@ -534,7 +534,7 @@ private:
     }
     if (measureSource) {
       const BitReference target{
-          .loc = loc, .identifier = id, .index = std::nullopt};
+          .location = loc, .identifier = id, .index = std::nullopt};
       return sink.measure(loc, &target, *measureSource);
     }
     return success();
@@ -886,7 +886,7 @@ private:
 
   [[nodiscard]] FailureOr<Operand> parseGateOperand() {
     Operand operand;
-    operand.loc = current().loc;
+    operand.location = current().loc;
     if (current().kind == TokenKind::HardwareQubit) {
       operand.hardwareQubit = static_cast<uint64_t>(current().intValue);
       advance();
@@ -911,7 +911,7 @@ private:
 
   [[nodiscard]] FailureOr<BitReference> parseBitReference() {
     BitReference reference;
-    reference.loc = current().loc;
+    reference.location = current().loc;
     if (current().kind != TokenKind::Identifier) {
       return expectedIdentifier("expected an identifier");
     }

--- a/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMParser.h
+++ b/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMParser.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "mlir/Target/OpenQASM/Detail/OpenQASMLexer.h"
+#include "mlir/Target/OpenQASM/Detail/OpenQASMSyntax.h"
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/STLExtras.h>
@@ -19,7 +20,6 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ADT/StringSwitch.h>
 #include <llvm/ADT/Twine.h>
-#include <llvm/Support/Allocator.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/SMLoc.h>
 #include <mlir/Support/LLVM.h>
@@ -27,232 +27,21 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
-#include <memory>
-#include <new>
 #include <optional>
 #include <utility>
 
 namespace mlir::oq3::frontend::detail {
-
-/// An exact OpenQASM version, preserving the decimal minor component.
-struct Version {
-  uint32_t major = 0;
-  uint32_t minor = 0;
-};
-
-enum class ScalarKind : uint8_t { Bool, Int, Uint, Float, Angle };
-
-/**
- * @defgroup ParseVocabulary Transient parse vocabulary
- * @brief The vocabulary the parser hands to a sink.
- *
- * @details
- * These types are cheap and trivially destructible. Expressions are allocated
- * in a bump allocator; other values borrow parser-local storage for the
- * duration of a sink call. `SyntaxBuilder` copies each completed construct into
- * the persistent, owning syntax program.
- */
-
-/**
- * @ingroup ParseVocabulary
- * @brief A (sub-)expression.
- *
- * @details
- * Bump-allocated; children are borrowed pointers.
- */
-struct Expr {
-  enum class Kind : uint8_t {
-    Int,
-    Float,
-    Bool,
-    Identifier,
-    IntCast,
-    BoolCast,
-    BitCast,
-    UintCast,
-    AngleCast,
-    Index,
-    Neg,
-    Not,
-    BitNot,
-    Add,
-    Sub,
-    Mul,
-    Div,
-    Equal,
-    NotEqual,
-    Less,
-    LessEqual,
-    Greater,
-    GreaterEqual,
-    And,
-    Or,
-    BitAnd,
-    BitOr,
-    BitXor,
-    ShiftLeft,
-    ShiftRight,
-    // Built-in math functions
-    ArcCos,
-    ArcSin,
-    ArcTan,
-    Ceiling,
-    Cos,
-    Exp,
-    Floor,
-    Log,
-    Mod,
-    BuiltinMod,
-    PopCount,
-    BuiltinPow,
-    Pow,
-    RotateLeft,
-    RotateRight,
-    Sin,
-    Sqrt,
-    Tan,
-  };
-
-  SMLoc loc;
-  Kind kind = Kind::Int;
-  uint64_t intValue = 0;
-  double floatValue = 0.0;
-  bool boolValue = false;
-  StringRef identifier;
-  StringRef wideInteger;
-  std::optional<uint64_t> hardwareQubit;
-  const Expr* lhs = nullptr;
-  const Expr* rhs = nullptr;
-};
-
-/// Get the kind of the built-in math function @p name.
-[[nodiscard]] inline std::optional<Expr::Kind>
-getMathFunctionKind(StringRef name) {
-  return llvm::StringSwitch<std::optional<Expr::Kind>>(name)
-      .Case("arccos", Expr::Kind::ArcCos)
-      .Case("arcsin", Expr::Kind::ArcSin)
-      .Case("arctan", Expr::Kind::ArcTan)
-      .Case("ceiling", Expr::Kind::Ceiling)
-      .Case("cos", Expr::Kind::Cos)
-      .Case("exp", Expr::Kind::Exp)
-      .Case("floor", Expr::Kind::Floor)
-      .Case("log", Expr::Kind::Log)
-      .Case("mod", Expr::Kind::BuiltinMod)
-      .Case("popcount", Expr::Kind::PopCount)
-      .Case("pow", Expr::Kind::BuiltinPow)
-      .Case("rotl", Expr::Kind::RotateLeft)
-      .Case("rotr", Expr::Kind::RotateRight)
-      .Case("sin", Expr::Kind::Sin)
-      .Case("sqrt", Expr::Kind::Sqrt)
-      .Case("tan", Expr::Kind::Tan)
-      .Default(std::nullopt);
-}
-
-/**
- * @ingroup ParseVocabulary
- * @brief A gate modifier: `inv @`, `pow(e) @`, `ctrl(e) @`, or `negctrl(e) @`.
- */
-struct Modifier {
-  enum class Kind : uint8_t { Inv, Pow, Ctrl, NegCtrl };
-  Kind kind = Kind::Inv;
-  const Expr* argument = nullptr;
-};
-
-/**
- * @ingroup ParseVocabulary
- * @brief A gate operand: a (possibly indexed) identifier, or a hardware qubit.
- */
-struct Operand {
-  SMLoc loc;
-  StringRef identifier;
-  const Expr* index = nullptr;
-  std::optional<uint64_t> hardwareQubit;
-};
-
-/// A (possibly indexed) classical reference (e.g., `c` or `c[0]`).
-struct BitReference {
-  SMLoc loc;
-  StringRef identifier;
-  const Expr* index = nullptr;
-};
-
-/**
- * @ingroup ParseVocabulary
- * @brief A parsed gate call.
- *
- * @details
- * Array members are borrowed for the duration of the sink call.
- */
-struct GateCall {
-  SMLoc loc;
-  StringRef identifier;
-  ArrayRef<Modifier> modifiers;
-  ArrayRef<const Expr*> parameters;
-  ArrayRef<Operand> operands;
-};
-
-//===----------------------------------------------------------------------===//
-// Sink concept
-//===----------------------------------------------------------------------===//
-
-/**
- * @brief The interface a `Parser` drives to materialize parsed constructs.
- *
- * @details
- * A sink consumes the events produced by `Parser`. The production sink copies
- * them into target-independent persistent syntax; the parser is templated so
- * dispatch remains static. Diagnostics are routed through `error`.
- *
- * Control flow uses continuations so the persistent syntax builder can select
- * the destination body while the parser recursively consumes a source block.
- */
-template <class S>
-concept QASMSink =
-    requires(S s, SMLoc loc, StringRef str, const Expr& expr,
-             const Operand& operand, const BitReference& reference,
-             const GateCall& call, ArrayRef<Operand> operands,
-             ArrayRef<StringRef> names, ArrayRef<const Expr*> expressions,
-             function_ref<LogicalResult()> cont, Version version, bool flag) {
-      s.error(loc, str);
-      s.version(loc, version);
-      s.include(loc, str);
-      s.scalarDecl(loc, ScalarKind::Int, str, &expr, &expr, flag, flag);
-      s.assignment(loc, reference, expr);
-      s.qubitRegister(loc, str, &expr);
-      s.classicalRegister(loc, str, &expr, &expr, flag);
-      s.measure(loc, &reference, operand);
-      s.reset(loc, operand);
-      s.barrier(loc, operands);
-      s.gateCall(call);
-      s.gateDefinition(loc, str, names, names, cont);
-      s.ifStmt(loc, expr, cont, cont);
-      s.forStmt(loc, str, flag, expr, expr, expr, cont);
-      s.whileStmt(loc, expr, cont);
-      s.breakStmt(loc);
-      s.continueStmt(loc);
-      s.switchStmt(loc, expr, cont);
-      s.switchCase(loc, expressions, cont);
-      s.switchDefault(loc, cont);
-    };
-
-//===----------------------------------------------------------------------===//
-// Parser
-//===----------------------------------------------------------------------===//
 
 /**
  * @brief A single-pass recursive-descent parser for OpenQASM 3.
  *
  * @details
  * The parser is target-independent. Its builder materializes a persistent
- * syntax program; expressions and temporary gate-definition vocabulary are
- * bump-allocated only for the duration of parsing.
+ * syntax program and stores expressions directly in its ID arena.
  */
-template <class Sink>
-  requires QASMSink<Sink>
 class Parser {
 public:
-  Parser(Lexer& lexer, Sink& sink, llvm::BumpPtrAllocator& allocator)
-      : lexer(lexer), sink(sink), allocator(allocator) {
+  Parser(Lexer& lexer, SyntaxBuilder& sink) : lexer(lexer), sink(sink) {
     currentToken = lexer.next();
     nextToken = lexer.next();
   }
@@ -322,10 +111,6 @@ private:
   }
 
   //===--- Allocation helpers -------------------------------------------===//
-
-  [[nodiscard]] Expr* makeExpr() {
-    return std::construct_at(allocator.Allocate<Expr>());
-  }
 
   //===--- Program and statements ---------------------------------------===//
 
@@ -447,7 +232,7 @@ private:
 
   //===--- Helpers ------------------------------------------------------===//
 
-  [[nodiscard]] FailureOr<const Expr*> parseDesignator() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseDesignator() {
     if (failed(expect(TokenKind::LBracket))) {
       return failure();
     }
@@ -554,7 +339,7 @@ private:
     }
     advance(); // type
 
-    const Expr* size = nullptr;
+    std::optional<SyntaxExpressionId> size;
     if ((kind == TokenKind::Angle || kind == TokenKind::Int ||
          kind == TokenKind::Uint) &&
         current().kind == TokenKind::LBracket) {
@@ -585,7 +370,7 @@ private:
                                  "' requires an initializer");
     }
 
-    const Expr* initializer = nullptr;
+    std::optional<SyntaxExpressionId> initializer;
     std::optional<Operand> measureSource;
     if (hasInitializer) {
       if (current().kind == TokenKind::Measure) {
@@ -621,7 +406,8 @@ private:
       return failure();
     }
     if (measureSource) {
-      const BitReference target{.loc = loc, .identifier = id, .index = nullptr};
+      const BitReference target{
+          .loc = loc, .identifier = id, .index = std::nullopt};
       return sink.measure(loc, &target, *measureSource);
     }
     return success();
@@ -631,7 +417,7 @@ private:
   [[nodiscard]] LogicalResult parseQuantumDecl() {
     const auto loc = current().loc;
     advance(); // qubit
-    const Expr* size = nullptr;
+    std::optional<SyntaxExpressionId> size;
     if (current().kind == TokenKind::LBracket) {
       auto designator = parseDesignator();
       if (failed(designator)) {
@@ -659,7 +445,7 @@ private:
     }
     const auto id = current().identifier;
     advance();
-    const Expr* size = nullptr;
+    std::optional<SyntaxExpressionId> size;
     if (current().kind == TokenKind::LBracket) {
       auto designator = parseDesignator();
       if (failed(designator)) {
@@ -700,7 +486,7 @@ private:
   [[nodiscard]] LogicalResult parseClassicalDecl(bool isOutput) {
     const auto loc = current().loc;
     advance(); // bit
-    const Expr* size = nullptr;
+    std::optional<SyntaxExpressionId> size;
     if (current().kind == TokenKind::LBracket) {
       auto designator = parseDesignator();
       if (failed(designator)) {
@@ -714,7 +500,7 @@ private:
     const auto id = current().identifier;
     advance();
 
-    const Expr* initializer = nullptr;
+    std::optional<SyntaxExpressionId> initializer;
     std::optional<Operand> measureSource;
     if (isOutput && current().kind == TokenKind::Equals) {
       return sink.error(
@@ -747,7 +533,8 @@ private:
       return failure();
     }
     if (measureSource) {
-      const BitReference target{.loc = loc, .identifier = id, .index = nullptr};
+      const BitReference target{
+          .loc = loc, .identifier = id, .index = std::nullopt};
       return sink.measure(loc, &target, *measureSource);
     }
     return success();
@@ -762,7 +549,7 @@ private:
     }
     const auto id = current().identifier;
     advance();
-    const Expr* size = nullptr;
+    std::optional<SyntaxExpressionId> size;
     if (current().kind == TokenKind::LBracket) {
       auto designator = parseDesignator();
       if (failed(designator)) {
@@ -773,7 +560,7 @@ private:
     if (failed(expect(TokenKind::Semicolon))) {
       return failure();
     }
-    return sink.classicalRegister(loc, id, size, /*initializer=*/nullptr,
+    return sink.classicalRegister(loc, id, size, /*initializer=*/std::nullopt,
                                   /*output=*/false);
   }
 
@@ -791,7 +578,7 @@ private:
     const auto compoundLocation = current().loc;
     const auto compoundSpelling = current().spelling;
     if (compound) {
-      if (target->index != nullptr) {
+      if (target->index.has_value()) {
         return sink.error(current().loc,
                           "indexed compound assignments are not supported");
       }
@@ -816,7 +603,7 @@ private:
     if (failed(value)) {
       return failure();
     }
-    const Expr* assignedValue = *value;
+    SyntaxExpressionId assignedValue = *value;
     if (compound) {
       const auto kind = llvm::StringSwitch<std::optional<Expr::Kind>>(
                             compoundSpelling.drop_back())
@@ -836,17 +623,17 @@ private:
         return sink.error(compoundLocation,
                           "unsupported compound assignment operator");
       }
-      auto* previous = makeExpr();
-      previous->loc = loc;
-      previous->kind = Expr::Kind::Identifier;
-      previous->identifier = target->identifier;
-      assignedValue =
-          makeBinary(*kind, previous, assignedValue, compoundLocation);
+      SyntaxExpression previous;
+      previous.location = loc;
+      previous.kind = Expr::Kind::Identifier;
+      previous.identifier = target->identifier;
+      assignedValue = makeBinary(*kind, sink.addExpression(previous),
+                                 assignedValue, compoundLocation);
     }
     if (failed(expect(TokenKind::Semicolon))) {
       return failure();
     }
-    return sink.assignment(loc, *target, *assignedValue);
+    return sink.assignment(loc, *target, assignedValue);
   }
 
   //===--- Measure ------------------------------------------------------===//
@@ -953,7 +740,7 @@ private:
     // The scratch buffers must outlive the sink call, so they live here rather
     // than inside `parseGateCall`.
     SmallVector<Modifier> modifiers;
-    SmallVector<const Expr*> parameters;
+    SmallVector<SyntaxExpressionId> parameters;
     SmallVector<Operand> operands;
     auto call = parseGateCall(modifiers, parameters, operands);
     if (failed(call)) {
@@ -964,7 +751,7 @@ private:
 
   [[nodiscard]] FailureOr<GateCall>
   parseGateCall(SmallVectorImpl<Modifier>& modifiers,
-                SmallVectorImpl<const Expr*>& parameters,
+                SmallVectorImpl<SyntaxExpressionId>& parameters,
                 SmallVectorImpl<Operand>& operands) {
     GateCall call;
     call.loc = current().loc;
@@ -1110,7 +897,7 @@ private:
     }
     operand.identifier = current().identifier;
     advance();
-    const Expr* index = nullptr;
+    std::optional<SyntaxExpressionId> index;
     if (current().kind == TokenKind::LBracket) {
       auto designator = parseDesignator();
       if (failed(designator)) {
@@ -1130,7 +917,7 @@ private:
     }
     reference.identifier = current().identifier;
     advance();
-    const Expr* index = nullptr;
+    std::optional<SyntaxExpressionId> index;
     if (current().kind == TokenKind::LBracket) {
       auto designator = parseDesignator();
       if (failed(designator)) {
@@ -1176,7 +963,7 @@ private:
       return failure();
     }
     return sink.ifStmt(
-        loc, **conditionOrFailure, [this] { return parseBlock(); },
+        loc, *conditionOrFailure, [this] { return parseBlock(); },
         [this] { return parseElse(); });
   }
 
@@ -1198,8 +985,7 @@ private:
     if (failed(control) || failed(expect(TokenKind::RParen))) {
       return failure();
     }
-    return sink.switchStmt(loc, **control,
-                           [this] { return parseSwitchBody(); });
+    return sink.switchStmt(loc, *control, [this] { return parseSwitchBody(); });
   }
 
   [[nodiscard]] LogicalResult parseSwitchBody() {
@@ -1216,7 +1002,7 @@ private:
         }
         sawCase = true;
         advance(); // case
-        SmallVector<const Expr*> labels;
+        SmallVector<SyntaxExpressionId> labels;
         while (true) {
           auto label = parseExpression();
           if (failed(label)) {
@@ -1289,8 +1075,8 @@ private:
       return failure();
     }
 
-    const Expr* step = nullptr;
-    const Expr* stop = nullptr;
+    SyntaxExpressionId step = 0;
+    SyntaxExpressionId stop = 0;
     if (current().kind == TokenKind::Colon) {
       advance();
       auto third = parseExpression();
@@ -1300,18 +1086,18 @@ private:
       step = *second;
       stop = *third;
     } else {
-      auto* one = makeExpr();
-      one->loc = loc;
-      one->kind = Expr::Kind::Int;
-      one->intValue = 1;
-      step = one;
+      SyntaxExpression one;
+      one.location = loc;
+      one.kind = Expr::Kind::Int;
+      one.integer = 1;
+      step = sink.addExpression(one);
       stop = *second;
     }
     if (failed(expect(TokenKind::RBracket))) {
       return failure();
     }
 
-    return sink.forStmt(loc, iv.identifier, isUnsigned, **start, *step, *stop,
+    return sink.forStmt(loc, iv.identifier, isUnsigned, *start, step, stop,
                         [this] { return parseBlock(); });
   }
 
@@ -1328,19 +1114,19 @@ private:
     if (failed(expect(TokenKind::RParen))) {
       return failure();
     }
-    return sink.whileStmt(loc, **conditionOrFailure,
+    return sink.whileStmt(loc, *conditionOrFailure,
                           [this] { return parseBlock(); });
   }
 
   //===--- Expressions --------------------------------------------------===//
 
   /// Parse an expression using OpenQASM's precedence hierarchy.
-  [[nodiscard]] FailureOr<const Expr*> parseExpression() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseExpression() {
     auto lhs = parseLogicalAnd();
     if (failed(lhs)) {
       return failure();
     }
-    const Expr* result = *lhs;
+    SyntaxExpressionId result = *lhs;
     while (current().kind == TokenKind::PipePipe) {
       const auto loc = current().loc;
       advance();
@@ -1353,12 +1139,12 @@ private:
     return result;
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseLogicalAnd() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseLogicalAnd() {
     auto lhs = parseBitwiseOr();
     if (failed(lhs)) {
       return failure();
     }
-    const Expr* result = *lhs;
+    SyntaxExpressionId result = *lhs;
     while (current().kind == TokenKind::AmpAmp) {
       const auto loc = current().loc;
       advance();
@@ -1371,12 +1157,12 @@ private:
     return result;
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseBitwiseOr() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseBitwiseOr() {
     auto lhs = parseBitwiseXor();
     if (failed(lhs)) {
       return failure();
     }
-    const Expr* result = *lhs;
+    SyntaxExpressionId result = *lhs;
     while (current().kind == TokenKind::Pipe) {
       const auto loc = current().loc;
       advance();
@@ -1389,12 +1175,12 @@ private:
     return result;
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseBitwiseXor() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseBitwiseXor() {
     auto lhs = parseBitwiseAnd();
     if (failed(lhs)) {
       return failure();
     }
-    const Expr* result = *lhs;
+    SyntaxExpressionId result = *lhs;
     while (current().kind == TokenKind::Caret) {
       const auto loc = current().loc;
       advance();
@@ -1407,12 +1193,12 @@ private:
     return result;
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseBitwiseAnd() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseBitwiseAnd() {
     auto lhs = parseEquality();
     if (failed(lhs)) {
       return failure();
     }
-    const Expr* result = *lhs;
+    SyntaxExpressionId result = *lhs;
     while (current().kind == TokenKind::Amp) {
       const auto loc = current().loc;
       advance();
@@ -1425,12 +1211,12 @@ private:
     return result;
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseEquality() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseEquality() {
     auto lhs = parseRelational();
     if (failed(lhs)) {
       return failure();
     }
-    const Expr* result = *lhs;
+    SyntaxExpressionId result = *lhs;
     while (current().kind == TokenKind::EqualsEquals ||
            current().kind == TokenKind::NotEquals) {
       const auto kind = current().kind == TokenKind::EqualsEquals
@@ -1447,7 +1233,7 @@ private:
     return result;
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseRelational() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseRelational() {
     auto lhs = parseShift();
     if (failed(lhs)) {
       return failure();
@@ -1478,12 +1264,12 @@ private:
     return makeBinary(*kind, *lhs, *rhs, loc);
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseShift() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseShift() {
     auto lhs = parseAdditive();
     if (failed(lhs)) {
       return failure();
     }
-    const Expr* result = *lhs;
+    SyntaxExpressionId result = *lhs;
     while (current().kind == TokenKind::ShiftLeft ||
            current().kind == TokenKind::ShiftRight) {
       const auto kind = current().kind == TokenKind::ShiftLeft
@@ -1500,12 +1286,12 @@ private:
     return result;
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseAdditive() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseAdditive() {
     auto lhs = parseTerm();
     if (failed(lhs)) {
       return failure();
     }
-    const Expr* result = *lhs;
+    SyntaxExpressionId result = *lhs;
     while (current().kind == TokenKind::Plus ||
            current().kind == TokenKind::Minus) {
       const auto kind =
@@ -1521,12 +1307,12 @@ private:
     return result;
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseTerm() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseTerm() {
     auto lhs = parseUnary();
     if (failed(lhs)) {
       return failure();
     }
-    const Expr* result = *lhs;
+    SyntaxExpressionId result = *lhs;
     while (current().kind == TokenKind::Asterisk ||
            current().kind == TokenKind::Slash ||
            current().kind == TokenKind::Percent) {
@@ -1547,7 +1333,7 @@ private:
     return result;
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parseUnary() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parseUnary() {
     ++recursiveExpressionDepth;
     auto depthGuard =
         llvm::make_scope_exit([&] { --recursiveExpressionDepth; });
@@ -1572,16 +1358,16 @@ private:
       if (failed(operand)) {
         return failure();
       }
-      auto* expr = makeExpr();
-      expr->loc = loc;
-      expr->kind = kind;
-      expr->lhs = *operand;
-      return expr;
+      SyntaxExpression expr;
+      expr.location = loc;
+      expr.kind = kind;
+      expr.lhs = *operand;
+      return sink.addExpression(expr);
     }
     return parsePower();
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parsePower() {
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parsePower() {
     auto lhs = parsePrimary();
     if (failed(lhs) || current().kind != TokenKind::DoubleAsterisk) {
       return lhs;
@@ -1595,37 +1381,50 @@ private:
     return makeBinary(Expr::Kind::Pow, *lhs, *rhs, loc);
   }
 
-  [[nodiscard]] FailureOr<const Expr*> parsePrimary() {
-    auto* expr = makeExpr();
-    expr->loc = current().loc;
+  [[nodiscard]] FailureOr<SyntaxExpressionId> parsePrimary() {
+    SyntaxExpression expr;
+    expr.location = current().loc;
     switch (current().kind) {
-    case TokenKind::True:
-    case TokenKind::False:
-      expr->kind = Expr::Kind::Bool;
-      expr->boolValue = current().kind == TokenKind::True;
-      advance();
-      return expr;
-    case TokenKind::FloatLiteral:
-      expr->kind = Expr::Kind::Float;
-      expr->floatValue = current().floatValue;
-      advance();
-      return expr;
-    case TokenKind::IntegerLiteral:
-      expr->kind = Expr::Kind::Int;
-      expr->intValue = current().intValue;
-      if (current().wideInteger) {
-        expr->wideInteger = current().stringValue;
+    case TokenKind::StringLiteral:
+      expr.kind = Expr::Kind::BitString;
+      expr.identifier = current().stringValue;
+      if (expr.identifier.empty() ||
+          !llvm::all_of(
+              expr.identifier,
+              [](char c) { return c == '0' || c == '1' || c == '_'; }) ||
+          llvm::all_of(expr.identifier, [](char c) { return c == '_'; })) {
+        return sink.error(current().loc, "bit strings require binary digits");
       }
       advance();
-      return expr;
+      return sink.addExpression(expr);
+    case TokenKind::True:
+    case TokenKind::False:
+      expr.kind = Expr::Kind::Bool;
+      expr.boolean = current().kind == TokenKind::True;
+      advance();
+      return sink.addExpression(expr);
+    case TokenKind::FloatLiteral:
+      expr.kind = Expr::Kind::Float;
+      expr.floatingPoint = current().floatValue;
+      advance();
+      return sink.addExpression(expr);
+    case TokenKind::IntegerLiteral:
+      expr.kind = Expr::Kind::Int;
+      expr.integer = current().intValue;
+      if (current().wideInteger) {
+        expr.wideInteger = current().stringValue;
+      }
+      advance();
+      return sink.addExpression(expr);
     case TokenKind::Bool:
     case TokenKind::Bit:
     case TokenKind::Int:
     case TokenKind::Uint:
+    case TokenKind::Float:
     case TokenKind::Angle: {
       const auto type = current().kind;
       advance();
-      const Expr* size = nullptr;
+      std::optional<SyntaxExpressionId> size;
       if (current().kind == TokenKind::LBracket) {
         auto designator = parseDesignator();
         if (failed(designator)) {
@@ -1640,14 +1439,15 @@ private:
       if (failed(operand) || failed(expect(TokenKind::RParen))) {
         return failure();
       }
-      expr->kind = type == TokenKind::Int    ? Expr::Kind::IntCast
-                   : type == TokenKind::Uint ? Expr::Kind::UintCast
-                   : type == TokenKind::Bool ? Expr::Kind::BoolCast
-                   : type == TokenKind::Bit  ? Expr::Kind::BitCast
+      expr.kind = type == TokenKind::Int     ? Expr::Kind::IntCast
+                  : type == TokenKind::Uint  ? Expr::Kind::UintCast
+                  : type == TokenKind::Bool  ? Expr::Kind::BoolCast
+                  : type == TokenKind::Float ? Expr::Kind::FloatCast
+                  : type == TokenKind::Bit   ? Expr::Kind::BitCast
                                              : Expr::Kind::AngleCast;
-      expr->lhs = size;
-      expr->rhs = *operand;
-      return expr;
+      expr.lhs = size;
+      expr.rhs = *operand;
+      return sink.addExpression(expr);
     }
     case TokenKind::Identifier: {
       if (peek().kind == TokenKind::LParen) {
@@ -1658,18 +1458,18 @@ private:
         }
         return parseMathCall(*kind, expr);
       }
-      expr->kind = Expr::Kind::Identifier;
-      expr->identifier = current().identifier;
+      expr.kind = Expr::Kind::Identifier;
+      expr.identifier = current().identifier;
       advance();
       if (current().kind == TokenKind::LBracket) {
         auto designator = parseDesignator();
         if (failed(designator)) {
           return failure();
         }
-        expr->kind = Expr::Kind::Index;
-        expr->lhs = *designator;
+        expr.kind = Expr::Kind::Index;
+        expr.lhs = *designator;
       }
-      return expr;
+      return sink.addExpression(expr);
     }
     // `pow` is also a gate modifier, so it has a dedicated token.
     case TokenKind::Pow:
@@ -1693,9 +1493,9 @@ private:
   }
 
   /// Parse the argument list of a call to the built-in math function @p kind.
-  [[nodiscard]] FailureOr<const Expr*> parseMathCall(Expr::Kind kind,
-                                                     Expr* expr) {
-    expr->kind = kind;
+  [[nodiscard]] FailureOr<SyntaxExpressionId>
+  parseMathCall(Expr::Kind kind, SyntaxExpression expr) {
+    expr.kind = kind;
     advance(); // function name
 
     if (failed(expect(TokenKind::LParen))) {
@@ -1706,7 +1506,7 @@ private:
     if (failed(lhs)) {
       return failure();
     }
-    expr->lhs = *lhs;
+    expr.lhs = *lhs;
 
     if (kind == Expr::Kind::BuiltinMod || kind == Expr::Kind::BuiltinPow ||
         kind == Expr::Kind::RotateLeft || kind == Expr::Kind::RotateRight) {
@@ -1717,29 +1517,30 @@ private:
       if (failed(rhs)) {
         return failure();
       }
-      expr->rhs = *rhs;
+      expr.rhs = *rhs;
     }
 
     if (failed(expect(TokenKind::RParen))) {
       return failure();
     }
-    return expr;
+    return sink.addExpression(expr);
   }
 
-  [[nodiscard]] Expr* makeBinary(const Expr::Kind kind, const Expr* lhs,
-                                 const Expr* rhs, const SMLoc loc) {
-    auto* expr = makeExpr();
-    expr->loc = loc;
-    expr->kind = kind;
-    expr->lhs = lhs;
-    expr->rhs = rhs;
-    return expr;
+  [[nodiscard]] SyntaxExpressionId makeBinary(const Expr::Kind kind,
+                                              SyntaxExpressionId lhs,
+                                              SyntaxExpressionId rhs,
+                                              const SMLoc loc) {
+    SyntaxExpression expr;
+    expr.location = loc;
+    expr.kind = kind;
+    expr.lhs = lhs;
+    expr.rhs = rhs;
+    return sink.addExpression(expr);
   }
 
   // Parser collaborators are mandatory and outlive this single parse.
   Lexer& lexer;
-  Sink& sink;
-  llvm::BumpPtrAllocator& allocator;
+  SyntaxBuilder& sink;
   Token currentToken;
   Token nextToken;
   size_t blockDepth = 0;

--- a/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMSemantics.h
+++ b/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMSemantics.h
@@ -19,8 +19,7 @@ namespace mlir::oq3::frontend::detail {
 
 [[nodiscard]] AnalysisResult
 analyzeSyntaxProgram(const SyntaxProgram& syntax,
-                     const llvm::SourceMgr& sources,
-                     const FrontendOptions& options);
+                     const llvm::SourceMgr& sources, GatePolicy gatePolicy);
 
 [[nodiscard]] SourceLocation sourceLocation(const llvm::SourceMgr& sources,
                                             llvm::SMLoc location);

--- a/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMSyntax.h
+++ b/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMSyntax.h
@@ -10,13 +10,12 @@
 
 #pragma once
 
-#include "mlir/Target/OpenQASM/Detail/OpenQASMParser.h"
-
 #include <llvm/ADT/ArrayRef.h>
-#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/ADT/StringSwitch.h>
 #include <llvm/Support/SMLoc.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -28,6 +27,153 @@
 namespace mlir::oq3::frontend::detail {
 
 using SyntaxExpressionId = uint32_t;
+
+/// An exact OpenQASM version, preserving the decimal minor component.
+struct Version {
+  uint32_t major = 0;
+  uint32_t minor = 0;
+};
+
+enum class ScalarKind : uint8_t { Bool, Int, Uint, Float, Angle };
+
+/**
+ * @defgroup ParseVocabulary Parser vocabulary
+ * @brief The vocabulary the parser hands to a sink.
+ *
+ * @details
+ * Expressions use IDs in the persistent syntax arena. Gate-call arrays borrow
+ * parser-local storage until the builder records the statement.
+ */
+
+/**
+ * @ingroup ParseVocabulary
+ * @brief A (sub-)expression.
+ *
+ * @details
+ * Expression kinds shared by parsing and semantic analysis.
+ */
+struct Expr {
+  enum class Kind : uint8_t {
+    Int,
+    Float,
+    BitString,
+    FloatCast,
+    Bool,
+    Identifier,
+    IntCast,
+    BoolCast,
+    BitCast,
+    UintCast,
+    AngleCast,
+    Index,
+    Neg,
+    Not,
+    BitNot,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Equal,
+    NotEqual,
+    Less,
+    LessEqual,
+    Greater,
+    GreaterEqual,
+    And,
+    Or,
+    BitAnd,
+    BitOr,
+    BitXor,
+    ShiftLeft,
+    ShiftRight,
+    /// Built-in math functions
+    ArcCos,
+    ArcSin,
+    ArcTan,
+    Ceiling,
+    Cos,
+    Exp,
+    Floor,
+    Log,
+    Mod,
+    BuiltinMod,
+    PopCount,
+    BuiltinPow,
+    Pow,
+    RotateLeft,
+    RotateRight,
+    Sin,
+    Sqrt,
+    Tan,
+  };
+};
+
+/// Get the kind of the built-in math function @p name.
+[[nodiscard]] inline std::optional<Expr::Kind>
+getMathFunctionKind(StringRef name) {
+  return llvm::StringSwitch<std::optional<Expr::Kind>>(name)
+      .Case("arccos", Expr::Kind::ArcCos)
+      .Case("arcsin", Expr::Kind::ArcSin)
+      .Case("arctan", Expr::Kind::ArcTan)
+      .Case("ceiling", Expr::Kind::Ceiling)
+      .Case("cos", Expr::Kind::Cos)
+      .Case("exp", Expr::Kind::Exp)
+      .Case("floor", Expr::Kind::Floor)
+      .Case("log", Expr::Kind::Log)
+      .Case("mod", Expr::Kind::BuiltinMod)
+      .Case("popcount", Expr::Kind::PopCount)
+      .Case("pow", Expr::Kind::BuiltinPow)
+      .Case("rotl", Expr::Kind::RotateLeft)
+      .Case("rotr", Expr::Kind::RotateRight)
+      .Case("sin", Expr::Kind::Sin)
+      .Case("sqrt", Expr::Kind::Sqrt)
+      .Case("tan", Expr::Kind::Tan)
+      .Default(std::nullopt);
+}
+
+/**
+ * @ingroup ParseVocabulary
+ * @brief A gate modifier: `inv @`, `pow(e) @`, `ctrl(e) @`, or `negctrl(e) @`.
+ */
+struct Modifier {
+  enum class Kind : uint8_t { Inv, Pow, Ctrl, NegCtrl };
+  Kind kind = Kind::Inv;
+  std::optional<SyntaxExpressionId> argument = std::nullopt;
+};
+
+/**
+ * @ingroup ParseVocabulary
+ * @brief A gate operand: a (possibly indexed) identifier, or a hardware qubit.
+ */
+struct Operand {
+  SMLoc loc;
+  StringRef identifier;
+  std::optional<SyntaxExpressionId> index = std::nullopt;
+  std::optional<uint64_t> hardwareQubit;
+};
+
+/// A (possibly indexed) classical reference (e.g., `c` or `c[0]`).
+struct BitReference {
+  SMLoc loc;
+  StringRef identifier;
+  std::optional<SyntaxExpressionId> index = std::nullopt;
+};
+
+/**
+ * @ingroup ParseVocabulary
+ * @brief A parsed gate call.
+ *
+ * @details
+ * Array members are borrowed for the duration of the sink call.
+ */
+struct GateCall {
+  SMLoc loc;
+  StringRef identifier;
+  ArrayRef<Modifier> modifiers;
+  ArrayRef<SyntaxExpressionId> parameters;
+  ArrayRef<Operand> operands;
+};
+
 using SyntaxStatementId = uint32_t;
 using SyntaxIncludeContextId = size_t;
 
@@ -201,22 +347,28 @@ struct SyntaxDiagnostic {
 
 class SyntaxBuilder {
 public:
+  [[nodiscard]] SyntaxExpressionId
+  addExpression(const SyntaxExpression& expression);
   [[nodiscard]] LogicalResult error(SMLoc location, const Twine& message);
   [[nodiscard]] LogicalResult version(SMLoc location, Version value);
   [[nodiscard]] LogicalResult include(SMLoc location, StringRef filename);
   [[nodiscard]] SyntaxStatementId
   standardLibraryInclude(SMLoc location, StandardLibraryKind kind);
-  [[nodiscard]] LogicalResult scalarDecl(SMLoc location, ScalarKind kind,
-                                         StringRef identifier, const Expr* size,
-                                         const Expr* initializer, bool isConst,
-                                         bool output);
   [[nodiscard]] LogicalResult
-  assignment(SMLoc location, const BitReference& target, const Expr& value);
+  scalarDecl(SMLoc location, ScalarKind kind, StringRef identifier,
+             std::optional<SyntaxExpressionId> size,
+             std::optional<SyntaxExpressionId> initializer, bool isConst,
+             bool output);
+  [[nodiscard]] LogicalResult assignment(SMLoc location,
+                                         const BitReference& target,
+                                         SyntaxExpressionId value);
   [[nodiscard]] LogicalResult
-  qubitRegister(SMLoc location, StringRef identifier, const Expr* size);
+  qubitRegister(SMLoc location, StringRef identifier,
+                std::optional<SyntaxExpressionId> size);
   [[nodiscard]] LogicalResult
-  classicalRegister(SMLoc location, StringRef identifier, const Expr* size,
-                    const Expr* initializer, bool output);
+  classicalRegister(SMLoc location, StringRef identifier,
+                    std::optional<SyntaxExpressionId> size,
+                    std::optional<SyntaxExpressionId> initializer, bool output);
   [[nodiscard]] LogicalResult
   measure(SMLoc location, const BitReference* target, const Operand& source);
   [[nodiscard]] LogicalResult reset(SMLoc location, const Operand& operand);
@@ -228,23 +380,23 @@ public:
                  ArrayRef<StringRef> parameters, ArrayRef<StringRef> qubits,
                  function_ref<LogicalResult()> continuation);
   [[nodiscard]] LogicalResult
-  ifStmt(SMLoc location, const Expr& condition,
+  ifStmt(SMLoc location, SyntaxExpressionId condition,
          function_ref<LogicalResult()> thenContinuation,
          function_ref<LogicalResult()> elseContinuation);
   [[nodiscard]] LogicalResult
   forStmt(SMLoc location, StringRef inductionVariable, bool isUnsigned,
-          const Expr& start, const Expr& step, const Expr& stop,
-          function_ref<LogicalResult()> continuation);
+          SyntaxExpressionId start, SyntaxExpressionId step,
+          SyntaxExpressionId stop, function_ref<LogicalResult()> continuation);
   [[nodiscard]] LogicalResult breakStmt(SMLoc location);
   [[nodiscard]] LogicalResult continueStmt(SMLoc location);
   [[nodiscard]] LogicalResult
-  whileStmt(SMLoc location, const Expr& condition,
+  whileStmt(SMLoc location, SyntaxExpressionId condition,
             function_ref<LogicalResult()> continuation);
   [[nodiscard]] LogicalResult
-  switchStmt(SMLoc location, const Expr& control,
+  switchStmt(SMLoc location, SyntaxExpressionId control,
              function_ref<LogicalResult()> continuation);
   [[nodiscard]] LogicalResult
-  switchCase(SMLoc location, ArrayRef<const Expr*> labels,
+  switchCase(SMLoc location, ArrayRef<SyntaxExpressionId> labels,
              function_ref<LogicalResult()> continuation);
   [[nodiscard]] LogicalResult
   switchDefault(SMLoc location, function_ref<LogicalResult()> continuation);
@@ -265,7 +417,6 @@ public:
       std::vector<SyntaxIncludeContext> contexts);
 
 private:
-  [[nodiscard]] SyntaxExpressionId copyExpression(const Expr& expression);
   [[nodiscard]] SyntaxOperand copyOperand(const Operand& operand);
   [[nodiscard]] SyntaxBitReference
   copyBitReference(const BitReference& reference);

--- a/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMSyntax.h
+++ b/mlir/include/mlir/Target/OpenQASM/Detail/OpenQASMSyntax.h
@@ -146,7 +146,7 @@ struct Modifier {
  * @brief A gate operand: a (possibly indexed) identifier, or a hardware qubit.
  */
 struct Operand {
-  SMLoc loc;
+  SMLoc location;
   StringRef identifier;
   std::optional<SyntaxExpressionId> index = std::nullopt;
   std::optional<uint64_t> hardwareQubit;
@@ -154,7 +154,7 @@ struct Operand {
 
 /// A (possibly indexed) classical reference (e.g., `c` or `c[0]`).
 struct BitReference {
-  SMLoc loc;
+  SMLoc location;
   StringRef identifier;
   std::optional<SyntaxExpressionId> index = std::nullopt;
 };
@@ -190,30 +190,12 @@ struct SyntaxExpression {
   std::optional<SyntaxExpressionId> rhs;
 };
 
-struct SyntaxOperand {
-  SMLoc location;
-  StringRef identifier;
-  std::optional<SyntaxExpressionId> index;
-  std::optional<uint64_t> hardwareQubit;
-};
-
-struct SyntaxBitReference {
-  SMLoc location;
-  StringRef identifier;
-  std::optional<SyntaxExpressionId> index;
-};
-
-struct SyntaxModifier {
-  Modifier::Kind kind = Modifier::Kind::Inv;
-  std::optional<SyntaxExpressionId> argument;
-};
-
 struct SyntaxGateCall {
   SMLoc location;
   StringRef identifier;
-  std::vector<SyntaxModifier> modifiers;
+  std::vector<Modifier> modifiers;
   std::vector<SyntaxExpressionId> parameters;
-  std::vector<SyntaxOperand> operands;
+  std::vector<Operand> operands;
 };
 
 struct SyntaxScalarDeclaration {
@@ -226,7 +208,7 @@ struct SyntaxScalarDeclaration {
 };
 
 struct SyntaxAssignment {
-  SyntaxBitReference target;
+  BitReference target;
   SyntaxExpressionId value = 0;
 };
 
@@ -243,16 +225,16 @@ struct SyntaxBitDeclaration {
 };
 
 struct SyntaxMeasurement {
-  std::optional<SyntaxBitReference> target;
-  SyntaxOperand source;
+  std::optional<BitReference> target;
+  Operand source;
 };
 
 struct SyntaxReset {
-  SyntaxOperand operand;
+  Operand operand;
 };
 
 struct SyntaxBarrier {
-  std::vector<SyntaxOperand> operands;
+  std::vector<Operand> operands;
 };
 
 struct SyntaxGateDefinition {
@@ -417,9 +399,6 @@ public:
       std::vector<SyntaxIncludeContext> contexts);
 
 private:
-  [[nodiscard]] SyntaxOperand copyOperand(const Operand& operand);
-  [[nodiscard]] SyntaxBitReference
-  copyBitReference(const BitReference& reference);
   [[nodiscard]] SyntaxGateCall copyGateCall(const GateCall& call);
   [[nodiscard]] SyntaxStatementId addStatement(SMLoc location,
                                                SyntaxStatementData data);

--- a/mlir/include/mlir/Target/OpenQASM/Frontend.h
+++ b/mlir/include/mlir/Target/OpenQASM/Frontend.h
@@ -62,10 +62,6 @@ enum class GatePolicy : uint8_t {
   MQTCompatibility,
 };
 
-struct FrontendOptions {
-  GatePolicy gatePolicy = GatePolicy::MQTCompatibility;
-};
-
 struct AnalysisResult;
 struct ParseResult;
 
@@ -87,7 +83,7 @@ private:
   friend ParseResult parseOpenQASM(llvm::StringRef source);
   friend ParseResult parseOpenQASM(llvm::SourceMgr& sourceMgr);
   friend AnalysisResult analyzeOpenQASM(const ParsedProgram& program,
-                                        const FrontendOptions& options);
+                                        GatePolicy gatePolicy);
 };
 
 struct ParseResult {
@@ -410,13 +406,14 @@ struct AnalysisResult {
 
 [[nodiscard]] AnalysisResult
 analyzeOpenQASM(const ParsedProgram& program,
-                const FrontendOptions& options = {});
+                GatePolicy gatePolicy = GatePolicy::MQTCompatibility);
 
 [[nodiscard]] AnalysisResult
 analyzeOpenQASM(llvm::SourceMgr& sourceMgr,
-                const FrontendOptions& options = {});
+                GatePolicy gatePolicy = GatePolicy::MQTCompatibility);
 
 [[nodiscard]] AnalysisResult
-analyzeOpenQASM(llvm::StringRef source, const FrontendOptions& options = {});
+analyzeOpenQASM(llvm::StringRef source,
+                GatePolicy gatePolicy = GatePolicy::MQTCompatibility);
 
 } // namespace mlir::oq3::frontend

--- a/mlir/include/mlir/Target/OpenQASM/Frontend.h
+++ b/mlir/include/mlir/Target/OpenQASM/Frontend.h
@@ -27,6 +27,11 @@ class SourceMgr;
 
 namespace mlir::oq3::frontend {
 
+/// Builtin floating constants reserved by the source language.
+[[nodiscard]] std::optional<double> getBuiltinConstant(llvm::StringRef name);
+/// Whether the whole spelling is an identifier that can be declared.
+[[nodiscard]] bool isValidIdentifier(llvm::StringRef name);
+
 using ExpressionId = uint32_t;
 using BitVectorExpressionId = uint32_t;
 using RegisterId = uint32_t;
@@ -232,7 +237,6 @@ enum class ConditionKind : uint8_t {
   Not,
   And,
   Or,
-  RegisterComparison,
   BitVectorComparison,
   Comparison,
 };
@@ -246,8 +250,6 @@ struct ConditionExpression {
   QubitReference measurement;
   ConditionId lhs = 0;
   ConditionId rhs = 0;
-  RegisterId reg = 0;
-  llvm::APInt expected = llvm::APInt(1, 0);
   BitVectorExpressionId bitVectorComparisonLhs = 0;
   BitVectorExpressionId bitVectorComparisonRhs = 0;
   ExpressionId comparisonLhs = 0;

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -71,13 +71,13 @@ using oq3::frontend::GateLowering;
 class OpenQASMToQCEmitter {
   class EmissionBudget final : public OpBuilder::Listener {
   public:
-    explicit EmissionBudget(MLIRContext& mlirContext)
-        : location(UnknownLoc::get(&mlirContext)) {}
+    explicit EmissionBudget(MLIRContext& mlirContext, size_t limit)
+        : operationLimit(limit), location(UnknownLoc::get(&mlirContext)) {}
 
     void setLocation(const Location newLocation) { location = newLocation; }
 
     [[nodiscard]] bool canConstruct(const size_t amount) {
-      if (exhausted || amount > OPERATION_LIMIT - operationCount) {
+      if (exhausted || amount > operationLimit - operationCount) {
         report();
         return false;
       }
@@ -92,15 +92,14 @@ class OpenQASMToQCEmitter {
         return;
       }
       ++operationCount;
-      if (operationCount > OPERATION_LIMIT) {
+      if (operationCount > operationLimit) {
         report();
       }
     }
 
-    static constexpr size_t OPERATION_LIMIT = 10'000'000;
-
   private:
     size_t operationCount = 0;
+    size_t operationLimit;
     Location location;
     bool exhausted = false;
 
@@ -117,19 +116,18 @@ class OpenQASMToQCEmitter {
 
 public:
   OpenQASMToQCEmitter(const oq3::frontend::TypedProgram& typedProgram,
-                      MLIRContext& mlirContext)
-      : program(typedProgram), context(mlirContext), emissionBudget(context),
-        builder(&context), qubitValues(program.registers.size()),
+                      MLIRContext& mlirContext, size_t operationLimit)
+      : program(typedProgram), context(mlirContext),
+        emissionBudget(context, operationLimit), builder(&context),
+        qubitValues(program.registers.size()),
         classicalRegisters(program.registers.size()),
-        scalarValues(program.scalars.size()),
-        expressionEmissionCosts(program.expressions.size()),
-        bitVectorExpressionEmissionCosts(program.bitVectorExpressions.size()) {
+        scalarValues(program.scalars.size()) {
     context
         .loadDialect<qc::QCDialect, arith::ArithDialect, cf::ControlFlowDialect,
                      func::FuncDialect, LLVM::LLVMDialect, math::MathDialect,
                      memref::MemRefDialect, scf::SCFDialect, ub::UBDialect>();
     builder.setListener(&emissionBudget);
-    builder.initialize();
+    builder.initialize(TypeRange{});
     for (const auto& gate : program.gates) {
       customGateIndex.try_emplace(gate.name, &gate);
       structuredGateCapabilities.try_emplace(
@@ -146,7 +144,7 @@ public:
   }
 
   OwningOpRef<ModuleOp> emit() {
-    if (!preflight()) {
+    if (emissionBudget.isExhausted() || !preflight()) {
       return nullptr;
     }
     for (const auto& gate : program.gates) {
@@ -187,13 +185,8 @@ public:
       }
       results.push_back(reg);
     }
-    OwningOpRef<ModuleOp> moduleOp;
-    if (results.empty()) {
-      moduleOp = builder.finalize();
-    } else {
-      builder.retype(ValueRange(results).getTypes());
-      moduleOp = builder.finalize(results);
-    }
+    builder.retype(ValueRange(results).getTypes());
+    auto moduleOp = builder.finalize(results);
     if (emissionBudget.isExhausted()) {
       return nullptr;
     }
@@ -210,8 +203,6 @@ private:
   std::vector<Value> classicalRegisters;
   std::vector<Value> scalarValues;
   llvm::DenseMap<frontend::ScalarId, Value> provenInductionValues;
-  mutable std::vector<std::optional<size_t>> expressionEmissionCosts;
-  mutable std::vector<std::optional<size_t>> bitVectorExpressionEmissionCosts;
   DenseMap<const oq3::frontend::GateDefinition*, bool>
       structuredGateCapabilities;
   llvm::StringMap<const oq3::frontend::GateDefinition*> customGateIndex;
@@ -229,9 +220,6 @@ private:
   getLocation(const frontend::SourceLocation& source) const {
     return getOpenQASMLocation(source, context);
   }
-
-  static constexpr size_t PROJECTED_EMISSION_LIMIT =
-      EmissionBudget::OPERATION_LIMIT;
 
   [[nodiscard]] static bool
   isExactlyRepresentableAsDouble(const uint64_t magnitude) {
@@ -290,138 +278,11 @@ private:
     return structuredGateCapabilities.lookup(&gate);
   }
 
-  [[nodiscard]] std::optional<bool>
-  staticCondition(const frontend::ConditionId id) const {
-    const auto& condition = program.conditions.at(id);
-    if (condition.kind == frontend::ConditionKind::Literal) {
-      return condition.literal;
-    }
-    return std::nullopt;
-  }
-
-  [[nodiscard]] bool reportProjectedEmissionLimit(
-      const oq3::frontend::SourceLocation& source) const {
-    emitError(getLocation(source))
-        << "OpenQASM QC emission error: projected emitted operation count "
-           "exceeds the safe lowering limit";
-    return false;
-  }
-
-  [[nodiscard]] bool
-  chargeProjectedEmission(const size_t amount, size_t& projectedEmission,
-                          const oq3::frontend::SourceLocation& source) const {
-    if (amount > PROJECTED_EMISSION_LIMIT - projectedEmission) {
-      return reportProjectedEmissionLimit(source);
-    }
-    projectedEmission += amount;
-    return true;
-  }
-
-  [[nodiscard]] bool
-  chargeScaledEmission(const size_t amount, const size_t multiplicity,
-                       size_t& projectedEmission,
-                       const oq3::frontend::SourceLocation& source) const {
-    if (multiplicity != 0 && amount > PROJECTED_EMISSION_LIMIT / multiplicity) {
-      return reportProjectedEmissionLimit(source);
-    }
-    return chargeProjectedEmission(amount * multiplicity, projectedEmission,
-                                   source);
-  }
-
-  [[nodiscard]] size_t
-  expressionEmissionCost(const frontend::ExpressionId id) const {
-    if (expressionEmissionCosts[id]) {
-      return *expressionEmissionCosts[id];
-    }
-    const auto& expression = program.expressions.at(id);
-    const auto add = [](const size_t lhs, const size_t rhs) {
-      return lhs > PROJECTED_EMISSION_LIMIT || rhs > PROJECTED_EMISSION_LIMIT ||
-                     lhs > PROJECTED_EMISSION_LIMIT - rhs
-                 ? PROJECTED_EMISSION_LIMIT + 1
-                 : lhs + rhs;
-    };
-    const auto remember = [&](const size_t cost) {
-      expressionEmissionCosts[id] = cost;
-      return cost;
-    };
-    const auto unary = [&](const size_t local) {
-      return add(expressionEmissionCost(expression.lhs), local);
-    };
-    const auto binary = [&](const size_t local) {
-      return add(add(expressionEmissionCost(expression.lhs),
-                     expressionEmissionCost(expression.rhs)),
-                 local);
-    };
-    switch (expression.kind) {
-    case frontend::ExpressionKind::Constant:
-      return remember(1);
-    case frontend::ExpressionKind::GateParameter:
-    case frontend::ExpressionKind::Variable:
-      return remember(0);
-    case frontend::ExpressionKind::Condition: {
-      size_t cost = 0;
-      if (!chargeConditionEmission(
-              expression.condition, 1, cost,
-              program.conditions.at(expression.condition).location)) {
-        return remember(PROJECTED_EMISSION_LIMIT + 1);
-      }
-      return remember(cost);
-    }
-    case frontend::ExpressionKind::BitNot:
-      return remember(unary(2));
-    case frontend::ExpressionKind::BitAnd:
-    case frontend::ExpressionKind::BitOr:
-    case frontend::ExpressionKind::BitXor:
-      return remember(binary(1));
-    case frontend::ExpressionKind::ShiftLeft:
-    case frontend::ExpressionKind::ShiftRight:
-      return remember(binary(9));
-    case frontend::ExpressionKind::Cast:
-      return remember(unary(2));
-    case frontend::ExpressionKind::BitVectorCast: {
-      return remember(
-          add(bitVectorExpressionEmissionCost(expression.bitVector), 1));
-    }
-    case frontend::ExpressionKind::Negate:
-      if (expression.type == frontend::ScalarType::Float ||
-          expression.type == frontend::ScalarType::Angle) {
-        return remember(unary(1));
-      }
-      return remember(unary(2));
-    case frontend::ExpressionKind::ArcCos:
-    case frontend::ExpressionKind::ArcSin:
-    case frontend::ExpressionKind::ArcTan:
-    case frontend::ExpressionKind::Ceiling:
-    case frontend::ExpressionKind::Sin:
-    case frontend::ExpressionKind::Cos:
-    case frontend::ExpressionKind::Floor:
-    case frontend::ExpressionKind::Tan:
-    case frontend::ExpressionKind::Exp:
-    case frontend::ExpressionKind::Log:
-    case frontend::ExpressionKind::Sqrt:
-      return remember(unary(2));
-    case frontend::ExpressionKind::PopCount: {
-      return remember(
-          add(bitVectorExpressionEmissionCost(expression.bitVector), 2));
-    }
-    case frontend::ExpressionKind::Add:
-    case frontend::ExpressionKind::Subtract:
-    case frontend::ExpressionKind::Multiply:
-    case frontend::ExpressionKind::Divide:
-    case frontend::ExpressionKind::Modulo:
-      return remember(binary(1));
-    case frontend::ExpressionKind::Power:
-      if (expression.type == frontend::ScalarType::Float) {
-        return remember(binary(3));
-      }
-      return remember(
-          binary(expression.type == frontend::ScalarType::Uint ? 16 : 42));
-    }
-    llvm_unreachable("unknown scalar expression kind");
-  }
-
   Value emitProvenIndexExpression(OpBuilder& opBuilder,
                                   const frontend::ExpressionId id) {
+    if (emissionBudget.isExhausted()) {
+      return {};
+    }
     const auto& expression = program.expressions.at(id);
     auto loc = opBuilder.getInsertionPoint() == opBuilder.getBlock()->end()
                    ? opBuilder.getUnknownLoc()
@@ -446,13 +307,22 @@ private:
     case frontend::ExpressionKind::Negate: {
       auto zero = arith::ConstantIndexOp::create(opBuilder, loc, 0);
       auto operand = emitProvenIndexExpression(opBuilder, expression.lhs);
+      if (!operand) {
+        return {};
+      }
       return arith::SubIOp::create(opBuilder, loc, zero, operand);
     }
     case frontend::ExpressionKind::Add:
     case frontend::ExpressionKind::Subtract:
     case frontend::ExpressionKind::Multiply: {
       auto lhs = emitProvenIndexExpression(opBuilder, expression.lhs);
+      if (!lhs) {
+        return {};
+      }
       auto rhs = emitProvenIndexExpression(opBuilder, expression.rhs);
+      if (!rhs) {
+        return {};
+      }
       switch (expression.kind) {
       case frontend::ExpressionKind::Add:
         return arith::AddIOp::create(opBuilder, loc, lhs, rhs);
@@ -467,463 +337,6 @@ private:
     default:
       llvm_unreachable("semantic analysis produced a non-affine expression");
     }
-  }
-
-  [[nodiscard]] size_t bitVectorExpressionEmissionCost(
-      const frontend::BitVectorExpressionId id) const {
-    if (bitVectorExpressionEmissionCosts[id]) {
-      return *bitVectorExpressionEmissionCosts[id];
-    }
-    const auto& expression = program.bitVectorExpressions.at(id);
-    const auto add = [](const size_t lhs, const size_t rhs) {
-      return lhs > PROJECTED_EMISSION_LIMIT || rhs > PROJECTED_EMISSION_LIMIT ||
-                     lhs > PROJECTED_EMISSION_LIMIT - rhs
-                 ? PROJECTED_EMISSION_LIMIT + 1
-                 : lhs + rhs;
-    };
-    const auto remember = [&](const size_t cost) {
-      bitVectorExpressionEmissionCosts[id] = cost;
-      return cost;
-    };
-    switch (expression.kind) {
-    case frontend::BitVectorExpressionKind::ScalarCast:
-      return remember(expressionEmissionCost(expression.scalar));
-    case frontend::BitVectorExpressionKind::Constant:
-    case frontend::BitVectorExpressionKind::Register:
-      return remember(1);
-    case frontend::BitVectorExpressionKind::Not:
-      return remember(
-          add(bitVectorExpressionEmissionCost(expression.operand), 2));
-    case frontend::BitVectorExpressionKind::And:
-    case frontend::BitVectorExpressionKind::Or:
-    case frontend::BitVectorExpressionKind::Xor:
-      return remember(
-          add(add(bitVectorExpressionEmissionCost(expression.operand),
-                  bitVectorExpressionEmissionCost(expression.rhs)),
-              1));
-    case frontend::BitVectorExpressionKind::ShiftLeft:
-    case frontend::BitVectorExpressionKind::ShiftRight:
-      return remember(
-          add(add(bitVectorExpressionEmissionCost(expression.operand),
-                  expressionEmissionCost(expression.distance)),
-              9));
-    case frontend::BitVectorExpressionKind::RotateLeft:
-    case frontend::BitVectorExpressionKind::RotateRight:
-      break;
-    }
-    const auto operand = bitVectorExpressionEmissionCost(expression.operand);
-    const auto distance = expressionEmissionCost(expression.distance);
-    return remember(add(add(operand, distance), 6));
-  }
-
-  [[nodiscard]] bool
-  chargeExpressionEmission(const frontend::ExpressionId id,
-                           const size_t multiplicity, size_t& projectedEmission,
-                           const frontend::SourceLocation& source) const {
-    return chargeScaledEmission(expressionEmissionCost(id), multiplicity,
-                                projectedEmission, source);
-  }
-
-  [[nodiscard]] bool
-  chargeDynamicBitRead(const frontend::BitReference& reference,
-                       const size_t multiplicity, size_t& projectedEmission,
-                       const frontend::SourceLocation& source) const {
-    if (!reference.dynamicIndex) {
-      return chargeScaledEmission(2, multiplicity, projectedEmission, source);
-    }
-    return chargeExpressionEmission(*reference.dynamicIndex, multiplicity,
-                                    projectedEmission, source) &&
-           chargeScaledEmission(11, multiplicity, projectedEmission, source);
-  }
-
-  [[nodiscard]] bool
-  chargeQubitAccesses(const ArrayRef<frontend::QubitReference> references,
-                      const size_t multiplicity, size_t& projectedEmission,
-                      const oq3::frontend::SourceLocation& source) const {
-    for (const auto& reference : references) {
-      if (reference.kind != frontend::QubitReferenceKind::Register ||
-          program.registers.at(reference.symbol).isScalar) {
-        continue;
-      }
-
-      if (reference.provenIndex &&
-          !chargeExpressionEmission(*reference.provenIndex, multiplicity,
-                                    projectedEmission, source)) {
-        return false;
-      }
-      // Each access emits an index value and a load. Semantic analysis has
-      // already proved a nonconstant index's bounds and uniqueness.
-      if (!chargeScaledEmission(2, multiplicity, projectedEmission, source)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  [[nodiscard]] size_t
-  modifierEmissionCost(const frontend::GateApplication& application) const {
-    auto cost = application.modifiers.size();
-    for (const auto& modifier : application.modifiers) {
-      if (modifier.kind == frontend::ModifierKind::Pow) {
-        const auto& expression = program.expressions.at(*modifier.operand);
-        if (expression.kind != frontend::ExpressionKind::Constant &&
-            (expression.type == frontend::ScalarType::Int ||
-             expression.type == frontend::ScalarType::Uint)) {
-          cost += expression.type == frontend::ScalarType::Int ? 17 : 14;
-        }
-        continue;
-      }
-      if (modifier.kind != frontend::ModifierKind::NegCtrl) {
-        continue;
-      }
-      uint64_t controls = 1;
-      if (modifier.operand) {
-        const auto& expression = program.expressions.at(*modifier.operand);
-        controls =
-            expression.type == frontend::ScalarType::Uint
-                ? std::get<uint64_t>(expression.constant)
-                : static_cast<uint64_t>(std::get<int64_t>(expression.constant));
-      }
-      if (controls > PROJECTED_EMISSION_LIMIT / 2) {
-        return PROJECTED_EMISSION_LIMIT + 1;
-      }
-      cost += static_cast<size_t>(2 * controls);
-    }
-    return cost;
-  }
-
-  [[nodiscard]] bool
-  chargeConditionEmission(const frontend::ConditionId id,
-                          const size_t multiplicity, size_t& projectedEmission,
-                          const oq3::frontend::SourceLocation& source) const {
-    const auto& condition = program.conditions.at(id);
-    if (condition.kind == frontend::ConditionKind::Measurement) {
-      return chargeQubitAccesses({condition.measurement}, multiplicity,
-                                 projectedEmission, source) &&
-             chargeScaledEmission(1, multiplicity, projectedEmission, source);
-    }
-    if (condition.kind == frontend::ConditionKind::Literal) {
-      return chargeScaledEmission(1, multiplicity, projectedEmission, source);
-    }
-    if (condition.kind == frontend::ConditionKind::Bit) {
-      return chargeDynamicBitRead(condition.bit, multiplicity,
-                                  projectedEmission, source);
-    }
-    if (condition.kind == frontend::ConditionKind::RegisterComparison) {
-      return chargeScaledEmission(3, multiplicity, projectedEmission, source);
-    }
-    if (condition.kind == frontend::ConditionKind::BitVectorComparison) {
-      return chargeScaledEmission(bitVectorExpressionEmissionCost(
-                                      condition.bitVectorComparisonLhs),
-                                  multiplicity, projectedEmission, source) &&
-             chargeScaledEmission(bitVectorExpressionEmissionCost(
-                                      condition.bitVectorComparisonRhs),
-                                  multiplicity, projectedEmission, source) &&
-             chargeScaledEmission(1, multiplicity, projectedEmission, source);
-    }
-    if (condition.kind == frontend::ConditionKind::Comparison) {
-      return chargeExpressionEmission(condition.comparisonLhs, multiplicity,
-                                      projectedEmission, source) &&
-             chargeExpressionEmission(condition.comparisonRhs, multiplicity,
-                                      projectedEmission, source) &&
-             chargeScaledEmission(3, multiplicity, projectedEmission, source);
-    }
-    if (condition.kind == frontend::ConditionKind::Not) {
-      return chargeConditionEmission(condition.lhs, multiplicity,
-                                     projectedEmission, source) &&
-             chargeScaledEmission(2, multiplicity, projectedEmission, source);
-    }
-    if (condition.kind == frontend::ConditionKind::And ||
-        condition.kind == frontend::ConditionKind::Or) {
-      return chargeConditionEmission(condition.lhs, multiplicity,
-                                     projectedEmission, source) &&
-             chargeConditionEmission(condition.rhs, multiplicity,
-                                     projectedEmission, source) &&
-             chargeScaledEmission(5, multiplicity, projectedEmission, source);
-    }
-    return true;
-  }
-
-  [[nodiscard]] bool
-  preflightStatements(const ArrayRef<oq3::frontend::StatementId> statements,
-                      size_t& projectedEmission,
-                      const size_t multiplicity = 1) {
-    for (const auto id : statements) {
-      const auto& statement = program.statements.at(id);
-      const auto* application =
-          std::get_if<oq3::frontend::GateApplication>(&statement.data);
-      if (application == nullptr) {
-        if (const auto* conditional =
-                std::get_if<oq3::frontend::IfStatement>(&statement.data)) {
-          if (!chargeConditionEmission(conditional->condition, multiplicity,
-                                       projectedEmission, statement.location)) {
-            return false;
-          }
-          if (const auto selected = staticCondition(conditional->condition)) {
-            const auto& selectedStatements = *selected
-                                                 ? conditional->thenStatements
-                                                 : conditional->elseStatements;
-            if (!preflightStatements(selectedStatements, projectedEmission,
-                                     multiplicity)) {
-              return false;
-            }
-            continue;
-          }
-          if (!preflightStatements(conditional->thenStatements,
-                                   projectedEmission, multiplicity) ||
-              !preflightStatements(conditional->elseStatements,
-                                   projectedEmission, multiplicity) ||
-              !chargeScaledEmission(5, multiplicity, projectedEmission,
-                                    statement.location)) {
-            return false;
-          }
-        } else if (const auto* loop = std::get_if<oq3::frontend::ForStatement>(
-                       &statement.data)) {
-          const size_t localCost = loop->provenPositiveRange ? 7 : 16;
-          if (!chargeScaledEmission(localCost, multiplicity, projectedEmission,
-                                    statement.location) ||
-              !chargeExpressionEmission(loop->start, multiplicity,
-                                        projectedEmission,
-                                        statement.location) ||
-              !chargeExpressionEmission(loop->step, multiplicity,
-                                        projectedEmission,
-                                        statement.location) ||
-              !chargeExpressionEmission(loop->stop, multiplicity,
-                                        projectedEmission,
-                                        statement.location) ||
-              !preflightStatements(loop->body, projectedEmission,
-                                   multiplicity)) {
-            return false;
-          }
-        } else if (const auto* loop =
-                       std::get_if<oq3::frontend::WhileStatement>(
-                           &statement.data)) {
-          if (!chargeConditionEmission(loop->condition, multiplicity,
-                                       projectedEmission, statement.location) ||
-              !chargeScaledEmission(10, multiplicity, projectedEmission,
-                                    statement.location)) {
-            return false;
-          }
-          if (!preflightStatements(loop->body, projectedEmission,
-                                   multiplicity)) {
-            return false;
-          }
-        } else if (const auto* switchStatement =
-                       std::get_if<oq3::frontend::SwitchStatement>(
-                           &statement.data)) {
-          if (!chargeExpressionEmission(switchStatement->control, multiplicity,
-                                        projectedEmission,
-                                        statement.location) ||
-              !chargeScaledEmission(3, multiplicity, projectedEmission,
-                                    statement.location)) {
-            return false;
-          }
-          for (const auto& switchCase : switchStatement->cases) {
-            const auto labelCount = switchCase.labels.size();
-            if (!chargeScaledEmission(labelCount, multiplicity,
-                                      projectedEmission, statement.location)) {
-              return false;
-            }
-            if (labelCount != 0 &&
-                multiplicity > PROJECTED_EMISSION_LIMIT / labelCount) {
-              return reportProjectedEmissionLimit(statement.location);
-            }
-            const auto caseMultiplicity = multiplicity * labelCount;
-            if (!preflightStatements(switchCase.body, projectedEmission,
-                                     caseMultiplicity)) {
-              return false;
-            }
-          }
-          if (!preflightStatements(switchStatement->defaultStatements,
-                                   projectedEmission, multiplicity)) {
-            return false;
-          }
-        } else if (const auto* declaration =
-                       std::get_if<frontend::ScalarDeclarationStatement>(
-                           &statement.data)) {
-          if (!chargeScaledEmission(2, multiplicity, projectedEmission,
-                                    statement.location) ||
-              (declaration->initializer &&
-               !chargeExpressionEmission(*declaration->initializer,
-                                         multiplicity, projectedEmission,
-                                         statement.location)) ||
-              (declaration->conditionInitializer &&
-               !chargeConditionEmission(*declaration->conditionInitializer,
-                                        multiplicity, projectedEmission,
-                                        statement.location))) {
-            return false;
-          }
-        } else if (const auto* assignment =
-                       std::get_if<frontend::ScalarAssignmentStatement>(
-                           &statement.data)) {
-          if ((assignment->value &&
-               !chargeExpressionEmission(*assignment->value, multiplicity,
-                                         projectedEmission,
-                                         statement.location)) ||
-              (assignment->condition &&
-               !chargeConditionEmission(*assignment->condition, multiplicity,
-                                        projectedEmission,
-                                        statement.location)) ||
-              !chargeScaledEmission(1, multiplicity, projectedEmission,
-                                    statement.location)) {
-            return false;
-          }
-        } else if (const auto* assignment =
-                       std::get_if<frontend::BitAssignmentStatement>(
-                           &statement.data)) {
-          if (!chargeConditionEmission(assignment->value, multiplicity,
-                                       projectedEmission, statement.location) ||
-              (!assignment->target.dynamicIndex &&
-               !chargeScaledEmission(2, multiplicity, projectedEmission,
-                                     statement.location))) {
-            return false;
-          }
-          if (assignment->target.dynamicIndex) {
-            const auto width = static_cast<size_t>(
-                program.registers.at(assignment->target.reg).width);
-            if (!chargeExpressionEmission(*assignment->target.dynamicIndex,
-                                          multiplicity, projectedEmission,
-                                          statement.location) ||
-                !chargeScaledEmission(9 + (3 * width), multiplicity,
-                                      projectedEmission, statement.location)) {
-              return false;
-            }
-          }
-        } else if (const auto* assignment =
-                       std::get_if<frontend::BitVectorAssignmentStatement>(
-                           &statement.data)) {
-          if (!chargeScaledEmission(
-                  bitVectorExpressionEmissionCost(assignment->value),
-                  multiplicity, projectedEmission, statement.location) ||
-              !chargeScaledEmission(1, multiplicity, projectedEmission,
-                                    statement.location)) {
-            return false;
-          }
-        } else if (std::holds_alternative<frontend::DeclarationStatement>(
-                       statement.data)) {
-          if (!chargeScaledEmission(1, multiplicity, projectedEmission,
-                                    statement.location)) {
-            return false;
-          }
-        } else if (const auto* measurement =
-                       std::get_if<frontend::MeasurementStatement>(
-                           &statement.data)) {
-          for (const auto& qubit : measurement->qubits) {
-            if (!chargeQubitAccesses({qubit}, multiplicity, projectedEmission,
-                                     statement.location) ||
-                !chargeScaledEmission(1, multiplicity, projectedEmission,
-                                      statement.location)) {
-              return false;
-            }
-          }
-          for (const auto& target : measurement->targets) {
-            if (!target.dynamicIndex &&
-                !chargeScaledEmission(2, multiplicity, projectedEmission,
-                                      statement.location)) {
-              return false;
-            }
-            if (!target.dynamicIndex) {
-              continue;
-            }
-            const auto width =
-                static_cast<size_t>(program.registers.at(target.reg).width);
-            if (!chargeExpressionEmission(*target.dynamicIndex, multiplicity,
-                                          projectedEmission,
-                                          statement.location) ||
-                !chargeScaledEmission(9 + (3 * width), multiplicity,
-                                      projectedEmission, statement.location)) {
-              return false;
-            }
-          }
-        } else if (const auto* reset =
-                       std::get_if<frontend::ResetStatement>(&statement.data)) {
-          for (const auto& qubit : reset->qubits) {
-            if (!chargeQubitAccesses({qubit}, multiplicity, projectedEmission,
-                                     statement.location) ||
-                !chargeScaledEmission(1, multiplicity, projectedEmission,
-                                      statement.location)) {
-              return false;
-            }
-          }
-        } else if (const auto* barrier =
-                       std::get_if<frontend::BarrierStatement>(
-                           &statement.data)) {
-          const bool canEmitBarrier =
-              chargeQubitAccesses(barrier->qubits, multiplicity,
-                                  projectedEmission, statement.location) &&
-              chargeScaledEmission(1, multiplicity, projectedEmission,
-                                   statement.location);
-          if (!canEmitBarrier) {
-            return false;
-          }
-        }
-        continue;
-      }
-      for (const auto& modifier : application->modifiers) {
-        if (modifier.kind == oq3::frontend::ModifierKind::Pow &&
-            !isExactlyRepresentableAsDouble(
-                program.expressions.at(*modifier.operand))) {
-          emitError(getLocation(statement.location))
-              << "OpenQASM QC emission error: power modifier exponent cannot "
-                 "be represented exactly as an f64";
-          return false;
-        }
-      }
-      for (const auto parameter : application->parameters) {
-        if (!chargeExpressionEmission(parameter, multiplicity,
-                                      projectedEmission, statement.location)) {
-          return false;
-        }
-      }
-      for (const auto& modifier : application->modifiers) {
-        if (modifier.operand &&
-            !chargeExpressionEmission(*modifier.operand, multiplicity,
-                                      projectedEmission, statement.location)) {
-          return false;
-        }
-      }
-      if (!chargeQubitAccesses(application->qubits, multiplicity,
-                               projectedEmission, statement.location)) {
-        return false;
-      }
-      const auto* gate = findCustomGate(application->callee);
-      if (gate == nullptr) {
-        auto leafCost = modifierEmissionCost(*application) + 1;
-        if (const auto* catalog =
-                oq3::frontend::lookupGate(application->callee)) {
-          if (catalog->controlCount != 0 || catalog->variadicControls) {
-            ++leafCost;
-          }
-          if (catalog->lowering == GateLowering::CU ||
-              catalog->lowering == GateLowering::U2 ||
-              catalog->lowering == GateLowering::U3 ||
-              (catalog->lowering == GateLowering::BuiltinU &&
-               program.openQASM2)) {
-            leafCost += 4;
-          } else if (catalog->lowering == GateLowering::BuiltinU) {
-            leafCost += 3;
-          }
-        }
-        if (!chargeScaledEmission(leafCost, multiplicity, projectedEmission,
-                                  statement.location)) {
-          return false;
-        }
-        continue;
-      }
-      if (!chargeScaledEmission(modifierEmissionCost(*application) + 1,
-                                multiplicity, projectedEmission,
-                                statement.location)) {
-        return false;
-      }
-      if (!application->modifiers.empty() &&
-          gateRequiresStructuredControlFlow(*gate)) {
-        emitError(getLocation(statement.location))
-            << "OpenQASM QC emission error: modifiers on custom gates with "
-               "structured control flow are not supported by the QC dialect";
-        return false;
-      }
-    }
-    return true;
   }
 
   [[nodiscard]] bool preflight() {
@@ -965,14 +378,7 @@ private:
         }
       }
     }
-    size_t projectedEmission = program.registers.size() + 4;
-    for (const auto& gate : program.gates) {
-      if (!chargeProjectedEmission(2, projectedEmission, gate.location) ||
-          !preflightStatements(gate.body, projectedEmission)) {
-        return false;
-      }
-    }
-    return preflightStatements(program.body, projectedEmission);
+    return true;
   }
 
   [[nodiscard]] static Value conditionalIntegerMultiply(OpBuilder& opBuilder,
@@ -1109,6 +515,9 @@ private:
   [[nodiscard]] Value
   emitBitVectorExpression(OpBuilder& opBuilder,
                           const frontend::BitVectorExpressionId id) {
+    if (emissionBudget.isExhausted()) {
+      return {};
+    }
     const auto& expression = program.bitVectorExpressions.at(id);
     auto loc = UnknownLoc::get(opBuilder.getContext());
     const auto type =
@@ -1126,6 +535,9 @@ private:
     }
     case frontend::BitVectorExpressionKind::Not: {
       auto operand = emitBitVectorExpression(opBuilder, expression.operand);
+      if (!operand) {
+        return {};
+      }
       auto ones = arith::ConstantOp::create(
           opBuilder, loc,
           IntegerAttr::get(type, APInt::getAllOnes(expression.width)));
@@ -1135,7 +547,13 @@ private:
     case frontend::BitVectorExpressionKind::Or:
     case frontend::BitVectorExpressionKind::Xor: {
       auto lhs = emitBitVectorExpression(opBuilder, expression.operand);
+      if (!lhs) {
+        return {};
+      }
       auto rhs = emitBitVectorExpression(opBuilder, expression.rhs);
+      if (!rhs) {
+        return {};
+      }
       if (expression.kind == frontend::BitVectorExpressionKind::And) {
         return arith::AndIOp::create(opBuilder, loc, lhs, rhs);
       }
@@ -1147,7 +565,13 @@ private:
     case frontend::BitVectorExpressionKind::ShiftLeft:
     case frontend::BitVectorExpressionKind::ShiftRight: {
       auto operand = emitBitVectorExpression(opBuilder, expression.operand);
+      if (!operand) {
+        return {};
+      }
       auto distance = emitExpression(opBuilder, expression.distance, {});
+      if (!distance) {
+        return {};
+      }
       return mqt::buildZeroFillingShift(
           opBuilder, loc, operand, distance,
           expression.kind == frontend::BitVectorExpressionKind::ShiftLeft);
@@ -1158,6 +582,9 @@ private:
     }
 
     auto operand = emitBitVectorExpression(opBuilder, expression.operand);
+    if (!operand) {
+      return {};
+    }
     const auto& distanceExpression =
         program.expressions.at(expression.distance);
     if (distanceExpression.kind == frontend::ExpressionKind::Constant) {
@@ -1180,6 +607,9 @@ private:
     }
 
     auto distance = emitExpression(opBuilder, expression.distance, {});
+    if (!distance) {
+      return {};
+    }
     distance =
         emitScalarCast(opBuilder, loc, distance, frontend::ScalarType::Int,
                        frontend::ScalarType::Int);
@@ -1209,6 +639,9 @@ private:
 
   Value emitExpression(OpBuilder& opBuilder, const frontend::ExpressionId id,
                        ValueRange gateParameters) {
+    if (emissionBudget.isExhausted()) {
+      return {};
+    }
     const auto& expression = program.expressions.at(id);
     auto loc = opBuilder.getInsertionPoint() == opBuilder.getBlock()->end()
                    ? opBuilder.getUnknownLoc()
@@ -1248,6 +681,9 @@ private:
       return scalarValues.at(expression.variable);
     case frontend::ExpressionKind::Cast: {
       auto operand = emitExpression(opBuilder, expression.lhs, gateParameters);
+      if (!operand) {
+        return {};
+      }
       return emitScalarCast(opBuilder, loc, operand,
                             program.expressions.at(expression.lhs).type,
                             expression.type, expression.integerWidth);
@@ -1259,6 +695,9 @@ private:
       return emitCondition(expression.condition, gateParameters, {});
     case frontend::ExpressionKind::BitNot: {
       auto operand = emitExpression(opBuilder, expression.lhs, gateParameters);
+      if (!operand) {
+        return {};
+      }
       auto ones =
           arith::ConstantIntOp::create(opBuilder, loc, operand.getType(), -1);
       return arith::XOrIOp::create(opBuilder, loc, operand, ones);
@@ -1269,7 +708,13 @@ private:
     case frontend::ExpressionKind::ShiftLeft:
     case frontend::ExpressionKind::ShiftRight: {
       auto lhs = emitExpression(opBuilder, expression.lhs, gateParameters);
+      if (!lhs) {
+        return {};
+      }
       auto rhs = emitExpression(opBuilder, expression.rhs, gateParameters);
+      if (!rhs) {
+        return {};
+      }
       switch (expression.kind) {
       case frontend::ExpressionKind::BitAnd:
         return arith::AndIOp::create(opBuilder, loc, lhs, rhs);
@@ -1285,6 +730,9 @@ private:
     }
     case frontend::ExpressionKind::Negate: {
       auto operand = emitExpression(opBuilder, expression.lhs, gateParameters);
+      if (!operand) {
+        return {};
+      }
       if (isa<FloatType>(operand.getType())) {
         return arith::NegFOp::create(opBuilder, loc, operand);
       }
@@ -1304,6 +752,9 @@ private:
     case frontend::ExpressionKind::Log:
     case frontend::ExpressionKind::Sqrt: {
       Value operand = emitExpression(opBuilder, expression.lhs, gateParameters);
+      if (!operand) {
+        return {};
+      }
       assert(isa<FloatType>(operand.getType()) &&
              "semantic analysis must normalize math operands");
       switch (expression.kind) {
@@ -1337,6 +788,9 @@ private:
       const auto& bitVector =
           program.bitVectorExpressions.at(expression.bitVector);
       auto packed = emitBitVectorExpression(opBuilder, expression.bitVector);
+      if (!packed) {
+        return {};
+      }
       auto count = math::CtPopOp::create(opBuilder, loc, packed);
       if (bitVector.width < 64) {
         return arith::ExtUIOp::create(opBuilder, loc, opBuilder.getI64Type(),
@@ -1355,7 +809,13 @@ private:
     case frontend::ExpressionKind::Modulo:
     case frontend::ExpressionKind::Power: {
       auto lhs = emitExpression(opBuilder, expression.lhs, gateParameters);
+      if (!lhs) {
+        return {};
+      }
       auto rhs = emitExpression(opBuilder, expression.rhs, gateParameters);
+      if (!rhs) {
+        return {};
+      }
       if (expression.type != frontend::ScalarType::Float &&
           expression.type != frontend::ScalarType::Angle) {
         const bool isUnsigned = expression.type == frontend::ScalarType::Uint;
@@ -1415,6 +875,9 @@ private:
                                        const int64_t width,
                                        const llvm::StringRef message) {
     auto index = emitExpression(builder, expression, {});
+    if (!index) {
+      return {};
+    }
     const auto type = program.expressions.at(expression).type;
     index = emitScalarCast(builder, builder.getLoc(), index, type, type);
     auto zero = builder.intConstant(0);
@@ -1461,6 +924,9 @@ private:
   emitQubitIndices(ArrayRef<frontend::QubitReference> references) {
     SmallVector<Value> indices(references.size());
     for (const auto [position, reference] : llvm::enumerate(references)) {
+      if (emissionBudget.isExhausted()) {
+        return {};
+      }
       if (reference.kind != frontend::QubitReferenceKind::Register ||
           program.registers.at(reference.symbol).isScalar) {
         continue;
@@ -1472,6 +938,9 @@ private:
       }
       indices[position] =
           emitProvenIndexExpression(builder, *reference.provenIndex);
+      if (!indices[position]) {
+        return {};
+      }
     }
     return indices;
   }
@@ -1482,6 +951,9 @@ private:
     SmallVector<Value> resolved;
     resolved.reserve(references.size());
     for (const auto [position, reference] : llvm::enumerate(references)) {
+      if (emissionBudget.isExhausted()) {
+        return {};
+      }
       resolved.push_back(
           resolveQubit(reference, gateQubits, indices[position]));
     }
@@ -1493,6 +965,9 @@ private:
                      ValueRange gateQubits,
                      llvm::function_ref<Value(Value)> emitResolvedOperation) {
     const auto indices = emitQubitIndices({reference});
+    if (indices.empty()) {
+      return {};
+    }
     return emitResolvedOperation(
         resolveQubit(reference, gateQubits, indices.front()));
   }
@@ -1537,6 +1012,9 @@ private:
       auto qubits = arguments.drop_front(gate.parameterCount);
       for (const auto statement : gate.body) {
         emitStatement(statement, parameters, qubits);
+        if (emissionFailed || emissionBudget.isExhausted()) {
+          return;
+        }
       }
     };
 
@@ -1697,10 +1175,32 @@ private:
                            const frontend::GateApplication& application,
                            const Location loc, ValueRange gateParameters,
                            ValueRange gateQubits) {
+    for (const auto& modifier : application.modifiers) {
+      if (modifier.kind == frontend::ModifierKind::Pow &&
+          !isExactlyRepresentableAsDouble(
+              program.expressions.at(*modifier.operand))) {
+        emissionFailed = true;
+        emitError(loc) << "OpenQASM QC emission error: power modifier exponent "
+                          "cannot be represented exactly as an f64";
+        return;
+      }
+    }
+    if (const auto* gate = findCustomGate(application.callee);
+        gate != nullptr && !application.modifiers.empty() &&
+        gateRequiresStructuredControlFlow(*gate)) {
+      emissionFailed = true;
+      emitError(loc)
+          << "OpenQASM QC emission error: modifiers on custom gates with "
+             "structured control flow are not supported by the QC dialect";
+      return;
+    }
     SmallVector<Value> parameters;
     parameters.reserve(application.parameters.size());
     for (const auto expression : application.parameters) {
       Value parameter = emitExpression(opBuilder, expression, gateParameters);
+      if (!parameter) {
+        return;
+      }
       if (isa<IntegerType>(parameter.getType())) {
         if (program.expressions.at(expression).type ==
             frontend::ScalarType::Uint) {
@@ -1714,6 +1214,9 @@ private:
       parameters.push_back(parameter);
     }
     const auto qubitIndices = emitQubitIndices(application.qubits);
+    if (emissionBudget.isExhausted()) {
+      return;
+    }
     SmallVector<int64_t> controlCounts(application.modifiers.size(), 0);
     SmallVector<std::variant<double, Value>> modifierOperands(
         application.modifiers.size());
@@ -1743,6 +1246,9 @@ private:
         }
         auto exponent =
             emitExpression(opBuilder, *modifier.operand, gateParameters);
+        if (!exponent) {
+          return;
+        }
         if (isa<IntegerType>(exponent.getType())) {
           exponent = emitExactlyRepresentableIntegerAsF64(
               opBuilder, loc, exponent,
@@ -1759,6 +1265,9 @@ private:
       if (modifier.operand) {
         auto countValue =
             emitExpression(opBuilder, *modifier.operand, gateParameters);
+        if (!countValue) {
+          return;
+        }
         auto constant = countValue.getDefiningOp<arith::ConstantIntOp>();
         if (!constant || constant.value() <= 0) {
           emissionFailed = true;
@@ -1773,6 +1282,9 @@ private:
 
     const auto qubits =
         resolveQubits(application.qubits, gateQubits, qubitIndices);
+    if (emissionBudget.isExhausted()) {
+      return;
+    }
     size_t negativeOffset = 0;
     for (const auto [position, modifier] :
          llvm::enumerate(application.modifiers)) {
@@ -1781,6 +1293,9 @@ private:
         if (modifier.kind == frontend::ModifierKind::NegCtrl) {
           for (auto control : ValueRange(qubits).slice(
                    negativeOffset, controlCounts[position])) {
+            if (!emissionBudget.canConstruct(1)) {
+              return;
+            }
             qc::XOp::create(opBuilder, loc, control);
           }
         }
@@ -1798,6 +1313,9 @@ private:
         if (modifier.kind == frontend::ModifierKind::NegCtrl) {
           for (auto control : ValueRange(qubits).slice(
                    negativeOffset, controlCounts[position])) {
+            if (!emissionBudget.canConstruct(1)) {
+              return;
+            }
             qc::XOp::create(opBuilder, loc, control);
           }
         }
@@ -1890,6 +1408,9 @@ private:
         static_cast<int64_t>(program.registers.at(reference.reg).width);
     auto index = emitCheckedIndex(*reference.dynamicIndex, width,
                                   "dynamic classical index out of bounds");
+    if (!index) {
+      return {};
+    }
     auto registerIndex =
         arith::IndexCastOp::create(builder, builder.getIndexType(), index);
     return builder.loadClassicalBit(reg, registerIndex.getResult());
@@ -1919,7 +1440,13 @@ private:
   emitComparison(const frontend::ConditionExpression& condition,
                  ValueRange gateParameters) {
     auto lhs = emitExpression(builder, condition.comparisonLhs, gateParameters);
+    if (!lhs) {
+      return {};
+    }
     auto rhs = emitExpression(builder, condition.comparisonRhs, gateParameters);
+    if (!rhs) {
+      return {};
+    }
     const auto lhsType = program.expressions.at(condition.comparisonLhs).type;
     const auto rhsType = program.expressions.at(condition.comparisonRhs).type;
     assert(lhsType == rhsType &&
@@ -1954,6 +1481,9 @@ private:
   [[nodiscard]] Value emitCondition(const frontend::ConditionId id,
                                     ValueRange gateParameters,
                                     ValueRange gateQubits) {
+    if (emissionBudget.isExhausted()) {
+      return {};
+    }
     const auto& condition = program.conditions.at(id);
     switch (condition.kind) {
     case frontend::ConditionKind::Literal:
@@ -1966,33 +1496,35 @@ private:
       return emitQubitOperation(
           condition.measurement, gateQubits,
           [&](Value qubit) { return builder.measure(qubit); });
-    case frontend::ConditionKind::RegisterComparison: {
-      auto reg = classicalRegisters.at(condition.reg);
-      assert(reg && "semantic analysis must declare bit registers before use");
-      auto rhs = builder.getIntegerAttr(
-          builder.getIntegerType(condition.expected.getBitWidth()),
-          condition.expected);
-      const auto predicate =
-          integerPredicate(condition.comparison, /*isUnsigned=*/true);
-      auto value = cbit::ReadOp::create(builder, rhs.getType(), reg);
-      auto constant = arith::ConstantOp::create(builder, rhs);
-      return arith::CmpIOp::create(builder, predicate, value, constant);
-    }
+
     case frontend::ConditionKind::BitVectorComparison: {
       auto lhs =
           emitBitVectorExpression(builder, condition.bitVectorComparisonLhs);
+      if (!lhs) {
+        return {};
+      }
       auto rhs =
           emitBitVectorExpression(builder, condition.bitVectorComparisonRhs);
+      if (!rhs) {
+        return {};
+      }
       return arith::CmpIOp::create(
           builder, integerPredicate(condition.comparison, /*isUnsigned=*/true),
           lhs, rhs);
     }
-    case frontend::ConditionKind::Not:
-      return arith::XOrIOp::create(
-          builder, emitCondition(condition.lhs, gateParameters, gateQubits),
-          builder.boolConstant(true));
+    case frontend::ConditionKind::Not: {
+      auto operand = emitCondition(condition.lhs, gateParameters, gateQubits);
+      if (!operand) {
+        return {};
+      }
+      return arith::XOrIOp::create(builder, operand,
+                                   builder.boolConstant(true));
+    }
     case frontend::ConditionKind::And: {
       auto lhs = emitCondition(condition.lhs, gateParameters, gateQubits);
+      if (!lhs) {
+        return {};
+      }
       auto ifOp = scf::IfOp::create(builder, builder.getI1Type(), lhs, true);
       OpBuilder::InsertionGuard guard(builder);
       auto& thenBlock = ifOp.getThenRegion().front();
@@ -2000,8 +1532,11 @@ private:
         thenBlock.back().erase();
       }
       builder.setInsertionPointToEnd(&thenBlock);
-      scf::YieldOp::create(
-          builder, emitCondition(condition.rhs, gateParameters, gateQubits));
+      auto rhs = emitCondition(condition.rhs, gateParameters, gateQubits);
+      if (!rhs) {
+        return {};
+      }
+      scf::YieldOp::create(builder, rhs);
       auto& elseBlock = ifOp.getElseRegion().front();
       if (!elseBlock.empty()) {
         elseBlock.back().erase();
@@ -2012,6 +1547,9 @@ private:
     }
     case frontend::ConditionKind::Or: {
       auto lhs = emitCondition(condition.lhs, gateParameters, gateQubits);
+      if (!lhs) {
+        return {};
+      }
       auto ifOp = scf::IfOp::create(builder, builder.getI1Type(), lhs, true);
       OpBuilder::InsertionGuard guard(builder);
       auto& thenBlock = ifOp.getThenRegion().front();
@@ -2025,8 +1563,11 @@ private:
         elseBlock.back().erase();
       }
       builder.setInsertionPointToEnd(&elseBlock);
-      scf::YieldOp::create(
-          builder, emitCondition(condition.rhs, gateParameters, gateQubits));
+      auto rhs = emitCondition(condition.rhs, gateParameters, gateQubits);
+      if (!rhs) {
+        return {};
+      }
+      scf::YieldOp::create(builder, rhs);
       return ifOp.getResult(0);
     }
     case frontend::ConditionKind::Comparison:
@@ -2150,11 +1691,21 @@ private:
           } else if constexpr (std::is_same_v<T, frontend::ResetStatement>) {
             for (const auto& qubit : data.qubits) {
               const auto indices = emitQubitIndices({qubit});
+              if (emissionBudget.isExhausted()) {
+                return;
+              }
               builder.reset(resolveQubit(qubit, gateQubits, indices.front()));
             }
           } else if constexpr (std::is_same_v<T, frontend::BarrierStatement>) {
             const auto indices = emitQubitIndices(data.qubits);
-            builder.barrier(resolveQubits(data.qubits, gateQubits, indices));
+            if (emissionBudget.isExhausted()) {
+              return;
+            }
+            const auto qubits = resolveQubits(data.qubits, gateQubits, indices);
+            if (emissionBudget.isExhausted()) {
+              return;
+            }
+            builder.barrier(qubits);
           } else if constexpr (std::is_same_v<T, frontend::IfStatement>) {
             emitIf(data, gateParameters, gateQubits);
           } else if constexpr (std::is_same_v<T, frontend::ForStatement>) {
@@ -2206,19 +1757,20 @@ private:
       value =
           arith::ConstantOp::create(builder, type, builder.getZeroAttr(type));
     }
-    scalarValues.at(statement.scalar) = value;
+    if (value) {
+      scalarValues.at(statement.scalar) = value;
+    }
   }
 
   void
   emitScalarAssignment(const frontend::ScalarAssignmentStatement& statement,
                        ValueRange gateQubits) {
-    if (statement.value) {
-      scalarValues.at(statement.scalar) =
-          emitExpression(builder, *statement.value, {});
-      return;
+    auto value = statement.value
+                     ? emitExpression(builder, *statement.value, {})
+                     : emitCondition(*statement.condition, {}, gateQubits);
+    if (value) {
+      scalarValues.at(statement.scalar) = value;
     }
-    scalarValues.at(statement.scalar) =
-        emitCondition(*statement.condition, {}, gateQubits);
   }
 
   void emitDeclaration(const frontend::DeclarationStatement& statement) {
@@ -2259,6 +1811,9 @@ private:
         static_cast<int64_t>(program.registers.at(target.reg).width);
     auto index = emitCheckedIndex(*target.dynamicIndex, width,
                                   "dynamic classical index out of bounds");
+    if (!index) {
+      return;
+    }
     auto registerIndex =
         arith::IndexCastOp::create(builder, builder.getIndexType(), index);
     builder.storeClassicalBit(value, reg, registerIndex.getResult());
@@ -2266,13 +1821,19 @@ private:
 
   void emitBitAssignment(const frontend::BitAssignmentStatement& assignment,
                          ValueRange gateQubits) {
-    assignBit(assignment.target,
-              emitCondition(assignment.value, {}, gateQubits));
+    auto value = emitCondition(assignment.value, {}, gateQubits);
+    if (!value) {
+      return;
+    }
+    assignBit(assignment.target, value);
   }
 
   void emitBitVectorAssignment(
       const frontend::BitVectorAssignmentStatement& assignment) {
     auto value = emitBitVectorExpression(builder, assignment.value);
+    if (!value) {
+      return;
+    }
     auto reg = classicalRegisters[assignment.target];
     assert(reg && "semantic analysis must declare bit registers before use");
     cbit::WriteOp::create(builder, builder.getUnknownLoc(), value, reg);
@@ -2283,6 +1844,9 @@ private:
     if (measurement.targets.empty()) {
       for (const auto& qubit : measurement.qubits) {
         const auto indices = emitQubitIndices({qubit});
+        if (emissionBudget.isExhausted()) {
+          return;
+        }
         std::ignore =
             builder.measure(resolveQubit(qubit, gateQubits, indices.front()));
       }
@@ -2301,7 +1865,8 @@ private:
     }
   }
 
-  bool hasLoopJump(ArrayRef<frontend::StatementId> statements) const {
+  [[nodiscard]] bool
+  hasLoopJump(ArrayRef<frontend::StatementId> statements) const {
     return llvm::any_of(statements, [&](auto id) {
       return std::visit(
           [&](const auto& data) -> bool {
@@ -2370,11 +1935,17 @@ private:
                                  : conditional.elseStatements;
       for (const auto statement : selected) {
         emitStatement(statement, gateParameters, gateQubits);
+        if (emissionFailed || emissionBudget.isExhausted()) {
+          return;
+        }
       }
       return;
     }
     auto condition =
         emitCondition(conditional.condition, gateParameters, gateQubits);
+    if (!condition) {
+      return;
+    }
     SmallVector<frontend::StatementId> nestedStatements(
         conditional.thenStatements.begin(), conditional.thenStatements.end());
     nestedStatements.append(conditional.elseStatements.begin(),
@@ -2386,11 +1957,17 @@ private:
           [&] {
             for (auto statement : conditional.thenStatements) {
               emitStatement(statement, gateParameters, gateQubits);
+              if (emissionFailed || emissionBudget.isExhausted()) {
+                return;
+              }
             }
           },
           [&] {
             for (auto statement : conditional.elseStatements) {
               emitStatement(statement, gateParameters, gateQubits);
+              if (emissionFailed || emissionBudget.isExhausted()) {
+                return;
+              }
             }
           });
       return;
@@ -2417,6 +1994,9 @@ private:
       builder.setInsertionPointToEnd(&block);
       for (const auto statement : statements) {
         emitStatement(statement, gateParameters, gateQubits);
+        if (emissionFailed || emissionBudget.isExhausted()) {
+          return;
+        }
       }
       scf::YieldOp::create(builder, stateValues(slots));
     };
@@ -2489,8 +2069,17 @@ private:
   [[nodiscard]] std::array<Value, 3>
   emitWideRange(const frontend::ForStatement& loop) {
     auto start = emitExpression(builder, loop.start, {});
+    if (!start) {
+      return {};
+    }
     auto step = emitExpression(builder, loop.step, {});
+    if (!step) {
+      return {};
+    }
     auto stop = emitExpression(builder, loop.stop, {});
+    if (!stop) {
+      return {};
+    }
     auto i128 = builder.getIntegerType(128);
     const bool unsignedEndpoints =
         program.expressions.at(loop.start).type == frontend::ScalarType::Uint ||
@@ -2523,8 +2112,17 @@ private:
 
     if (loop.provenPositiveRange) {
       auto start = emitProvenIndexExpression(builder, loop.start);
+      if (!start) {
+        return;
+      }
       auto step = emitProvenIndexExpression(builder, loop.step);
+      if (!step) {
+        return;
+      }
       auto stop = emitProvenIndexExpression(builder, loop.stop);
+      if (!stop) {
+        return;
+      }
       auto exclusiveStop = builder.createOrFold<arith::AddIOp>(
           stop, arith::ConstantIndexOp::create(builder, 1));
       auto forOp = scf::ForOp::create(builder, start, exclusiveStop, step,
@@ -2543,6 +2141,9 @@ private:
             builder, builder.getI64Type(), forOp.getInductionVar());
         for (const auto statement : loop.body) {
           emitStatement(statement, gateParameters, gateQubits);
+          if (emissionFailed || emissionBudget.isExhausted()) {
+            return;
+          }
         }
         scf::YieldOp::create(builder, stateValues(slots));
       }
@@ -2568,6 +2169,9 @@ private:
                                         emitExpression(builder, loop.step, {}),
                          emitExpression(builder, loop.stop, {}),}
                            : emitWideRange(loop);
+    if (!startValue || !stepValue || !stopValue) {
+      return;
+    }
     auto i128 = builder.getIntegerType(128);
     if (const auto tripCount = constantRangeTripCount(loop)) {
       auto lowerBound = arith::ConstantIndexOp::create(builder, 0);
@@ -2593,6 +2197,9 @@ private:
             builder, builder.getI64Type(), inductionWide);
         for (const auto statement : loop.body) {
           emitStatement(statement, gateParameters, gateQubits);
+          if (emissionFailed || emissionBudget.isExhausted()) {
+            return;
+          }
         }
         scf::YieldOp::create(builder, stateValues(slots));
       }
@@ -2641,6 +2248,9 @@ private:
                                             arguments.front());
           for (const auto statement : loop.body) {
             emitStatement(statement, gateParameters, gateQubits);
+            if (emissionFailed || emissionBudget.isExhausted()) {
+              return;
+            }
           }
           SmallVector<Value> yielded{
               arith::AddIOp::create(builder, arguments.front(), stepValue),
@@ -2671,20 +2281,26 @@ private:
     if constexpr (std::is_same_v<Loop, frontend::ForStatement>) {
       indexRange = loop.provenPositiveRange;
       if (indexRange) {
+        auto startIndex = emitProvenIndexExpression(builder, loop.start);
+        auto stepIndex = emitProvenIndexExpression(builder, loop.step);
+        auto stopIndex = emitProvenIndexExpression(builder, loop.stop);
+        if (!startIndex || !stepIndex || !stopIndex) {
+          return;
+        }
         initial.push_back(builder.createOrFold<arith::IndexCastOp>(
-            builder.getI64Type(),
-            emitProvenIndexExpression(builder, loop.start)));
-        step = builder.createOrFold<arith::IndexCastOp>(
-            builder.getI64Type(),
-            emitProvenIndexExpression(builder, loop.step));
-        stop = arith::AddIOp::create(
-            builder,
-            builder.createOrFold<arith::IndexCastOp>(
-                builder.getI64Type(),
-                emitProvenIndexExpression(builder, loop.stop)),
-            arith::ConstantIntOp::create(builder, 1, 64));
+            builder.getI64Type(), startIndex));
+        step = builder.createOrFold<arith::IndexCastOp>(builder.getI64Type(),
+                                                        stepIndex);
+        stop =
+            arith::AddIOp::create(builder,
+                                  builder.createOrFold<arith::IndexCastOp>(
+                                      builder.getI64Type(), stopIndex),
+                                  arith::ConstantIntOp::create(builder, 1, 64));
       } else {
         auto [startWide, stepWide, stopWide] = emitWideRange(loop);
+        if (!startWide || !stepWide || !stopWide) {
+          return;
+        }
         initial.push_back(startWide);
         step = stepWide;
         stop = stopWide;
@@ -2725,9 +2341,15 @@ private:
       assignState(slots, arguments);
       condition = emitCondition(loop.condition, gateParameters, gateQubits);
     }
+    if (!condition || emissionBudget.isExhausted()) {
+      return;
+    }
     cfg.enterBody(condition, arguments);
     for (auto statement : loop.body) {
       emitStatement(statement, gateParameters, gateQubits);
+      if (emissionFailed || emissionBudget.isExhausted()) {
+        return;
+      }
     }
     if (flowReachable) {
       SmallVector<Value> state;
@@ -2736,6 +2358,9 @@ private:
       }
       llvm::append_range(state, stateValues(slots));
       cfg.branch(true, state);
+    }
+    if (emissionFailed || emissionBudget.isExhausted()) {
+      return;
     }
     auto results = cfg.finish();
     flowReachable = true;
@@ -2771,6 +2396,9 @@ private:
           assignState(slots, arguments);
           auto condition =
               emitCondition(loop.condition, gateParameters, gateQubits);
+          if (!condition) {
+            return;
+          }
           scf::ConditionOp::create(builder, condition, stateValues(slots));
         },
         [&](OpBuilder& nested, Location, ValueRange arguments) {
@@ -2781,6 +2409,9 @@ private:
           assignState(slots, arguments);
           for (const auto statement : loop.body) {
             emitStatement(statement, gateParameters, gateQubits);
+            if (emissionFailed || emissionBudget.isExhausted()) {
+              return;
+            }
           }
           scf::YieldOp::create(builder, stateValues(slots));
         });
@@ -2802,17 +2433,29 @@ private:
     const auto savedScalars = scalarValues;
 
     auto control = emitExpression(builder, switchStatement.control, {});
+    if (!control) {
+      return;
+    }
     if (activeLoop != nullptr && hasLoopJump(nestedStatements)) {
       const auto emitCases = [&](auto&& self, size_t index) -> void {
+        if (emissionFailed || emissionBudget.isExhausted()) {
+          return;
+        }
         if (index == switchStatement.cases.size()) {
           for (auto statement : switchStatement.defaultStatements) {
             emitStatement(statement, gateParameters, gateQubits);
+            if (emissionFailed || emissionBudget.isExhausted()) {
+              return;
+            }
           }
           return;
         }
         const auto& branch = switchStatement.cases[index];
         Value match = builder.boolConstant(false);
         for (const auto label : branch.labels) {
+          if (emissionBudget.isExhausted()) {
+            return;
+          }
           auto equal = arith::CmpIOp::create(
               builder, arith::CmpIPredicate::eq, control,
               arith::ConstantIntOp::create(builder, control.getType(), label));
@@ -2823,6 +2466,9 @@ private:
             [&] {
               for (auto statement : branch.body) {
                 emitStatement(statement, gateParameters, gateQubits);
+                if (emissionFailed || emissionBudget.isExhausted()) {
+                  return;
+                }
               }
             },
             [&] { self(self, index + 1); });
@@ -2845,6 +2491,9 @@ private:
           scalarValues = savedScalars;
           for (const auto statement : statements) {
             emitStatement(statement, gateParameters, gateQubits);
+            if (emissionFailed || emissionBudget.isExhausted()) {
+              return;
+            }
           }
           scf::YieldOp::create(builder, stateValues(slots));
         };
@@ -2852,6 +2501,9 @@ private:
     for (const auto& switchCase : switchStatement.cases) {
       for ([[maybe_unused]] const auto label : switchCase.labels) {
         emitBranch(switchOp.getCaseRegions()[region++], switchCase.body);
+        if (emissionFailed || emissionBudget.isExhausted()) {
+          return;
+        }
       }
     }
     emitBranch(switchOp.getDefaultRegion(), switchStatement.defaultStatements);
@@ -2875,8 +2527,9 @@ Location getOpenQASMLocation(const frontend::SourceLocation& source,
 }
 
 OwningOpRef<ModuleOp> emitOpenQASMToQC(const frontend::TypedProgram& program,
-                                       MLIRContext& context) {
-  return OpenQASMToQCEmitter(program, context).emit();
+                                       MLIRContext& context,
+                                       size_t operationLimit) {
+  return OpenQASMToQCEmitter(program, context, operationLimit).emit();
 }
 
 } // namespace mlir::qc::detail

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -1795,7 +1795,10 @@ private:
       return;
     }
     classicalRegisters[statement.reg] = builder.allocClassicalBitRegister(
-        static_cast<int64_t>(declaration.width), declaration.name,
+        static_cast<int64_t>(declaration.width),
+        isa<func::FuncOp>(builder.getInsertionBlock()->getParentOp())
+            ? StringRef(declaration.name)
+            : StringRef{},
         program.openQASM2 ? cbit::Initialization::Zero
                           : cbit::Initialization::Undefined);
   }

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h
@@ -29,7 +29,7 @@ getOpenQASMLocation(const oq3::frontend::SourceLocation& source,
 
 [[nodiscard]] OwningOpRef<ModuleOp>
 emitOpenQASMToQC(const oq3::frontend::TypedProgram& program,
-                 MLIRContext& context, size_t operationLimit = 10'000'000);
+                 MLIRContext& context, size_t operationLimit);
 
 } // namespace qc::detail
 } // namespace mlir

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h
@@ -14,6 +14,8 @@
 
 #include <mlir/IR/OwningOpRef.h>
 
+#include <cstddef>
+
 namespace mlir {
 class MLIRContext;
 class ModuleOp;
@@ -27,7 +29,7 @@ getOpenQASMLocation(const oq3::frontend::SourceLocation& source,
 
 [[nodiscard]] OwningOpRef<ModuleOp>
 emitOpenQASMToQC(const oq3::frontend::TypedProgram& program,
-                 MLIRContext& context);
+                 MLIRContext& context, size_t operationLimit = 10'000'000);
 
 } // namespace qc::detail
 } // namespace mlir

--- a/mlir/lib/Dialect/QC/Translation/TranslateQASM3ToQC.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQASM3ToQC.cpp
@@ -36,7 +36,7 @@ emitDiagnostics(const ArrayRef<oq3::frontend::Diagnostic> diagnostics,
 OwningOpRef<ModuleOp> translateQASM3ToQC(llvm::SourceMgr& sourceMgr,
                                          MLIRContext* context,
                                          const QASM3ImportOptions& options) {
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr, options.frontend);
+  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr, options.gatePolicy);
   if (!analyzed) {
     emitDiagnostics(analyzed.diagnostics, *context);
     return nullptr;

--- a/mlir/lib/Dialect/QC/Translation/TranslateQASM3ToQC.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQASM3ToQC.cpp
@@ -34,13 +34,15 @@ emitDiagnostics(const ArrayRef<oq3::frontend::Diagnostic> diagnostics,
 }
 
 OwningOpRef<ModuleOp> translateQASM3ToQC(llvm::SourceMgr& sourceMgr,
-                                         MLIRContext* context) {
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr);
+                                         MLIRContext* context,
+                                         const QASM3ImportOptions& options) {
+  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr, options.frontend);
   if (!analyzed) {
     emitDiagnostics(analyzed.diagnostics, *context);
     return nullptr;
   }
-  auto moduleOp = detail::emitOpenQASMToQC(*analyzed.program, *context);
+  auto moduleOp = detail::emitOpenQASMToQC(*analyzed.program, *context,
+                                           options.maxOperations);
   if (!moduleOp) {
     return nullptr;
   }
@@ -51,11 +53,12 @@ OwningOpRef<ModuleOp> translateQASM3ToQC(llvm::SourceMgr& sourceMgr,
 }
 
 OwningOpRef<ModuleOp> translateQASM3ToQC(const StringRef source,
-                                         MLIRContext* context) {
+                                         MLIRContext* context,
+                                         const QASM3ImportOptions& options) {
   llvm::SourceMgr sourceMgr;
   sourceMgr.AddNewSourceBuffer(
       llvm::MemoryBuffer::getMemBufferCopy(source, "<input>"), llvm::SMLoc());
-  return translateQASM3ToQC(sourceMgr, context);
+  return translateQASM3ToQC(sourceMgr, context, options);
 }
 
 } // namespace mlir::qc

--- a/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/QC/IR/QCInterfaces.h"
 #include "mlir/Dialect/QC/IR/QCOps.h"
 #include "mlir/Support/IntegerExpressions.h"
+#include "mlir/Target/OpenQASM/Frontend.h"
 #include "mlir/Target/OpenQASM/GateCatalog.h"
 
 #include <llvm/ADT/APInt.h>
@@ -82,7 +83,7 @@ struct Resource {
   cbit::Initialization initialization = cbit::Initialization::Undefined;
 };
 
-struct ScalarOutput {
+struct ProgramOutput {
   Value value;
   std::string name;
   std::string kind;
@@ -97,36 +98,9 @@ struct GateCall {
 
 } // namespace
 
-[[nodiscard]] static bool isOpenQASMIdentifier(const StringRef value) {
-  if (value.empty() ||
-      (!llvm::isAlpha(value.front()) && value.front() != '_')) {
-    return false;
-  }
-  return llvm::all_of(value.drop_front(), [](const char character) {
-    return llvm::isAlnum(character) || character == '_';
-  });
-}
-
-[[nodiscard]] static bool isReservedOpenQASMIdentifier(const StringRef value) {
-  return llvm::StringSwitch<bool>(value)
-      .Cases({"OPENQASM", "include", "input", "output", "const"}, true)
-      .Cases({"let", "fixed", "gate", "def", "extern"}, true)
-      .Cases({"defcalgrammar", "defcal", "cal", "opaque", "box"}, true)
-      .Cases({"delay", "reset", "measure", "barrier"}, true)
-      .Cases({"ctrl", "negctrl", "inv", "pow"}, true)
-      .Cases({"if", "else", "while", "for", "in"}, true)
-      .Cases({"break", "continue", "end", "return"}, true)
-      .Cases({"switch", "case", "default"}, true)
-      .Cases({"qubit", "qreg", "creg", "bit", "bool"}, true)
-      .Cases({"int", "uint", "float", "angle", "complex"}, true)
-      .Cases({"array", "duration", "stretch", "readonly", "mutable"}, true)
-      .Cases({"sizeof", "durationof", "true", "false"}, true)
-      .Default(false);
-}
-
 [[nodiscard]] static bool isValidOutputName(const StringRef value) {
-  return isOpenQASMIdentifier(value) && !value.starts_with("_mqt_") &&
-         !isReservedOpenQASMIdentifier(value) &&
+  return oq3::frontend::isValidIdentifier(value) &&
+         !value.starts_with("_mqt_") &&
          oq3::frontend::lookupGate(value) == nullptr;
 }
 
@@ -156,10 +130,13 @@ public:
     raw_indented_ostream bodyOutput(bodyStream);
     output = &bodyOutput;
 
-    indexClassicalWrites(function.getBody().front());
     if (failed(emitDeclarations()) ||
         failed(emitBlock(function.getBody().front()))) {
       return failure();
+    }
+    if (outputs.empty()) {
+      bodyOutput.unindent();
+      bodyOutput << "}\n";
     }
     bodyOutput.flush();
 
@@ -171,7 +148,7 @@ public:
     for (const auto& definition : gateDefinitions_) {
       sourceStream << definition << "\n";
     }
-    sourceStream << measurementDeclarations << body;
+    sourceStream << body;
     return source;
   }
 
@@ -183,23 +160,19 @@ private:
   SmallVector<Value> resourceOrder;
   DenseMap<Value, std::string> valueNames;
   DenseSet<Value> returnedRegisters;
-  SmallVector<ScalarOutput> scalarOutputs;
+  SmallVector<ProgramOutput> outputs;
   SmallVector<func::FuncOp> gateFunctions_;
   DenseMap<Operation*, std::string> gateNames_;
   SymbolTableCollection symbolTables_;
   llvm::StringSet<> usedNames;
   llvm::StringSet<> fixedHelpers;
   SmallVector<std::string> gateDefinitions_;
-  std::string measurementDeclarations;
-  DenseMap<Operation*, size_t> operationPositions;
-  DenseMap<Block*, DenseMap<Value, SmallVector<size_t>>> classicalWrites;
   Operation* expressionConsumer = nullptr;
   size_t nextQubit = 0;
   size_t nextBit = 0;
   size_t nextScalar = 0;
   size_t nextLoop = 0;
   size_t nextHelper = 0;
-  bool materializeScalars = false;
   size_t expressionNesting = 0;
   size_t expressionWork = 0;
   size_t numClassicalBits = 0;
@@ -384,22 +357,11 @@ private:
     if (!returnOp) {
       return fail(function, "entry block must end in func.return");
     }
-    for (const auto [index, value] : llvm::enumerate(returnOp.getOperands())) {
-      if (returnOp.getNumOperands() == 1 && isCanonicalStatus(value, index)) {
-        continue;
+    for (auto value : returnOp.getOperands()) {
+      if (isa<cbit::RegisterType>(value.getType()) &&
+          !returnedRegisters.insert(value).second) {
+        return fail(returnOp, "repeated register results are not supported");
       }
-      if (isa<cbit::RegisterType>(value.getType())) {
-        returnedRegisters.insert(value);
-        continue;
-      }
-      auto kind = inferScalarKind(value);
-      if (kind.empty()) {
-        return fail(returnOp, "unsupported scalar output type for function "
-                              "result " +
-                                  Twine(index));
-      }
-      scalarOutputs.push_back(
-          {.value = value, .name = outputName({}), .kind = std::move(kind)});
     }
 
     for (Operation& operation : function.getBody().front().getOperations()) {
@@ -468,24 +430,31 @@ private:
       resourceOrder.push_back(alloc.getResult());
     }
 
-    for (auto value : returnedRegisters) {
-      if (!resources.contains(value)) {
-        return fail(returnOp, "returned CBit registers must be entry-block "
-                              "allocations");
+    for (const auto [index, value] : llvm::enumerate(returnOp.getOperands())) {
+      if (isa<cbit::RegisterType>(value.getType())) {
+        const auto found = resources.find(value);
+        if (found == resources.end()) {
+          return fail(
+              returnOp,
+              "returned CBit registers must be entry-block allocations");
+        }
+        outputs.push_back({
+            .value = value,
+            .name = found->second.name,
+            .kind = (Twine("bit[") + Twine(found->second.width) + "]").str(),
+        });
+      } else {
+        auto kind = inferScalarKind(value);
+        if (kind.empty()) {
+          return fail(returnOp,
+                      "unsupported scalar output type for function result " +
+                          Twine(index));
+        }
+        outputs.push_back(
+            {.value = value, .name = outputName({}), .kind = std::move(kind)});
       }
     }
     return success();
-  }
-
-  [[nodiscard]] static bool isCanonicalStatus(Value value,
-                                              const size_t resultIndex) {
-    if (resultIndex != 0 || !value.getType().isInteger(64)) {
-      return false;
-    }
-    auto constant = value.getDefiningOp<arith::ConstantOp>();
-    auto integer =
-        constant ? dyn_cast<IntegerAttr>(constant.getValue()) : IntegerAttr{};
-    return integer && integer.getValue().isZero();
   }
 
   [[nodiscard]] static std::string inferScalarKind(Value value) {
@@ -507,29 +476,39 @@ private:
   }
 
   [[nodiscard]] LogicalResult emitDeclarations() {
+    for (const auto& result : outputs) {
+      *output << "output " << result.kind << ' ' << result.name << ";\n";
+    }
     for (auto value : resourceOrder) {
       const auto& resource = resources.at(value);
-      if (resource.output) {
-        *output << "output ";
+      if (resource.kind != ResourceKind::Qubit) {
+        continue;
       }
-      *output << (resource.kind == ResourceKind::Qubit ? "qubit" : "bit");
+      *output << "qubit";
       if (!resource.scalar) {
         *output << '[' << resource.width << ']';
       }
       *output << ' ' << resource.name << ";\n";
-      if (resource.kind == ResourceKind::Bit &&
-          resource.initialization == cbit::Initialization::Zero) {
-        for (int64_t bit = 0; bit < resource.width; ++bit) {
-          *output << resource.name << '[' << bit << "] = false;\n";
-        }
+    }
+    if (outputs.empty()) {
+      /// Global classical declarations become implicit outputs on import.
+      *output << "if (true) {\n";
+      output->indent();
+    }
+    for (auto value : resourceOrder) {
+      const auto& resource = resources.at(value);
+      if (resource.kind != ResourceKind::Bit) {
+        continue;
+      }
+      if (!resource.output) {
+        *output << "bit[" << resource.width << "] " << resource.name << ";\n";
+      }
+      if (resource.initialization == cbit::Initialization::Zero) {
+        *output << resource.name << " = \"" << std::string(resource.width, '0')
+                << "\";\n";
       }
     }
-    for (const auto& scalar : scalarOutputs) {
-      *output << "output " << scalar.kind << ' ' << scalar.name << ";\n";
-    }
-    if (!resourceOrder.empty() || !scalarOutputs.empty()) {
-      *output << '\n';
-    }
+    *output << '\n';
     return success();
   }
 
@@ -605,12 +584,18 @@ private:
       return fail(&operation,
                   "arith.select is not supported in an OpenQASM gate function");
     }
-    if (materializeScalars && isInlineExpressionOperation(operation) &&
+    const auto resultType =
+        operation.getNumResults() == 1
+            ? dyn_cast<IntegerType>(operation.getResult(0).getType())
+            : IntegerType{};
+    const bool wideBridge =
+        resultType && resultType.getWidth() > 64 &&
+        (isa<arith::ExtUIOp>(&operation) ||
+         operation.getName().getStringRef() == "math.ctpop");
+    if (!gateNames_.contains(function) &&
+        isInlineExpressionOperation(operation) &&
         !isa<arith::ConstantOp>(&operation) && operation.getNumResults() == 1 &&
-        !(isa<cbit::ReadOp>(operation) &&
-          cast<IntegerType>(operation.getResult(0).getType()).getWidth() >
-              64U) &&
-        !operation.getResult(0).use_empty()) {
+        !wideBridge && !operation.getResult(0).use_empty()) {
       return materialize(operation.getResult(0));
     }
     if (isa<qc::AllocOp, memref::AllocOp, cbit::AllocOp>(&operation) &&
@@ -725,60 +710,6 @@ private:
            !mathFunction(name).empty();
   }
 
-  void indexClassicalWrites(Block& block) {
-    size_t position = 0;
-    for (Operation& operation : block) {
-      operationPositions[&operation] = position;
-      DenseSet<Value> writtenRegisters;
-      operation.walk([&](Operation* nested) {
-        if (auto store = dyn_cast<cbit::StoreOp>(nested)) {
-          writtenRegisters.insert(store.getReg());
-        } else if (auto write = dyn_cast<cbit::WriteOp>(nested)) {
-          writtenRegisters.insert(write.getReg());
-        }
-      });
-      for (auto reg : writtenRegisters) {
-        classicalWrites[&block][reg].push_back(position);
-      }
-      for (Region& region : operation.getRegions()) {
-        for (Block& nested : region) {
-          indexClassicalWrites(nested);
-        }
-      }
-      ++position;
-    }
-  }
-
-  [[nodiscard]] LogicalResult validateClassicalSnapshot(Operation* read,
-                                                        Value reg) {
-    if (expressionConsumer == nullptr ||
-        read->getBlock() != expressionConsumer->getBlock()) {
-      return fail(read, "cannot preserve a classical snapshot across a "
-                        "control-flow region");
-    }
-    const auto readPosition = operationPositions.at(read);
-    const auto consumerPosition = operationPositions.at(expressionConsumer);
-    if (readPosition > consumerPosition) {
-      return fail(read, "classical snapshot does not dominate its use");
-    }
-    const auto blockWrites = classicalWrites.find(read->getBlock());
-    if (blockWrites == classicalWrites.end()) {
-      return success();
-    }
-    const auto registerWrites = blockWrites->second.find(reg);
-    if (registerWrites == blockWrites->second.end()) {
-      return success();
-    }
-    auto* const nextWrite =
-        std::upper_bound(registerWrites->second.begin(),
-                         registerWrites->second.end(), readPosition);
-    if (nextWrite != registerWrites->second.end() &&
-        *nextWrite < consumerPosition) {
-      return fail(read, "cannot preserve a stale classical snapshot");
-    }
-    return success();
-  }
-
   [[nodiscard]] FailureOr<std::string> emitQubit(Value value) {
     if (const auto found = valueNames.find(value); found != valueNames.end()) {
       return found->second;
@@ -850,14 +781,16 @@ private:
       return found->second;
     }
     if (auto load = value.getDefiningOp<cbit::LoadOp>()) {
-      if (failed(validateClassicalSnapshot(load, load.getReg()))) {
-        return failure();
+      if (load.getOperation() != expressionConsumer) {
+        return failExpression(value,
+                              "bit load requires a snapshot at its definition");
       }
       return emitBitReference(load.getReg(), load.getIndex());
     }
     if (auto read = value.getDefiningOp<cbit::ReadOp>()) {
-      if (failed(validateClassicalSnapshot(read, read.getReg()))) {
-        return failure();
+      if (read.getOperation() != expressionConsumer) {
+        return failExpression(
+            value, "register read requires a snapshot at its definition");
       }
       const auto resource = resources.find(read.getReg());
       if (resource == resources.end() ||
@@ -1229,7 +1162,7 @@ private:
     switch (predicate) {
     case arith::CmpFPredicate::OEQ:
       return "==";
-    case arith::CmpFPredicate::ONE:
+    case arith::CmpFPredicate::UNE:
       return "!=";
     case arith::CmpFPredicate::OLT:
       return "<";
@@ -1325,9 +1258,13 @@ private:
     if (failed(qubit)) {
       return failure();
     }
+    if (measurement.getResult().use_empty()) {
+      *output << "measure " << *qubit << ";\n";
+      return success();
+    }
     const auto name = uniqueName("b", nextBit);
     valueNames.try_emplace(measurement.getResult(), name);
-    measurementDeclarations += "bit " + name + ";\n";
+    *output << "bit " << name << ";\n";
     *output << name << " = measure " << *qubit << ";\n";
     return success();
   }
@@ -1368,10 +1305,26 @@ private:
   }
 
   [[nodiscard]] LogicalResult materialize(Value value) {
-    auto type = localType(value);
-    auto expression = emitExpression(value);
+    const auto integer = dyn_cast<IntegerType>(value.getType());
+    const bool wide = integer && integer.getWidth() > 64;
+    if (wide) {
+      if (integer.getWidth() > MAX_CLASSICAL_BITS - numClassicalBits) {
+        return fail(value.getDefiningOp(),
+                    "classical snapshots exceed the supported bit limit");
+      }
+      numClassicalBits += integer.getWidth();
+    }
+    auto type =
+        wide ? FailureOr<std::string>(
+                   (Twine("bit[") + Twine(integer.getWidth()) + "]").str())
+             : localType(value);
+    auto expression = emitExpression(value, wide ? ExpressionContext::BitVector
+                                                 : ExpressionContext::Scalar);
     if (failed(type) || failed(expression)) {
       return failure();
+    }
+    if (integer && integer.getWidth() > 1 && !wide) {
+      *expression = *type + "(" + *expression + ")";
     }
     auto name = uniqueName("v", nextScalar);
     *output << *type << ' ' << name << " = " << *expression << ";\n";
@@ -1414,8 +1367,6 @@ private:
     if (failed(declareLocals(ifOp.getResults()))) {
       return failure();
     }
-    llvm::SaveAndRestore materializeGuard(
-        materializeScalars, materializeScalars || ifOp.getNumResults() != 0);
     auto condition = emitExpression(ifOp.getCondition());
     if (failed(condition)) {
       return failure();
@@ -1455,8 +1406,6 @@ private:
          llvm::zip_equal(forOp.getRegionIterArgs(), forOp.getResults())) {
       valueNames[argument] = valueNames.at(result);
     }
-    llvm::SaveAndRestore materializeGuard(
-        materializeScalars, materializeScalars || forOp.getNumResults() != 0);
     const auto lower = getConstantInteger(forOp.getLowerBound());
     const auto upper = getConstantInteger(forOp.getUpperBound());
     const auto step = getConstantInteger(forOp.getStep());
@@ -1526,55 +1475,43 @@ private:
     auto& after = whileOp.getAfter().front();
     auto conditionOp = cast<scf::ConditionOp>(before.getTerminator());
     auto yieldOp = cast<scf::YieldOp>(after.getTerminator());
-    const bool ordinary =
-        whileOp.getInits().empty() && whileOp.getNumResults() == 0 &&
-        llvm::all_of(before.without_terminator(), [](Operation& operation) {
-          return isInlineExpressionOperation(operation) &&
-                 (isa<cbit::LoadOp, cbit::ReadOp>(&operation) ||
-                  isMemoryEffectFree(&operation));
-        });
-    if (!ordinary) {
-      if (failed(declareLocals(before.getArguments())) ||
-          failed(declareLocals(whileOp.getResults())) ||
-          failed(
-              assignEdge(before.getArguments(), whileOp.getInits(), whileOp))) {
-        return failure();
+    if (gateNames_.contains(function)) {
+      if (!whileOp.getInits().empty() || whileOp.getNumResults() != 0 ||
+          !llvm::all_of(before.without_terminator(), [](Operation& operation) {
+            return isInlineExpressionOperation(operation) &&
+                   isMemoryEffectFree(&operation);
+          })) {
+        return fail(
+            whileOp,
+            "gate while loops require a pure condition and no carried values");
       }
-      for (auto [argument, result] :
-           llvm::zip_equal(after.getArguments(), whileOp.getResults())) {
-        valueNames[argument] = valueNames.at(result);
-      }
-      llvm::SaveAndRestore materializeGuard(materializeScalars, true);
-      *output << "while (true) {\n";
-      output->indent();
-      if (failed(emitBlock(before))) {
-        return failure();
-      }
-      llvm::SaveAndRestore consumerGuard(expressionConsumer,
-                                         conditionOp.getOperation());
       auto condition = emitExpression(conditionOp.getCondition());
       if (failed(condition)) {
         return failure();
       }
-      const auto conditionName = uniqueName("cond", nextScalar);
-      *output << "bool " << conditionName << " = " << *condition << ";\n";
-      if (failed(assignEdge(whileOp.getResults(), conditionOp.getArgs(),
-                            conditionOp))) {
-        return failure();
-      }
-      *output << "if (!" << conditionName << ") {\n";
+      *output << "while (" << *condition << ") {\n";
       output->indent();
-      *output << "break;\n";
-      output->unindent();
-      *output << "}\n";
-      if (failed(emitBlock(after)) ||
-          failed(assignEdge(before.getArguments(), yieldOp.getResults(),
-                            yieldOp))) {
+      if (failed(emitBlock(after))) {
         return failure();
       }
       output->unindent();
       *output << "}\n";
       return success();
+    }
+    if (failed(declareLocals(before.getArguments())) ||
+        failed(declareLocals(whileOp.getResults())) ||
+        failed(
+            assignEdge(before.getArguments(), whileOp.getInits(), whileOp))) {
+      return failure();
+    }
+    for (auto [argument, result] :
+         llvm::zip_equal(after.getArguments(), whileOp.getResults())) {
+      valueNames[argument] = valueNames.at(result);
+    }
+    *output << "while (true) {\n";
+    output->indent();
+    if (failed(emitBlock(before))) {
+      return failure();
     }
     llvm::SaveAndRestore consumerGuard(expressionConsumer,
                                        conditionOp.getOperation());
@@ -1582,9 +1519,20 @@ private:
     if (failed(condition)) {
       return failure();
     }
-    *output << "while (" << *condition << ") {\n";
+    const auto conditionName = uniqueName("cond", nextScalar);
+    *output << "bool " << conditionName << " = " << *condition << ";\n";
+    if (failed(assignEdge(whileOp.getResults(), conditionOp.getArgs(),
+                          conditionOp))) {
+      return failure();
+    }
+    *output << "if (!" << conditionName << ") {\n";
     output->indent();
-    if (failed(emitBlock(after))) {
+    *output << "break;\n";
+    output->unindent();
+    *output << "}\n";
+    if (failed(emitBlock(after)) ||
+        failed(
+            assignEdge(before.getArguments(), yieldOp.getResults(), yieldOp))) {
       return failure();
     }
     output->unindent();
@@ -1596,9 +1544,6 @@ private:
     if (failed(declareLocals(switchOp.getResults()))) {
       return failure();
     }
-    llvm::SaveAndRestore materializeGuard(materializeScalars,
-                                          materializeScalars ||
-                                              switchOp.getNumResults() != 0);
     auto argument = emitExpression(switchOp.getArg());
     if (failed(argument)) {
       return failure();
@@ -1635,11 +1580,7 @@ private:
   }
 
   [[nodiscard]] LogicalResult emitReturn(func::ReturnOp returnOp) {
-    size_t scalarIndex = 0;
     for (const auto [index, value] : llvm::enumerate(returnOp.getOperands())) {
-      if (returnOp.getNumOperands() == 1 && isCanonicalStatus(value, index)) {
-        continue;
-      }
       if (isa<cbit::RegisterType>(value.getType())) {
         continue;
       }
@@ -1649,11 +1590,9 @@ private:
       }
       if (auto integer = dyn_cast<IntegerType>(value.getType());
           integer && integer.getWidth() > 1) {
-        *expression = scalarOutputs[scalarIndex].kind + "(" + *expression + ")";
+        *expression = outputs[index].kind + "(" + *expression + ")";
       }
-      *output << scalarOutputs[scalarIndex].name << " = " << *expression
-              << ";\n";
-      ++scalarIndex;
+      *output << outputs[index].name << " = " << *expression << ";\n";
     }
     return success();
   }
@@ -1717,6 +1656,9 @@ private:
         return failure();
       }
       call.parameters.push_back(std::move(*expression));
+    }
+    if (baseSymbol == "u2") {
+      call.parameters.insert(call.parameters.begin(), "pi / 2");
     }
     for (auto qubitValue : unitary.getTargets()) {
       auto qubit = emitQubit(qubitValue);
@@ -1941,8 +1883,9 @@ private:
     if (symbol == "sxdg") {
       return std::string("sx");
     }
-    if (symbol == "u") {
-      return std::string("U");
+    if (symbol == "u" || symbol == "u2") {
+      fixedHelpers.insert("_mqt_u");
+      return std::string("_mqt_u");
     }
     const auto* gate = oq3::frontend::lookupGate(symbol);
     if (gate == nullptr ||
@@ -1961,6 +1904,10 @@ private:
   void emitFixedHelpers(llvm::raw_ostream& stream) const {
     using HelperDefinition = std::pair<StringLiteral, StringLiteral>;
     constexpr std::array helpers{
+        HelperDefinition{"_mqt_u", "gate _mqt_u(p0, p1, p2) q {\n"
+                                   "  gphase(-p0 / 2);\n"
+                                   "  U(p0, p1, p2) q;\n"
+                                   "}\n"},
         HelperDefinition{"r", "gate r(p0, p1) q {\n"
                               "  rz(-p1) q;\n"
                               "  rx(p0) q;\n"

--- a/mlir/lib/Target/OpenQASM/Frontend.cpp
+++ b/mlir/lib/Target/OpenQASM/Frontend.cpp
@@ -21,7 +21,6 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/StringRef.h>
-#include <llvm/Support/Allocator.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/VirtualFileSystem.h>
@@ -30,6 +29,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <numbers>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -37,6 +37,28 @@
 #include <vector>
 
 namespace mlir::oq3::frontend {
+
+std::optional<double> getBuiltinConstant(llvm::StringRef name) {
+  if (name == "pi" || name == "π") {
+    return std::numbers::pi;
+  }
+  if (name == "tau" || name == "τ") {
+    return 2.0 * std::numbers::pi;
+  }
+  if (name == "euler" || name == "ℇ") {
+    return std::numbers::e;
+  }
+  return std::nullopt;
+}
+
+bool isValidIdentifier(llvm::StringRef name) {
+  detail::Lexer lexer(name);
+  const auto token = lexer.next();
+  return token.kind == detail::TokenKind::Identifier &&
+         token.identifier == name &&
+         lexer.next().kind == detail::TokenKind::Eof &&
+         !getBuiltinConstant(name);
+}
 
 struct ParsedProgram::Impl {
   std::unique_ptr<llvm::SourceMgr> sources;
@@ -94,7 +116,6 @@ parseBuffer(std::unique_ptr<llvm::MemoryBuffer> buffer,
     }
   }
 
-  llvm::BumpPtrAllocator allocator;
   detail::SyntaxBuilder builder;
   bool failedParsing = false;
   const auto reportIncludeNestingLimit = [&](const llvm::SMLoc location) {
@@ -124,7 +145,7 @@ parseBuffer(std::unique_ptr<llvm::MemoryBuffer> buffer,
     const auto bodyBegin = builder.getBody().size();
     const auto includeBegin = builder.getIncludes().size();
     detail::Lexer lexer(sources->getMemoryBuffer(bufferId)->getBuffer());
-    detail::Parser parser(lexer, builder, allocator);
+    detail::Parser parser(lexer, builder);
     if (failed(parser.parseProgram())) {
       failedParsing = true;
     }

--- a/mlir/lib/Target/OpenQASM/Frontend.cpp
+++ b/mlir/lib/Target/OpenQASM/Frontend.cpp
@@ -357,27 +357,27 @@ ParseResult parseOpenQASM(const llvm::StringRef source) {
 }
 
 AnalysisResult analyzeOpenQASM(const ParsedProgram& parsedProgram,
-                               const FrontendOptions& options) {
+                               GatePolicy gatePolicy) {
   return detail::analyzeSyntaxProgram(parsedProgram.impl->syntax,
-                                      *parsedProgram.impl->sources, options);
+                                      *parsedProgram.impl->sources, gatePolicy);
 }
 
 AnalysisResult analyzeOpenQASM(llvm::SourceMgr& sourceMgr,
-                               const FrontendOptions& options) {
+                               GatePolicy gatePolicy) {
   auto parsed = parseOpenQASM(sourceMgr);
   if (!parsed) {
     return {.diagnostics = std::move(parsed.diagnostics)};
   }
-  return analyzeOpenQASM(*parsed.program, options);
+  return analyzeOpenQASM(*parsed.program, gatePolicy);
 }
 
 AnalysisResult analyzeOpenQASM(const llvm::StringRef source,
-                               const FrontendOptions& options) {
+                               GatePolicy gatePolicy) {
   auto parsed = parseOpenQASM(source);
   if (!parsed) {
     return {.diagnostics = std::move(parsed.diagnostics)};
   }
-  return analyzeOpenQASM(*parsed.program, options);
+  return analyzeOpenQASM(*parsed.program, gatePolicy);
 }
 
 } // namespace mlir::oq3::frontend

--- a/mlir/lib/Target/OpenQASM/OpenQASMLexer.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMLexer.cpp
@@ -134,7 +134,8 @@ decodeCodePoint(const char* position, const char* end) {
              TokenKind::UnsupportedKeyword)
       .Cases({"complex", "array", "void", "stretch"},
              TokenKind::UnsupportedKeyword)
-      .Cases({"durationof", "delay", "im"}, TokenKind::UnsupportedKeyword)
+      .Cases({"durationof", "delay", "im", "sizeof"},
+             TokenKind::UnsupportedKeyword)
       .Default(TokenKind::Identifier);
 }
 

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -45,6 +45,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -420,33 +421,23 @@ private:
     llvm::DynamicAPInt constant{0};
   };
 
-  struct DynamicBitFact {
-    ExpressionId expression = 0;
-    std::vector<std::pair<uint64_t, uint64_t>> dependencies;
-  };
   using BitInitialization = std::vector<bool>;
-  using DynamicBitFactSet = std::vector<DynamicBitFact>;
   struct InitializationState {
     std::vector<std::shared_ptr<BitInitialization>> bits;
     std::vector<bool> scalars;
     std::vector<uint64_t> scalarGenerations;
-    std::vector<uint64_t> bitGenerations;
     bool continuing = false;
   };
   SmallVector<SmallVector<InitializationState>> loopExits;
   bool reachable = true;
   bool activePath = true;
 
-  void mergeExitGenerations(ArrayRef<InitializationState> exits, size_t scalars,
-                            size_t registers) {
+  void mergeExitGenerations(ArrayRef<InitializationState> exits,
+                            size_t scalars) {
     for (const auto& exit : exits) {
       for (size_t scalar = 0; scalar < scalars; ++scalar) {
         scalarGenerations[scalar] =
             std::max(scalarGenerations[scalar], exit.scalarGenerations[scalar]);
-      }
-      for (size_t reg = 0; reg < registers; ++reg) {
-        bitGenerations[reg] =
-            std::max(bitGenerations[reg], exit.bitGenerations[reg]);
       }
     }
   }
@@ -473,7 +464,6 @@ private:
   SmallVector<llvm::StringMap<Symbol>> scopes;
   llvm::StringMap<GateSignature> customGates;
   std::vector<std::shared_ptr<BitInitialization>> initializedBits;
-  std::vector<std::shared_ptr<DynamicBitFactSet>> dynamicBitFacts;
   std::vector<bool> initializedScalars;
   std::vector<uint64_t> scalarGenerations;
   std::vector<std::optional<ExpressionId>> affineScalarValues;
@@ -481,7 +471,6 @@ private:
   llvm::DenseSet<ScalarId> loopVariantScalars;
   presburger::IntegerPolyhedron affineDomain{
       presburger::PresburgerSpace::getSetSpace()};
-  std::vector<uint64_t> bitGenerations;
   std::vector<ProgramOutput> implicitOutputs;
   std::vector<ProgramOutput> explicitOutputs;
   mutable std::vector<int8_t> constantExpressionStatus;
@@ -630,7 +619,23 @@ private:
   }
 
   [[nodiscard]] std::optional<AffineForm>
-  buildAffineForm(const ExpressionId expression) const {
+  buildAffineForm(ExpressionId expression) const {
+    /// Facts depend on the active scope and induction domains.
+    llvm::DenseMap<ExpressionId, std::optional<AffineForm>> cache;
+    return buildAffineForm(expression, cache, 0);
+  }
+
+  [[nodiscard]] std::optional<AffineForm> buildAffineForm(
+      ExpressionId expression,
+      llvm::DenseMap<ExpressionId, std::optional<AffineForm>>& cache,
+      size_t depth) const {
+    if (const auto found = cache.find(expression); found != cache.end()) {
+      return found->second;
+    }
+    if (depth == 256 || cache.size() == 4096) {
+      return std::nullopt;
+    }
+    cache.try_emplace(expression, std::nullopt);
     const auto& value = program.expressions.at(expression);
     if (value.integerWidth != 0) {
       return std::nullopt;
@@ -658,25 +663,26 @@ private:
       }
       if (value.variable < affineScalarValues.size() &&
           affineScalarValues[value.variable]) {
-        result = buildAffineForm(*affineScalarValues[value.variable]);
+        result = buildAffineForm(*affineScalarValues[value.variable], cache,
+                                 depth + 1);
       }
       break;
     }
     case ExpressionKind::Cast:
       if (isInteger(value.type) &&
           isInteger(program.expressions.at(value.lhs).type)) {
-        result = buildAffineForm(value.lhs);
+        result = buildAffineForm(value.lhs, cache, depth + 1);
       }
       break;
     case ExpressionKind::Negate:
-      if (auto operand = buildAffineForm(value.lhs)) {
+      if (auto operand = buildAffineForm(value.lhs, cache, depth + 1)) {
         result = negateAffineForm(*operand);
       }
       break;
     case ExpressionKind::Add:
     case ExpressionKind::Subtract: {
-      auto lhs = buildAffineForm(value.lhs);
-      auto rhs = buildAffineForm(value.rhs);
+      auto lhs = buildAffineForm(value.lhs, cache, depth + 1);
+      auto rhs = buildAffineForm(value.rhs, cache, depth + 1);
       if (lhs && rhs) {
         result = addAffineForms(*lhs, value.kind == ExpressionKind::Add
                                           ? *rhs
@@ -685,8 +691,8 @@ private:
       break;
     }
     case ExpressionKind::Multiply: {
-      auto lhs = buildAffineForm(value.lhs);
-      auto rhs = buildAffineForm(value.rhs);
+      auto lhs = buildAffineForm(value.lhs, cache, depth + 1);
+      auto rhs = buildAffineForm(value.rhs, cache, depth + 1);
       if (!lhs || !rhs) {
         break;
       }
@@ -703,6 +709,7 @@ private:
     if (!result || !affineFormFitsType(*result, value.type)) {
       return std::nullopt;
     }
+    cache[expression] = result;
     return result;
   }
 
@@ -877,27 +884,13 @@ private:
   void restoreStatePrefix(
       const std::vector<std::shared_ptr<BitInitialization>>& bitsInitialized,
       const std::vector<bool>& scalarsInitialized,
-      const std::vector<uint64_t>& generations,
-      const std::vector<uint64_t>& registerGenerations) {
+      const std::vector<uint64_t>& generations) {
     for (size_t reg = 0; reg < bitsInitialized.size(); ++reg) {
       initializedBits[reg] = bitsInitialized[reg];
     }
     for (size_t scalar = 0; scalar < scalarsInitialized.size(); ++scalar) {
       initializedScalars[scalar] = scalarsInitialized[scalar];
       scalarGenerations[scalar] = generations[scalar];
-    }
-    for (size_t reg = 0; reg < registerGenerations.size(); ++reg) {
-      bitGenerations[reg] = registerGenerations[reg];
-    }
-  }
-
-  void restoreDynamicFactsPrefix(
-      const std::vector<std::shared_ptr<DynamicBitFactSet>>& facts) {
-    for (size_t reg = 0; reg < facts.size(); ++reg) {
-      dynamicBitFacts[reg] = facts[reg];
-    }
-    for (size_t reg = facts.size(); reg < dynamicBitFacts.size(); ++reg) {
-      dynamicBitFacts[reg] = std::make_shared<DynamicBitFactSet>();
     }
   }
 
@@ -915,169 +908,6 @@ private:
           std::make_shared<BitInitialization>(*initializedBits[reg]);
     }
     return *initializedBits[reg];
-  }
-
-  [[nodiscard]] DynamicBitFactSet&
-  mutableDynamicBitFacts(const RegisterId reg) {
-    if (dynamicBitFacts[reg].use_count() != 1) {
-      dynamicBitFacts[reg] =
-          std::make_shared<DynamicBitFactSet>(*dynamicBitFacts[reg]);
-    }
-    return *dynamicBitFacts[reg];
-  }
-
-  [[nodiscard]] bool sameExpression(const ExpressionId lhs,
-                                    const ExpressionId rhs) const {
-    const auto& left = program.expressions[lhs];
-    const auto& right = program.expressions[rhs];
-    if (left.kind != right.kind || left.type != right.type ||
-        left.constant != right.constant || left.parameter != right.parameter ||
-        left.variable != right.variable ||
-        left.integerWidth != right.integerWidth) {
-      return false;
-    }
-    switch (left.kind) {
-    case ExpressionKind::Constant:
-    case ExpressionKind::GateParameter:
-    case ExpressionKind::Variable:
-      return true;
-    case ExpressionKind::PopCount:
-    case ExpressionKind::BitVectorCast:
-      return sameBitVectorExpression(left.bitVector, right.bitVector);
-    case ExpressionKind::Condition:
-      return left.condition == right.condition;
-    case ExpressionKind::BitNot:
-    case ExpressionKind::Cast:
-    case ExpressionKind::Negate:
-    case ExpressionKind::ArcCos:
-    case ExpressionKind::ArcSin:
-    case ExpressionKind::ArcTan:
-    case ExpressionKind::Ceiling:
-    case ExpressionKind::Sin:
-    case ExpressionKind::Cos:
-    case ExpressionKind::Floor:
-    case ExpressionKind::Tan:
-    case ExpressionKind::Exp:
-    case ExpressionKind::Log:
-    case ExpressionKind::Sqrt:
-      return sameExpression(left.lhs, right.lhs);
-    default:
-      return sameExpression(left.lhs, right.lhs) &&
-             sameExpression(left.rhs, right.rhs);
-    }
-  }
-
-  [[nodiscard]] bool
-  sameBitVectorExpression(const BitVectorExpressionId lhs,
-                          const BitVectorExpressionId rhs) const {
-    const auto& left = program.bitVectorExpressions[lhs];
-    const auto& right = program.bitVectorExpressions[rhs];
-    if (left.kind != right.kind || left.width != right.width) {
-      return false;
-    }
-    switch (left.kind) {
-    case BitVectorExpressionKind::ScalarCast:
-      return sameExpression(left.scalar, right.scalar);
-    case BitVectorExpressionKind::Constant:
-      return left.constant == right.constant;
-    case BitVectorExpressionKind::Register:
-      return left.reg == right.reg;
-    case BitVectorExpressionKind::Not:
-      return sameBitVectorExpression(left.operand, right.operand);
-    case BitVectorExpressionKind::And:
-    case BitVectorExpressionKind::Or:
-    case BitVectorExpressionKind::Xor:
-      return sameBitVectorExpression(left.operand, right.operand) &&
-             sameBitVectorExpression(left.rhs, right.rhs);
-    case BitVectorExpressionKind::ShiftLeft:
-    case BitVectorExpressionKind::ShiftRight:
-    case BitVectorExpressionKind::RotateLeft:
-    case BitVectorExpressionKind::RotateRight:
-      return sameBitVectorExpression(left.operand, right.operand) &&
-             sameExpression(left.distance, right.distance);
-    }
-    llvm_unreachable("unknown bit-vector expression kind");
-  }
-
-  void collectBitVectorDependencies(
-      const BitVectorExpressionId expression,
-      std::vector<std::pair<uint64_t, uint64_t>>& dependencies) const {
-    const auto& value = program.bitVectorExpressions[expression];
-    switch (value.kind) {
-    case BitVectorExpressionKind::ScalarCast:
-      collectDependencies(value.scalar, dependencies);
-      return;
-    case BitVectorExpressionKind::Constant:
-      return;
-    case BitVectorExpressionKind::Register:
-      dependencies.emplace_back(value.reg, bitGenerations[value.reg]);
-      return;
-    case BitVectorExpressionKind::Not:
-      collectBitVectorDependencies(value.operand, dependencies);
-      return;
-    case BitVectorExpressionKind::And:
-    case BitVectorExpressionKind::Or:
-    case BitVectorExpressionKind::Xor:
-      collectBitVectorDependencies(value.operand, dependencies);
-      collectBitVectorDependencies(value.rhs, dependencies);
-      return;
-    case BitVectorExpressionKind::ShiftLeft:
-    case BitVectorExpressionKind::ShiftRight:
-    case BitVectorExpressionKind::RotateLeft:
-    case BitVectorExpressionKind::RotateRight:
-      collectBitVectorDependencies(value.operand, dependencies);
-      collectDependencies(value.distance, dependencies);
-      return;
-    }
-    llvm_unreachable("unknown bit-vector expression kind");
-  }
-
-  void collectDependencies(
-      const ExpressionId expression,
-      std::vector<std::pair<uint64_t, uint64_t>>& dependencies) const {
-    const auto& value = program.expressions[expression];
-    if (value.kind == ExpressionKind::Variable) {
-      dependencies.emplace_back((uint64_t{1} << 63U) | value.variable,
-                                scalarGenerations[value.variable]);
-      return;
-    }
-    if (value.kind == ExpressionKind::Constant ||
-        value.kind == ExpressionKind::GateParameter) {
-      return;
-    }
-    if (value.kind == ExpressionKind::PopCount ||
-        value.kind == ExpressionKind::BitVectorCast) {
-      collectBitVectorDependencies(value.bitVector, dependencies);
-      return;
-    }
-    if (value.kind == ExpressionKind::Condition) {
-      /// Boolean expressions used as indices depend on the current classical
-      /// state.
-      for (const auto [id, generation] : llvm::enumerate(scalarGenerations)) {
-        dependencies.emplace_back((uint64_t{1} << 63U) | id, generation);
-      }
-      for (const auto [id, generation] : llvm::enumerate(bitGenerations)) {
-        dependencies.emplace_back(id, generation);
-      }
-      return;
-    }
-    collectDependencies(value.lhs, dependencies);
-    if (value.kind != ExpressionKind::BitNot &&
-        value.kind != ExpressionKind::Cast &&
-        value.kind != ExpressionKind::Negate &&
-        value.kind != ExpressionKind::ArcCos &&
-        value.kind != ExpressionKind::ArcSin &&
-        value.kind != ExpressionKind::ArcTan &&
-        value.kind != ExpressionKind::Ceiling &&
-        value.kind != ExpressionKind::Sin &&
-        value.kind != ExpressionKind::Cos &&
-        value.kind != ExpressionKind::Floor &&
-        value.kind != ExpressionKind::Tan &&
-        value.kind != ExpressionKind::Exp &&
-        value.kind != ExpressionKind::Log &&
-        value.kind != ExpressionKind::Sqrt) {
-      collectDependencies(value.rhs, dependencies);
-    }
   }
 
   [[nodiscard]] FailureOr<std::optional<bool>>
@@ -1475,17 +1305,8 @@ private:
 
   [[nodiscard]] static std::optional<Constant>
   builtinConstant(StringRef identifier) {
-    if (identifier == "pi" || identifier == "π") {
-      return Constant{.type = ScalarType::Float, .value = std::numbers::pi};
-    }
-    if (identifier == "tau" || identifier == "τ") {
-      return Constant{
-          .type = ScalarType::Float,
-          .value = 2.0 * std::numbers::pi,
-      };
-    }
-    if (identifier == "euler" || identifier == "ℇ") {
-      return Constant{.type = ScalarType::Float, .value = std::numbers::e};
+    if (const auto value = getBuiltinConstant(identifier)) {
+      return Constant{.type = ScalarType::Float, .value = *value};
     }
     return std::nullopt;
   }
@@ -1530,6 +1351,15 @@ private:
         }
         return *symbol->constant;
       }
+      case Expr::Kind::FloatCast: {
+        MQT_OQ3_TRY_ASSIGN(
+            width, bitVectorCastWidth(expression.lhs, expression.location));
+        if (width != 64) {
+          return fail(expression.location, "float casts support only width 64");
+        }
+        MQT_OQ3_TRY_ASSIGN(operand, evaluateConstant(*expression.rhs));
+        return Constant{.type = ScalarType::Float, .value = asDouble(operand)};
+      }
       case Expr::Kind::AngleCast: {
         MQT_OQ3_TRY_ASSIGN(width,
                            angleWidth(expression.lhs, expression.location));
@@ -1546,6 +1376,7 @@ private:
             .value = asDouble(operand) != 0,
         };
       }
+      case Expr::Kind::BitString:
       case Expr::Kind::BitCast:
         return fail(expression.location,
                     "bit-register value is not a scalar constant");
@@ -1891,7 +1722,9 @@ private:
         }
         return symbol->constant->type;
       }
+      case Expr::Kind::FloatCast:
       case Expr::Kind::BoolCast:
+      case Expr::Kind::BitString:
       case Expr::Kind::BitCast:
       case Expr::Kind::AngleCast: {
         MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(id));
@@ -2398,6 +2231,7 @@ private:
         return true;
       case Expr::Kind::Index:
       case Expr::Kind::PopCount:
+      case Expr::Kind::BitString:
       case Expr::Kind::BitCast:
       case Expr::Kind::RotateLeft:
       case Expr::Kind::RotateRight:
@@ -2438,6 +2272,7 @@ private:
              !program.registers[symbol->id].isScalar;
     }
     switch (expression.kind) {
+    case Expr::Kind::BitString:
     case Expr::Kind::BitCast:
       return true;
     case Expr::Kind::BitNot:
@@ -2460,6 +2295,25 @@ private:
       const SyntaxExpressionId syntaxId,
       const std::optional<uint64_t> expectedWidth = std::nullopt) {
     const auto& expression = syntax.expressions[syntaxId];
+    if (expression.kind == Expr::Kind::BitString) {
+      llvm::SmallString<64> digits;
+      for (char digit : expression.identifier) {
+        if (digit != '_') {
+          digits.push_back(digit);
+        }
+      }
+      if (digits.size() > REGISTER_WIDTH_LIMIT ||
+          (expectedWidth && *expectedWidth != digits.size())) {
+        return fail(expression.location,
+                    "bit-string width must match the supported register width");
+      }
+      return addBitVectorExpression({
+          .kind = BitVectorExpressionKind::Constant,
+          .width = digits.size(),
+          .constant =
+              llvm::APInt(static_cast<unsigned>(digits.size()), digits, 2),
+      });
+    }
     if (expression.kind == Expr::Kind::BitCast) {
       MQT_OQ3_TRY_ASSIGN(
           width, bitVectorCastWidth(expression.lhs, expression.location));
@@ -2698,6 +2552,15 @@ private:
       MQT_OQ3_TRY_ASSIGN(constant, evaluateConstant(syntaxId));
       return addConstant(constant);
     }
+    if (expression.kind == Expr::Kind::FloatCast) {
+      MQT_OQ3_TRY_ASSIGN(
+          width, bitVectorCastWidth(expression.lhs, expression.location));
+      if (width != 64) {
+        return fail(expression.location, "float casts support only width 64");
+      }
+      MQT_OQ3_TRY_ASSIGN(operand, analyzeExpression(*expression.rhs));
+      return castExpression(operand, ScalarType::Float, expression.location);
+    }
     if (expression.kind == Expr::Kind::PopCount) {
       MQT_OQ3_TRY_ASSIGN(bitVector,
                          analyzeBitVectorExpression(*expression.lhs));
@@ -2789,10 +2652,12 @@ private:
 
     auto kind = ExpressionKind::Constant;
     switch (expression.kind) {
+    case Expr::Kind::FloatCast:
     case Expr::Kind::IntCast:
     case Expr::Kind::UintCast:
     case Expr::Kind::BoolCast:
       llvm_unreachable("handled cast");
+    case Expr::Kind::BitString:
     case Expr::Kind::BitCast:
       return fail(expression.location, "expected a scalar, not a bit register");
     case Expr::Kind::AngleCast:
@@ -3274,7 +3139,7 @@ private:
                   .bits = initializedBits,
                   .scalars = initializedScalars,
                   .scalarGenerations = scalarGenerations,
-                  .bitGenerations = bitGenerations,
+
                   .continuing = continuing,
               });
             }
@@ -3455,22 +3320,9 @@ private:
   }
 
   void markBitInitialized(const frontend::BitReference& target) {
-    ++bitGenerations[target.reg];
     if (!target.dynamicIndex) {
       mutableBitInitialization(target.reg)[target.index] = true;
       return;
-    }
-    DynamicBitFact fact{
-        .expression = *target.dynamicIndex,
-        .dependencies = {},
-    };
-    collectDependencies(*target.dynamicIndex, fact.dependencies);
-    auto& facts = mutableDynamicBitFacts(target.reg);
-    if (llvm::none_of(facts, [&](const auto& existing) {
-          return existing.dependencies == fact.dependencies &&
-                 sameExpression(existing.expression, fact.expression);
-        })) {
-      facts.push_back(std::move(fact));
     }
   }
 
@@ -3581,8 +3433,6 @@ private:
     const bool initiallyInitialized = !isQubit && program.openQASM2;
     initializedBits.push_back(
         std::make_shared<BitInitialization>(width, initiallyInitialized));
-    dynamicBitFacts.push_back(std::make_shared<DynamicBitFactSet>());
-    bitGenerations.push_back(0);
     if (failed(declare(location, identifier,
                        {
                            .kind = SymbolKind::Register,
@@ -3883,8 +3733,6 @@ private:
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
     const auto beforeAffineScalarValues = affineScalarValues;
-    const auto beforeBitGenerations = bitGenerations;
-    const auto beforeDynamicBitFacts = dynamicBitFacts;
     scopes.emplace_back();
     const auto thenResult =
         analyzeBody(conditional.thenStatements, result.thenStatements,
@@ -3899,14 +3747,11 @@ private:
     const auto afterThenInitialized = initializedScalars;
     const auto afterThenGenerations = scalarGenerations;
     const auto afterThenAffineScalarValues = affineScalarValues;
-    const auto afterThenBitGenerations = bitGenerations;
-    const auto afterThenDynamicBitFacts = dynamicBitFacts;
     scopes.pop_back();
 
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
-                       beforeGenerations, beforeBitGenerations);
+                       beforeGenerations);
     restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
-    restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     activePath = entryActive && (!knownCondition || !*knownCondition);
     reachable = entryReachable;
     scopes.emplace_back();
@@ -3925,8 +3770,6 @@ private:
     const auto afterElseInitialized = initializedScalars;
     const auto afterElseGenerations = scalarGenerations;
     const auto afterElseAffineScalarValues = affineScalarValues;
-    const auto afterElseBitGenerations = bitGenerations;
-    const auto afterElseDynamicBitFacts = dynamicBitFacts;
     scopes.pop_back();
 
     if (!thenReachable && elseReachable) {
@@ -3934,9 +3777,8 @@ private:
     }
     if (thenReachable && !elseReachable) {
       restoreStatePrefix(afterThenBitsInitialized, afterThenInitialized,
-                         afterThenGenerations, afterThenBitGenerations);
+                         afterThenGenerations);
       restoreAffineScalarValuesPrefix(afterThenAffineScalarValues);
-      restoreDynamicFactsPrefix(afterThenDynamicBitFacts);
       return addStatement(location, std::move(result));
     }
     if (knownCondition) {
@@ -3949,40 +3791,20 @@ private:
       const auto& knownAffineScalarValues = *knownCondition
                                                 ? afterThenAffineScalarValues
                                                 : afterElseAffineScalarValues;
-      const auto& knownBitGenerations =
-          *knownCondition ? afterThenBitGenerations : afterElseBitGenerations;
-      const auto& knownDynamicBitFacts =
-          *knownCondition ? afterThenDynamicBitFacts : afterElseDynamicBitFacts;
       restoreStatePrefix(knownBitsInitialized, knownInitialized,
-                         knownGenerations, knownBitGenerations);
+                         knownGenerations);
       restoreAffineScalarValuesPrefix(knownAffineScalarValues);
-      restoreDynamicFactsPrefix(knownDynamicBitFacts);
       return addStatement(location, std::move(result));
     }
 
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
-                       beforeGenerations, beforeBitGenerations);
+                       beforeGenerations);
     restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
-    restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     for (size_t reg = 0; reg < beforeBitsInitialized.size(); ++reg) {
       auto& merged = mutableBitInitialization(static_cast<RegisterId>(reg));
       for (size_t bit = 0; bit < beforeBitsInitialized[reg]->size(); ++bit) {
         merged[bit] = (*afterThenBitsInitialized[reg])[bit] &&
                       (*afterElseBitsInitialized[reg])[bit];
-      }
-    }
-    for (size_t reg = 0; reg < beforeDynamicBitFacts.size(); ++reg) {
-      auto& merged = mutableDynamicBitFacts(static_cast<RegisterId>(reg));
-      merged.clear();
-      for (const auto& thenFact : *afterThenDynamicBitFacts[reg]) {
-        if (llvm::any_of(
-                *afterElseDynamicBitFacts[reg], [&](const auto& elseFact) {
-                  return thenFact.dependencies == elseFact.dependencies &&
-                         sameExpression(thenFact.expression,
-                                        elseFact.expression);
-                })) {
-          merged.push_back(thenFact);
-        }
       }
     }
     for (size_t scalar = 0; scalar < beforeInitialized.size(); ++scalar) {
@@ -3998,10 +3820,6 @@ private:
       } else {
         affineScalarValues[scalar].reset();
       }
-    }
-    for (size_t reg = 0; reg < beforeBitGenerations.size(); ++reg) {
-      bitGenerations[reg] =
-          std::max(afterThenBitGenerations[reg], afterElseBitGenerations[reg]);
     }
     return addStatement(location, std::move(result));
   }
@@ -4059,8 +3877,6 @@ private:
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
     const auto beforeAffineScalarValues = affineScalarValues;
-    const auto beforeBitGenerations = bitGenerations;
-    const auto beforeDynamicBitFacts = dynamicBitFacts;
     scopes.emplace_back();
     const auto scalar = static_cast<ScalarId>(program.scalars.size());
     const auto type = loop.isUnsigned ? ScalarType::Uint : ScalarType::Int;
@@ -4119,19 +3935,15 @@ private:
     }
     const auto afterBodyBitsInitialized = initializedBits;
     const auto afterBodyInitialized = initializedScalars;
-    mergeExitGenerations(exits, beforeGenerations.size(),
-                         beforeBitGenerations.size());
+    mergeExitGenerations(exits, beforeGenerations.size());
     const auto afterBodyGenerations = scalarGenerations;
-    const auto afterBodyBitGenerations = bitGenerations;
-    const auto afterBodyDynamicBitFacts = dynamicBitFacts;
     activeInductions.erase(scalar);
     affineDomain = outerDomain;
     loopVariantScalars = outerLoopVariantScalars;
     scopes.pop_back();
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
-                       beforeGenerations, beforeBitGenerations);
+                       beforeGenerations);
     restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
-    restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     bool rangeMayExecute = true;
     if (isConstantExpression(loop.start) && isConstantExpression(loop.step) &&
         isConstantExpression(loop.stop)) {
@@ -4178,12 +3990,6 @@ private:
           initializedScalars[scalar] = afterBodyInitialized[scalar];
           scalarGenerations[scalar] = afterBodyGenerations[scalar];
         }
-        for (size_t reg = 0; reg < beforeBitGenerations.size(); ++reg) {
-          bitGenerations[reg] = afterBodyBitGenerations[reg];
-        }
-        for (size_t reg = 0; reg < beforeDynamicBitFacts.size(); ++reg) {
-          dynamicBitFacts[reg] = afterBodyDynamicBitFacts[reg];
-        }
       }
     }
     if (rangeMayExecute) {
@@ -4213,8 +4019,6 @@ private:
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
     const auto beforeAffineScalarValues = affineScalarValues;
-    const auto beforeBitGenerations = bitGenerations;
-    const auto beforeDynamicBitFacts = dynamicBitFacts;
     scopes.emplace_back();
     const auto outerLoopVariantScalars = loopVariantScalars;
     llvm::DenseSet<StringRef> blockLocalScalars;
@@ -4231,24 +4035,17 @@ private:
     if (failed(bodyResult)) {
       return failure();
     }
-    mergeExitGenerations(exits, beforeGenerations.size(),
-                         beforeBitGenerations.size());
+    mergeExitGenerations(exits, beforeGenerations.size());
     const auto afterBodyGenerations = scalarGenerations;
-    const auto afterBodyBitGenerations = bitGenerations;
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
-                       beforeGenerations, beforeBitGenerations);
+                       beforeGenerations);
     restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
-    restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     for (size_t scalar = 0; scalar < beforeGenerations.size(); ++scalar) {
       scalarGenerations[scalar] =
           std::max(beforeGenerations[scalar], afterBodyGenerations[scalar]);
       if (afterBodyGenerations[scalar] != beforeGenerations[scalar]) {
         affineScalarValues[scalar].reset();
       }
-    }
-    for (size_t reg = 0; reg < beforeBitGenerations.size(); ++reg) {
-      bitGenerations[reg] =
-          std::max(beforeBitGenerations[reg], afterBodyBitGenerations[reg]);
     }
     llvm::erase_if(exits, [](const auto& state) { return state.continuing; });
     MQT_OQ3_TRY_ASSIGN(knownCondition, constantCondition(loop.condition));
@@ -4286,10 +4083,7 @@ private:
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
     const auto beforeAffineScalarValues = affineScalarValues;
-    const auto beforeBitGenerations = bitGenerations;
-    const auto beforeDynamicBitFacts = dynamicBitFacts;
     auto mergedScalarGenerations = beforeGenerations;
-    auto mergedBitGenerations = beforeBitGenerations;
     std::vector<std::vector<std::shared_ptr<BitInitialization>>>
         branchBitsInitialized;
     std::vector<std::vector<bool>> branchScalarsInitialized;
@@ -4299,9 +4093,8 @@ private:
         [&](const ArrayRef<SyntaxStatementId> syntaxStatements,
             std::vector<StatementId>& statements) -> LogicalResult {
       restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
-                         beforeGenerations, beforeBitGenerations);
+                         beforeGenerations);
       restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
-      restoreDynamicFactsPrefix(beforeDynamicBitFacts);
       reachable = entryReachable;
       scopes.emplace_back();
       const auto branchResult =
@@ -4320,10 +4113,6 @@ private:
       for (size_t index = 0; index < beforeGenerations.size(); ++index) {
         mergedScalarGenerations[index] =
             std::max(mergedScalarGenerations[index], scalarGenerations[index]);
-      }
-      for (size_t index = 0; index < beforeBitGenerations.size(); ++index) {
-        mergedBitGenerations[index] =
-            std::max(mergedBitGenerations[index], bitGenerations[index]);
       }
       return success();
     };
@@ -4368,9 +4157,8 @@ private:
     }
 
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
-                       mergedScalarGenerations, mergedBitGenerations);
+                       mergedScalarGenerations);
     restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
-    restoreDynamicFactsPrefix(beforeDynamicBitFacts);
     for (size_t reg = 0; reg < beforeBitsInitialized.size(); ++reg) {
       auto& initialized =
           mutableBitInitialization(static_cast<RegisterId>(reg));
@@ -4458,6 +4246,7 @@ private:
         return fail(condition.location, "bool casts do not have a width");
       }
       return analyzeBoolValue(*condition.rhs);
+    case Expr::Kind::BitString:
     case Expr::Kind::BitCast:
       return fail(condition.location,
                   "bit registers require an explicit comparison");
@@ -4620,13 +4409,23 @@ private:
         } else if (expectedBits.getBitWidth() > bits.size()) {
           expectedBits = expectedBits.trunc(static_cast<unsigned>(bits.size()));
         }
+        const auto reg = addBitVectorExpression({
+            .kind = BitVectorExpressionKind::Register,
+            .width = bits.size(),
+            .reg = registerSymbol->id,
+        });
+        const auto expected = addBitVectorExpression({
+            .kind = BitVectorExpressionKind::Constant,
+            .width = bits.size(),
+            .constant = std::move(expectedBits),
+        });
         return addCondition({
-            .kind = ConditionKind::RegisterComparison,
+            .kind = ConditionKind::BitVectorComparison,
             .location = getSourceLocation(condition.location),
             .bit = {},
             .measurement = {},
-            .reg = registerSymbol->id,
-            .expected = std::move(expectedBits),
+            .bitVectorComparisonLhs = reg,
+            .bitVectorComparisonRhs = expected,
             .comparison = registerComparison,
         });
       }
@@ -4712,6 +4511,7 @@ private:
     case Expr::Kind::Int:
     case Expr::Kind::Float:
     case Expr::Kind::Bool:
+    case Expr::Kind::FloatCast:
     case Expr::Kind::IntCast:
     case Expr::Kind::UintCast:
     case Expr::Kind::AngleCast:
@@ -4952,13 +4752,34 @@ private:
         application.qubits.push_back(
             selection[selection.size() == 1 ? 0 : index]);
       }
-      for (const auto [position, qubit] : llvm::enumerate(application.qubits)) {
-        for (const auto& previous :
-             ArrayRef(application.qubits).take_front(position)) {
-          if (!proveDistinct(previous, qubit, affineComparisons)) {
-            return fail(call.location,
-                        "cannot prove that gate operands reference distinct "
-                        "qubits");
+      llvm::DenseSet<std::tuple<QubitReferenceKind, uint32_t, uint64_t>>
+          staticQubits;
+      llvm::DenseMap<RegisterId, SmallVector<const QubitReference*>>
+          registerQubits;
+      for (const auto& qubit : application.qubits) {
+        if (!qubit.provenIndex &&
+            !staticQubits.insert({qubit.kind, qubit.symbol, qubit.index})
+                 .second) {
+          return fail(
+              call.location,
+              "cannot prove that gate operands reference distinct qubits");
+        }
+        if (qubit.kind == QubitReferenceKind::Register) {
+          registerQubits[qubit.symbol].push_back(&qubit);
+        }
+      }
+      for (const auto& qubit : application.qubits) {
+        if (!qubit.provenIndex) {
+          continue;
+        }
+        for (const auto* other : registerQubits[qubit.symbol]) {
+          if (other == &qubit || (other->provenIndex && other < &qubit)) {
+            continue;
+          }
+          if (!proveDistinct(*other, qubit, affineComparisons)) {
+            return fail(
+                call.location,
+                "cannot prove that gate operands reference distinct qubits");
           }
         }
       }
@@ -5130,14 +4951,6 @@ private:
     if (bit.dynamicIndex) {
       if (llvm::all_of(*initializedBits[bit.reg],
                        [](const bool initialized) { return initialized; })) {
-        return success();
-      }
-      std::vector<std::pair<uint64_t, uint64_t>> dependencies;
-      collectDependencies(*bit.dynamicIndex, dependencies);
-      if (llvm::any_of(*dynamicBitFacts[bit.reg], [&](const auto& fact) {
-            return fact.dependencies == dependencies &&
-                   sameExpression(fact.expression, *bit.dynamicIndex);
-          })) {
         return success();
       }
       return fail(location,

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -391,9 +391,8 @@ namespace {
 class SemanticAnalyzer {
 public:
   SemanticAnalyzer(const SyntaxProgram& syntaxProgram,
-                   const llvm::SourceMgr& sourceManager,
-                   const FrontendOptions& frontendOptions)
-      : syntax(syntaxProgram), sources(sourceManager), options(frontendOptions),
+                   const llvm::SourceMgr& sourceManager, GatePolicy policy)
+      : syntax(syntaxProgram), sources(sourceManager), gatePolicy(policy),
         constantExpressionStatus(syntax.expressions.size(), 0),
         constantValues(syntax.expressions.size()),
         constantTypes(syntax.expressions.size()) {
@@ -459,7 +458,7 @@ private:
   // The analyzed syntax and source manager are mandatory and outlive this run.
   const SyntaxProgram& syntax;
   const llvm::SourceMgr& sources;
-  FrontendOptions options;
+  GatePolicy gatePolicy;
   TypedProgram program;
   SmallVector<llvm::StringMap<Symbol>> scopes;
   llvm::StringMap<GateSignature> customGates;
@@ -956,7 +955,7 @@ private:
     if (gate.availability == GateAvailability::Language) {
       return true;
     }
-    if (options.gatePolicy == GatePolicy::MQTCompatibility) {
+    if (gatePolicy == GatePolicy::MQTCompatibility) {
       return true;
     }
     return (belongsToStdGates(gate.availability) && program.stdGatesIncluded) ||
@@ -3458,7 +3457,7 @@ private:
       return analyzeAssignment(location,
                                SyntaxAssignment{
                                    .target =
-                                       SyntaxBitReference{
+                                       BitReference{
                                            .location = location,
                                            .identifier = identifier,
                                            .index = std::nullopt,
@@ -4789,7 +4788,7 @@ private:
   }
 
   [[nodiscard]] FailureOr<std::vector<QubitReference>>
-  resolveQubitOperand(const SyntaxOperand& operand) {
+  resolveQubitOperand(const Operand& operand) {
     if (operand.hardwareQubit) {
       if (!activeGate_.empty()) {
         return fail(operand.location,
@@ -4904,7 +4903,7 @@ private:
   }
 
   [[nodiscard]] FailureOr<std::vector<frontend::BitReference>>
-  resolveBits(const SyntaxBitReference& reference) {
+  resolveBits(const BitReference& reference) {
     const auto* symbol = lookup(reference.identifier);
     if (symbol == nullptr || symbol->kind != SymbolKind::Register ||
         program.registers[symbol->id].kind == RegisterKind::Qubit) {
@@ -5029,8 +5028,8 @@ SourceLocation sourceLocation(const llvm::SourceMgr& sources,
 
 AnalysisResult analyzeSyntaxProgram(const SyntaxProgram& syntax,
                                     const llvm::SourceMgr& sources,
-                                    const FrontendOptions& options) {
-  return SemanticAnalyzer(syntax, sources, options).run();
+                                    GatePolicy gatePolicy) {
+  return SemanticAnalyzer(syntax, sources, gatePolicy).run();
 }
 
 } // namespace mlir::oq3::frontend::detail

--- a/mlir/lib/Target/OpenQASM/OpenQASMSyntax.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSyntax.cpp
@@ -12,11 +12,9 @@
 
 #include "mlir/Target/OpenQASM/Detail/OpenQASMParser.h"
 
-#include <llvm/ADT/STLExtras.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
-#include <iterator>
 #include <optional>
 #include <tuple>
 #include <utility>
@@ -84,49 +82,14 @@ SyntaxBuilder::addExpression(const SyntaxExpression& expression) {
   return id;
 }
 
-SyntaxOperand SyntaxBuilder::copyOperand(const Operand& operand) {
-  SyntaxOperand copy{
-      .location = operand.loc,
-      .identifier = operand.identifier,
-      .index = operand.index,
-      .hardwareQubit = operand.hardwareQubit,
-  };
-
-  return copy;
-}
-
-SyntaxBitReference
-SyntaxBuilder::copyBitReference(const BitReference& reference) {
-  SyntaxBitReference copy{
-      .location = reference.loc,
-      .identifier = reference.identifier,
-      .index = reference.index,
-  };
-  return copy;
-}
-
 SyntaxGateCall SyntaxBuilder::copyGateCall(const GateCall& call) {
-  SyntaxGateCall copy{
+  return {
       .location = call.loc,
       .identifier = call.identifier,
-      .modifiers = {},
+      .modifiers = call.modifiers.vec(),
       .parameters = call.parameters.vec(),
-      .operands = {},
+      .operands = call.operands.vec(),
   };
-  copy.modifiers.reserve(call.modifiers.size());
-  for (const auto& modifier : call.modifiers) {
-    SyntaxModifier converted{
-        .kind = modifier.kind,
-        .argument = modifier.argument,
-    };
-
-    copy.modifiers.push_back(converted);
-  }
-
-  copy.operands.reserve(call.operands.size());
-  llvm::transform(call.operands, std::back_inserter(copy.operands),
-                  [&](const Operand& operand) { return copyOperand(operand); });
-  return copy;
 }
 
 LogicalResult
@@ -151,7 +114,7 @@ LogicalResult SyntaxBuilder::assignment(SMLoc location,
                                         const BitReference& target,
                                         SyntaxExpressionId value) {
   std::ignore = addStatement(location, SyntaxAssignment{
-                                           .target = copyBitReference(target),
+                                           .target = target,
                                            .value = value,
                                        });
   return success();
@@ -187,28 +150,24 @@ LogicalResult SyntaxBuilder::measure(SMLoc location, const BitReference* target,
                                      const Operand& source) {
   SyntaxMeasurement measurement{
       .target = std::nullopt,
-      .source = copyOperand(source),
+      .source = source,
   };
   if (target != nullptr) {
-    measurement.target = copyBitReference(*target);
+    measurement.target = *target;
   }
   std::ignore = addStatement(location, measurement);
   return success();
 }
 
 LogicalResult SyntaxBuilder::reset(SMLoc location, const Operand& operand) {
-  std::ignore =
-      addStatement(location, SyntaxReset{.operand = copyOperand(operand)});
+  std::ignore = addStatement(location, SyntaxReset{.operand = operand});
   return success();
 }
 
 LogicalResult SyntaxBuilder::barrier(SMLoc location,
                                      ArrayRef<Operand> operands) {
-  SyntaxBarrier barrier;
-  barrier.operands.reserve(operands.size());
-  llvm::transform(operands, std::back_inserter(barrier.operands),
-                  [&](const Operand& operand) { return copyOperand(operand); });
-  std::ignore = addStatement(location, std::move(barrier));
+  std::ignore =
+      addStatement(location, SyntaxBarrier{.operands = operands.vec()});
   return success();
 }
 

--- a/mlir/lib/Target/OpenQASM/OpenQASMSyntax.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSyntax.cpp
@@ -12,7 +12,6 @@
 
 #include "mlir/Target/OpenQASM/Detail/OpenQASMParser.h"
 
-#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/STLExtras.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
@@ -78,59 +77,21 @@ SyntaxStatementId SyntaxBuilder::addStatement(SMLoc location,
   return id;
 }
 
-SyntaxExpressionId SyntaxBuilder::copyExpression(const Expr& expression) {
-  llvm::DenseMap<const Expr*, SyntaxExpressionId> copies;
-  SmallVector<std::pair<const Expr*, bool>> worklist{{&expression, false}};
-  while (!worklist.empty()) {
-    const auto [current, expanded] = worklist.pop_back_val();
-    if (copies.contains(current)) {
-      continue;
-    }
-    if (!expanded) {
-      worklist.emplace_back(current, true);
-      if (current->rhs != nullptr) {
-        worklist.emplace_back(current->rhs, false);
-      }
-      if (current->lhs != nullptr) {
-        worklist.emplace_back(current->lhs, false);
-      }
-      continue;
-    }
-    SyntaxExpression copy{
-        .kind = current->kind,
-        .location = current->loc,
-        .integer = current->intValue,
-        .floatingPoint = current->floatValue,
-        .boolean = current->boolValue,
-        .identifier = current->identifier,
-        .wideInteger = current->wideInteger,
-        .hardwareQubit = current->hardwareQubit,
-        .lhs = std::nullopt,
-        .rhs = std::nullopt,
-    };
-    if (current->lhs != nullptr) {
-      copy.lhs = copies.lookup(current->lhs);
-    }
-    if (current->rhs != nullptr) {
-      copy.rhs = copies.lookup(current->rhs);
-    }
-    const auto id = static_cast<SyntaxExpressionId>(program.expressions.size());
-    program.expressions.push_back(copy);
-    copies.try_emplace(current, id);
-  }
-  return copies.lookup(&expression);
+SyntaxExpressionId
+SyntaxBuilder::addExpression(const SyntaxExpression& expression) {
+  const auto id = static_cast<SyntaxExpressionId>(program.expressions.size());
+  program.expressions.push_back(expression);
+  return id;
 }
 
 SyntaxOperand SyntaxBuilder::copyOperand(const Operand& operand) {
   SyntaxOperand copy{
       .location = operand.loc,
       .identifier = operand.identifier,
-      .index = std::nullopt,
+      .index = operand.index,
       .hardwareQubit = operand.hardwareQubit,
   };
-  if (operand.index != nullptr) {
-    copy.index = copyExpression(*operand.index);
-  }
+
   return copy;
 }
 
@@ -139,11 +100,8 @@ SyntaxBuilder::copyBitReference(const BitReference& reference) {
   SyntaxBitReference copy{
       .location = reference.loc,
       .identifier = reference.identifier,
-      .index = std::nullopt,
+      .index = reference.index,
   };
-  if (reference.index != nullptr) {
-    copy.index = copyExpression(*reference.index);
-  }
   return copy;
 }
 
@@ -152,92 +110,75 @@ SyntaxGateCall SyntaxBuilder::copyGateCall(const GateCall& call) {
       .location = call.loc,
       .identifier = call.identifier,
       .modifiers = {},
-      .parameters = {},
+      .parameters = call.parameters.vec(),
       .operands = {},
   };
   copy.modifiers.reserve(call.modifiers.size());
   for (const auto& modifier : call.modifiers) {
     SyntaxModifier converted{
         .kind = modifier.kind,
-        .argument = std::nullopt,
+        .argument = modifier.argument,
     };
-    if (modifier.argument != nullptr) {
-      converted.argument = copyExpression(*modifier.argument);
-    }
+
     copy.modifiers.push_back(converted);
   }
-  copy.parameters.reserve(call.parameters.size());
-  for (const auto* parameter : call.parameters) {
-    copy.parameters.push_back(copyExpression(*parameter));
-  }
+
   copy.operands.reserve(call.operands.size());
   llvm::transform(call.operands, std::back_inserter(copy.operands),
                   [&](const Operand& operand) { return copyOperand(operand); });
   return copy;
 }
 
-LogicalResult SyntaxBuilder::scalarDecl(SMLoc location, const ScalarKind kind,
-                                        StringRef identifier, const Expr* size,
-                                        const Expr* initializer,
-                                        const bool isConst, const bool output) {
+LogicalResult
+SyntaxBuilder::scalarDecl(SMLoc location, const ScalarKind kind,
+                          StringRef identifier,
+                          std::optional<SyntaxExpressionId> size,
+                          std::optional<SyntaxExpressionId> initializer,
+                          const bool isConst, const bool output) {
   SyntaxScalarDeclaration declaration{
       .kind = kind,
       .identifier = identifier,
-      .size = std::nullopt,
-      .initializer = std::nullopt,
+      .size = size,
+      .initializer = initializer,
       .isConst = isConst,
       .output = output,
   };
-  if (size != nullptr) {
-    declaration.size = copyExpression(*size);
-  }
-  if (initializer != nullptr) {
-    declaration.initializer = copyExpression(*initializer);
-  }
   std::ignore = addStatement(location, declaration);
   return success();
 }
 
 LogicalResult SyntaxBuilder::assignment(SMLoc location,
                                         const BitReference& target,
-                                        const Expr& value) {
+                                        SyntaxExpressionId value) {
   std::ignore = addStatement(location, SyntaxAssignment{
                                            .target = copyBitReference(target),
-                                           .value = copyExpression(value),
+                                           .value = value,
                                        });
   return success();
 }
 
-LogicalResult SyntaxBuilder::qubitRegister(SMLoc location, StringRef identifier,
-                                           const Expr* size) {
+LogicalResult
+SyntaxBuilder::qubitRegister(SMLoc location, StringRef identifier,
+                             std::optional<SyntaxExpressionId> size) {
   SyntaxQubitDeclaration declaration{
       .identifier = identifier,
-      .size = std::nullopt,
+      .size = size,
   };
-  if (size != nullptr) {
-    declaration.size = copyExpression(*size);
-  }
   std::ignore = addStatement(location, declaration);
   return success();
 }
 
-LogicalResult SyntaxBuilder::classicalRegister(SMLoc location,
-                                               StringRef identifier,
-                                               const Expr* size,
-                                               const Expr* initializer,
-                                               const bool output) {
+LogicalResult
+SyntaxBuilder::classicalRegister(SMLoc location, StringRef identifier,
+                                 std::optional<SyntaxExpressionId> size,
+                                 std::optional<SyntaxExpressionId> initializer,
+                                 const bool output) {
   SyntaxBitDeclaration declaration{
       .identifier = identifier,
-      .size = std::nullopt,
-      .initializer = std::nullopt,
+      .size = size,
+      .initializer = initializer,
       .output = output,
   };
-  if (size != nullptr) {
-    declaration.size = copyExpression(*size);
-  }
-  if (initializer != nullptr) {
-    declaration.initializer = copyExpression(*initializer);
-  }
   std::ignore = addStatement(location, declaration);
   return success();
 }
@@ -317,7 +258,7 @@ LogicalResult SyntaxBuilder::breakStmt(SMLoc location) {
 }
 
 LogicalResult
-SyntaxBuilder::ifStmt(SMLoc location, const Expr& condition,
+SyntaxBuilder::ifStmt(SMLoc location, SyntaxExpressionId condition,
                       function_ref<LogicalResult()> thenContinuation,
                       function_ref<LogicalResult()> elseContinuation) {
   auto thenStatements = parseNestedBody(thenContinuation);
@@ -330,7 +271,7 @@ SyntaxBuilder::ifStmt(SMLoc location, const Expr& condition,
   }
   std::ignore =
       addStatement(location, SyntaxIf{
-                                 .condition = copyExpression(condition),
+                                 .condition = condition,
                                  .thenStatements = std::move(*thenStatements),
                                  .elseStatements = std::move(*elseStatements),
                              });
@@ -339,8 +280,8 @@ SyntaxBuilder::ifStmt(SMLoc location, const Expr& condition,
 
 LogicalResult
 SyntaxBuilder::forStmt(SMLoc location, StringRef inductionVariable,
-                       const bool isUnsigned, const Expr& start,
-                       const Expr& step, const Expr& stop,
+                       const bool isUnsigned, SyntaxExpressionId start,
+                       SyntaxExpressionId step, SyntaxExpressionId stop,
                        function_ref<LogicalResult()> continuation) {
   auto body = parseNestedBody(continuation);
   if (failed(body)) {
@@ -350,34 +291,33 @@ SyntaxBuilder::forStmt(SMLoc location, StringRef inductionVariable,
       addStatement(location, SyntaxFor{
                                  .inductionVariable = inductionVariable,
                                  .isUnsigned = isUnsigned,
-                                 .start = copyExpression(start),
-                                 .step = copyExpression(step),
-                                 .stop = copyExpression(stop),
+                                 .start = start,
+                                 .step = step,
+                                 .stop = stop,
                                  .body = std::move(*body),
                              });
   return success();
 }
 
 LogicalResult
-SyntaxBuilder::whileStmt(SMLoc location, const Expr& condition,
+SyntaxBuilder::whileStmt(SMLoc location, SyntaxExpressionId condition,
                          function_ref<LogicalResult()> continuation) {
   auto body = parseNestedBody(continuation);
   if (failed(body)) {
     return failure();
   }
-  std::ignore =
-      addStatement(location, SyntaxWhile{
-                                 .condition = copyExpression(condition),
-                                 .body = std::move(*body),
-                             });
+  std::ignore = addStatement(location, SyntaxWhile{
+                                           .condition = condition,
+                                           .body = std::move(*body),
+                                       });
   return success();
 }
 
 LogicalResult
-SyntaxBuilder::switchStmt(SMLoc location, const Expr& control,
+SyntaxBuilder::switchStmt(SMLoc location, SyntaxExpressionId control,
                           function_ref<LogicalResult()> continuation) {
   SyntaxSwitch statement{
-      .control = copyExpression(control),
+      .control = control,
       .cases = {},
       .defaultStatements = {},
   };
@@ -393,13 +333,10 @@ SyntaxBuilder::switchStmt(SMLoc location, const Expr& control,
 
 LogicalResult
 SyntaxBuilder::switchCase(SMLoc /*location*/,
-                          const ArrayRef<const Expr*> labels,
+                          const ArrayRef<SyntaxExpressionId> labels,
                           function_ref<LogicalResult()> continuation) {
   SyntaxSwitchCase switchCase;
-  switchCase.labels.reserve(labels.size());
-  for (const auto* label : labels) {
-    switchCase.labels.push_back(copyExpression(*label));
-  }
+  switchCase.labels = labels.vec();
   auto body = parseNestedBody(continuation);
   if (failed(body)) {
     return failure();

--- a/mlir/unittests/Dialect/QC/Translation/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QC/Translation/CMakeLists.txt
@@ -15,6 +15,8 @@ target_link_libraries(
   ${target_name}
   PRIVATE GTest::gtest_main
           MLIRParser
+          MLIRFuncInlinerExtension
+          MLIRLLVMIRTransforms
           MLIRSupportMQT
           MLIRQCToQCO
           MLIRQCODDFunctionality
@@ -23,6 +25,6 @@ target_link_libraries(
           MLIRQCPrograms
           MLIRQASMPrograms)
 
-mqt_mlir_configure_unittest_target(${target_name})
+mqt_mlir_configure_unittest_target(${target_name} REQUIRES_EH)
 
 gtest_discover_tests(${target_name} PROPERTIES LABELS mqt-mlir-unittests DISCOVERY_TIMEOUT 60)

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -8,6 +8,8 @@
  * Licensed under the MIT License
  */
 
+#include "../../../../lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h"
+#include "dd/Package.hpp"
 #include "mlir/Conversion/QCToQCO/QCToQCO.h"
 #include "mlir/Dialect/CBit/IR/CBitDialect.h"
 #include "mlir/Dialect/MQT/IR/MQTDialect.h"
@@ -26,7 +28,9 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlow.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
+#include <mlir/Dialect/Func/Extensions/InlinerExtension.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h>
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
@@ -39,8 +43,10 @@
 #include <mlir/Parser/Parser.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/Passes.h>
 
 #include <array>
+#include <complex>
 #include <cstddef>
 #include <string>
 #include <tuple>
@@ -57,7 +63,7 @@ static DialectRegistry emissionDialects() {
   return registry;
 }
 
-static void expectOneSample(ModuleOp moduleOp) {
+static void expectOneSample(ModuleOp moduleOp, StringRef expected = "1") {
   PassManager manager(moduleOp.getContext());
   manager.addPass(createQCToQCO());
   ASSERT_TRUE(succeeded(manager.run(moduleOp)));
@@ -66,7 +72,7 @@ static void expectOneSample(ModuleOp moduleOp) {
   const auto samples = qco::sample(entry, 1, 1);
   ASSERT_TRUE(succeeded(samples));
   ASSERT_EQ(samples->size(), 1U);
-  EXPECT_EQ(samples->begin()->first, "1");
+  EXPECT_EQ(samples->begin()->first, expected);
 }
 
 namespace {
@@ -140,9 +146,12 @@ TEST(OpenQASM3EmissionTest, PreservesMeasurementOrderBeforeDelayedStore) {
       << *emitted;
 }
 
-TEST(OpenQASM3EmissionTest, RejectsStaleClassicalSnapshots) {
+TEST(OpenQASM3EmissionTest, PreservesStaleClassicalSnapshots) {
   constexpr llvm::StringLiteral source = R"mlir(module {
-    func.func @main() -> (!cbit.reg<2>, i1) attributes {mqt.entry_point} {
+    func.func @main() -> !cbit.reg<1> attributes {mqt.entry_point} {
+      %q = qc.alloc : !qc.qubit
+      %result = cbit.alloc(#cbit.init<undefined>) : !cbit.reg<1>
+      %index = arith.constant 0 : index
       %one = arith.constant 1 : i2
       %zero = arith.constant 0 : i2
       %bits = cbit.alloc(#cbit.init<undefined>) {mqt.register_name = "c"}
@@ -151,7 +160,11 @@ TEST(OpenQASM3EmissionTest, RejectsStaleClassicalSnapshots) {
       %old = cbit.read %bits : !cbit.reg<2> -> i2
       cbit.write %zero, %bits : i2, !cbit.reg<2>
       %condition = arith.cmpi eq, %old, %one : i2
-      return %bits, %condition : !cbit.reg<2>, i1
+      scf.if %condition { qc.x %q : !qc.qubit }
+      %measured = qc.measure %q : !qc.qubit -> i1
+      cbit.store %measured, %result[%index] : !cbit.reg<1>
+      qc.dealloc %q : !qc.qubit
+      return %result : !cbit.reg<1>
     }
   })mlir";
   DialectRegistry registry = emissionDialects();
@@ -159,7 +172,11 @@ TEST(OpenQASM3EmissionTest, RejectsStaleClassicalSnapshots) {
   auto moduleOp = parseSourceString<ModuleOp>(source, &context);
   ASSERT_TRUE(moduleOp);
 
-  EXPECT_TRUE(failed(qc::translateQCToOpenQASM3(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  ASSERT_TRUE(restored) << *emitted;
+  expectOneSample(*restored);
 }
 
 TEST(OpenQASM3EmissionTest, CanonicalizesFixedAnglesToPortableFloats) {
@@ -415,7 +432,7 @@ module {
       << *emitted;
 }
 
-TEST(OpenQASM3EmissionTest, RejectsComparisonAfterInterveningRegisterWrite) {
+TEST(OpenQASM3EmissionTest, PreservesComparisonBeforeInterveningRegisterWrite) {
   constexpr llvm::StringLiteral source = R"mlir(
 module {
   func.func @main() -> !cbit.reg<3> attributes {mqt.entry_point} {
@@ -433,6 +450,9 @@ module {
     scf.if %forwarded {
       qc.x %q : !qc.qubit
     }
+    %measured = qc.measure %q : !qc.qubit -> i1
+    cbit.store %measured, %c[%zero] : !cbit.reg<3>
+    qc.dealloc %q : !qc.qubit
     return %c : !cbit.reg<3>
   }
 }
@@ -442,7 +462,11 @@ module {
   auto moduleOp = parseSourceString<ModuleOp>(source, &context);
   ASSERT_TRUE(moduleOp);
 
-  EXPECT_TRUE(failed(qc::translateQCToOpenQASM3(*moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  ASSERT_TRUE(restored) << *emitted;
+  expectOneSample(*restored, "001");
 }
 
 TEST(OpenQASM3EmissionTest, EmitsFixedWidthRegisterExpressions) {
@@ -711,7 +735,7 @@ TEST(OpenQASM3EmissionTest, EmitsCatalogHelpersUnderTheirNativeNames) {
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("inv @ sx"), std::string::npos);
-  EXPECT_NE(emitted->find("u2("), std::string::npos);
+  EXPECT_NE(emitted->find("_mqt_u(pi / 2,"), std::string::npos);
   EXPECT_NE(emitted->find("U("), std::string::npos);
   constexpr std::array helperNames{
       "r",   "iswap", "dcx",        "ecr",         "rxx",  "ryy",
@@ -955,6 +979,22 @@ TEST(OpenQASM3EmissionTest, DropsUnreachableGateFunctions) {
 TEST(OpenQASM3EmissionTest, RejectsInvalidGateFunctions) {
   constexpr std::array sources{
       llvm::StringLiteral{R"mlir(module {
+        func.func private @condition_effect(%qubit: !qc.qubit) {
+          scf.while : () -> () {
+            qc.x %qubit : !qc.qubit
+            %false = arith.constant false
+            scf.condition(%false)
+          } do { scf.yield }
+          return
+        }
+        func.func @entry() attributes {mqt.entry_point} {
+          %qubit = qc.alloc : !qc.qubit
+          func.call @condition_effect(%qubit) : (!qc.qubit) -> ()
+          qc.dealloc %qubit : !qc.qubit
+          return
+        }
+      })mlir"},
+      llvm::StringLiteral{R"mlir(module {
         func.func private @dynamic(%qubit: !qc.qubit) {
           %zero = arith.constant 0 : index
           %one = arith.constant 1 : index
@@ -1073,8 +1113,8 @@ module {
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_NE(emitted->find("sin((-0.25))"), std::string::npos);
-  EXPECT_NE(emitted->find("mod(0.25, sin((-0.25)))"), std::string::npos);
+  EXPECT_NE(emitted->find("sin("), std::string::npos);
+  EXPECT_NE(emitted->find("mod(0.25,"), std::string::npos);
   EXPECT_NE(emitted->find("int[64]("), std::string::npos) << *emitted;
 }
 
@@ -1119,7 +1159,7 @@ module {
     %igt = arith.cmpi sgt, %one, %two : i64
     %ige = arith.cmpi sge, %one, %two : i64
     %feq = arith.cmpf oeq, %one_float, %two_float : f64
-    %fne = arith.cmpf one, %one_float, %two_float : f64
+    %fne = arith.cmpf une, %one_float, %two_float : f64
     %flt = arith.cmpf olt, %one_float, %two_float : f64
     %fle = arith.cmpf ole, %one_float, %two_float : f64
     %fgt = arith.cmpf ogt, %one_float, %two_float : f64
@@ -1495,7 +1535,7 @@ TEST(OpenQASM3EmissionTest, LeavesDestinationEmptyOnFailure) {
   EXPECT_TRUE(output.empty());
 }
 
-TEST(OpenQASM3EmissionTest, RejectsExcessiveExpressionNesting) {
+TEST(OpenQASM3EmissionTest, MaterializesDeepScalarExpressions) {
   DialectRegistry registry = emissionDialects();
   MLIRContext context(registry);
   context.loadAllAvailableDialects();
@@ -1517,10 +1557,23 @@ TEST(OpenQASM3EmissionTest, RejectsExcessiveExpressionNesting) {
   func::ReturnOp::create(builder, location, value);
   ASSERT_TRUE(succeeded(verify(moduleOp)));
 
-  EXPECT_TRUE(failed(qc::translateQCToOpenQASM3(moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_LT(emitted->size(), 100000);
+  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  ASSERT_TRUE(restored) << *emitted;
+  PassManager manager(&context);
+  manager.addPass(createCanonicalizerPass());
+  ASSERT_TRUE(succeeded(manager.run(*restored)));
+  auto entry = restored->lookupSymbol<func::FuncOp>("main");
+  auto returned = cast<func::ReturnOp>(entry.getBody().front().getTerminator());
+  APInt result;
+  ASSERT_TRUE(matchPattern(returned.getOperand(0), m_ConstantInt(&result)));
+  EXPECT_EQ(result.getSExtValue(), 257);
+  moduleOp.erase();
 }
 
-TEST(OpenQASM3EmissionTest, RejectsExcessiveExpressionExpansion) {
+TEST(OpenQASM3EmissionTest, MaterializesSharedScalarExpressions) {
   DialectRegistry registry = emissionDialects();
   MLIRContext context(registry);
   context.loadAllAvailableDialects();
@@ -1541,7 +1594,20 @@ TEST(OpenQASM3EmissionTest, RejectsExcessiveExpressionExpansion) {
   func::ReturnOp::create(builder, location, value);
   ASSERT_TRUE(succeeded(verify(moduleOp)));
 
-  EXPECT_TRUE(failed(qc::translateQCToOpenQASM3(moduleOp)));
+  auto emitted = qc::translateQCToOpenQASM3(moduleOp);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_LT(emitted->size(), 10000);
+  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  ASSERT_TRUE(restored) << *emitted;
+  PassManager manager(&context);
+  manager.addPass(createCanonicalizerPass());
+  ASSERT_TRUE(succeeded(manager.run(*restored)));
+  auto entry = restored->lookupSymbol<func::FuncOp>("main");
+  auto returned = cast<func::ReturnOp>(entry.getBody().front().getTerminator());
+  APInt result;
+  ASSERT_TRUE(matchPattern(returned.getOperand(0), m_ConstantInt(&result)));
+  EXPECT_EQ(result.getSExtValue(), 65536);
+  moduleOp.erase();
 }
 
 TEST(OpenQASM3EmissionTest, RejectsExcessiveClassicalRegisterWidth) {
@@ -1982,6 +2048,182 @@ for int i in [0:5] {
   auto imported = qc::translateQASM3ToQC(source, &context);
   ASSERT_TRUE(imported);
   EXPECT_TRUE(succeeded(verify(*imported)));
+}
+
+TEST(OpenQASM3EmissionTest, PreservesZeroAndMixedOutputResults) {
+  constexpr std::array sources{
+      "OPENQASM 3.1; output int answer; answer = 0;",
+      "OPENQASM 3.1; output int a; output bit b; a = 1; b = false;",
+  };
+  for (const auto* source : sources) {
+    MLIRContext context;
+    auto original = qc::translateQASM3ToQC(source, &context);
+    ASSERT_TRUE(original);
+    auto emitted = qc::translateQCToOpenQASM3(*original);
+    ASSERT_TRUE(succeeded(emitted));
+    auto restored = qc::translateQASM3ToQC(*emitted, &context);
+    ASSERT_TRUE(restored) << *emitted;
+    EXPECT_EQ(original->lookupSymbol<func::FuncOp>("main").getResultTypes(),
+              restored->lookupSymbol<func::FuncOp>("main").getResultTypes());
+  }
+}
+
+TEST(OpenQASM3EmissionTest, RejectsRepeatedRegisterResults) {
+  auto registry = emissionDialects();
+  MLIRContext context(registry);
+  auto moduleOp = parseSourceString<ModuleOp>(R"mlir(module {
+    func.func @main() -> (!cbit.reg<1>, !cbit.reg<1>) {
+      %c = cbit.alloc(#cbit.init<zero>) : !cbit.reg<1>
+      return %c, %c : !cbit.reg<1>, !cbit.reg<1>
+    }
+  })mlir",
+                                              &context);
+  ASSERT_TRUE(moduleOp);
+  EXPECT_TRUE(failed(qc::translateQCToOpenQASM3(*moduleOp)));
+}
+
+TEST(OpenQASM3EmissionTest, UsesFrontendIdentifierRulesForOutputNames) {
+  for (const auto* name :
+       {"void", "im", "pragma", "pi", "tau", "euler", "sin", "valid_name"}) {
+    SCOPED_TRACE(name);
+    auto registry = emissionDialects();
+    MLIRContext context(registry);
+    const auto input =
+        std::string(R"mlir(module { func.func @main() -> !cbit.reg<1> {
+      %c = cbit.alloc(#cbit.init<zero>) {mqt.register_name = ")mlir") +
+        name + R"mlir("} : !cbit.reg<1>
+      return %c : !cbit.reg<1>
+    } })mlir";
+    auto moduleOp = parseSourceString<ModuleOp>(input, &context);
+    ASSERT_TRUE(moduleOp);
+    auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+    ASSERT_TRUE(succeeded(emitted));
+    EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+        *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+        << *emitted;
+  }
+}
+
+TEST(OpenQASM3EmissionTest, DoesNotIntroduceOutputsForUnusedMeasurements) {
+  MLIRContext context;
+  auto original =
+      qc::translateQASM3ToQC("OPENQASM 3.1; qubit q; measure q;", &context);
+  ASSERT_TRUE(original);
+  auto emitted = qc::translateQCToOpenQASM3(*original);
+  ASSERT_TRUE(succeeded(emitted));
+  EXPECT_EQ(emitted->find("\nbit "), std::string::npos);
+  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  ASSERT_TRUE(restored);
+  EXPECT_TRUE(
+      restored->lookupSymbol<func::FuncOp>("main").getResultTypes().empty());
+  size_t measurements = 0;
+  restored->walk([&](qc::MeasureOp) { ++measurements; });
+  EXPECT_EQ(measurements, 1);
+}
+
+TEST(OpenQASM3EmissionTest,
+     RoundTripsFloatingInequalityAndRejectsOrderedNotEqual) {
+  MLIRContext context;
+  auto original =
+      qc::translateQASM3ToQC("OPENQASM 3.1; qubit q; bit value = measure q; "
+                             "float f = float(bool(value)); "
+                             "output bool b; b = f != 2.0;",
+                             &context);
+  ASSERT_TRUE(original);
+  auto emitted = qc::translateQCToOpenQASM3(*original);
+  ASSERT_TRUE(succeeded(emitted));
+  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  ASSERT_TRUE(restored);
+  size_t comparisons = 0;
+  restored->walk([&](arith::CmpFOp comparison) {
+    EXPECT_EQ(comparison.getPredicate(), arith::CmpFPredicate::UNE);
+    ++comparisons;
+  });
+  EXPECT_EQ(comparisons, 1);
+  original->walk([&](arith::CmpFOp comparison) {
+    comparison.setPredicate(arith::CmpFPredicate::ONE);
+  });
+  EXPECT_TRUE(failed(qc::translateQCToOpenQASM3(*original)));
+}
+
+TEST(OpenQASM3EmissionTest,
+     StrictCatalogDefinitionsPreserveControlledUnitaries) {
+  struct Gate {
+    const char* call;
+    size_t arity;
+  };
+  constexpr std::array gates{
+      Gate{.call = "r(0.1, 0.2)", .arity = 1},
+      Gate{.call = "u2(0.2, 0.3)", .arity = 1},
+      Gate{.call = "U(0.1, 0.2, 0.3)", .arity = 1},
+      Gate{.call = "u3(0.1, 0.2, 0.3)", .arity = 1},
+      Gate{.call = "rxx(0.1)", .arity = 2},
+      Gate{.call = "ryy(0.2)", .arity = 2},
+      Gate{.call = "rzx(0.3)", .arity = 2},
+      Gate{.call = "rzz(0.4)", .arity = 2},
+      Gate{.call = "iswap", .arity = 2},
+      Gate{.call = "dcx", .arity = 2},
+      Gate{.call = "ecr", .arity = 2},
+      Gate{.call = "xx_plus_yy(0.5, 0.6)", .arity = 2},
+      Gate{.call = "xx_minus_yy(0.7, 0.8)", .arity = 2},
+      Gate{.call = "rccx", .arity = 3},
+  };
+  for (const auto& gate : gates) {
+    for (bool controlled : {false, true}) {
+      SCOPED_TRACE(gate.call);
+      SCOPED_TRACE(controlled);
+      const auto width = gate.arity + static_cast<size_t>(controlled);
+      std::string input = "OPENQASM 3.1; include \"stdgates.inc\"; ";
+      for (size_t i = 0; i < width; ++i) {
+        input += "qubit q" + std::to_string(i) + "; ";
+      }
+      if (controlled) {
+        input += "ctrl @ ";
+      }
+      input += std::string(gate.call) + " ";
+      for (size_t i = 0; i < width; ++i) {
+        input += "q" + std::to_string(i) + (i + 1 == width ? ";" : ",");
+      }
+      DialectRegistry registry;
+      func::registerInlinerExtension(registry);
+      LLVM::registerInlinerInterface(registry);
+      MLIRContext context(registry);
+      auto original = qc::translateQASM3ToQC(input, &context);
+      ASSERT_TRUE(original);
+      auto emitted = qc::translateQCToOpenQASM3(*original);
+      ASSERT_TRUE(succeeded(emitted));
+      auto analyzed = oq3::frontend::analyzeOpenQASM(
+          *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict});
+      ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+      auto restored = qc::detail::emitOpenQASMToQC(*analyzed.program, context);
+      ASSERT_TRUE(restored);
+      dd::Package package(width);
+      PassManager manager(&context);
+      manager.addPass(createInlinerPass());
+      manager.addPass(createCanonicalizerPass());
+      manager.addPass(createQCToQCO());
+      ASSERT_TRUE(succeeded(manager.run(*original)));
+      ASSERT_TRUE(succeeded(manager.run(*restored)));
+      auto lhs = qco::buildFunctionality(
+          original->lookupSymbol<func::FuncOp>("main"), package);
+      ASSERT_TRUE(succeeded(lhs));
+      const auto expected = lhs->getMatrix(width);
+      auto rhs = qco::buildFunctionality(
+          restored->lookupSymbol<func::FuncOp>("main"), package);
+      ASSERT_TRUE(succeeded(rhs));
+      const auto actual = rhs->getMatrix(width);
+      bool nonIdentity = false;
+      for (size_t row = 0; row < expected.size(); ++row) {
+        for (size_t column = 0; column < expected.size(); ++column) {
+          nonIdentity |= std::abs(expected[row][column] -
+                                  (row == column ? 1.0 : 0.0)) > 1e-10;
+          EXPECT_LT(std::abs(expected[row][column] - actual[row][column]),
+                    1e-10);
+        }
+      }
+      EXPECT_TRUE(nonIdentity);
+    }
+  }
 }
 
 } // namespace

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -105,7 +105,7 @@ TEST(OpenQASM3EmissionTest, EmitsStrictPortableBellProgram) {
   EXPECT_NE(source->find("ctrl @ x"), std::string::npos);
   EXPECT_NE(source->find("output bit[2] c;"), std::string::npos);
   EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *source, {.gatePolicy = oq3::frontend::GatePolicy::Strict}));
+      *source, oq3::frontend::GatePolicy::Strict));
   EXPECT_TRUE(qc::translateQASM3ToQC(*source, &context));
 }
 
@@ -140,8 +140,8 @@ TEST(OpenQASM3EmissionTest, PreservesMeasurementOrderBeforeDelayedStore) {
   ASSERT_NE(store, std::string::npos) << *emitted;
   EXPECT_LT(measurement, gate);
   EXPECT_LT(gate, store);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -198,8 +198,8 @@ result = measure q;
   EXPECT_EQ(emitted->find("mqt.openqasm"), std::string::npos);
   EXPECT_NE(emitted->find("rx(1.5707963267948966)"), std::string::npos)
       << *emitted;
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -256,8 +256,8 @@ r = measure q;
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("gate r("), std::string::npos);
   EXPECT_NE(emitted->find("output bit[1] _mqt_out0;"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -278,8 +278,8 @@ TEST(OpenQASM3EmissionTest, RenamesOutputsThatCollideWithStandardGates) {
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("output bit[1] _mqt_out0;"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
   EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
 }
@@ -320,8 +320,8 @@ switch (selector) {
   EXPECT_NE(emitted->find("if ("), std::string::npos);
   EXPECT_NE(emitted->find("for int "), std::string::npos);
   EXPECT_NE(emitted->find("while ("), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -342,8 +342,8 @@ while (c == 1) {
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("while ("), std::string::npos) << *emitted;
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -426,8 +426,8 @@ module {
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -500,8 +500,8 @@ module {
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -575,8 +575,8 @@ module {
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -695,8 +695,8 @@ module {
   EXPECT_NE(emitted->find("switch (1)"), std::string::npos);
   EXPECT_NE(emitted->find("case 1 {"), std::string::npos);
   EXPECT_NE(emitted->find("default {"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -748,8 +748,8 @@ TEST(OpenQASM3EmissionTest, EmitsCatalogHelpersUnderTheirNativeNames) {
   }
   EXPECT_NE(emitted->find("gate _mqt_gate"), std::string::npos);
   EXPECT_NE(emitted->find("pow(0.5) @ z"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 
   auto roundTripped = qc::translateQASM3ToQC(*emitted, &context);
@@ -786,8 +786,8 @@ inv @ pair(theta) q;
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("gate pair(p0) q0"), std::string::npos);
   EXPECT_NE(emitted->find("inv @ pair("), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
   auto roundTripped = qc::translateQASM3ToQC(*emitted, &context);
   ASSERT_TRUE(roundTripped);
@@ -830,8 +830,8 @@ TEST(OpenQASM3EmissionTest, OrdersNestedGateFunctionsBeforeTheirCallers) {
   ASSERT_NE(call, std::string::npos) << *emitted;
   EXPECT_LT(inner, outer);
   EXPECT_LT(outer, call);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -860,8 +860,8 @@ wrapper(0.5) q;
   EXPECT_LT(repeated, wrapper);
   EXPECT_NE(emitted->find("for int ", repeated), std::string::npos);
   EXPECT_NE(emitted->find("while (false)", repeated), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
   auto roundTripped = qc::translateQASM3ToQC(*emitted, &context);
   ASSERT_TRUE(roundTripped);
@@ -1137,8 +1137,8 @@ module {
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("mod(5.5, 2.0)"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -1491,8 +1491,8 @@ TEST(OpenQASM3EmissionTest, ReusesQubitRegisterNames) {
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("qubit[2] named_qubits;"), std::string::npos);
   EXPECT_EQ(emitted->find("qubit[2] not-valid;"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
+                                             oq3::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -2098,7 +2098,7 @@ TEST(OpenQASM3EmissionTest, UsesFrontendIdentifierRulesForOutputNames) {
     auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
     ASSERT_TRUE(succeeded(emitted));
     EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-        *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict}))
+        *emitted, oq3::frontend::GatePolicy::Strict))
         << *emitted;
   }
 }
@@ -2193,7 +2193,7 @@ TEST(OpenQASM3EmissionTest,
       ASSERT_TRUE(succeeded(emitted));
       auto restored = qc::translateQASM3ToQC(
           *emitted, &context,
-          {.frontend = {.gatePolicy = oq3::frontend::GatePolicy::Strict}});
+          {.gatePolicy = oq3::frontend::GatePolicy::Strict});
       ASSERT_TRUE(restored);
       dd::Package package(width);
       PassManager manager(&context);

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -8,7 +8,6 @@
  * Licensed under the MIT License
  */
 
-#include "../../../../lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h"
 #include "dd/Package.hpp"
 #include "mlir/Conversion/QCToQCO/QCToQCO.h"
 #include "mlir/Dialect/CBit/IR/CBitDialect.h"
@@ -2192,10 +2191,9 @@ TEST(OpenQASM3EmissionTest,
       ASSERT_TRUE(original);
       auto emitted = qc::translateQCToOpenQASM3(*original);
       ASSERT_TRUE(succeeded(emitted));
-      auto analyzed = oq3::frontend::analyzeOpenQASM(
-          *emitted, {.gatePolicy = oq3::frontend::GatePolicy::Strict});
-      ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
-      auto restored = qc::detail::emitOpenQASMToQC(*analyzed.program, context);
+      auto restored = qc::translateQASM3ToQC(
+          *emitted, &context,
+          {.frontend = {.gatePolicy = oq3::frontend::GatePolicy::Strict}});
       ASSERT_TRUE(restored);
       dd::Package package(width);
       PassManager manager(&context);

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -8,7 +8,6 @@
  * Licensed under the MIT License
  */
 
-#include "../../../lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h"
 #include "OpenQASMTestUtils.h"
 #include "mlir/Dialect/CBit/IR/CBitAttributes.h"
 #include "mlir/Dialect/CBit/IR/CBitDialect.h"
@@ -2849,8 +2848,6 @@ TEST(OpenQASMTargetTest, StopsEmissionAtEveryOperationBudgetBoundary) {
   };
   for (const auto* source : sources) {
     SCOPED_TRACE(source);
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
-    ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
     bool succeededOnce = false;
     for (size_t limit = 0; limit <= 256; ++limit) {
       SCOPED_TRACE(limit);
@@ -2861,7 +2858,7 @@ TEST(OpenQASMTargetTest, StopsEmissionAtEveryOperationBudgetBoundary) {
         return success();
       });
       auto moduleOp =
-          qc::detail::emitOpenQASMToQC(*analyzed.program, context, limit);
+          qc::translateQASM3ToQC(source, &context, {.maxOperations = limit});
       if (moduleOp) {
         EXPECT_TRUE(succeeded(verify(*moduleOp)));
         EXPECT_EQ(diagnostics, 0);

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -60,6 +60,29 @@ using namespace mlir::oq3::test;
 
 namespace {
 
+TEST(OpenQASMTargetTest, LoopLocalBitStorageHasNoGlobalRegisterName) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+output bit result;
+for int i in [0:1] {
+  bit local = true;
+  result = local;
+}
+)qasm";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  size_t localRegisters = 0;
+  moduleOp->walk([&](cbit::AllocOp allocation) {
+    if (!isa<func::FuncOp>(allocation->getParentOp())) {
+      ++localRegisters;
+      EXPECT_FALSE(allocation->hasAttr("mqt.register_name"));
+    }
+  });
+  EXPECT_EQ(localRegisters, 1);
+}
+
 TEST(OpenQASMTargetTest, FirstIterationInitializationHasRepresentableState) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.0;
@@ -2820,6 +2843,9 @@ TEST(OpenQASMTargetTest, StopsEmissionAtEveryOperationBudgetBoundary) {
       R"qasm(OPENQASM 3.1; qubit[8] q; barrier q; reset q;)qasm",
       R"qasm(OPENQASM 3.1; gate custom(a) q { inv @ U(a, 0.2, 0.3) q; } qubit[2] q; ctrl @ pow(2) @ custom(0.1) q[0], q[1];)qasm",
       R"qasm(OPENQASM 3.1; gate repeated(a) q { for int i in [0:2] { rx(a) q; } } qubit q; repeated(0.1) q;)qasm",
+      R"qasm(OPENQASM 3.1; qubit[4] q; for int i in [0:3] { x q[-i * 1 + 3]; })qasm",
+      R"qasm(OPENQASM 3.1; bit[8] c = "00000001"; int n = 1; c = (~c & c) | (c ^ c); c = (c << uint(n + 1)) >> uint(n); c = rotl(~c, n + 1); c = rotr(c, 2);)qasm",
+      R"qasm(OPENQASM 3.1; output uint[8] result; uint[8] n = 1; result = (~n & n) | (n ^ n); result = (result << uint(n + 1)) >> n; result = uint[8](-int(sin(float(n + 1))));)qasm",
   };
   for (const auto* source : sources) {
     SCOPED_TRACE(source);

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "../../../lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h"
 #include "OpenQASMTestUtils.h"
 #include "mlir/Dialect/CBit/IR/CBitAttributes.h"
 #include "mlir/Dialect/CBit/IR/CBitDialect.h"
@@ -2801,6 +2802,69 @@ TEST(OpenQASMTargetTest, PreservesImportedWhileBehavior) {
           << "each imported while-loop body must retain its gate behavior";
     }
   }
+}
+
+TEST(OpenQASMTargetTest, StopsEmissionAtEveryOperationBudgetBoundary) {
+  constexpr std::array sources{
+      R"qasm(OPENQASM 3.1; output int result; int x = 2; result = (x + x) ** 3;)qasm",
+      R"qasm(OPENQASM 3.1; output bool result; int x = 2; result = !(x == 1) && (x < 3 || x > 4);)qasm",
+      R"qasm(OPENQASM 3.1; bit[4] c = "0000"; int i = 1; c[i] = true; output bool result; result = c[i];)qasm",
+      R"qasm(OPENQASM 3.1; output int result; result = 0; for int i in [0:2] { result += i; })qasm",
+      R"qasm(OPENQASM 3.1; output int result; result = 0; for int i in [0:2] { if (i == 1) { continue; } result += i; })qasm",
+      R"qasm(OPENQASM 3.1; output int result; result = 0; while (result < 2) { result += 1; })qasm",
+      R"qasm(OPENQASM 3.1; output int result; result = 0; while (result < 2) { result += 1; if (result == 1) { continue; } break; })qasm",
+      R"qasm(OPENQASM 3.1; output int result; int i = 1; switch(i) { case 1, 2 { result = i + 1; } default { result = 0; } })qasm",
+      R"qasm(OPENQASM 3.1; qubit[3] q; for int i in [0:2] { x q[i]; })qasm",
+      R"qasm(OPENQASM 3.1; qubit[3] q; for int i in [0:2] { x q[i]; if (i == 1) { break; } })qasm",
+      R"qasm(OPENQASM 3.1; qubit[3] q; negctrl(2) @ x q[0], q[1], q[2]; bit[3] c = measure q;)qasm",
+      R"qasm(OPENQASM 3.1; qubit[8] q; barrier q; reset q;)qasm",
+      R"qasm(OPENQASM 3.1; gate custom(a) q { inv @ U(a, 0.2, 0.3) q; } qubit[2] q; ctrl @ pow(2) @ custom(0.1) q[0], q[1];)qasm",
+      R"qasm(OPENQASM 3.1; gate repeated(a) q { for int i in [0:2] { rx(a) q; } } qubit q; repeated(0.1) q;)qasm",
+  };
+  for (const auto* source : sources) {
+    SCOPED_TRACE(source);
+    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+    bool succeededOnce = false;
+    for (size_t limit = 0; limit <= 256; ++limit) {
+      SCOPED_TRACE(limit);
+      MLIRContext context;
+      size_t diagnostics = 0;
+      ScopedDiagnosticHandler handler(&context, [&](Diagnostic&) {
+        ++diagnostics;
+        return success();
+      });
+      auto moduleOp =
+          qc::detail::emitOpenQASMToQC(*analyzed.program, context, limit);
+      if (moduleOp) {
+        EXPECT_TRUE(succeeded(verify(*moduleOp)));
+        EXPECT_EQ(diagnostics, 0);
+        size_t operations = 0;
+        moduleOp->walk([&](Operation* operation) {
+          operations += static_cast<size_t>(!isa<ModuleOp>(operation));
+        });
+        EXPECT_LE(operations, limit);
+        succeededOnce = true;
+        break;
+      }
+      EXPECT_EQ(diagnostics, 1);
+    }
+    EXPECT_TRUE(succeededOnce);
+  }
+}
+
+TEST(OpenQASMTargetTest, DynamicStoresDoNotChargeForEveryRegisterBit) {
+  std::string source = "OPENQASM 3.1; bit[99999] c; output int i; i = 0;";
+  for (size_t i = 0; i < 40; ++i) {
+    source += "c[i] = false;";
+  }
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  size_t stores = 0;
+  moduleOp->walk([&](cbit::StoreOp) { ++stores; });
+  EXPECT_EQ(stores, 40);
 }
 
 } // namespace

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_parser.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_parser.cpp
@@ -63,8 +63,7 @@ include "stdgates.inc";
 qubit q;
 x q;
 )qasm";
-  oq3::frontend::FrontendOptions strict;
-  strict.gatePolicy = oq3::frontend::GatePolicy::Strict;
+  const auto strict = oq3::frontend::GatePolicy::Strict;
 
   EXPECT_FALSE(oq3::frontend::analyzeOpenQASM(withoutInclude, strict));
   EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(withInclude, strict));

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -288,8 +288,7 @@ cu3(0.1, 0.2, 0.3) q[0], q[1];
 )qasm";
   EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(source));
 
-  oq3::frontend::FrontendOptions strict;
-  strict.gatePolicy = oq3::frontend::GatePolicy::Strict;
+  const auto strict = oq3::frontend::GatePolicy::Strict;
   auto analyzed = oq3::frontend::analyzeOpenQASM(source, strict);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
@@ -298,8 +297,7 @@ cu3(0.1, 0.2, 0.3) q[0], q[1];
 }
 
 TEST(OpenQASMFrontendTest, PreservesStandardLibraryIdentity) {
-  oq3::frontend::FrontendOptions strict;
-  strict.gatePolicy = oq3::frontend::GatePolicy::Strict;
+  const auto strict = oq3::frontend::GatePolicy::Strict;
 
   EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
@@ -342,8 +340,7 @@ swap q[0], q[1];
 }
 
 TEST(OpenQASMFrontendTest, AcceptsHybridOpenQASM2Libraries) {
-  oq3::frontend::FrontendOptions strict;
-  strict.gatePolicy = oq3::frontend::GatePolicy::Strict;
+  const auto strict = oq3::frontend::GatePolicy::Strict;
   EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 2.0;
 include "stdgates.inc";
@@ -362,8 +359,7 @@ gate x q {
 qubit q;
 x q;
 )qasm";
-  oq3::frontend::FrontendOptions strict;
-  strict.gatePolicy = oq3::frontend::GatePolicy::Strict;
+  const auto strict = oq3::frontend::GatePolicy::Strict;
   EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(source, strict));
 }
 
@@ -938,8 +934,7 @@ if (true) {
 }
 
 TEST(OpenQASMFrontendTest, ActivatesStandardGatesSequentially) {
-  oq3::frontend::FrontendOptions strict;
-  strict.gatePolicy = oq3::frontend::GatePolicy::Strict;
+  const auto strict = oq3::frontend::GatePolicy::Strict;
   auto beforeInclude = oq3::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 qubit q;
@@ -1798,8 +1793,8 @@ r(0.5, 0.25) q;
   EXPECT_TRUE(llvm::none_of(compatible.program->gates,
                             [](const auto& gate) { return gate.name == "r"; }));
 
-  auto strict = oq3::frontend::analyzeOpenQASM(
-      source, {.gatePolicy = oq3::frontend::GatePolicy::Strict});
+  auto strict =
+      oq3::frontend::analyzeOpenQASM(source, oq3::frontend::GatePolicy::Strict);
   ASSERT_TRUE(strict) << strict.diagnostics.front().message;
   EXPECT_TRUE(llvm::any_of(strict.program->gates,
                            [](const auto& gate) { return gate.name == "r"; }));

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -656,7 +656,7 @@ if (rotr(value, 1)) { x q; }
       "OPENQASM 3.1; bit[2] value; uint n = popcount(value, 1);"));
 }
 
-TEST(OpenQASMFrontendTest, InvalidatesPopcountIndexFactsOnBitMutation) {
+TEST(OpenQASMFrontendTest, RequiresFullInitializationForPopcountIndices) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 bit[2] source;
@@ -690,10 +690,11 @@ output bit out;
 out = true;
 )qasm";
   auto preserved = oq3::frontend::analyzeOpenQASM(noMutation);
-  EXPECT_TRUE(preserved) << preserved.diagnostics.front().message;
+  EXPECT_FALSE(preserved);
 }
 
-TEST(OpenQASMFrontendTest, InvalidatesBitRegisterCastIndexFactsOnBitMutation) {
+TEST(OpenQASMFrontendTest,
+     RequiresFullInitializationForBitRegisterCastIndices) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 bit[2] source;
@@ -727,7 +728,7 @@ output bit out;
 out = true;
 )qasm";
   auto preserved = oq3::frontend::analyzeOpenQASM(noMutation);
-  EXPECT_TRUE(preserved) << preserved.diagnostics.front().message;
+  EXPECT_FALSE(preserved);
 }
 
 TEST(OpenQASMFrontendTest, RejectsBoolMeasurementTargetsInAllSourceModes) {
@@ -764,7 +765,7 @@ TEST(OpenQASMFrontendTest, RejectsBoolMeasurementTargetsInAllSourceModes) {
   EXPECT_EQ(located.diagnostics.front().location.column, 1);
 }
 
-TEST(OpenQASMFrontendTest, InvalidatesDynamicBitFactsOnIndexChanges) {
+TEST(OpenQASMFrontendTest, RejectsDynamicReadsOfPartiallyInitializedRegisters) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 qubit[2] q;
@@ -875,7 +876,7 @@ TEST(OpenQASMFrontendTest, RejectsShadowingBuiltInConstants) {
   }
 }
 
-TEST(OpenQASMFrontendTest, PropagatesDynamicBitFactsThroughKnownControlFlow) {
+TEST(OpenQASMFrontendTest, DynamicWritesDoNotProveWholeRegisterInitialization) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 qubit[2] q;
@@ -887,14 +888,16 @@ output bit result;
 result = measure q[0];
 )qasm";
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
-  ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+  ASSERT_FALSE(analyzed);
+  EXPECT_NE(analyzed.diagnostics.front().message.find("uninitialized bit"),
+            std::string::npos);
 }
 
 TEST(OpenQASMFrontendTest, SelectsKnownBranchStateForWideRegisters) {
   constexpr llvm::StringLiteral source = R"qasm(
 OPENQASM 3.1;
 qubit q;
-bit[99998] c;
+bit[99998] c = 0;
 int i = 99997;
 int selected;
 if (true) {
@@ -1848,10 +1851,11 @@ if(c==1180591620717411303433) x q[0];
 )qasm";
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
-  EXPECT_TRUE(llvm::any_of(analyzed.program->conditions, [](const auto& c) {
-    return c.kind == oq3::frontend::ConditionKind::RegisterComparison &&
-           c.expected[70];
-  }));
+  EXPECT_TRUE(
+      llvm::any_of(analyzed.program->bitVectorExpressions, [](const auto& c) {
+        return c.kind == oq3::frontend::BitVectorExpressionKind::Constant &&
+               c.width == 80 && c.constant[70];
+      }));
 }
 
 TEST(OpenQASMFrontendTest, PromotesNarrowUnsignedBitRegisterCastToInt) {
@@ -1972,10 +1976,11 @@ if(c==1_180_591_620_717_411_303_433) x q[0];
 )qasm";
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
-  EXPECT_TRUE(llvm::any_of(analyzed.program->conditions, [](const auto& c) {
-    return c.kind == oq3::frontend::ConditionKind::RegisterComparison &&
-           c.expected[70];
-  }));
+  EXPECT_TRUE(
+      llvm::any_of(analyzed.program->bitVectorExpressions, [](const auto& c) {
+        return c.kind == oq3::frontend::BitVectorExpressionKind::Constant &&
+               c.width == 80 && c.constant[70];
+      }));
 }
 
 TEST(OpenQASMFrontendTest,
@@ -2017,10 +2022,11 @@ if(c==1) x q[0];
   auto analyzed = oq3::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   /// Truncating to 64 bits would omit the leading zero bits.
-  EXPECT_TRUE(llvm::any_of(analyzed.program->conditions, [](const auto& c) {
-    return c.kind == oq3::frontend::ConditionKind::RegisterComparison &&
-           c.expected.getBitWidth() == 80U && c.expected == 1U;
-  }));
+  EXPECT_TRUE(
+      llvm::any_of(analyzed.program->bitVectorExpressions, [](const auto& c) {
+        return c.kind == oq3::frontend::BitVectorExpressionKind::Constant &&
+               c.constant.getBitWidth() == 80U && c.constant == 1U;
+      }));
 }
 
 TEST(OpenQASMFrontendTest, RejectsNegativeOpenQASM2RegisterCondition) {
@@ -2069,6 +2075,39 @@ TEST(OpenQASMFrontendTest,
               std::string::npos)
         << analyzed.diagnostics.front().message;
   }
+}
+
+TEST(OpenQASMFrontendTest, BoundsAffineProofWorkAcrossAssignments) {
+  std::string source = "OPENQASM 3.1; int a = 1;";
+  for (size_t i = 0; i < 60; ++i) {
+    source += "a = a + a;";
+  }
+  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+}
+
+TEST(OpenQASMFrontendTest, DeduplicatesLargeStaticControlledGateOperands) {
+  constexpr size_t width = 16000;
+  std::string source = "OPENQASM 3.1; qubit[" + std::to_string(width) +
+                       "] q; ctrl(" + std::to_string(width - 1) + ") @ x ";
+  for (size_t i = 0; i < width; ++i) {
+    source += "q[" + std::to_string(i) + "]" + (i + 1 == width ? ";" : ",");
+  }
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(source));
+  source.replace(source.rfind("q["), std::string::npos, "q[0];");
+  EXPECT_FALSE(oq3::frontend::analyzeOpenQASM(source));
+}
+
+TEST(OpenQASMFrontendTest, AcceptsExactWidthBitStringsAndFloatCasts) {
+  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+      "OPENQASM 3.1; bit[5] b = \"10_001\"; float f = float(int[64](1));"));
+  EXPECT_FALSE(
+      oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; bit[4] b = \"10_001\";"));
+  EXPECT_FALSE(
+      oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; bit[3] b = \"102\";"));
+  EXPECT_FALSE(oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; bit b = \"_\";"));
+  EXPECT_FALSE(
+      oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; float f = float[32](1);"));
 }
 
 } // namespace

--- a/mlir/unittests/programs/qasm_programs.cpp
+++ b/mlir/unittests/programs/qasm_programs.cpp
@@ -120,11 +120,15 @@ c[1] = measure q;
 const std::string globalPhase = R"qasm(OPENQASM 3.0;
 include "stdgates.inc";
 gphase(0.123);
+output int result;
+result = 0;
 )qasm";
 
 const std::string inverseGlobalPhase = R"qasm(OPENQASM 3.0;
 include "stdgates.inc";
 inv @ gphase(-0.123);
+output int result;
+result = 0;
 )qasm";
 
 const std::string identity = R"qasm(OPENQASM 3.0;

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -300,9 +300,7 @@ def test_openqasm_helper_gate_matrix(gate: Gate) -> None:
     circuit.append(gate, range(gate.num_qubits))
 
     source = QCProgram.from_qiskit(circuit).to_openqasm3().source
-    imported = QCProgram.from_qasm_str(source).to_qco()
-    imported.run_pass_pipeline("inline,canonicalize")
-    round_tripped = imported.to_qc().to_qiskit()
+    round_tripped = QCProgram.from_qasm_str(source).to_qiskit()
 
     assert np.allclose(Operator(round_tripped).data, Operator(circuit).data)
 

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 import qiskit
 from packaging import version
-from qiskit import QuantumCircuit, qasm3
+from qiskit import QuantumCircuit
 from qiskit.circuit import Gate, library
 from qiskit.quantum_info import Operator
 
@@ -300,7 +300,9 @@ def test_openqasm_helper_gate_matrix(gate: Gate) -> None:
     circuit.append(gate, range(gate.num_qubits))
 
     source = QCProgram.from_qiskit(circuit).to_openqasm3().source
-    round_tripped = qasm3.loads(source)
+    imported = QCProgram.from_qasm_str(source).to_qco()
+    imported.run_pass_pipeline("inline,canonicalize")
+    round_tripped = imported.to_qc().to_qiskit()
 
     assert np.allclose(Operator(round_tripped).data, Operator(circuit).data)
 

--- a/test/python/test_mlir_loops.py
+++ b/test/python/test_mlir_loops.py
@@ -112,18 +112,21 @@ result = false;
 
 @pytest.mark.parametrize("stale", [False, True])
 def test_wide_register_condition_in_do_while(*, stale: bool) -> None:
-    """Preserve direct wide comparisons and reject snapshots read before a store."""
+    """Preserve wide snapshots across stores in OpenQASM loop conditions."""
     read = "%bits = cbit.read %out : !cbit.reg<65> -> i65"
     program = QCProgram.from_mlir_str(f"""
 module {{
   func.func @main() -> !cbit.reg<65> attributes {{mqt.entry_point}} {{
     %q = qc.alloc : !qc.qubit
+    %parity = qc.alloc : !qc.qubit
     %out = cbit.alloc(#cbit.init<zero>) : !cbit.reg<65>
+    %lowest = arith.constant 0 : index
     %highest = arith.constant 64 : index
     %expected = arith.constant {1 << 64} : i65
     scf.while : () -> () {{
       qc.reset %q : !qc.qubit
       qc.x %q : !qc.qubit
+      qc.x %parity : !qc.qubit
       {read if stale else ""}
       %measured = qc.measure %q : !qc.qubit -> i1
       cbit.store %measured, %out[%highest] : !cbit.reg<65>
@@ -134,6 +137,9 @@ module {{
       scf.yield
     }}
     qc.dealloc %q : !qc.qubit
+    %odd = qc.measure %parity : !qc.qubit -> i1
+    cbit.store %odd, %out[%lowest] : !cbit.reg<65>
+    qc.dealloc %parity : !qc.qubit
     return %out : !cbit.reg<65>
   }}
 }}
@@ -141,10 +147,9 @@ module {{
     if stale:
         with pytest.raises(RuntimeError, match="stale classical snapshot"):
             program.to_qiskit()
-        with pytest.raises(RuntimeError, match="stale classical snapshot"):
-            program.to_openqasm3()
+        assert observe(QCProgram.from_qasm_str(program.to_openqasm3().source)) == 1 << 64
     else:
-        check_paths(program, 1 << 64)
+        check_paths(program, (1 << 64) | 1)
         assert program.to_qiskit().num_clbits == 65
 
 

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -1220,26 +1220,40 @@ def test_qiskit_export_rejects_measurement_with_multiple_destinations() -> None:
         program.to_qiskit()
 
 
-def test_qiskit_export_rejects_dynamic_measurement_destination() -> None:
-    """Require each Qiskit measurement destination to be static."""
-    program = QCProgram.from_mlir_str(
-        """module {
-  func.func @main() -> !cbit.reg<1> attributes {mqt.entry_point} {
-    %c0 = arith.constant 0 : index
-    %index = arith.addi %c0, %c0 : index
-    %q = qc.alloc : !qc.qubit
-    %c = cbit.alloc(#cbit.init<undefined>) : !cbit.reg<1>
-    %result = qc.measure %q : !qc.qubit -> i1
-    cbit.store %result, %c[%index] : !cbit.reg<1>
-    qc.dealloc %q : !qc.qubit
-    return %c : !cbit.reg<1>
-  }
-}
-"""
+@pytest.mark.parametrize("dynamic", [False, True])
+def test_qiskit_measurement_destination_requires_foldable_index(*, dynamic: bool) -> None:
+    """Fold a constant index, but reject a measurement-dependent destination."""
+    index = (
+        """%initial = qc.measure %q : !qc.qubit -> i1
+    cbit.store %initial, %c[%c0] : !cbit.reg<2>
+    %bit = cbit.load %c[%c0] : !cbit.reg<2>
+    %index = arith.index_castui %bit : i1 to index"""
+        if dynamic
+        else "%index = arith.addi %c0, %c0 : index"
     )
-
-    with pytest.raises(RuntimeError, match="dynamic classical destination"):
-        program.to_qiskit()
+    program = QCProgram.from_mlir_str(f"""module {{
+  func.func @main() -> !cbit.reg<2> attributes {{mqt.entry_point}} {{
+    %c0 = arith.constant 0 : index
+    %q = qc.alloc : !qc.qubit
+    %c = cbit.alloc(#cbit.init<zero>) : !cbit.reg<2>
+    {index}
+    %result = qc.measure %q : !qc.qubit -> i1
+    cbit.store %result, %c[%index] : !cbit.reg<2>
+    qc.dealloc %q : !qc.qubit
+    return %c : !cbit.reg<2>
+  }}
+}}
+""")
+    source_ir = program.ir
+    if dynamic:
+        with pytest.raises(RuntimeError, match="dynamic classical destination"):
+            program.to_qiskit()
+    else:
+        restored = program.to_qiskit()
+        assert restored.count_ops() == {"measure": 1}
+        assert restored.find_bit(restored.data[0].clbits[0]).index == 0
+        assert restored.num_clbits == 2
+    assert program.ir == source_ir
 
 
 def test_layout_is_accepted_and_ignored() -> None:
@@ -1610,7 +1624,7 @@ def test_custom_gate_export_checks_longest_shared_call_path() -> None:
 
 
 def test_unnamed_custom_gate_parameters_export_without_mutation() -> None:
-    """Name local formals without colliding with existing parameter metadata."""
+    """Bind local formals by position regardless of existing name metadata."""
     program = QCProgram.from_mlir_str("""module {
   func.func private @custom(%first: f64, %second: f64 {mqt.input_name = "p0"}, %q: !qc.qubit) attributes {mqt.unitary} {
     qc.rx(%first) %q : !qc.qubit
@@ -1682,8 +1696,9 @@ def test_constant_unary_custom_gate_argument_is_folded() -> None:
     assert restored.data[0].operation.params == [pytest.approx(np.sin(0.5))]
 
 
-def test_float_castable_custom_gate_argument_keeps_its_symbol() -> None:
-    """Do not fold a unary expression whose operand still tracks a symbol."""
+@pytest.mark.parametrize("cleanup", [False, True])
+def test_float_castable_custom_gate_argument_keeps_its_symbol(*, cleanup: bool) -> None:
+    """Preserve a live symbol through normalization and numeric binding."""
     program = QCProgram.from_mlir_str(
         """module {
   func.func private @custom(%angle: f64 {mqt.input_name = "angle"}, %q: !qc.qubit) attributes {mqt.unitary} {
@@ -1702,10 +1717,22 @@ def test_float_castable_custom_gate_argument_keeps_its_symbol() -> None:
 """
     )
 
+    if cleanup:
+        program.cleanup()
+    source_ir = program.ir
     restored = program.to_qiskit()
 
     assert {parameter.name for parameter in restored.parameters} == {"theta"}
     assert restored.data[0].operation.params[0].parameters == restored.parameters
+
+    expected = QuantumCircuit(1)
+    expected.rx(0, 0)
+    for theta in (-0.5, 0.0, 1.25):
+        assert np.allclose(
+            Operator(_assign_parameter_values(restored, {"theta": theta})).data,
+            Operator(expected).data,
+        )
+    assert program.ir == source_ir
 
 
 def test_distinct_custom_gate_specializations_round_trip() -> None:
@@ -2298,18 +2325,31 @@ def test_constant_index_switch_exports() -> None:
     assert [labels for labels, _ in switch.cases_specifier()] == [(0,), (CASE_DEFAULT,)]
 
 
-def test_shared_expression_dag_expansion_is_bounded() -> None:
-    """Bound tree expansion when both operands reuse the same SSA value."""
+@pytest.mark.parametrize("foldable", [False, True])
+def test_shared_expression_dag_expansion_is_bounded(*, foldable: bool) -> None:
+    """Simplify idempotent trees; retain the size bound for repeated squaring."""
     operations = [
         '%classical = cbit.alloc(#cbit.init<zero>) {mqt.register_name = "c"} : !cbit.reg<1>',
-        "%zero = arith.constant 0 : index",
-        "%value0 = cbit.load %classical[%zero] : !cbit.reg<1>",
+        "%zero = arith.constant 0 : i64",
+        "%bit = cbit.read %classical : !cbit.reg<1> -> i1",
+        "%value0 = arith.extui %bit : i1 to i64",
     ]
-    operations.extend(f"%value{index} = arith.andi %value{index - 1}, %value{index - 1} : i1" for index in range(1, 15))
-    operations.extend(["scf.if %value14 {", "  qc.x %q : !qc.qubit", "}"])
+    operation = "andi" if foldable else "muli"
+    operations.extend(
+        f"%value{index} = arith.{operation} %value{index - 1}, %value{index - 1} : i64" for index in range(1, 15)
+    )
+    operations.extend([
+        "%condition = arith.cmpi ne, %value14, %zero : i64",
+        "scf.if %condition { qc.x %q : !qc.qubit }",
+    ])
     program = _single_qubit_program(operations, returns_classical=True)
-    with pytest.raises(RuntimeError, match="size limit of 16384 nodes"):
-        program.to_qiskit()
+    source_ir = program.ir
+    if foldable:
+        assert program.to_qiskit().count_ops() == {"if_else": 1}
+    else:
+        with pytest.raises(RuntimeError, match="size limit of 16384 nodes"):
+            program.to_qiskit()
+    assert program.ir == source_ir
 
 
 @pytest.mark.parametrize("initial", [False, True])
@@ -2655,20 +2695,20 @@ def test_conditional_measurement_does_not_initialize_returned_cbit() -> None:
     ("expression", "error"),
     [
         (
-            """%left = arith.constant 0 : index
+            """%left = arith.index_castui %bit : i1 to index
     %right = arith.constant 1 : index
     %condition = arith.cmpi eq, %left, %right : index""",
             "integer comparisons require integer operands",
         ),
         (
-            """%left = arith.constant 0 : i65
+            """%left = arith.extui %bit : i1 to i65
     %right = arith.constant 1 : i65
     %condition = arith.cmpi eq, %left, %right : i65""",
             "unsigned classical values must be between 1 and 64 bits",
         ),
         (
             """%infinity = arith.constant 0x7FF0000000000000 : f64
-    %zero = arith.constant 0.0 : f64
+    %zero = arith.uitofp %bit : i1 to f64
     %condition = arith.cmpf oeq, %infinity, %zero : f64""",
             "floating-point literals must be finite",
         ),
@@ -2678,6 +2718,9 @@ def test_conditional_measurement_does_not_initialize_returned_cbit() -> None:
 def test_unsupported_export_expressions_fail_closed(expression: str, error: str) -> None:
     """Reject unsupported expression forms before modifying the source program."""
     program = _single_qubit_program([
+        '%classical = cbit.alloc(#cbit.init<zero>) {mqt.register_name = "c"} : !cbit.reg<1>',
+        "%index = arith.constant 0 : index",
+        "%bit = cbit.load %classical[%index] : !cbit.reg<1>",
         *expression.splitlines(),
         "scf.if %condition {",
         "  qc.x %q : !qc.qubit",
@@ -2734,7 +2777,7 @@ def test_bool_uint_and_float_expressions(condition: expr.Expr, operation: str) -
 
 
 def test_index_expression_export_preserves_low_bit() -> None:
-    """Export integer truncation as bit indexing instead of a truthiness cast."""
+    """Folding preserves the low bit rather than using a truthiness cast."""
     condition = expr.index(expr.lift(2, types.Uint(3)), expr.lift(0, types.Uint(3)))
     circuit = QuantumCircuit(1)
     with circuit.if_test(condition):
@@ -2745,11 +2788,12 @@ def test_index_expression_export_preserves_low_bit() -> None:
 
     restored = program.to_qiskit()
     restored_condition = restored.data[0].operation.condition
-    assert isinstance(restored_condition, expr.Expr)
-    assert expr.structurally_equivalent(restored_condition, condition)
+    assert isinstance(restored_condition, expr.Value)
+    assert restored_condition.type == types.Bool()
+    assert not restored_condition.value
 
 
-def test_integer_truncation_exports_as_low_bit_index() -> None:
+def test_integer_truncation_folds_to_low_bit() -> None:
     """Preserve the low-bit semantics of a generic integer truncation."""
     program = _single_qubit_program([
         "%two = arith.constant 2 : i3",
@@ -2761,9 +2805,9 @@ def test_integer_truncation_exports_as_low_bit_index() -> None:
 
     restored = program.to_qiskit()
     restored_condition = restored.data[0].operation.condition
-    expected = expr.index(expr.lift(2, types.Uint(3)), expr.lift(0, types.Uint(3)))
-    assert isinstance(restored_condition, expr.Expr)
-    assert expr.structurally_equivalent(restored_condition, expected)
+    assert isinstance(restored_condition, expr.Value)
+    assert restored_condition.type == types.Bool()
+    assert not restored_condition.value
 
 
 def _cbit_load_indices(ir: str) -> list[int]:
@@ -3378,8 +3422,9 @@ def test_partially_bound_symbolic_expression_round_trip() -> None:
     )
 
 
-def test_float_castable_symbolic_expression_keeps_parameter_identity() -> None:
-    """Do not collapse a float-castable expression that still tracks a symbol."""
+@pytest.mark.parametrize("cleanup", [False, True])
+def test_float_castable_symbolic_expression_keeps_parameter_identity(*, cleanup: bool) -> None:
+    """Preserve live parameter identity and values through normalization."""
     theta = Parameter("theta")
     angle = (theta - theta) + 2
     assert angle.parameters == {theta}
@@ -3388,15 +3433,20 @@ def test_float_castable_symbolic_expression_keeps_parameter_identity() -> None:
     circuit.rz(angle, 0)
 
     program = QCProgram.from_qiskit(circuit)
+    if cleanup:
+        program.cleanup()
+    source_ir = program.ir
     restored = program.to_qiskit()
 
     assert 'mqt.input_name = "theta"' in program.ir
     assert {parameter.name for parameter in restored.parameters} == {"theta"}
-    values = {"theta": 0.3}
-    assert np.allclose(
-        Operator(_assign_parameter_values(restored, values)).data,
-        Operator(_assign_parameter_values(circuit, values)).data,
-    )
+    for value in (-0.5, 0.0, 1.25):
+        values = {"theta": value}
+        assert np.allclose(
+            Operator(_assign_parameter_values(restored, values)).data,
+            Operator(_assign_parameter_values(circuit, values)).data,
+        )
+    assert program.ir == source_ir
 
 
 def test_parameterized_custom_definition_round_trip() -> None:

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -1609,6 +1609,54 @@ def test_custom_gate_export_checks_longest_shared_call_path() -> None:
         program.to_qiskit()
 
 
+def test_unnamed_custom_gate_parameters_export_without_mutation() -> None:
+    """Name local formals without colliding with existing parameter metadata."""
+    program = QCProgram.from_mlir_str("""module {
+  func.func private @custom(%first: f64, %second: f64 {mqt.input_name = "p0"}, %q: !qc.qubit) attributes {mqt.unitary} {
+    qc.rx(%first) %q : !qc.qubit
+    qc.ry(%second) %q : !qc.qubit
+    return
+  }
+  func.func @main() attributes {mqt.entry_point} {
+    %q = qc.alloc : !qc.qubit
+    %first = arith.constant 0.2 : f64
+    %second = arith.constant 0.3 : f64
+    qc.call @custom(%first, %second, %q) : f64, f64, !qc.qubit
+    qc.dealloc %q : !qc.qubit
+    return
+  }
+}
+""")
+    source_ir = program.ir
+    expected = QuantumCircuit(1)
+    expected.rx(0.2, 0)
+    expected.ry(0.3, 0)
+
+    restored = program.to_qiskit()
+
+    assert np.allclose(Operator(restored).data, Operator(expected).data)
+    assert restored == program.to_qiskit()
+    assert program.ir == source_ir
+
+
+@pytest.mark.parametrize(("cast", "angle"), [("sitofp", -1.0), ("uitofp", 255.0)])
+def test_constant_integer_cast_gate_parameter(cast: str, angle: float) -> None:
+    """Preserve the signedness of constant integer-to-float gate parameters."""
+    program = QCProgram.from_mlir_str(f"""module {{
+  func.func @main() attributes {{mqt.entry_point}} {{
+    %q = qc.alloc : !qc.qubit
+    %integer = arith.constant -1 : i8
+    %angle = arith.{cast} %integer : i8 to f64
+    qc.rx(%angle) %q : !qc.qubit
+    qc.dealloc %q : !qc.qubit
+    return
+  }}
+}}
+""")
+
+    assert program.to_qiskit().data[0].operation.params == [angle]
+
+
 def test_constant_unary_custom_gate_argument_is_folded() -> None:
     """Fold constant expressions before reconstructing Python parameters."""
     program = QCProgram.from_mlir_str(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Correct OpenQASM import/export contracts and implement the accepted audit simplifications. Affine quantum indexing remains supported.

- Bound shared-expression affine proofs and replace quadratic static distinctness checks with set lookup. Build persistent syntax IDs directly and use one bit-vector comparison representation.
- Count actual inserted QC operations instead of duplicating lowering in a projected cost model. Dynamic stores no longer pay an obsolete register-wide cost.
- Preserve output order, zero-valued data, and scalar snapshots across writes and regions. Keep global register-name metadata off loop-local bit storage. Reject repeated register results explicitly, use void for absent outputs, and avoid storage for unused measurements.
- Share frontend name validation, support float casts and exact-width bit strings, and preserve unordered floating inequality. Use compact register initialization and a shared native-U helper to preserve global phase under controls.

Analysis accepts `GatePolicy` directly, and public `QASM3ImportOptions` contains a flat gate policy and emission limit. Parser operands, bit references, and modifiers share one representation. The typed emitter remains private.

Direct `QCProgram.from_qasm_str(source).to_qiskit()` export binds private gate parameters by position with generated local names. Native MLIR folding replaces custom constant-cast handling and simplifies scalar expressions on a clone. Public parameter identities and vector metadata remain validated. Tests check numeric binding and explicit cleanup, allow foldable expressions, and retain rejection coverage with dynamic operands and non-foldable expression DAGs.

Full resource and snapshot canonicalization remains explicit: it can remove unused standalone qubits or introduce scratch bits in Qiskit export. The audit and plan retain compact decisions, reproducers, and current validation.

Dynamic reads now require full-register initialization. The documentation states this supported subset and the existing include lookup policy. No changelog or upgrade-guide entry is needed for this unreleased v4 functionality.

Local validation: 3,201 CTest passes with one optional QDMI job-ID test skipped, all 1,156 Python tests (including 328 Qiskit translation tests), repository lint, and complete C++ lint of the PR diff with zero findings. The release build uses `ENABLE_IPO=OFF` locally because GCC LTO encountered duplicate MLIR symbols. Regenerated Python stubs are unchanged. Strict matrix tests preserve controlled global phase, and snapshot round trips distinguish one loop iteration from two. Fresh hosted CI is pending.

On the local 100,000-declaration parser probe, peak RSS fell from about 137,600 KiB to 88,000 KiB. The audit records the inputs, timing observations, and host-contention limits.

Codex assisted with implementation, tests, documentation, and this PR description. The implementation decision record and audit are included for review.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
