### PR TITLE
⚡ Release the GIL during native QDMI calls

### DIFF
--- a/.agent/audits/qdmi-python-gil.md
+++ b/.agent/audits/qdmi-python-gil.md
@@ -1,0 +1,103 @@
+# Contract audit: Python QDMI calls and concurrency
+
+Status: accepted fixes implemented. Date: 2026-09-08. Core baseline:
+`7e2a2679f`; isolated worktree initially clean. Braket baseline: `a5ace5a`; its
+separate fix is PR #217. Related open Core PRs were refreshed: #2472 covers
+Slurm overhead; #2373 changes native multi-program jobs. Neither implements
+these GIL boundaries.
+
+## Result
+
+Release the GIL across native QDMI opening, queries, job operations, and
+compiler-target snapshots. Protect the SC provider's shared job map before
+allowing Python submissions to overlap. Keep Python conversion under the GIL.
+
+The maintainer declined registry indexing and IQM timeout changes, and retained
+eager child initialization. These are not remediation work for this PR.
+
+## Contract and ownership
+
+- `bindings/qdmi/qdmi.cpp` delegates to `qdmi::Session`, `Device`, `Site`,
+  `Operation`, and `Job` in `include/mqt-core/qdmi/Client.hpp` and
+  `src/qdmi/Client.cpp`. Their native calls do not use Python objects.
+- `src/qdmi/driver/Driver.cpp` copies definitions under `stateMutex_` before
+  provider work. Its module cache serializes provider initialization within one
+  loaded module. Its job map has its own lock. Fresh sessions and child handles
+  retain their existing ownership and eager initialization.
+- Provider calls can block during initialization, metadata queries, submission,
+  cancellation, retrieval, and results. Restricting GIL release to `Job.wait`,
+  shots, and counts does not cover those other entry points.
+- `bindings/mlir/register_mlir.cpp` has separate QDMI paths in
+  `CompilerTarget.from_device` and `from_device_id`. Their snapshot work is
+  native; `takeResult` converts errors at the Python boundary.
+
+## Findings and implemented changes
+
+### 1. Release the GIL across native provider work
+
+The nanobind call guards cover direct native methods. Scoped guards cover native
+parts of lambdas, including custom-property queries and binary submissions.
+Bytes pointers and lengths are obtained before releasing the GIL; the immutable
+Python payload remains alive for the synchronous native call. Results are
+converted to Python only after the guard is destroyed. Custom type inspection,
+`nb::bytes` construction, and compiler error conversion keep the GIL.
+
+The regression uses a named pipe as the SC configuration file. A Python writer
+thread cannot write until native opening has opened the reader. Holding the GIL
+then prevents the writer from progressing. A subprocess timeout bounds failure
+without a timing threshold for successful execution. The test covers generic,
+Slurm, and compiler-target opening with the real SC provider. It is POSIX-only.
+
+All three cases timed out against the previous bindings and passed with the fix.
+A separate native fixture with a 400 ms session-init delay measured a maximum
+Python heartbeat gap of 405-406 ms before the fix and 5.91-5.96 ms after it.
+Opening still took about 400 ms and created one fresh session: the change
+restores Python progress without reducing provider latency.
+
+### 2. Protect the SC provider's shared job map
+
+`src/qdmi/devices/sc/Device.cpp::createDeviceJob` and `freeDeviceJob` mutate one
+session's unordered map without synchronization. Python submission allocates a
+job before the SC provider rejects execution, so even unsupported submissions
+can reach this race. The driver job-map lock does not cover provider allocation
+or release. Add one provider-owned mutex around insertion and erasure.
+
+A native regression creates and frees 4,000 jobs on four workers sharing one
+initialized session. Other SC metadata is immutable after initialization. DDSIM
+already protects its session/job maps and lazy result materialization. These
+checks do not certify every external provider for concurrent calls on one
+handle; provider thread-safety requirements still apply.
+
+## Further opportunities and retained boundaries
+
+- Python object destruction can still block while a provider frees a job or
+  session. DDSIM can wait for its asynchronous job during destruction. Explicit
+  waiting already releases the GIL. Changing finalization needs a separate
+  lifetime design and regression; it is not equivalent to adding a call guard.
+- Do not add a global provider-call lock: it would prevent cancellation and
+  independent queries from progressing during a wait. Shared-handle concurrency
+  remains provider-owned and is documented in `docs/qdmi/driver.md`.
+- Keep the ordered registry without an index. The earlier 32-definition probe
+  measured about 0.53 microseconds per warm native open; the maintainer expects
+  at most a couple dozen definitions.
+- Keep eager child initialization and its construction-time errors. The delay
+  fixture still initialized one, two, and nine sessions for zero, one, and eight
+  children, respectively.
+- Keep IQM's timeout behavior as requested. No live provider requests or
+  hardware executions were made.
+- Braket PR #217 dispatches local and unsupported properties before GetDevice.
+  Its refreshed baseline already caches architecture and refreshes status/queue;
+  it does not fetch architecture for every warm property query.
+
+## Validation
+
+- `uvx nox -s tests-3.14 -- test/python/qdmi test/python/test_mlir.py`: 304
+  passed, including the three named-pipe cases and existing custom-value,
+  binary-job, exception, lifetime, and compiler-target tests.
+- `mqt-core-qdmi-sc-device-test`: 44 passed; one existing unsupported job-ID
+  test skipped. The concurrent job lifecycle regression passed.
+- `uvx nox -s stubs`: regenerated successfully, with no committed stub changes.
+- `uvx nox -s cpp-lint`: all five changed C++ source files checked in full, zero
+  findings. `uvx nox -s lint`: passed.
+- Measurements describe local native fixtures, not network latency. Windows,
+  live providers, and hosted CI are not validated by these local checks.

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -821,7 +821,11 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
       .def_static(
           "from_device",
           [](const qdmi::Device& device) {
-            return takeResult(mlir::compilerTargetFromDevice(device));
+            auto target = [&device] {
+              const nb::gil_scoped_release release;
+              return mlir::compilerTargetFromDevice(device);
+            }();
+            return takeResult(std::move(target));
           },
           "device"_a, "Snapshot a circuit-model QDMI device.")
       .def_static(
@@ -853,8 +857,12 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
                 std::move(deviceConfig), std::move(deviceConfigFile),
                 std::move(custom1), std::move(custom2), std::move(custom3),
                 std::move(custom4), std::move(custom5));
