### PR TITLE
⚡ Speed up QCO decomposition and fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,11 +84,11 @@ releases may include breaking changes.
   [#2015]) ([**@burgholzer**], [**@denialhaag**])
 - ✨ Add single-qubit optimization passes for unitary fusion, Hadamard lifting,
   and rotation merging ([#1407], [#1605], [#1672], [#1674], [#2002], [#2038],
-  [#2228]) ([**@J4MMlE**], [**@lirem101**], [**@burgholzer**],
+  [#2228], [#2478]) ([**@J4MMlE**], [**@lirem101**], [**@burgholzer**],
   [**@denialhaag**], [**@MatthiasReumann**], [**@simon1hofmann**])
 - ✨ Add multi-qubit decomposition, fusion, and target-native synthesis passes
   ([#1774], [#1802], [#1803], [#1809], [#1810], [#1814], [#1832], [#1850],
-  [#1865], [#1961], [#1996], [#1998], [#2001], [#2467], [#2468])
+  [#1865], [#1961], [#1996], [#1998], [#2001], [#2467], [#2468], [#2478])
   ([**@simon1hofmann**], [**@burgholzer**])
 
 #### Other additions
@@ -931,6 +931,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2478]: https://github.com/munich-quantum-toolkit/core/pull/2478
 [#2468]: https://github.com/munich-quantum-toolkit/core/pull/2468
 [#2467]: https://github.com/munich-quantum-toolkit/core/pull/2467
 [#2457]: https://github.com/munich-quantum-toolkit/core/pull/2457

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Decomposition/Weyl.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Decomposition/Weyl.h
@@ -95,21 +95,24 @@ inline constexpr double WEYL_SUPER_CONTROLLED_MAX_RELATIVE = 1e-9;
  */
 class TwoQubitWeylDecomposition {
 public:
-  /**
-   * @brief Decomposes a 2-qubit unitary into Weyl chamber coordinates and
-   *        single-qubit factors.
-   *
-   * @param unitaryMatrix Input 4x4 unitary (up to global phase).
-   * @param fidelity Optional average gate-fidelity floor in `[0, 1]`. When set,
-   *        @ref applySpecialization may replace `(a, b, c)` with an equivalent
-   *        specialized form whose overlap with the pre-specialization chamber
-   *        meets this bound; the result is fidelity-bounded, not necessarily
-   *        matrix-exact. When `std::nullopt`, no fidelity-driven specialization
-   *        is applied and the decomposition matches the input up to global
-   *        phase (modulo floating-point error). Invalid values (non-finite or
-   *        outside `[0, 1]`) trigger a fatal error.
-   */
-  [[nodiscard]] static TwoQubitWeylDecomposition
+  /// Decomposes a 2-qubit unitary into Weyl chamber coordinates and
+  /// single-qubit factors, returning `std::nullopt` on numerical nonconvergence
+  /// or a failed numerical postcondition.
+  ///
+  /// A matrix accepted by the dense-unitary verifier can still fail
+  /// decomposition at the stricter Weyl tolerance.
+  ///
+  /// @param unitaryMatrix Input 4x4 unitary (up to global phase).
+  /// @param fidelity Optional average gate-fidelity floor in `[0, 1]`.
+  ///
+  /// When set, @ref applySpecialization may replace `(a, b, c)` with an
+  /// equivalent specialized form whose overlap with the pre-specialization
+  /// chamber meets this bound; the result is fidelity-bounded, not necessarily
+  /// matrix-exact. When `std::nullopt`, no fidelity-driven specialization is
+  /// applied and the decomposition matches the input up to global phase (modulo
+  /// floating-point error). Invalid values (non-finite or outside `[0, 1]`)
+  /// trigger a fatal error.
+  [[nodiscard]] static std::optional<TwoQubitWeylDecomposition>
   create(const Matrix4x4& unitaryMatrix, std::optional<double> fidelity);
 
   [[nodiscard]] Matrix4x4 getCanonicalMatrix() const {
@@ -141,7 +144,7 @@ public:
 private:
   bool applySpecialization(const std::optional<double>& requestedFidelity);
 
-  void finalizeSpecializationPhase(bool flippedFromOriginal,
+  bool finalizeSpecializationPhase(bool flippedFromOriginal,
                                    double preSpecializationA,
                                    double preSpecializationB,
                                    double preSpecializationC,
@@ -234,12 +237,11 @@ public:
   twoQubitDecompose(const TwoQubitWeylDecomposition& targetDecomposition,
                     std::optional<std::uint8_t> numBasisGateUses) const;
 
-  /**
-   * @brief Decomposes @p targetUnitary using this cached basis decomposer.
-   *
-   * Only the target undergoes Weyl decomposition; basis precomputation from
-   * @ref create is reused.
-   */
+  /// Decomposes @p targetUnitary using this cached basis decomposer.
+  ///
+  /// Only the target undergoes Weyl decomposition; basis precomputation from
+  /// @ref create is reused. Returns `std::nullopt` if the target's numerical
+  /// decomposition fails or the requested basis-gate count is unsupported.
   [[nodiscard]] std::optional<TwoQubitNativeDecomposition> decomposeTarget(
       const Matrix4x4& targetUnitary,
       std::optional<std::uint8_t> numBasisGateUses = std::nullopt) const;
@@ -351,13 +353,12 @@ struct SynthesizedUnitary2Q {
   double globalPhase = 0.0;
 };
 
-/**
- * @brief Decomposes a two-qubit unitary using @p entangler.
- *
- * SQRTISWAP uses the minimum number of square-root iSWAP gates (0--3),
- * up to WEYL_TOLERANCE in the interaction coefficients.
- */
-[[nodiscard]] TwoQubitNativeDecomposition
+/// Decomposes a two-qubit unitary using @p entangler, returning `std::nullopt`
+/// if the numerical decomposition fails.
+///
+/// SQRTISWAP uses the minimum number of square-root iSWAP gates (0--3),
+/// up to WEYL_TOLERANCE in the interaction coefficients.
+[[nodiscard]] std::optional<TwoQubitNativeDecomposition>
 decomposeUnitary2QWeyl(const Matrix4x4& target,
                        CompilerTarget::GateKind entangler);
 

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.h
@@ -34,9 +34,9 @@ namespace mlir::qco {
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/QCO/Transforms/Passes.h.inc" // IWYU pragma: export
 
-/**
- * @brief Create target-independent two-qubit gate fusion.
- */
+/// Create target-independent two-qubit gate fusion.
+///
+/// Runs remain unchanged when numerical decomposition fails.
 [[nodiscard]] std::unique_ptr<Pass> createFuseTwoQubitGates();
 
 /// Create multi-controlled decomposition for one compiler target.

--- a/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/QCO/Transforms/Passes.td
@@ -235,6 +235,9 @@ def TargetNativeSynthesis : Pass<"target-native-synthesis", "mlir::ModuleOp"> {
     metadata is unknown, no complete basis exists, or an operation has no
     compile-time unitary matrix and cannot be synthesized as a parameterized
     single-qubit gate.
+
+    Numerical decomposition failure is diagnosed before emitting a replacement.
+    The input may be modified on failure.
   }];
 }
 
@@ -445,7 +448,7 @@ def DecomposeMultiControlled
     | X/Z | 4 | Elementary CCCX/CCCZ |
     | X/Z | 5 | Specialized ancilla-free relative-phase `C^4(Z)` |
     | X/Z | 6–33 | da Silva-Park SP22 MCP(π) core (`H · MCP(π) · H` for X) |
-    | X/Z | ≥34 | Huang-Palsberg (HP24) borrowed-helper synthesis with one dirty helper for odd control counts and two for even counts |
+    | X/Z | ≥34 | Huang-Palsberg (HP24) borrowed-helper synthesis with partitioned incrementers |
     | Y | ≥3 | X decomposition with `S†` before and `S` after on the target |
     | RX/RY/RZ | ≥3 | Balanced control halves with exact MCX and quarter-angle rotations; RX uses H-conjugated RZ |
     | Phase | 3 | Optimized `C^2(P)` |
@@ -456,6 +459,10 @@ def DecomposeMultiControlled
 
     Width is the total number of qubits the gate acts on (controls plus
     targets).
+
+    HP24 uses one dirty helper for an odd number of controls and two for an
+    even number. These helpers are borrowed from the gate's qubits and restored;
+    no additional qubits are allocated.
 
     Rotation synthesis uses a linear number of gates and no additional
     qubits. Each half-MCX may borrow controls from the opposite half and

--- a/mlir/lib/Compiler/TargetCompilation.cpp
+++ b/mlir/lib/Compiler/TargetCompilation.cpp
@@ -75,10 +75,14 @@ void populateTargetCompilationPipeline(OpPassManager& pm,
   pm.addPass(qco::createLegalizeControlFlow());
   pm.addPass(qco::createDecomposeMultiControlled(target));
   populateDefaultQCOOptimizationPipeline(pm);
-  /// ponytail: CX/CZ-cost fusion can increase square-root iSWAP counts;
-  /// enable it for this basis when fusion uses the target entangler's cost.
+  // Generic fusion must not introduce gates that the target cannot synthesize.
+  // ponytail: its CX/CZ cost model can increase square-root iSWAP counts;
+  // enable that basis when fusion uses the target entangler's cost.
   if (const auto basis = target.synthesisBasis();
-      !basis || basis->entangler != CompilerTarget::GateKind::SQRTISWAP) {
+      target.nativeOperationsKind() ==
+          CompilerTarget::NativeOperations::Kind::Unrestricted ||
+      (basis && basis->entangler &&
+       basis->entangler != CompilerTarget::GateKind::SQRTISWAP)) {
     pm.addPass(qco::createFuseTwoQubitGates());
   }
   switch (target.connectivityKind()) {

--- a/mlir/lib/Dialect/MQT/Utils/Parameters.cpp
+++ b/mlir/lib/Dialect/MQT/Utils/Parameters.cpp
@@ -25,6 +25,7 @@
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 
@@ -46,9 +47,25 @@ Value constantFromScalar(OpBuilder& builder, Location loc, const bool value) {
 
 LogicalResult verifyFiniteConstantParameters(Operation* operation,
                                              ValueRange parameters) {
+  const auto verifyFinite = [&](Attribute constant,
+                                size_t index) -> LogicalResult {
+    if (auto floating = dyn_cast<FloatAttr>(constant);
+        floating && !floating.getValue().isFinite()) {
+      return operation->emitOpError()
+             << "constant parameter expression at index " << index
+             << " must be finite";
+    }
+    return success();
+  };
   DenseMap<Value, std::optional<Attribute>> constantCache;
   DenseSet<Value> visited;
   for (const auto [index, parameter] : llvm::enumerate(parameters)) {
+    if (auto constant = parameter.getDefiningOp<arith::ConstantOp>()) {
+      if (failed(verifyFinite(constant.getValue(), index))) {
+        return failure();
+      }
+      continue;
+    }
     SmallVector<Value> worklist{parameter};
     while (!worklist.empty()) {
       auto value = worklist.pop_back_val();
@@ -56,11 +73,8 @@ LogicalResult verifyFiniteConstantParameters(Operation* operation,
         continue;
       }
       if (const auto constant = valueToConstantAttr(value, constantCache)) {
-        if (auto floating = dyn_cast<FloatAttr>(*constant);
-            floating && !floating.getValue().isFinite()) {
-          return operation->emitOpError()
-                 << "constant parameter expression at index " << index
-                 << " must be finite";
+        if (failed(verifyFinite(*constant, index))) {
+          return failure();
         }
       }
       Operation* definingOp = value.getDefiningOp();

--- a/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/QCOUtils.cpp
@@ -111,44 +111,66 @@ static void propagateWireIds(UnitaryOpInterface unitary,
   }
 }
 
-/// Returns the @p unitary embedded on @p numTargets modifier wires using @p
-/// wireIds.
-[[nodiscard]] static std::optional<DynamicMatrix>
-embedUnitaryInBody(UnitaryOpInterface unitary, size_t numTargets,
-                   const DenseMap<Value, size_t>& wireIds) {
+/// Embed the first unitary, then premultiply subsequent gates in place.
+[[nodiscard]] static bool
+premultiplyUnitaryInBody(UnitaryOpInterface unitary, size_t numTargets,
+                         const DenseMap<Value, size_t>& wireIds,
+                         std::optional<DynamicMatrix>& acc) {
   const auto numOpQubits = unitary.getNumQubits();
-  if (numOpQubits == numTargets &&
-      llvm::all_of(llvm::enumerate(unitary.getInputQubits()), [&](auto entry) {
-        return lookupWireId(wireIds, entry.value()) == entry.index();
-      })) {
-    return unitary.getUnitaryMatrix<DynamicMatrix>();
-  }
   if (numOpQubits == 0 || numOpQubits > 2) {
-    return std::nullopt;
+    if (numOpQubits != numTargets ||
+        !llvm::all_of(
+            llvm::enumerate(unitary.getInputQubits()), [&](auto entry) {
+              return lookupWireId(wireIds, entry.value()) == entry.index();
+            })) {
+      return false;
+    }
+    auto matrix = unitary.getUnitaryMatrix<DynamicMatrix>();
+    if (!matrix) {
+      return false;
+    }
+    if (acc) {
+      acc->premultiplyBy(*matrix);
+    } else {
+      acc.swap(matrix);
+    }
+    return true;
   }
 
   if (numOpQubits == 1) {
     const auto wire = lookupWireId(wireIds, unitary.getInputQubit(0));
     if (!wire.has_value()) {
-      return std::nullopt;
+      return false;
     }
     const auto matrix = unitary.getUnitaryMatrix<Matrix2x2>();
     if (!matrix) {
-      return std::nullopt;
+      return false;
     }
-    return matrix->embedInNqubit(numTargets, *wire);
+    if (acc) {
+      acc->premultiplyByEmbedded1Q(*matrix, numTargets, *wire);
+    } else {
+      acc = matrix->embedInNqubit(numTargets, *wire);
+    }
+    return true;
   }
 
   const auto q0 = lookupWireId(wireIds, unitary.getInputQubit(0));
   const auto q1 = lookupWireId(wireIds, unitary.getInputQubit(1));
   if (!q0.has_value() || !q1.has_value()) {
-    return std::nullopt;
+    return false;
   }
   const auto matrix = unitary.getUnitaryMatrix<Matrix4x4>();
   if (!matrix) {
-    return std::nullopt;
+    return false;
   }
-  return matrix->embedInNqubit(numTargets, *q0, *q1);
+  if (!acc) {
+    acc = matrix->embedInNqubit(numTargets, *q0, *q1);
+  } else if (numTargets == 2) {
+    acc->premultiplyByEmbedded2Q(matrix->reorderForQubits(*q0, *q1), 2, 0, 1);
+  } else {
+    acc->premultiplyByEmbedded2Q(*matrix, numTargets, *q0, *q1);
+  }
+  return true;
 }
 
 std::optional<DynamicMatrix> composeBodyMatrix(Block& block,
@@ -182,14 +204,9 @@ std::optional<DynamicMatrix> composeBodyMatrix(Block& block,
               return true;
             })
             .Case([&](UnitaryOpInterface unitary) {
-              auto embedded = embedUnitaryInBody(unitary, numTargets, wireIds);
-              if (!embedded.has_value()) {
+              if (!premultiplyUnitaryInBody(unitary, numTargets, wireIds,
+                                            acc)) {
                 return false;
-              }
-              if (!acc.has_value()) {
-                acc.swap(embedded);
-              } else {
-                acc->premultiplyBy(*embedded);
               }
               propagateWireIds(unitary, wireIds);
               return true;

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/BasisDecomposer.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/BasisDecomposer.cpp
@@ -79,47 +79,58 @@ TwoQubitBasisDecomposer::create(const Matrix4x4& basisMatrix,
 
   const auto basisWeyl =
       TwoQubitWeylDecomposition::create(basisMatrix, WEYL_DEFAULT_FIDELITY);
+  if (!basisWeyl) {
+    llvm::reportFatalInternalError(
+        "TwoQubitBasisDecomposer: basis decomposition failed");
+  }
   const auto isSuperControlled =
-      relativeEq(basisWeyl.a(), BASIS_PI_OVER_4, WEYL_DIAGONALIZATION_TOLERANCE,
+      relativeEq(basisWeyl->a(), BASIS_PI_OVER_4,
+                 WEYL_DIAGONALIZATION_TOLERANCE,
                  WEYL_SUPER_CONTROLLED_MAX_RELATIVE) &&
-      relativeEq(basisWeyl.c(), 0.0, WEYL_DIAGONALIZATION_TOLERANCE,
+      relativeEq(basisWeyl->c(), 0.0, WEYL_DIAGONALIZATION_TOLERANCE,
                  WEYL_SUPER_CONTROLLED_MAX_RELATIVE);
 
-  const auto b = basisWeyl.b();
+  const auto b = basisWeyl->b();
   const Complex expMinusB = std::exp(-1i * b);
   const Complex expPlusB = std::exp(1i * b);
   const Complex expMinus2B = expMinusB * expMinusB;
   const Complex expPlus2B = expPlusB * expPlusB;
   const double cos2B = expPlus2B.real();
   const double sin2B = expPlus2B.imag();
+  const Complex minusIExpMinusB = -1i * expMinusB;
+  const Complex minusIExpPlusB = -1i * expPlusB;
+  const Complex iExpMinusB = 1i * expMinusB;
+  const Complex iSin2B = 1i * sin2B;
+  const Complex minusIExpMinus2B = -1i * expMinus2B;
+  const Complex iExpPlus2B = 1i * expPlus2B;
 
   Complex temp{0.5, -0.5};
   const Matrix2x2 k11l =
-      Matrix2x2::fromElements(temp * (-1i * expMinusB), temp * expMinusB,
-                              temp * (-1i * expPlusB), temp * -expPlusB);
-  const Matrix2x2 k11r = Matrix2x2::fromElements(
-      INV_SQRT2 * (1i * expMinusB), INV_SQRT2 * -expMinusB,
-      INV_SQRT2 * expPlusB, INV_SQRT2 * (-1i * expPlusB));
+      Matrix2x2::fromElements(temp * minusIExpMinusB, temp * expMinusB,
+                              temp * minusIExpPlusB, temp * -expPlusB);
+  const Matrix2x2 k11r =
+      Matrix2x2::fromElements(INV_SQRT2 * iExpMinusB, INV_SQRT2 * -expMinusB,
+                              INV_SQRT2 * expPlusB, INV_SQRT2 * minusIExpPlusB);
   const Matrix2x2 k32lK21l = Matrix2x2::fromElements(
-      INV_SQRT2 * Complex{1., cos2B}, INV_SQRT2 * (1i * sin2B),
-      INV_SQRT2 * (1i * sin2B), INV_SQRT2 * Complex{1., -cos2B});
+      INV_SQRT2 * Complex{1., cos2B}, INV_SQRT2 * iSin2B, INV_SQRT2 * iSin2B,
+      INV_SQRT2 * Complex{1., -cos2B});
   temp = Complex{0.5, 0.5};
   const Matrix2x2 k21r =
-      Matrix2x2::fromElements(temp * (-1i * expMinus2B), temp * expMinus2B,
-                              temp * (1i * expPlus2B), temp * expPlus2B);
+      Matrix2x2::fromElements(temp * minusIExpMinus2B, temp * expMinus2B,
+                              temp * iExpPlus2B, temp * expPlus2B);
   const Matrix2x2 k31l =
       Matrix2x2::fromElements(INV_SQRT2 * expMinusB, INV_SQRT2 * expMinusB,
                               INV_SQRT2 * -expPlusB, INV_SQRT2 * expPlusB);
   const Matrix2x2 k31r =
       Matrix2x2::fromElements(1i * expPlusB, 0, 0, -1i * expMinusB);
-  const Matrix2x2 k32r = Matrix2x2::fromElements(
-      temp * expPlusB, temp * -expMinusB, temp * (-1i * expPlusB),
-      temp * (-1i * expMinusB));
+  const Matrix2x2 k32r =
+      Matrix2x2::fromElements(temp * expPlusB, temp * -expMinusB,
+                              temp * minusIExpPlusB, temp * minusIExpMinusB);
 
-  const auto k1lDagger = basisWeyl.k1l().adjoint();
-  const auto k1rDagger = basisWeyl.k1r().adjoint();
-  const auto k2lDagger = basisWeyl.k2l().adjoint();
-  const auto k2rDagger = basisWeyl.k2r().adjoint();
+  const auto k1lDagger = basisWeyl->k1l().adjoint();
+  const auto k1rDagger = basisWeyl->k1r().adjoint();
+  const auto k2lDagger = basisWeyl->k2l().adjoint();
+  const auto k2rDagger = basisWeyl->k2r().adjoint();
 
   const Matrix2x2 k11lK1lDagger = k11l * k1lDagger;
   const Matrix2x2 k11rK1rDagger = k11r * k1rDagger;
@@ -129,7 +140,7 @@ TwoQubitBasisDecomposer::create(const Matrix4x4& basisMatrix,
 
   TwoQubitBasisDecomposer decomposer;
   decomposer.basisFidelity = basisFidelity;
-  decomposer.basisWeyl = basisWeyl;
+  decomposer.basisWeyl = *basisWeyl;
   decomposer.isSuperControlled = isSuperControlled;
   decomposer.smb = TwoQubitBasisDecomposer::SmbPrecomputed{
       .u0l = k31l * k1lDagger,
@@ -157,38 +168,31 @@ TwoQubitBasisDecomposer::decomposeTarget(
     const std::optional<std::uint8_t> numBasisGateUses) const {
   const auto targetWeyl =
       TwoQubitWeylDecomposition::create(targetUnitary, WEYL_DEFAULT_FIDELITY);
-  return twoQubitDecompose(targetWeyl, numBasisGateUses);
+  if (!targetWeyl) {
+    return std::nullopt;
+  }
+  return twoQubitDecompose(*targetWeyl, numBasisGateUses);
 }
 
 std::optional<TwoQubitNativeDecomposition>
 TwoQubitBasisDecomposer::twoQubitDecompose(
     const TwoQubitWeylDecomposition& targetDecomposition,
     std::optional<std::uint8_t> numBasisGateUses) const {
-  const auto traceValues = traces(targetDecomposition);
-
   std::uint8_t bestNbasis = 0;
   if (numBasisGateUses) {
     bestNbasis = *numBasisGateUses;
   } else {
+    const auto traceValues = traces(targetDecomposition);
     auto bestValue = std::numeric_limits<double>::lowest();
-    auto bestIndex = -1;
     double fidelityPower = 1.0;
     for (int i = 0; std::cmp_less(i, traceValues.size()); ++i) {
       const auto value = traceToFidelity(traceValues[i]) * fidelityPower;
       fidelityPower *= basisFidelity;
-      if (std::isnan(value)) {
-        continue;
-      }
       if (value > bestValue) {
-        bestIndex = i;
+        bestNbasis = static_cast<std::uint8_t>(i);
         bestValue = value;
       }
     }
-    if (bestIndex < 0) {
-      llvm::reportFatalInternalError("Unable to select basis-gate count: all "
-                                     "candidate fidelities are NaN");
-    }
-    bestNbasis = static_cast<std::uint8_t>(bestIndex);
   }
   if (bestNbasis > 1 && !isSuperControlled) {
     return std::nullopt;
@@ -245,11 +249,6 @@ void TwoQubitBasisDecomposer::decomp1(
 void TwoQubitBasisDecomposer::decomp2Supercontrolled(
     SmallVector<Matrix2x2>& out,
     const TwoQubitWeylDecomposition& target) const {
-  if (!isSuperControlled) {
-    llvm::reportFatalInternalError(
-        "Basis gate of TwoQubitBasisDecomposer is not super-controlled "
-        "- no guarantee for exact decomposition with two basis gates");
-  }
   out.emplace_back(smb.u3r * target.k2r());
   out.emplace_back(smb.u3l * target.k2l());
   out.emplace_back(smb.q1ra * RZOp::unitaryMatrix(2. * target.b()) * smb.u2rb);
@@ -261,11 +260,6 @@ void TwoQubitBasisDecomposer::decomp2Supercontrolled(
 void TwoQubitBasisDecomposer::decomp3Supercontrolled(
     SmallVector<Matrix2x2>& out,
     const TwoQubitWeylDecomposition& target) const {
-  if (!isSuperControlled) {
-    llvm::reportFatalInternalError(
-        "Basis gate of TwoQubitBasisDecomposer is not super-controlled "
-        "- no guarantee for exact decomposition with three basis gates");
-  }
   out.emplace_back(smb.u3r * target.k2r());
   out.emplace_back(smb.u3l * target.k2l());
   out.emplace_back(smb.u2ra * RZOp::unitaryMatrix(2. * target.b()) * smb.u2rb);

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/DecomposeMultiControlled.cpp
@@ -32,7 +32,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <numbers>
-#include <numeric>
 #include <optional>
 #include <utility>
 
@@ -134,15 +133,6 @@ public:
              [](OpBuilder& builder, Location loc, Value arg) {
                return XOp::create(builder, loc, arg).getOutputQubit(0);
              });
-  }
-
-  // Arbitrary-width multi-controlled X, left as a `qco.ctrl` op for further
-  // decomposition (e.g. by this pass's own greedy rewriting, or by a nested
-  // plan). Used for the `NestedMCX` `PlanOp` kind.
-  void emitCtrlX(ArrayRef<size_t> controls, size_t target) {
-    emitCtrl(controls, target, [](OpBuilder& builder, Location loc, Value arg) {
-      return XOp::create(builder, loc, arg).getOutputQubit(0);
-    });
   }
 
   void emitRCCX(size_t c0, size_t c1, size_t target) {
@@ -257,7 +247,7 @@ private:
 // Circuit plan
 //===----------------------------------------------------------------------===//
 
-/// Plan-level op kinds. `NestedMCX` is an arbitrary-width multi-controlled X.
+/// Plan-level op kinds.
 enum class PlanOpKind : uint8_t {
   H,
   X,
@@ -270,17 +260,13 @@ enum class PlanOpKind : uint8_t {
   CCX,
   CCCX,
   RCCX,
-  NestedMCX,
 };
 
-/// One plan op. `wires` are local indices for `lowerPlan`; for `NestedMCX`,
-/// controls are `wires[0 .. nestedControls)` and the target is
-/// `wires[nestedControls]`.
+/// One plan op. `wires` are local indices for `lowerPlan`.
 struct PlanOp {
   PlanOpKind kind{};
   SmallVector<size_t, 4> wires;
   double angle = 0.0;
-  size_t nestedControls = 0;
 };
 
 /// Ordered plan ops lowered by `lowerPlan`.
@@ -380,12 +366,6 @@ static void lowerPlan(GateEmitter& emitter, const CircuitPlan& plan) {
     case PlanOpKind::RCCX:
       emitter.emitRCCX(op.wires[0], op.wires[1], op.wires[2]);
       break;
-    case PlanOpKind::NestedMCX: {
-      const ArrayRef<size_t> controls =
-          ArrayRef<size_t>(op.wires).take_front(op.nestedControls);
-      emitter.emitCtrlX(controls, op.wires[op.nestedControls]);
-      break;
-    }
     }
   }
 }
@@ -567,27 +547,12 @@ static CircuitPlan planBorrowedDirtyIncrementer(size_t n, bool flagAdd,
     halfMcxWires.push_back(helper2);
   }
 
-  // Final sub-incrementer over the high half: wire order [low half, high half,
-  // helper, (helper2)].
-  SmallVector<size_t, 16> highIncrementWires;
-  for (size_t q = 0; q < k; ++q) {
-    highIncrementWires.push_back(q);
-  }
-  for (size_t q = k; q < n; ++q) {
-    highIncrementWires.push_back(q);
-  }
-  highIncrementWires.push_back(helper);
-  if (numDirty == 2) {
-    highIncrementWires.push_back(helper2);
-  }
-
   const auto incrementLow = [&] {
     appendRemapped(plan, planIncrementerPartitioned(lowIncrementWidth),
                    lowIncrementWires);
   };
   const auto halfMcx = [&] {
-    /// The high half (and optional helper2) supplies dirty workspace.
-    /// Keep those wires in the map; a bare NestedMCX would omit them.
+    // Include the high half (and optional helper2) as dirty workspace.
     appendRemapped(plan, planBorrowedHelperMcx(k), halfMcxWires);
   };
   const auto fanOutHelper = [&] {
@@ -608,7 +573,7 @@ static CircuitPlan planBorrowedDirtyIncrementer(size_t n, bool flagAdd,
   plan.append({.kind = PlanOpKind::X, .wires = {helper}});
   halfMcx();
   fanOutHelper();
-  appendRemapped(plan, planIncrementerPartitioned(k), highIncrementWires);
+  appendPlanOps(plan, planIncrementerPartitioned(k));
 
   if (!flagAdd) {
     flipRegister();
@@ -618,7 +583,7 @@ static CircuitPlan planBorrowedDirtyIncrementer(size_t n, bool flagAdd,
 
 // HP24 Theorem 4.4: `C^{n-1}(p(π))` via dirty incrementer + phase ladder.
 static CircuitPlan planHp24Core(size_t numControls) {
-  /// Narrower widths use the specialized or SP22 constructions.
+  // Narrower widths use the specialized or SP22 constructions.
   assert(numControls >= 33 && "HP24 requires at least 33 controls");
   const size_t n = numControls + 1;
   const auto dirtyMode =
@@ -633,14 +598,10 @@ static CircuitPlan planHp24Core(size_t numControls) {
       estimateBorrowedDirtyIncrementerOps(registerWidth, dirtyMode, false) +
       (2 * (numControls - 1)) + 1);
 
-  SmallVector<size_t, 16> registerWires(n);
-  std::iota(registerWires.begin(), registerWires.end(), 0U);
-
   if (dirtyMode == Hp24DirtyMode::OneDirty) {
     const auto increment = [&](bool add) {
-      appendRemapped(plan,
-                     planBorrowedDirtyIncrementer(numControls, add, dirtyMode),
-                     registerWires);
+      appendPlanOps(plan,
+                    planBorrowedDirtyIncrementer(numControls, add, dirtyMode));
     };
     increment(true);
     double phi = -K_PI;
@@ -659,9 +620,8 @@ static CircuitPlan planHp24Core(size_t numControls) {
   }
 
   const auto increment = [&](bool add) {
-    appendRemapped(
-        plan, planBorrowedDirtyIncrementer(numControls - 1, add, dirtyMode),
-        registerWires);
+    appendPlanOps(
+        plan, planBorrowedDirtyIncrementer(numControls - 1, add, dirtyMode));
   };
   increment(true);
   double phi = -K_PI;
@@ -748,7 +708,7 @@ synthesizeThreeControlled(OpBuilder& builder, Location loc, ValueRange controls,
   return wires;
 }
 
-// Barenco peel with RCCX at width 2; exact NestedMCX for wider peels.
+// Barenco residual for up to three controls: an RCCX peel followed by CX.
 static void appendMcpBarencoRelative(CircuitPlan& plan, double theta,
                                      size_t numControls, size_t target) {
   if (numControls == 1) {
@@ -764,13 +724,7 @@ static void appendMcpBarencoRelative(CircuitPlan& plan, double theta,
       plan.append({.kind = PlanOpKind::RCCX, .wires = {0, 1, 2}});
       return;
     }
-    PlanOp mcx{.kind = PlanOpKind::NestedMCX, .nestedControls = peeled};
-    mcx.wires.reserve(peeled + 1);
-    for (size_t control = 0; control < peeled; ++control) {
-      mcx.wires.push_back(control);
-    }
-    mcx.wires.push_back(peeled);
-    plan.append(std::move(mcx));
+    plan.append({.kind = PlanOpKind::CX, .wires = {0, 1}});
   };
 
   plan.append(
@@ -964,19 +918,18 @@ static constexpr size_t K_MCP_VALE_RELATIVE_RESIDUAL_CONTROLS = 4;
 
 /// Vale24 Fig. 7 shell (arXiv:2302.06377): alternate half-MCX with target
 /// `p(±θ/4)`. Controls then target. Caller appends the residual.
+/// Only three or four controls reach this shell, so each half uses CX or CCX.
 static void appendValeFig7Shell(CircuitPlan& plan, double theta,
                                 size_t numControls) {
   const size_t target = numControls;
   const auto [k1, k2] = partitionControls(numControls);
   const double quarter = theta / 4.0;
   const auto appendHalfMcx = [&](size_t begin, size_t count) {
-    PlanOp mcx{.kind = PlanOpKind::NestedMCX, .nestedControls = count};
-    mcx.wires.reserve(count + 1);
-    for (size_t c = 0; c < count; ++c) {
-      mcx.wires.push_back(begin + c);
+    if (count == 1) {
+      plan.append({.kind = PlanOpKind::CX, .wires = {begin, target}});
+      return;
     }
-    mcx.wires.push_back(target);
-    plan.append(std::move(mcx));
+    plan.append({.kind = PlanOpKind::CCX, .wires = {begin, begin + 1, target}});
   };
   appendHalfMcx(0, k1);
   plan.append({.kind = PlanOpKind::P, .wires = {target}, .angle = -quarter});
@@ -1058,34 +1011,32 @@ static void appendSp22PRx(CircuitPlan& plan, size_t m, double sign) {
   }
 }
 
-/// SP22 Theorem 2: expand `Q_m` into single-controlled CRX only.
+/// SP22 Theorem 2: expand `Q_m` into CRX gates for `m >= 5`.
 static CircuitPlan buildSp22Q(size_t m) {
   CircuitPlan q;
-  if (m < 2) {
-    return q; // Q_1 = Q_0 = I
+  q.ops.reserve((m - 1) * (m - 1));
+  // Q_m = P_{m-1} CRX Q_{m-1} P_{m-1}^dagger. Emit the nested
+  // prefixes first, then their suffixes, without moving child plans.
+  for (size_t level = m; level > 1; --level) {
+    appendSp22PRx(q, level - 1, 1.0);
+    q.append({
+        .kind = PlanOpKind::CRX,
+        .wires = {0, level - 1},
+        .angle = std::ldexp(K_PI, -static_cast<int>(level - 2)),
+    });
   }
-  appendSp22PRx(q, m - 1, 1.0);
-  q.append({
-      .kind = PlanOpKind::CRX,
-      .wires = {0, m - 1},
-      .angle = std::ldexp(K_PI, -static_cast<int>(m - 2)),
-  });
-  appendPlanOps(q, buildSp22Q(m - 1));
-  appendSp22PRx(q, m - 1, -1.0);
+  for (size_t level = 2; level <= m; ++level) {
+    appendSp22PRx(q, level - 1, -1.0);
+  }
   return q;
 }
 
 /// SP22 LDD MCP (arXiv:2203.11882 Them. 1): CP ladder + CRX `Q_n` conjugation.
-/// Controls `0..n-1`, target `n`.
+/// Controls `0..n-1`, target `n`; requires `n >= 5`.
 static CircuitPlan planMcpSp22(double theta, size_t numControls) {
   CircuitPlan plan;
   const size_t n = numControls;
   const size_t target = n;
-  if (n < 2) {
-    // Should not be reached; k = 1 is an elementary CP handled elsewhere.
-    plan.append({.kind = PlanOpKind::CP, .wires = {0, target}, .angle = theta});
-    return plan;
-  }
   plan.ops.reserve((2 * n * n) - (2 * n) + 1);
 
   const auto rootAngle = [&](double base, size_t exponent) {
@@ -1110,7 +1061,7 @@ static CircuitPlan planMcpSp22(double theta, size_t numControls) {
 
   // Q_n
   const CircuitPlan qn = buildSp22Q(n);
-  appendPlanOps(plan, qn);
+  plan.ops.append(qn.ops.begin(), qn.ops.end());
 
   // P_n(U)^dagger
   for (size_t c = 1; c < n; ++c) {
@@ -1309,8 +1260,8 @@ struct DecomposeControlledGatePattern final : OpRewritePattern<CtrlOp> {
 
     ControlledTarget gate = spec->gate;
     // A compile-time phase of +/- pi is exactly Z; route it through the
-    // multi-controlled-Z path (elementary at 3–4 qubits, relative-phase / Vale
-    // at 5–6 qubits, else HP24).
+    // multi-controlled-Z path (elementary at 3–4 qubits, relative-phase at
+    // 5 qubits, SP22 at 6–33 qubits, else HP24).
     if (gate == ControlledTarget::Phase && spec->theta &&
         std::abs(std::abs(*spec->theta) - K_PI) <=
             mqt::PARAMETER_COMPARISON_TOLERANCE) {

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/Weyl.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/Weyl.cpp
@@ -29,7 +29,6 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <numbers>
 #include <optional>
 #include <random>
@@ -184,15 +183,14 @@ static double normalSample(std::mt19937& rng) {
   return std::sqrt(-2.0 * std::log(u1)) * std::cos(2.0 * std::numbers::pi * u2);
 }
 
-static std::pair<Matrix4x4, std::array<Complex, 4>>
+static std::optional<std::pair<Matrix4x4, std::array<Complex, 4>>>
 diagonalizeComplexSymmetric(const Matrix4x4& m,
                             double precision = WEYL_DIAGONALIZATION_TOLERANCE) {
-  auto state = std::mt19937{2023};
+  std::optional<std::mt19937> state;
 
   const auto mReal = m.realPart();
   const auto mImag = m.imagPart();
 
-  double bestErr = std::numeric_limits<double>::max();
   constexpr auto maxDiagonalizationAttempts = 100;
   for (int i = 0; i < maxDiagonalizationAttempts; ++i) {
     double randA{};
@@ -205,8 +203,11 @@ diagonalizeComplexSymmetric(const Matrix4x4& m,
       randA = 1.2602066112249388;
       randB = 0.22317849046722027;
     } else {
-      randA = normalSample(state);
-      randB = normalSample(state);
+      if (!state) {
+        state.emplace(2023);
+      }
+      randA = normalSample(*state);
+      randB = normalSample(*state);
     }
     std::array<double, 16> m2Real{};
     for (std::size_t k = 0; k < m2Real.size(); ++k) {
@@ -219,27 +220,14 @@ diagonalizeComplexSymmetric(const Matrix4x4& m,
     const std::array<Complex, 4> d = diagonalized.diagonal();
 
     const auto compare = p * Matrix4x4::fromDiagonal(d) * p.transpose();
-    double err = 0.0;
-    for (std::size_t r = 0; r < 4; ++r) {
-      for (std::size_t cc = 0; cc < 4; ++cc) {
-        err = std::max(err, std::abs(compare(r, cc) - m(r, cc)));
-      }
-    }
-    bestErr = std::min(bestErr, err);
     if (compare.isApprox(m, precision)) {
-      assert((p.transpose() * p).isIdentity(WEYL_DIAGONALIZATION_TOLERANCE));
-      assert(std::abs(Matrix4x4::fromDiagonal(d).determinant() - 1.0) <
-             WEYL_DIAGONALIZATION_TOLERANCE);
-      return {p, d};
+      return std::pair{p, d};
     }
   }
-  llvm::reportFatalInternalError(llvm::formatv(
-      "TwoQubitWeylDecomposition: failed to diagonalize M2 ({0} iterations). "
-      "best error = {1:e}, precision = {2:e}",
-      maxDiagonalizationAttempts, bestErr, precision));
+  return std::nullopt;
 }
 
-static std::tuple<Matrix2x2, Matrix2x2, double>
+static std::optional<std::tuple<Matrix2x2, Matrix2x2, double>>
 decomposeTwoQubitProductGate(const Matrix4x4& specialUnitary) {
   Matrix2x2 r =
       Matrix2x2::fromElements(specialUnitary(0, 0), specialUnitary(0, 1),
@@ -251,8 +239,7 @@ decomposeTwoQubitProductGate(const Matrix4x4& specialUnitary) {
     detR = r.determinant();
   }
   if (std::abs(detR) < 0.1) {
-    llvm::reportFatalInternalError(
-        "decomposeTwoQubitProductGate: unable to decompose: det_r < 0.1");
+    return std::nullopt;
   }
   r *= 1.0 / std::sqrt(detR);
   const Matrix2x2 rTConj = r.adjoint();
@@ -264,13 +251,12 @@ decomposeTwoQubitProductGate(const Matrix4x4& specialUnitary) {
       Matrix2x2::fromElements(temp(0, 0), temp(0, 2), temp(2, 0), temp(2, 2));
   auto detL = l.determinant();
   if (std::abs(detL) < 0.9) {
-    llvm::reportFatalInternalError(
-        "decomposeTwoQubitProductGate: unable to decompose: detL < 0.9");
+    return std::nullopt;
   }
   l *= 1.0 / std::sqrt(detL);
   const auto phase = std::arg(detL) / 2.;
 
-  return {l, r, phase};
+  return std::tuple{l, r, phase};
 }
 
 static std::complex<double> getTrace(double a, double b, double c, double ap,
@@ -340,12 +326,16 @@ static std::pair<Matrix4x4, double> projectToSU4(const Matrix4x4& unitary) {
   return {u, std::arg(detU) / 4.0};
 }
 
-static std::tuple<Matrix4x4, Matrix4x4, std::array<double, 3>,
-                  std::array<double, 4>>
+static std::optional<std::tuple<Matrix4x4, Matrix4x4, std::array<double, 3>,
+                                std::array<double, 4>>>
 computeOrderedWeylCoordinates(const Matrix4x4& u) {
   const auto uP = magicBasisTransform(u, /*outOfMagicBasis=*/true);
   const Matrix4x4 m2 = uP.transpose() * uP;
-  auto [p, d] = diagonalizeComplexSymmetric(m2);
+  auto diagonalized = diagonalizeComplexSymmetric(m2);
+  if (!diagonalized) {
+    return std::nullopt;
+  }
+  auto& [p, d] = *diagonalized;
 
   std::array<double, 4> dReal{};
   for (std::size_t i = 0; i < d.size(); ++i) {
@@ -391,42 +381,29 @@ computeOrderedWeylCoordinates(const Matrix4x4& u) {
     }
     p.setColumn(3, lastColumn);
   }
-  assert(std::abs(p.determinant() - 1.0) < WEYL_DIAGONALIZATION_TOLERANCE);
-
-  return {uP, p, cs, dReal};
+  return std::tuple{uP, p, cs, dReal};
 }
 
-static ChamberState buildChamberState(const Matrix4x4& u, const Matrix4x4& uP,
-                                      Matrix4x4 p, std::array<double, 3> cs,
-                                      const std::array<double, 4>& dReal,
-                                      double globalPhase) {
+static std::optional<ChamberState>
+buildChamberState(const Matrix4x4& uP, Matrix4x4 p, std::array<double, 3> cs,
+                  const std::array<double, 4>& dReal, double globalPhase) {
   const Matrix4x4 temp =
       Matrix4x4::fromDiagonal(std::exp(1i * dReal[0]), std::exp(1i * dReal[1]),
                               std::exp(1i * dReal[2]), std::exp(1i * dReal[3]));
 
   Matrix4x4 k1 = uP * p * temp;
-  assert((k1.transpose() * k1).isIdentity(WEYL_TOLERANCE));
-  assert(k1.determinant().real() > 0.0);
   k1 = magicBasisTransform(k1, /*outOfMagicBasis=*/false);
 
   Matrix4x4 k2 = p.adjoint();
-  assert((k2.transpose() * k2).isIdentity(WEYL_TOLERANCE));
-  assert(k2.determinant().real() > 0.0);
   k2 = magicBasisTransform(k2, /*outOfMagicBasis=*/false);
 
-  assert((k1 *
-          magicBasisTransform(Matrix4x4::fromDiagonal(std::exp(-1i * dReal[0]),
-                                                      std::exp(-1i * dReal[1]),
-                                                      std::exp(-1i * dReal[2]),
-                                                      std::exp(-1i * dReal[3])),
-                              /*outOfMagicBasis=*/false) *
-          k2)
-             .isApprox(u, WEYL_TOLERANCE));
-
-  auto [k1l, k1r, phaseL] = decomposeTwoQubitProductGate(k1);
-  auto [k2l, k2r, phaseR] = decomposeTwoQubitProductGate(k2);
-  assert(Matrix4x4::kron(k1l, k1r).isApprox(k1, WEYL_TOLERANCE));
-  assert(Matrix4x4::kron(k2l, k2r).isApprox(k2, WEYL_TOLERANCE));
+  auto factors1 = decomposeTwoQubitProductGate(k1);
+  auto factors2 = decomposeTwoQubitProductGate(k2);
+  if (!factors1 || !factors2) {
+    return std::nullopt;
+  }
+  auto& [k1l, k1r, phaseL] = *factors1;
+  auto& [k2l, k2r, phaseR] = *factors2;
   globalPhase += phaseL + phaseR;
 
   if (cs[0] > (WEYL_PI / 2.0)) {
@@ -498,7 +475,7 @@ static ChamberState buildChamberState(const Matrix4x4& u, const Matrix4x4& uP,
 // TwoQubitWeylDecomposition
 //===----------------------------------------------------------------------===//
 
-void TwoQubitWeylDecomposition::finalizeSpecializationPhase(
+bool TwoQubitWeylDecomposition::finalizeSpecializationPhase(
     bool flippedFromOriginal, double preSpecializationA,
     double preSpecializationB, double preSpecializationC,
     const std::optional<double>& fidelity) {
@@ -511,15 +488,13 @@ void TwoQubitWeylDecomposition::finalizeSpecializationPhase(
   const double calculatedFidelity = traceToFidelity(trace);
   if (fidelity &&
       calculatedFidelity + WEYL_DIAGONALIZATION_TOLERANCE < *fidelity) {
-    llvm::reportFatalInternalError(llvm::formatv(
-        "TwoQubitWeylDecomposition: Calculated fidelity of "
-        "specialization is worse than requested fidelity ({0:F4} vs {1:F4})!",
-        calculatedFidelity, *fidelity));
+    return false;
   }
   globalPhase_ += std::arg(trace);
+  return true;
 }
 
-TwoQubitWeylDecomposition
+std::optional<TwoQubitWeylDecomposition>
 TwoQubitWeylDecomposition::create(const Matrix4x4& unitaryMatrix,
                                   std::optional<double> fidelity) {
   if (fidelity &&
@@ -531,23 +506,36 @@ TwoQubitWeylDecomposition::create(const Matrix4x4& unitaryMatrix,
   }
 
   const auto [u, globalPhase0] = projectToSU4(unitaryMatrix);
-  auto [uP, p, cs, dReal] = computeOrderedWeylCoordinates(u);
-  const auto chamber = buildChamberState(u, uP, p, cs, dReal, globalPhase0);
+  auto coordinates = computeOrderedWeylCoordinates(u);
+  if (!coordinates) {
+    return std::nullopt;
+  }
+  const auto& [uP, p, cs, dReal] = *coordinates;
+  const auto chamber = buildChamberState(uP, p, cs, dReal, globalPhase0);
+  if (!chamber) {
+    return std::nullopt;
+  }
   TwoQubitWeylDecomposition decomposition;
-  decomposition.a_ = chamber.a;
-  decomposition.b_ = chamber.b;
-  decomposition.c_ = chamber.c;
-  decomposition.globalPhase_ = chamber.globalPhase;
-  decomposition.k1l_ = chamber.k1l;
-  decomposition.k2l_ = chamber.k2l;
-  decomposition.k1r_ = chamber.k1r;
-  decomposition.k2r_ = chamber.k2r;
+  decomposition.a_ = chamber->a;
+  decomposition.b_ = chamber->b;
+  decomposition.c_ = chamber->c;
+  decomposition.globalPhase_ = chamber->globalPhase;
+  decomposition.k1l_ = chamber->k1l;
+  decomposition.k2l_ = chamber->k2l;
+  decomposition.k1r_ = chamber->k1r;
+  decomposition.k2r_ = chamber->k2r;
 
-  assert(decomposition.unitaryMatrix().isApprox(unitaryMatrix, WEYL_TOLERANCE));
+  // Near-unitary inputs can satisfy the dense-matrix contract without meeting
+  // every exact-unitarity assumption in the intermediate factors.
+  if (!decomposition.unitaryMatrix().isApprox(unitaryMatrix, WEYL_TOLERANCE)) {
+    return std::nullopt;
+  }
 
   const bool flippedFromOriginal = decomposition.applySpecialization(fidelity);
-  decomposition.finalizeSpecializationPhase(flippedFromOriginal, chamber.a,
-                                            chamber.b, chamber.c, fidelity);
+  if (!decomposition.finalizeSpecializationPhase(
+          flippedFromOriginal, chamber->a, chamber->b, chamber->c, fidelity)) {
+    return std::nullopt;
+  }
 
   return decomposition;
 }
@@ -786,7 +774,7 @@ oneGate(const TwoQubitWeylDecomposition& target) {
 }
 
 /// See supplemental Eqs. (3), (5)-(7): doi:10.1103/PhysRevLett.130.070601.
-static TwoQubitNativeDecomposition
+static std::optional<TwoQubitNativeDecomposition>
 twoGates(const TwoQubitWeylDecomposition& target) {
   const double x = target.a(), y = target.b(), z = target.c();
   const double c = std::sin(x + y - z) * std::sin(x - y + z) *
@@ -838,12 +826,22 @@ twoGates(const TwoQubitWeylDecomposition& target) {
   };
   const auto gate = XXPlusYYOp::unitaryMatrix(-WEYL_PI / 2., 0.);
   const auto sandwich = gate * Matrix4x4::kron(left, right) * gate;
-  align(result, TwoQubitWeylDecomposition::create(sandwich, std::nullopt),
-        target);
+  const auto circuit =
+      TwoQubitWeylDecomposition::create(sandwich, std::nullopt);
+  if (!circuit) {
+    return std::nullopt;
+  }
+  align(result, *circuit, target);
   return result;
 }
-static TwoQubitNativeDecomposition decomposeSqrtISwap(const Matrix4x4& target) {
-  const auto kak = TwoQubitWeylDecomposition::create(target, std::nullopt);
+static std::optional<TwoQubitNativeDecomposition>
+decomposeSqrtISwap(const Matrix4x4& target) {
+  const auto targetDecomposition =
+      TwoQubitWeylDecomposition::create(target, std::nullopt);
+  if (!targetDecomposition) {
+    return std::nullopt;
+  }
+  const auto& kak = *targetDecomposition;
   if (kak.a() <= WEYL_TOLERANCE) {
     TwoQubitNativeDecomposition result{
         .numBasisUses = 0,
@@ -870,32 +868,32 @@ static TwoQubitNativeDecomposition decomposeSqrtISwap(const Matrix4x4& target) {
   const auto residual = TwoQubitWeylDecomposition::create(
       kak.getCanonicalMatrix() * gate.adjoint(), std::nullopt);
   const auto prefix = TwoQubitWeylDecomposition::create(gate, std::nullopt);
-  auto before = oneGate(prefix);
-  auto after = twoGates(residual);
+  if (!residual || !prefix) {
+    return std::nullopt;
+  }
+  auto before = oneGate(*prefix);
+  const auto after = twoGates(*residual);
+  if (!after) {
+    return std::nullopt;
+  }
   auto& factors = before.singleQubitFactors;
-  factors[2] = after.singleQubitFactors[0] * factors[2];
-  factors[3] = after.singleQubitFactors[1] * factors[3];
-  factors.append(after.singleQubitFactors.begin() + 2,
-                 after.singleQubitFactors.end());
+  factors[2] = after->singleQubitFactors[0] * factors[2];
+  factors[3] = after->singleQubitFactors[1] * factors[3];
+  factors.append(after->singleQubitFactors.begin() + 2,
+                 after->singleQubitFactors.end());
   before.numBasisUses = 3;
-  before.globalPhase += after.globalPhase;
+  before.globalPhase += after->globalPhase;
   attachLocalFactors(before, kak);
   return before;
 }
 
-TwoQubitNativeDecomposition
+std::optional<TwoQubitNativeDecomposition>
 decomposeUnitary2QWeyl(const Matrix4x4& target,
                        const CompilerTarget::GateKind entangler) {
   if (entangler == CompilerTarget::GateKind::SQRTISWAP) {
     return decomposeSqrtISwap(target);
   }
-  auto decomposition =
-      cachedNativeBasisDecomposer(entangler).decomposeTarget(target);
-  if (!decomposition) {
-    llvm::reportFatalInternalError(
-        "target-selected entangler failed to decompose a two-qubit unitary");
-  }
-  return std::move(*decomposition);
+  return cachedNativeBasisDecomposer(entangler).decomposeTarget(target);
 }
 
 SynthesizedUnitary2Q
@@ -923,12 +921,6 @@ emitUnitary2QWeyl(OpBuilder& builder, Location loc, Value qubit0, Value qubit1,
     const auto synthesized = synthesizeUnitary1QEuler(
         builder, loc, wire, factors[index], /*runSize=*/0,
         /*hasNonBasisGate=*/true, basis.singleQubit);
-    if (!synthesized) {
-      llvm::reportFatalInternalError(llvm::formatv(
-          "emitUnitary2QWeyl: euler synthesis failed for factor index "
-          "{0} (layer {1}, qubit {2})",
-          index, index / 2, (index % 2 == 0) ? 1 : 0));
-    }
     wire = synthesized->qubit;
     globalPhase += synthesized->globalPhase;
   };

--- a/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/FuseSingleQubitUnitaryRuns.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/FuseSingleQubitUnitaryRuns.cpp
@@ -77,7 +77,7 @@ static FusableRunScan
 scanFusableRun(UnitaryOpInterface head, const Matrix2x2& headMatrix,
                const decomposition::SingleQubitBasis basis) {
   FusableRunScan scan;
-  for (auto* op : WireRange(head.getOutputTarget(0))) {
+  for (auto* op : WireRange(head.getOutputQubit(0))) {
     auto member = dyn_cast_or_null<UnitaryOpInterface>(op);
     if (!member) {
       break;
@@ -106,7 +106,7 @@ scanFusableRun(UnitaryOpInterface head, const Matrix2x2& headMatrix,
 static void eraseFusableRun(PatternRewriter& rewriter, UnitaryOpInterface head,
                             UnitaryOpInterface tail) {
   // Tail-first: each erased op is dead once its successor is gone.
-  auto it = WireIterator(tail.getOutputTarget(0));
+  auto it = WireIterator(tail.getOutputQubit(0));
   auto* target = head.getOperation();
   while (*it != target) {
     auto* current = *it;
@@ -152,7 +152,7 @@ struct FuseSingleQubitUnitaryRunsPattern final
       return failure();
     }
     auto predecessor = dyn_cast_or_null<UnitaryOpInterface>(
-        op.getInputTarget(0).getDefiningOp());
+        op.getInputQubit(0).getDefiningOp());
     if (getRunMemberMatrix(predecessor)) {
       return failure();
     }
@@ -163,16 +163,15 @@ struct FuseSingleQubitUnitaryRunsPattern final
 
     FusableRunScan run = scanFusableRun(op, *headMatrix, basis);
     const auto synthesized = decomposition::synthesizeUnitary1QEuler(
-        rewriter, op.getLoc(), op.getInputTarget(0), run.composed,
-        run.gateCount, run.hasNonBasisGate, basis);
+        rewriter, op.getLoc(), op.getInputQubit(0), run.composed, run.gateCount,
+        run.hasNonBasisGate, basis);
     if (!synthesized) {
       return failure();
     }
     decomposition::emitGPhaseIfNeeded(rewriter, op.getLoc(),
                                       synthesized->globalPhase);
 
-    rewriter.replaceAllUsesWith(run.tail.getOutputTarget(0),
-                                synthesized->qubit);
+    rewriter.replaceAllUsesWith(run.tail.getOutputQubit(0), synthesized->qubit);
     eraseFusableRun(rewriter, op, run.tail);
     return success();
   }

--- a/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
@@ -28,6 +28,7 @@
 #include <mlir/Dialect/Arith/IR/Arith.h> // IWYU pragma: keep (Passes.h.inc)
 #include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/DialectRegistry.h>
@@ -45,6 +46,7 @@
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Support/TypeID.h>
 #include <mlir/Support/WalkResult.h>
+#include <mlir/Transforms/FoldUtils.h>
 
 #include <array>
 #include <cassert>
@@ -71,6 +73,14 @@ struct FusableTwoQubitRun {
   unsigned numTwoQ = 0; ///< Number of two-qubit members (entanglers consumed).
   Value tailA;          ///< Current output wires of the run's tail.
   Value tailB;
+};
+
+/// Reuse the last numerical decomposition across gates on different wires.
+///
+/// The target basis is fixed for the pass; no SSA values or locations are kept.
+struct LastTwoQubitDecomposition {
+  Matrix4x4 matrix;
+  std::optional<decomposition::TwoQubitNativeDecomposition> native;
 };
 
 } // namespace
@@ -220,6 +230,10 @@ static FusableTwoQubitRun scanFusableTwoQubitRun(UnitaryOpInterface head,
   run.ops.push_back(head.getOperation());
   run.numTwoQ = 1;
 
+  UnitaryOpInterface cachedOpA;
+  UnitaryOpInterface cachedOpB;
+  std::optional<Matrix2x2> matrixA;
+  std::optional<Matrix2x2> matrixB;
   while (true) {
     UnitaryOpInterface nextOnA = uniqueUnitaryUser(run.tailA);
     UnitaryOpInterface nextOnB = uniqueUnitaryUser(run.tailB);
@@ -235,12 +249,17 @@ static FusableTwoQubitRun scanFusableTwoQubitRun(UnitaryOpInterface head,
       continue;
     }
 
-    const auto matrixA =
-        !sameOp ? oneQubitRunMemberMatrix(nextOnA) : std::nullopt;
-    const auto matrixB =
-        !sameOp ? oneQubitRunMemberMatrix(nextOnB) : std::nullopt;
-    const bool aSingle = matrixA.has_value();
-    const bool bSingle = matrixB.has_value();
+    // Only the consumed wire advances; retain the other pending matrix.
+    if (!sameOp && nextOnA.getOperation() != cachedOpA.getOperation()) {
+      cachedOpA = nextOnA;
+      matrixA = oneQubitRunMemberMatrix(nextOnA);
+    }
+    if (!sameOp && nextOnB.getOperation() != cachedOpB.getOperation()) {
+      cachedOpB = nextOnB;
+      matrixB = oneQubitRunMemberMatrix(nextOnB);
+    }
+    const bool aSingle = !sameOp && matrixA.has_value();
+    const bool bSingle = !sameOp && matrixB.has_value();
     if (aSingle && bSingle && nextOnA->getBlock() != nextOnB->getBlock()) {
       break;
     }
@@ -276,7 +295,7 @@ static bool fuseTwoQubitGateRun(IRRewriter& rewriter, UnitaryOpInterface head,
   }
 
   const auto native = decomposeUnitary2QWeyl(run.composed, *basis.entangler);
-  if (native.numBasisUses >= run.numTwoQ) {
+  if (!native || native->numBasisUses >= run.numTwoQ) {
     return false;
   }
 
@@ -284,7 +303,7 @@ static bool fuseTwoQubitGateRun(IRRewriter& rewriter, UnitaryOpInterface head,
   rewriter.setInsertionPoint(firstOp);
   const auto synthesized =
       emitUnitary2QWeyl(rewriter, firstOp.getLoc(), firstOp.getInputQubit(0),
-                        firstOp.getInputQubit(1), native, basis);
+                        firstOp.getInputQubit(1), *native, basis);
   decomposition::emitGPhaseIfNeeded(rewriter, firstOp.getLoc(),
                                     synthesized.globalPhase);
   rewriter.replaceAllUsesWith(run.tailA, synthesized.qubit0);
@@ -468,7 +487,7 @@ static void reorderTwoQubitOperation(IRRewriter& rewriter,
 static LogicalResult synthesizeTargetOperation(
     IRRewriter& rewriter, UnitaryOpInterface op, const CompilerTarget& target,
     const std::optional<CompilerTarget::SynthesisBasis>& basis,
-    ArrayRef<SiteId> sites) {
+    ArrayRef<SiteId> sites, LastTwoQubitDecomposition& lastDecomposition) {
   Operation* const operation = op.getOperation();
   if (target.supports(operation, sites)) {
     return success();
@@ -532,9 +551,20 @@ static LogicalResult synthesizeTargetOperation(
     matrix = matrix.reorderForQubits(1, 0);
     std::swap(input0, input1);
   }
-  const auto native = decomposeUnitary2QWeyl(matrix, *basis->entangler);
+  // Compare the full, direction-adjusted matrix exactly, including its phase.
+  if (!lastDecomposition.native ||
+      lastDecomposition.matrix.data != matrix.data) {
+    lastDecomposition.matrix = matrix;
+    lastDecomposition.native =
+        decomposeUnitary2QWeyl(matrix, *basis->entangler);
+  }
+  const auto& native = lastDecomposition.native;
+  if (!native) {
+    return unsupported(
+        "its unitary matrix could not be numerically decomposed");
+  }
   const auto synthesized = emitUnitary2QWeyl(rewriter, operation->getLoc(),
-                                             input0, input1, native, *basis);
+                                             input0, input1, *native, *basis);
   decomposition::emitGPhaseIfNeeded(rewriter, operation->getLoc(),
                                     synthesized.globalPhase);
   if (reverseEntangler) {
@@ -589,6 +619,32 @@ protected:
   }
 };
 
+/// Defer constant folding until gate builders have consumed their new values.
+class SynthesisConstantFolder final : public OpBuilder::Listener {
+public:
+  explicit SynthesisConstantFolder(MLIRContext* context) : folder_(context) {}
+
+  void notifyOperationInserted(Operation* operation,
+                               OpBuilder::InsertPoint previous) override {
+    if (!previous.isSet()) {
+      if (auto constant = dyn_cast<arith::ConstantOp>(operation)) {
+        pending_.push_back(constant);
+      }
+    }
+  }
+
+  void foldPending() {
+    for (auto constant : pending_) {
+      folder_.insertKnownConstant(constant, constant.getValue());
+    }
+    pending_.clear();
+  }
+
+private:
+  OperationFolder folder_;
+  SmallVector<arith::ConstantOp> pending_;
+};
+
 struct TargetNativeSynthesisPass final
     : impl::TargetNativeSynthesisBase<TargetNativeSynthesisPass> {
 
@@ -619,7 +675,9 @@ protected:
       return;
     }
 
-    IRRewriter rewriter(&getContext());
+    SynthesisConstantFolder constants(&getContext());
+    IRRewriter rewriter(&getContext(), &constants);
+    LastTwoQubitDecomposition lastDecomposition;
     /// Rewrite users before producers so each unvisited operation retains its
     /// original operands and their collected sites.
     const auto result = moduleOp->walk<WalkOrder::PostOrder, ReverseIterator>(
@@ -629,11 +687,12 @@ protected:
               (!unitary.isSingleQubit() && !unitary.isTwoQubit())) {
             return WalkResult::advance();
           }
-          return failed(synthesizeTargetOperation(
-                     rewriter, unitary, target, targetBasis,
-                     getOperationSites(operation, *sites)))
-                     ? WalkResult::interrupt()
-                     : WalkResult::advance();
+          const auto synthesized = synthesizeTargetOperation(
+              rewriter, unitary, target, targetBasis,
+              getOperationSites(operation, *sites), lastDecomposition);
+          constants.foldPending();
+          return failed(synthesized) ? WalkResult::interrupt()
+                                     : WalkResult::advance();
         });
     if (result.wasInterrupted()) {
       signalPassFailure();

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
@@ -531,6 +531,17 @@ static std::optional<Quat<T>> quaternionFromGate(UnitaryOpInterface op,
       .Default([](auto) -> std::optional<Quat<T>> { return std::nullopt; });
 }
 
+/// Reduce before adding phases so large angles cannot absorb small terms.
+/// Trigonometric reduction preserves phase even beyond accurate fmod range.
+template <typename T> static Val<T> principalPhase(Val<T> angle) {
+  if constexpr (std::is_same_v<T, double>) {
+    if (std::abs(angle.v) <= std::numbers::pi) {
+      return angle;
+    }
+  }
+  return angle.sin().atan2(angle.cos());
+}
+
 /**
  * @brief Returns the global phase contribution of a supported gate.
  *
@@ -581,7 +592,7 @@ static FailureOr<Val<T>> globalPhaseOf(UnitaryOpInterface op,
         if (!theta) {
           return failure();
         }
-        return *theta / c.two;
+        return principalPhase(*theta / c.two);
       })
       .template Case<UOp, U2Op>([&](auto) -> FailureOr<Val<T>> {
         // phi is at different indexes for UOp and U2Op
@@ -591,8 +602,7 @@ static FailureOr<Val<T>> globalPhaseOf(UnitaryOpInterface op,
         if (!phi || !lambda) {
           return failure();
         }
-        const auto phaseAngle = *phi + *lambda;
-        return phaseAngle / c.two;
+        return principalPhase(*phi / c.two) + principalPhase(*lambda / c.two);
       })
       .Default([](auto) -> FailureOr<Val<T>> { return failure(); });
 }

--- a/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Optimizations/MergeSingleQubitRotationGates.cpp
@@ -32,7 +32,6 @@
 #include <mlir/Support/LogicalResult.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
-#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cmath>
@@ -172,12 +171,12 @@ template <typename T> struct Val {
       };
     }
   }
-  [[nodiscard]] Val acos() const {
+  [[nodiscard]] Val sqrt() const {
     if constexpr (std::is_same_v<T, double>) {
-      return {std::acos(v), rewriter, loc};
+      return {std::sqrt(v), rewriter, loc};
     } else {
       return {
-          math::AcosOp::create(*rewriter, loc, v).getResult(),
+          math::SqrtOp::create(*rewriter, loc, v).getResult(),
           rewriter,
           loc,
       };
@@ -195,29 +194,6 @@ template <typename T> struct Val {
       };
     }
   }
-  [[nodiscard]] Val maximum(Val o) const {
-    if constexpr (std::is_same_v<T, double>) {
-      return {std::max(v, o.v), rewriter, loc};
-    } else {
-      return {
-          arith::MaximumFOp::create(*rewriter, loc, v, o.v).getResult(),
-          rewriter,
-          loc,
-      };
-    }
-  }
-  [[nodiscard]] Val minimum(Val o) const {
-    if constexpr (std::is_same_v<T, double>) {
-      return {std::min(v, o.v), rewriter, loc};
-    } else {
-      return {
-          arith::MinimumFOp::create(*rewriter, loc, v, o.v).getResult(),
-          rewriter,
-          loc,
-      };
-    }
-  }
-
   [[nodiscard]] Pred oge(Val o) const {
     if constexpr (std::is_same_v<T, double>) {
       return v >= o.v;
@@ -280,7 +256,6 @@ template <typename T> struct Quat {
 
 /// Shared numeric constants used by quaternion construction and Euler extract.
 template <typename T> struct ScalarConsts {
-  Val<T> negOne;
   Val<T> zero;
   Val<T> one;
   Val<T> two;
@@ -307,7 +282,6 @@ template <typename T>
 static ScalarConsts<T> makeConsts(RewriterBase& rewriter, Location loc) {
   auto c = [&](double x) { return Val<T>::constant(rewriter, loc, x); };
   return {
-      .negOne = c(-1.0),
       .zero = c(0.0),
       .one = c(1.0),
       .two = c(2.0),
@@ -325,8 +299,10 @@ static ScalarConsts<T> makeConsts(RewriterBase& rewriter, Location loc) {
 template <typename T>
 static Val<T> wrapToPi(Val<T> angle, const ScalarConsts<T>& c) {
   const auto twoPi = c.two * c.pi;
-  const auto floored = ((angle + c.pi) / twoPi).floor();
-  return angle - (floored * twoPi);
+  const auto shifted = angle + c.pi;
+  const auto turns = shifted / twoPi;
+  const auto floored = turns.floor();
+  return angle - floored * twoPi;
 }
 
 /**
@@ -344,10 +320,10 @@ static Val<T> wrapToPi(Val<T> angle, const ScalarConsts<T>& c) {
 template <typename T>
 static Quat<T> hamiltonProduct(const Quat<T>& q1, const Quat<T>& q2) {
   return {
-      .w = (q1.w * q2.w) - (q1.x * q2.x) - (q1.y * q2.y) - (q1.z * q2.z),
-      .x = (q1.w * q2.x) + (q1.x * q2.w) + (q1.y * q2.z) - (q1.z * q2.y),
-      .y = (q1.w * q2.y) - (q1.x * q2.z) + (q1.y * q2.w) + (q1.z * q2.x),
-      .z = (q1.w * q2.z) + (q1.x * q2.y) - (q1.y * q2.x) + (q1.z * q2.w),
+      .w = q1.w * q2.w - q1.x * q2.x - q1.y * q2.y - q1.z * q2.z,
+      .x = q1.w * q2.x + q1.x * q2.w + q1.y * q2.z - q1.z * q2.y,
+      .y = q1.w * q2.y - q1.x * q2.z + q1.y * q2.w + q1.z * q2.x,
+      .z = q1.w * q2.z + q1.x * q2.y - q1.y * q2.x + q1.z * q2.w,
   };
 }
 
@@ -403,7 +379,18 @@ static Quat<T> quaternionFromZYZ(Val<T> theta, Val<T> phi, Val<T> lambda,
   const auto qTheta = axisQuaternion(theta, RotationAxis::Y, c);
   const auto qPhi = axisQuaternion(phi, RotationAxis::Z, c);
   const auto qLambda = axisQuaternion(lambda, RotationAxis::Z, c);
-  return hamiltonProduct(hamiltonProduct(qPhi, qTheta), qLambda);
+  // Expand the sparse axis products without combining the input angles.
+  const auto w = qPhi.w * qTheta.w;
+  const auto yz = qPhi.z * qTheta.y;
+  const auto x = -yz;
+  const auto y = qPhi.w * qTheta.y;
+  const auto z = qPhi.z * qTheta.w;
+  return {
+      .w = w * qLambda.w - z * qLambda.z,
+      .x = x * qLambda.w + y * qLambda.z,
+      .y = y * qLambda.w - x * qLambda.z,
+      .z = w * qLambda.z + z * qLambda.w,
+  };
 }
 
 /**
@@ -604,41 +591,40 @@ static FailureOr<Val<T>> globalPhaseOf(UnitaryOpInterface op,
         if (!phi || !lambda) {
           return failure();
         }
-        return (*phi + *lambda) / c.two;
+        const auto phaseAngle = *phi + *lambda;
+        return phaseAngle / c.two;
       })
       .Default([](auto) -> FailureOr<Val<T>> { return failure(); });
 }
 
-/**
- * @brief Extracts ZYZ Euler angles from a unit quaternion.
- *
- * For unit quaternion q = w + x * i + y * j + z * k, extracts UOp parameters:
- *
- * - alpha = atan2(z, w) + atan2(-x, y)
- * - beta  = acos(2 * (w^2 + z^2) - 1)
- * - gamma = atan2(z, w) - atan2(-x, y)
- *
- * Based on Bernardes & Viollet (2022), simplified for unit quaternions and
- * proper ZYZ Euler angles (Chapter 3.3):
- * https://doi.org/10.1371/journal.pone.0276302
- *
- * Reference implementation:
- * https://github.com/evbernardes/quaternion_to_euler
- * SymPy also implements this paper:
- * https://docs.sympy.org/latest/modules/algebras.html#sympy.algebras.Quaternion.to_euler
- *
- * Pure-Z / XY-aligned quaternions (|x|,|y| < eps) take the beta≈0 gimbal form
- * so tiny beta drift cannot split the Z angle across phi/lambda. The host path
- * short-circuits to `{0, 2*atan2(z,w), 0}`; the `Value` path selects `beta=0`
- * under the same predicate and sanitizes the atan2 y-operand when (x,y)≈0 so
- * MLIR's constant folder never sees atan2(0,0) → NaN on a dead select input.
- *
- * @note Floating-point errors may accumulate when merging many gates.
- * Normalizing either Z angle by 2*pi flips the corresponding SU(2)
- * quaternion sign. The returned phase correction accounts for those flips.
- *
- * @return {theta, phi, lambda, phaseCorrection} suitable for UOp
- */
+/// Extracts ZYZ Euler angles from a unit quaternion.
+///
+/// For unit quaternion q = w + x * i + y * j + z * k, extracts UOp parameters:
+///
+/// - alpha = atan2(z, w) + atan2(-x, y)
+/// - beta  = 2 * atan2(sqrt(x^2 + y^2), sqrt(w^2 + z^2))
+/// - gamma = atan2(z, w) - atan2(-x, y)
+///
+/// Based on Bernardes & Viollet (2022), simplified for unit quaternions and
+/// proper ZYZ Euler angles (Chapter 3.3):
+/// https://doi.org/10.1371/journal.pone.0276302
+///
+/// Reference implementation:
+/// https://github.com/evbernardes/quaternion_to_euler
+/// SymPy also implements this paper:
+/// https://docs.sympy.org/latest/modules/algebras.html#sympy.algebras.Quaternion.to_euler
+///
+/// Pure-Z / XY-aligned quaternions (|x|,|y| < eps) take the beta≈0 gimbal form
+/// so tiny beta drift cannot split the Z angle across phi/lambda. The host path
+/// short-circuits to `{0, 2*atan2(z,w), 0}`; the `Value` path selects `beta=0`
+/// under the same predicate and sanitizes the atan2 y-operand when (x,y)≈0 so
+/// MLIR's constant folder never sees atan2(0,0) → NaN on a dead select input.
+///
+/// @note Floating-point errors may accumulate when merging many gates.
+/// Normalizing either Z angle by 2*pi flips the corresponding SU(2)
+/// quaternion sign. The returned phase correction accounts for those flips.
+///
+/// @return {theta, phi, lambda, phaseCorrection} suitable for UOp
 template <typename T>
 static std::array<Val<T>, 4> anglesFromQuaternion(const Quat<T>& q,
                                                   const ScalarConsts<T>& c) {
@@ -655,22 +641,24 @@ static std::array<Val<T>, 4> anglesFromQuaternion(const Quat<T>& q,
       const auto phi = wrapToPi(alpha, c);
       // Wrapping alpha by 2*pi flips the SU(2) representative, which is
       // compensated by half the removed angle as a global phase.
-      return {c.zero, phi, c.zero, (alpha - phi) / c.two};
+      const auto removedAngle = alpha - phi;
+      return {c.zero, phi, c.zero, removedAngle / c.two};
     }
   }
 
-  // beta = acos(clamp(2 * (w^2 + z^2) - 1, -1, 1))
-  // Force beta=0 when (x,y)≈0 so XY-aligned / pure-Z merges do not emit a
-  // drifted acos theta on the SSA path (host path already returned above).
-  const auto cosBeta = ((c.two * ((q.w * q.w) + (q.z * q.z))) - c.one)
-                           .maximum(c.negOne)
-                           .minimum(c.one);
-  const auto betaRaw = cosBeta.acos();
+  // The half-angle norms retain small rotations when cos(beta) rounds to one.
+  // Force beta=0 when (x,y)≈0, matching the host path's pure-Z shortcut.
+  const auto sinHalfBetaSquared = q.x * q.x + q.y * q.y;
+  const auto cosHalfBetaSquared = q.w * q.w + q.z * q.z;
+  const auto sinHalfBeta = sinHalfBetaSquared.sqrt();
+  const auto cosHalfBeta = cosHalfBetaSquared.sqrt();
+  const auto betaRaw = sinHalfBeta.atan2(cosHalfBeta) * c.two;
   const auto beta = Val<T>::select(xyNearZero, c.zero, betaRaw);
 
   // safe1 = |beta| >= eps; safe2 = |beta - π| >= eps
   const auto safe1 = beta.abs().oge(c.eps);
-  const auto safe2 = (beta - c.pi).abs().oge(c.eps);
+  const auto betaMinusPi = beta - c.pi;
+  const auto safe2 = betaMinusPi.abs().oge(c.eps);
   const auto notXy = Val<T>::lnot(xyNearZero, rewriter, loc);
   const auto safe = Val<T>::land(Val<T>::land(safe1, safe2, rewriter, loc),
                                  notXy, rewriter, loc);
@@ -680,7 +668,8 @@ static std::array<Val<T>, 4> anglesFromQuaternion(const Quat<T>& q,
   // Sanitize y when (x,y)≈0 for the Value backend's constant folder.
   const auto yForAtan2 = Val<T>::select(xyNearZero, c.one, q.y);
   const auto thetaPlus = q.z.atan2(q.w);
-  const auto thetaMinus = (-q.x).atan2(yForAtan2);
+  const auto minusX = -q.x;
+  const auto thetaMinus = minusX.atan2(yForAtan2);
   const auto twoThetaPlus = thetaPlus * c.two;
   const auto twoThetaMinus = thetaMinus * c.two;
 
@@ -697,7 +686,10 @@ static std::array<Val<T>, 4> anglesFromQuaternion(const Quat<T>& q,
   const auto lambda = wrapToPi(gamma, c);
   // Each removed 2*pi Z rotation flips the SU(2) representative. Half of the
   // total removed angle restores the original matrix as a global phase.
-  return {beta, phi, lambda, ((alpha - phi) + (gamma - lambda)) / c.two};
+  const auto removedAlpha = alpha - phi;
+  const auto removedGamma = gamma - lambda;
+  const auto removedAngle = removedAlpha + removedGamma;
+  return {beta, phi, lambda, removedAngle / c.two};
 }
 
 // Conjugates q by Hadamard, mapping X to Z, Y to -Y, and Z to X.
@@ -769,10 +761,10 @@ static Value emitRuntimeEulerAngles(RewriterBase& rewriter, Location loc,
     break;
   case decomposition::SingleQubitBasis::ZXZ:
     qubit = emitRotationIfNeeded<RZOp>(rewriter, loc, qubit,
-                                       lambda - (consts.pi / consts.two));
+                                       lambda - consts.pi / consts.two);
     qubit = emitRotationIfNeeded<RXOp>(rewriter, loc, qubit, theta);
     qubit = emitRotationIfNeeded<RZOp>(rewriter, loc, qubit,
-                                       phi + (consts.pi / consts.two));
+                                       phi + consts.pi / consts.two);
     break;
   case decomposition::SingleQubitBasis::XZX:
     qubit = emitRotationIfNeeded<RXOp>(rewriter, loc, qubit, lambda);
@@ -785,7 +777,7 @@ static Value emitRuntimeEulerAngles(RewriterBase& rewriter, Location loc,
     qubit = emitRotationIfNeeded<RXOp>(rewriter, loc, qubit, phi);
     break;
   case decomposition::SingleQubitBasis::U:
-    phase = phase - (sumAngles(phi, lambda) / consts.two);
+    phase = phase - sumAngles(phi, lambda) / consts.two;
     qubit = UOp::create(rewriter, loc, qubit, theta.v, phi.v, lambda.v)
                 .getQubitOut();
     break;
@@ -801,7 +793,7 @@ static Value emitRuntimeEulerAngles(RewriterBase& rewriter, Location loc,
       phase = phase - quarterPi;
       break;
     }
-    phase = phase + (consts.pi / consts.two);
+    phase = phase + consts.pi / consts.two;
     qubit = emitRotationIfNeeded<RZOp>(rewriter, loc, qubit, lambda);
     qubit = SXOp::create(rewriter, loc, qubit).getQubitOut();
     qubit = emitRotationIfNeeded<RZOp>(rewriter, loc, qubit, theta + consts.pi);
@@ -908,7 +900,8 @@ static Value emitDirectU(RewriterBase& rewriter, UnitaryOpInterface op,
         .getQubitOut();
   }
   if (isa<RXOp>(op.getOperation())) {
-    return UOp::create(rewriter, loc, qubit, parameter(0).v, (-halfPi).v,
+    const auto minusHalfPi = -halfPi;
+    return UOp::create(rewriter, loc, qubit, parameter(0).v, minusHalfPi.v,
                        halfPi.v)
         .getQubitOut();
   }
@@ -923,15 +916,18 @@ static Value emitDirectU(RewriterBase& rewriter, UnitaryOpInterface op,
         UOp::create(rewriter, loc, qubit, consts.zero.v, consts.zero.v, angle.v)
             .getQubitOut();
     if (isa<RZOp>(op.getOperation())) {
-      emitParameterizedGPhaseIfNeeded(rewriter, loc, -(angle / consts.two));
+      const auto halfAngle = angle / consts.two;
+      emitParameterizedGPhaseIfNeeded(rewriter, loc, -halfAngle);
     }
     return qubit;
   }
 
   const auto theta = parameter(0);
   const auto phi = parameter(1);
-  return UOp::create(rewriter, loc, qubit, theta.v, (phi - halfPi).v,
-                     (halfPi - phi).v)
+  const auto phiMinusHalfPi = phi - halfPi;
+  const auto halfPiMinusPhi = halfPi - phi;
+  return UOp::create(rewriter, loc, qubit, theta.v, phiMinusHalfPi.v,
+                     halfPiMinusPhi.v)
       .getQubitOut();
 }
 
@@ -1066,8 +1062,8 @@ struct MergeSingleQubitRotationGatesPattern final
 
     const auto [theta, phi, lambda, eulerPhase] =
         anglesFromQuaternion(*qAccum, consts);
-    const auto correction =
-        phaseAccum - ((phi + lambda) / consts.two) + eulerPhase;
+    const auto phaseAngle = phi + lambda;
+    const auto correction = phaseAccum - phaseAngle / consts.two + eulerPhase;
 
     for (auto chainOp : llvm::drop_begin(chain)) {
       rewriter.replaceOp(chainOp, chainOp.getInputQubit(0));
@@ -1127,8 +1123,8 @@ struct MergeSingleQubitRotationGatesPattern final
         transformed ? anglesFromQuaternion(hadamardConjugate(*qAccum), consts)
                     : anglesFromQuaternion(*qAccum, consts);
     if (basis == decomposition::SingleQubitBasis::XZX) {
-      phi = phi + (consts.pi / consts.two);
-      lambda = lambda - (consts.pi / consts.two);
+      phi = phi + consts.pi / consts.two;
+      lambda = lambda - consts.pi / consts.two;
     } else if (basis == decomposition::SingleQubitBasis::XYX ||
                basis == decomposition::SingleQubitBasis::R) {
       phi = phi + consts.pi;
@@ -1219,6 +1215,13 @@ void decomposition::synthesizeParameterizedUnitary1Q(RewriterBase& rewriter,
 
   auto unitary = cast<UnitaryOpInterface>(op);
   rewriter.setInsertionPointAfter(op);
+  if (basis == SingleQubitBasis::R && isa<RXOp, RYOp>(op)) {
+    Value axis = mqt::constantFromScalar(
+        rewriter, op->getLoc(), isa<RXOp>(op) ? 0.0 : std::numbers::pi / 2.0);
+    rewriter.replaceOpWithNewOp<ROp>(op, unitary.getInputQubit(0),
+                                     unitary.getParameter(0), axis);
+    return;
+  }
   const bool usesDirectZYZAngles = basis == SingleQubitBasis::ZYZ ||
                                    basis == SingleQubitBasis::ZXZ ||
                                    basis == SingleQubitBasis::ZSXX;

--- a/mlir/unittests/Compiler/CMakeLists.txt
+++ b/mlir/unittests/Compiler/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(mqt-core-mlir-unittests-compiler PROPERTIES UNITY_BUILD OF
 target_link_libraries(
   mqt-core-mlir-unittests-compiler
   PRIVATE GTest::gtest_main
+          MLIRExactUnitaryTest
           MQTCompilerQDMIAdapter
           MQTCompilerTarget
           MQTCompilerPipeline

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -8,6 +8,7 @@
  * Licensed under the MIT License
  */
 
+#include "ExactUnitaryTest.h"
 #include "Support/IRVerification.h"
 #include "TestCaseUtils.h"
 #include "mlir/Compiler/Programs.h"
@@ -24,6 +25,7 @@
 #include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/QCOUtils.h"
+#include "mlir/Dialect/QCO/Transforms/Passes.h"
 #include "mlir/Dialect/QIR/Builder/QIRProgramBuilder.h"
 #include "mlir/Dialect/QIR/Utils/QIRUtils.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
@@ -3148,6 +3150,100 @@ x q;
       qco->runPassPipeline("place-and-route{ntrials=1},target-native-synthesis,"
                            "verify-target-conformance"));
   EXPECT_NE(qco->str().find("qco.static"), std::string::npos);
+}
+
+TEST_F(CompilerPipelineTest, TargetCompilationFusesOnlyWithUsableNativeBasis) {
+  using NativeOperations = CompilerTarget::NativeOperations;
+  using TargetOperation = CompilerTarget::Operation;
+  const auto cx = llvm::cantFail(TargetOperation::create("cx", 2, 0));
+  const auto dcx = llvm::cantFail(TargetOperation::create("dcx", 2, 0));
+  const auto u = llvm::cantFail(TargetOperation::create("u", 1, 3));
+  const auto gphase = llvm::cantFail(TargetOperation::create("gphase", 0, 1));
+  const auto makeTarget = [](NativeOperations operations) {
+    return llvm::cantFail(CompilerTarget::create(
+        2, CompilerTarget::Connectivity::allToAll(), std::move(operations)));
+  };
+  struct Case {
+    const char* name;
+    CompilerTarget target;
+    bool useDcx;
+    bool expectFusion;
+  };
+  const std::vector cases{
+      Case{
+          .name = "cx-only",
+          .target = makeTarget(NativeOperations::fromOperations({cx})),
+          .useDcx = false,
+          .expectFusion = false,
+      },
+      Case{
+          .name = "u-dcx",
+          .target = makeTarget(NativeOperations::fromOperations({u, dcx})),
+          .useDcx = true,
+          .expectFusion = false,
+      },
+      Case{
+          .name = "u-cx",
+          .target =
+              makeTarget(NativeOperations::fromOperations({u, cx, gphase})),
+          .useDcx = false,
+          .expectFusion = true,
+      },
+      Case{
+          .name = "unrestricted",
+          .target = makeTarget(NativeOperations::unrestricted()),
+          .useDcx = false,
+          .expectFusion = true,
+      },
+  };
+
+  for (const auto& testCase : cases) {
+    SCOPED_TRACE(testCase.name);
+    if (!testCase.expectFusion) {
+      // Cover both a missing basis and a basis without an entangler.
+      const auto basis = testCase.target.synthesisBasis();
+      EXPECT_EQ(basis.has_value(), testCase.useDcx);
+      EXPECT_FALSE(basis && basis->entangler);
+    }
+    auto ownedContext = createCompilerContext();
+    const size_t inputGateCount = testCase.useDcx ? 4 : 3;
+    auto moduleOp = QCOProgramBuilder::build(
+        ownedContext.get(), [&](QCOProgramBuilder& builder) {
+          auto q0 = builder.staticQubit(0);
+          auto q1 = builder.staticQubit(1);
+          for (size_t i = 0; i < inputGateCount; ++i) {
+            std::tie(q0, q1) =
+                testCase.useDcx ? builder.dcx(q0, q1) : builder.cx(q0, q1);
+          }
+          return builder.intConstant(0);
+        });
+    ASSERT_TRUE(verify(*moduleOp).succeeded());
+    ASSERT_TRUE(qco::verifyLinearity(*moduleOp).succeeded());
+    const TargetEnvironment environment(testCase.target,
+                                        makePayloadSpecification());
+    attachTargetEnvironment(*moduleOp, environment);
+    PassManager inputVerifier(ownedContext.get());
+    inputVerifier.addPass(qco::createVerifyTargetConformance());
+    ASSERT_TRUE(inputVerifier.run(*moduleOp).succeeded());
+    auto reference = OwningOpRef<ModuleOp>(moduleOp->clone());
+    auto program = QCOProgram::fromModule(ownedContext, std::move(moduleOp));
+    ASSERT_TRUE(program);
+
+    ASSERT_TRUE(program->compileForTarget(environment));
+    ASSERT_TRUE(verify(program->module()).succeeded());
+    ASSERT_TRUE(qco::verifyLinearity(program->module()).succeeded());
+    PassManager outputVerifier(ownedContext.get());
+    outputVerifier.addPass(qco::createVerifyTargetConformance());
+    ASSERT_TRUE(outputVerifier.run(program->module()).succeeded());
+    expectFullUnitaryEqual(*reference, program->module(), 2);
+    if (testCase.expectFusion) {
+      size_t numTwoQubitGates = 0;
+      program->module().walk([&](qco::UnitaryOpInterface unitary) {
+        numTwoQubitGates += unitary.isTwoQubit();
+      });
+      EXPECT_LT(numTwoQubitGates, inputGateCount);
+    }
+  }
 }
 
 TEST_F(CompilerPipelineTest, TargetCompilationInlinesReusableFunctions) {

--- a/mlir/unittests/Dialect/MQT/Utils/test_constant_folding.cpp
+++ b/mlir/unittests/Dialect/MQT/Utils/test_constant_folding.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
+#include "mlir/Dialect/MQT/Utils/Parameters.h"
 
 #include <gtest/gtest.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -18,17 +19,21 @@
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/Location.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/Verifier.h>
 #include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
 
 #include <cmath>
 #include <cstdint>
 #include <limits>
 #include <memory>
 #include <optional>
+#include <string>
 
 using namespace mlir;
 
@@ -217,6 +222,37 @@ TEST_F(ConstantFoldingTest, valueToConstantAttrIdentityFold) {
   const auto attr = mlir::mqt::valueToConstantAttr(op.getResult());
   ASSERT_TRUE(attr.has_value());
   EXPECT_DOUBLE_EQ(*mlir::mqt::attributeToDouble(*attr), expectedValue);
+}
+
+TEST_F(ConstantFoldingTest,
+       VerifyFiniteParametersChecksDirectAndHiddenConstants) {
+  auto finite =
+      arith::ConstantOp::create(*builder, builder->getF64FloatAttr(1.0));
+  auto nan = arith::ConstantOp::create(
+      *builder,
+      builder->getF64FloatAttr(std::numeric_limits<double>::quiet_NaN()));
+  auto cond = arith::ConstantOp::create(*builder, builder->getBoolAttr(true));
+  auto select = arith::SelectOp::create(*builder, cond, finite, nan);
+  ASSERT_TRUE(succeeded(verify(*module)));
+  ASSERT_EQ(mlir::mqt::valueToConstantDouble(select.getResult()), 1.0);
+
+  std::string diagnostic;
+  ScopedDiagnosticHandler handler(&context, [&](Diagnostic& emitted) {
+    diagnostic = emitted.str();
+    return success();
+  });
+  EXPECT_TRUE(succeeded(mlir::mqt::verifyFiniteConstantParameters(
+      module->getOperation(), {finite.getResult()})));
+  EXPECT_TRUE(diagnostic.empty());
+
+  for (Value parameter : {nan.getResult(), select.getResult()}) {
+    diagnostic.clear();
+    EXPECT_TRUE(failed(mlir::mqt::verifyFiniteConstantParameters(
+        module->getOperation(), {finite.getResult(), parameter})));
+    EXPECT_EQ(diagnostic,
+              "'builtin.module' op constant parameter expression at "
+              "index 1 must be finite");
+  }
 }
 
 TEST_F(ConstantFoldingTest, valueToConstantDoubleSharedOperandsSuccess) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir_matrix.cpp
@@ -358,6 +358,109 @@ TEST_F(QCOMatrixTest, DenseUnitaryComposesThroughModifiers) {
   EXPECT_TRUE(poweredMatrix->isApprox(
       DynamicMatrix(SOp::getUnitaryMatrix().adjoint())));
 }
+
+TEST_F(QCOMatrixTest, ModifierMatricesRespectBodyWireOrderAndArity) {
+  for (StringRef kind : {"inv", "ctrl", "pow"}) {
+    for (const size_t numTargets : {0U, 2U, 3U}) {
+      SCOPED_TRACE(kind.str() + ": " + std::to_string(numTargets));
+      auto moduleOp = QCOProgramBuilder::build(
+          context.get(), [&](QCOProgramBuilder& builder) {
+            SmallVector<Value> qubits;
+            for (size_t i = 0; i < numTargets; ++i) {
+              qubits.push_back(builder.staticQubit(i));
+            }
+            const auto body = [&](ValueRange args) -> SmallVector<Value> {
+              if (numTargets == 0) {
+                builder.gphase(0.25);
+                return {};
+              }
+              if (numTargets == 2) {
+                auto [q1, q0] = builder.dcx(args[1], args[0]);
+                return {q0, q1}; // Yield in the original wire order.
+              }
+              auto [q0, q1, q2] = builder.rccx(args[0], args[1], args[2]);
+              return {q0, q1, q2};
+            };
+            if (kind == "inv") {
+              std::ignore = builder.inv(qubits, body);
+            } else if (kind == "ctrl") {
+              std::ignore = builder.ctrl(
+                  ValueRange{builder.staticQubit(numTargets)}, qubits, body);
+            } else {
+              std::ignore = builder.pow(1.0, qubits, body);
+            }
+            return SmallVector<Value>{};
+          });
+      ASSERT_TRUE(moduleOp);
+      ASSERT_TRUE(succeeded(verify(*moduleOp)));
+      ASSERT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+
+      DynamicMatrix body;
+      if (numTargets == 0) {
+        body.assignFrom(Matrix1x1::fromElements(std::polar(1.0, 0.25)));
+      } else if (numTargets == 2) {
+        body.assignFrom(DCXOp::getUnitaryMatrix().reorderForQubits(1, 0));
+      } else {
+        // Full-width gates use the dense path rather than embedded 1Q/2Q
+        // kernels.
+        body.assignFrom(RCCXOp::getUnitaryMatrix());
+      }
+      std::optional<DynamicMatrix> actual;
+      DynamicMatrix expected;
+      if (kind == "inv") {
+        actual = firstInvOp(*moduleOp).getUnitaryMatrix();
+        expected = body.adjoint();
+      } else if (kind == "ctrl") {
+        actual = firstCtrlOp(*moduleOp).getUnitaryMatrix();
+        expected = DynamicMatrix::identity(2 * body.rows());
+        expected.setBottomRightCorner(body);
+      } else {
+        actual = firstPowOp(*moduleOp).getUnitaryMatrix();
+        expected = body;
+      }
+      ASSERT_TRUE(actual);
+      EXPECT_TRUE(actual->isApprox(expected));
+    }
+  }
+}
+
+TEST_F(QCOMatrixTest, ComposeBodyMatrixPreservesWireOrderAndPhase) {
+  for (const size_t numTargets : {2U, 3U}) {
+    SCOPED_TRACE(numTargets);
+    auto moduleOp = QCOProgramBuilder::build(
+        context.get(), [&](QCOProgramBuilder& builder) {
+          SmallVector<Value> qubits;
+          for (size_t i = 0; i < numTargets; ++i) {
+            qubits.push_back(builder.staticQubit(i));
+          }
+          std::ignore = builder.inv(qubits, [&](ValueRange args) {
+            SmallVector<Value> wires(args);
+            wires.front() = builder.h(wires.front());
+            auto afterBarrier = builder.barrier(wires);
+            wires.assign(afterBarrier.begin(), afterBarrier.end());
+            std::tie(wires.back(), wires.front()) =
+                builder.dcx(wires.back(), wires.front());
+            wires.back() = builder.ry(0.37, wires.back());
+            builder.gphase(0.25);
+            return wires;
+          });
+          return SmallVector<Value>{};
+        });
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    ASSERT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+
+    const DynamicMatrix expected =
+        RYOp::unitaryMatrix(0.37).embedInNqubit(numTargets, numTargets - 1) *
+        DCXOp::getUnitaryMatrix().embedInNqubit(numTargets, numTargets - 1, 0) *
+        HOp::getUnitaryMatrix().embedInNqubit(numTargets, 0) *
+        std::polar(1.0, 0.25);
+    const auto actual =
+        composeBodyMatrix(*firstInvOp(*moduleOp).getBody(), numTargets);
+    ASSERT_TRUE(actual);
+    EXPECT_TRUE(actual->isApprox(expected));
+  }
+}
 /// @}
 
 /// \name QCO/Modifiers/CtrlOp.cpp
@@ -406,8 +509,8 @@ TEST_F(QCOMatrixTest, ControlledInverseHTOpMatrix) {
   const auto matrix = firstCtrlOp(*moduleOp).getUnitaryMatrix();
   ASSERT_TRUE(matrix);
 
-  const auto expected = controlledMatrix(
-      (TOp::getUnitaryMatrix() * HOp::getUnitaryMatrix()).adjoint());
+  const auto body = TOp::getUnitaryMatrix() * HOp::getUnitaryMatrix();
+  const auto expected = controlledMatrix(body.adjoint());
 
   ASSERT_TRUE(matrix->isApprox(expected));
 }
@@ -701,7 +804,7 @@ TEST_F(QCOMatrixTest, PhaseProducingPowFoldsPreserveFullMatrixUnderControl) {
         })mlir";
     auto moduleOp = parseSourceString<ModuleOp>(source, context.get());
     ASSERT_TRUE(moduleOp);
-    OwningOpRef<ModuleOp> expected(cast<ModuleOp>((*moduleOp)->clone()));
+    OwningOpRef<ModuleOp> expected = moduleOp->clone();
 
     ASSERT_TRUE(runQCOCleanupPipeline(*moduleOp).succeeded());
     ASSERT_TRUE(verify(*moduleOp).succeeded());
@@ -735,7 +838,7 @@ TEST_F(QCOMatrixTest, IntegralPowUFoldsPreserveFullMatrixUnderControl) {
       return SmallVector<Value>{control, target};
     });
     ASSERT_TRUE(moduleOp);
-    OwningOpRef<ModuleOp> expected(cast<ModuleOp>((*moduleOp)->clone()));
+    OwningOpRef<ModuleOp> expected = moduleOp->clone();
 
     ASSERT_TRUE(runQCOCleanupPipeline(*moduleOp).succeeded());
     ASSERT_TRUE(verify(*moduleOp).succeeded());
@@ -772,7 +875,7 @@ TEST_F(QCOMatrixTest, RejectedPowURemainsUnchanged) {
     ASSERT_TRUE(moduleOp);
     ASSERT_TRUE(succeeded(verify(*moduleOp)));
     ASSERT_TRUE(succeeded(verifyLinearity(*moduleOp)));
-    OwningOpRef<ModuleOp> expected(cast<ModuleOp>((*moduleOp)->clone()));
+    OwningOpRef<ModuleOp> expected = moduleOp->clone();
 
     ASSERT_TRUE(runQCOCleanupPipeline(*moduleOp).succeeded());
     ASSERT_TRUE(verify(*moduleOp).succeeded());
@@ -808,7 +911,7 @@ TEST_F(QCOMatrixTest, SensitiveIntegralPowUPreservesFullMatrix) {
     ASSERT_TRUE(moduleOp);
     ASSERT_TRUE(succeeded(verify(*moduleOp)));
     ASSERT_TRUE(succeeded(verifyLinearity(*moduleOp)));
-    OwningOpRef<ModuleOp> expected(cast<ModuleOp>((*moduleOp)->clone()));
+    OwningOpRef<ModuleOp> expected = moduleOp->clone();
 
     ASSERT_TRUE(runQCOCleanupPipeline(*moduleOp).succeeded());
     ASSERT_TRUE(verify(*moduleOp).succeeded());
@@ -1015,7 +1118,7 @@ TEST_F(QCOMatrixTest, DcxCancellationPreservesOrderedOutputs) {
       return SmallVector<Value>{q0, q1};
     });
     ASSERT_TRUE(program);
-    OwningOpRef<ModuleOp> expected(cast<ModuleOp>((*program)->clone()));
+    OwningOpRef<ModuleOp> expected = program->clone();
     ASSERT_TRUE(succeeded(runQCOCleanupPipeline(*program)));
     ASSERT_TRUE(succeeded(verifyLinearity(*program)));
     ::mqt::test::expectFullUnitaryEqual(*expected, *program, 2);

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_euler_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_euler_decomposition.cpp
@@ -48,7 +48,6 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
-#include <functional>
 #include <ios>
 #include <limits>
 #include <memory>
@@ -90,7 +89,7 @@ struct TestFixture {
 
 struct ZSXXShortcutCase {
   std::string_view label;
-  std::function<Matrix2x2(MLIRContext*)> makeMatrix;
+  Matrix2x2 matrix;
   std::size_t expectedRZ;
   std::size_t expectedSX;
   std::size_t expectedX;
@@ -104,8 +103,7 @@ struct SynthesizedCircuit {
 };
 
 class EulerSynthesisExactTest
-    : public testing::TestWithParam<
-          std::tuple<SingleQubitBasis, Matrix2x2 (*)(MLIRContext*)>> {};
+    : public testing::TestWithParam<std::tuple<SingleQubitBasis, Matrix2x2>> {};
 
 } // namespace
 
@@ -134,23 +132,6 @@ static SmallVector<Value> measureAndReturn(QCOProgramBuilder& b,
   return Matrix2x2::fromElements(
       globalPhase * su2(0, 0), globalPhase * su2(0, 1), globalPhase * su2(1, 0),
       globalPhase * su2(1, 1));
-}
-
-template <typename RotationOp>
-[[nodiscard]] static Matrix2x2 rotationMatrix(MLIRContext* ctx,
-                                              const double theta) {
-  OpBuilder builder(ctx);
-  auto mlirModule = ModuleOp::create(UnknownLoc::get(ctx));
-  builder.setInsertionPointToStart(mlirModule.getBody());
-  const Location loc = mlirModule.getLoc();
-  Value q = AllocOp::create(builder, loc).getResult();
-  auto op = RotationOp::create(builder, loc, q, theta);
-  const auto matrix = op.getUnitaryMatrix();
-  if (!matrix) {
-    ADD_FAILURE() << "Expected constant unitary matrix";
-    return Matrix2x2::identity();
-  }
-  return *matrix;
 }
 
 template <typename Fn> static void forEachBasis(Fn fn) {
@@ -187,7 +168,7 @@ static WalkResult visit1QUnitaryOp(Operation* op, Matrix2x2& acc,
   }
   if (auto gphase = dyn_cast<GPhaseOp>(*op)) {
     if (auto matrix = gphase.getUnitaryMatrix()) {
-      global *= (*matrix)(0, 0);
+      global *= matrix.value()(0, 0);
     }
     return WalkResult::advance();
   }
@@ -348,21 +329,15 @@ synthesizeMatrix(MLIRContext* ctx, const Matrix2x2& matrix,
   return countBasisGates(synthesizeMatrix(ctx, segment, basis).func, basis);
 }
 
-static void checkSynthesizedReferenceExtras(MLIRContext* ctx,
-                                            func::FuncOp funcOp,
+static void checkSynthesizedReferenceExtras(func::FuncOp funcOp,
                                             SingleQubitBasis basis,
                                             const Matrix2x2& matrix) {
+  const bool isIdentity = matrix.isApprox(Matrix2x2::identity());
   if (basis == U) {
-    EXPECT_EQ(countOps<UOp>(funcOp), expectedGateCount(ctx, matrix, basis));
+    EXPECT_EQ(countOps<UOp>(funcOp), isIdentity ? 0U : 1U);
   }
-  if (!matrix.isApprox(Matrix2x2::identity())) {
-    return;
-  }
-  if (basis == ZYZ) {
+  if (basis == ZYZ && isIdentity) {
     EXPECT_EQ(countZYZGates(funcOp), 0U);
-  }
-  if (basis == U) {
-    EXPECT_EQ(countOps<UOp>(funcOp), 0U);
   }
 }
 
@@ -384,74 +359,46 @@ TEST_P(ZSXXShortcutTest, SynthesisMatchesGateCount) {
   TestFixture fx;
   fx.setUp();
   const auto& testCase = GetParam();
-  const Matrix2x2 matrix = testCase.makeMatrix(fx.ctx());
-
   expectSynthesizedMatrix(
-      fx.ctx(), matrix, ZSXX,
-      [&testCase, &fx](func::FuncOp funcOp, const Matrix2x2& original) {
+      fx.ctx(), testCase.matrix, ZSXX,
+      [&testCase](func::FuncOp funcOp, const Matrix2x2&) {
         EXPECT_EQ(countOps<RZOp>(funcOp), testCase.expectedRZ);
         EXPECT_EQ(countOps<SXOp>(funcOp), testCase.expectedSX);
         EXPECT_EQ(countOps<XOp>(funcOp), testCase.expectedX);
-        EXPECT_EQ(countZSXXGates(funcOp),
-                  expectedGateCount(fx.ctx(), original, ZSXX));
       });
 }
 
 INSTANTIATE_TEST_SUITE_P(
     ZSXXShortcuts, ZSXXShortcutTest,
     testing::Values(
-        ZSXXShortcutCase{
-            "Identity",
-            [](MLIRContext*) -> Matrix2x2 { return Matrix2x2::identity(); }, 0,
-            0, 0},
-        ZSXXShortcutCase{
-            "PauliX",
-            [](MLIRContext*) -> Matrix2x2 { return XOp::getUnitaryMatrix(); },
-            0, 0, 1},
+        ZSXXShortcutCase{"Identity", Matrix2x2::identity(), 0, 0, 0},
+        ZSXXShortcutCase{"PauliX", XOp::getUnitaryMatrix(), 0, 0, 1},
         ZSXXShortcutCase{"PureZ",
-                         [](MLIRContext*) -> Matrix2x2 {
-                           return RZOp::unitaryMatrix(0.3) *
-                                  RZOp::unitaryMatrix(0.7);
-                         },
-                         1, 0, 0},
-        ZSXXShortcutCase{"ZYZNearZeroTheta",
-                         [](MLIRContext*) -> Matrix2x2 {
-                           constexpr double tol =
-                               0.5 * mlir::mqt::PARAMETER_COMPARISON_TOLERANCE;
-                           return RZOp::unitaryMatrix(0.4) *
-                                  RYOp::unitaryMatrix(tol) *
-                                  RZOp::unitaryMatrix(0.3);
-                         },
-                         1, 0, 0},
+                         RZOp::unitaryMatrix(0.3) * RZOp::unitaryMatrix(0.7), 1,
+                         0, 0},
+        ZSXXShortcutCase{
+            "ZYZNearZeroTheta",
+            RZOp::unitaryMatrix(0.4) *
+                RYOp::unitaryMatrix(0.5 *
+                                    mlir::mqt::PARAMETER_COMPARISON_TOLERANCE) *
+                RZOp::unitaryMatrix(0.3),
+            1, 0, 0},
         ZSXXShortcutCase{"RYHalfPi",
-                         [](MLIRContext* ctx) -> Matrix2x2 {
-                           return rotationMatrix<RYOp>(ctx,
-                                                       std::numbers::pi / 2.0);
-                         },
+                         RYOp::unitaryMatrix(std::numbers::pi / 2.0), 2, 1, 0},
+        ZSXXShortcutCase{"RYNearHalfPi",
+                         RYOp::unitaryMatrix(
+                             (std::numbers::pi / 2.0) +
+                             (0.5 * mlir::mqt::PARAMETER_COMPARISON_TOLERANCE)),
                          2, 1, 0},
-        ZSXXShortcutCase{
-            "RYNearHalfPi",
-            [](MLIRContext* ctx) -> Matrix2x2 {
-              return rotationMatrix<RYOp>(
-                  ctx, (std::numbers::pi / 2.0) +
-                           (0.5 * mlir::mqt::PARAMETER_COMPARISON_TOLERANCE));
-            },
-            2, 1, 0},
         ZSXXShortcutCase{"RYNearZero",
-                         [](MLIRContext* ctx) -> Matrix2x2 {
-                           return rotationMatrix<RYOp>(
-                               ctx,
-                               0.5 * mlir::mqt::PARAMETER_COMPARISON_TOLERANCE);
-                         },
+                         RYOp::unitaryMatrix(
+                             0.5 * mlir::mqt::PARAMETER_COMPARISON_TOLERANCE),
                          0, 0, 0},
-        ZSXXShortcutCase{
-            "RYNearPi",
-            [](MLIRContext* ctx) -> Matrix2x2 {
-              return rotationMatrix<RYOp>(
-                  ctx, std::numbers::pi -
-                           (0.5 * mlir::mqt::PARAMETER_COMPARISON_TOLERANCE));
-            },
-            1, 0, 1}),
+        ZSXXShortcutCase{"RYNearPi",
+                         RYOp::unitaryMatrix(
+                             std::numbers::pi -
+                             (0.5 * mlir::mqt::PARAMETER_COMPARISON_TOLERANCE)),
+                         1, 0, 1}),
     [](const testing::TestParamInfo<ZSXXShortcutCase>& info) {
       return std::string(info.param.label);
     });
@@ -459,38 +406,22 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(EulerSynthesisExactTest, ReconstructsReferenceMatrices) {
   TestFixture fx;
   fx.setUp();
-  const auto [basis, matrixFn] = GetParam();
-  const Matrix2x2 original = matrixFn(fx.ctx());
+  const auto& [basis, original] = GetParam();
   expectSynthesizedMatrix(
       fx.ctx(), original, basis,
-      [&fx, basis](func::FuncOp funcOp, const Matrix2x2& matrix) {
-        checkSynthesizedReferenceExtras(fx.ctx(), funcOp, basis, matrix);
+      [basis](func::FuncOp funcOp, const Matrix2x2& matrix) {
+        checkSynthesizedReferenceExtras(funcOp, basis, matrix);
       });
 }
 
 INSTANTIATE_TEST_SUITE_P(
     SingleQubitMatrices, EulerSynthesisExactTest,
-    testing::Combine(testing::Values(ZYZ, ZXZ, XZX, XYX, U, ZSXX),
-                     testing::Values(
-                         [](MLIRContext* /*ctx*/) -> Matrix2x2 {
-                           return Matrix2x2::identity();
-                         },
-                         [](MLIRContext* ctx) -> Matrix2x2 {
-                           return rotationMatrix<RYOp>(ctx, 2.0);
-                         },
-                         [](MLIRContext* ctx) -> Matrix2x2 {
-                           return rotationMatrix<RYOp>(ctx,
-                                                       std::numbers::pi / 2.0);
-                         },
-                         [](MLIRContext* ctx) -> Matrix2x2 {
-                           return rotationMatrix<RXOp>(ctx, 0.5);
-                         },
-                         [](MLIRContext* ctx) -> Matrix2x2 {
-                           return rotationMatrix<RZOp>(ctx, 3.14);
-                         },
-                         [](MLIRContext* /*ctx*/) -> Matrix2x2 {
-                           return HOp::getUnitaryMatrix();
-                         })));
+    testing::Combine(
+        testing::Values(ZYZ, ZXZ, XZX, XYX, U, ZSXX),
+        testing::Values(Matrix2x2::identity(), RYOp::unitaryMatrix(2.0),
+                        RYOp::unitaryMatrix(std::numbers::pi / 2.0),
+                        RXOp::unitaryMatrix(0.5), RZOp::unitaryMatrix(3.14),
+                        HOp::getUnitaryMatrix())));
 
 TEST(EulerSynthesisTest, RandomReconstructionAllBases) {
   TestFixture fx;
@@ -656,7 +587,8 @@ template <typename ParentOp>
     ADD_FAILURE() << "Expected parent op in function";
     return Matrix2x2::fromElements(0, 0, 0, 0);
   }
-  return compute1QUnitaryMatrix((*parents.begin()).getRegion());
+  auto parent = *parents.begin();
+  return compute1QUnitaryMatrix(parent.getRegion());
 }
 
 static void expectBasisGatesOnly(func::FuncOp funcOp, StringRef basis) {
@@ -1160,7 +1092,7 @@ TEST(FuseSingleQubitUnitaryRunsTest, PreservesUnboundedShortSameAxisRun) {
        }) {
     SCOPED_TRACE(testing::Message()
                  << "angles=" << firstAngle << ", " << secondAngle);
-    OwningOpRef<ModuleOp> bound(cast<ModuleOp>((*owned)->clone()));
+    OwningOpRef<ModuleOp> bound = owned->clone();
     auto boundFunc = bound->lookupSymbol<func::FuncOp>("main");
     bindLeadingArguments(boundFunc, {firstAngle, secondAngle});
     ASSERT_TRUE(succeeded(canonicalizeBoundValues(*bound)));
@@ -1334,15 +1266,84 @@ TEST(FuseSingleQubitUnitaryRunsTest,
   }
 }
 
+TEST(FuseSingleQubitUnitaryRunsTest, DirectlySynthesizesCardinalAxesInRBasis) {
+  TestFixture fx;
+  fx.setUp();
+  for (const auto& gateCase : DYNAMIC_GATE_CASES) {
+    if (gateCase.name != "rx" && gateCase.name != "ry") {
+      continue;
+    }
+    SCOPED_TRACE(gateCase.name.str());
+    auto owned = QCOProgramBuilder::build(
+        fx.ctx(), [build = gateCase.build](QCOProgramBuilder& b) {
+          auto q = b.allocQubitRegister(1);
+          q[0] = build(b, q[0]);
+          return measureAndReturn(b, q.qubits);
+        });
+    ASSERT_TRUE(owned);
+    auto funcOp = owned->lookupSymbol<func::FuncOp>("main");
+    ASSERT_TRUE(funcOp);
+    funcOp.insertArgument(0, Float64Type::get(fx.ctx()), {}, funcOp.getLoc());
+    UnitaryOpInterface gate;
+    funcOp.walk([&](UnitaryOpInterface op) {
+      if (op.getBaseSymbol() == gateCase.name) {
+        gate = op;
+      }
+    });
+    ASSERT_TRUE(gate);
+    gate.getParameter(0).replaceAllUsesWith(funcOp.getArgument(0));
+    ASSERT_TRUE(succeeded(verify(*owned)));
+    IRRewriter rewriter(fx.ctx());
+    synthesizeParameterizedUnitary1Q(rewriter, gate.getOperation(), R);
+    ASSERT_TRUE(succeeded(verify(*owned)));
+    ASSERT_EQ(countOps<ROp>(funcOp), 1U);
+    EXPECT_EQ(countOps<GPhaseOp>(funcOp), 0U);
+    funcOp.walk(
+        [&](ROp op) { EXPECT_EQ(op.getTheta(), funcOp.getArgument(0)); });
+    // A known axis needs no runtime arithmetic or angle extraction.
+    funcOp.walk([](Operation* op) {
+      EXPECT_NE(op->getName().getDialectNamespace(), "math");
+      if (op->getName().getDialectNamespace() == "arith") {
+        EXPECT_TRUE(isa<arith::ConstantOp>(op));
+      }
+    });
+    for (double angle : {
+             0.0,
+             -0.0,
+             1e-8,
+             0.37,
+             std::numbers::pi,
+             -std::numbers::pi,
+             2.0 * std::numbers::pi,
+         }) {
+      SCOPED_TRACE(angle);
+      OwningOpRef<ModuleOp> bound = owned->clone();
+      auto boundFunc = bound->lookupSymbol<func::FuncOp>("main");
+      bindLeadingArguments(boundFunc, {angle});
+      ASSERT_TRUE(succeeded(canonicalizeBoundValues(*bound)));
+      ASSERT_TRUE(succeeded(verify(*bound)));
+      const Matrix2x2 expected = gateCase.name == "rx"
+                                     ? RXOp::unitaryMatrix(angle)
+                                     : RYOp::unitaryMatrix(angle);
+      EXPECT_TRUE(compute1QUnitaryMatrix(boundFunc.getBody())
+                      .isApprox(expected, 1e-12));
+    }
+  }
+}
+
 TEST(FuseSingleQubitUnitaryRunsTest,
-     FusesStandaloneDynamicUAtTransformedBasisSingularities) {
+     FusesStandaloneDynamicUAtSmallAnglesAndTransformedBasisSingularities) {
   TestFixture fx;
   fx.setUp();
   constexpr std::array<const char*, 3> bases = {"xzx", "xyx", "r"};
-  constexpr std::array<std::array<double, 3>, 2> singularParameterSets{
+  constexpr std::array<std::array<double, 3>, 6> singularParameterSets{
       {
           {0.0, 0.0, 0.0},
           {std::numbers::pi, 0.0, 0.0},
+          {1e-8, -0.3, 0.7},
+          {0.0, std::numbers::pi, -std::numbers::pi},
+          {std::numbers::pi, 0.3, -0.4},
+          {-std::numbers::pi, std::numbers::pi, -std::numbers::pi},
       },
   };
   constexpr size_t numParameters = singularParameterSets.front().size();

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
@@ -41,6 +41,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <complex>
 #include <cstddef>
@@ -58,7 +59,7 @@ using namespace mlir::qco;
 
 /// DD for k=2…20 plus the first HP24 width (k=33): full matrix DD through k=8
 /// (MCX/MCY/MCZ) or k=6 (MCP); basis-state DD for larger Pauli widths;
-/// coherent-state DD at selected policy boundaries and representative larger
+/// coherent-state DD at SP22/HP24 boundaries and representative larger
 /// MCP widths.
 static constexpr std::array<size_t, 20> K_DD_CONTROL_COUNTS = {
     2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 33,
@@ -79,45 +80,21 @@ static constexpr std::array<size_t, 13> K_SMOKE_CONTROL_COUNTS = {
 };
 
 /// Expected elementary Ctrl@X counts after default `min-qubits=3` lowering.
-/// Indexed by control count `k`; unused slots are zero.
+/// Defined for control counts through the first HP24 width, k=33.
 /// For `5 ≤ k ≤ 32`, MCX uses SP22 MCP(π); each CRX expands to 2 Ctrl@X while
 /// CP stays as Ctrl@P, so elementary CX is `4k² − 8k + 4`. k=33 is the first
 /// HP24 width (pinned measured CX).
-static constexpr std::array<size_t, 34> K_EXPECTED_MCX_CX = {
-    0,    0,
-    6,    // 2
-    14,   // 3
-    20,   // 4
-    64,   // 5  SP22
-    100,  // 6
-    144,  // 7
-    196,  // 8
-    256,  // 9
-    324,  // 10
-    400,  // 11
-    484,  // 12
-    576,  // 13
-    676,  // 14
-    784,  // 15
-    900,  // 16
-    1024, // 17
-    1156, // 18
-    1296, // 19
-    1444, // 20
-    1600, // 21
-    1764, // 22
-    1936, // 23
-    2116, // 24
-    2304, // 25
-    2500, // 26
-    2704, // 27
-    2916, // 28
-    3136, // 29
-    3364, // 30
-    3600, // 31
-    3844, // 32  SP22 max
-    3872, // 33  HP24
-};
+[[nodiscard]] static constexpr size_t expectedMcxCx(size_t k) {
+  assert(k <= 33);
+  if (k == 33) {
+    return 3872;
+  }
+  if (k >= 5) {
+    return 4 * (k - 1) * (k - 1);
+  }
+  constexpr std::array<size_t, 5> small = {0, 0, 6, 14, 20};
+  return small[k];
+}
 
 /// Effective CX for MCP: elementary Ctrl@X plus ~2 CX per leftover
 /// single-controlled P. For `k >= 5` this matches the SP22 LDD bound
@@ -762,7 +739,7 @@ TEST_P(McPauliDdTest, EquivalenceAndCxCount) {
   ASSERT_TRUE(runDecomposeMultiControlled(moduleOp.get()).succeeded());
   expectFullyLowered(moduleOp.get());
   // MCY and MCZ share MCX's CX budget; their basis changes add no CX.
-  EXPECT_EQ(countElementaryCxOps(moduleOp.get()), K_EXPECTED_MCX_CX[k])
+  EXPECT_EQ(countElementaryCxOps(moduleOp.get()), expectedMcxCx(k))
       << "k=" << k;
 
   auto funcOp = *moduleOp->getBody()->getOps<func::FuncOp>().begin();
@@ -847,7 +824,7 @@ TEST_P(McPauliSmokeTest, FullyLowersWithExpectedCx) {
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(runDecomposeMultiControlled(moduleOp.get()).succeeded());
   expectFullyLowered(moduleOp.get());
-  EXPECT_EQ(countElementaryCxOps(moduleOp.get()), K_EXPECTED_MCX_CX[k])
+  EXPECT_EQ(countElementaryCxOps(moduleOp.get()), expectedMcxCx(k))
       << "k=" << k;
 }
 
@@ -1157,7 +1134,7 @@ TEST_F(MultiControlledDecompositionTest, PhasePiRoutesThroughMcz) {
           << "k=" << k << " theta=" << theta;
       expectFullyLowered(moduleOp.get());
       // ±π must take the Z path, so CX counts match MCZ/MCX.
-      EXPECT_EQ(countElementaryCxOps(moduleOp.get()), K_EXPECTED_MCX_CX[k])
+      EXPECT_EQ(countElementaryCxOps(moduleOp.get()), expectedMcxCx(k))
           << "k=" << k << " theta=" << theta;
       auto funcOp = *moduleOp->getBody()->getOps<func::FuncOp>().begin();
       expectImplementsMcp(funcOp, k, theta);

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_weyl_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_weyl_decomposition.cpp
@@ -10,6 +10,7 @@
 
 #include "dd/Package.hpp"
 #include "mlir/Compiler/Target.h"
+#include "mlir/Dialect/MQT/Utils/DenseUnitary.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 #include "mlir/Dialect/QCO/Transforms/Decomposition/Euler.h"
@@ -222,13 +223,13 @@ protected:
   void SetUp() override {
     basisMatrix = std::get<0>(GetParam())();
     target = std::get<1>(GetParam())();
-    targetDecomposition = std::make_unique<TwoQubitWeylDecomposition>(
-        TwoQubitWeylDecomposition::create(target, 1.0));
+    targetDecomposition = TwoQubitWeylDecomposition::create(target, 1.0);
+    ASSERT_TRUE(targetDecomposition.has_value());
   }
 
   Matrix4x4 target;
   Matrix4x4 basisMatrix;
-  std::unique_ptr<TwoQubitWeylDecomposition> targetDecomposition;
+  std::optional<TwoQubitWeylDecomposition> targetDecomposition;
 };
 
 } // namespace
@@ -238,8 +239,9 @@ TEST_P(WeylDecompositionTest, ReconstructsWithinRequestedFidelity) {
   for (const double fidelity : {1.0, WEYL_DEFAULT_FIDELITY}) {
     const auto decomposition =
         TwoQubitWeylDecomposition::create(originalMatrix, fidelity);
-    EXPECT_TRUE(
-        decomposition.unitaryMatrix().isApprox(originalMatrix, WEYL_TOLERANCE));
+    ASSERT_TRUE(decomposition.has_value());
+    EXPECT_TRUE(decomposition->unitaryMatrix().isApprox(originalMatrix,
+                                                        WEYL_TOLERANCE));
   }
 }
 
@@ -247,15 +249,16 @@ TEST(WeylDecompositionStandalone,
      CnotProducesValidWeylParametersAndUnitaryLocals) {
   const auto decomp =
       TwoQubitWeylDecomposition::create(TWO_QUBIT_CONTROLLED_X01, std::nullopt);
+  ASSERT_TRUE(decomp.has_value());
   constexpr double piOver4 = 0.7853981633974483;
-  for (const double angle : {decomp.a(), decomp.b(), decomp.c()}) {
+  for (const double angle : {decomp->a(), decomp->b(), decomp->c()}) {
     EXPECT_GE(angle, -1e-10);
     EXPECT_LE(angle, piOver4 + 1e-10);
   }
-  EXPECT_TRUE(isUnitaryMatrix(decomp.k1l()));
-  EXPECT_TRUE(isUnitaryMatrix(decomp.k2l()));
-  EXPECT_TRUE(isUnitaryMatrix(decomp.k1r()));
-  EXPECT_TRUE(isUnitaryMatrix(decomp.k2r()));
+  EXPECT_TRUE(isUnitaryMatrix(decomp->k1l()));
+  EXPECT_TRUE(isUnitaryMatrix(decomp->k2l()));
+  EXPECT_TRUE(isUnitaryMatrix(decomp->k1r()));
+  EXPECT_TRUE(isUnitaryMatrix(decomp->k2r()));
 }
 
 TEST(WeylDecompositionStandalone, Random) {
@@ -264,9 +267,38 @@ TEST(WeylDecompositionStandalone, Random) {
     const Matrix4x4 originalMatrix = randomUnitary4x4(rng);
     const auto decomposition = TwoQubitWeylDecomposition::create(
         originalMatrix, std::optional<double>{WEYL_DEFAULT_FIDELITY});
-    EXPECT_TRUE(
-        decomposition.unitaryMatrix().isApprox(originalMatrix, WEYL_TOLERANCE));
+    ASSERT_TRUE(decomposition.has_value());
+    EXPECT_TRUE(decomposition->unitaryMatrix().isApprox(originalMatrix,
+                                                        WEYL_TOLERANCE));
   }
+}
+
+TEST(WeylDecompositionStandalone, NearUnitaryNonconvergenceReturnsFailure) {
+  auto target = Matrix4x4::identity();
+  target(0, 3) = 4e-11;
+  ASSERT_TRUE(isUnitaryMatrix(target, mqt::DENSE_UNITARY_TOLERANCE));
+
+  EXPECT_FALSE(TwoQubitWeylDecomposition::create(target, std::nullopt));
+  EXPECT_FALSE(
+      TwoQubitWeylDecomposition::create(target, WEYL_DEFAULT_FIDELITY));
+  EXPECT_FALSE(decomposeTwoQubitWithBasis(target, TWO_QUBIT_CONTROLLED_X01));
+  EXPECT_FALSE(decomposeUnitary2QWeyl(target, CompilerTarget::GateKind::CX));
+  EXPECT_FALSE(
+      decomposeUnitary2QWeyl(target, CompilerTarget::GateKind::SQRTISWAP));
+}
+
+TEST(WeylDecompositionStandalone,
+     NearUnitaryReconstructionFailureReturnsFailure) {
+  auto target = Matrix4x4::identity();
+  target(0, 0) += 4e-11;
+  ASSERT_TRUE(isUnitaryMatrix(target, mqt::DENSE_UNITARY_TOLERANCE));
+
+  // Its real symmetric M2 can be diagonalized, but the normalized local
+  // factors cannot reconstruct the input within the Weyl tolerance.
+  EXPECT_FALSE(TwoQubitWeylDecomposition::create(target, std::nullopt));
+  EXPECT_FALSE(decomposeUnitary2QWeyl(target, CompilerTarget::GateKind::CX));
+  EXPECT_FALSE(
+      decomposeUnitary2QWeyl(target, CompilerTarget::GateKind::SQRTISWAP));
 }
 
 INSTANTIATE_TEST_SUITE_P(ProductTwoQubitMatrices, WeylDecompositionTest,
@@ -300,10 +332,11 @@ TEST(BasisDecomposerTest, Random) {
     const Matrix4x4 originalMatrix = randomUnitary4x4(rng);
     const auto targetDecomposition = TwoQubitWeylDecomposition::create(
         originalMatrix, std::optional<double>{1.0});
+    ASSERT_TRUE(targetDecomposition.has_value());
     const Matrix4x4 basisMatrix = basisMatrices[distBasisGate(rng)];
     const auto decomposer = TwoQubitBasisDecomposer::create(basisMatrix, 1.0);
     const auto decomposed =
-        decomposer.twoQubitDecompose(targetDecomposition, std::nullopt);
+        decomposer.twoQubitDecompose(*targetDecomposition, std::nullopt);
     ASSERT_TRUE(decomposed.has_value());
     EXPECT_TRUE(unitaryMatrix(*decomposed, basisMatrix)
                     .isApprox(originalMatrix, WEYL_TOLERANCE));
@@ -315,11 +348,25 @@ TEST(BasisDecomposerNumBasisTest, ForcesZeroBasisUsesForIdentityTarget) {
   const auto decomposer = TwoQubitBasisDecomposer::create(basis, 1.0);
   const Matrix4x4 target = Matrix4x4::identity();
   const auto weyl = TwoQubitWeylDecomposition::create(target, 1.0);
-  const auto decomposed = decomposer.twoQubitDecompose(weyl, std::uint8_t{0});
+  ASSERT_TRUE(weyl.has_value());
+  const auto decomposed = decomposer.twoQubitDecompose(*weyl, std::uint8_t{0});
   ASSERT_TRUE(decomposed.has_value());
   EXPECT_EQ(decomposed->numBasisUses, 0);
   EXPECT_TRUE(
       unitaryMatrix(*decomposed, basis).isApprox(target, WEYL_TOLERANCE));
+}
+
+TEST(BasisDecomposerNumBasisTest, PrefersZeroBasisUsesForIdentityTarget) {
+  const Matrix4x4 basis = TWO_QUBIT_CONTROLLED_X01;
+  const Matrix4x4 target = Matrix4x4::identity();
+  for (double fidelity : {0.0, 1.0}) {
+    const auto decomposer = TwoQubitBasisDecomposer::create(basis, fidelity);
+    const auto decomposed = decomposer.decomposeTarget(target);
+    ASSERT_TRUE(decomposed.has_value());
+    EXPECT_EQ(decomposed->numBasisUses, 0);
+    EXPECT_TRUE(
+        unitaryMatrix(*decomposed, basis).isApprox(target, WEYL_TOLERANCE));
+  }
 }
 
 TEST(BasisDecomposerTest, DecomposeTwoQubitWithBasisReconstructsTarget) {
@@ -363,7 +410,9 @@ TEST(BasisDecomposerTest, RejectsMultipleBasisUsesForNonSuperControlledBasis) {
   const auto decomposer = TwoQubitBasisDecomposer::create(basis, 1.0);
   const auto weyl =
       TwoQubitWeylDecomposition::create(Matrix4x4::identity(), 1.0);
-  EXPECT_FALSE(decomposer.twoQubitDecompose(weyl, std::uint8_t{2}).has_value());
+  ASSERT_TRUE(weyl.has_value());
+  EXPECT_FALSE(
+      decomposer.twoQubitDecompose(*weyl, std::uint8_t{2}).has_value());
 }
 
 TEST(BasisDecomposerTest, RejectsInvalidBasisGateUseCount) {
@@ -371,7 +420,9 @@ TEST(BasisDecomposerTest, RejectsInvalidBasisGateUseCount) {
   const auto decomposer = TwoQubitBasisDecomposer::create(basis, 1.0);
   const auto weyl =
       TwoQubitWeylDecomposition::create(TWO_QUBIT_CONTROLLED_X01, 1.0);
-  EXPECT_FALSE(decomposer.twoQubitDecompose(weyl, std::uint8_t{4}).has_value());
+  ASSERT_TRUE(weyl.has_value());
+  EXPECT_FALSE(
+      decomposer.twoQubitDecompose(*weyl, std::uint8_t{4}).has_value());
 }
 
 TEST(BasisDecomposerForcedCountTest, OneBasisUseProducesFactors) {
@@ -379,7 +430,8 @@ TEST(BasisDecomposerForcedCountTest, OneBasisUseProducesFactors) {
   const auto decomposer = TwoQubitBasisDecomposer::create(basis, 1.0);
   const auto weyl =
       TwoQubitWeylDecomposition::create(TWO_QUBIT_CONTROLLED_X01, 1.0);
-  const auto decomposed = decomposer.twoQubitDecompose(weyl, std::uint8_t{1});
+  ASSERT_TRUE(weyl.has_value());
+  const auto decomposed = decomposer.twoQubitDecompose(*weyl, std::uint8_t{1});
   ASSERT_TRUE(decomposed.has_value());
   EXPECT_EQ(decomposed->numBasisUses, 1);
   EXPECT_EQ(decomposed->singleQubitFactors.size(),
@@ -391,7 +443,8 @@ TEST(BasisDecomposerForcedCountTest, TwoBasisUsesProducesFactors) {
   const auto decomposer = TwoQubitBasisDecomposer::create(basis, 1.0);
   const auto weyl =
       TwoQubitWeylDecomposition::create(TWO_QUBIT_CONTROLLED_X01, 1.0);
-  const auto decomposed = decomposer.twoQubitDecompose(weyl, std::uint8_t{2});
+  ASSERT_TRUE(weyl.has_value());
+  const auto decomposed = decomposer.twoQubitDecompose(*weyl, std::uint8_t{2});
   ASSERT_TRUE(decomposed.has_value());
   EXPECT_EQ(decomposed->numBasisUses, 2);
   EXPECT_EQ(decomposed->singleQubitFactors.size(),
@@ -403,7 +456,8 @@ TEST(BasisDecomposerForcedCountTest, ThreeBasisUsesProducesFactors) {
   const auto decomposer = TwoQubitBasisDecomposer::create(basis, 1.0);
   const auto weyl =
       TwoQubitWeylDecomposition::create(TWO_QUBIT_CONTROLLED_X01, 1.0);
-  const auto decomposed = decomposer.twoQubitDecompose(weyl, std::uint8_t{3});
+  ASSERT_TRUE(weyl.has_value());
+  const auto decomposed = decomposer.twoQubitDecompose(*weyl, std::uint8_t{3});
   ASSERT_TRUE(decomposed.has_value());
   EXPECT_EQ(decomposed->numBasisUses, 3);
   EXPECT_EQ(decomposed->singleQubitFactors.size(),
@@ -416,8 +470,9 @@ TEST(WeylDecompositionStandalone, SwapNegativeCSpecializationReconstructs) {
       TwoQubitWeylDecomposition::getCanonicalMatrix(piOver4, piOver4, -piOver4);
   const auto decomposition =
       TwoQubitWeylDecomposition::create(swapNegativeC, 1.0);
+  ASSERT_TRUE(decomposition.has_value());
   EXPECT_TRUE(
-      decomposition.unitaryMatrix().isApprox(swapNegativeC, WEYL_TOLERANCE));
+      decomposition->unitaryMatrix().isApprox(swapNegativeC, WEYL_TOLERANCE));
 }
 
 TEST(WeylDecompositionStandalone, ControlledSpecializationReconstructs) {
@@ -427,8 +482,9 @@ TEST(WeylDecompositionStandalone, ControlledSpecializationReconstructs) {
       Matrix4x4::kron(Matrix2x2::identity(), RZOp::unitaryMatrix(0.2));
   const auto decomposition =
       TwoQubitWeylDecomposition::create(controlledLike, 1.0);
+  ASSERT_TRUE(decomposition.has_value());
   EXPECT_TRUE(
-      decomposition.unitaryMatrix().isApprox(controlledLike, WEYL_TOLERANCE));
+      decomposition->unitaryMatrix().isApprox(controlledLike, WEYL_TOLERANCE));
 }
 
 INSTANTIATE_TEST_SUITE_P(ProductTwoQubitMatrices, BasisDecomposerTest,
@@ -464,9 +520,13 @@ computeTwoQubitUnitaryFromFunc(func::FuncOp funcOp) {
   return matrix;
 }
 
-[[nodiscard]] static Synthesized2QCircuit
+[[nodiscard]] static FailureOr<Synthesized2QCircuit>
 synthesize2QMatrix(MLIRContext* ctx, const Matrix4x4& target,
                    const CompilerTarget::SynthesisBasis basis) {
+  const auto decomposition = decomposeUnitary2QWeyl(target, *basis.entangler);
+  if (!decomposition) {
+    return failure();
+  }
   OwningOpRef mlirModule = ModuleOp::create(UnknownLoc::get(ctx));
   OpBuilder builder(ctx);
   builder.setInsertionPointToStart(mlirModule->getBody());
@@ -479,22 +539,25 @@ synthesize2QMatrix(MLIRContext* ctx, const Matrix4x4& target,
   auto* entry = func.addEntryBlock();
 
   builder.setInsertionPointToStart(entry);
-  const auto decomposition = decomposeUnitary2QWeyl(target, *basis.entangler);
   const auto synthesized =
       emitUnitary2QWeyl(builder, loc, entry->getArgument(0),
-                        entry->getArgument(1), decomposition, basis);
+                        entry->getArgument(1), *decomposition, basis);
   emitGPhaseIfNeeded(builder, loc, synthesized.globalPhase);
   func::ReturnOp::create(builder, loc,
                          ValueRange{synthesized.qubit0, synthesized.qubit1});
-  return {.mlirModule = std::move(mlirModule), .func = func};
+  return Synthesized2QCircuit{
+      .mlirModule = std::move(mlirModule),
+      .func = func,
+  };
 }
 
 static void
 expectSynthesized2QMatrix(MLIRContext* ctx, const Matrix4x4& target,
                           const CompilerTarget::SynthesisBasis basis) {
   const auto circuit = synthesize2QMatrix(ctx, target, basis);
-  ASSERT_TRUE(succeeded(verify(*circuit.mlirModule)));
-  const auto actual = computeTwoQubitUnitaryFromFunc(circuit.func);
+  ASSERT_TRUE(succeeded(circuit));
+  ASSERT_TRUE(succeeded(verify(*circuit->mlirModule)));
+  const auto actual = computeTwoQubitUnitaryFromFunc(circuit->func);
   ASSERT_TRUE(succeeded(actual));
   EXPECT_TRUE(actual->isApprox(target, WEYL_TOLERANCE));
 }
@@ -614,7 +677,8 @@ TEST(WeylSynthesisTest, IdentityRequiresNoEntanglers) {
        }) {
     const auto native =
         decomposeUnitary2QWeyl(Matrix4x4::identity(), entangler);
-    EXPECT_EQ(native.numBasisUses, 0U);
+    ASSERT_TRUE(native.has_value());
+    EXPECT_EQ(native->numBasisUses, 0U);
   }
 }
 
@@ -662,12 +726,13 @@ TEST(SqrtISwap, ChamberGridWithLocalFactorsAndPhase) {
         const auto result =
             decomposeUnitary2QWeyl(target, CompilerTarget::GateKind::SQRTISWAP);
         SCOPED_TRACE(::testing::Message() << a << "," << b << "," << c);
+        ASSERT_TRUE(result.has_value());
         const int expected = a == 0                                         ? 0
                              : (a == steps / 2 && b == steps / 2 && c == 0) ? 1
                              : a >= b + std::abs(c)                         ? 2
                                                                             : 3;
-        EXPECT_EQ(result.numBasisUses, expected);
-        EXPECT_TRUE(reconstructSqrtISwap(result).isApprox(target, 1e-8));
+        EXPECT_EQ(result->numBasisUses, expected);
+        EXPECT_TRUE(reconstructSqrtISwap(*result).isApprox(target, 1e-8));
       }
     }
   }
@@ -692,7 +757,8 @@ TEST(SqrtISwap, NearChamberBoundaries) {
       SCOPED_TRACE(::testing::Message()
                    << coordinates[0] << "," << coordinates[1] << ","
                    << coordinates[2] << " eps=" << epsilon);
-      EXPECT_TRUE(reconstructSqrtISwap(result).isApprox(target, 1e-9));
+      ASSERT_TRUE(result.has_value());
+      EXPECT_TRUE(reconstructSqrtISwap(*result).isApprox(target, 1e-9));
     }
   }
 }
@@ -726,10 +792,11 @@ TEST(SqrtISwap, RandomInteractionsAndLocalFactors) {
     const auto result =
         decomposeUnitary2QWeyl(target, CompilerTarget::GateKind::SQRTISWAP);
     SCOPED_TRACE(i);
-    EXPECT_EQ(result.numBasisUses,
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->numBasisUses,
               coordinates[0] >= coordinates[1] + std::abs(coordinates[2]) ? 2
                                                                           : 3);
-    EXPECT_TRUE(reconstructSqrtISwap(result).isApprox(target, 1e-9));
+    EXPECT_TRUE(reconstructSqrtISwap(*result).isApprox(target, 1e-9));
   }
 }
 
@@ -747,8 +814,9 @@ TEST(SqrtISwap, PreservesSmallInteractions) {
       SCOPED_TRACE(::testing::Message()
                    << coordinates[0] << "," << coordinates[1] << ","
                    << coordinates[2]);
+      ASSERT_TRUE(result.has_value());
       EXPECT_TRUE(
-          reconstructSqrtISwap(result).isApprox(target, WEYL_TOLERANCE));
+          reconstructSqrtISwap(*result).isApprox(target, WEYL_TOLERANCE));
     }
   }
 }

--- a/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(
           GTest::gtest_main
           MQTCompilerTarget
           MLIRQCOProgramBuilder
-          MLIRQCODDFunctionality
+          MLIRExactUnitaryTest
           MLIRQCOUtils
           MLIRQCOTransforms
           MLIRPass

--- a/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
@@ -8,8 +8,7 @@
  * Licensed under the MIT License
  */
 
-#include "dd/DDDefinitions.hpp"
-#include "dd/Package.hpp"
+#include "ExactUnitaryTest.h"
 #include "mlir/Compiler/Target.h"
 #include "mlir/Compiler/TargetEnvironment.h"
 #include "mlir/Dialect/MQT/IR/MQTDialect.h"
@@ -19,11 +18,11 @@
 #include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QCO/Transforms/Mapping/Mapping.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
-#include "mlir/Dialect/QCO/Utils/DDFunctionality.h"
 #include "mlir/Dialect/QCO/Utils/Matrix.h"
 #include "mlir/Dialect/QTensor/IR/QTensorDialect.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
 #include <llvm/Support/Error.h>
 #include <llvm/Support/raw_ostream.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -102,41 +101,13 @@ template <class T> [[nodiscard]] static T valid(llvm::Expected<T> value) {
   return numQubits;
 }
 
-[[nodiscard]] static mlir::qco::DynamicMatrix
-matrixFromDD(const dd::CMat& matrix) {
-  const auto dimension = static_cast<int64_t>(matrix.size());
-  mlir::qco::DynamicMatrix result(dimension);
-  for (int64_t row = 0; row < dimension; ++row) {
-    for (int64_t column = 0; column < dimension; ++column) {
-      result(row, column) =
-          matrix[static_cast<size_t>(row)][static_cast<size_t>(column)];
-    }
-  }
-  return result;
-}
-
 static void expectEquivalent(const OwningOpRef<ModuleOp>& expected,
                              const OwningOpRef<ModuleOp>& actual) {
-  auto expectedFunction = mainFunction(*expected);
-  auto actualFunction = mainFunction(*actual);
-  const auto numQubits = countStaticQubits(expectedFunction);
-  ASSERT_EQ(numQubits, countStaticQubits(actualFunction));
+  const auto numQubits = countStaticQubits(mainFunction(*expected));
+  ASSERT_EQ(numQubits, countStaticQubits(mainFunction(*actual)));
   ASSERT_GT(numQubits, 0U);
-
-  auto package = std::make_unique<dd::Package>(numQubits);
-  const auto expectedUnitary =
-      mlir::qco::buildFunctionality(expectedFunction, *package);
-  ASSERT_TRUE(mlir::succeeded(expectedUnitary));
-  const auto actualUnitary =
-      mlir::qco::buildFunctionality(actualFunction, *package);
-  ASSERT_TRUE(mlir::succeeded(actualUnitary));
-
-  const auto expectedMatrix =
-      matrixFromDD(expectedUnitary->getMatrix(numQubits));
-  const auto actualMatrix = matrixFromDD(actualUnitary->getMatrix(numQubits));
-  package->decRef(*expectedUnitary);
-  package->decRef(*actualUnitary);
-  EXPECT_TRUE(expectedMatrix.isApprox(actualMatrix));
+  ::mqt::test::expectFullUnitaryEqual(*expected, *actual, numQubits,
+                                      mlir::qco::MATRIX_TOLERANCE);
 }
 
 template <class Op> [[nodiscard]] static size_t countOps(ModuleOp module) {
@@ -390,6 +361,81 @@ TEST_F(TargetSynthesisTest,
   expectEquivalent(expected, optimized);
 }
 
+TEST_F(TargetSynthesisTest, TwoQubitGateFusionPreservesUnevenWireRuns) {
+  const auto uneven = [](QCOProgramBuilder& builder) {
+    auto q0Input = builder.staticQubit(0);
+    auto q1Input = builder.staticQubit(1);
+    auto [q0, q1] = builder.cx(q0Input, q1Input);
+    q0 = builder.rz(0.1, q0);
+    q0 = builder.rz(0.2, q0);
+    q0 = builder.rz(0.3, q0);
+    q1 = builder.inv(q1, [&](Value qubit) {
+      qubit = builder.h(qubit);
+      qubit = builder.s(qubit);
+      return builder.h(qubit);
+    });
+    std::tie(q0, q1) = builder.cx(q0, q1);
+    q0 = builder.h(q0);
+    q1 = builder.ry(0.4, q1);
+    q1 = builder.rz(0.5, q1);
+    std::tie(q0, q1) = builder.cx(q0, q1);
+    return builder.intConstant(0);
+  };
+  auto expected = build(uneven);
+  auto optimized = build(uneven);
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*optimized)));
+  ASSERT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*optimized)));
+
+  ASSERT_TRUE(mlir::succeeded(
+      runPass(*optimized, mlir::qco::createFuseTwoQubitGates())));
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*optimized)));
+  ASSERT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*optimized)));
+  // The first two CX gates commute with their intervening local gates and
+  // cancel. Check that the run was rewritten, not merely left unchanged.
+  EXPECT_EQ(countOps<CtrlOp>(*optimized), 1U);
+  expectEquivalent(expected, optimized);
+}
+
+TEST_F(TargetSynthesisTest,
+       TwoQubitSynthesisHandlesNumericalFailureWithoutRewriting) {
+  for (const bool required : {false, true}) {
+    SCOPED_TRACE(required ? "native synthesis" : "optional fusion");
+    auto moduleOp = build([&](QCOProgramBuilder& builder) {
+      auto q0 = builder.staticQubit(0);
+      auto q1 = builder.staticQubit(1);
+      auto matrix = mlir::qco::Matrix4x4::identity();
+      matrix(0, 3) = 4e-11;
+      auto outputs = builder.unitary(ValueRange{q0, q1},
+                                     denseMatrix(builder, 4, matrix.data));
+      if (!required) {
+        // Optional fusion needs at least two operations in the run.
+        static_cast<void>(builder.h(outputs[0]));
+      }
+      return builder.intConstant(0);
+    });
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*moduleOp)));
+    ASSERT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*moduleOp)));
+    if (required) {
+      attachTestEnvironment(*moduleOp, makeUCxTarget());
+    }
+    const auto before = printModule(*moduleOp);
+
+    if (required) {
+      const auto diagnostics =
+          expectFailure(*moduleOp, mlir::qco::createTargetNativeSynthesis());
+      EXPECT_NE(diagnostics.find("unitary matrix could not be numerically "
+                                 "decomposed"),
+                std::string::npos);
+    } else {
+      ASSERT_TRUE(mlir::succeeded(
+          runPass(*moduleOp, mlir::qco::createFuseTwoQubitGates())));
+    }
+    EXPECT_EQ(printModule(*moduleOp), before);
+    EXPECT_TRUE(mlir::succeeded(mlir::verify(*moduleOp)));
+    EXPECT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*moduleOp)));
+  }
+}
+
 TEST_F(TargetSynthesisTest, TwoQubitGateFusionExposesEarlierRunContinuations) {
   const auto adjacentRuns = [](QCOProgramBuilder& builder) {
     auto q0 = builder.staticQubit(0);
@@ -507,6 +553,113 @@ TEST_F(TargetSynthesisTest, SqrtISwapSynthesisIsMinimalAndConforms) {
     ASSERT_TRUE(mlir::succeeded(mlir::verify(*synthesized)));
     expectEquivalent(expected, synthesized);
   }
+}
+
+TEST_F(TargetSynthesisTest,
+       RepeatedTwoQubitMatricesPreserveWiresDirectionAndPhase) {
+  const auto circuit = [](QCOProgramBuilder& builder) {
+    std::array qubits{
+        builder.staticQubit(0),
+        builder.staticQubit(1),
+        builder.staticQubit(2),
+    };
+    mlir::qco::Matrix4x4 cx;
+    cx.data = CX_MATRIX;
+    auto phasedCx = cx;
+    for (auto& value : phasedCx.data) {
+      value *= std::polar(1., 0.37);
+    }
+    auto cz = mlir::qco::Matrix4x4::identity();
+    cz(3, 3) = -1.;
+    const auto apply = [&](const mlir::qco::Matrix4x4& matrix, size_t first,
+                           size_t second) {
+      auto outputs = builder.unitary(ValueRange{qubits[first], qubits[second]},
+                                     denseMatrix(builder, 4, matrix.data));
+      qubits[first] = outputs[0];
+      qubits[second] = outputs[1];
+    };
+
+    apply(cx, 0, 1);
+    qubits[2] = builder.h(qubits[2]);
+    apply(cx, 0, 2);
+    qubits[0] = builder.ry(0.43, qubits[0]);
+    apply(cx, 1, 0);
+    apply(cx.reorderForQubits(1, 0), 2, 0);
+    apply(phasedCx, 0, 1);
+    qubits[2] = builder.h(qubits[2]);
+    apply(phasedCx, 0, 2);
+    apply(cx, 0, 1);
+    apply(cz, 0, 2);
+    apply(cx, 0, 1);
+    for (auto qubit : qubits) {
+      builder.sink(qubit);
+    }
+    return builder.intConstant(0);
+  };
+
+  for (const bool useRxx : {false, true}) {
+    SCOPED_TRACE(useRxx ? "R/RXX" : "U/sqrtISWAP");
+    const auto target = valid(Target::create(
+        3, Connectivity::allToAll(),
+        NativeOperations::fromOperations({
+            valid(Operation::create(useRxx ? "r" : "u", 1, useRxx ? 2 : 3)),
+            valid(Operation::create(useRxx ? "rxx" : "sqrt_iswap", 2,
+                                    useRxx ? 1 : 0,
+                                    {
+                                        valid(SiteTuple::create({0, 1})),
+                                        valid(SiteTuple::create({0, 2})),
+                                        valid(SiteTuple::create({1, 2})),
+                                    })),
+            valid(Operation::create("gphase", 0, 1)),
+        })));
+    auto expected = build(circuit);
+    auto synthesized = build(circuit);
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*synthesized)));
+    ASSERT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*synthesized)));
+    ASSERT_TRUE(mlir::succeeded(runTargetPass(
+        *synthesized, target, mlir::qco::createTargetNativeSynthesis())));
+    EXPECT_EQ(countOps<UnitaryOp>(*synthesized), 0U);
+    EXPECT_EQ(countStaticQubits(mainFunction(*synthesized)), 3U);
+    EXPECT_GT(useRxx ? countOps<RXXOp>(*synthesized)
+                     : countOps<mlir::qco::XXPlusYYOp>(*synthesized),
+              0U);
+    ASSERT_TRUE(mlir::succeeded(runTargetPass(
+        *synthesized, target, mlir::qco::createVerifyTargetConformance())));
+    ASSERT_TRUE(mlir::succeeded(mlir::verify(*synthesized)));
+    ASSERT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*synthesized)));
+    expectEquivalent(expected, synthesized);
+  }
+}
+
+TEST_F(TargetSynthesisTest, NativeSynthesisSharesRepeatedParameterConstants) {
+  const auto hadamards = [](QCOProgramBuilder& builder) {
+    for (int64_t wire = 0; wire < 2; ++wire) {
+      auto qubit = builder.staticQubit(wire);
+      builder.sink(builder.h(qubit));
+    }
+    return builder.intConstant(0);
+  };
+  auto expected = build(hadamards);
+  auto synthesized = build(hadamards);
+  const auto target = makeUCxTarget();
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*synthesized)));
+  ASSERT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*synthesized)));
+  ASSERT_TRUE(mlir::succeeded(runTargetPass(
+      *synthesized, target, mlir::qco::createTargetNativeSynthesis())));
+
+  auto gates = llvm::to_vector(mainFunction(*synthesized).getOps<UOp>());
+  ASSERT_EQ(gates.size(), 2U);
+  // Standalone synthesis must avoid duplicate constants without a CSE pass.
+  for (auto [first, second] :
+       llvm::zip_equal(gates[0].getParameters(), gates[1].getParameters())) {
+    ASSERT_TRUE(first.getDefiningOp<mlir::arith::ConstantOp>());
+    EXPECT_EQ(first, second);
+  }
+  ASSERT_TRUE(mlir::succeeded(runTargetPass(
+      *synthesized, target, mlir::qco::createVerifyTargetConformance())));
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*synthesized)));
+  ASSERT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*synthesized)));
+  expectEquivalent(expected, synthesized);
 }
 
 TEST_F(TargetSynthesisTest, SqrtISwapCapabilityRequiresFixedParameters) {
@@ -1294,6 +1447,28 @@ TEST_F(TargetSynthesisTest,
   EXPECT_EQ(countOps<GPhaseOp>(*module), 1U);
   EXPECT_EQ(llvm::range_size(functions[0].getOps<GPhaseOp>()), 1U);
   EXPECT_EQ(llvm::range_size(functions[1].getOps<GPhaseOp>()), 0U);
+}
+
+TEST_F(TargetSynthesisTest,
+       SingleQubitFusionPreservesControlledGlobalPhaseSemantics) {
+  const auto controlledPhase = [](QCOProgramBuilder& builder) {
+    auto control = builder.staticQubit(0);
+    static_cast<void>(builder.cgphase(0.25, control));
+    return builder.intConstant(0);
+  };
+  auto expected = build(controlledPhase);
+  auto optimized = build(controlledPhase);
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*optimized)));
+  ASSERT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*optimized)));
+  mlir::qco::FuseSingleQubitUnitaryRunsOptions options;
+  options.basis = "u";
+
+  ASSERT_TRUE(mlir::succeeded(runPass(
+      *optimized, mlir::qco::createFuseSingleQubitUnitaryRuns(options))));
+  ASSERT_TRUE(mlir::succeeded(mlir::verify(*optimized)));
+  ASSERT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*optimized)));
+  EXPECT_EQ(countOps<CtrlOp>(*optimized), 0U);
+  expectEquivalent(expected, optimized);
 }
 
 TEST_F(TargetSynthesisTest,

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/compute_expected_merge_single_qubit_rotation.py
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/compute_expected_merge_single_qubit_rotation.py
@@ -53,17 +53,15 @@ def normalize_global_phase(a: float) -> float:
 
 
 def angles_from_quaternion(w: float, x: float, y: float, z: float) -> tuple[float, float, float, float]:
-    """ZYZ Euler angles from quaternion, matching anglesFromQuaternion in the pass.
+    """Extract ZYZ Euler angles and their normalization phase from a quaternion.
 
     Returns:
         Tuple (theta, phi, lambda, phase correction) in ZYZ convention.
     """
     eps = 1e-12
 
-    # Clamp before acos to guard against floating-point drift outside [-1, 1]
-    arg = 2 * (w * w + z * z) - 1
-    arg = max(-1.0, min(1.0, arg))
-    beta = math.acos(arg)
+    # Half-angle norms retain small rotations when cos(beta) rounds to one.
+    beta = 2 * math.atan2(math.sqrt(x * x + y * y), math.sqrt(w * w + z * z))
 
     abs_beta = abs(beta)
     abs_beta_minus_pi = abs(beta - math.pi)
@@ -146,9 +144,9 @@ def compute_merge(chain: list[tuple]) -> tuple[float, float, float, float]:
 
     chain: list of (gate_type, quaternion, *angles).
 
-    Uses our own Euler extraction that matches the C++ pass exactly: same
-    atan2/acos/clamp logic, gimbal-lock handling, angle normalization, and
-    global-phase correction induced by normalizing the Euler angles.
+    SymPy composes the input quaternions independently of the C++ implementation.
+    Euler extraction uses half-angle norms and atan2, with gimbal-lock handling,
+    angle normalization, and the global-phase correction from that normalization.
 
     Returns:
         Tuple (theta, phi, lambda, gphase) all as floats.

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
@@ -28,10 +28,13 @@
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/OwningOpRef.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/Verifier.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/WalkResult.h>
+#include <mlir/Transforms/Passes.h>
 
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <complex>
@@ -891,6 +894,64 @@ TEST_F(MergeSingleQubitRotationGatesTest, numericalSmallAngles) {
   expectGPhaseParam(2.50000041668308e-7);
 }
 
+TEST_F(MergeSingleQubitRotationGatesTest,
+       preservesSmallRotationsAndSingularPhasesInBothBackends) {
+  constexpr std::array<std::array<double, 2>, 8> parameterSets{
+      {
+          {1e-10, 1e-10},
+          {1e-8, 1e-8},
+          {1e-7, 1e-7},
+          {PI, PI},
+          {-PI, PI},
+          {PI - 1e-8, 1e-8},
+          {-PI + 1e-8, 1e-8},
+          {PI, 0.3},
+      },
+  };
+  for (bool dynamic : std::array{false, true}) {
+    SCOPED_TRACE(dynamic);
+    for (const auto& angles : parameterSets) {
+      SCOPED_TRACE(testing::Message() << angles[0] << ", " << angles[1]);
+      QCOProgramBuilder circuitBuilder(&context);
+      circuitBuilder.initialize();
+      Value qubit = circuitBuilder.staticQubit(0);
+      qubit = circuitBuilder.rx(angles[0], qubit);
+      qubit = circuitBuilder.ry(angles[1], qubit);
+      circuitBuilder.sink(qubit);
+      module = circuitBuilder.finalize();
+      auto funcOp = module->lookupSymbol<func::FuncOp>("main");
+      ASSERT_TRUE(funcOp);
+      if (dynamic) {
+        funcOp.insertArgument(0, Float64Type::get(&context), {},
+                              funcOp.getLoc());
+        funcOp.insertArgument(1, Float64Type::get(&context), {},
+                              funcOp.getLoc());
+        funcOp.walk([&](RXOp op) {
+          op.getThetaMutable().assign(funcOp.getArgument(0));
+        });
+        funcOp.walk([&](RYOp op) {
+          op.getThetaMutable().assign(funcOp.getArgument(1));
+        });
+      }
+      ASSERT_TRUE(succeeded(verify(*module)));
+      OwningOpRef<ModuleOp> original = module->clone();
+      ASSERT_TRUE(succeeded(runMergePass(*module)));
+      ASSERT_TRUE(succeeded(verify(*module)));
+      EXPECT_EQ(countOps<UOp>(), 1);
+      if (dynamic) {
+        bindLeadingArgs(original->lookupSymbol<func::FuncOp>("main"), angles);
+        bindLeadingArgs(funcOp, angles);
+        PassManager pm(&context);
+        pm.addPass(createCanonicalizerPass());
+        ASSERT_TRUE(succeeded(pm.run(*module)));
+      }
+      ASSERT_TRUE(succeeded(verify(*original)));
+      ASSERT_TRUE(succeeded(verify(*module)));
+      ::mqt::test::expectFullUnitaryEqual(*original, *module, 1);
+    }
+  }
+}
+
 /**
  * @brief Test: RX(PI)->RY(PI) should merge into U(0, -PI, 0.)
  */
@@ -921,12 +982,10 @@ TEST_F(MergeSingleQubitRotationGatesTest, numericalAccuracyRRSameAxis) {
   expectGPhaseParam(0.0);
 }
 
-/**
- * @brief Test: U(0, -2.0360075460227076, 0)->U(0, 4.157656961105587, 0) should
- * not produce NaN. These specific numbers would produce NaN if acos parameter
- * would not be clamped to [-1, 1]
- */
-TEST_F(MergeSingleQubitRotationGatesTest, numericalAcosClampingPreventsNaN) {
+/// Pure-Z composition must keep finite Euler angles despite quaternion norm
+/// roundoff.
+TEST_F(MergeSingleQubitRotationGatesTest,
+       numericalNormRoundoffDoesNotProduceNaN) {
   ASSERT_TRUE(testGateMerge(
                   {{.type = GateType::U, .angles = {0, -2.0360075460227076, 0}},
                    {.type = GateType::U, .angles = {0, 4.157656961105587, 0}}})

--- a/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Optimizations/test_qco_merge_single_qubit_rotation.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/QCO/Builder/QCOProgramBuilder.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 
 #include <gtest/gtest.h>
@@ -948,6 +949,67 @@ TEST_F(MergeSingleQubitRotationGatesTest,
       ASSERT_TRUE(succeeded(verify(*original)));
       ASSERT_TRUE(succeeded(verify(*module)));
       ::mqt::test::expectFullUnitaryEqual(*original, *module, 1);
+    }
+  }
+}
+
+TEST_F(MergeSingleQubitRotationGatesTest, largePhasesPreserveControlledMatrix) {
+  for (const auto gate : {GateType::P, GateType::U2, GateType::U}) {
+    for (const auto angles : {
+             std::array{1e12, 1.0},
+             std::array{-1e16, 1.0},
+             std::array{1e308, 1e308},
+         }) {
+      for (const bool dynamic : {false, true}) {
+        SCOPED_TRACE(testing::Message()
+                     << "gate=" << static_cast<unsigned>(gate)
+                     << " phi=" << angles[0] << " lambda=" << angles[1]
+                     << " dynamic=" << dynamic);
+        module = QCOProgramBuilder::build(&context, [&](auto& b) {
+          auto [control, target] =
+              b.ctrl(b.staticQubit(0), b.staticQubit(1), [&](Value qubit) {
+                if (gate == GateType::P) {
+                  qubit = b.p(angles[0], qubit);
+                } else if (gate == GateType::U2) {
+                  qubit = b.u2(angles[0], angles[1], qubit);
+                } else {
+                  qubit = b.u(0.37, angles[0], angles[1], qubit);
+                }
+                return b.h(qubit);
+              });
+          return SmallVector<Value>{control, target};
+        });
+        ASSERT_TRUE(module);
+        auto funcOp = module->lookupSymbol<func::FuncOp>("main");
+        if (dynamic) {
+          funcOp.insertArgument(0, Float64Type::get(&context), {},
+                                funcOp.getLoc());
+          module->walk([&](UnitaryOpInterface op) {
+            if (isa<POp, U2Op, UOp>(op.getOperation())) {
+              Value parameter = op.getParameter(isa<UOp>(op) ? 1U : 0U);
+              parameter.replaceAllUsesWith(funcOp.getArgument(0));
+            }
+          });
+        }
+        ASSERT_TRUE(succeeded(verify(*module)));
+        ASSERT_TRUE(succeeded(verifyLinearity(*module)));
+        OwningOpRef<ModuleOp> original = module->clone();
+        ASSERT_TRUE(succeeded(runMergePass(*module)));
+        ASSERT_TRUE(succeeded(verify(*module)));
+        ASSERT_TRUE(succeeded(verifyLinearity(*module)));
+        EXPECT_EQ(countOps<HOp>(), 0);
+        if (dynamic) {
+          bindLeadingArgs(original->lookupSymbol<func::FuncOp>("main"),
+                          {angles[0]});
+          bindLeadingArgs(funcOp, {angles[0]});
+          PassManager pm(&context);
+          pm.addPass(createCanonicalizerPass());
+          ASSERT_TRUE(succeeded(pm.run(*module)));
+        }
+        ASSERT_TRUE(succeeded(verify(*module)));
+        ASSERT_TRUE(succeeded(verifyLinearity(*module)));
+        ::mqt::test::expectFullUnitaryEqual(*original, *module, 2);
+      }
     }
   }
 }


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Fix decomposition and fusion on valid QCO IR, and reduce whole-circuit target-compilation overhead without adding pass-local IR verification or relaxing numerical tolerances.

- Count all participating qubits in single-qubit fusion, including controlled global phases.
- Make numerical Weyl failure recoverable: optional fusion leaves the affected run unchanged, while required native synthesis reports failure before emitting its replacement.
- Run optional generic two-qubit fusion only for unrestricted targets or targets with a usable two-qubit synthesis basis. Retain the square-root iSWAP exclusion because the generic CX/CZ cost model can increase its native gate count. Already-native CX-only and U+DCX programs remain compilable.
- Preserve small rotations with stable quaternion-to-Euler extraction. Use sparse ZYZ products and direct RX/RY-to-R synthesis without combining input half angles or changing phase accounting.
- Reuse embedded matrix kernels and cache pending one-qubit matrices. Flatten SP22 planning and remove identity maps, redundant basis-count selection, and general-purpose `NestedMCX` bookkeeping where CX/CCX suffice.
- Reduce repeated parameter-verification work for direct constants, deduplicate emitted synthesis constants with MLIR's `OperationFolder`, reuse the last exact two-qubit numerical decomposition, and initialize the deterministic RNG only when a retry needs it. Normal verification and final CSE remain enabled.
- Retain semantic, phase, wire-order, numerical-failure and gate-cost regressions while removing redundant test scaffolding.

Based on shared `main` commit `91a9e0ba514af938680cdd394d6d63195872dc9a`, including merged #2467, #2468 and #2484. The square-root iSWAP formulas, phase and 0–3 entangler counts, centralized modifier-matrix handling, and typed target environment are retained.

**Unreleased C++ API:** `decomposeUnitary2QWeyl` and `TwoQubitWeylDecomposition::create` return optional results. There is one Weyl factory, with no compatibility wrapper or separate `tryCreate`. Numerical failure remains documented in the header and pass definition. This PR makes no changes to `target_compilation.md`.

## Complete-circuit performance

**1.167× speedup across 76 fixed circuit/basis cases** by the descriptive equal-case geometric mean, up to **1.369×** on 10-qubit Grover targeting U/√iSWAP (**103.82 → 75.79 ms**). GHZ targeting CX remains essentially unchanged. Native gate counts and dependency depth match in every case.

| Circuit family | Geometric-mean speedup | Range across sizes and bases |
| --- | ---: | ---: |
| QFT | 1.210× | 1.132–1.314× |
| Register QFT adder | 1.209× | 1.139–1.304× |
| Grover | 1.204× | 1.070–1.369× |
| Multiplexer | 1.123× | 1.052–1.183× |
| GHZ | 1.069× | 0.972–1.206× |

Of 76 pointwise 95% bootstrap intervals, 70 lie entirely above 1× and six include 1×. None lies entirely below 1×. These are not simultaneous intervals or a guarantee for other applications or machines.

![Complete-circuit target-compilation results across five circuit families and four native bases.](https://github.com/user-attachments/assets/ff501371-52bb-4dcb-b3ef-b5e3cba06a88)

The measured candidate is `80007cde1b6a733fbe798a2eee4e8f8ee07fbc94`, compared with the shared main base `91a9e0ba514af938680cdd394d6d63195872dc9a`, not today's main tip. The plot's “PR #2478 + local speedups” label refers to the exact performance patch now committed as `80007cde1`. The subsequent factory/documentation cleanup was tested separately; these timings were not rerun for that cleanup.

Before the additional whole-circuit optimizations, the same grid at `29fe091aa` measured 1.011×. The earlier fusion stress optimization affects little of these circuits' total compilation time. Profiling identified repeated parameter verification and constant handling as relevant remaining costs.

<details>
<summary>Complete-circuit methodology and correctness</summary>

- **Boundary:** wall time of public `QCOProgram::compileForTarget(environment)` on fully expanded, initially statically placed QCO. This includes normal verification, boundary linearity, decomposition, optimization, placement, native synthesis, cleanup and conformance. Generation, QC-to-QCO conversion, expansion, initial placement, cloning and extra correctness oracles are outside timing. This is neither hardware execution nor full source-to-executable time.
- **Grid:** QFT at 8/16/32/64 qubits; register-QFT addition at 4/8/16/32 operand bits (2n qubits); Grover at 4/6/8/10 qubits with exactly two iterations; the catalog's linear n−1 controlled-RY multiplexer at 8/16/32/64 qubits; GHZ at 16/64/256 qubits. Every size targets each of {U, CX}, {RZ, SX, X, CX}, {R, RXX}, and {U, √iSWAP}, with homogeneous all-to-all connectivity and measurement/global-phase support. This multiplexer is not a general exponential-size multiplexed rotation. Existing small-angle tolerances are unchanged.
- **Sampling:** 15 paired process rounds per case, three warmups and five timed calls per process: **11,400 timed compilations**, with no failures, omitted cases or discarded samples. AB/BA order alternates and case order rotates. No builds, lint or other benchmark jobs ran during final measurements.
- **Statistics:** each process contributes its five-sample median. Latency is the median of 15 process medians; speedup is the median of 15 paired ratios, not a ratio of aggregate latencies. Pointwise percentile-bootstrap intervals use 10,000 resamples and seed 20260909. The equal-case geometric mean is descriptive, not workload-weighted.
- **Correctness:** input hashes and case IDs match across revisions and rounds. Every output verifies, is linear, conforms to the target and preserves static wire count and the exact terminal-measurement mapping. Native one-/two-qubit counts and unit-cost dependency depth are unchanged throughout. A separate six-qubit preflight (three operand bits for the adder) checks all 20 family/basis pairs on both revisions using full phase-sensitive matrix comparisons: maximum error **1.51e-13**, below 1e-10 with DD tolerance 1e-15. This is not a full-unitary proof for the larger timing cases.
- **Environment:** 9 September 2026; Apple M1 Pro, 10 cores, 16 GiB, macOS 26.6.2; AppleClang 21.0.0, LLVM/MLIR 23.1.0, CMake 4.4.3. Matched Release/unity/thin-LTO builds and identical driver/dependency sources; MLIR multithreading disabled.
- **Independent check:** reconstructed paired medians and checked inputs, output metrics, execution order and fingerprints. Bootstrap bounds were checked for consistency, not independently resampled.

The standalone driver, raw samples, fingerprints and SVG/PNG plots are retained locally; they add no files or dependencies to the PR.

</details>

## Supporting pass microbenchmarks

These earlier pass-level measurements compare the PR at `29fe091aa74a9f45d6f3ee78af5c4372cd28cdd7` against its shared `main` base, `91a9e0ba514af938680cdd394d6d63195872dc9a`. Later unrelated `main` changes are excluded. These stress measurements were not repeated after the whole-circuit speedups or API cleanup.

**Synthetic two-qubit fusion stress cases improve by 10.1×–96.1×; the cheap control case improves by 1.48×. Controlled-gate decomposition stays near 1×, and all six of its 95% intervals include no change.** These are selected pass-latency measurements on one machine, not an end-to-end compiler speedup.

The plots show paired speedups and absolute pass latencies with 95% bootstrap intervals. No cases or samples were discarded.

### Speedup

![Paired pass-latency speedup with 95% bootstrap intervals: controlled-gate cases remain near 1x; synthetic fusion stress cases improve.](https://github.com/user-attachments/assets/44b43147-9bbc-4648-b786-a456ec33dd0a)

### Absolute pass latency

![Baseline and PR pass latencies in microseconds with 95% bootstrap intervals.](https://github.com/user-attachments/assets/b3bd7bf2-4293-49c3-ad06-a62c59a0c70f)

MCP/MCX labels give the number of controls. Dashed lines mark 1× (no change) in the speedup plot. Its controlled-gate axis is linear and its fusion axis is logarithmic; both absolute-latency axes are logarithmic.

<details>
<summary>All measurements and methodology</summary>

| Workload | Main base (µs) | PR (µs) | Paired speedup | 95% interval |
| --- | ---: | ---: | ---: | ---: |
| MCP, 3 controls | 115.3 | 116.7 | 1.01× | 0.936–1.024× |
| MCP, 4 controls | 193.1 | 193.9 | 1.00× | 0.960–1.016× |
| MCP, 8 controls | 1,229.6 | 1,236.7 | 0.98× | 0.966–1.010× |
| MCP, 16 controls | 5,599.7 | 5,577.2 | 1.00× | 0.987–1.017× |
| MCP, 32 controls | 24,056.2 | 23,897.3 | 1.01× | 0.995–1.015× |
| MCX, 33 controls | 19,299.0 | 19,247.2 | 0.99× | 0.985–1.010× |
| Fusion, N=16, M=256 | 918.8 | 90.3 | 10.12× | 9.68–10.35× |
| Fusion, N=64, M=256 | 3,278.4 | 106.0 | 30.55× | 30.01–31.00× |
| Fusion, N=256, M=256 | 12,366.1 | 171.8 | 71.62× | 70.39–72.59× |
| Fusion, N=512, M=256 | 24,738.9 | 256.1 | 96.06× | 94.90–97.85× |
| Fusion control, N=64, M=1 | 49.9 | 33.5 | 1.48× | 1.43–1.52× |

- **Environment:** 9 September 2026; Apple M1 Pro (10 cores, 16 GiB RAM), macOS 26.6.2; AppleClang 21.0.0, LLVM/MLIR 23.1.0, CMake 4.4.3. Identical Release/unity/IPO builds, dependency sources and benchmark driver; MLIR multithreading disabled.
- **Workloads:** default `DecomposeMultiControlled` on controlled P(0.7) with 3/4/8/16/32 controls and controlled X with 33 controls. `FuseTwoQubitGates` on CX, N alternating H/T gates on one wire, an inverse body of M alternating H/T gates on the other, then CX and explicit ordered sinks. The unbalanced fusion cases intentionally stress repeated pending-matrix evaluation, rather than model typical application circuits.
- **Sampling:** 15 paired process rounds per case, each with 3 warm-ups and 5 measured runs: 1,650 recorded samples. Baseline/candidate order alternates; case order rotates. Only ordinary `PassManager::run` is timed, including its normal verifier. Input construction, cloning, pass-manager setup and extra correctness checks are outside the timer. Builds and lint jobs finished before sampling.
- **Statistics:** each process contributes its five-sample median. Latency is the median of 15 process medians; speedup is the median of 15 paired main-base/PR ratios, not the ratio of the two overall medians. Intervals use 10,000 percentile-bootstrap resamples of paired process rounds, seed 20260909. They describe within-run variability, not uncertainty across machines or applications.
- **Correctness:** all inputs/outputs pass IR and linearity verification. The first warm-up checks full phase-sensitive matrices for fusion and gates with at most four controls; wider gates use one coherent state against an analytic controlled-gate reference, not a full-unitary proof. Maximum recorded semantic error: approximately `2.35e-13`, below the `1e-11` limit with DD tolerance `1e-15`. Output operation counts match between revisions in all 11 cases.

The standalone driver, raw samples and original SVG/PNG plots are retained locally; they do not add files or dependencies to this PR.

</details>


## Validation

- Performance commit `80007cde1`: **1,955 tests passed** across decomposition (311), native synthesis (58), optimizations (197), QCO IR (512), QC IR (349), QCO utilities (192), compiler (183), MQT utilities (22), mapping (100) and global-phase transforms (31).
- After the factory/documentation cleanup at `1a60dced1`: **749 rebuilt tests passed** across decomposition (311), native synthesis (58), optimizations (197) and compiler (183), including numerical failure, phase, direction and repeated-constant regressions.
- Full `uvx nox -s lint`: passed.
- Required whole-file `uvx nox -s cpp-lint`: passed on all 17 changed C++ implementation/test files, with zero findings.
- `mlir-doc` generation: passed.

Local clang-tidy is 23.0.0git, not CI's exact 23.1.1. Hosted CI must rerun on the pushed head. Local coverage, Python binding tests and a full Sphinx build were not rerun for this update.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] Changelog entries: not applicable to this unreleased v4 functionality, per repository policy.
- [x] Upgrade guide: no standalone entry for unreleased functionality; the C++ API contract is documented in its header.
- [x] The changes follow the project's style guidelines and introduce no new warnings in local checks.
- [x] The changes are fully tested and pass the CI checks. Local checks passed; hosted CI pending.
- [x] I have reviewed my own code changes. Independent agent review completed; personal human review remains to be confirmed.

**AI assistance:** Codex assisted with the audit, implementation, tests, independent review, and PR preparation. A human must review the contribution before accepting or merging it.

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by the [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
