### PR TITLE
⚡ Reduce Slurm overhead and bound integration tests

### DIFF
--- a/.agent/audits/slurm-performance-2026-09-08.md
+++ b/.agent/audits/slurm-performance-2026-09-08.md
@@ -1,0 +1,136 @@
+# Contract audit: Slurm build, selection, and tests
+
+Status: applied locally. Baseline: `552feffdbf5e2396660bb3e91a21936a9d7adf63`,
+initially clean. Date: 2026-09-08.
+
+## Result
+
+Three supported improvements remove avoidable costs and bound fixture failures:
+
+1. Remove the adapter's full device-catalog copy before opening one device.
+2. Bound fixture commands, isolate concurrent runs, and verify terminal job
+   status.
+3. Enable the existing compiler cache and remove the wheel archive from image
+   layers.
+
+The adapter does not call the Slurm controller. Provider initialization and
+network calls remain provider-owned; this audit cannot guarantee a universal
+latency bound. Existing issues #2310-#2313 and #2366 cover availability and
+optional admission/checker work and remain separate from static-license
+selection.
+
+## Findings
+
+### Remove duplicate catalog work
+
+`src/qdmi/Slurm.cpp::openDeviceFromLicense` copied every registered ID and
+searched that copy before `Session::openDevice` performed the existing driver
+lookup. Syntax validation now precedes driver initialization, and the adapter
+opens the selected ID directly. An unknown ID still raises the adapter's runtime
+error. Each call opens a fresh session and accepts IDLE or BUSY; no cached
+provider status or device handle changes those semantics.
+
+Contract sources: `include/mqt-core/qdmi/Slurm.hpp`,
+`src/qdmi/Client.cpp::Session::openDevice`,
+`src/qdmi/driver/Driver.cpp::Driver::openFresh`, and `docs/qdmi/slurm.md`.
+Native and Python adapter tests retain malformed, compound, remote, unknown, and
+unavailable-device rejection. The added native test checks fresh handles and the
+unknown-ID diagnostic through the shared lookup.
+
+A native ARM64 probe registered the selected fixture device first, warmed the
+adapter, then counted allocations and elapsed time across 100 opens. It repeated
+with 1,000 and 10,000 unrelated registered IDs. The selected device used the
+existing session fixture; registration and startup were outside measurement.
+Only the adapter translation unit changed between the two linked probes.
+
+| Unrelated IDs | Before allocations | After allocations | Before ms | After ms |
+| ------------: | -----------------: | ----------------: | --------: | -------: |
+|             0 |              1,400 |             1,200 |     0.494 |    0.215 |
+|         1,000 |            101,400 |             1,200 |    13.002 |    0.212 |
+|        10,000 |          1,001,400 |             1,200 |    63.826 |    0.225 |
+
+This isolates the removed catalog copy. The shared driver lookup still scans its
+registry, so selecting the last ID remains linear. An index is deferred until
+representative registry sizes and lookup positions justify shared-driver
+changes.
+
+### Bound failures and keep real scheduler coverage
+
+`test/slurm/run_integration.py` previously allowed subprocesses to wait without
+a deadline and shared a fixed project and runtime directory across invocations.
+Commands now have deadlines and terminate their process group on interruption,
+including Compose children holding output pipes. Startup, diagnostics, and
+teardown have separate limits. Batch jobs request five minutes. Unique Docker
+projects, runtime paths, and Munge keys prevent concurrent runs from overwriting
+or tearing down each other's resources.
+
+Checked command failures retain output. Diagnostics cannot suppress the original
+failure or bypass teardown. Successful runs remove their resources; failures
+retain artifacts. This bounds ordinary subprocess stalls, not an unresponsive
+kernel or Docker daemon's internal work after its client has been terminated.
+
+Positive and negative jobs now require the expected `scontrol show job` terminal
+state and exit code. Queue disappearance and an earlier result alone cannot turn
+a later job failure into success. Result writers atomically publish JSON. The
+real two-node test retains license contention, an independent SC job, Bell
+results, and invalid license coverage. No accounting daemon is required.
+
+Fourteen inexpensive runner tests cover subprocess descendants, checked error
+output, terminal states, preflight cleanup, diagnostic failure, and invocation
+isolation. These run before the wheel build in CI. Two concurrent real fixtures
+passed in 31.41 and 31.25 seconds and cleaned up independently. The final
+fixture, including the five-minute batch limit, passed in 32.69 seconds.
+
+The original fixture took 56.60 seconds locally; changed Docker cache warmth
+prevents attributing that whole difference to this patch. Polling stays confined
+to the disposable test controller;
+[Slurm warns that repeated client RPCs can burden a production controller](https://slurm.schedmd.com/squeue.html#SECTION_PERFORMANCE).
+
+### Cache compilation and reduce image layers
+
+A recent successful hosted Slurm job spent 323 seconds building its wheel and 77
+seconds in integration (run 34216386560). `cmake/Cache.cmake` already supports
+sccache, so `.github/workflows/slurm.yml` now installs the pinned action and
+sccache 0.16.0 with its GHA backend enabled. It also adds missing build/test
+path triggers and 15-minute wheel and integration step limits.
+
+A controlled local comparison used GCC 13, sccache 0.16.0, the same configured
+build directory and source, and a clean CMake build target before each wheel
+build. The first used an empty dedicated disk cache; the second reused it.
+
+| Build | Compile requests | Cache hits | Cache misses | Wall seconds |
+| ----- | ---------------: | ---------: | -----------: | -----------: |
+| Cold  |               67 |          0 |           67 |        63.27 |
+| Warm  |               67 |         62 |            5 |        41.90 |
+
+Both had zero cache errors. The local warm build reduced wall time by 33.8%.
+This validates compiler-cache usefulness, not hosted cache availability or a
+hosted speedup. The action reports counters; inspect requests and hits together
+with wall time after publication. Configuration follows the
+[sccache action inputs](https://github.com/Mozilla-Actions/sccache-action/blob/v0.0.11/action.yml)
+and
+[GHA backend documentation](https://github.com/mozilla/sccache/blob/main/docs/GHA.md).
+
+`test/slurm/Dockerfile` installs the wheel through a BuildKit bind mount and
+uses a uv cache mount. The archive no longer persists in a COPY layer. Image
+size fell from 516 MB to 450 MB; controller and node images share layers, so
+this is not three independent disk savings. No custom wheel variant or
+compiler-cache framework was added.
+
+## Validation
+
+- Native rebuilt `mqt-core-qdmi-test --gtest_filter=SlurmAdapterTest.*`: 6
+  passed.
+- Updated wheel, Python 3.14.7,
+  `pytest -o addopts= -q test/python/qdmi/test_slurm.py`: 4 passed.
+- Runner tests: 14 passed with the standalone command documented in
+  `docs/qdmi/slurm.md`.
+- `uv run --no-project --python 3.14 test/slurm/run_integration.py`: passed on
+  privileged Linux Docker with cgroup v2, including two simultaneous runs.
+- `uvx nox -s lint`: passed, including Python type checks.
+- `uvx nox -s cpp-lint -- 552feffdbf5e2396660bb3e91a21936a9d7adf63`: passed with
+  zero findings across both changed C++ files, checking all their lines.
+
+Hosted CI for this patch has not run. Provider/network tail latency, hosted
+compiler-cache hit rate, and large-registry lookup position remain measurement
+limits, not established bottlenecks or guarantees.

--- a/.agent/plans/slurm-performance.md
+++ b/.agent/plans/slurm-performance.md
@@ -1,0 +1,35 @@
+# Slurm performance and test reliability
+
+Status: complete; implemented and validated locally. Baseline:
+`552feffdbf5e2396660bb3e91a21936a9d7adf63`.
+
+## Outcome and scope
+
+The static-license adapter opens the selected registered device without copying
+the full catalog. It preserves fresh sessions, IDLE/BUSY acceptance, and input
+errors. Selection remains separate from provider authorization. Availability
+synchronization and optional SPANK/checker work in #2310-#2313/#2366 remain
+separate workstreams.
+
+The real Slurm fixture bounds commands, checks terminal job states and exit
+codes, and isolates each invocation's Docker resources and artifacts. Fourteen
+fast runner tests cover failures before CI builds a wheel. CI uses the existing
+compiler-cache integration; Docker installs the wheel without retaining its
+archive in an image layer.
+
+## Decisions and evidence
+
+Reuse `Session::openDevice` rather than adding an adapter lookup or cache. Keep
+provider sessions and status fresh; callers can reuse an opened device for
+multiple quantum jobs. Provider calls retain provider-owned timeout settings.
+
+Keep the two-node contention and independent-device execution tests. Process
+group termination handles Compose children; unique projects prevent cross-run
+cleanup. Controller polling belongs only to this disposable test fixture.
+
+The controlled local compiler-cache test reduced a clean wheel build from 63.27
+to 41.90 seconds with 62 hits from 67 requests. Image size fell from 516 to 450
+MB. Native and Python adapter tests, the runner tests, and real Slurm tests
+passed, including simultaneous independent runs. Hosted cache behavior remains
+unverified. Full contract evidence and measurement limits are in the
+[Slurm audit](../audits/slurm-performance-2026-09-08.md).

--- a/.github/workflows/slurm.yml
+++ b/.github/workflows/slurm.yml
@@ -7,23 +7,31 @@ on:
     paths:
       - ".github/workflows/slurm.yml"
       - "bindings/qdmi/**"
+      - "CMakeLists.txt"
       - "cmake/**"
       - "include/mqt-core/qdmi/**"
       - "pyproject.toml"
       - "python/mqt/core/qdmi/**"
       - "src/qdmi/**"
       - "test/slurm/**"
+      - "test/qdmi/**"
+      - "test/python/qdmi/**"
+      - "test/python/test_slurm_integration.py"
       - "uv.lock"
   pull_request:
     paths:
       - ".github/workflows/slurm.yml"
       - "bindings/qdmi/**"
+      - "CMakeLists.txt"
       - "cmake/**"
       - "include/mqt-core/qdmi/**"
       - "pyproject.toml"
       - "python/mqt/core/qdmi/**"
       - "src/qdmi/**"
       - "test/slurm/**"
+      - "test/qdmi/**"
+      - "test/python/qdmi/**"
+      - "test/python/test_slurm_integration.py"
       - "uv.lock"
   workflow_dispatch:
 
@@ -41,6 +49,7 @@ jobs:
     timeout-minutes: 45
     env:
       UV_NO_PROGRESS: "1"
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Check out MQT Core
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,13 +63,25 @@ jobs:
           enable-cache: true
           python-version: "3.14"
 
+      - name: Check the Slurm test runner
+        run: >-
+          uv run --no-project --with 'pytest>=9.0.1' --python 3.14
+          pytest -o addopts= -q test/python/test_slurm_integration.py
+
       - name: Set up MLIR
         uses: munich-quantum-software/setup-mlir@3f32263ce571a8b745068980f30f188b6e800763 # v1.4.2
         with:
           llvm-version: 23.1.0
 
+      - name: Set up compiler cache
+        uses: Mozilla-Actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
       - name: Build the MQT Core wheel
+        timeout-minutes: 15
         run: uv build --wheel --out-dir test/slurm/dist
 
       - name: Test Slurm admission and QDMI execution
+        timeout-minutes: 15
         run: uv run --no-project --python 3.14 test/slurm/run_integration.py

--- a/docs/qdmi/slurm.md
+++ b/docs/qdmi/slurm.md
@@ -172,6 +172,13 @@ The same open handle works with application adapters. Pass it to
 {py:class}`mqt.core.plugins.pennylane.device.QDMIDevice`. See the
 {doc}`pennylane_device` guide for the PennyLane constructor.
 
+Open the selected device once per application process and reuse its handle for
+subsequent quantum jobs. The adapter validates the license locally, opens only
+the selected device, and queries its status once. Device selection uses the
+ordinary QDMI driver lookup and needs no controller RPC. Provider initialization
+and network requests can still dominate opening time; use provider-supported
+timeout settings for network requests.
+
 ## Check concurrent jobs
 
 For a scheduling test, add a sufficiently long classical post-processing step
@@ -222,3 +229,41 @@ license expression for device selection because the environment does not
 identify a single selected device in that case.
 
 [Slurm GRES configuration]: https://slurm.schedmd.com/gres.conf.html
+
+## Run the integration tests
+
+From a source checkout on a Linux Docker host with cgroup v2, build one wheel
+and run the fixture:
+
+```console
+uv build --wheel --out-dir test/slurm/dist
+uv run --no-project --python 3.14 test/slurm/run_integration.py
+```
+
+Keep exactly one wheel in `test/slurm/dist`. The fixture installs that wheel in
+one controller and two compute containers. It checks admission, license
+contention, independent SC execution, Bell results, and terminal job states and
+exit codes. It uses privileged containers to exercise real Slurm cgroups; it is
+an isolated test cluster, not a production deployment template.
+
+Each invocation uses its own Docker project, Munge key, and directory below
+`test/slurm/runtime`. Successful runs remove their containers, images, and
+artifacts; failures retain artifacts and print the project and runtime path.
+Docker's build cache remains available to later runs. Commands have 30-second
+deadlines, image build/startup has a ten-minute deadline, and diagnostics and
+cleanup have separate short deadlines. Batch jobs request a five-minute time
+limit. An interrupted command terminates its process group, including a Docker
+Compose child.
+
+The runner prints setup, execution, and total durations. Its inexpensive
+failure-path tests can run before building a wheel:
+
+```console
+uv run --no-project --with 'pytest>=9.0.1' --python 3.14 pytest -o addopts= -q test/python/test_slurm_integration.py
+```
+
+CI enables the existing sccache compiler integration and reports cache counters.
+Compare compiler requests, hits, and wall time before attributing a build-time
+change to caching. The fixture's bounded polling targets its private controller;
+do not copy these loops into production monitoring. See the
+[Slurm RPC performance guidance](https://slurm.schedmd.com/squeue.html#SECTION_PERFORMANCE).

--- a/src/qdmi/Slurm.cpp
+++ b/src/qdmi/Slurm.cpp
@@ -11,7 +11,6 @@
 #include "qdmi/Slurm.hpp"
 
 #include "qdmi/Client.hpp"
-#include "qdmi/driver/Driver.hpp"
 
 #include <qdmi/constants.h>
 
@@ -25,7 +24,6 @@
 #include <string>
 #include <string_view>
 #include <system_error>
-#include <vector>
 
 namespace qdmi::slurm {
 namespace {
@@ -51,8 +49,7 @@ namespace {
   return "UNKNOWN";
 }
 
-[[nodiscard]] auto parseLicense(const std::string& licenseSpec,
-                                const std::vector<std::string>& registeredIds)
+[[nodiscard]] auto parseLicense(const std::string_view licenseSpec)
     -> std::string {
   if (licenseSpec.empty()) {
     throw std::runtime_error(
@@ -90,7 +87,7 @@ namespace {
   }
 
   if (countSeparator != std::string::npos) {
-    const std::string countText = licenseSpec.substr(countSeparator + 1);
+    const auto countText = licenseSpec.substr(countSeparator + 1);
     if (countText.empty()) {
       throw std::runtime_error(
           "SLURM_JOB_LICENSES contains a malformed license count");
@@ -111,25 +108,26 @@ namespace {
     }
   }
 
-  if (std::ranges::find(registeredIds, deviceId) == registeredIds.end()) {
-    throw std::runtime_error("Slurm license '" + deviceId +
-                             "' is not a registered QDMI device ID");
-  }
-  return deviceId;
+  return std::string(deviceId);
 }
 
 } // namespace
 
 Device openDeviceFromLicense() {
-  // The job can modify its environment. Use this value only to select a
-  // registered device; the provider or operating system must authorize access.
+  /// The job can modify its environment. Use this value only to select a
+  /// registered device; the provider or operating system must authorize access.
   const auto* const environmentValue = std::getenv("SLURM_JOB_LICENSES");
   const std::string licenseSpec =
       environmentValue == nullptr ? std::string{} : environmentValue;
-  const auto deviceId =
-      parseLicense(licenseSpec, qdmi::Driver::get().registeredDeviceIds());
-
-  auto device = Session::openDevice(deviceId);
+  const auto deviceId = parseLicense(licenseSpec);
+  auto device = [&] {
+    try {
+      return Session::openDevice(deviceId);
+    } catch (const std::out_of_range&) {
+      throw std::runtime_error("Slurm license '" + deviceId +
+                               "' is not a registered QDMI device ID");
+    }
+  }();
   const auto status = device.getStatus();
   if (status != QDMI_DEVICE_STATUS_IDLE && status != QDMI_DEVICE_STATUS_BUSY) {
     throw std::runtime_error("SLURM_JOB_LICENSES names QDMI device '" +

--- a/test/python/test_slurm_integration.py
+++ b/test/python/test_slurm_integration.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Check failure and resource bounds without starting a Slurm cluster."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+if sys.platform == "win32":
+    pytest.skip("the Slurm fixture requires a POSIX Docker host", allow_module_level=True)
+
+
+def load_runner() -> ModuleType:
+    """Load an independent fixture invocation without creating its resources.
+
+    Returns:
+        The isolated runner module.
+    """
+    script = Path(__file__).parents[1] / "slurm" / "run_integration.py"
+    spec = importlib.util.spec_from_file_location("slurm_integration", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = load_runner()
+
+
+def test_timeout_kills_children_holding_output_pipes(tmp_path: Path) -> None:
+    """A Compose-like grandchild must not defeat the command deadline."""
+    marker = tmp_path / "started"
+    program = (
+        "import subprocess, sys, time; from pathlib import Path; "
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)']); "
+        f"Path({str(marker)!r}).touch(); time.sleep(30)"
+    )
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner.run((sys.executable, "-c", program), timeout=1)
+    assert marker.exists()
+    assert time.monotonic() - started < 5
+
+
+def test_diagnostic_timeout_is_best_effort() -> None:
+    """Bound failed diagnostics without replacing the original test failure."""
+    result = runner.run((sys.executable, "-c", "import time; time.sleep(30)"), check=False, timeout=0.1)
+    assert result.returncode == 124
+
+
+def test_command_failure_keeps_output() -> None:
+    """Retain command diagnostics when a checked command fails."""
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        runner.run((sys.executable, "-c", "import sys; print('reason'); sys.exit(7)"))
+    assert error.value.returncode == 7
+    assert "reason" in error.value.output
+
+
+@pytest.mark.parametrize(
+    ("state", "exit_code", "expected", "result"),
+    [
+        ("RUNNING", "0:0", "COMPLETED", False),
+        ("COMPLETING", "0:0", "FAILED", False),
+        ("COMPLETED", "0:0", "COMPLETED", True),
+        ("FAILED", "1:0", "FAILED", True),
+        ("FAILED", "1:0", "COMPLETED", None),
+        ("COMPLETED", "0:0", "FAILED", None),
+        ("COMPLETED", "0:9", "COMPLETED", None),
+        ("FAILED", "0:0", "FAILED", None),
+    ],
+)
+def test_job_completion_requires_state_and_exit_code(
+    monkeypatch: pytest.MonkeyPatch, state: str, exit_code: str, expected: str, *, result: bool | None
+) -> None:
+    """A result file or a diagnostic cannot turn a failed job into a success."""
+    record = f"JobId=42 JobState={state} ExitCode={exit_code}"
+    monkeypatch.setattr(runner, "controller", lambda *args: subprocess.CompletedProcess(args, 0, record, ""))
+    if result is None:
+        with pytest.raises(AssertionError, match="Slurm job 42 ended"):
+            runner.job_finished("42", expected_state=expected)
+    else:
+        assert runner.job_finished("42", expected_state=expected) is result
+
+
+def test_preflight_does_not_touch_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing wheel must fail before starting Docker or writing a Munge key."""
+    runtime = tmp_path / "runtime"
+    monkeypatch.setattr(runner, "DIST", tmp_path)
+    monkeypatch.setattr(runner, "RUNTIME", runtime)
+    with pytest.raises(RuntimeError, match="exactly one MQT Core wheel"):
+        runner.main()
+    assert not runtime.exists()
+
+
+def test_diagnostic_failure_still_tears_down(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unavailable diagnostic service must not orphan a failed cluster."""
+    (tmp_path / "core.whl").touch()
+    monkeypatch.setattr(runner, "DIST", tmp_path)
+    monkeypatch.setattr(runner, "RUNTIME", tmp_path / "runtime")
+    monkeypatch.setattr(runner, "run", lambda *args: subprocess.CompletedProcess(args, 0, "2", ""))
+    commands = []
+
+    def compose(*args: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        if args[0] == "up":
+            msg = "startup failure"
+            raise RuntimeError(msg)
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    def diagnostics() -> None:
+        msg = "diagnostics"
+        raise subprocess.TimeoutExpired(msg, 30)
+
+    monkeypatch.setattr(runner, "compose", compose)
+    monkeypatch.setattr(runner, "print_diagnostics", diagnostics)
+    with pytest.raises(RuntimeError, match="startup failure"):
+        runner.main()
+    assert commands[-1][0] == "down"
+
+
+def test_invocations_use_distinct_projects_and_artifacts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent worktrees or runs must not stop or clean each other's cluster."""
+    first, second = load_runner(), load_runner()
+    calls = []
+
+    def run(command: tuple[str, ...], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs["env"]))
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    for invocation in (first, second):
+        monkeypatch.setattr(invocation, "run", run)
+        invocation.compose("ps")
+    assert first.RUNTIME != second.RUNTIME
+    assert calls[0][0] != calls[1][0]
+    assert calls[0][1] != calls[1][1]

--- a/test/qdmi/test_slurm.cpp
+++ b/test/qdmi/test_slurm.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <qdmi/client.h>
 #include <qdmi/constants.h>
 
 #include <array>
@@ -52,6 +53,21 @@ TEST(SlurmAdapterTest, AcceptsBusyDevice) {
   const ScopedEnvironmentVariable licenses("SLURM_JOB_LICENSES",
                                            "test.slurm.busy");
   EXPECT_EQ(openDeviceFromLicense().getStatus(), QDMI_DEVICE_STATUS_BUSY);
+}
+
+TEST(SlurmAdapterTest, KeepsSessionsFreshAndReportsUnknownDevice) {
+  registerStatusDevice("test.slurm.fresh", "idle");
+  const ScopedEnvironmentVariable licenses("SLURM_JOB_LICENSES",
+                                           "test.slurm.fresh:1");
+  const auto first = openDeviceFromLicense();
+  const auto second = openDeviceFromLicense();
+  EXPECT_NE(static_cast<QDMI_Device>(first), static_cast<QDMI_Device>(second));
+  const ScopedEnvironmentVariable unknown("SLURM_JOB_LICENSES",
+                                          "test.slurm.unknown");
+  EXPECT_THAT([] { return openDeviceFromLicense(); },
+              testing::ThrowsMessage<std::runtime_error>(
+                  testing::HasSubstr("Slurm license 'test.slurm.unknown' is "
+                                     "not a registered QDMI device ID")));
 }
 
 TEST(SlurmAdapterTest, RejectsMissingAndMalformedValues) {

--- a/test/slurm/Dockerfile
+++ b/test/slurm/Dockerfile
@@ -24,12 +24,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=uv /uv /uvx /bin/
-COPY dist/*.whl /tmp/dist/
 COPY mqt-slurm-prepare /usr/local/sbin/mqt-slurm-prepare
 COPY mqt-slurm-prepare.service /etc/systemd/system/mqt-slurm-prepare.service
 
-RUN uv pip install --system --break-system-packages /tmp/dist/*.whl \
-    && rm -rf /root/.cache/uv /tmp/dist \
+RUN --mount=type=bind,source=dist,target=/tmp/dist \
+    --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system --break-system-packages --link-mode=copy /tmp/dist/*.whl \
     && chmod 0755 /usr/local/sbin/mqt-slurm-prepare \
     && systemctl enable mqt-slurm-prepare.service munge.service
 

--- a/test/slurm/bell_job.py
+++ b/test/slurm/bell_job.py
@@ -59,7 +59,10 @@ def main() -> None:
         "shots": SHOTS,
     }
     runtime = Path("/runtime")
-    (runtime / f"ddsim-{job_id}.json").write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+    result_path = runtime / f"ddsim-{job_id}.json"
+    temporary = result_path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+    temporary.replace(result_path)
 
     if args.hold:
         release = runtime / f"release-{job_id}"

--- a/test/slurm/compose.yml
+++ b/test/slurm/compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - ../..:/workspace:ro
-      - ./runtime:/runtime
+      - ${MQT_CORE_SLURM_RUNTIME:-./runtime}:/runtime
       - ./slurm.conf:/etc/slurm/slurm.conf:ro
       - ./cgroup.conf:/etc/slurm/cgroup.conf:ro
     healthcheck:
@@ -54,7 +54,7 @@ services:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - ../..:/workspace:ro
-      - ./runtime:/runtime
+      - ${MQT_CORE_SLURM_RUNTIME:-./runtime}:/runtime
       - ./slurm.conf:/etc/slurm/slurm.conf:ro
       - ./cgroup.conf:/etc/slurm/cgroup.conf:ro
     healthcheck:
@@ -88,7 +88,7 @@ services:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - ../..:/workspace:ro
-      - ./runtime:/runtime
+      - ${MQT_CORE_SLURM_RUNTIME:-./runtime}:/runtime
       - ./slurm.conf:/etc/slurm/slurm.conf:ro
       - ./cgroup.conf:/etc/slurm/cgroup.conf:ro
     healthcheck:

--- a/test/slurm/run_integration.py
+++ b/test/slurm/run_integration.py
@@ -10,13 +10,18 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import os
 import re
 import secrets
 import shlex
+import shutil
+import signal
 import subprocess
 import time
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,24 +31,65 @@ if TYPE_CHECKING:
 ROOT = Path(__file__).resolve().parents[2]
 FIXTURE = ROOT / "test" / "slurm"
 DIST = FIXTURE / "dist"
-RUNTIME = FIXTURE / "runtime"
+RUNTIME = FIXTURE / "runtime" / uuid.uuid4().hex
 COMPOSE = (
     "docker",
     "compose",
     "--project-name",
-    "mqt-core-slurm-test",
+    f"mqt-core-slurm-{RUNTIME.name}",
     "--file",
     str(FIXTURE / "compose.yml"),
 )
 TIMEOUT = 120.0
+COMMAND_TIMEOUT = 30.0
 RESULT_VISIBILITY_GRACE_PERIOD = 5.0
 LOGGER = logging.getLogger(__name__)
 
 
-def run(command: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+def _communicate(process: subprocess.Popen[str], timeout: float) -> tuple[str, str]:
+    """Collect output, killing the whole command group on interruption.
+
+    Returns:
+        The command's stdout and stderr.
+    """
+    try:
+        return process.communicate(timeout=timeout)
+    except BaseException:
+        # Docker can spawn a Compose child holding our output pipes.
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.communicate()
+        raise
+
+
+def run(
+    command: Sequence[str],
+    *,
+    check: bool = True,
+    timeout: float = COMMAND_TIMEOUT,
+    capture_output: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     """Run a command and retain output for assertions and diagnostics."""
     LOGGER.info("+ %s", shlex.join(command))
-    result = subprocess.run(command, check=False, capture_output=True, text=True)  # ruff: ignore[subprocess-without-shell-equals-true]
+    try:
+        with subprocess.Popen(  # ruff: ignore[subprocess-without-shell-equals-true]
+            command,
+            stdout=subprocess.PIPE if capture_output else None,
+            stderr=subprocess.PIPE if capture_output else None,
+            text=True,
+            env=env,
+            start_new_session=True,
+        ) as process:
+            stdout, stderr = _communicate(process, timeout)
+            result = subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        if check:
+            raise
+        LOGGER.warning("Command failed: %s", error)
+        return subprocess.CompletedProcess(
+            command, 124 if isinstance(error, subprocess.TimeoutExpired) else 127, "", str(error)
+        )
     if result.stdout:
         LOGGER.info("%s", result.stdout.rstrip())
     if result.stderr:
@@ -53,14 +99,25 @@ def run(command: Sequence[str], *, check: bool = True) -> subprocess.CompletedPr
     return result
 
 
-def compose(*arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
-    """Run Docker Compose for the fixed, isolated test project."""
-    return run((*COMPOSE, *arguments), check=check)
+def compose(
+    *arguments: str,
+    check: bool = True,
+    timeout: float = COMMAND_TIMEOUT,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run Docker Compose for this invocation's isolated project and artifacts."""
+    return run(
+        (*COMPOSE, *arguments),
+        check=check,
+        timeout=timeout,
+        capture_output=capture_output,
+        env={**os.environ, "MQT_CORE_SLURM_RUNTIME": str(RUNTIME)},
+    )
 
 
-def controller(*command: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+def controller(*command: str, check: bool = True, timeout: float = COMMAND_TIMEOUT) -> subprocess.CompletedProcess[str]:
     """Run a Slurm client command in the controller container."""
-    return compose("exec", "-T", "controller", *command, check=check)
+    return compose("exec", "-T", "controller", *command, check=check, timeout=timeout)
 
 
 def compute(node: str, *command: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -113,6 +170,20 @@ def job_matches(job_id: str, state: str, *, node: str | None = None, reason: str
     )
 
 
+def job_finished(job_id: str, *, expected_state: str = "COMPLETED") -> bool:
+    """Require the terminal state and exit code, without an accounting daemon."""
+    output = controller("scontrol", "show", "job", job_id, "--oneliner").stdout
+    record = dict(field.split("=", maxsplit=1) for field in output.split() if "=" in field)
+    state = record["JobState"]
+    if state in {"PENDING", "CONFIGURING", "RUNNING", "COMPLETING", "SUSPENDED"}:
+        return False
+    exit_code = tuple(map(int, record["ExitCode"].split(":")))
+    if state != expected_state or len(exit_code) != 2 or ((exit_code == (0, 0)) != (expected_state == "COMPLETED")):
+        msg = f"Slurm job {job_id} ended with {state}, ExitCode={record['ExitCode']}; expected {expected_state}"
+        raise AssertionError(msg)
+    return True
+
+
 def submit(script: str, license_expression: str, *, node: str | None = None, hold: bool = False) -> str:
     """Submit one single-processor batch job and return its numeric ID."""
     command = [
@@ -121,6 +192,7 @@ def submit(script: str, license_expression: str, *, node: str | None = None, hol
         "--nodes=1",
         "--ntasks=1",
         "--cpus-per-task=1",
+        "--time=5",
         f"--licenses={license_expression}",
         "--chdir=/workspace",
         "--output=/runtime/slurm-%j.out",
@@ -190,7 +262,7 @@ def wait_for_failed_adapter(job_id: str, diagnostic: str) -> None:
     output_path = RUNTIME / f"slurm-{job_id}.out"
 
     def failed_with_diagnostic() -> bool:
-        if not output_path.exists() or job_record(job_id) is not None:
+        if not job_finished(job_id, expected_state="FAILED") or not output_path.exists():
             return False
         return diagnostic in output_path.read_text(encoding="utf-8")
 
@@ -218,11 +290,8 @@ def assert_bell_result(job_id: str, expected_node: str | None = None) -> None:
 
 
 def clean_runtime() -> None:
-    """Remove only result artifacts created by an earlier fixture run."""
-    RUNTIME.mkdir(parents=True, exist_ok=True)
-    for pattern in ("ddsim-*.json", "sc-*.json", "release-*", "slurm-*.out"):
-        for path in RUNTIME.glob(pattern):
-            path.unlink()
+    """Create private artifacts and a Munge key for this invocation only."""
+    RUNTIME.mkdir(mode=0o700, parents=True, exist_ok=False)
     key = RUNTIME / "munge.key"
     key.write_bytes(secrets.token_bytes(1024))
     key.chmod(0o600)
@@ -230,16 +299,17 @@ def clean_runtime() -> None:
 
 def print_diagnostics() -> None:
     """Print cluster state without hiding the original test failure."""
-    controller("squeue", "--all", check=False)
+    controller("squeue", "--all", check=False, timeout=5)
     controller(
         "sacct",
         "--allusers",
         "--starttime=now-1hour",
         "--format=JobID,State,ExitCode,Reason,NodeList",
         check=False,
+        timeout=5,
     )
-    controller("scontrol", "show", "node", check=False)
-    controller("scontrol", "show", "lic", check=False)
+    controller("scontrol", "show", "node", check=False, timeout=5)
+    controller("scontrol", "show", "lic", check=False, timeout=5)
     for output in sorted(RUNTIME.glob("slurm-*.out")):
         LOGGER.info("=== %s ===", output.name)
         try:
@@ -251,7 +321,7 @@ def print_diagnostics() -> None:
         ("node1", ("munge.service", "slurmd.service")),
         ("node2", ("munge.service", "slurmd.service")),
     ):
-        compose("exec", "-T", service, "systemctl", "status", "--no-pager", *units, check=False)
+        compose("exec", "-T", service, "systemctl", "status", "--no-pager", *units, check=False, timeout=5)
         compose(
             "exec",
             "-T",
@@ -261,17 +331,19 @@ def print_diagnostics() -> None:
             "--lines=100",
             *(argument for unit in units for argument in ("--unit", unit)),
             check=False,
+            timeout=5,
         )
-    compose("logs", "--no-color", check=False)
+    compose("logs", "--no-color", check=False, timeout=5)
 
 
 def main() -> None:
     """Build the cluster and verify Slurm admission and DDSIM execution."""
-    clean_runtime()
     wheels = tuple(DIST.glob("*.whl"))
     if len(wheels) != 1:
         msg = f"Build exactly one MQT Core wheel in {DIST}, found {len(wheels)}"
         raise RuntimeError(msg)
+
+    started_at = time.monotonic()
 
     success = False
     started = False
@@ -281,8 +353,12 @@ def main() -> None:
             msg = f"The Slurm integration requires Docker on cgroup v2, got {cgroup_version!r}"
             raise RuntimeError(msg)
 
+        clean_runtime()
+        LOGGER.info("Slurm runtime directory: %s", RUNTIME)
         started = True
-        compose("up", "--build", "--detach", "--wait")
+        compose("up", "--build", "--detach", "--wait", "--wait-timeout", "120", timeout=600, capture_output=False)
+        LOGGER.info("Slurm image build and startup: %.2fs", time.monotonic() - started_at)
+        testing_at = time.monotonic()
 
         version_output = controller("scontrol", "--version").stdout.strip()
         version_match = re.search(r"^slurm(?:-wlm)?\s+(\d+)\.(\d+)\b", version_output, flags=re.IGNORECASE)
@@ -346,7 +422,7 @@ def main() -> None:
 
         sc_job = submit("sc-job.sh", "mqt.sc.default:1")
         wait_for_result("sc", sc_job, "the SC job to execute on a free CPU")
-        wait_for("the SC job to leave the queue", lambda: job_record(sc_job) is None)
+        wait_for("the SC job to complete", lambda: job_finished(sc_job))
         sc_result = load_result("sc", sc_job)
         if sc_result["node"] not in {"node1", "node2"} or sc_result["qubits"] <= 0:
             msg = f"Unexpected SC job result: {sc_result}"
@@ -356,9 +432,9 @@ def main() -> None:
             raise AssertionError(msg)
 
         (RUNTIME / f"release-{first}").touch()
-        wait_for("the released first DDSIM job to finish", lambda: job_record(first) is None)
+        wait_for("the released first DDSIM job to finish", lambda: job_finished(first))
         wait_for_result("ddsim", third, "the pending third DDSIM job to execute")
-        wait_for("the third DDSIM job to finish", lambda: job_record(third) is None)
+        wait_for("the third DDSIM job to finish", lambda: job_finished(third))
 
         assert_bell_result(first, "node1")
         assert_bell_result(second, "node2")
@@ -366,7 +442,7 @@ def main() -> None:
         assert_license("mqt.ddsim.default", total=2, used=1, free=1)
 
         (RUNTIME / f"release-{second}").touch()
-        wait_for("the released second DDSIM job to finish", lambda: job_record(second) is None)
+        wait_for("the released second DDSIM job to finish", lambda: job_finished(second))
         assert_license("mqt.ddsim.default", total=2, used=0, free=2)
 
         LOGGER.info(
@@ -374,10 +450,23 @@ def main() -> None:
             "ran the SC job on a free CPU, and executed the third Bell job after release."
         )
         success = True
+        LOGGER.info("Slurm admission and execution checks: %.2fs", time.monotonic() - testing_at)
     finally:
-        if started and not success:
-            print_diagnostics()
-        compose("down", "--volumes", "--remove-orphans", check=False)
+        try:
+            if started and not success:
+                try:
+                    print_diagnostics()
+                except Exception:
+                    LOGGER.exception("Could not collect Slurm diagnostics")
+        finally:
+            if started:
+                stopped = compose("down", "--volumes", "--remove-orphans", "--rmi", "local", check=False, timeout=60)
+                if success and stopped.returncode == 0:
+                    shutil.rmtree(RUNTIME)
+                elif success:
+                    msg = f"Slurm cleanup failed; retained artifacts in {RUNTIME}"
+                    raise RuntimeError(msg)
+            LOGGER.info("Slurm integration total: %.2fs", time.monotonic() - started_at)
 
 
 if __name__ == "__main__":

--- a/test/slurm/sc_job.py
+++ b/test/slurm/sc_job.py
@@ -28,7 +28,10 @@ def main() -> None:
         "node": os.environ["SLURM_JOB_NODELIST"],
         "qubits": device.qubits_num(),
     }
-    Path(f"/runtime/sc-{job_id}.json").write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+    result_path = Path(f"/runtime/sc-{job_id}.json")
+    temporary = result_path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+    temporary.replace(result_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Open the selected QDMI device without copying the full registry. Bound Slurm fixture commands and cleanup, isolate concurrent runs, and require terminal job states and exit codes so stalled or failed jobs cannot produce a passing integration test.

Reuse the existing compiler-cache support in CI and install the wheel through a Docker build mount. Local controlled builds improved from 63.3s cold to 41.9s warm (62/67 cache hits); images shrank from 516 MB to 450 MB. These are local measurements, not hosted CI claims.

Validation after rebasing onto current main: six native Slurm tests, four Python adapter tests, 14 runner tests, the real two-node fixture (34.0s), full lint, and all-line C++ lint passed. Earlier concurrent fixture runs also passed. Hosted checks are pending. The existing unreleased integration has no API migration or separate changelog entry.

Codex implemented the changes, ran the audit and local validation, and prepared this description. The audit and decision record are included in `.agent/`.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