-            auto device = qdmi::Session::openDevice(deviceId, overrides);
-            return takeResult(mlir::compilerTargetFromDevice(device));
+            auto target = [&] {
+              const nb::gil_scoped_release release;
+              auto device = qdmi::Session::openDevice(deviceId, overrides);
+              return mlir::compilerTargetFromDevice(device);
+            }();
+            return takeResult(std::move(target));
           },
           "device_id"_a, nb::kw_only(), "base_url"_a = std::nullopt,
           "token"_a = std::nullopt, "auth_file"_a = std::nullopt,

--- a/bindings/qdmi/qdmi.cpp
+++ b/bindings/qdmi/qdmi.cpp
@@ -92,7 +92,8 @@ NB_MODULE(MQT_CORE_MODULE_NAME, qdmiModule) {
       qdmiModule, "Job",
       "A job represents a submitted quantum program execution.");
 
-  job.def("check", &qdmi::Job::check, "Returns the current status of the job.");
+  job.def("check", &qdmi::Job::check, nb::call_guard<nb::gil_scoped_release>(),
+          "Returns the current status of the job.");
 
   job.def("wait", &qdmi::Job::wait, "timeout"_a = 0,
           nb::call_guard<nb::gil_scoped_release>(),
@@ -104,7 +105,8 @@ Args:
 Returns:
     True if the job completed within the timeout, False otherwise.)pb");
 
