### PR TITLE
⚡️ Accelerate DDSIM QIR execution

### DIFF
--- a/.agent/audits/ddsim-qir-runner-refresh.md
+++ b/.agent/audits/ddsim-qir-runner-refresh.md
@@ -1,0 +1,126 @@
+# DDSIM QIR runner after DD and QCO improvements
+
+Status: all five confirmed findings implemented and locally validated. Baseline:
+PR #2466 at `b115e36209ee337b4f196472ec322779a7f6e919`, based on upstream main
+`b75b02fa95e7e686a6d14c825d8d3ffa3a9aa421`. Scope: QIR analysis, execution and
+ordered sampling; runtime DD capacity; shared unique-table growth;
+state-extraction validation.
+
+## Existing shared behavior
+
+Main already supplies shared DD gate construction (PR #2455), zero-capacity
+packages for the QCO sampler (PR #2459), and QIR lowering cleanup (PR #2463).
+QIR retains shared gate construction through the QCO adapter. The QC/QCO
+conversion and modifier work in PR #2464 does not replace the sampling or
+allocation changes here. No additional gate cache or execution engine is needed.
+
+## Implemented findings
+
+### Static Adaptive programs can reuse terminal sampling
+
+`getStaticSamplingOutputs` in `IRRewriter.cpp` now accepts Base and Adaptive
+profiles. The same body proof requires constant gate arguments and static IDs,
+an acyclic unconditional path, terminal measurements, known output mapping and a
+successful return. Allocation, reset, feedback, memory operations, unknown calls
+and loops still use ordinary per-shot execution. This optimizes static programs
+carrying an Adaptive profile; it does not defer genuinely adaptive measurements.
+State extraction remains Base-only.
+
+The sampling-plan tests run for both profiles, including rejected effects and
+control flow. The missing-initialize fallback test explicitly reads a result, so
+it still exercises ordinary per-shot resets after the eligibility change.
+
+### Full-register samples move directly into the output batch
+
+`Runtime::sampleMeasurements` owns the complete DD sampling loop. It classifies
+physical output order once after state preparation. For a full ascending
+register, it reverses the DD sampler's string in place and moves it into the
+batch. Subsets, repetitions and other permutations retain generic mapping. The
+runtime's last measurement string still matches the last returned shot. Empty
+output maps and zero-shot calls retain their behavior.
+
+`QIRBatchSampling.PreservesWideSeededOutputMappings` checks asymmetric 64-bit
+states, ascending and descending outputs, repeated/subset records, SWAPs and
+seeded repeatability. An independent comparison against the baseline executable
+also produced byte-identical seeded sequences for all four mappings. RNG
+consumption within each sampling path is unchanged.
+
+### Static capacity is exact; unknown resources grow geometrically
+
+`Runtime::QState` and package recreation start at zero capacity. Declared
+resources grow directly to their capacity. Dynamic and metadata-free execution
+allocate at least `Package::DEFAULT_QUBITS` on first quantum use, then double
+capacity as needed, bounded by the DD qubit limit. The state itself spans only
+used or declared qubits. Warm resets retain package capacity; transferring a
+state leaves lazy recreation for the next job.
+
+Native runtime tests cover phase, logical width and state transfer while
+incrementally growing static IDs and dynamic allocations. JIT tests cover exact
+declared capacity, unused qubits, zero-qubit states and repeated transfers.
+
+### Unique-table growth initializes only appended levels
+
+`UniqueTable::resize` resizes the outer storage and initializes bucket storage
+and invariant statistics only for appended levels. Existing buckets and
+statistics survive unchanged. It no longer constructs a full temporary bucket
+table on every resize. This shared change benefits both QIR and QCO.
+
+`DDPackageTest.UniqueTableGrowthPreservesLookupsStatisticsAndRoots` checks
+vector and matrix lookup identity, preserved statistics, new levels, retained
+roots, forced garbage collection and regrowth after clearing. Shrinking
+populated tables retains its existing unsupported cleanup limitation.
+
+### State extraction rejects unproven helper effects
+
+Previously, a Base-tagged entry containing `H(q0); call readout(); return`, with
+measurement inside `readout`, was accepted and returned a collapsed state. Such
+helper calls are outside the supported flat Base structure. The extraction scan
+now rejects defined or indirect callees and non-ordinary call instructions
+before changing IR. This closes the acceptance gap without interprocedural
+analysis. Regressions check direct and indirect helpers, calls after a direct
+irreversible boundary, and unchanged valid IR after rejection.
+
+## Combined performance evidence
+
+Seven-trial median process CPU times on native ARM64, GCC release and LLVM/MLIR
+23.1. Each comparison ran serially on CPU 0 and was repeated in reverse order.
+Batch measurements include preparation and output collection, but exclude JIT
+construction. Allocation counters measure C++ allocation requests, not peak RSS
+or all malloc calls. These workloads have small, compressed DDs.
+
+| Workload                                      |       Baseline | Combined patch |
+| --------------------------------------------- | -------------: | -------------: |
+| Adaptive Bell, 10,000 shots                   |       12.04 ms |        0.38 ms |
+| Adaptive GHZ32, 10,000 shots                  |     470-471 ms |   2.34-2.35 ms |
+| Base GHZ32, 100,000 full-register shots       | 33.27-33.52 ms | 23.11-23.23 ms |
+| Base GHZ64, 100,000 full-register shots       | 60.57-61.09 ms | 41.00-41.48 ms |
+| Empty runtime, requested bytes                |     26,075,208 |      8,767,048 |
+| Incremental 256-qubit growth, requested bytes |    376,938,454 |    143,106,006 |
+
+Full-register output allocation calls fall from about 200,000 to 100,000 per
+100,000-shot batch. Generic single-output sampling did not regress in either
+comparison. Incremental 32-qubit growth also retained its allocation and timing
+behavior. At 128 and 256 qubits, growth timings varied between runs and did not
+establish a stable combined latency benefit; the allocation reduction is the
+supported claim. Do not multiply gains from the earlier isolated prototypes.
+
+## Deferred candidates
+
+Skipping RNG draws on deterministic DD branches changes seeded sequences and
+regressed uniform superposition sampling in the isolated experiment. It remains
+deferred. A general gate cache, an LLVM optimization pipeline, replacing QIR's
+direct growth with Kronecker construction, removing ordered shots, and removing
+the forwarding DD adapter have no evidence warranting changes in this PR.
+
+## Validation
+
+Focused release tests passed: 46 JIT/analysis, 79 runtime and 180 DD tests. Full
+Clang CTest passed 3,190 tests with no failures and one existing skip.
+`uvx nox -s cpp-lint -- b75b02fa95e7e686a6d14c825d8d3ffa3a9aa421` checked all
+changed C++ implementation and test files with zero findings. Both
+`uvx nox -s lint` and the complete warning-as-error
+`uvx nox --non-interactive -s docs` build passed.
+
+The combined benchmark's output correlation, widths and final-record checks
+passed, and baseline/updated seeded mapping output matched byte for byte. Hosted
+CI is separate from these local results.

--- a/.agent/audits/ddsim-qir-runner.md
+++ b/.agent/audits/ddsim-qir-runner.md
@@ -1,6 +1,8 @@
 # DDSIM QIR runner audit
 
-Status: implemented. Date: 2026-09-08. Audit baseline:
+Status: implemented; historical baseline. The
+[refreshed audit](ddsim-qir-runner-refresh.md) records the subsequent sampling,
+allocation and extraction changes. Date: 2026-09-08. Audit baseline:
 `33dbc843e589d9e9166308084e825c9f8b2ff89d`; implementation based on main
 `3be5ee96f`. Scope: DDSIM, QIR execution, resource metadata and shared DD roots.
 

--- a/.agent/audits/ddsim-qir-runner.md
+++ b/.agent/audits/ddsim-qir-runner.md
@@ -1,0 +1,69 @@
+# DDSIM QIR runner audit
+
+Status: implemented. Date: 2026-09-08. Audit baseline:
+`33dbc843e589d9e9166308084e825c9f8b2ff89d`; implementation based on main
+`3be5ee96f`. Scope: DDSIM, QIR execution, resource metadata and shared DD roots.
+
+## Findings and disposition
+
+1. **Repeated static simulation:** DDSIM executed every gate for every shot. A
+   conservative Base-profile analysis now proves a straight-line path with known
+   constant QIS calls, terminal measurements and static recorded outputs.
+   Eligible batches execute once and sample the prepared DD. Result order,
+   repeated records and logical wire mapping are preserved. Unknown calls,
+   memory operations, branches, loops, resets and feedback retain per-shot JIT
+   execution. Text-enabled sessions also retain per-shot execution.
+2. **Unused output:** DDSIM retained formatted text it never read. Explicitly
+   disabled output now skips formatting while preserving measurement records.
+   Public text output and shot framing remain available.
+3. **Temporary allocations:** Address and generic-control translation now use
+   inline SmallVector storage; scalar measurement translates directly. Generic
+   control bytes still use memcpy. Shared DD gate validation remains with #2455.
+4. **Unused lazy JIT:** Replace LLLazyJITBuilder with LLJITBuilder and remove
+   its unused lazy manager, duplicate process-symbol generator and moved-out
+   state. Cache the immutable ABI registry. Preserve debugger and MinGW support,
+   host CPU tuning and explicit codegen options; reject incompatible
+   architecture/OS.
+5. **Logical SWAP extraction:** X(q0); SWAP(q0,q1) previously exported physical
+   order. Materialize the final permutation once when transferring state.
+6. **Phase and root ownership:** State growth discarded an initial scalar phase;
+   global phase changed a tracked edge without updating its root reference.
+   Growth now preserves weight, and the shared DD helper replaces the reference.
+   Regression tests cover following gates and forced collection.
+7. **Static resources:** Configure validated capacities from QIR attributes,
+   initialize declared width and use indexed static result storage. Missing
+   metadata retains inference. Avoid a second shot reset only when the entry
+   starts with runtime initialization. The metadata producer also counts
+   measured and read result IDs that have no output record.
+8. **Dynamic lifetime:** Recycle reset wire slots while issuing distinct handles
+   within a shot. Unused released wires are not materialized; the DD limit now
+   bounds peak live allocation. Tests retain stale-handle rejection and SWAP
+   behavior across reuse.
+
+## Retained boundaries
+
+Canonical gates and DD construction remain shared with QCO. No second
+interpreter, new dependency, general gate cache or LLVM optimization pipeline
+was added. Gate-cache evidence only covered repeated X gates; ownership, GC and
+large-DD behavior need separate evaluation. State-extraction analysis remains
+separate from the stricter sampling proof. Seeds are repeatable within a path;
+optimized sampling does not promise the previous RNG sequence.
+
+## Validation
+
+Release tests passed: 38 JIT/analysis, 78 runtime, 65 DDSIM, 169 DD and 122 QIR
+IR cases. These cover fallback side effects, no-initialize shot reset, output
+mapping, phase, resource limits and metadata production. Required lint is
+tracked in the companion plan and PR.
+
+A local GCC/LLVM 23.1 ARM64 comparison uses the same current DD implementation
+for both runners, including JIT construction, sampling, histogram insertion and
+destruction. Five warmed trials pinned to CPU 0 gave these median process CPU
+milliseconds (baseline / implementation): Bell 10,000 shots 43.3 / 17.9;
+16-qubit GHZ with 256 rotations and 4096 shots 409.0 / 21.6; 8-qubit dense
+circuit with 256 shots 37.8 / 16.5; Adaptive Bell 10,000 shots 32.8 / 24.1;
+one-shot Bell 11.4 / 9.6. Bell ordinary C++ allocations fell from about 284,000
+to 8,100. Host contention makes wall-clock comparisons unstable. These are
+diagnostic local measurements, not portable latency claims or large-DD
+benchmarks. Local sources and raw measurements are retained under
+`build/qir-audit/`.

--- a/.agent/plans/ddsim-qir-runner.md
+++ b/.agent/plans/ddsim-qir-runner.md
@@ -1,0 +1,33 @@
+# DDSIM QIR execution
+
+Status: implemented and locally validated.
+
+## Goal and scope
+
+Implement the eight findings in `.agent/audits/ddsim-qir-runner.md` and submit
+one PR. Preserve Adaptive execution and the public textual QIR runtime ABI.
+Terminal sampling must preserve recorded-result order and fall back for
+unsupported inputs. State extraction must preserve logical wires and phase.
+
+## Decisions
+
+- Build on current main. Shared gate-validation allocation work in #2455 stays
+  with that PR; QIR address-storage improvements are independent.
+- Declared static qubit capacity determines extracted state width. Missing
+  metadata keeps the existing direct-ABI and legacy-session inference behavior.
+- Recycle physical dynamic wires, not opaque handles, to reject stale handles.
+- Enable terminal sampling only after proving a straight-line static program
+  with known QIS calls, terminal measurements and static output mapping. Keep
+  full JIT execution for other sampling programs.
+- Keep canonical matrices and DD construction shared with QCO. A general gate
+  cache and an LLVM optimization pipeline remain benchmark-dependent candidates,
+  outside the eight confirmed findings.
+
+## Validation
+
+Release suites passed: 38 JIT/analysis, 78 runtime, 65 DDSIM, 169 DD and 122 QIR
+IR tests. The audit records CPU-time and allocation comparisons with their
+limits. Full Clang CTest: 4013 tests, no failures, one existing skip. Both
+`uvx nox -s lint` and `uvx nox -s cpp-lint` pass; C++ lint inspected all changed
+implementation and test files. The final JIT suite also passes after the
+naming-only cleanup. Hosted CI is not part of this local validation.

--- a/.agent/plans/ddsim-qir-runner.md
+++ b/.agent/plans/ddsim-qir-runner.md
@@ -4,30 +4,38 @@ Status: implemented and locally validated.
 
 ## Goal and scope
 
-Implement the eight findings in `.agent/audits/ddsim-qir-runner.md` and submit
-one PR. Preserve Adaptive execution and the public textual QIR runtime ABI.
-Terminal sampling must preserve recorded-result order and fall back for
-unsupported inputs. State extraction must preserve logical wires and phase.
+Implement the findings in `.agent/audits/ddsim-qir-runner.md` and
+`.agent/audits/ddsim-qir-runner-refresh.md` in one PR. Preserve Adaptive
+execution, ordered shot results and the public textual QIR runtime ABI. State
+extraction must preserve logical wires, declared width and phase.
 
 ## Decisions
 
-- Build on current main. Shared gate-validation allocation work in #2455 stays
-  with that PR; QIR address-storage improvements are independent.
-- Declared static qubit capacity determines extracted state width. Missing
-  metadata keeps the existing direct-ABI and legacy-session inference behavior.
+- Keep canonical gate matrices and DD construction shared with QCO. General
+  caching and LLVM optimization remain dependent on workload evidence.
+- Declared static capacities bound resource IDs and determine extracted width.
+  Missing metadata retains direct-ABI and legacy-session inference behavior.
+- Start packages at zero capacity. Size declared resources exactly; grow unknown
+  resources geometrically from the DD default capacity on first quantum use.
+  Warm resets retain storage, and moved-out packages are recreated lazily.
 - Recycle physical dynamic wires, not opaque handles, to reject stale handles.
-- Enable terminal sampling only after proving a straight-line static program
-  with known QIS calls, terminal measurements and static output mapping. Keep
-  full JIT execution for other sampling programs.
-- Keep canonical matrices and DD construction shared with QCO. A general gate
-  cache and an LLVM optimization pipeline remain benchmark-dependent candidates,
-  outside the eight confirmed findings.
+- Prove terminal sampling eligibility from the actual Base or Adaptive body:
+  unconditional acyclic execution, constant gates and static resources, terminal
+  measurements, and known output mapping. Other programs execute for every shot.
+- Keep batch DD sampling in Runtime. Move full ascending physical sample strings
+  directly into the batch; preserve generic mappings, the final measurement
+  record and RNG consumption.
+- Initialize only appended unique-table levels in the shared DD implementation.
+  Preserve existing lookups, statistics, roots and GC behavior.
+- Reject defined and indirect helpers during state-extraction analysis before
+  changing IR. Do not infer effects through function bodies.
 
 ## Validation
 
-Release suites passed: 38 JIT/analysis, 78 runtime, 65 DDSIM, 169 DD and 122 QIR
-IR tests. The audit records CPU-time and allocation comparisons with their
-limits. Full Clang CTest: 4013 tests, no failures, one existing skip. Both
-`uvx nox -s lint` and `uvx nox -s cpp-lint` pass; C++ lint inspected all changed
-implementation and test files. The final JIT suite also passes after the
-naming-only cleanup. Hosted CI is not part of this local validation.
+Focused release tests passed: 46 JIT/analysis, 79 runtime and 180 DD tests. Full
+Clang CTest passed 3,190 tests with no failures and one existing skip. Both
+required lint sessions and the complete strict documentation build passed. C++
+lint inspected the full changed-file set, including shared DD code. The
+refreshed audit records combined CPU-time and allocation measurements, including
+noisy growth timings and unchanged seeded output mappings. Hosted CI is separate
+from these local results.

--- a/docs/qdmi/ddsim_device.md
+++ b/docs/qdmi/ddsim_device.md
@@ -49,8 +49,8 @@ classical bit before submitting its generated OpenQASM 3 program.
 Sampling returns ordered bitstrings through `QDMI_JOB_RESULT_SHOTS` and their
 histogram through `QDMI_JOB_RESULT_HIST_KEYS` and `QDMI_JOB_RESULT_HIST_VALUES`.
 Both results come from the same samples, including mid-circuit measurements. QIR
-Base programs with a static terminal measurement region can sample one prepared
-DD; other QIR programs run once per shot. See the
+Base or Adaptive programs with a static terminal measurement region can sample
+one prepared DD; other QIR programs run once per shot. See the
 [QIR execution contract](../qir/index.md) for eligibility and resource limits.
 OpenQASM classical registers use reverse declaration order, with each register
 most-significant-bit first. QIR samples follow the program's recorded outputs.

--- a/docs/qdmi/ddsim_device.md
+++ b/docs/qdmi/ddsim_device.md
@@ -48,7 +48,10 @@ classical bit before submitting its generated OpenQASM 3 program.
 
 Sampling returns ordered bitstrings through `QDMI_JOB_RESULT_SHOTS` and their
 histogram through `QDMI_JOB_RESULT_HIST_KEYS` and `QDMI_JOB_RESULT_HIST_VALUES`.
-Both results come from the same samples, including mid-circuit measurements.
+Both results come from the same samples, including mid-circuit measurements. QIR
+Base programs with a static terminal measurement region can sample one prepared
+DD; other QIR programs run once per shot. See the
+[QIR execution contract](../qir/index.md) for eligibility and resource limits.
 OpenQASM classical registers use reverse declaration order, with each register
 most-significant-bit first. QIR samples follow the program's recorded outputs.
 

--- a/docs/qir/index.md
+++ b/docs/qir/index.md
@@ -102,13 +102,37 @@ non-text formats. The `num_shots` argument is optional for device-defined
 formats that encode their repetition count in the program payload.
 
 Every DDSIM QIR job owns its JIT session, runtime, simulator state,
-random-number generator, and output sink. QIR jobs can therefore execute
-concurrently without sharing measurements or interleaving runtime output.
-Sampling supports Base and Adaptive formats. Statevector extraction is limited
-to Base formats: the JIT stops the selected entry point immediately before the
-first call to a function marked `irreversible`, following the semantic boundary
-defined by the Base Profile. It rejects other profiles and Base Profile programs
-whose irreversible region is not terminal.
+random-number generator, and output settings. QIR jobs can therefore execute
+concurrently without sharing measurements. DDSIM records result bits directly;
+it does not format or retain the textual QIR output stream. Direct runtime
+callers can still request that stream, including its per-shot framing.
+
+Sampling supports Base and Adaptive formats. For Base programs with an acyclic,
+unconditional entry path, constant gate arguments, terminal Z measurements and
+scalar result records, DDSIM prepares the DD once and samples it for all shots.
+Repeated and reordered result records retain their program order, including
+after SWAPs. Programs with classical memory accesses, helper calls, conditional
+branches, resets, dynamic resources or generic controlled argument arrays use
+ordinary per-shot execution. These inputs remain supported by the runner; they
+are not eligible for this sampling optimization. A fixed seed reproduces a shot
+sequence for the same execution path; sequences need not match across different
+sampling algorithms or software versions.
+
+When provided for static resources, `required_num_qubits` and
+`required_num_results` specify capacities, and out-of-range IDs are rejected.
+Extracted states include unused qubits within the declared capacity, initialized
+to zero. Programs without those attributes retain the runtime's inference of
+static IDs or dynamic allocations. Dynamic qubit release resets and recycles the
+simulator wire; the qubit limit applies to peak simultaneous allocations rather
+than their cumulative number in a shot. Released handles remain invalid.
+
+Statevector extraction is limited to Base formats: the JIT stops the selected
+entry point immediately before the first call to a function marked
+`irreversible`, following the semantic boundary defined by the Base Profile. It
+rejects other profiles and Base Profile programs whose irreversible region is
+not terminal. Extracted amplitudes preserve global phase and logical qubit
+order, including SWAPs. LLVM target triples must match the host architecture and
+operating system because the JIT executes in process.
 
 The generic submission APIs intentionally reject QDMI calibration and batch-job
 formats. Calibration jobs do not carry a program, while batch jobs contain job

--- a/docs/qir/index.md
+++ b/docs/qir/index.md
@@ -107,7 +107,7 @@ concurrently without sharing measurements. DDSIM records result bits directly;
 it does not format or retain the textual QIR output stream. Direct runtime
 callers can still request that stream, including its per-shot framing.
 
-Sampling supports Base and Adaptive formats. For Base programs with an acyclic,
+Sampling supports Base and Adaptive formats. For either profile with an acyclic,
 unconditional entry path, constant gate arguments, terminal Z measurements and
 scalar result records, DDSIM prepares the DD once and samples it for all shots.
 Repeated and reordered result records retain their program order, including
@@ -130,7 +130,8 @@ Statevector extraction is limited to Base formats: the JIT stops the selected
 entry point immediately before the first call to a function marked
 `irreversible`, following the semantic boundary defined by the Base Profile. It
 rejects other profiles and Base Profile programs whose irreversible region is
-not terminal. Extracted amplitudes preserve global phase and logical qubit
+not terminal, as well as defined or indirect helper calls whose quantum effects
+cannot be proven. Extracted amplitudes preserve global phase and logical qubit
 order, including SWAPs. LLVM target triples must match the host architecture and
 operating system because the JIT executes in process.
 

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -22,7 +22,7 @@ namespace dd {
 /**
  * @brief Apply global phase to a given DD.
  *
- * @param in The input DD
+ * @param in The input DD, with an owned reference that is replaced in place
  * @param phase The phase to apply
  * @param dd The DD package to use
  * @return The output DD

--- a/mlir/include/mlir/Dialect/QIR/Execution/JIT/IRRewriter.h
+++ b/mlir/include/mlir/Dialect/QIR/Execution/JIT/IRRewriter.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <optional>
+#include <vector>
+
 namespace llvm {
 class Function;
 }
@@ -39,5 +43,13 @@ namespace qir {
  * operations.
  */
 bool prepareForStateExtraction(llvm::Function& entryPoint);
+
+/// Return logical qubit IDs in recorded-result order when measurements can be
+/// deferred for sampling. Only an acyclic unconditional Base entry path with
+/// constant gate arguments and scalar result records is supported. Unknown
+/// calls, result-dependent computation, resets and memory accesses return
+/// std::nullopt, leaving ordinary per-shot execution available.
+std::optional<std::vector<uintptr_t>>
+getStaticSamplingOutputs(const llvm::Function& entryPoint);
 
 } // namespace qir

--- a/mlir/include/mlir/Dialect/QIR/Execution/JIT/IRRewriter.h
+++ b/mlir/include/mlir/Dialect/QIR/Execution/JIT/IRRewriter.h
@@ -40,13 +40,13 @@ namespace qir {
  * @return Whether an irreversible boundary was found and truncated.
  * @throws std::invalid_argument if the entry point is not Base Profile, does
  * not use the QIR 2.x @c i64() signature, or has non-terminal irreversible
- * operations.
+ * operations or calls to defined or indirect callees.
  */
 bool prepareForStateExtraction(llvm::Function& entryPoint);
 
 /// Return logical qubit IDs in recorded-result order when measurements can be
-/// deferred for sampling. Only an acyclic unconditional Base entry path with
-/// constant gate arguments and scalar result records is supported. Unknown
+/// deferred for sampling. Only an acyclic unconditional Base or Adaptive path
+/// with constant gate arguments and scalar result records is supported. Unknown
 /// calls, result-dependent computation, resets and memory accesses return
 /// std::nullopt, leaving ordinary per-shot execution available.
 std::optional<std::vector<uintptr_t>>

--- a/mlir/include/mlir/Dialect/QIR/Execution/JIT/Session.h
+++ b/mlir/include/mlir/Dialect/QIR/Execution/JIT/Session.h
@@ -82,10 +82,10 @@ public:
 
   /// Execute a batch, preserving recorded-result order and returning the first
   /// nonzero exit code. With textual output disabled, eligible static Base
-  /// programs are executed once with deferred measurements, then sampled.
-  /// Other programs execute normally for every shot. State-extraction sessions
-  /// cannot be sampled. The supplied vector is replaced, including for zero
-  /// shots.
+  /// or Adaptive programs are executed once with deferred measurements, then
+  /// sampled. Other programs execute normally for every shot. State-extraction
+  /// sessions cannot be sampled. The supplied vector is replaced, including for
+  /// zero shots.
   int64_t sample(size_t shots, std::vector<std::string>& results);
 
   [[nodiscard]] auto runtime() -> Runtime&;

--- a/mlir/include/mlir/Dialect/QIR/Execution/JIT/Session.h
+++ b/mlir/include/mlir/Dialect/QIR/Execution/JIT/Session.h
@@ -17,11 +17,14 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
-#include <llvm/IR/LLVMContext.h>
 #include <llvm/Support/Error.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace qir {
 
@@ -42,7 +45,7 @@ enum class Execution { Sampling, StateExtraction };
  * @brief In-process JIT executor for QIR programs.
  * @details The session does the following, in order:
  * - Loads an LLVM module from an in-memory buffer,
- * - JIT-compiles it via LLVM's OrcJIT with lazy compilation.
+ * - JIT-compiles it via LLVM's OrcJIT,
  * - wires up the QIR runtime symbols, and
  * - runs the module function marked as its QIR entry point.
  * A session owns a single LLJIT instance and is not meant to be reused across
@@ -60,11 +63,13 @@ public:
    * @param irBytes Byte view of the IR.
    * @param bufferName Identifier used in diagnostics.
    * @param execution Execution mode.
+   * @param randomSeed Optional deterministic runtime seed.
    * @throws std::runtime_error if the IR cannot be parsed or the JIT fails
    * to initialize.
    */
   JitSession(llvm::StringRef irBytes, llvm::StringRef bufferName,
-             Execution execution = Execution::Sampling);
+             Execution execution = Execution::Sampling,
+             std::optional<uint64_t> randomSeed = std::nullopt);
 
   /// Tears down the LLJIT and any JIT'd resources owned by the session.
   ~JitSession();
@@ -75,22 +80,31 @@ public:
    */
   int64_t run();
 
+  /// Execute a batch, preserving recorded-result order and returning the first
+  /// nonzero exit code. With textual output disabled, eligible static Base
+  /// programs are executed once with deferred measurements, then sampled.
+  /// Other programs execute normally for every shot. State-extraction sessions
+  /// cannot be sampled. The supplied vector is replaced, including for zero
+  /// shots.
+  int64_t sample(size_t shots, std::vector<std::string>& results);
+
   [[nodiscard]] auto runtime() -> Runtime&;
 
 private:
-  llvm::orc::ThreadSafeContext tsCtx_{std::make_unique<llvm::LLVMContext>()};
-  llvm::orc::ThreadSafeModule module_;
   std::unique_ptr<Runtime> runtime_;
   std::unique_ptr<llvm::orc::LLJIT> jit_;
   EntryPointFn* entryPointFn_ = nullptr;
+  std::optional<std::vector<uintptr_t>> samplingOutputs_;
+  bool initializesRuntime_ = false;
+  Execution execution_;
 
   /// Initializes the native target, asm printer and asm parser.
   /// Safe to call multiple times; the work runs only on the first call.
   static void initNativeTargets();
 
   /// Parses LLVM IR (textual or bitcode) from @p irBytes using the session's
-  /// thread-safe context. @p bufferName is used in diagnostics.
-  llvm::Expected<llvm::orc::ThreadSafeModule>
+  /// own thread-safe context. @p bufferName is used in diagnostics.
+  static llvm::Expected<llvm::orc::ThreadSafeModule>
   loadModuleFromMemory(llvm::StringRef irBytes, llvm::StringRef bufferName);
 
   /// Prepares the session to run the program:

--- a/mlir/include/mlir/Dialect/QIR/Execution/Runtime/Runtime.h
+++ b/mlir/include/mlir/Dialect/QIR/Execution/Runtime/Runtime.h
@@ -19,11 +19,14 @@
 #include "dd/Package.hpp"
 #include "mlir/Dialect/QIR/Execution/Runtime/QIR.h"
 
+#include <llvm/ADT/SmallVector.h>
+
 #include <array>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <random>
 #include <span>
@@ -84,14 +87,11 @@ public:
     /// If @c dd is currently populated, the existing package's `decRef` plus
     /// `garbageCollect` path is used so the package (and its internal caches)
     /// is kept warm.
-    /// If @c dd was moved out (e.g., by @ref Runtime::takeState), a new package
-    /// is allocated.
+    /// A moved-out package is recreated on the next quantum operation.
     auto reset() -> void {
       if (dd) {
         dd->decRef(edge);
         dd->garbageCollect();
-      } else {
-        dd = std::make_unique<dd::Package>();
       }
       edge = dd::vEdge::one();
       numQubits = 0;
@@ -109,11 +109,16 @@ private:
 
   ResourceMode qubitMode;
   std::unordered_map<const Qubit*, dd::Qubit> qRegister;
+  std::vector<dd::Qubit> freeQubits_;
   // swap gates are not executed, they are tracked here
   std::vector<dd::Qubit> qubitPermutation;
   static constexpr uintptr_t MIN_DYN_RESULT_ADDRESS = 0x10000;
   ResourceMode resultMode;
   std::unordered_map<Result*, ResultStruct> rRegister;
+  std::optional<size_t> staticQubits_;
+  std::optional<size_t> staticResults_;
+  std::vector<ResultStruct> resultValues_;
+  bool deferMeasurements_ = false;
   std::string measurements;
   uintptr_t currentMaxQubitAddress;
   size_t currentMaxQubitId;
@@ -127,6 +132,9 @@ private:
   std::vector<std::pair<std::string, std::string>> metadata;
 
   auto enlargeState(size_t maxQubit) -> void;
+  void configureStaticResources(std::optional<size_t> qubits,
+                                std::optional<size_t> results);
+  auto sampleMeasurements(std::span<const uintptr_t> qubits) -> std::string;
   static auto staticQubitId(const Qubit* qubit) -> dd::Qubit {
     const auto id = reinterpret_cast<uintptr_t>(qubit);
     if (id >= dd::Package::MAX_POSSIBLE_QUBITS) {
@@ -139,7 +147,7 @@ private:
   auto resolveAddress(const Qubit* qubit) -> dd::Qubit;
   auto translateAddresses(std::span<Qubit* const> qubits,
                           std::span<Qubit* const> additionalQubits = {})
-      -> std::vector<dd::Qubit>;
+      -> llvm::SmallVector<dd::Qubit, 5>;
 
   // Helper function to output a type (bool, int...) to @c os, honoring the
   // active @c outputSchema.
@@ -175,6 +183,7 @@ public:
     apply(matrix.entries(), controls, targets);
   }
   auto applyGlobalPhase(dd::fp phase) -> void;
+  auto measure(Qubit* qubit, Result* result) -> void;
   template <typename... Args> auto measure(Args... args) -> void {
     const auto qubits = packOfType<Qubit*>(args...);
     const auto results = packOfType<Result*>(args...);
@@ -186,12 +195,8 @@ public:
         qubits.size() + results.size() == sizeof...(Args),
         "Number of qubits and results must match the number of arguments. "
         "First, all qubits followed then by all results.");
-    auto targets = translateAddresses(qubits);
-    for (size_t i = 0; i < targets.size(); ++i) {
-      targets[i] = qubitPermutation[targets[i]];
-      const auto result =
-          qState.dd->measureOneCollapsing(qState.edge, targets[i], mt);
-      deref(results[i]).r = result == '1';
+    for (size_t i = 0; i < qubits.size(); ++i) {
+      measure(qubits[i], results[i]);
     }
   }
   auto reset(std::span<Qubit* const> qubits) -> void;
@@ -217,6 +222,9 @@ public:
 
   auto setOstream(std::ostream& other) -> void;
   auto resetOstream() -> void;
+  /// Disable textual records while retaining measurement bits.
+  auto disableOutput() -> void;
+  [[nodiscard]] auto hasOutput() const -> bool { return os != nullptr; }
 
   /// Emit `OUTPUT\tRESULT\t<0|1>[\tlabel]\n` to the output stream.
   auto outputResult(bool value, const char* label) const -> void;

--- a/mlir/include/mlir/Dialect/QIR/Execution/Runtime/Runtime.h
+++ b/mlir/include/mlir/Dialect/QIR/Execution/Runtime/Runtime.h
@@ -80,7 +80,7 @@ public:
     size_t numQubits;
 
     QState()
-        : dd(std::make_unique<dd::Package>()), edge(dd::vEdge::one()),
+        : dd(std::make_unique<dd::Package>(0)), edge(dd::vEdge::one()),
           numQubits(0) {}
 
     /// Reset to a fresh empty state.
@@ -134,7 +134,8 @@ private:
   auto enlargeState(size_t maxQubit) -> void;
   void configureStaticResources(std::optional<size_t> qubits,
                                 std::optional<size_t> results);
-  auto sampleMeasurements(std::span<const uintptr_t> qubits) -> std::string;
+  auto sampleMeasurements(std::span<const uintptr_t> qubits, size_t shots,
+                          std::vector<std::string>& results) -> void;
   static auto staticQubitId(const Qubit* qubit) -> dd::Qubit {
     const auto id = reinterpret_cast<uintptr_t>(qubit);
     if (id >= dd::Package::MAX_POSSIBLE_QUBITS) {

--- a/mlir/lib/Dialect/QIR/Execution/JIT/IRRewriter.cpp
+++ b/mlir/lib/Dialect/QIR/Execution/JIT/IRRewriter.cpp
@@ -104,9 +104,19 @@ bool prepareForStateExtraction(llvm::Function& entryPoint) {
   llvm::SmallVector<llvm::CallInst*, 8> irreversibleCalls;
   for (auto& block : entryPoint) {
     for (auto& instruction : block) {
-      auto* call = llvm::dyn_cast<llvm::CallInst>(&instruction);
-      if (call != nullptr && isIrreversible(*call)) {
-        irreversibleCalls.emplace_back(call);
+      auto* call = llvm::dyn_cast<llvm::CallBase>(&instruction);
+      if (call == nullptr) {
+        continue;
+      }
+      const auto* callee = llvm::dyn_cast<llvm::Function>(
+          call->getCalledOperand()->stripPointerCasts());
+      if (!llvm::isa<llvm::CallInst>(call) || callee == nullptr ||
+          !callee->isDeclaration()) {
+        throw std::invalid_argument(
+            "QIR state extraction requires direct calls to declared functions");
+      }
+      if (isIrreversible(*call)) {
+        irreversibleCalls.emplace_back(llvm::cast<llvm::CallInst>(call));
       }
     }
   }
@@ -182,7 +192,8 @@ std::optional<std::vector<uintptr_t>>
 getStaticSamplingOutputs(const llvm::Function& entryPoint) {
   const auto profile = entryPoint.getFnAttribute(QIR_PROFILES_ATTR);
   if (entryPoint.isDeclaration() || !profile.isStringAttribute() ||
-      profile.getValueAsString().compare(BASE_PROFILE) != 0) {
+      (profile.getValueAsString().compare(BASE_PROFILE) != 0 &&
+       profile.getValueAsString().compare(ADAPTIVE_PROFILE) != 0)) {
     return std::nullopt;
   }
   std::unordered_map<uintptr_t, uintptr_t> results;

--- a/mlir/lib/Dialect/QIR/Execution/JIT/IRRewriter.cpp
+++ b/mlir/lib/Dialect/QIR/Execution/JIT/IRRewriter.cpp
@@ -15,10 +15,12 @@
 #include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/ADT/StringSwitch.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/CFG.h>
 #include <llvm/IR/Constant.h>
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/Dominators.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/IRBuilder.h>
@@ -26,7 +28,13 @@
 #include <llvm/Support/Casting.h>
 #include <llvm/Transforms/Utils/Local.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <optional>
 #include <stdexcept>
+#include <unordered_map>
+#include <vector>
 
 namespace qir {
 
@@ -134,6 +142,133 @@ bool prepareForStateExtraction(llvm::Function& entryPoint) {
   oldTerminator->eraseFromParent();
   llvm::removeUnreachableBlocks(entryPoint);
   return true;
+}
+
+static std::optional<uintptr_t> staticResourceId(const llvm::Value* value) {
+  if (llvm::isa<llvm::ConstantPointerNull>(value)) {
+    return 0;
+  }
+  const auto* cast = llvm::dyn_cast<llvm::ConstantExpr>(value);
+  if (cast == nullptr || cast->getOpcode() != llvm::Instruction::IntToPtr) {
+    return std::nullopt;
+  }
+  const auto* id = llvm::dyn_cast<llvm::ConstantInt>(cast->getOperand(0));
+  if (id == nullptr ||
+      id->getValue().getActiveBits() > std::numeric_limits<uintptr_t>::digits) {
+    return std::nullopt;
+  }
+  return static_cast<uintptr_t>(id->getZExtValue());
+}
+
+static bool isStaticGate(const llvm::CallInst& call, llvm::StringRef name) {
+  const auto known = llvm::StringSwitch<bool>(name)
+#define MQT_GATE(KEY, NAME, GETTER, TARGETS, PARAMS, SUFFIX, CTL_SUFFIX)       \
+  .Case("__quantum__qis__" #NAME "__" #SUFFIX, true)                           \
+      .Case("__quantum__qis__c" #NAME "__" #SUFFIX, true)                      \
+      .Case("__quantum__qis__cc" #NAME "__" #SUFFIX, true)
+#include "mlir/Conversion/GateTable.def"
+                         .Case("__quantum__qis__gphase__body", true)
+                         .Case("__quantum__qis__cnot__body", true)
+                         .Default(false);
+  return known && std::ranges::all_of(call.args(), [](const llvm::Value* arg) {
+           if (const auto* fp = llvm::dyn_cast<llvm::ConstantFP>(arg)) {
+             return fp->getValueAPF().isFinite();
+           }
+           return staticResourceId(arg).has_value();
+         });
+}
+
+std::optional<std::vector<uintptr_t>>
+getStaticSamplingOutputs(const llvm::Function& entryPoint) {
+  const auto profile = entryPoint.getFnAttribute(QIR_PROFILES_ATTR);
+  if (entryPoint.isDeclaration() || !profile.isStringAttribute() ||
+      profile.getValueAsString().compare(BASE_PROFILE) != 0) {
+    return std::nullopt;
+  }
+  std::unordered_map<uintptr_t, uintptr_t> results;
+  std::vector<uintptr_t> outputs;
+  llvm::SmallPtrSet<const llvm::BasicBlock*, 4> visited;
+  const auto* block = &entryPoint.getEntryBlock();
+  bool terminal = false;
+  bool started = false;
+  while (visited.insert(block).second) {
+    for (const auto& instruction : *block) {
+      if (const auto* ret = llvm::dyn_cast<llvm::ReturnInst>(&instruction)) {
+        const auto* code =
+            llvm::dyn_cast_or_null<llvm::ConstantInt>(ret->getReturnValue());
+        if (code != nullptr && code->isZero()) {
+          return outputs;
+        }
+        return std::nullopt;
+      }
+      if (const auto* branch = llvm::dyn_cast<llvm::BranchInst>(&instruction)) {
+        if (branch->isConditional()) {
+          return std::nullopt;
+        }
+        break;
+      }
+      const auto* call = llvm::dyn_cast<llvm::CallInst>(&instruction);
+      const auto* callee =
+          call == nullptr ? nullptr : call->getCalledFunction();
+      if (callee == nullptr || !callee->isDeclaration()) {
+        return std::nullopt;
+      }
+      const auto name = callee->getName();
+      if (name == "__quantum__rt__initialize" && !started &&
+          call->arg_size() == 1 &&
+          llvm::isa<llvm::ConstantPointerNull>(call->getArgOperand(0))) {
+        started = true;
+        continue;
+      }
+      started = true;
+      if (!terminal && isStaticGate(*call, name)) {
+        continue;
+      }
+      if (name == "__quantum__qis__mz__body" && call->arg_size() == 2) {
+        const auto qubit = staticResourceId(call->getArgOperand(0));
+        const auto result = staticResourceId(call->getArgOperand(1));
+        if (!qubit || !result) {
+          return std::nullopt;
+        }
+        terminal = true;
+        results[*result] = *qubit;
+        continue;
+      }
+      if (name == "__quantum__rt__result_record_output" &&
+          call->arg_size() == 2) {
+        const auto result = staticResourceId(call->getArgOperand(0));
+        if (!result) {
+          return std::nullopt;
+        }
+        const auto it = results.find(*result);
+        if (it == results.end()) {
+          return std::nullopt;
+        }
+        terminal = true;
+        outputs.push_back(it->second);
+        continue;
+      }
+      if ((name == "__quantum__rt__tuple_record_output" ||
+           name == "__quantum__rt__array_record_output" ||
+           name == "__quantum__rt__bool_record_output" ||
+           name == "__quantum__rt__int_record_output" ||
+           name == "__quantum__rt__double_record_output") &&
+          call->arg_size() == 2 &&
+          (llvm::isa<llvm::ConstantInt>(call->getArgOperand(0)) ||
+           llvm::isa<llvm::ConstantFP>(call->getArgOperand(0)))) {
+        terminal = true;
+        continue;
+      }
+      return std::nullopt;
+    }
+    const auto* branch =
+        llvm::dyn_cast<llvm::BranchInst>(block->getTerminator());
+    if (branch == nullptr || branch->isConditional()) {
+      return std::nullopt;
+    }
+    block = branch->getSuccessor(0);
+  }
+  return std::nullopt;
 }
 
 } // namespace qir

--- a/mlir/lib/Dialect/QIR/Execution/JIT/Session.cpp
+++ b/mlir/lib/Dialect/QIR/Execution/JIT/Session.cpp
@@ -24,15 +24,15 @@
 #include <llvm/ExecutionEngine/Orc/Core.h>
 #include <llvm/ExecutionEngine/Orc/CoreContainers.h>
 #include <llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h>
-#include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
 #include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
-#include <llvm/ExecutionEngine/Orc/LazyReexports.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
-#include <llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h>
 #include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/DataLayout.h>
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/Casting.h>
@@ -48,8 +48,8 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <initializer_list>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -70,19 +70,19 @@ static auto isEntryPoint(const llvm::Function& function) -> bool {
 }
 
 static auto selectEntryPoint(llvm::Module& module) -> llvm::Function& {
-  std::vector<llvm::Function*> matches;
+  llvm::Function* selected = nullptr;
   for (auto& function : module) {
     if (!function.isDeclaration() && isEntryPoint(function)) {
-      matches.emplace_back(&function);
+      if (selected != nullptr) {
+        throw std::runtime_error("Multiple QIR entry points were found");
+      }
+      selected = &function;
     }
   }
-  if (matches.empty()) {
+  if (selected == nullptr) {
     throw std::runtime_error("No QIR entry point was found");
   }
-  if (matches.size() != 1) {
-    throw std::runtime_error("Multiple QIR entry points were found");
-  }
-  auto& entryPoint = *matches.front();
+  auto& entryPoint = *selected;
   const auto* type = entryPoint.getFunctionType();
   if (type->isVarArg() || type->getNumParams() != 0 ||
       !type->getReturnType()->isIntegerTy(64)) {
@@ -103,8 +103,6 @@ static auto readOutputSchema(const llvm::Function& entryPoint)
   }
   return Runtime::OutputSchema::Labeled;
 }
-
-static void exitOnLazyCallThroughFailure() { exit(1); }
 
 static int mingwNoopMain() {
   // Cygwin and MinGW insert calls from the main function to the runtime
@@ -324,15 +322,15 @@ static auto createRuntimeRegistry() -> RuntimeRegistry {
 
 static auto selectRuntimeSymbols(const llvm::Module& module)
     -> std::vector<std::pair<std::string, void*>> {
-  const auto registry = createRuntimeRegistry();
+  static const auto REGISTRY = createRuntimeRegistry();
   std::vector<std::pair<std::string, void*>> selected;
   for (const auto& function : module) {
     if (!function.isDeclaration() || function.use_empty() ||
         !function.getName().starts_with("__quantum__")) {
       continue;
     }
-    const auto it = registry.find(function.getName().str());
-    if (it == registry.end()) {
+    const auto it = REGISTRY.find(function.getName().str());
+    if (it == REGISTRY.end()) {
       throw std::runtime_error("Unsupported QIR runtime declaration '" +
                                function.getName().str() + "'");
     }
@@ -352,38 +350,34 @@ static auto selectRuntimeSymbols(const llvm::Module& module)
   return selected;
 }
 
-static llvm::Expected<llvm::orc::ThreadSafeModule>
-getThreadSafeModuleOrError(std::unique_ptr<llvm::Module> llvmModule,
-                           const llvm::SMDiagnostic& err,
-                           llvm::orc::ThreadSafeContext tsCtx) {
-  if (!llvmModule) {
-    std::string errMsg;
-    {
-      llvm::raw_string_ostream errMsgStream(errMsg);
-      err.print(DEBUG_TYPE, errMsgStream);
-    }
-    return llvm::make_error<llvm::StringError>(std::move(errMsg),
-                                               llvm::inconvertibleErrorCode());
-  }
-  return llvm::orc::ThreadSafeModule(std::move(llvmModule), std::move(tsCtx));
-}
-
 llvm::Expected<llvm::orc::ThreadSafeModule>
 JitSession::loadModuleFromMemory(const llvm::StringRef irBytes,
                                  const llvm::StringRef bufferName) {
+  llvm::orc::ThreadSafeContext context{std::make_unique<llvm::LLVMContext>()};
   llvm::SMDiagnostic err;
   auto buffer = llvm::MemoryBuffer::getMemBuffer(
       irBytes, bufferName,
       /*RequiresNullTerminator=*/false); // bitcode isn't null-terminated
-  auto m = tsCtx_.withContextDo([&](llvm::LLVMContext* ctx) {
+  auto m = context.withContextDo([&](llvm::LLVMContext* ctx) {
     return parseIR(buffer->getMemBufferRef(), err, *ctx);
   });
-  return getThreadSafeModuleOrError(std::move(m), err, tsCtx_);
+  if (!m) {
+    std::string message;
+    llvm::raw_string_ostream stream(message);
+    err.print(DEBUG_TYPE, stream);
+    return llvm::make_error<llvm::StringError>(std::move(message),
+                                               llvm::inconvertibleErrorCode());
+  }
+  return llvm::orc::ThreadSafeModule(std::move(m), std::move(context));
 }
 
 JitSession::JitSession(const llvm::StringRef irBytes,
                        const llvm::StringRef bufferName,
-                       const Execution execution) {
+                       const Execution execution,
+                       std::optional<uint64_t> randomSeed)
+    : runtime_(std::make_unique<Runtime>(
+          randomSeed ? *randomSeed : Runtime::generateRandomSeed())),
+      execution_(execution) {
   initialize(loadModuleFromMemory(irBytes, bufferName), execution);
 }
 
@@ -394,6 +388,43 @@ int64_t JitSession::run() {
   const auto restoreRuntime =
       llvm::make_scope_exit([previous] { Runtime::bind(previous); });
   return entryPointFn_();
+}
+
+int64_t JitSession::sample(size_t shots, std::vector<std::string>& results) {
+  if (execution_ != Execution::Sampling) {
+    throw std::logic_error("Cannot sample a QIR state-extraction session");
+  }
+  results.clear();
+  results.reserve(shots);
+  runtime_->outputProgramHeader();
+  const auto execute = [&] {
+    if (!initializesRuntime_) {
+      runtime_->reset();
+    }
+    runtime_->outputShotStart();
+    const auto code = run();
+    runtime_->outputShotEnd(code);
+    return code;
+  };
+  if (samplingOutputs_ && !runtime_->hasOutput() && shots != 0) {
+    runtime_->deferMeasurements_ = true;
+    const auto restore =
+        llvm::make_scope_exit([&] { runtime_->deferMeasurements_ = false; });
+    if (const auto code = execute(); code != 0) {
+      return code;
+    }
+    for (size_t i = 0; i < shots; ++i) {
+      results.push_back(runtime_->sampleMeasurements(*samplingOutputs_));
+    }
+    return 0;
+  }
+  for (size_t i = 0; i < shots; ++i) {
+    if (const auto code = execute(); code != 0) {
+      return code;
+    }
+    results.push_back(runtime_->getMeasurements());
+  }
+  return 0;
 }
 
 auto JitSession::runtime() -> Runtime& { return *runtime_; }
@@ -411,18 +442,44 @@ void JitSession::initNativeTargets() {
   });
 }
 
+static std::optional<size_t>
+readStaticCapacity(const llvm::Module& llvmModule,
+                   const llvm::Function& entryPoint, llvm::StringRef flagName,
+                   llvm::StringRef attributeName) {
+  if (auto* flag = llvmModule.getModuleFlag(flagName)) {
+    const auto* dynamic = llvm::mdconst::dyn_extract<llvm::ConstantInt>(flag);
+    if (dynamic == nullptr || dynamic->getValue().getLimitedValue() > 1) {
+      throw std::invalid_argument("Invalid QIR resource flag '" +
+                                  flagName.str() + "'");
+    }
+    if (!dynamic->isZero()) {
+      return std::nullopt;
+    }
+  }
+  const auto attribute = entryPoint.getFnAttribute(attributeName);
+  if (!attribute.isValid()) {
+    return std::nullopt;
+  }
+  uint64_t capacity = 0;
+  if (attribute.getValueAsString().getAsInteger(10, capacity) ||
+      capacity > std::numeric_limits<size_t>::max()) {
+    throw std::invalid_argument("Invalid QIR resource capacity '" +
+                                attributeName.str() + "'");
+  }
+  return static_cast<size_t>(capacity);
+}
+
 void JitSession::initialize(
     llvm::Expected<llvm::orc::ThreadSafeModule> llvmModule,
     const Execution execution) {
   if (!llvmModule) {
     throw std::runtime_error(llvm::toString(llvmModule.takeError()));
   }
-  module_ = std::move(*llvmModule);
-  runtime_ = std::make_unique<Runtime>();
+  auto loadedModule = std::move(*llvmModule);
 
   std::string entryPointName;
   std::vector<std::pair<std::string, void*>> runtimeSymbols;
-  module_.withModuleDo([&](llvm::Module& module) {
+  loadedModule.withModuleDo([&](llvm::Module& module) {
     auto& entryPoint = selectEntryPoint(module);
     entryPointName = entryPoint.getName().str();
     runtime_->setOutputSchema(readOutputSchema(entryPoint));
@@ -438,6 +495,20 @@ void JitSession::initialize(
       prepareForStateExtraction(entryPoint);
     }
     runtimeSymbols = selectRuntimeSymbols(module);
+    runtime_->configureStaticResources(
+        readStaticCapacity(module, entryPoint, "dynamic_qubit_management",
+                           "required_num_qubits"),
+        readStaticCapacity(module, entryPoint, "dynamic_result_management",
+                           "required_num_results"));
+    const auto* first =
+        llvm::dyn_cast<llvm::CallInst>(&entryPoint.getEntryBlock().front());
+    initializesRuntime_ =
+        first != nullptr && first->getCalledFunction() != nullptr &&
+        first->getCalledFunction()->isDeclaration() &&
+        first->getCalledFunction()->getName() == "__quantum__rt__initialize";
+    if (execution == Execution::Sampling) {
+      samplingOutputs_ = getStaticSamplingOutputs(entryPoint);
+    }
   });
   initNativeTargets();
 
@@ -445,7 +516,7 @@ void JitSession::initialize(
   // set.
   std::optional<llvm::Triple> tt;
   std::optional<llvm::DataLayout> dl;
-  module_.withModuleDo([&](llvm::Module& m) {
+  loadedModule.withModuleDo([&](llvm::Module& m) {
     if (!m.getTargetTriple().empty()) {
       tt = m.getTargetTriple();
     }
@@ -454,19 +525,25 @@ void JitSession::initialize(
     }
   });
 
-  // Configure the lazy JIT builder.
-  llvm::orc::LLLazyJITBuilder builder;
+  /// Use the ordinary module JIT; no function-lazy modules are submitted.
+  llvm::orc::LLJITBuilder builder;
 
   // Use the module's target triple if set, otherwise detect the host's.
   auto host = llvm::orc::JITTargetMachineBuilder::detectHost();
   if (!host) {
     throw std::runtime_error(llvm::toString(host.takeError()));
   }
-  builder.setJITTargetMachineBuilder(
-      tt ? llvm::orc::JITTargetMachineBuilder(*tt) : *host);
+  if (tt) {
+    if (tt->getArch() != host->getTargetTriple().getArch() ||
+        tt->getOS() != host->getTargetTriple().getOS()) {
+      throw std::invalid_argument(
+          "QIR target triple must match the execution host");
+    }
+    host->getTargetTriple() = *tt;
+  }
+  builder.setJITTargetMachineBuilder(*host);
 
-  // Cache the resolved triple; apply the module's explicit data layout if any.
-  tt = builder.getJITTargetMachineBuilder()->getTargetTriple();
+  /// Apply the module's explicit data layout if present.
   if (dl) {
     builder.setDataLayout(dl);
   }
@@ -478,29 +555,13 @@ void JitSession::initialize(
   }
 
   // Apply CPU, features, relocation model, and code model from codegen flags.
+  if (const auto cpu = llvm::codegen::getCPUStr(); !cpu.empty()) {
+    builder.getJITTargetMachineBuilder()->setCPU(cpu);
+  }
   builder.getJITTargetMachineBuilder()
-      ->setCPU(llvm::codegen::getCPUStr())
-      .addFeatures(llvm::codegen::getFeatureList())
+      ->addFeatures(llvm::codegen::getFeatureList())
       .setRelocationModel(llvm::codegen::getExplicitRelocModel())
       .setCodeModel(llvm::codegen::getExplicitCodeModel());
-
-  // Link process symbols.
-  builder.setLinkProcessSymbolsByDefault(true);
-
-  // Set up the in-process execution session and lazy call-through manager.
-  auto pc = llvm::orc::SelfExecutorProcessControl::Create();
-  if (!pc) {
-    throw std::runtime_error(llvm::toString(pc.takeError()));
-  }
-  auto es = std::make_unique<llvm::orc::ExecutionSession>(std::move(*pc));
-  builder.setLazyCallthroughManager(
-      std::make_unique<llvm::orc::LazyCallThroughManager>(
-          *es, llvm::orc::ExecutorAddr(), nullptr));
-  builder.setExecutionSession(std::move(es));
-
-  // Abort on lazy compilation failure.
-  builder.setLazyCompileFailureAddr(
-      llvm::orc::ExecutorAddr::fromPtr(exitOnLazyCallThroughFailure));
 
   // Enable debugging of JIT'd code (only works on JITLink for ELF and MachO).
   builder.setPrePlatformSetup(tryEnableDebugSupport);
@@ -522,14 +583,6 @@ void JitSession::initialize(
   if (auto err = jd.define(llvm::orc::absoluteSymbols(hostSymbols))) {
     throw std::runtime_error(llvm::toString(std::move(err)));
   }
-
-  // DynamicLibrarySearchGenerator
-  auto gen = llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
-      jit_->getDataLayout().getGlobalPrefix());
-  if (!gen) {
-    throw std::runtime_error(llvm::toString(gen.takeError()));
-  }
-  jit_->getMainJITDylib().addGenerator(std::move(*gen));
 
   // GDB listener (no error path)
   auto* objLayer = &jit_->getObjLinkingLayer();
@@ -558,17 +611,7 @@ void JitSession::initialize(
     }
   }
 
-  // Regular modules are greedy: They materialize as a whole and trigger
-  // materialization for all required symbols recursively. Lazy modules go
-  // through partitioning, and they replace outgoing calls with reexport stubs
-  // that resolve on call-through.
-  auto addModule = [&](llvm::orc::JITDylib& jdlib,
-                       llvm::orc::ThreadSafeModule m) {
-    return jit_->addIRModule(jdlib, std::move(m));
-  };
-
-  // Add the main module.
-  if (auto err = addModule(jit_->getMainJITDylib(), std::move(module_))) {
+  if (auto err = jit_->addIRModule(std::move(loadedModule))) {
     throw std::runtime_error(llvm::toString(std::move(err)));
   }
 

--- a/mlir/lib/Dialect/QIR/Execution/JIT/Session.cpp
+++ b/mlir/lib/Dialect/QIR/Execution/JIT/Session.cpp
@@ -413,9 +413,7 @@ int64_t JitSession::sample(size_t shots, std::vector<std::string>& results) {
     if (const auto code = execute(); code != 0) {
       return code;
     }
-    for (size_t i = 0; i < shots; ++i) {
-      results.push_back(runtime_->sampleMeasurements(*samplingOutputs_));
-    }
+    runtime_->sampleMeasurements(*samplingOutputs_, shots, results);
     return 0;
   }
   for (size_t i = 0; i < shots; ++i) {

--- a/mlir/lib/Dialect/QIR/Execution/Runtime/QIR.cpp
+++ b/mlir/lib/Dialect/QIR/Execution/Runtime/QIR.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/QIR/Execution/Runtime/Runtime.h"
 
 #include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/SmallVector.h>
 
 #include <algorithm>
 #include <array>
@@ -45,7 +46,7 @@ static auto getTupleHeader(Tuple* tuple) -> TupleHeader* {
   return reinterpret_cast<TupleHeader*>(tuple) - 1;
 }
 
-static auto controlsFromArray(Array* array) -> std::vector<Qubit*> {
+static auto controlsFromArray(Array* array) -> llvm::SmallVector<Qubit*, 4> {
   if (array == nullptr) {
     throw std::invalid_argument("QIR control array must not be null");
   }
@@ -54,7 +55,7 @@ static auto controlsFromArray(Array* array) -> std::vector<Qubit*> {
         "QIR control array elements must contain qubit pointers");
   }
   const auto size = __quantum__rt__array_get_size_1d(array);
-  std::vector<Qubit*> controls(static_cast<std::size_t>(size));
+  llvm::SmallVector<Qubit*, 4> controls(static_cast<std::size_t>(size));
   if (!controls.empty()) {
     std::memcpy(static_cast<void*>(controls.data()), array->data.data(),
                 array->data.size());
@@ -518,10 +519,14 @@ void __quantum__rt__result_array_record_output(const int64_t size,
   }
   auto& runtime = qir::Runtime::getInstance();
   std::string values;
-  values.reserve(static_cast<std::size_t>(size));
+  if (runtime.hasOutput()) {
+    values.reserve(static_cast<std::size_t>(size));
+  }
   for (Result* result : std::span(results, static_cast<std::size_t>(size))) {
     const auto value = runtime.deref(result).r;
-    values.push_back(value ? '1' : '0');
+    if (runtime.hasOutput()) {
+      values.push_back(value ? '1' : '0');
+    }
     runtime.appendMeasurementBit(value);
   }
   runtime.outputResultArray(values, label);

--- a/mlir/lib/Dialect/QIR/Execution/Runtime/Runtime.cpp
+++ b/mlir/lib/Dialect/QIR/Execution/Runtime/Runtime.cpp
@@ -14,13 +14,13 @@
 #include "dd/Node.hpp"
 #include "dd/Operations.hpp"
 #include "dd/Package.hpp"
-#include "dd/StateGeneration.hpp"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Utils/DDAdapter.h"
 #include "mlir/Dialect/QIR/Execution/Runtime/QIR.h"
 #include "mlir/Dialect/QIR/QIRDefinitions.h"
 
 #include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/SmallVector.h>
 
 #include <algorithm>
 #include <array>
@@ -28,8 +28,10 @@
 #include <cstdint>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <ostream>
 #include <random>
 #include <span>
@@ -69,16 +71,37 @@ auto Runtime::bind(Runtime* runtime) noexcept -> Runtime* {
 }
 
 auto Runtime::reset() -> void {
-  qubitMode = ResourceMode::UNKNOWN;
-  resultMode = ResourceMode::UNKNOWN;
+  qubitMode = staticQubits_ ? ResourceMode::STATIC : ResourceMode::UNKNOWN;
+  resultMode = staticResults_ ? ResourceMode::STATIC : ResourceMode::UNKNOWN;
   qRegister.clear();
+  freeQubits_.clear();
   qubitPermutation.clear();
   rRegister.clear();
+  std::ranges::fill(resultValues_, ResultStruct{});
   measurements.clear();
   currentMaxQubitAddress = MIN_DYN_QUBIT_ADDRESS;
   currentMaxQubitId = 0;
   currentMaxResultAddress = MIN_DYN_RESULT_ADDRESS;
   qState.reset();
+  if (qState.dd && staticQubits_ && *staticQubits_ != 0) {
+    enlargeState(*staticQubits_ - 1);
+  }
+}
+
+void Runtime::configureStaticResources(std::optional<size_t> qubits,
+                                       std::optional<size_t> results) {
+  if (qubits && *qubits > dd::Package::MAX_POSSIBLE_QUBITS) {
+    throw std::out_of_range(
+        "Static QIR qubit capacity exceeds the supported range");
+  }
+  if (results && *results > resultValues_.max_size()) {
+    throw std::out_of_range(
+        "Static QIR result capacity exceeds the supported range");
+  }
+  staticQubits_ = qubits;
+  staticResults_ = results;
+  resultValues_.resize(results.value_or(0));
+  reset();
 }
 
 auto Runtime::seed(const uint64_t randomSeed) -> void { mt.seed(randomSeed); }
@@ -90,42 +113,37 @@ Runtime::Runtime(const uint64_t randomSeed)
       currentMaxQubitAddress(MIN_DYN_QUBIT_ADDRESS), currentMaxQubitId(0),
       currentMaxResultAddress(MIN_DYN_RESULT_ADDRESS), mt(randomSeed) {}
 
-auto Runtime::enlargeState(const size_t maxQubit) -> void {
-  if (maxQubit >= dd::Package::MAX_POSSIBLE_QUBITS) {
+auto Runtime::enlargeState(size_t maxQubit) -> void {
+  if (maxQubit >= dd::Package::MAX_POSSIBLE_QUBITS ||
+      (staticQubits_ && maxQubit >= *staticQubits_)) {
     throw std::out_of_range("QIR qubit ID exceeds the supported qubit range");
   }
-  if (maxQubit >= qState.numQubits) {
-    const auto d = maxQubit - qState.numQubits + 1;
-    qubitPermutation.resize(qState.numQubits + d);
-    std::iota(qubitPermutation.begin() +
-                  static_cast<ptrdiff_t>(qState.numQubits),
-              qubitPermutation.end(), static_cast<dd::Qubit>(qState.numQubits));
-    qState.numQubits += d;
-
-    // Resize the DD package only if necessary.
-    if (qState.dd->qubits() < qState.numQubits) {
-      qState.dd->resize(qState.numQubits);
-    }
-
-    // If the state is terminal, we need to create a new node.
-    if (qState.edge.isTerminal()) {
-      qState.edge = makeZeroState(d, *qState.dd);
-      return;
-    }
-
-    // Enlarge state.
-    // Each iteration adds one level above the current root, raising root.v by
-    // one. After the loop, root.v == numQubits - 1.
-    for (auto q = static_cast<size_t>(qState.edge.p->v);
-         q + 1U < qState.numQubits; ++q) {
-      auto old = qState.edge;
-      qState.edge =
-          qState.dd->makeDDNode(static_cast<dd::Qubit>(q + 1U),
-                                std::array{qState.edge, dd::vEdge::zero()});
-      qState.dd->incRef(qState.edge);
-      qState.dd->decRef(old);
-    }
+  if (staticQubits_) {
+    maxQubit = std::max(maxQubit, *staticQubits_ - 1);
   }
+  if (maxQubit < qState.numQubits) {
+    return;
+  }
+  const auto numQubits = maxQubit + 1;
+  if (!qState.dd) {
+    qState.dd = std::make_unique<dd::Package>(numQubits);
+  } else if (qState.dd->qubits() < numQubits) {
+    qState.dd->resize(numQubits);
+  }
+  qubitPermutation.resize(numQubits);
+  std::iota(qubitPermutation.begin() + static_cast<ptrdiff_t>(qState.numQubits),
+            qubitPermutation.end(), static_cast<dd::Qubit>(qState.numQubits));
+
+  /// Extending the root preserves its weight, including a scalar global phase.
+  auto edge = qState.edge;
+  for (auto q = qState.numQubits; q < numQubits; ++q) {
+    edge = qState.dd->makeDDNode(static_cast<dd::Qubit>(q),
+                                 std::array{edge, dd::vEdge::zero()});
+  }
+  qState.dd->incRef(edge);
+  qState.dd->decRef(qState.edge);
+  qState.edge = edge;
+  qState.numQubits = numQubits;
 }
 
 auto Runtime::resolveAddress(const Qubit* qubit) -> dd::Qubit {
@@ -133,7 +151,12 @@ auto Runtime::resolveAddress(const Qubit* qubit) -> dd::Qubit {
     qubitMode = ResourceMode::STATIC;
   }
   if (qubitMode == ResourceMode::STATIC) {
-    return staticQubitId(qubit);
+    const auto id = staticQubitId(qubit);
+    if (staticQubits_ && id >= *staticQubits_) {
+      throw std::out_of_range(
+          "Static QIR qubit ID exceeds its declared capacity");
+    }
+    return id;
   }
 
   const auto it = qRegister.find(qubit);
@@ -148,8 +171,8 @@ auto Runtime::resolveAddress(const Qubit* qubit) -> dd::Qubit {
 
 auto Runtime::translateAddresses(const std::span<Qubit* const> qubits,
                                  const std::span<Qubit* const> additionalQubits)
-    -> std::vector<dd::Qubit> {
-  std::vector<dd::Qubit> qubitIds;
+    -> llvm::SmallVector<dd::Qubit, 5> {
+  llvm::SmallVector<dd::Qubit, 5> qubitIds;
   qubitIds.reserve(qubits.size() + additionalQubits.size());
   for (const auto* qubit : qubits) {
     qubitIds.push_back(resolveAddress(qubit));
@@ -167,6 +190,9 @@ auto Runtime::apply(const std::span<const std::complex<dd::fp>> matrix,
                     std::span<Qubit* const> controls,
                     std::span<Qubit* const> targets) -> void {
   auto addresses = translateAddresses(controls, targets);
+  if (!qState.dd) {
+    qState.dd = std::make_unique<dd::Package>();
+  }
   std::ranges::transform(addresses, addresses.begin(), [&](const auto address) {
     return qubitPermutation[address];
   });
@@ -182,7 +208,34 @@ auto Runtime::apply(const std::span<const std::complex<dd::fp>> matrix,
 }
 
 auto Runtime::applyGlobalPhase(dd::fp phase) -> void {
+  if (!qState.dd) {
+    qState.dd = std::make_unique<dd::Package>();
+  }
   qState.edge = dd::applyGlobalPhase(qState.edge, phase, *qState.dd);
+}
+
+auto Runtime::measure(Qubit* qubit, Result* result) -> void {
+  const auto target = resolveAddress(qubit);
+  enlargeState(target);
+  auto& value = deref(result);
+  if (!deferMeasurements_) {
+    value.r = qState.dd->measureOneCollapsing(
+                  qState.edge, qubitPermutation[target], mt) == '1';
+  }
+}
+
+auto Runtime::sampleMeasurements(std::span<const uintptr_t> qubits)
+    -> std::string {
+  measurements.clear();
+  if (qubits.empty()) {
+    return measurements;
+  }
+  const auto basis = qState.dd->measureAll(qState.edge, false, mt);
+  measurements.reserve(qubits.size());
+  for (const auto qubit : qubits) {
+    measurements.push_back(basis[basis.size() - 1 - qubitPermutation[qubit]]);
+  }
+  return measurements;
 }
 
 auto Runtime::reset(std::span<Qubit* const> qubits) -> void {
@@ -214,20 +267,33 @@ auto Runtime::qAlloc() -> Qubit* {
         "Cannot dynamically allocate qubits after using static qubit IDs");
   }
   qubitMode = ResourceMode::DYNAMIC;
-  if (currentMaxQubitId >= dd::Package::MAX_POSSIBLE_QUBITS) {
+  if ((freeQubits_.empty() &&
+       currentMaxQubitId >= dd::Package::MAX_POSSIBLE_QUBITS) ||
+      currentMaxQubitAddress == std::numeric_limits<uintptr_t>::max()) {
     throw std::out_of_range("QIR runtime exceeds the supported qubit range");
   }
   auto* qubit = reinterpret_cast<Qubit*>(currentMaxQubitAddress++);
-  qRegister.emplace(qubit, static_cast<dd::Qubit>(currentMaxQubitId++));
+  const auto id = freeQubits_.empty()
+                      ? static_cast<dd::Qubit>(currentMaxQubitId++)
+                      : freeQubits_.back();
+  if (!freeQubits_.empty()) {
+    freeQubits_.pop_back();
+  }
+  qRegister.emplace(qubit, id);
   return qubit;
 }
 
 auto Runtime::qFree(Qubit* qubit) -> void {
-  if (qubitMode != ResourceMode::DYNAMIC || !qRegister.contains(qubit)) {
+  const auto it = qRegister.find(qubit);
+  if (qubitMode != ResourceMode::DYNAMIC || it == qRegister.end()) {
     throw std::out_of_range("QIR qubit was not dynamically allocated");
   }
-  reset(std::array{qubit});
-  qRegister.erase(qubit);
+  const auto id = it->second;
+  if (id < qState.numQubits) {
+    reset(std::array{qubit});
+  }
+  freeQubits_.push_back(id);
+  qRegister.erase(it);
 }
 
 auto Runtime::rAlloc() -> Result* {
@@ -248,6 +314,14 @@ auto Runtime::rFree(Result* result) -> void {
 }
 
 auto Runtime::deref(Result* result) -> ResultStruct& {
+  if (staticResults_) {
+    const auto id = reinterpret_cast<uintptr_t>(result);
+    if (id >= *staticResults_) {
+      throw std::out_of_range(
+          "Static QIR result ID exceeds its declared capacity");
+    }
+    return resultValues_[id];
+  }
   auto it = rRegister.find(result);
   if (it == rRegister.end()) {
     if (resultMode == ResourceMode::DYNAMIC) {
@@ -271,6 +345,24 @@ auto Runtime::getMeasurements() const -> const std::string& {
 }
 
 auto Runtime::takeState() -> QState {
+  if (staticQubits_ && *staticQubits_ != 0) {
+    enlargeState(*staticQubits_ - 1);
+  }
+  const auto matrix = mlir::qco::getStandardGateMatrix<mlir::qco::SWAPOp>({});
+  for (size_t q = 0; q < qubitPermutation.size(); ++q) {
+    /// Each transposition places at least one logical wire at its own index.
+    while (qubitPermutation[q] != q) {
+      const auto other = qubitPermutation[q];
+      const std::array targets{other, qubitPermutation[other]};
+      qState.edge = qState.dd->applyOperation(
+          mlir::qco::makeGateDD(*qState.dd, matrix, qState.numQubits, targets),
+          qState.edge);
+      std::swap(qubitPermutation[q], qubitPermutation[other]);
+    }
+  }
+  if (!qState.dd) {
+    qState.dd = std::make_unique<dd::Package>();
+  }
   QState ret = std::move(qState);
   reset();
   return ret;
@@ -280,8 +372,13 @@ auto Runtime::setOstream(std::ostream& other) -> void { os = &other; }
 
 auto Runtime::resetOstream() -> void { os = &std::cout; }
 
+auto Runtime::disableOutput() -> void { os = nullptr; }
+
 void Runtime::outputType(const char* type, std::string_view value,
                          const char* label) const {
+  if (!hasOutput()) {
+    return;
+  }
   *os << "OUTPUT\t" << type << "\t" << value;
   if (label != nullptr && outputSchema == OutputSchema::Labeled) {
     *os << "\t" << label;
@@ -303,10 +400,16 @@ auto Runtime::outputBool(bool value, const char* label) const -> void {
 }
 
 auto Runtime::outputInt(int64_t value, const char* label) const -> void {
+  if (!hasOutput()) {
+    return;
+  }
   outputType("INT", std::to_string(value), label);
 }
 
 auto Runtime::outputFloat(double value, const char* label) const -> void {
+  if (!hasOutput()) {
+    return;
+  }
   // Use std::ostringstream rather than std::to_string.
   // std::to_string formats with six digits after the decimal point and
   // can print 0.000000 for very small numbers.
@@ -319,20 +422,32 @@ auto Runtime::outputFloat(double value, const char* label) const -> void {
 
 auto Runtime::outputTuple(int64_t elementCount, const char* label) const
     -> void {
+  if (!hasOutput()) {
+    return;
+  }
   outputType("TUPLE", std::to_string(elementCount), label);
 }
 
 auto Runtime::outputArray(int64_t elementCount, const char* label) const
     -> void {
+  if (!hasOutput()) {
+    return;
+  }
   outputType("ARRAY", std::to_string(elementCount), label);
 }
 
 auto Runtime::outputProgramHeader() const -> void {
+  if (!hasOutput()) {
+    return;
+  }
   *os << "HEADER\tschema_id\t" << outputSchema << "\n";
   *os << "HEADER\tschema_version\t2.1\n";
 }
 
 auto Runtime::outputShotStart() const -> void {
+  if (!hasOutput()) {
+    return;
+  }
   *os << "START\n";
   if (metadata.empty()) {
     *os << "METADATA\toutput_labeling_schema\t" << outputSchema << "\n";
@@ -348,6 +463,9 @@ auto Runtime::outputShotStart() const -> void {
 }
 
 auto Runtime::outputShotEnd(const int64_t exitCode) const -> void {
+  if (!hasOutput()) {
+    return;
+  }
   *os << "END\t" << exitCode << "\n";
 }
 

--- a/mlir/lib/Dialect/QIR/Execution/Runtime/Runtime.cpp
+++ b/mlir/lib/Dialect/QIR/Execution/Runtime/Runtime.cpp
@@ -125,10 +125,17 @@ auto Runtime::enlargeState(size_t maxQubit) -> void {
     return;
   }
   const auto numQubits = maxQubit + 1;
-  if (!qState.dd) {
-    qState.dd = std::make_unique<dd::Package>(numQubits);
-  } else if (qState.dd->qubits() < numQubits) {
-    qState.dd->resize(numQubits);
+  const auto capacity = qState.dd ? qState.dd->qubits() : 0;
+  if (capacity < numQubits) {
+    /// Unknown resources grow geometrically; declared resources fit exactly.
+    const auto newCapacity = staticQubits_.value_or(std::min(
+        dd::Package::MAX_POSSIBLE_QUBITS,
+        std::max({numQubits, dd::Package::DEFAULT_QUBITS, 2 * capacity})));
+    if (!qState.dd) {
+      qState.dd = std::make_unique<dd::Package>(newCapacity);
+    } else {
+      qState.dd->resize(newCapacity);
+    }
   }
   qubitPermutation.resize(numQubits);
   std::iota(qubitPermutation.begin() + static_cast<ptrdiff_t>(qState.numQubits),
@@ -191,7 +198,7 @@ auto Runtime::apply(const std::span<const std::complex<dd::fp>> matrix,
                     std::span<Qubit* const> targets) -> void {
   auto addresses = translateAddresses(controls, targets);
   if (!qState.dd) {
-    qState.dd = std::make_unique<dd::Package>();
+    qState.dd = std::make_unique<dd::Package>(0);
   }
   std::ranges::transform(addresses, addresses.begin(), [&](const auto address) {
     return qubitPermutation[address];
@@ -209,7 +216,7 @@ auto Runtime::apply(const std::span<const std::complex<dd::fp>> matrix,
 
 auto Runtime::applyGlobalPhase(dd::fp phase) -> void {
   if (!qState.dd) {
-    qState.dd = std::make_unique<dd::Package>();
+    qState.dd = std::make_unique<dd::Package>(0);
   }
   qState.edge = dd::applyGlobalPhase(qState.edge, phase, *qState.dd);
 }
@@ -224,18 +231,38 @@ auto Runtime::measure(Qubit* qubit, Result* result) -> void {
   }
 }
 
-auto Runtime::sampleMeasurements(std::span<const uintptr_t> qubits)
-    -> std::string {
+auto Runtime::sampleMeasurements(std::span<const uintptr_t> qubits,
+                                 size_t shots,
+                                 std::vector<std::string>& results) -> void {
   measurements.clear();
   if (qubits.empty()) {
-    return measurements;
+    results.resize(shots);
+    return;
   }
-  const auto basis = qState.dd->measureAll(qState.edge, false, mt);
+  bool ascending = qubits.size() == qState.numQubits;
+  for (size_t i = 0; ascending && i < qubits.size(); ++i) {
+    ascending = qubitPermutation[qubits[i]] == i;
+  }
+  if (ascending) {
+    for (size_t i = 0; i < shots; ++i) {
+      auto basis = qState.dd->measureAll(qState.edge, false, mt);
+      std::ranges::reverse(basis);
+      results.push_back(std::move(basis));
+    }
+    if (shots != 0) {
+      measurements = results.back();
+    }
+    return;
+  }
   measurements.reserve(qubits.size());
-  for (const auto qubit : qubits) {
-    measurements.push_back(basis[basis.size() - 1 - qubitPermutation[qubit]]);
+  for (size_t i = 0; i < shots; ++i) {
+    const auto basis = qState.dd->measureAll(qState.edge, false, mt);
+    measurements.clear();
+    for (const auto qubit : qubits) {
+      measurements.push_back(basis[basis.size() - 1 - qubitPermutation[qubit]]);
+    }
+    results.push_back(measurements);
   }
-  return measurements;
 }
 
 auto Runtime::reset(std::span<Qubit* const> qubits) -> void {
@@ -361,7 +388,7 @@ auto Runtime::takeState() -> QState {
     }
   }
   if (!qState.dd) {
-    qState.dd = std::make_unique<dd::Package>();
+    qState.dd = std::make_unique<dd::Package>(0);
   }
   QState ret = std::move(qState);
   reset();

--- a/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
+++ b/mlir/lib/Dialect/QIR/Transforms/AttachQIRAttributes.cpp
@@ -116,7 +116,7 @@ private:
   /// - `output_labeling_schema`: labeled
   /// - `qir_profiles`: base_profile
   /// - `required_num_qubits`: Capacity through the highest static qubit ID
-  /// - `required_num_results`: Capacity through the highest recorded result ID
+  /// - `required_num_results`: Capacity through the highest static result ID
   /// - `qir_major_version`: 2
   /// - `qir_minor_version`: 1
   /// - `dynamic_qubit_management`: true/false
@@ -323,7 +323,7 @@ private:
     return numQubits;
   }
 
-  /// Return the capacity required to address every recorded static result ID.
+  /// Return the capacity required to address every static result ID.
   static FailureOr<uint64_t> getNumResults(LLVM::LLVMFuncOp& main) {
     FailureOr<uint64_t> numResults = uint64_t{0};
     main->walk([&](LLVM::CallOp callOp) {
@@ -331,11 +331,17 @@ private:
         return;
       }
 
-      if (*callOp.getCallee() != QIR_RECORD_OUTPUT) {
+      const auto callee = *callOp.getCallee();
+      if (callee != QIR_RECORD_OUTPUT && callee != QIR_MEASURE &&
+          callee != QIR_READ_RESULT) {
+        return;
+      }
+      const auto index = callee == QIR_MEASURE ? 1U : 0U;
+      if (callOp.getNumOperands() <= index) {
         return;
       }
 
-      auto operand = callOp->getOperand(0);
+      auto operand = callOp->getOperand(index);
       auto toPtrOp = dyn_cast<LLVM::IntToPtrOp>(operand.getDefiningOp());
       if (!toPtrOp) {
         return;

--- a/mlir/unittests/Dialect/QIR/Execution/JIT/test_ir_rewriter.cpp
+++ b/mlir/unittests/Dialect/QIR/Execution/JIT/test_ir_rewriter.cpp
@@ -23,11 +23,13 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <vector>
 
 static std::size_t countCallsTo(const llvm::Module& m, llvm::StringRef name) {
   std::size_t count = 0;
@@ -161,3 +163,107 @@ attributes #0 = { "entry_point" }
 }
 
 } // namespace
+
+static auto samplingOutputs(llvm::StringRef ir) {
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic error;
+  auto llvmModule = llvm::parseAssemblyString(ir, error, context);
+  if (!llvmModule) {
+    throw std::runtime_error(error.getMessage().str());
+  }
+  return qir::getStaticSamplingOutputs(*llvmModule->getFunction("main"));
+}
+
+TEST(QIRSamplingPlan, PreservesRepeatedOutputsAndOverwrittenResults) {
+  const auto outputs = samplingOutputs(R"(
+define i64 @main() #0 {
+entry:
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__h__body(ptr null)
+  br label %measure
+measure:
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 2 to ptr), ptr null)
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  ret i64 0
+}
+declare void @__quantum__rt__initialize(ptr)
+declare void @__quantum__qis__h__body(ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+)");
+  ASSERT_TRUE(outputs.has_value());
+  EXPECT_EQ(*outputs, (std::vector<uintptr_t>{0, 2, 2}));
+}
+
+TEST(QIRSamplingPlan, DoesNotDeferMeasurementsBeforeQuantumWork) {
+  EXPECT_FALSE(samplingOutputs(R"(
+define i64 @main() #0 {
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__qis__x__body(ptr null)
+  ret i64 0
+}
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__qis__x__body(ptr)
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+)")
+                   .has_value());
+}
+
+TEST(QIRSamplingPlan, RejectsUnknownCallsAndHiddenQuantumEffects) {
+  EXPECT_FALSE(samplingOutputs(R"(
+define i64 @main() #0 {
+  call void @helper()
+  ret i64 0
+}
+define void @helper() {
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  ret void
+}
+declare void @__quantum__qis__mz__body(ptr, ptr)
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+)")
+                   .has_value());
+  EXPECT_FALSE(samplingOutputs(R"(
+define i64 @main() #0 {
+  call void @external()
+  ret i64 0
+}
+declare void @external()
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+)")
+                   .has_value());
+}
+
+TEST(QIRSamplingPlan, RejectsControlFlowMemoryAndResets) {
+  for (const auto* body : {
+           "br label %loop\nloop: br label %loop",
+           "br i1 true, label %left, label %right\nleft: ret i64 0\nright: ret "
+           "i64 0",
+           "store i64 1, ptr @counter\nret i64 0",
+           "call void @__quantum__qis__reset__body(ptr null)\nret i64 0",
+           "call void @__quantum__qis__mz__body(ptr null, ptr null)\n"
+           "%r = call i1 @__quantum__rt__read_result(ptr null)\nret i64 0",
+           "call void @__quantum__qis__x__body(ptr null)\n"
+           "call void @__quantum__rt__initialize(ptr null)\nret i64 0",
+           "ret i64 1",
+       }) {
+    SCOPED_TRACE(body);
+    const std::string ir = std::string(R"(
+@counter = global i64 0
+define i64 @main() #0 {
+)") + body + R"(
+}
+declare void @__quantum__qis__reset__body(ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__rt__initialize(ptr)
+declare i1 @__quantum__rt__read_result(ptr)
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+)";
+    EXPECT_FALSE(samplingOutputs(ir).has_value());
+  }
+}

--- a/mlir/unittests/Dialect/QIR/Execution/JIT/test_ir_rewriter.cpp
+++ b/mlir/unittests/Dialect/QIR/Execution/JIT/test_ir_rewriter.cpp
@@ -17,6 +17,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/Verifier.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/SourceMgr.h>
@@ -162,19 +163,25 @@ attributes #0 = { "entry_point" }
                std::invalid_argument);
 }
 
-} // namespace
-
-static auto samplingOutputs(llvm::StringRef ir) {
-  llvm::LLVMContext context;
-  llvm::SMDiagnostic error;
-  auto llvmModule = llvm::parseAssemblyString(ir, error, context);
-  if (!llvmModule) {
-    throw std::runtime_error(error.getMessage().str());
+class QIRSamplingPlan : public testing::TestWithParam<const char*> {
+protected:
+  auto samplingOutputs(std::string ir) {
+    ir.replace(ir.find("base_profile"), std::string_view("base_profile").size(),
+               GetParam());
+    llvm::LLVMContext context;
+    llvm::SMDiagnostic error;
+    auto llvmModule = llvm::parseAssemblyString(ir, error, context);
+    if (!llvmModule) {
+      throw std::runtime_error(error.getMessage().str());
+    }
+    return qir::getStaticSamplingOutputs(*llvmModule->getFunction("main"));
   }
-  return qir::getStaticSamplingOutputs(*llvmModule->getFunction("main"));
-}
+};
 
-TEST(QIRSamplingPlan, PreservesRepeatedOutputsAndOverwrittenResults) {
+INSTANTIATE_TEST_SUITE_P(Profiles, QIRSamplingPlan,
+                         testing::Values("base_profile", "adaptive_profile"));
+
+TEST_P(QIRSamplingPlan, PreservesRepeatedOutputsAndOverwrittenResults) {
   const auto outputs = samplingOutputs(R"(
 define i64 @main() #0 {
 entry:
@@ -199,7 +206,7 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
   EXPECT_EQ(*outputs, (std::vector<uintptr_t>{0, 2, 2}));
 }
 
-TEST(QIRSamplingPlan, DoesNotDeferMeasurementsBeforeQuantumWork) {
+TEST_P(QIRSamplingPlan, DoesNotDeferMeasurementsBeforeQuantumWork) {
   EXPECT_FALSE(samplingOutputs(R"(
 define i64 @main() #0 {
   call void @__quantum__qis__mz__body(ptr null, ptr null)
@@ -213,7 +220,7 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
                    .has_value());
 }
 
-TEST(QIRSamplingPlan, RejectsUnknownCallsAndHiddenQuantumEffects) {
+TEST_P(QIRSamplingPlan, RejectsUnknownCallsAndHiddenQuantumEffects) {
   EXPECT_FALSE(samplingOutputs(R"(
 define i64 @main() #0 {
   call void @helper()
@@ -238,7 +245,7 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
                    .has_value());
 }
 
-TEST(QIRSamplingPlan, RejectsControlFlowMemoryAndResets) {
+TEST_P(QIRSamplingPlan, RejectsControlFlowMemoryAndResets) {
   for (const auto* body : {
            "br label %loop\nloop: br label %loop",
            "br i1 true, label %left, label %right\nleft: ret i64 0\nright: ret "
@@ -267,3 +274,45 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
     EXPECT_FALSE(samplingOutputs(ir).has_value());
   }
 }
+
+TEST(IRRewriter, RejectsDefinedAndIndirectCallsBeforeChangingIR) {
+  for (const auto* body : {
+           "call void @readout()",
+           "%callee = load ptr, ptr @readout_ptr\ncall void %callee()",
+           "call void @__quantum__qis__mz__body(ptr null, ptr null)\n"
+           "call void @readout()",
+       }) {
+    SCOPED_TRACE(body);
+    const auto ir = std::string(R"(
+@readout_ptr = global ptr @readout
+define i64 @main() #0 {
+  call void @__quantum__qis__h__body(ptr null)
+)") + body + R"(
+  ret i64 0
+}
+define void @readout() {
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  ret void
+}
+declare void @__quantum__qis__h__body(ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr) #1
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+attributes #1 = { "irreversible" }
+)";
+    llvm::LLVMContext context;
+    llvm::SMDiagnostic error;
+    auto llvmModule = llvm::parseAssemblyString(ir, error, context);
+    ASSERT_NE(llvmModule, nullptr);
+    ASSERT_FALSE(llvm::verifyModule(*llvmModule));
+    const auto measurements =
+        countCallsTo(*llvmModule, "__quantum__qis__mz__body");
+    EXPECT_THROW(
+        qir::prepareForStateExtraction(*llvmModule->getFunction("main")),
+        std::invalid_argument);
+    EXPECT_EQ(countCallsTo(*llvmModule, "__quantum__qis__mz__body"),
+              measurements);
+    EXPECT_FALSE(llvm::verifyModule(*llvmModule));
+  }
+}
+
+} // namespace

--- a/mlir/unittests/Dialect/QIR/Execution/JIT/test_jit_session.cpp
+++ b/mlir/unittests/Dialect/QIR/Execution/JIT/test_jit_session.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "mlir/Dialect/QIR/Execution/JIT/Session.h"
+#include "mlir/Dialect/QIR/Execution/Runtime/QIR.h"
 #include "mlir/Dialect/QIR/Execution/Runtime/Runtime.h"
 
 #include <gmock/gmock-matchers.h>
@@ -506,36 +507,44 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "required_num_qubi
   EXPECT_THROW(session.sample(1, results), std::logic_error);
 }
 
-TEST(QIRStaticResources, RejectsInvalidResourceCapacities) {
+TEST(QIRStaticResources, RejectsQubitCapacityBeyondDDRange) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 { ret i64 0 }
+attributes #0 = { "entry_point" "required_num_qubits"="65537" }
+)";
+  EXPECT_THROW(qir::JitSession(ir, "excess-qubit-capacity"), std::out_of_range);
+}
+
+TEST(QIRStaticResources, RejectsMalformedResourceCapacities) {
   for (const auto* attribute : {
-           R"("required_num_qubits"="65537")",
            R"("required_num_qubits"="-1")",
            R"("required_num_results"="18446744073709551616")",
        }) {
+    SCOPED_TRACE(attribute);
     const std::string ir = std::string("define i64 @main() #0 { ret i64 0 }\n"
                                        "attributes #0 = { \"entry_point\" ") +
                            attribute + " }";
-    EXPECT_THROW(qir::JitSession(ir, "invalid-capacity"), std::exception);
+    EXPECT_THROW(qir::JitSession(ir, "invalid-capacity"),
+                 std::invalid_argument);
   }
 }
 
-TEST(QIRStaticResources, RejectsResourceIdsBeyondDeclaredCapacity) {
-  for (const auto* body : {
-           "call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))",
-           "call void @__quantum__qis__mz__body(ptr null, ptr inttoptr (i64 1 "
-           "to "
-           "ptr))",
-       }) {
-    const std::string ir = std::string("define i64 @main() #0 {\n") + body + R"(
-  ret i64 0
-}
-declare void @__quantum__qis__x__body(ptr)
-declare void @__quantum__qis__mz__body(ptr, ptr)
+TEST(QIRStaticResources, ConfiguresRuntimeResourceBounds) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 { ret i64 0 }
 attributes #0 = { "entry_point" "required_num_qubits"="1" "required_num_results"="1" }
 )";
-    qir::JitSession session(ir, "invalid-id");
-    EXPECT_THROW(session.run(), std::out_of_range);
-  }
+  qir::JitSession session(ir, "resource-bounds");
+  auto& runtime = session.runtime();
+  Qubit* zeroQubit = nullptr;
+  Result* zeroResult = nullptr;
+  EXPECT_NO_THROW(runtime.measure(zeroQubit, zeroResult));
+  EXPECT_THROW(
+      runtime.measure(reinterpret_cast<Qubit*>(uintptr_t{1}), zeroResult),
+      std::out_of_range);
+  EXPECT_THROW(
+      runtime.measure(zeroQubit, reinterpret_cast<Result*>(uintptr_t{1})),
+      std::out_of_range);
 }
 
 TEST(QIRJIT, ResolvesProcessSymbolsWithDefaultGenerator) {

--- a/mlir/unittests/Dialect/QIR/Execution/JIT/test_jit_session.cpp
+++ b/mlir/unittests/Dialect/QIR/Execution/JIT/test_jit_session.cpp
@@ -470,11 +470,13 @@ TEST(QIRBatchSampling, ResetsProgramsWithoutInitializeBetweenShots) {
 define i64 @main() #0 {
   call void @__quantum__qis__x__body(ptr null)
   call void @__quantum__qis__mz__body(ptr null, ptr null)
+  %measured = call i1 @__quantum__rt__read_result(ptr null)
   call void @__quantum__rt__result_record_output(ptr null, ptr null)
   ret i64 0
 }
 declare void @__quantum__qis__x__body(ptr)
 declare void @__quantum__qis__mz__body(ptr, ptr)
+declare i1 @__quantum__rt__read_result(ptr)
 declare void @__quantum__rt__result_record_output(ptr, ptr)
 attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" }
 )";
@@ -496,13 +498,16 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "required_num_qubi
 )";
   qir::JitSession session(ir, "declared-width",
                           qir::Execution::StateExtraction);
-  ASSERT_EQ(session.run(), 0);
-  auto state = session.runtime().takeState();
-  EXPECT_EQ(state.numQubits, 3);
-  const auto values = state.edge.getVector();
-  ASSERT_EQ(values.size(), 8);
-  EXPECT_EQ(values[1], 1.);
-  state.dd->decRef(state.edge);
+  for (size_t job = 0; job < 2; ++job) {
+    ASSERT_EQ(session.run(), 0);
+    auto state = session.runtime().takeState();
+    EXPECT_EQ(state.numQubits, 3);
+    EXPECT_EQ(state.dd->qubits(), 3);
+    const auto values = state.edge.getVector();
+    ASSERT_EQ(values.size(), 8);
+    EXPECT_EQ(values[1], 1.);
+    state.dd->decRef(state.edge);
+  }
   std::vector<std::string> results;
   EXPECT_THROW(session.sample(1, results), std::logic_error);
 }
@@ -569,4 +574,93 @@ attributes #0 = { "entry_point" }
 )";
   EXPECT_THROW(qir::JitSession(ir, "incompatible-target"),
                std::invalid_argument);
+}
+
+TEST(QIRBatchSampling, PreservesWideSeededOutputMappings) {
+  constexpr size_t width = 64;
+  std::vector<std::string> reference;
+  for (size_t mode = 0; mode < 4; ++mode) {
+    SCOPED_TRACE(mode);
+    std::vector<size_t> outputs;
+    if (mode == 2) {
+      outputs = {0, 5, 0, 2, 63};
+    } else {
+      for (size_t q = 0; q < width; ++q) {
+        outputs.push_back(mode == 1 ? width - 1 - q : q);
+      }
+    }
+    const auto pointer = [](size_t q) {
+      return "ptr inttoptr (i64 " + std::to_string(q) + " to ptr)";
+    };
+    std::ostringstream ir;
+    ir << "define i64 @main() #0 {\n";
+    for (const size_t q : {0, 5, 63}) {
+      ir << "call void @__quantum__qis__x__body(" << pointer(q) << ")\n";
+    }
+    ir << "call void @__quantum__qis__h__body(" << pointer(2) << ")\n";
+    if (mode == 3) {
+      ir << "call void @__quantum__qis__swap__body(" << pointer(0) << ", "
+         << pointer(10) << ")\n";
+    }
+    for (size_t q = 0; q < width; ++q) {
+      ir << "call void @__quantum__qis__mz__body(" << pointer(q) << ", "
+         << pointer(q) << ")\n";
+    }
+    for (const auto q : outputs) {
+      ir << "call void @__quantum__rt__result_record_output(" << pointer(q)
+         << ", ptr null)\n";
+    }
+    ir << R"(ret i64 0
+}
+declare void @__quantum__qis__h__body(ptr)
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__qis__swap__body(ptr, ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" "required_num_qubits"="64" "required_num_results"="64" }
+)";
+    qir::JitSession session(ir.str(), "wide-output", qir::Execution::Sampling,
+                            42);
+    session.runtime().disableOutput();
+    std::vector<std::string> shots;
+    ASSERT_EQ(session.sample(32, shots), 0);
+    ASSERT_EQ(shots.size(), 32);
+    EXPECT_EQ(session.runtime().getMeasurements(), shots.back());
+    if (mode == 0) {
+      reference = shots;
+    }
+    for (size_t shot = 0; shot < shots.size(); ++shot) {
+      ASSERT_EQ(shots[shot].size(), outputs.size());
+      for (size_t bit = 0; bit < outputs.size(); ++bit) {
+        auto q = outputs[bit];
+        if (mode == 3 && (q == 0 || q == 10)) {
+          q = 10 - q;
+        }
+        EXPECT_EQ(shots[shot][bit], reference[shot][q]);
+        if (q != 2) {
+          EXPECT_EQ(shots[shot][bit], q == 0 || q == 5 || q == 63 ? '1' : '0');
+        }
+      }
+    }
+    session.runtime().seed(42);
+    std::vector<std::string> repeated;
+    ASSERT_EQ(session.sample(32, repeated), 0);
+    EXPECT_EQ(repeated, shots);
+  }
+}
+
+TEST(QIRStaticResources, EmptyStatesKeepZeroCapacityAfterTransfer) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 { ret i64 0 }
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "required_num_qubits"="0" }
+)";
+  qir::JitSession session(ir, "empty-state", qir::Execution::StateExtraction);
+  for (size_t job = 0; job < 2; ++job) {
+    ASSERT_EQ(session.run(), 0);
+    auto state = session.runtime().takeState();
+    ASSERT_NE(state.dd, nullptr);
+    EXPECT_EQ(state.dd->qubits(), 0);
+    EXPECT_EQ(state.numQubits, 0);
+    EXPECT_TRUE(state.edge.isOneTerminal());
+  }
 }

--- a/mlir/unittests/Dialect/QIR/Execution/JIT/test_jit_session.cpp
+++ b/mlir/unittests/Dialect/QIR/Execution/JIT/test_jit_session.cpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 static std::string getProgram(const std::string_view file) {
   const auto path = std::filesystem::path(QIR_FILES_DIR) / file;
@@ -378,3 +379,185 @@ attributes #0 = { "entry_point" }
 }
 
 } // namespace
+
+TEST(QIRBatchSampling, PreservesLogicalOutputOrderAndRepeatedMeasurements) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 {
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__x__body(ptr null)
+  call void @__quantum__qis__swap__body(ptr null, ptr inttoptr (i64 2 to ptr))
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+  ret i64 0
+}
+declare void @__quantum__rt__initialize(ptr)
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__qis__swap__body(ptr, ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "required_num_qubits"="3" "required_num_results"="2" }
+)";
+  qir::JitSession session(ir, "output-order");
+  session.runtime().disableOutput();
+  std::vector<std::string> results;
+  ASSERT_EQ(session.sample(32, results), 0);
+  EXPECT_EQ(results, std::vector<std::string>(32, "101"));
+  ASSERT_EQ(session.sample(2, results), 0);
+  EXPECT_EQ(results, std::vector<std::string>(2, "101"));
+  ASSERT_EQ(session.sample(0, results), 0);
+  EXPECT_TRUE(results.empty());
+}
+
+TEST(QIRBatchSampling, SeedReproducesBellSamples) {
+  const auto ir = getProgram("BellPairStatic.ll");
+  qir::JitSession first(ir, "first", qir::Execution::Sampling, 42);
+  qir::JitSession second(ir, "second", qir::Execution::Sampling, 42);
+  first.runtime().disableOutput();
+  second.runtime().disableOutput();
+  std::vector<std::string> a;
+  std::vector<std::string> b;
+  ASSERT_EQ(first.sample(256, a), 0);
+  ASSERT_EQ(second.sample(256, b), 0);
+  EXPECT_EQ(a, b);
+  EXPECT_THAT(a, testing::Each(testing::AnyOf("00", "11")));
+  EXPECT_THAT(a, testing::Contains("00"));
+  EXPECT_THAT(a, testing::Contains("11"));
+}
+
+TEST(QIRBatchSampling, TextOutputKeepsPerShotRecords) {
+  const auto ir = getProgram("BellPairStatic.ll");
+  qir::JitSession session(ir, "text", qir::Execution::Sampling, 42);
+  std::ostringstream output;
+  session.runtime().setOstream(output);
+  std::vector<std::string> results;
+  ASSERT_EQ(session.sample(4, results), 0);
+  EXPECT_EQ(results.size(), 4);
+  const auto text = output.str();
+  size_t ends = 0;
+  for (size_t pos = text.find("END\t0\n"); pos != std::string::npos;
+       pos = text.find("END\t0\n", pos + 1)) {
+    ++ends;
+  }
+  EXPECT_EQ(ends, 4);
+}
+
+TEST(QIRBatchSampling, ExecutesClassicalSideEffectsOnEveryShot) {
+  constexpr llvm::StringRef ir = R"(
+@counter = internal global i64 0
+define i64 @main() #0 {
+  %old = load i64, ptr @counter
+  %new = add i64 %old, 1
+  store i64 %new, ptr @counter
+  %failed = icmp eq i64 %new, 3
+  %code = zext i1 %failed to i64
+  ret i64 %code
+}
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+)";
+  qir::JitSession session(ir, "side-effects");
+  session.runtime().disableOutput();
+  std::vector<std::string> results;
+  EXPECT_EQ(session.sample(5, results), 1);
+  EXPECT_EQ(results.size(), 2);
+}
+
+TEST(QIRBatchSampling, ResetsProgramsWithoutInitializeBetweenShots) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 {
+  call void @__quantum__qis__x__body(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  ret i64 0
+}
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" }
+)";
+  qir::JitSession session(ir, "no-initialize");
+  session.runtime().disableOutput();
+  std::vector<std::string> results;
+  ASSERT_EQ(session.sample(32, results), 0);
+  EXPECT_EQ(results, std::vector<std::string>(32, "1"));
+}
+
+TEST(QIRStaticResources, ExtractsDeclaredWidthIncludingUnusedQubits) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 {
+  call void @__quantum__qis__x__body(ptr null)
+  ret i64 0
+}
+declare void @__quantum__qis__x__body(ptr)
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "required_num_qubits"="3" }
+)";
+  qir::JitSession session(ir, "declared-width",
+                          qir::Execution::StateExtraction);
+  ASSERT_EQ(session.run(), 0);
+  auto state = session.runtime().takeState();
+  EXPECT_EQ(state.numQubits, 3);
+  const auto values = state.edge.getVector();
+  ASSERT_EQ(values.size(), 8);
+  EXPECT_EQ(values[1], 1.);
+  state.dd->decRef(state.edge);
+  std::vector<std::string> results;
+  EXPECT_THROW(session.sample(1, results), std::logic_error);
+}
+
+TEST(QIRStaticResources, RejectsInvalidResourceCapacities) {
+  for (const auto* attribute : {
+           R"("required_num_qubits"="65537")",
+           R"("required_num_qubits"="-1")",
+           R"("required_num_results"="18446744073709551616")",
+       }) {
+    const std::string ir = std::string("define i64 @main() #0 { ret i64 0 }\n"
+                                       "attributes #0 = { \"entry_point\" ") +
+                           attribute + " }";
+    EXPECT_THROW(qir::JitSession(ir, "invalid-capacity"), std::exception);
+  }
+}
+
+TEST(QIRStaticResources, RejectsResourceIdsBeyondDeclaredCapacity) {
+  for (const auto* body : {
+           "call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))",
+           "call void @__quantum__qis__mz__body(ptr null, ptr inttoptr (i64 1 "
+           "to "
+           "ptr))",
+       }) {
+    const std::string ir = std::string("define i64 @main() #0 {\n") + body + R"(
+  ret i64 0
+}
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+attributes #0 = { "entry_point" "required_num_qubits"="1" "required_num_results"="1" }
+)";
+    qir::JitSession session(ir, "invalid-id");
+    EXPECT_THROW(session.run(), std::out_of_range);
+  }
+}
+
+TEST(QIRJIT, ResolvesProcessSymbolsWithDefaultGenerator) {
+  constexpr llvm::StringRef ir = R"(
+@text = private constant [5 x i8] c"test\00"
+define i64 @main() #0 {
+  %length = call i64 @strlen(ptr @text)
+  ret i64 %length
+}
+declare i64 @strlen(ptr)
+attributes #0 = { "entry_point" }
+)";
+  qir::JitSession session(ir, "process-symbol");
+  EXPECT_EQ(session.run(), 4);
+}
+
+TEST(QIRJIT, RejectsTargetIncompatibleWithInProcessExecution) {
+  constexpr llvm::StringRef ir = R"(
+target triple = "wasm32-unknown-unknown"
+define i64 @main() #0 { ret i64 0 }
+attributes #0 = { "entry_point" }
+)";
+  EXPECT_THROW(qir::JitSession(ir, "incompatible-target"),
+               std::invalid_argument);
+}

--- a/mlir/unittests/Dialect/QIR/Execution/Runtime/test_qir_runtime.cpp
+++ b/mlir/unittests/Dialect/QIR/Execution/Runtime/test_qir_runtime.cpp
@@ -29,6 +29,7 @@
 #include <limits>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 #ifdef _WIN32
 #define SYSTEM _wsystem
@@ -799,8 +800,7 @@ TEST_F(QIRRuntimeTest, GHZ4Dynamic) {
 }
 
 TEST_F(QIRRuntimeTest, PackageResizeWhenEnlargingState) {
-  // dd::Package starts at 32 qubits.
-  // Acting on qubit 32 forces qState.dd->resize.
+  /// Acting on qubit 32 must extend the initially empty state.
   auto* q32 = reinterpret_cast<Qubit*>(32UL);
   __quantum__rt__initialize(nullptr);
   __quantum__qis__h__body(q32);
@@ -1009,3 +1009,28 @@ TEST_F(QIRRuntimeTest, DisabledTextOutputStillRecordsResults) {
 }
 
 } // namespace qir
+
+TEST(QIRRuntimeGrowth, PreservesStateAndPhaseAcrossGrowthAndTransfer) {
+  constexpr size_t width = 65;
+  const std::array<std::complex<dd::fp>, 4> x{0., 1., 1., 0.};
+  for (const bool dynamic : {false, true}) {
+    qir::Runtime runtime(42);
+    for (size_t job = 0; job < 2; ++job) {
+      runtime.applyGlobalPhase(dd::PI);
+      for (size_t q = 0; q < width; ++q) {
+        auto* qubit = dynamic ? runtime.qAlloc() : reinterpret_cast<Qubit*>(q);
+        const std::array targets{qubit};
+        runtime.apply(x, {}, targets);
+      }
+      auto state = runtime.takeState();
+      EXPECT_EQ(state.numQubits, width);
+      EXPECT_GE(state.dd->qubits(), width);
+      EXPECT_LT(state.dd->qubits(), 2 * width);
+      const auto amplitude =
+          state.edge.getValueByPath(width, std::string(width, '1'));
+      EXPECT_NEAR(amplitude.real(), -1., 1e-12);
+      EXPECT_NEAR(amplitude.imag(), 0., 1e-12);
+      state.dd->decRef(state.edge);
+    }
+  }
+}

--- a/mlir/unittests/Dialect/QIR/Execution/Runtime/test_qir_runtime.cpp
+++ b/mlir/unittests/Dialect/QIR/Execution/Runtime/test_qir_runtime.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <array>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -900,4 +901,111 @@ TEST_P(QIRFilesTest, Executables) {
   const auto result = SYSTEM(path.c_str());
   EXPECT_EQ(result, 0);
 }
+} // namespace qir
+
+namespace qir {
+
+TEST_F(QIRRuntimeTest, PreservesPhaseBeforeFirstQubitAndFollowingGates) {
+  __quantum__rt__initialize(nullptr);
+  __quantum__qis__gphase__body(0.3);
+  __quantum__qis__x__body(nullptr);
+  __quantum__qis__gphase__body(0.4);
+  __quantum__qis__x__body(nullptr);
+  auto state = Runtime::getInstance().takeState();
+  state.dd->garbageCollect(true);
+  const auto values = state.edge.getVector();
+  ASSERT_EQ(values.size(), 2);
+  EXPECT_NEAR(std::abs(values[0] - std::polar(1., 0.7)), 0., 1e-12);
+  EXPECT_EQ(values[1], 0.);
+  state.dd->decRef(state.edge);
+  EXPECT_NO_THROW(__quantum__rt__initialize(nullptr));
+}
+
+TEST_F(QIRRuntimeTest, ExtractsLogicalOrderAfterSwapCycle) {
+  __quantum__rt__initialize(nullptr);
+  auto* q0 = reinterpret_cast<Qubit*>(0);
+  auto* q1 = reinterpret_cast<Qubit*>(1);
+  auto* q2 = reinterpret_cast<Qubit*>(2);
+  __quantum__qis__x__body(q0);
+  __quantum__qis__swap__body(q0, q1);
+  __quantum__qis__swap__body(q1, q2);
+  auto state = Runtime::getInstance().takeState();
+  const auto values = state.edge.getVector();
+  ASSERT_EQ(values.size(), 8);
+  for (size_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(values[i], i == 4 ? 1. : 0.);
+  }
+  state.dd->decRef(state.edge);
+}
+
+TEST_F(QIRRuntimeTest, ReusesReleasedWiresWithoutReusingHandles) {
+  __quantum__rt__initialize(nullptr);
+  auto* first = __quantum__rt__qubit_allocate(nullptr);
+  __quantum__qis__x__body(first);
+  __quantum__rt__qubit_release(first);
+  for (size_t i = 0; i < 32; ++i) {
+    auto* qubit = __quantum__rt__qubit_allocate(nullptr);
+    EXPECT_NE(qubit, first);
+    __quantum__qis__mz__body(qubit, nullptr);
+    EXPECT_FALSE(__quantum__rt__read_result(nullptr));
+    __quantum__qis__x__body(qubit);
+    __quantum__rt__qubit_release(qubit);
+  }
+  EXPECT_THROW(__quantum__qis__x__body(first), std::out_of_range);
+  auto state = Runtime::getInstance().takeState();
+  EXPECT_EQ(state.numQubits, 1);
+  state.dd->decRef(state.edge);
+}
+
+TEST_F(QIRRuntimeTest, ReleasedSwappedWireIsResetBeforeReuse) {
+  __quantum__rt__initialize(nullptr);
+  auto* a = __quantum__rt__qubit_allocate(nullptr);
+  auto* b = __quantum__rt__qubit_allocate(nullptr);
+  __quantum__qis__x__body(a);
+  __quantum__qis__swap__body(a, b);
+  __quantum__rt__qubit_release(b);
+  auto* c = __quantum__rt__qubit_allocate(nullptr);
+  __quantum__qis__mz__body(c, nullptr);
+  EXPECT_FALSE(__quantum__rt__read_result(nullptr));
+  __quantum__qis__x__body(a);
+  __quantum__qis__mz__body(c, nullptr);
+  EXPECT_FALSE(__quantum__rt__read_result(nullptr));
+  auto state = Runtime::getInstance().takeState();
+  EXPECT_EQ(state.numQubits, 2);
+  state.dd->decRef(state.edge);
+}
+
+TEST_F(QIRRuntimeTest, ReleasingUnusedQubitsDoesNotEnlargeState) {
+  __quantum__rt__initialize(nullptr);
+  for (size_t i = 0; i <= dd::Package::MAX_POSSIBLE_QUBITS; ++i) {
+    __quantum__rt__qubit_release(__quantum__rt__qubit_allocate(nullptr));
+  }
+  auto state = Runtime::getInstance().takeState();
+  EXPECT_EQ(state.numQubits, 0);
+}
+
+TEST_F(QIRRuntimeTest, DisabledTextOutputStillRecordsResults) {
+  auto& runtime = Runtime::getInstance();
+  __quantum__rt__initialize(nullptr);
+  runtime.disableOutput();
+  runtime.outputProgramHeader();
+  runtime.outputShotStart();
+  __quantum__qis__x__body(nullptr);
+  __quantum__qis__mz__body(nullptr, nullptr);
+  __quantum__rt__result_record_output(nullptr, "one");
+  std::array<Result*, 2> results{nullptr, nullptr};
+  __quantum__rt__result_array_record_output(2, results.data(), "pair");
+  __quantum__rt__bool_record_output(true, nullptr);
+  __quantum__rt__int_record_output(42, nullptr);
+  __quantum__rt__double_record_output(0.3, nullptr);
+  __quantum__rt__tuple_record_output(1, nullptr);
+  __quantum__rt__array_record_output(1, nullptr);
+  runtime.outputShotEnd();
+  EXPECT_EQ(runtime.getMeasurements(), "111");
+  EXPECT_TRUE(sink.str().empty());
+  runtime.setOstream(sink);
+  __quantum__rt__result_record_output(nullptr, "one");
+  EXPECT_FALSE(sink.str().empty());
+}
+
 } // namespace qir

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -1117,3 +1117,36 @@ INSTANTIATE_TEST_SUITE_P(
                     MQT_NAMED_BUILDER(staticQubitsWithDuplicates),
                     MQT_NAMED_BUILDER(staticQubitsCanonical)}));
 /// @}
+
+TEST_F(QIRTest, MetadataIncludesUnrecordedMeasuredAndReadResults) {
+  for (const auto* call : {
+           "llvm.call @__quantum__qis__mz__body(%qubit, %result) : (!llvm.ptr, "
+           "!llvm.ptr) -> ()",
+           "%value = llvm.call @__quantum__rt__read_result(%result) : "
+           "(!llvm.ptr) "
+           "-> i1",
+       }) {
+    SCOPED_TRACE(call);
+    const std::string ir = std::string(R"mlir(module {
+      llvm.func @__quantum__qis__mz__body(!llvm.ptr, !llvm.ptr)
+      llvm.func @__quantum__rt__read_result(!llvm.ptr) -> i1
+      llvm.func @main() attributes {passthrough = ["entry_point"]} {
+        %zero = llvm.mlir.constant(0 : i64) : i64
+        %seven = llvm.mlir.constant(7 : i64) : i64
+        %qubit = llvm.inttoptr %zero : i64 to !llvm.ptr
+        %result = llvm.inttoptr %seven : i64 to !llvm.ptr
+    )mlir") + call + R"mlir(
+        llvm.return
+      }
+    })mlir";
+    auto moduleOp = parseSourceString<ModuleOp>(ir, context.get());
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    ASSERT_TRUE(succeeded(attachQIRMetadata(*moduleOp)));
+    auto main = getMainFunction(*moduleOp);
+    OpBuilder builder(context.get());
+    EXPECT_TRUE(llvm::is_contained(
+        main.getPassthroughAttr(),
+        builder.getStrArrayAttr({"required_num_results", "8"})));
+  }
+}

--- a/src/dd/Operations.cpp
+++ b/src/dd/Operations.cpp
@@ -19,7 +19,10 @@
 namespace dd {
 
 VectorDD applyGlobalPhase(VectorDD& in, const fp& phase, Package& dd) {
+  const auto previous = in;
   in.w = dd.cn.lookup(in.w * ComplexValue{std::polar(1.0, phase)});
+  dd.incRef(in);
+  dd.decRef(previous);
   return in;
 }
 

--- a/src/dd/UniqueTable.cpp
+++ b/src/dd/UniqueTable.cpp
@@ -34,14 +34,15 @@ UniqueTable::UniqueTable(MemoryManager& manager,
 }
 
 void UniqueTable::resize(const std::size_t nVars) {
+  const auto oldSize = tables.size();
   cfg.nVars = nVars;
-  tables.resize(nVars, Table(cfg.nBuckets));
-  // TODO: if the new size is smaller than the old one we might have to
-  // release the unique table entries for the superfluous variables
+  tables.resize(nVars);
+  /// TODO: release entries for removed levels when shrinking populated tables.
   stats.resize(nVars);
-  for (auto& stat : stats) {
-    stat.entrySize = sizeof(Bucket);
-    stat.numBuckets = cfg.nBuckets;
+  for (auto i = oldSize; i < nVars; ++i) {
+    tables[i].resize(cfg.nBuckets);
+    stats[i].entrySize = sizeof(Bucket);
+    stats[i].numBuckets = cfg.nBuckets;
   }
 }
 

--- a/src/qdmi/devices/dd/Device.cpp
+++ b/src/qdmi/devices/dd/Device.cpp
@@ -47,7 +47,6 @@
 #include <optional>
 #include <ranges>
 #include <span>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -582,26 +581,18 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgramSampling()
                                  p.size());
         },
         program_);
-    auto jitSession = qir::JitSession(irBytes, "QDMI job");
-    auto& runtime = jitSession.runtime();
-    if (seed_.has_value()) {
-      runtime.seed(static_cast<uint64_t>(*seed_));
+    const auto seed =
+        seed_ ? std::optional<uint64_t>{static_cast<uint64_t>(*seed_)}
+              : std::nullopt;
+    auto jitSession =
+        qir::JitSession(irBytes, "QDMI job", qir::Execution::Sampling, seed);
+    jitSession.runtime().disableOutput();
+    if (const auto rc = jitSession.sample(numShots_, shots_); rc != 0) {
+      std::cerr << "Error: QIR program failed with error: " << rc << '\n';
+      return false;
     }
-    std::ostringstream output;
-    runtime.setOstream(output);
-    runtime.outputProgramHeader();
-    shots_.reserve(numShots_);
-    for (size_t i = 0; i < numShots_; ++i) {
-      runtime.reset();
-      runtime.outputShotStart();
-      const auto rc = jitSession.run();
-      runtime.outputShotEnd(rc);
-      if (rc != 0) {
-        std::cerr << "Error: QIR program failed with error: " << rc << '\n';
-        return false;
-      }
-      shots_.push_back(runtime.getMeasurements());
-      ++counts_[shots_.back()];
+    for (const auto& shot : shots_) {
+      ++counts_[shot];
     }
     return true;
   });
@@ -625,8 +616,7 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::submitQIRProgramStateExtraction()
     auto jitSession =
         qir::JitSession(irBytes, "QDMI job", qir::Execution::StateExtraction);
     auto& runtime = jitSession.runtime();
-    std::ostringstream output;
-    runtime.setOstream(output);
+    runtime.disableOutput();
     if (const auto rc = jitSession.run(); rc != 0) {
       std::cerr << "Error: QIR program failed with error: " << rc << '\n';
       return false;

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <complex>
 #include <cstddef>
 #include <numbers>
@@ -35,6 +36,27 @@ TEST(DDGateConstruction, AppliesGlobalPhase) {
   EXPECT_NEAR(vector[0].real(), 0., RealNumber::eps);
   EXPECT_NEAR(vector[0].imag(), 1., RealNumber::eps);
   EXPECT_EQ(vector[1], std::complex<fp>{});
+
+  package.garbageCollect(true);
+  state = package.applyOperation(Package::makeIdent(), state);
+  EXPECT_EQ(state.getVector(), vector);
+  package.decRef(state);
+  package.garbageCollect(true);
+  const auto [vectors, matrices, reals] = package.computeActiveCounts();
+  EXPECT_EQ(vectors, 0);
+  EXPECT_EQ(matrices, 0);
+  EXPECT_EQ(reals, 0);
+}
+
+TEST(DDGateConstruction, ScalarGlobalPhaseSurvivesCollection) {
+  Package package(0);
+  auto state = vEdge::one();
+  applyGlobalPhase(state, 0.3, package);
+  package.garbageCollect(true);
+  EXPECT_NEAR(std::abs(state.getVector().front() - std::polar(1., 0.3)), 0.,
+              RealNumber::eps);
+  package.decRef(state);
+  package.garbageCollect(true);
 }
 
 TEST(DDGateConstruction, VectorKroneckerWithTerminal) {

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -1118,6 +1118,56 @@ TEST(DDPackageTest, trackTwiceThenuntrackTwice) {
   EXPECT_EQ(dd->mUniqueTable.getNumEntries(), 0);
 }
 
+TEST(DDPackageTest, UniqueTableGrowthPreservesLookupsStatisticsAndRoots) {
+  Package package(0);
+  package.resize(1);
+  const auto state = makeZeroState(1, package);
+  const GateMatrix x{0., 1., 1., 0.};
+  const auto gate = package.makeGateDD(x, 0);
+  package.incRef(gate);
+  const auto vectorStats = package.vUniqueTable.getStats(0).toString();
+  const auto matrixStats = package.mUniqueTable.getStats(0).toString();
+  for (const size_t width : {1, 4, 4}) {
+    package.resize(width);
+    EXPECT_EQ(package.vUniqueTable.getStats(0).toString(), vectorStats);
+    EXPECT_EQ(package.mUniqueTable.getStats(0).toString(), matrixStats);
+    for (const auto* table : {&package.vUniqueTable, &package.mUniqueTable}) {
+      for (size_t q = 1; q < width; ++q) {
+        const auto& stats = table->getStats(q);
+        EXPECT_EQ(stats.numEntries, 0);
+        EXPECT_EQ(stats.lookups, 0);
+        EXPECT_EQ(stats.entrySize, table->getStats(0).entrySize);
+        EXPECT_EQ(stats.numBuckets, table->getStats(0).numBuckets);
+        EXPECT_EQ(table->getTables()[q].size(), stats.numBuckets);
+      }
+    }
+  }
+  EXPECT_EQ(package.makeDDNode(0, std::array{vEdge::one(), vEdge::zero()}),
+            state);
+  EXPECT_EQ(package.makeGateDD(x, 0), gate);
+  const auto largerState = makeZeroState(4, package);
+  const auto largerGate = package.makeGateDD(x, 3);
+  package.incRef(largerGate);
+  package.decRef(largerState);
+  package.decRef(largerGate);
+  package.garbageCollect(true);
+  EXPECT_EQ(package.vUniqueTable.getNumEntries(), 1);
+  EXPECT_EQ(package.mUniqueTable.getNumEntries(), 1);
+  EXPECT_EQ(package.makeDDNode(0, std::array{vEdge::one(), vEdge::zero()}),
+            state);
+  EXPECT_EQ(package.makeGateDD(x, 0), gate);
+  package.decRef(state);
+  package.decRef(gate);
+  package.garbageCollect(true);
+  EXPECT_EQ(package.vUniqueTable.getNumEntries(), 0);
+  EXPECT_EQ(package.mUniqueTable.getNumEntries(), 0);
+  package.resize(0);
+  package.resize(1);
+  const auto fresh = makeZeroState(1, package);
+  EXPECT_EQ(fresh.getVector(), (CVec{1., 0.}));
+  package.decRef(fresh);
+}
+
 TEST(DDPackageTest, UniqueTableAllocation) {
   auto dd = std::make_unique<Package>(1);
 

--- a/test/qdmi/devices/dd/results_sampling_test.cpp
+++ b/test/qdmi/devices/dd/results_sampling_test.cpp
@@ -371,3 +371,27 @@ TEST(ResultsSampling, StateAndProbRequestsAreInvalidWhenShotsPositive) {
                 nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
 }
+
+TEST_F(QIRHistogramTestString, StaticSamplingPreservesRepeatedOutputOrder) {
+  constexpr std::string_view program = R"(
+define i64 @main() #0 {
+  call void @__quantum__qis__x__body(ptr null)
+  call void @__quantum__qis__swap__body(ptr null, ptr inttoptr (i64 2 to ptr))
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+  ret i64 0
+}
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__qis__swap__body(ptr, ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr)
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "required_num_qubits"="3" "required_num_results"="2" }
+)";
+  const auto [keys, values] =
+      runProgram(QDMI_PROGRAM_FORMAT_QIRBASESTRING, program);
+  EXPECT_EQ(keys, std::vector<std::string>{"101"});
+  EXPECT_EQ(values, std::vector<size_t>{NUM_SHOTS});
+}

--- a/test/qdmi/devices/dd/results_statevector_test.cpp
+++ b/test/qdmi/devices/dd/results_statevector_test.cpp
@@ -198,3 +198,35 @@ TEST(ResultsStatevector, QIRBaseStringYieldsBellState) {
   EXPECT_NEAR(std::abs(vec[2]), 0.0, 1e-6);
   EXPECT_NEAR(std::abs(vec[3]), invSqrt2, 1e-6);
 }
+
+TEST(ResultsStatevector, QIRPreservesPhaseWireOrderAndDeclaredWidth) {
+  constexpr std::string_view program = R"(
+define i64 @main() #0 {
+  call void @__quantum__qis__gphase__body(double 0.3)
+  call void @__quantum__qis__x__body(ptr null)
+  call void @__quantum__qis__swap__body(ptr null, ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  ret i64 0
+}
+declare void @__quantum__qis__gphase__body(double)
+declare void @__quantum__qis__x__body(ptr)
+declare void @__quantum__qis__swap__body(ptr, ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr) #1
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "required_num_qubits"="3" "required_num_results"="1" }
+attributes #1 = { "irreversible" }
+)";
+  const qdmi_test::SessionGuard s{};
+  const qdmi_test::JobGuard j{s.session};
+  ASSERT_EQ(
+      qdmi_test::setProgram(j.job, QDMI_PROGRAM_FORMAT_QIRBASESTRING, program),
+      QDMI_SUCCESS);
+  ASSERT_EQ(qdmi_test::setShots(j.job, 0), QDMI_SUCCESS);
+  ASSERT_EQ(qdmi_test::submitAndWait(j.job, 0), QDMI_SUCCESS);
+  const auto values = qdmi_test::getDenseState(j.job);
+  ASSERT_EQ(values.size(), 8);
+  for (size_t i = 0; i < values.size(); ++i) {
+    EXPECT_NEAR(std::abs(values[i] - (i == 2 ? std::polar(1., 0.3)
+                                             : std::complex<double>{})),
+                0., 1e-12);
+  }
+}


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

DDSIM QIR sampling previously executed the entire program for every shot and
retained text output that the device never consumed. This change prepares a DD
once for proven static terminal-measurement programs, then samples in recorded
output order. Both Base and Adaptive profiles can qualify; feedback, dynamic
allocation, memory operations, helper calls and unsupported control flow retain
ordinary per-shot execution.

- Keep batch DD sampling in the runtime and move full-register sample strings
  directly into the output vector. Preserve reordered, repeated and subset
  records, SWAP mappings, the final measurement record and seeded repeatability.
- Disable unused text formatting, use inline storage for common address/control
  translation, replace unused lazy-JIT machinery with LLJIT, and cache the
  immutable ABI registry while preserving host CPU settings.
- Size declared static resources exactly. Start empty packages at zero capacity
  and grow unknown resources geometrically. Preserve warm resets and lazy
  recreation after state transfer. Recycle released wires while rejecting stale
  handles, and include measured/read result IDs in capacity metadata even without
  output records.
- Initialize only appended shared DD unique-table levels, preserving existing
  lookup entries, statistics and GC roots. Preserve phase during state growth,
  repair DD root ownership and export logical wire order after SWAPs.
- Reject defined or indirect helper calls during Base state-extraction analysis
  before changing IR, so hidden measurements cannot silently collapse the
  extracted state.

The execution contract and both audits document supported inputs, resource
bounds, seed semantics and measured limits. Shared gate construction and
validation reuse main's DD implementation. RNG-draw skipping and general gate
caching remain deferred because their compatibility or workload tradeoffs are
not resolved.

Local ARM64 measurements against the already-optimized `b115e3629` revision,
using seven-trial medians and a reverse-order repeat, show:

| Workload | Before | After |
| --- | ---: | ---: |
| Static Adaptive GHZ32, 10,000 shots | 470-471 ms | 2.34-2.35 ms |
| Base GHZ32, 100,000 full-register shots | 33.27-33.52 ms | 23.11-23.23 ms |
| Base GHZ64, 100,000 full-register shots | 60.57-61.09 ms | 41.00-41.48 ms |
| Empty runtime, requested allocation bytes | 26,075,208 | 8,767,048 |
| Incremental 256-qubit growth, requested allocation bytes | 376,938,454 | 143,106,006 |

Batch times measure process CPU time and exclude JIT construction. These are
compressed DD workloads, not portable speedup claims. Full-register output
allocations halve, generic single-output sampling did not regress, and seeded
mapping sequences match the baseline byte for byte. Growth timings varied;
only its allocation reduction is claimed.

Validation: 46 JIT/analysis, 79 runtime and 180 DD release tests pass. Full Clang
CTest passes 3,190 tests with one existing skip. Both required lint sessions
pass, including changed-file C++ lint over the full PR diff. The complete strict
documentation build passes. Hosted CI must run on the new published head; earlier
CI results do not validate this update. All commits are signed.

No standalone changelog or upgrade entry is added for unreleased v4 behavior,
per repository policy. Codex/GPT-6 implemented, tested and submitted this change
under explicit authorization. Human review and acceptance remain pending.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