-  job.def("cancel", &qdmi::Job::cancel, "Cancels the job.");
+  job.def("cancel", &qdmi::Job::cancel,
+          nb::call_guard<nb::gil_scoped_release>(), "Cancels the job.");
 
   job.def("get_shots", &qdmi::Job::getShots,
           nb::call_guard<nb::gil_scoped_release>(),
@@ -115,18 +117,22 @@ Returns:
           "Returns the measurement counts from the job.");
 
   job.def("get_dense_statevector", &qdmi::Job::getDenseStateVector,
+          nb::call_guard<nb::gil_scoped_release>(),
           "Returns the dense statevector from the job (typically only "
           "available from simulator devices).");
 
   job.def("get_dense_probabilities", &qdmi::Job::getDenseProbabilities,
+          nb::call_guard<nb::gil_scoped_release>(),
           "Returns the dense probabilities from the job (typically only "
           "available from simulator devices).");
 
   job.def("get_sparse_statevector", &qdmi::Job::getSparseStateVector,
+          nb::call_guard<nb::gil_scoped_release>(),
           "Returns the sparse statevector from the job (typically only "
           "available from simulator devices).");
 
   job.def("get_sparse_probabilities", &qdmi::Job::getSparseProbabilities,
+          nb::call_guard<nb::gil_scoped_release>(),
           "Returns the sparse probabilities from the job (typically only "
           "available from simulator devices).");
 
@@ -136,6 +142,7 @@ Returns:
          const nb::handle valueType) {
         return queryCustomValue(
             [&self, customProperty]<qdmi::custom_property_value T> {
+              const nb::gil_scoped_release release;
               return self.queryCustomProperty<T>(customProperty);
             },
             valueType);
@@ -157,6 +164,7 @@ when the custom slot is unsupported.)pb");
          const nb::handle valueType) {
         return queryCustomValue(
             [&self, customProperty]<qdmi::custom_property_value T> {
+              const nb::gil_scoped_release release;
               return self.getCustomResult<T>(customProperty);
             },
             valueType);
@@ -171,25 +179,35 @@ The caller must provide the type documented by the device implementation.
 Use ``bytes`` to retrieve the value without interpretation. Returns ``None``
 when the custom slot is unsupported.)pb");
 
-  job.def_prop_ro("id", &qdmi::Job::getId, "The job ID.");
+  job.def_prop_ro("id", &qdmi::Job::getId,
+                  nb::call_guard<nb::gil_scoped_release>(), "The job ID.");
 
   job.def_prop_ro("program_format", &qdmi::Job::getProgramFormat,
+                  nb::call_guard<nb::gil_scoped_release>(),
                   "The format of the submitted program.");
 
-  job.def_prop_ro("program", &qdmi::Job::getProgram, "The submitted program.");
+  job.def_prop_ro("program", &qdmi::Job::getProgram,
+                  nb::call_guard<nb::gil_scoped_release>(),
+                  "The submitted program.");
 
   job.def_prop_ro(
       "program_bytes",
       [](const qdmi::Job& self) {
-        const auto program = self.getProgramBytes();
+        const auto program = [&self] {
+          const nb::gil_scoped_release release;
+          return self.getProgramBytes();
+        }();
         return nb::bytes(program.data(), program.size());
       },
       "The exact bytes of the submitted program.");
 
-  job.def_prop_ro("num_shots", &qdmi::Job::getNumShots, "The number of shots.");
+  job.def_prop_ro("num_shots", &qdmi::Job::getNumShots,
+                  nb::call_guard<nb::gil_scoped_release>(),
+                  "The number of shots.");
 
   job.def_prop_ro(
       "queue_position", &qdmi::Job::getQueuePosition,
+      nb::call_guard<nb::gil_scoped_release>(),
       "The number of jobs ahead in the queue, or None if unavailable or not "
       "applicable in the current state.");
 
@@ -266,69 +284,89 @@ Returns:
       .value("MAINTENANCE", QDMI_DEVICE_STATUS_MAINTENANCE)
       .value("CALIBRATION", QDMI_DEVICE_STATUS_CALIBRATION);
 
-  device.def("name", &qdmi::Device::getName, "Returns the name of the device.");
+  device.def("name", &qdmi::Device::getName,
+             nb::call_guard<nb::gil_scoped_release>(),
+             "Returns the name of the device.");
 
   device.def("version", &qdmi::Device::getVersion,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the version of the device.");
 
   device.def("status", &qdmi::Device::getStatus,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the current status of the device.");
 
   device.def("library_version", &qdmi::Device::getLibraryVersion,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the version of the library used to define the device.");
 
   device.def("qubits_num", &qdmi::Device::getQubitsNum,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the number of qubits available on the device.");
 
   device.def("sites", &qdmi::Device::getSites,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the list of all sites (zone and regular sites) available "
              "on the device.");
 
   device.def("regular_sites", &qdmi::Device::getRegularSites,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the list of regular sites (without zone sites) available "
              "on the device.");
 
   device.def("zones", &qdmi::Device::getZones,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the list of zone sites (without regular sites) available "
              "on the device.");
 
   device.def("operations", &qdmi::Device::getOperations,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the list of operations supported by the device.");
 
   device.def("coupling_map", &qdmi::Device::getCouplingMap,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the coupling map of the device as a list of site pairs.");
 
   device.def("needs_calibration", &qdmi::Device::getNeedsCalibration,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns whether the device needs calibration.");
 
   device.def("queue_length", &qdmi::Device::getQueueLength,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the current queue length, or None if unavailable.");
 
   device.def("length_unit", &qdmi::Device::getLengthUnit,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the unit of length used by the device.");
 
   device.def("length_scale_factor", &qdmi::Device::getLengthScaleFactor,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the scale factor for length used by the device.");
 
   device.def("duration_unit", &qdmi::Device::getDurationUnit,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the unit of duration used by the device.");
 
   device.def("duration_scale_factor", &qdmi::Device::getDurationScaleFactor,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the scale factor for duration used by the device.");
 
   device.def("min_atom_distance", &qdmi::Device::getMinAtomDistance,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the minimum atom distance on the device.");
 
   device.def("supported_program_formats",
              &qdmi::Device::getSupportedProgramFormats,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the list of program formats supported by the device.");
 
   device.def("child_devices", &qdmi::Device::getChildDevices,
+             nb::call_guard<nb::gil_scoped_release>(),
              "Returns the direct child devices managed by this device.");
 
   device.def(
       "query_custom_operations", &qdmi::Device::queryCustomOperations,
-      "custom_property"_a,
+      nb::call_guard<nb::gil_scoped_release>(), "custom_property"_a,
       R"pb(Query a custom device property that contains operation handles.
 
 Returns normal :class:`Device.Operation` objects, or ``None`` when the custom
@@ -340,6 +378,7 @@ slot is unsupported. A supported empty list is returned as an empty list.)pb");
          const nb::handle valueType) {
         return queryCustomValue(
             [&self, customProperty]<qdmi::custom_property_value T> {
+              const nb::gil_scoped_release release;
               return self.queryCustomProperty<T>(customProperty);
             },
             valueType);
@@ -364,6 +403,7 @@ when the custom slot is unsupported.)pb");
          const std::optional<qdmi::CustomJobParameter>& custom3,
          const std::optional<qdmi::CustomJobParameter>& custom4,
          const std::optional<qdmi::CustomJobParameter>& custom5) {
+        const nb::gil_scoped_release release;
         if (numShots.has_value()) {
           return self.submitJob(program, format, *numShots, custom1, custom2,
                                 custom3, custom4, custom5);
@@ -388,6 +428,7 @@ when the custom slot is unsupported.)pb");
          const std::optional<qdmi::CustomJobParameter>& custom5) {
         const auto bytes = std::span{
             static_cast<const std::byte*>(program.data()), program.size()};
+        const nb::gil_scoped_release release;
         if (numShots.has_value()) {
           return self.submitJob(bytes, format, *numShots, custom1, custom2,
                                 custom3, custom4, custom5);
@@ -411,17 +452,20 @@ when the custom slot is unsupported.)pb");
          const std::optional<qdmi::CustomJobParameter>& custom4,
          const std::optional<qdmi::CustomJobParameter>& custom5) {
         if (!program.has_value()) {
+          const nb::gil_scoped_release release;
           return self.submitCalibrationJob(std::nullopt, custom1, custom2,
                                            custom3, custom4, custom5);
         }
         if (const auto* text = std::get_if<std::string>(&*program);
             text != nullptr) {
+          const nb::gil_scoped_release release;
           return self.submitCalibrationJob(*text, custom1, custom2, custom3,
                                            custom4, custom5);
         }
         const auto& payload = std::get<nb::bytes>(*program);
         const auto bytes = std::span{
             static_cast<const std::byte*>(payload.data()), payload.size()};
+        const nb::gil_scoped_release release;
         return self.submitCalibrationJob(bytes, custom1, custom2, custom3,
                                          custom4, custom5);
       },
@@ -439,12 +483,14 @@ executes no circuit, so it takes no shot count.)pb");
   device.def(
       "retrieve_job_by_id",
       [](const qdmi::Device& self, const std::string& jobId) {
+        const nb::gil_scoped_release release;
         return self.retrieveJobById(jobId);
       },
       "job_id"_a, nb::rv_policy::reference_internal,
       "Retrieves an existing job by its device-provided ID.");
 
   device.def("__repr__", [](const qdmi::Device& dev) {
+    const nb::gil_scoped_release release;
     return "<Device name=\"" + dev.getName() + "\">";
   });
 
@@ -458,41 +504,54 @@ executes no circuit, so it takes no shot count.)pb");
       device, "Site",
       "A site represents a potential qubit location on a quantum device.");
 
-  site.def("index", &qdmi::Site::getIndex, "Returns the index of the site.");
+  site.def("index", &qdmi::Site::getIndex,
+           nb::call_guard<nb::gil_scoped_release>(),
+           "Returns the index of the site.");
 
-  site.def("t1", &qdmi::Site::getT1,
+  site.def("t1", &qdmi::Site::getT1, nb::call_guard<nb::gil_scoped_release>(),
            "Returns the T1 coherence time of the site.");
 
-  site.def("t2", &qdmi::Site::getT2,
+  site.def("t2", &qdmi::Site::getT2, nb::call_guard<nb::gil_scoped_release>(),
            "Returns the T2 coherence time of the site.");
 
-  site.def("name", &qdmi::Site::getName, "Returns the name of the site.");
+  site.def("name", &qdmi::Site::getName,
+           nb::call_guard<nb::gil_scoped_release>(),
+           "Returns the name of the site.");
 
   site.def("x_coordinate", &qdmi::Site::getXCoordinate,
+           nb::call_guard<nb::gil_scoped_release>(),
            "Returns the x coordinate of the site.");
 
   site.def("y_coordinate", &qdmi::Site::getYCoordinate,
+           nb::call_guard<nb::gil_scoped_release>(),
            "Returns the y coordinate of the site.");
 
   site.def("z_coordinate", &qdmi::Site::getZCoordinate,
+           nb::call_guard<nb::gil_scoped_release>(),
            "Returns the z coordinate of the site.");
 
   site.def("is_zone", &qdmi::Site::isZone,
+           nb::call_guard<nb::gil_scoped_release>(),
            "Returns whether the site is a zone.");
 
   site.def("x_extent", &qdmi::Site::getXExtent,
+           nb::call_guard<nb::gil_scoped_release>(),
            "Returns the x extent of the site.");
 
   site.def("y_extent", &qdmi::Site::getYExtent,
+           nb::call_guard<nb::gil_scoped_release>(),
            "Returns the y extent of the site.");
 
   site.def("z_extent", &qdmi::Site::getZExtent,
+           nb::call_guard<nb::gil_scoped_release>(),
            "Returns the z extent of the site.");
 
   site.def("module_index", &qdmi::Site::getModuleIndex,
+           nb::call_guard<nb::gil_scoped_release>(),
            "Returns the index of the module the site belongs to.");
 
   site.def("submodule_index", &qdmi::Site::getSubmoduleIndex,
+           nb::call_guard<nb::gil_scoped_release>(),
            "Returns the index of the submodule the site belongs to.");
 
   site.def(
@@ -501,6 +560,7 @@ executes no circuit, so it takes no shot count.)pb");
          const nb::handle valueType) {
         return queryCustomValue(
             [&self, customProperty]<qdmi::custom_property_value T> {
+              const nb::gil_scoped_release release;
               return self.queryCustomProperty<T>(customProperty);
             },
             valueType);
@@ -517,6 +577,7 @@ Use ``bytes`` to retrieve the value without interpretation. Returns ``None``
 when the custom slot is unsupported.)pb");
 
   site.def("__repr__", [](const qdmi::Site& s) {
+    const nb::gil_scoped_release release;
     return "<Site index=" + std::to_string(s.getIndex()) + ">";
   });
 
@@ -531,56 +592,68 @@ when the custom slot is unsupported.)pb");
       "quantum device.");
 
   operation.def("name", &qdmi::Operation::getName,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "sites"_a.sig("...") = std::vector<qdmi::Site>{},
                 "params"_a.sig("...") = std::vector<double>{},
                 "Returns the name of the operation.");
 
   operation.def("qubits_num", &qdmi::Operation::getQubitsNum,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "sites"_a.sig("...") = std::vector<qdmi::Site>{},
                 "params"_a.sig("...") = std::vector<double>{},
                 "Returns the number of qubits the operation acts on.");
 
   operation.def("parameters_num", &qdmi::Operation::getParametersNum,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "sites"_a.sig("...") = std::vector<qdmi::Site>{},
                 "params"_a.sig("...") = std::vector<double>{},
                 "Returns the number of parameters the operation has.");
 
   operation.def("duration", &qdmi::Operation::getDuration,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "sites"_a.sig("...") = std::vector<qdmi::Site>{},
                 "params"_a.sig("...") = std::vector<double>{},
                 "Returns the duration of the operation.");
 
   operation.def("fidelity", &qdmi::Operation::getFidelity,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "sites"_a.sig("...") = std::vector<qdmi::Site>{},
                 "params"_a.sig("...") = std::vector<double>{},
                 "Returns the fidelity of the operation.");
 
   operation.def("interaction_radius", &qdmi::Operation::getInteractionRadius,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "sites"_a.sig("...") = std::vector<qdmi::Site>{},
                 "params"_a.sig("...") = std::vector<double>{},
                 "Returns the interaction radius of the operation.");
 
   operation.def("blocking_radius", &qdmi::Operation::getBlockingRadius,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "sites"_a.sig("...") = std::vector<qdmi::Site>{},
                 "params"_a.sig("...") = std::vector<double>{},
                 "Returns the blocking radius of the operation.");
 
   operation.def("idling_fidelity", &qdmi::Operation::getIdlingFidelity,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "sites"_a.sig("...") = std::vector<qdmi::Site>{},
                 "params"_a.sig("...") = std::vector<double>{},
                 "Returns the idling fidelity of the operation.");
 
   operation.def("is_zoned", &qdmi::Operation::isZoned,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "Returns whether the operation is zoned.");
 
   operation.def("sites", &qdmi::Operation::getSites,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "Returns the list of sites the operation can be performed on.");
 
   operation.def("site_pairs", &qdmi::Operation::getSitePairs,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "Returns the list of site pairs the local 2-qubit operation "
                 "can be performed on.");
 
   operation.def("mean_shuttling_speed", &qdmi::Operation::getMeanShuttlingSpeed,
+                nb::call_guard<nb::gil_scoped_release>(),
                 "sites"_a.sig("...") = std::vector<qdmi::Site>{},
                 "params"_a.sig("...") = std::vector<double>{},
                 "Returns the mean shuttling speed of the operation.");
@@ -593,6 +666,7 @@ when the custom slot is unsupported.)pb");
         return queryCustomValue(
             [&self, customProperty, &sites,
              &params]<qdmi::custom_property_value T> {
+              const nb::gil_scoped_release release;
               return self.queryCustomProperty<T>(customProperty, sites, params);
             },
             valueType);
@@ -613,6 +687,7 @@ Use ``bytes`` to retrieve the value without interpretation. Returns ``None``
 when the custom slot is unsupported.)pb");
 
   operation.def("__repr__", [](const qdmi::Operation& op) {
+    const nb::gil_scoped_release release;
     return "<Operation name=\"" + op.getName() + "\">";
   });
 
@@ -750,6 +825,7 @@ libraries or expose their definitions.)pb");
             std::move(deviceConfig), std::move(deviceConfigFile),
             std::move(custom1), std::move(custom2), std::move(custom3),
             std::move(custom4), std::move(custom5));
+        const nb::gil_scoped_release release;
         return qdmi::Session::openDevice(deviceId, overrides);
       },
       "device_id"_a, nb::kw_only(), "base_url"_a = std::nullopt,

--- a/bindings/qdmi/slurm.cpp
+++ b/bindings/qdmi/slurm.cpp
@@ -21,6 +21,7 @@ void registerSlurm(nb::module_& qdmiModule) {
   auto slurm = qdmiModule.def_submodule(
       "slurm", "Open a QDMI device named by the Slurm license environment.");
   slurm.def("open_device_from_license", &qdmi::slurm::openDeviceFromLicense,
+            nb::call_guard<nb::gil_scoped_release>(),
             R"pb(Open the QDMI device named by the Slurm license environment.
 
 ``SLURM_JOB_LICENSES`` must contain one local license whose name equals a

--- a/docs/qdmi/driver.md
+++ b/docs/qdmi/driver.md
@@ -62,6 +62,13 @@ operations, and jobs. The Python module exposes these QDMI entities through
 {py:mod}`mqt.core.qdmi`. Its {py:mod}`mqt.core.qdmi.driver` submodule provides
 device discovery, registration, and opening.
 
+Native device opening, property queries, job calls, and compiler-target
+snapshots release Python's GIL. Other Python threads can run while a provider
+waits for a remote response. Python argument and result conversion still holds
+the GIL. Concurrent calls into a shared device or job must satisfy the
+provider's thread safety contract; releasing the GIL does not serialize provider
+access.
+
 ## Usage
 
 The following example opens each registered device by its stable ID.

--- a/include/mqt-core/qdmi/devices/sc/Device.hpp
+++ b/include/mqt-core/qdmi/devices/sc/Device.hpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -96,6 +97,7 @@ struct MQT_SC_QDMI_Device_Session_impl_d {
   std::vector<std::pair<MQT_SC_QDMI_Site, MQT_SC_QDMI_Site>> couplingMap;
   std::vector<std::unique_ptr<MQT_SC_QDMI_Operation_impl_d>> operationStorage;
   std::vector<MQT_SC_QDMI_Operation> operations;
+  std::mutex jobsMutex;
   std::unordered_map<MQT_SC_QDMI_Device_Job,
                      std::unique_ptr<MQT_SC_QDMI_Device_Job_impl_d>>
       jobs;

--- a/src/qdmi/devices/sc/Device.cpp
+++ b/src/qdmi/devices/sc/Device.cpp
@@ -28,6 +28,7 @@
 #include <cstring>
 #include <exception>
 #include <memory>
+#include <mutex>
 #include <new>
 #include <optional>
 #include <span>
@@ -225,12 +226,14 @@ int MQT_SC_QDMI_Device_Session_impl_d::createDeviceJob(
   }
   auto value = std::make_unique<MQT_SC_QDMI_Device_Job_impl_d>(this);
   *job = value.get();
+  const std::scoped_lock lock(jobsMutex);
   jobs.emplace(*job, std::move(value));
   return QDMI_SUCCESS;
 }
 
 void MQT_SC_QDMI_Device_Session_impl_d::freeDeviceJob(
     MQT_SC_QDMI_Device_Job job) {
+  const std::scoped_lock lock(jobsMutex);
   jobs.erase(job);
 }
 

--- a/test/python/qdmi/test_qdmi.py
+++ b/test/python/qdmi/test_qdmi.py
@@ -849,6 +849,56 @@ def test_open_device_creates_a_fresh_session() -> None:
     assert first != second
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="Requires POSIX named pipes")
+@pytest.mark.parametrize("entrypoint", ["driver", "slurm", "compiler"])
+def test_device_open_releases_gil(tmp_path: Path, entrypoint: str) -> None:
+    """A Python thread can supply configuration while native opening waits."""
+    script = """
+import json
+import os
+import sys
+from pathlib import Path
+from threading import Thread
+
+from mqt.core.mlir import CompilerTarget
+from mqt.core.qdmi import slurm
+from mqt.core.qdmi.driver import open_device
+
+fifo = Path(sys.argv[1]) / "device.json"
+os.mkfifo(fifo)
+configuration = Path("json/sc/mqt-core-qdmi-sc-device.json").read_bytes()
+os.environ["MQT_CORE_QDMI_CONFIG_JSON"] = json.dumps({
+    "schema-version": 1,
+    "qdmi": {"devices": [{
+        "id": "mqt.sc.default",
+        "session": {"device-config": {"file": str(fifo)}},
+    }]},
+})
+os.environ["SLURM_JOB_LICENSES"] = "mqt.sc.default:1"
+
+def supply_configuration():
+    # Opening the write end blocks until the native reader opens the FIFO.
+    with fifo.open("wb") as stream:
+        stream.write(configuration)
+
+writer = Thread(target=supply_configuration, daemon=True)
+writer.start()
+entrypoint = sys.argv[2]
+if entrypoint == "driver":
+    assert open_device("mqt.sc.default").qubits_num() > 0
+elif entrypoint == "slurm":
+    assert slurm.open_device_from_license().qubits_num() > 0
+else:
+    assert CompilerTarget.from_device_id("mqt.sc.default").num_sites > 0
+writer.join()
+"""
+    subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
+        [sys.executable, "-c", script, str(tmp_path), entrypoint],
+        check=True,
+        timeout=15,
+    )
+
+
 def test_device_configuration_arguments_are_mutually_exclusive() -> None:
     """Typed device configuration must select exactly one source."""
     DeviceDefinition(

--- a/test/qdmi/devices/sc/test_device.cpp
+++ b/test/qdmi/devices/sc/test_device.cpp
@@ -543,6 +543,25 @@ TEST_F(ScQDMISpecificationTest, JobCreate) {
   MQT_SC_QDMI_device_session_free(uninitializedSession);
 }
 
+TEST_F(ScQDMISpecificationTest, CreatesAndFreesJobsConcurrently) {
+  std::array<std::future<void>, 4> workers;
+  for (auto& worker : workers) {
+    worker = std::async(std::launch::async, [this] {
+      for (size_t iteration = 0; iteration < 1000; ++iteration) {
+        MQT_SC_QDMI_Device_Job concurrentJob = nullptr;
+        ASSERT_EQ(MQT_SC_QDMI_device_session_create_device_job(session,
+                                                               &concurrentJob),
+                  QDMI_SUCCESS);
+        ASSERT_NE(concurrentJob, nullptr);
+        MQT_SC_QDMI_device_job_free(concurrentJob);
+      }
+    });
+  }
+  for (auto& worker : workers) {
+    worker.get();
+  }
+}
+
 TEST_F(ScQDMISpecificationTest, JobSetParameter) {
   EXPECT_EQ(MQT_SC_QDMI_device_job_set_parameter(
                 nullptr, QDMI_DEVICE_JOB_PARAMETER_MAX, 0, nullptr),


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Slow native QDMI calls hold Python's GIL during opening, metadata queries, submission, cancellation, retrieval, and compiler-target snapshots. Release it across those native calls while keeping Python argument/result conversion protected. Also lock the SC provider's job map, which concurrent submissions can reach even though this provider rejects execution.

The audit traces binding, driver, provider, and lifetime boundaries. A 400 ms initialization probe reduced the longest Python heartbeat gap from about 406 ms to 6 ms; provider latency and eager child initialization stay the same. Registry indexing and IQM timeout changes remain excluded as requested. Destruction of an unfinished job is a separate remaining opportunity recorded in the audit.

Validation:
- 304 Python QDMI/MLIR tests passed. The three new named-pipe regressions fail against the old bindings and pass with this change.
- 44 native SC-provider tests passed; one existing unsupported job-ID test skipped. This includes concurrent creation/freeing of 4,000 jobs.
- `uvx nox -s lint` and full-file `uvx nox -s cpp-lint` passed; type stubs regenerated without changes.
- No live provider requests. Hosted CI remains to be evaluated for this head.

Codex assisted with the audit, implementation, regression tests, and this description. Human review and acceptance remain with the maintainer. This changes unreleased v4 functionality; no standalone changelog or migration entry is added under the repository policy.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
