### PR TITLE
🐛 Preserve canonicalization wire mappings

### DIFF
--- a/.agent/plans/canonicalization-wire-mapping.md
+++ b/.agent/plans/canonicalization-wire-mapping.md
@@ -1,0 +1,44 @@
+# Preserve wire mapping in canonicalization
+
+Status: complete and validated locally.
+
+## Scope and decisions
+
+QC and QCO canonicalization must preserve gate targets and the complete action
+of modifier bodies. The changes cover `CtrlOp`, `InvOp`, and `PowOp` under
+`mlir/lib/Dialect/{QC,QCO}/IR/Modifiers/`, plus the XXPlusYY merge in
+`mlir/include/mlir/Dialect/QCO/QCOUtils.h`. Numerical arithmetic, matrix
+evaluation, folders, dialect dependencies, and transformation and conversion
+patterns are outside this scope.
+
+Valid QCO bodies can yield a permutation of their wires. The shared
+`hasPositionalBodyYields` helper follows the unitary interface's input/output
+correspondence. Algebraic rewrites require positional outer yields because an
+extra permutation changes the body unitary. They keep nested bodies intact;
+requiring positional yields recursively would reject safe rewrites.
+
+Zero controls and power one inline the complete body, including its yields.
+Power zero erases the complete action. Double inversion inlines each region
+separately to preserve both mappings. These rewrites accept multi-gate bodies.
+Nested controls can hoist supported classical operations after all match checks
+succeed. Controlled global phase acts on the last control; unused original
+targets do not change that target.
+
+QC U powering maps the inner gate's actual target to the outer operand. XXPlusYY
+merging requires ordered wires because reversing the wires negates beta.
+XXMinusYY retains its symmetric-wire merge.
+
+## Validation
+
+Regression tests are in the QC and QCO `IR/test_*_modifier_canonicalization.cpp`
+files, QCO `IR/test_qco_modifier_yield_canonicalization.cpp`, and QCO
+`IR/test_qco_wire_canonicalization.cpp`. They verify input and output IR, check
+QCO linearity, retain unsupported yield permutations, and check safe inlining
+and ordered gate outputs. XXPlusYY tests compare the full unitary against the
+uncanonicalized input.
+
+With LLVM/MLIR 23.1.0, the release build passes. The QC and QCO IR binaries pass
+all 357 and 549 tests, respectively. The complete release CTest run reports
+3,341 passed entries and one skip for the SC device's unsupported job-ID
+property. Full-file C++ lint against the main base `46f98eabe` and repository
+lint pass. Hosted CI has not tested this extracted change.

--- a/.agent/plans/canonicalization-wire-mapping.md
+++ b/.agent/plans/canonicalization-wire-mapping.md
@@ -17,6 +17,12 @@ correspondence. Algebraic rewrites require positional outer yields because an
 extra permutation changes the body unitary. They keep nested bodies intact;
 requiring positional yields recursively would reject safe rewrites.
 
+Valid bodies with fewer than two wires need no correspondence traversal. Stop
+following each wire as soon as it reaches its expected argument, including
+direct pass-throughs. Current callers establish empty or single-unitary bodies;
+no shared cache is needed. Power folding rejects unsupported gate types before
+checking correspondence.
+
 Zero controls and power one inline the complete body, including its yields.
 Power zero erases the complete action. Double inversion inlines each region
 separately to preserve both mappings. These rewrites accept multi-gate bodies.
@@ -41,4 +47,4 @@ With LLVM/MLIR 23.1.0, the release build passes. The QC and QCO IR binaries pass
 all 357 and 549 tests, respectively. The complete release CTest run reports
 3,341 passed entries and one skip for the SC device's unsupported job-ID
 property. Full-file C++ lint against the main base `46f98eabe` and repository
-lint pass. Hosted CI has not tested this extracted change.
+lint pass. These results describe local validation.

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -337,7 +337,9 @@ LogicalResult mergeXXPlusMinusYY(OpType op, PatternRewriter& rewriter) {
   if (!valuesMatchWithinTolerance(op.getBeta(), nextOp.getBeta())) {
     return failure();
   }
-  return mergeTwoTargetOneParameterImpl(op, nextOp, rewriter, true);
+  // Reversing XXPlusYY targets negates beta; XXMinusYY is symmetric.
+  return mergeTwoTargetOneParameterImpl(op, nextOp, rewriter,
+                                        isa<XXMinusYYOp>(op));
 }
 
 /**

--- a/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/CtrlOp.cpp
@@ -18,14 +18,12 @@
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>
-#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 
@@ -44,11 +42,6 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
     // Require at least one control
     // Trivial case is handled by ReduceCtrl
     if (op.getNumControls() == 0) {
-      return failure();
-    }
-
-    // Only proceed if body contains only one operation besides terminator
-    if (op.getBody()->getOperations().size() != 2) {
       return failure();
     }
 
@@ -77,6 +70,8 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
           return mqt::getValueFromBlockArgument(t, outerTargets);
         });
 
+    mqt::hoistSupportingOpsBefore(*op.getBody(), innerCtrlOp, op, rewriter);
+
     CtrlOp::create(rewriter, op.getLoc(), controls, targets,
                    [&](ValueRange mergedTargets) {
                      mqt::inlineBodyReturningYields(*innerCtrlOp.getBody(),
@@ -96,14 +91,19 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CtrlOp op,
                                 PatternRewriter& rewriter) const override {
+    if (op.getNumControls() == 0) {
+      mqt::inlineModifierBody(op, *op.getBody(), op.getTargets(), rewriter);
+      return success();
+    }
+
     auto inner = mqt::getSoleBodyUnitary<UnitaryOpInterface>(*op.getBody());
     if (!inner) {
       return failure();
     }
     auto* innerOp = inner.getOperation();
 
-    // Inline ops from empty control modifiers, IdOp and BarrierOp
-    if (op.getNumControls() == 0 || isa<IdOp, BarrierOp>(innerOp)) {
+    // Control does not change an identity gate or barrier.
+    if (isa<IdOp, BarrierOp>(innerOp)) {
       mqt::inlineModifierBody(op, *op.getBody(), op.getTargets(), rewriter);
       return success();
     }
@@ -114,10 +114,7 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
       return failure();
     }
 
-    // Only proceed if the GPhaseOp is the only operation besides the terminator
-    if (op.getBody()->getOperations().size() != 2) {
-      return failure();
-    }
+    mqt::hoistSupportingOpsBefore(*op.getBody(), gPhaseOp, op, rewriter);
 
     // Special case for single control: replace with a single POp
     if (op.getNumControls() == 1) {
@@ -126,24 +123,12 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
       return success();
     }
 
-    // Reinterpret the last control as a target qubit and apply a phase gate to
-    // it inside the (smaller) controlled region
-    const auto opSegmentsAttrName = CtrlOp::getOperandSegmentSizeAttr();
-    auto segmentsAttr =
-        op->getAttrOfType<DenseI32ArrayAttr>(opSegmentsAttrName);
-    auto newSegments = DenseI32ArrayAttr::get(
-        rewriter.getContext(), {segmentsAttr[0] - 1, segmentsAttr[1] + 1});
-    op->setAttr(opSegmentsAttrName, newSegments);
-
-    // Add a block argument for the target qubit
-    auto arg = op.getBody()->addArgument(QubitType::get(rewriter.getContext()),
-                                         op.getLoc());
-
-    // Replace the current GPhaseOp with a PhaseOp
-    const OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(gPhaseOp);
-    POp::create(rewriter, gPhaseOp.getLoc(), arg, gPhaseOp.getTheta());
-    rewriter.eraseOp(gPhaseOp);
+    // The phase acts on the last control. The original targets are unused.
+    rewriter.replaceOpWithNewOp<CtrlOp>(
+        op, op.getControls().drop_back(), op.getControls().back(),
+        [&](Value target) {
+          POp::create(rewriter, gPhaseOp.getLoc(), target, gPhaseOp.getTheta());
+        });
 
     return success();
   }

--- a/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/InvOp.cpp
@@ -314,20 +314,9 @@ struct CancelNestedInv final : OpRewritePattern<InvOp> {
     if (!innerInvOp) {
       return failure();
     }
-    if (!mqt::getSoleBodyUnitary<UnitaryOpInterface>(*innerInvOp.getBody())) {
-      return failure();
-    }
-
-    mqt::hoistSupportingOpsBefore(*op.getBody(), innerInvOp, op, rewriter);
-
-    // inv(inv(x)) == x: inline the doubly-nested body directly onto the outer
-    // qubits. The inner body's block arguments alias the inner modifier's
-    // inputs, which in turn alias the outer qubits.
-    const auto replacements =
-        llvm::map_to_vector(innerInvOp.getQubits(), [&](Value q) {
-          return mqt::getValueFromBlockArgument(q, op.getQubits());
-        });
-    mqt::inlineModifierBody(op, *innerInvOp.getBody(), replacements, rewriter);
+    mqt::inlineModifierBody(innerInvOp, *innerInvOp.getBody(),
+                            innerInvOp.getQubits(), rewriter);
+    mqt::inlineModifierBody(op, *op.getBody(), op.getQubits(), rewriter);
     return success();
   }
 };

--- a/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
@@ -378,13 +378,15 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
         })
         // pow(n) { u(theta, phi, lambda) } =>
         // gphase(delta); u(theta', phi', lambda')
-        .Case([&](UOp) {
+        .Case([&](UOp gate) {
           if (std::abs(normalizeAngle(uPower->phase)) >
               PARAMETER_COMPARISON_TOLERANCE) {
             GPhaseOp::create(rewriter, loc, uPower->phase);
           }
-          rewriter.replaceOpWithNewOp<UOp>(op, op.getTarget(0), uPower->theta,
-                                           uPower->phi, uPower->lambda);
+          rewriter.replaceOpWithNewOp<UOp>(
+              op,
+              mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
+              uPower->theta, uPower->phi, uPower->lambda);
           return success();
         })
         // --- Pauli gates: decompose to rotation + global phase ---

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/CtrlOp.cpp
@@ -23,7 +23,6 @@
 #include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/Builders.h>
-#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
 #include <mlir/IR/PatternMatch.h>
@@ -54,11 +53,6 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
       return failure();
     }
 
-    // Only proceed if body contains only one operation besides terminator
-    if (op.getBody()->getOperations().size() != 2) {
-      return failure();
-    }
-
     auto inner = mqt::getSoleBodyUnitary<UnitaryOpInterface>(*op.getBody());
     if (!inner) {
       return failure();
@@ -71,6 +65,10 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
     // The rewrite hands the qubits of the modifier to the inner operation, so
     // it must act on all of them.
     if (innerCtrlOp.getNumQubits() != op.getNumTargets()) {
+      return failure();
+    }
+
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
       return failure();
     }
 
@@ -90,6 +88,8 @@ struct MergeNestedCtrl final : OpRewritePattern<CtrlOp> {
     const auto targets = llvm::map_to_vector(innerTargets, [&](Value t) {
       return mqt::getValueFromBlockArgument(t, outerTargets);
     });
+
+    mqt::hoistSupportingOpsBefore(*op.getBody(), innerCtrlOp, op, rewriter);
 
     auto merged =
         CtrlOp::create(rewriter, op.getLoc(), controls, targets,
@@ -117,6 +117,11 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(CtrlOp op,
                                 PatternRewriter& rewriter) const override {
+    if (op.getNumControls() == 0) {
+      mqt::inlineModifierBody(op, *op.getBody(), op.getTargetsIn(), rewriter);
+      return success();
+    }
+
     auto inner = mqt::getSoleBodyUnitary<UnitaryOpInterface>(*op.getBody());
     if (!inner) {
       return failure();
@@ -128,8 +133,11 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
       return failure();
     }
 
-    // Inline ops from empty control modifiers, IdOp and BarrierOp
-    if (op.getNumControls() == 0 || isa<IdOp, BarrierOp>(innerOp)) {
+    // Control does not change an identity gate or barrier.
+    if (isa<IdOp, BarrierOp>(innerOp)) {
+      if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
+        return failure();
+      }
       auto* body = op.getBody();
       auto* terminator = body->getTerminator();
       // Controls are pass-through results outside the body yield, so the
@@ -148,10 +156,7 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
       return failure();
     }
 
-    // Only proceed if the GPhaseOp is the only operation besides the terminator
-    if (op.getBody()->getOperations().size() != 2) {
-      return failure();
-    }
+    mqt::hoistSupportingOpsBefore(*op.getBody(), gPhaseOp, op, rewriter);
 
     // Special case for single control: replace with a single POp
     if (op.getNumControls() == 1) {
@@ -164,33 +169,14 @@ struct ReduceCtrl final : OpRewritePattern<CtrlOp> {
       return success();
     }
 
-    // Reinterpret the last control as a target qubit and apply a phase gate to
-    // it inside the (smaller) controlled region
-    const auto opSegmentsAttrName = CtrlOp::getOperandSegmentSizeAttr();
-    auto segmentsAttr =
-        op->getAttrOfType<DenseI32ArrayAttr>(opSegmentsAttrName);
-    auto newSegments = DenseI32ArrayAttr::get(
-        rewriter.getContext(), {segmentsAttr[0] - 1, segmentsAttr[1] + 1});
-    op->setAttr(opSegmentsAttrName, newSegments);
-    const auto opResultSegmentsAttrName = CtrlOp::getResultSegmentSizeAttr();
-    op->setAttr(opResultSegmentsAttrName, newSegments);
-
-    // Add a block argument for the target qubit
-    auto arg = op.getBody()->addArgument(QubitType::get(rewriter.getContext()),
-                                         op.getLoc());
-
-    // Replace the current GPhaseOp with a PhaseOp
-    const OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(gPhaseOp);
-    auto pOp =
-        POp::create(rewriter, gPhaseOp.getLoc(), arg, gPhaseOp.getTheta());
-
-    // Add the results of the POp to the yield operation
-    auto yieldOp = cast<YieldOp>(op.getBody()->back());
-    yieldOp->setOperands(pOp->getResults());
-
-    // Erase the GPhaseOp
-    rewriter.eraseOp(gPhaseOp);
+    // The last control becomes the phase target, retaining its result position.
+    rewriter.replaceOpWithNewOp<CtrlOp>(
+        op, op.getControlsIn().drop_back(), op.getControlsIn().back(),
+        [&](Value target) -> Value {
+          return POp::create(rewriter, gPhaseOp.getLoc(), target,
+                             gPhaseOp.getTheta())
+              .getResult();
+        });
 
     return success();
   }
@@ -204,6 +190,10 @@ struct EraseEmptyCtrl final : OpRewritePattern<CtrlOp> {
   LogicalResult matchAndRewrite(CtrlOp op,
                                 PatternRewriter& rewriter) const override {
     if (op.getNumBodyUnitaries() != 0) {
+      return failure();
+    }
+
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
       return failure();
     }
 

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/InvOp.cpp
@@ -66,6 +66,10 @@ struct MoveCtrlOutsideInv final : OpRewritePattern<InvOp> {
       return failure();
     }
 
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
+      return failure();
+    }
+
     // inv(ctrl(x)) == ctrl(inv(x)). The inner control's controls and targets
     // are block arguments aliasing the inverse modifier's qubits. Pull the
     // controls out to a new control modifier and wrap the inner body in an
@@ -133,6 +137,10 @@ struct InvPowToNegPow final : OpRewritePattern<InvOp> {
       return failure();
     }
 
+    if (!qco::detail::hasPositionalBodyYields(*invOp.getBody())) {
+      return failure();
+    }
+
     // Move supporting ops (constants, arithmetic) out of the body so their
     // Values are accessible from outside and survive InvOp erasure.
     mqt::hoistSupportingOpsBefore(*invOp.getBody(), innerPow.getOperation(),
@@ -186,6 +194,10 @@ struct InlineSelfAdjoint final : OpRewritePattern<InvOp> {
       return failure();
     }
 
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
+      return failure();
+    }
+
     // A self-adjoint gate is its own inverse, so the modifier can be dropped
     // and its body applied directly to the input qubits.
     mqt::inlineModifierBody(op, *op.getBody(), op.getInputQubits(), rewriter);
@@ -208,13 +220,11 @@ struct ReplaceWithKnownGates final : OpRewritePattern<InvOp> {
     if (!inner) {
       return failure();
     }
-    auto* innerOp = inner.getOperation();
-    // The modifier is replaced by a single operation, so it must not act on
-    // more qubits than its body.
-    if (inner.getNumQubits() != op.getNumQubits()) {
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
       return failure();
     }
 
+    auto* innerOp = inner.getOperation();
     // Replace the body gate in place with its inverse, operating on the same
     // (block-argument) operands; inlining the body afterwards substitutes those
     // block arguments with the modifier's input qubits.
@@ -362,26 +372,14 @@ struct CancelNestedInv final : OpRewritePattern<InvOp> {
       return failure();
     }
 
-    // The rewrite hands the qubits of the modifier to the inner operation, so
-    // it must act on all of them.
-    if (innerInvOp.getNumQubits() != op.getNumQubits()) {
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
       return failure();
     }
 
-    if (!mqt::getSoleBodyUnitary<UnitaryOpInterface>(*innerInvOp.getBody())) {
-      return failure();
-    }
-
-    mqt::hoistSupportingOpsBefore(*op.getBody(), innerInvOp, op, rewriter);
-
-    // inv(inv(x)) == x: inline the doubly-nested body directly onto the outer
-    // input qubits. The inner body's block arguments alias the inner modifier's
-    // inputs, which in turn alias the outer input qubits.
-    const auto replacements =
-        llvm::map_to_vector(innerInvOp.getInputQubits(), [&](Value q) {
-          return mqt::getValueFromBlockArgument(q, op.getInputQubits());
-        });
-    mqt::inlineModifierBody(op, *innerInvOp.getBody(), replacements, rewriter);
+    // Inline each region separately so both yield mappings are preserved.
+    mqt::inlineModifierBody(innerInvOp, *innerInvOp.getBody(),
+                            innerInvOp.getInputQubits(), rewriter);
+    mqt::inlineModifierBody(op, *op.getBody(), op.getInputQubits(), rewriter);
     return success();
   }
 };
@@ -394,6 +392,10 @@ struct EraseEmptyInv final : OpRewritePattern<InvOp> {
   LogicalResult matchAndRewrite(InvOp op,
                                 PatternRewriter& rewriter) const override {
     if (op.getNumBodyUnitaries() != 0) {
+      return failure();
+    }
+
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
       return failure();
     }
 

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
@@ -61,14 +61,20 @@ LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
 }
 
 bool hasPositionalBodyYields(Block& body) {
+  // A valid modifier cannot permute fewer than two wires.
+  if (body.getNumArguments() < 2) {
+    return true;
+  }
+
   for (auto [argument, yielded] : llvm::zip_equal(
            body.getArguments(), body.getTerminator()->getOperands())) {
     Value origin = yielded;
-    while (auto unitary = origin.getDefiningOp<UnitaryOpInterface>()) {
+    while (origin != argument) {
+      auto unitary = origin.getDefiningOp<UnitaryOpInterface>();
+      if (!unitary) {
+        return false;
+      }
       origin = unitary.getInputForOutput(origin);
-    }
-    if (origin != argument) {
-      return false;
     }
   }
   return true;

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.cpp
@@ -11,6 +11,7 @@
 #include "ModifierUtils.h"
 
 #include "mlir/Dialect/MQT/Utils/Modifiers.h"
+#include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
 
 #include <llvm/ADT/STLExtras.h>
@@ -57,6 +58,20 @@ LogicalResult verifyModifierBody(Operation* modifierOp, Block& body) {
   }
 
   return success();
+}
+
+bool hasPositionalBodyYields(Block& body) {
+  for (auto [argument, yielded] : llvm::zip_equal(
+           body.getArguments(), body.getTerminator()->getOperands())) {
+    Value origin = yielded;
+    while (auto unitary = origin.getDefiningOp<UnitaryOpInterface>()) {
+      origin = unitary.getInputForOutput(origin);
+    }
+    if (origin != argument) {
+      return false;
+    }
+  }
+  return true;
 }
 
 SmallVector<size_t> getUsedQubitIndices(Block& body) {

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.h
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.h
@@ -31,6 +31,11 @@ namespace qco::detail {
 [[nodiscard]] LogicalResult verifyModifierBody(Operation* modifierOp,
                                                Block& body);
 
+/// Check whether a valid modifier body yields each wire in argument order.
+/// Follow the unitary operations' input/output correspondence without treating
+/// a permutation in the terminator as part of any individual body gate.
+[[nodiscard]] bool hasPositionalBodyYields(Block& body);
+
 /**
  * @brief Return the positions of the qubits that the body of a modifier uses.
  *

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.h
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/ModifierUtils.h
@@ -32,6 +32,7 @@ namespace qco::detail {
                                                Block& body);
 
 /// Check whether a valid modifier body yields each wire in argument order.
+///
 /// Follow the unitary operations' input/output correspondence without treating
 /// a permutation in the terminator as part of any individual body gate.
 [[nodiscard]] bool hasPositionalBodyYields(Block& body);

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
@@ -229,6 +229,10 @@ struct MergeNestedPow final : OpRewritePattern<PowOp> {
       return failure();
     }
 
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
+      return failure();
+    }
+
     // The inner pow's operands alias the outer pow's block args, possibly in a
     // different order / subset. Translate them back to the outer pow's operands
     // so the merged pow's footprint matches the inner pow positionally.
@@ -280,6 +284,10 @@ struct MoveCtrlOutsidePow final : OpRewritePattern<PowOp> {
     // The rewrite hands the qubits of the modifier to the inner operation, so
     // it must act on all of them.
     if (innerCtrlOp.getNumQubits() != op.getNumQubits()) {
+      return failure();
+    }
+
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
       return failure();
     }
 
@@ -355,6 +363,10 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     if (!exponent) {
       return failure();
     }
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
+      return failure();
+    }
+
     const double r = *exponent;
     auto loc = op.getLoc();
 
@@ -717,6 +729,10 @@ struct EraseEmptyPow final : OpRewritePattern<PowOp> {
   LogicalResult matchAndRewrite(PowOp op,
                                 PatternRewriter& rewriter) const override {
     if (op.getNumBodyUnitaries() != 0) {
+      return failure();
+    }
+
+    if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
       return failure();
     }
 

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
@@ -363,6 +363,12 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     if (!exponent) {
       return failure();
     }
+    if (!isa<GPhaseOp, XOp, YOp, ZOp, SOp, SdgOp, TOp, TdgOp, SXOp, SXdgOp, HOp,
+             ECROp, RCCXOp, SWAPOp, RXOp, RYOp, RZOp, POp, ROp, RXXOp, RYYOp,
+             RZXOp, RZZOp, XXPlusYYOp, XXMinusYYOp, iSWAPOp, UOp, IdOp,
+             BarrierOp>(innerOp)) {
+      return failure();
+    }
     if (!qco::detail::hasPositionalBodyYields(*op.getBody())) {
       return failure();
     }
@@ -396,12 +402,6 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     // integral exponents.
     if (isa<HOp, ECROp, RCCXOp, SWAPOp>(innerOp) &&
         !mqt::isIntegerExponent(r)) {
-      return failure();
-    }
-    if (!isa<GPhaseOp, XOp, YOp, ZOp, SOp, SdgOp, TOp, TdgOp, SXOp, SXdgOp, HOp,
-             ECROp, RCCXOp, SWAPOp, RXOp, RYOp, RZOp, POp, ROp, RXXOp, RYYOp,
-             RZXOp, RZZOp, XXPlusYYOp, XXMinusYYOp, iSWAPOp, UOp, IdOp,
-             BarrierOp>(innerOp)) {
       return failure();
     }
 

--- a/mlir/unittests/Dialect/QC/IR/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QC/IR/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Licensed under the MIT License
 
 set(target_name mqt-core-mlir-unittest-qc-ir)
-add_executable(${target_name} test_qc_ir.cpp)
+add_executable(${target_name} test_qc_ir.cpp test_qc_modifier_canonicalization.cpp)
 target_link_libraries(
   ${target_name}
   PRIVATE MLIRParser

--- a/mlir/unittests/Dialect/QC/IR/test_qc_modifier_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_modifier_canonicalization.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
+#include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
+
+#include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/StringRef.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/Passes.h>
+
+using namespace mlir;
+using namespace mlir::qc;
+
+namespace {
+
+class QCModifierCanonicalizationTest : public testing::Test {
+protected:
+  MLIRContext context_;
+
+  void SetUp() override {
+    context_.loadDialect<mlir::mqt::MQTDialect, QCDialect, arith::ArithDialect,
+                         func::FuncDialect>();
+  }
+
+  OwningOpRef<ModuleOp> canonicalize(StringRef source) {
+    auto moduleOp = parseSourceString<ModuleOp>(source, &context_);
+    EXPECT_TRUE(moduleOp);
+    if (!moduleOp) {
+      return {};
+    }
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    PassManager manager(&context_);
+    manager.addPass(createCanonicalizerPass());
+    EXPECT_TRUE(succeeded(manager.run(*moduleOp)));
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    return moduleOp;
+  }
+};
+
+TEST_F(QCModifierCanonicalizationTest, ControlledPhaseDropsUnusedTargets) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%c0: !qc.qubit, %c1: !qc.qubit, %q: !qc.qubit, %angle: f64) {
+        qc.ctrl(%c0, %c1) targets(%t = %q) {
+          qc.gphase(%angle)
+          qc.yield
+        } : {!qc.qubit, !qc.qubit}, {!qc.qubit}
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto controls = function.getBody().getOps<CtrlOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(controls));
+  auto ctrl = *controls.begin();
+  ASSERT_EQ(ctrl.getNumControls(), 1U);
+  ASSERT_EQ(ctrl.getNumTargets(), 1U);
+  EXPECT_EQ(ctrl.getControls().front(), function.getArgument(0));
+  EXPECT_EQ(ctrl.getTargets().front(), function.getArgument(1));
+  auto phases = ctrl.getBody()->getOps<POp>();
+  ASSERT_TRUE(llvm::hasSingleElement(phases));
+  auto phase = *phases.begin();
+  EXPECT_EQ(phase.getTarget(0), ctrl.getBody()->getArgument(0));
+  EXPECT_EQ(phase.getTheta(), function.getArgument(3));
+}
+
+TEST_F(QCModifierCanonicalizationTest,
+       ControlledPhaseHoistsParameterArithmetic) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%c0: !qc.qubit, %c1: !qc.qubit, %angle: f64) {
+        qc.ctrl(%c0, %c1) targets() {
+          %square = arith.mulf %angle, %angle : f64
+          qc.gphase(%square)
+          qc.yield
+        } : {!qc.qubit, !qc.qubit}
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto ctrl = *function.getBody().getOps<CtrlOp>().begin();
+  EXPECT_EQ(ctrl.getNumControls(), 1U);
+  auto phase = *ctrl.getBody()->getOps<POp>().begin();
+  auto square = phase.getTheta().getDefiningOp<arith::MulFOp>();
+  ASSERT_TRUE(square);
+  EXPECT_EQ(square->getBlock(), &function.getBody().front());
+  EXPECT_EQ(square.getLhs(), function.getArgument(2));
+  EXPECT_EQ(square.getRhs(), function.getArgument(2));
+}
+
+TEST_F(QCModifierCanonicalizationTest, ZeroControlsInlineMultipleGates) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qc.qubit, %q1: !qc.qubit, %angle: f64) {
+        "qc.ctrl"(%q0, %q1) <{operandSegmentSizes = array<i32: 0, 2>}> ({
+        ^bb0(%a: !qc.qubit, %b: !qc.qubit):
+          %square = arith.mulf %angle, %angle : f64
+          qc.h %b : !qc.qubit
+          qc.rx(%square) %b : !qc.qubit
+          qc.yield
+        }) : (!qc.qubit, !qc.qubit) -> ()
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<CtrlOp>().empty());
+  auto h = *function.getBody().getOps<HOp>().begin();
+  auto rx = *function.getBody().getOps<RXOp>().begin();
+  EXPECT_EQ(h.getTarget(0), function.getArgument(1));
+  EXPECT_EQ(rx.getTarget(0), function.getArgument(1));
+  EXPECT_TRUE(h->isBeforeInBlock(rx));
+  EXPECT_TRUE(rx.getTheta().getDefiningOp<arith::MulFOp>());
+}
+
+TEST_F(QCModifierCanonicalizationTest, NestedControlsHoistParameterArithmetic) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%c0: !qc.qubit, %c1: !qc.qubit, %q: !qc.qubit, %angle: f64) {
+        qc.ctrl(%c0) targets(%a = %c1, %b = %q) {
+          %square = arith.mulf %angle, %angle : f64
+          qc.ctrl(%a) targets(%t = %b) {
+            qc.rx(%square) %t : !qc.qubit
+            qc.yield
+          } : {!qc.qubit}, {!qc.qubit}
+          qc.yield
+        } : {!qc.qubit}, {!qc.qubit, !qc.qubit}
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto ctrl = *function.getBody().getOps<CtrlOp>().begin();
+  ASSERT_EQ(ctrl.getNumControls(), 2U);
+  ASSERT_EQ(ctrl.getNumTargets(), 1U);
+  EXPECT_EQ(ctrl.getControls()[0], function.getArgument(0));
+  EXPECT_EQ(ctrl.getControls()[1], function.getArgument(1));
+  EXPECT_EQ(ctrl.getTargets().front(), function.getArgument(2));
+  auto rx = *ctrl.getBody()->getOps<RXOp>().begin();
+  auto square = rx.getTheta().getDefiningOp<arith::MulFOp>();
+  ASSERT_TRUE(square);
+  EXPECT_EQ(square->getBlock(), &function.getBody().front());
+  EXPECT_EQ(square.getLhs(), function.getArgument(3));
+}
+
+TEST_F(QCModifierCanonicalizationTest, NestedControlsRetainOtherBodyGates) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%c0: !qc.qubit, %c1: !qc.qubit, %q: !qc.qubit) {
+        qc.ctrl(%c0) targets(%a = %c1, %b = %q) {
+          qc.h %a : !qc.qubit
+          qc.ctrl(%a) targets(%t = %b) {
+            qc.x %t : !qc.qubit
+            qc.yield
+          } : {!qc.qubit}, {!qc.qubit}
+          qc.yield
+        } : {!qc.qubit}, {!qc.qubit, !qc.qubit}
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto ctrl = *function.getBody().getOps<CtrlOp>().begin();
+  EXPECT_EQ(ctrl.getNumControls(), 1U);
+  EXPECT_EQ(ctrl.getNumBodyUnitaries(), 2U);
+  EXPECT_TRUE(llvm::hasSingleElement(ctrl.getBody()->getOps<HOp>()));
+  EXPECT_TRUE(llvm::hasSingleElement(ctrl.getBody()->getOps<CtrlOp>()));
+}
+
+TEST_F(QCModifierCanonicalizationTest, DoubleInverseInlinesMultipleGates) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qc.qubit, %q1: !qc.qubit, %angle: f64) {
+        qc.inv (%a = %q0, %b = %q1) {
+          %square = arith.mulf %angle, %angle : f64
+          qc.inv (%t = %b) {
+            qc.h %t : !qc.qubit
+            qc.rx(%square) %t : !qc.qubit
+            qc.yield
+          } : !qc.qubit
+          qc.yield
+        } : !qc.qubit, !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<InvOp>().empty());
+  auto h = *function.getBody().getOps<HOp>().begin();
+  auto rx = *function.getBody().getOps<RXOp>().begin();
+  EXPECT_EQ(h.getTarget(0), function.getArgument(1));
+  EXPECT_EQ(rx.getTarget(0), function.getArgument(1));
+  EXPECT_TRUE(h->isBeforeInBlock(rx));
+  EXPECT_TRUE(rx.getTheta().getDefiningOp<arith::MulFOp>());
+}
+
+TEST_F(QCModifierCanonicalizationTest, SingleInverseRetainsMultipleGates) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qc.qubit, %angle: f64) {
+        qc.inv (%a = %q) {
+          qc.h %a : !qc.qubit
+          qc.rx(%angle) %a : !qc.qubit
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto inverses = function.getBody().getOps<InvOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(inverses));
+  auto inverse = *inverses.begin();
+  EXPECT_EQ(inverse.getNumBodyUnitaries(), 2U);
+}
+
+TEST_F(QCModifierCanonicalizationTest, UPowerPreservesSecondModifierTarget) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qc.qubit, %q1: !qc.qubit) {
+        %exponent = arith.constant 2.0 : f64
+        %theta = arith.constant 0.1 : f64
+        %phi = arith.constant 0.2 : f64
+        %lambda = arith.constant 0.3 : f64
+        qc.pow(%exponent) (%a = %q0, %b = %q1) {
+          qc.u(%theta, %phi, %lambda) %b : !qc.qubit
+          qc.yield
+        } : !qc.qubit, !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<PowOp>().empty());
+  auto gates = function.getBody().getOps<UOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(gates));
+  auto gate = *gates.begin();
+  EXPECT_EQ(gate.getTarget(0), function.getArgument(1));
+}
+
+} // namespace

--- a/mlir/unittests/Dialect/QCO/IR/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/IR/CMakeLists.txt
@@ -7,7 +7,9 @@
 # Licensed under the MIT License
 
 set(qco_ir_target mqt-core-mlir-unittest-qco-ir)
-add_executable(${qco_ir_target} test_qco_ir.cpp test_qco_ir_matrix.cpp)
+add_executable(
+  ${qco_ir_target} test_qco_ir.cpp test_qco_ir_matrix.cpp test_qco_modifier_canonicalization.cpp
+                   test_qco_modifier_yield_canonicalization.cpp test_qco_wire_canonicalization.cpp)
 target_link_libraries(
   ${qco_ir_target}
   PRIVATE MLIRParser

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -2357,7 +2357,7 @@ TEST_F(QCOTest, PowBarrierFoldPreservesReorderedBodyResults) {
   EXPECT_EQ(measurements[1].getQubitIn(), barriers[0].getOutputQubits()[0]);
 }
 
-TEST_F(QCOTest, EvenPowFoldPreservesReorderedBodyResults) {
+TEST_F(QCOTest, EvenPowerRetainsBodyYieldPermutation) {
   auto program = ::mqt::test::buildMLIRProgram(
       context.get(), MQT_NAMED_BUILDER(powEvenSwapWithReorderedBody));
   ASSERT_TRUE(program);
@@ -2368,14 +2368,16 @@ TEST_F(QCOTest, EvenPowFoldPreservesReorderedBodyResults) {
   ASSERT_TRUE(succeeded(pm.run(*program)));
   ASSERT_TRUE(succeeded(verify(*program)));
 
-  SmallVector<AllocOp> allocations;
+  SmallVector<PowOp> powers;
   SmallVector<MeasureOp> measurements;
-  program->walk([&](AllocOp alloc) { allocations.push_back(alloc); });
+  program->walk([&](PowOp power) { powers.push_back(power); });
   program->walk([&](MeasureOp measure) { measurements.push_back(measure); });
-  ASSERT_EQ(allocations.size(), 2);
-  ASSERT_EQ(measurements.size(), 2);
-  EXPECT_EQ(measurements[0].getQubitIn(), allocations[1].getResult());
-  EXPECT_EQ(measurements[1].getQubitIn(), allocations[0].getResult());
+  // The yielded permutation belongs to the powered body. Folding only SWAP
+  // would apply that permutation once instead of powering the complete body.
+  ASSERT_EQ(powers.size(), 1U);
+  ASSERT_EQ(measurements.size(), 2U);
+  EXPECT_EQ(measurements[0].getQubitIn(), powers[0].getOutputQubit(0));
+  EXPECT_EQ(measurements[1].getQubitIn(), powers[0].getOutputQubit(1));
 }
 
 // pow(-0.5) { h } cannot fold a negative fractional exponent
@@ -3260,7 +3262,7 @@ INSTANTIATE_TEST_SUITE_P(
                     MQT_NAMED_BUILDER(alloc2QubitRegister)},
         QCOTestCase{"TwoXXPlusYYSwappedTargets",
                     MQT_NAMED_BUILDER(twoXxPlusYYSwappedTargets),
-                    MQT_NAMED_BUILDER(xxPlusYY)},
+                    MQT_NAMED_BUILDER(twoXxPlusYYSwappedTargets)},
         QCOTestCase{"PowXxPlusYYScaled", MQT_NAMED_BUILDER(powXxPlusYYScaled),
                     MQT_NAMED_BUILDER(powXxPlusYYScaledRef)}));
 

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_modifier_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_modifier_canonicalization.cpp
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
+
+#include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/StringRef.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/Passes.h>
+
+using namespace mlir;
+using namespace mlir::qco;
+
+namespace {
+
+class QCOModifierCanonicalizationTest : public testing::Test {
+protected:
+  MLIRContext context_;
+
+  void SetUp() override {
+    context_.loadDialect<mlir::mqt::MQTDialect, QCODialect, arith::ArithDialect,
+                         func::FuncDialect>();
+  }
+
+  OwningOpRef<ModuleOp> canonicalize(StringRef source) {
+    auto moduleOp = parseSourceString<ModuleOp>(source, &context_);
+    EXPECT_TRUE(moduleOp);
+    if (!moduleOp) {
+      return {};
+    }
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+    PassManager manager(&context_);
+    manager.addPass(createCanonicalizerPass());
+    EXPECT_TRUE(succeeded(manager.run(*moduleOp)));
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+    return moduleOp;
+  }
+};
+
+TEST_F(QCOModifierCanonicalizationTest, ControlledPhaseDropsUnusedTargets) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%c0: !qco.qubit, %c1: !qco.qubit, %q: !qco.qubit, %angle: f64)
+          -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2 = qco.ctrl(%c0, %c1) targets(%t = %q) {
+          qco.gphase(%angle)
+          qco.yield %t : !qco.qubit
+        } : ({!qco.qubit, !qco.qubit}, {!qco.qubit})
+          -> ({!qco.qubit, !qco.qubit}, {!qco.qubit})
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto controls = function.getBody().getOps<CtrlOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(controls));
+  auto ctrl = *controls.begin();
+  ASSERT_EQ(ctrl.getNumControls(), 1U);
+  ASSERT_EQ(ctrl.getNumTargets(), 1U);
+  EXPECT_EQ(ctrl.getControlsIn().front(), function.getArgument(0));
+  EXPECT_EQ(ctrl.getTargetsIn().front(), function.getArgument(1));
+  auto phases = ctrl.getBody()->getOps<POp>();
+  ASSERT_TRUE(llvm::hasSingleElement(phases));
+  auto phase = *phases.begin();
+  EXPECT_EQ(phase.getInputTarget(0), ctrl.getBody()->getArgument(0));
+  EXPECT_EQ(phase.getTheta(), function.getArgument(3));
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), ctrl.getControlsOut().front());
+  EXPECT_EQ(returned.getOperand(1), ctrl.getTargetsOut().front());
+  EXPECT_EQ(returned.getOperand(2), function.getArgument(2));
+}
+
+TEST_F(QCOModifierCanonicalizationTest,
+       ControlledPhaseHoistsParameterArithmetic) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%c0: !qco.qubit, %c1: !qco.qubit, %angle: f64)
+          -> (!qco.qubit, !qco.qubit) {
+        %o0, %o1 = qco.ctrl(%c0, %c1) targets() {
+          %square = arith.mulf %angle, %angle : f64
+          qco.gphase(%square)
+          qco.yield
+        } : ({!qco.qubit, !qco.qubit}) -> ({!qco.qubit, !qco.qubit})
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto ctrl = *function.getBody().getOps<CtrlOp>().begin();
+  EXPECT_EQ(ctrl.getNumControls(), 1U);
+  auto phase = *ctrl.getBody()->getOps<POp>().begin();
+  auto square = phase.getTheta().getDefiningOp<arith::MulFOp>();
+  ASSERT_TRUE(square);
+  EXPECT_EQ(square->getBlock(), &function.getBody().front());
+  EXPECT_EQ(square.getLhs(), function.getArgument(2));
+  EXPECT_EQ(square.getRhs(), function.getArgument(2));
+}
+
+TEST_F(QCOModifierCanonicalizationTest, ZeroControlsInlineMultipleGates) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %angle: f64)
+          -> (!qco.qubit, !qco.qubit) {
+        %o0, %o1 = "qco.ctrl"(%q0, %q1) <{
+          operandSegmentSizes = array<i32: 0, 2>,
+          resultSegmentSizes = array<i32: 0, 2>
+        }> ({
+        ^bb0(%a: !qco.qubit, %b: !qco.qubit):
+          %square = arith.mulf %angle, %angle : f64
+          %h = qco.h %b : !qco.qubit -> !qco.qubit
+          %r = qco.rx(%square) %h : !qco.qubit -> !qco.qubit
+          qco.yield %a, %r : !qco.qubit, !qco.qubit
+        }) : (!qco.qubit, !qco.qubit) -> (!qco.qubit, !qco.qubit)
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<CtrlOp>().empty());
+  auto h = *function.getBody().getOps<HOp>().begin();
+  auto rx = *function.getBody().getOps<RXOp>().begin();
+  EXPECT_EQ(h.getInputTarget(0), function.getArgument(1));
+  EXPECT_EQ(rx.getInputTarget(0), h.getResult());
+  EXPECT_TRUE(rx.getTheta().getDefiningOp<arith::MulFOp>());
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), function.getArgument(0));
+  EXPECT_EQ(returned.getOperand(1), rx.getResult());
+}
+
+TEST_F(QCOModifierCanonicalizationTest,
+       NestedControlsHoistParameterArithmetic) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%c0: !qco.qubit, %c1: !qco.qubit, %q: !qco.qubit, %angle: f64)
+          -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2 = qco.ctrl(%c0) targets(%a = %c1, %b = %q) {
+          %square = arith.mulf %angle, %angle : f64
+          %i0, %i1 = qco.ctrl(%a) targets(%t = %b) {
+            %r = qco.rx(%square) %t : !qco.qubit -> !qco.qubit
+            qco.yield %r : !qco.qubit
+          } : ({!qco.qubit}, {!qco.qubit}) -> ({!qco.qubit}, {!qco.qubit})
+          qco.yield %i0, %i1 : !qco.qubit, !qco.qubit
+        } : ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+          -> ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto ctrl = *function.getBody().getOps<CtrlOp>().begin();
+  ASSERT_EQ(ctrl.getNumControls(), 2U);
+  ASSERT_EQ(ctrl.getNumTargets(), 1U);
+  EXPECT_EQ(ctrl.getControlsIn()[0], function.getArgument(0));
+  EXPECT_EQ(ctrl.getControlsIn()[1], function.getArgument(1));
+  EXPECT_EQ(ctrl.getTargetsIn().front(), function.getArgument(2));
+  auto rx = *ctrl.getBody()->getOps<RXOp>().begin();
+  auto square = rx.getTheta().getDefiningOp<arith::MulFOp>();
+  ASSERT_TRUE(square);
+  EXPECT_EQ(square->getBlock(), &function.getBody().front());
+  EXPECT_EQ(square.getLhs(), function.getArgument(3));
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_TRUE(llvm::equal(returned.getOperands(), ctrl.getResults()));
+}
+
+TEST_F(QCOModifierCanonicalizationTest, NestedControlsRetainOtherBodyGates) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%c0: !qco.qubit, %c1: !qco.qubit, %q: !qco.qubit)
+          -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2 = qco.ctrl(%c0) targets(%a = %c1, %b = %q) {
+          %h = qco.h %a : !qco.qubit -> !qco.qubit
+          %i0, %i1 = qco.ctrl(%h) targets(%t = %b) {
+            %x = qco.x %t : !qco.qubit -> !qco.qubit
+            qco.yield %x : !qco.qubit
+          } : ({!qco.qubit}, {!qco.qubit}) -> ({!qco.qubit}, {!qco.qubit})
+          qco.yield %i0, %i1 : !qco.qubit, !qco.qubit
+        } : ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+          -> ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto ctrl = *function.getBody().getOps<CtrlOp>().begin();
+  EXPECT_EQ(ctrl.getNumControls(), 1U);
+  EXPECT_EQ(ctrl.getNumBodyUnitaries(), 2U);
+  EXPECT_TRUE(llvm::hasSingleElement(ctrl.getBody()->getOps<HOp>()));
+  EXPECT_TRUE(llvm::hasSingleElement(ctrl.getBody()->getOps<CtrlOp>()));
+}
+
+TEST_F(QCOModifierCanonicalizationTest, DoubleInversePreservesOutputOrder) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        %o0, %o1 = qco.inv (%a = %q0, %b = %q1) {
+          %i0, %i1 = qco.inv (%c = %b, %d = %a) {
+            %s0, %s1 = qco.iswap %c, %d
+              : !qco.qubit, !qco.qubit -> !qco.qubit, !qco.qubit
+            qco.yield %s0, %s1 : !qco.qubit, !qco.qubit
+          } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+          qco.yield %i1, %i0 : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<InvOp>().empty());
+  auto swaps = function.getBody().getOps<iSWAPOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(swaps));
+  auto iswap = *swaps.begin();
+  EXPECT_EQ(iswap.getInputQubits()[0], function.getArgument(1));
+  EXPECT_EQ(iswap.getInputQubits()[1], function.getArgument(0));
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), iswap.getOutputQubits()[1]);
+  EXPECT_EQ(returned.getOperand(1), iswap.getOutputQubits()[0]);
+}
+
+TEST_F(QCOModifierCanonicalizationTest, DoubleInverseInlinesMultipleGates) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %angle: f64)
+          -> (!qco.qubit, !qco.qubit) {
+        %o0, %o1 = qco.inv (%a = %q0, %b = %q1) {
+          %square = arith.mulf %angle, %angle : f64
+          %i = qco.inv (%t = %b) {
+            %h = qco.h %t : !qco.qubit -> !qco.qubit
+            %r = qco.rx(%square) %h : !qco.qubit -> !qco.qubit
+            qco.yield %r : !qco.qubit
+          } : {!qco.qubit} -> {!qco.qubit}
+          qco.yield %a, %i : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<InvOp>().empty());
+  auto h = *function.getBody().getOps<HOp>().begin();
+  auto rx = *function.getBody().getOps<RXOp>().begin();
+  EXPECT_EQ(h.getInputTarget(0), function.getArgument(1));
+  EXPECT_EQ(rx.getInputTarget(0), h.getResult());
+  EXPECT_TRUE(rx.getTheta().getDefiningOp<arith::MulFOp>());
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), function.getArgument(0));
+  EXPECT_EQ(returned.getOperand(1), rx.getResult());
+}
+
+TEST_F(QCOModifierCanonicalizationTest, SingleInverseRetainsMultipleGates) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit, %angle: f64) -> !qco.qubit {
+        %o = qco.inv (%a = %q) {
+          %h = qco.h %a : !qco.qubit -> !qco.qubit
+          %r = qco.rx(%angle) %h : !qco.qubit -> !qco.qubit
+          qco.yield %r : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto inverses = function.getBody().getOps<InvOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(inverses));
+  auto inverse = *inverses.begin();
+  EXPECT_EQ(inverse.getNumBodyUnitaries(), 2U);
+}
+
+TEST_F(QCOModifierCanonicalizationTest, KnownInversePreservesUnusedQubits) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        %o0, %o1 = qco.inv (%a = %q0, %b = %q1) {
+          %t = qco.t %b : !qco.qubit -> !qco.qubit
+          qco.yield %a, %t : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<InvOp>().empty());
+  auto gates = function.getBody().getOps<TdgOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(gates));
+  auto tdg = *gates.begin();
+  EXPECT_EQ(tdg.getInputTarget(0), function.getArgument(1));
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), function.getArgument(0));
+  EXPECT_EQ(returned.getOperand(1), tdg.getResult());
+}
+
+} // namespace

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_modifier_yield_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_modifier_yield_canonicalization.cpp
@@ -1,0 +1,614 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
+#include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
+
+#include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/StringRef.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/Passes.h>
+
+using namespace mlir;
+using namespace mlir::qco;
+
+namespace {
+
+class QCOModifierYieldCanonicalizationTest : public testing::Test {
+protected:
+  MLIRContext context_;
+
+  void SetUp() override {
+    context_.loadDialect<mlir::mqt::MQTDialect, QCODialect, arith::ArithDialect,
+                         func::FuncDialect>();
+  }
+
+  OwningOpRef<ModuleOp> canonicalize(StringRef source) {
+    auto moduleOp = parseSourceString<ModuleOp>(source, &context_);
+    EXPECT_TRUE(moduleOp);
+    if (!moduleOp) {
+      return {};
+    }
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+    PassManager manager(&context_);
+    manager.addPass(createCanonicalizerPass());
+    EXPECT_TRUE(succeeded(manager.run(*moduleOp)));
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+    return moduleOp;
+  }
+
+  static void expectModifiers(ModuleOp moduleOp, unsigned controls,
+                              unsigned inverses, unsigned powers) {
+    unsigned ctrlCount = 0;
+    unsigned invCount = 0;
+    unsigned powCount = 0;
+    moduleOp.walk([&](CtrlOp) { ++ctrlCount; });
+    moduleOp.walk([&](InvOp) { ++invCount; });
+    moduleOp.walk([&](PowOp) { ++powCount; });
+    EXPECT_EQ(ctrlCount, controls);
+    EXPECT_EQ(invCount, inverses);
+    EXPECT_EQ(powCount, powers);
+  }
+};
+
+TEST_F(QCOModifierYieldCanonicalizationTest, EmptyInverseRetainsYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2 = qco.inv(%a = %q0, %b = %q1, %c = %q2) {
+          qco.yield %b, %c, %a : !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 1U, 0U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest, EmptyPowerRetainsYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %two = arith.constant 2.0 : f64
+        %o0, %o1, %o2 = qco.pow(%two) (%a = %q0, %b = %q1, %c = %q2) {
+          qco.yield %b, %c, %a : !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 1U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       EmptyControlRetainsYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2 = qco.ctrl(%q0) targets(%a = %q1, %b = %q2) {
+          qco.yield %b, %a : !qco.qubit, !qco.qubit
+        } : ({!qco.qubit}, {!qco.qubit, !qco.qubit}) -> ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 1U, 0U, 0U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       ControlledBarrierRetainsYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2 = qco.ctrl(%q0) targets(%a = %q1, %b = %q2) {
+          %x, %y = qco.barrier %a, %b : !qco.qubit, !qco.qubit -> !qco.qubit, !qco.qubit
+          qco.yield %y, %x : !qco.qubit, !qco.qubit
+        } : ({!qco.qubit}, {!qco.qubit, !qco.qubit}) -> ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 1U, 0U, 0U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       SelfAdjointInverseRetainsYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        %o0, %o1 = qco.inv(%a = %q0, %b = %q1) {
+          %x = qco.x %a : !qco.qubit -> !qco.qubit
+          qco.yield %b, %x : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 1U, 0U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       KnownInverseRetainsYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        %o0, %o1 = qco.inv(%a = %q0, %b = %q1) {
+          %x = qco.s %a : !qco.qubit -> !qco.qubit
+          qco.yield %b, %x : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 1U, 0U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       NestedInverseRetainsOuterYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %angle: f64) -> (!qco.qubit, !qco.qubit) {
+        %o0, %o1 = qco.inv(%a = %q0, %b = %q1) {
+          %square = arith.mulf %angle, %angle : f64
+          %i0, %i1 = qco.inv(%c = %a, %d = %b) {
+            %h = qco.h %c : !qco.qubit -> !qco.qubit
+            %r = qco.rx(%square) %h : !qco.qubit -> !qco.qubit
+            %x = qco.x %d : !qco.qubit -> !qco.qubit
+            qco.yield %r, %x : !qco.qubit, !qco.qubit
+          } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+          qco.yield %i1, %i0 : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 2U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto inverse = *function.getBody().getOps<InvOp>().begin();
+  EXPECT_TRUE(
+      llvm::hasSingleElement(inverse.getBody()->getOps<arith::MulFOp>()));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       NestedControlRetainsOuterYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit, %q3: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2, %o3 = qco.ctrl(%q0) targets(%a = %q1, %b = %q2, %c = %q3) {
+          %i0, %i1, %i2 = qco.ctrl(%a) targets(%d = %b, %e = %c) {
+            %x = qco.x %d : !qco.qubit -> !qco.qubit
+            %s = qco.s %e : !qco.qubit -> !qco.qubit
+            qco.yield %x, %s : !qco.qubit, !qco.qubit
+          } : ({!qco.qubit}, {!qco.qubit, !qco.qubit}) -> ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+          qco.yield %i0, %i2, %i1 : !qco.qubit, !qco.qubit, !qco.qubit
+        } : ({!qco.qubit}, {!qco.qubit, !qco.qubit, !qco.qubit}) -> ({!qco.qubit}, {!qco.qubit, !qco.qubit, !qco.qubit})
+        return %o0, %o1, %o2, %o3 : !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 2U, 0U, 0U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       InverseControlRetainsOuterYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        %o0, %o1 = qco.inv(%a = %q0, %b = %q1) {
+          %i0, %i1 = qco.ctrl(%a) targets(%c = %b) {
+            %x = qco.x %c : !qco.qubit -> !qco.qubit
+            qco.yield %x : !qco.qubit
+          } : ({!qco.qubit}, {!qco.qubit}) -> ({!qco.qubit}, {!qco.qubit})
+          qco.yield %i1, %i0 : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 1U, 1U, 0U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       PoweredControlRetainsOuterYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        %two = arith.constant 2.0 : f64
+        %o0, %o1 = qco.pow(%two) (%a = %q0, %b = %q1) {
+          %i0, %i1 = qco.ctrl(%a) targets(%c = %b) {
+            %x = qco.x %c : !qco.qubit -> !qco.qubit
+            qco.yield %x : !qco.qubit
+          } : ({!qco.qubit}, {!qco.qubit}) -> ({!qco.qubit}, {!qco.qubit})
+          qco.yield %i1, %i0 : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 1U, 0U, 1U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       InversePowerRetainsOuterYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        %three = arith.constant 3.0 : f64
+        %o0, %o1 = qco.inv(%a = %q0, %b = %q1) {
+          %i0, %i1 = qco.pow(%three) (%c = %a, %d = %b) {
+            %x = qco.x %c : !qco.qubit -> !qco.qubit
+            %s = qco.s %d : !qco.qubit -> !qco.qubit
+            qco.yield %x, %s : !qco.qubit, !qco.qubit
+          } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+          qco.yield %i1, %i0 : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 1U, 1U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       NestedPowerRetainsOuterYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        %two = arith.constant 2.0 : f64
+        %three = arith.constant 3.0 : f64
+        %o0, %o1 = qco.pow(%two) (%a = %q0, %b = %q1) {
+          %i0, %i1 = qco.pow(%three) (%c = %a, %d = %b) {
+            %x = qco.x %c : !qco.qubit -> !qco.qubit
+            %s = qco.s %d : !qco.qubit -> !qco.qubit
+            qco.yield %x, %s : !qco.qubit, !qco.qubit
+          } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+          qco.yield %i1, %i0 : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 2U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest, GatePowerRetainsYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit) -> (!qco.qubit, !qco.qubit) {
+        %two = arith.constant 2.0 : f64
+        %angle = arith.constant 0.3 : f64
+        %o0, %o1 = qco.pow(%two) (%a = %q0, %b = %q1) {
+          %r0, %r1 = qco.rzx(%angle) %a, %b : !qco.qubit, !qco.qubit -> !qco.qubit, !qco.qubit
+          qco.yield %r1, %r0 : !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit}
+        return %o0, %o1 : !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 1U);
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest, PowerOneInlinesYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %exponent = arith.constant 1.0 : f64
+        %o0, %o1, %o2 = qco.pow(%exponent) (%a = %q0, %b = %q1, %c = %q2) {
+          qco.yield %b, %c, %a : !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), function.getArgument(1));
+  EXPECT_EQ(returned.getOperand(1), function.getArgument(2));
+  EXPECT_EQ(returned.getOperand(2), function.getArgument(0));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest, PowerZeroErasesYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %exponent = arith.constant 0.0 : f64
+        %o0, %o1, %o2 = qco.pow(%exponent) (%a = %q0, %b = %q1, %c = %q2) {
+          qco.yield %b, %c, %a : !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), function.getArgument(0));
+  EXPECT_EQ(returned.getOperand(1), function.getArgument(1));
+  EXPECT_EQ(returned.getOperand(2), function.getArgument(2));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest, ZeroControlsInlineYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2 = "qco.ctrl"(%q0, %q1, %q2) <{
+          operandSegmentSizes = array<i32: 0, 3>,
+          resultSegmentSizes = array<i32: 0, 3>
+        }> ({
+        ^bb0(%a: !qco.qubit, %b: !qco.qubit, %c: !qco.qubit):
+          qco.yield %b, %c, %a : !qco.qubit, !qco.qubit, !qco.qubit
+        }) : (!qco.qubit, !qco.qubit, !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit)
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), function.getArgument(1));
+  EXPECT_EQ(returned.getOperand(1), function.getArgument(2));
+  EXPECT_EQ(returned.getOperand(2), function.getArgument(0));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       DoubleInverseInlinesInnerYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2 = qco.inv(%a = %q0, %b = %q1, %c = %q2) {
+          %i0, %i1, %i2 = qco.inv(%d = %a, %e = %b, %f = %c) {
+            qco.yield %e, %f, %d : !qco.qubit, !qco.qubit, !qco.qubit
+          } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+          qco.yield %i0, %i1, %i2 : !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), function.getArgument(1));
+  EXPECT_EQ(returned.getOperand(1), function.getArgument(2));
+  EXPECT_EQ(returned.getOperand(2), function.getArgument(0));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       NestedPowerInlinesInnerYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %two = arith.constant 2.0 : f64
+        %half = arith.constant 0.5 : f64
+        %o0, %o1, %o2 = qco.pow(%two) (%a = %q0, %b = %q1, %c = %q2) {
+          %i0, %i1, %i2 = qco.pow(%half) (%d = %a, %e = %b, %f = %c) {
+            qco.yield %e, %f, %d : !qco.qubit, !qco.qubit, !qco.qubit
+          } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+          qco.yield %i0, %i1, %i2 : !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), function.getArgument(1));
+  EXPECT_EQ(returned.getOperand(1), function.getArgument(2));
+  EXPECT_EQ(returned.getOperand(2), function.getArgument(0));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       NestedControlMergesInnerYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit, %q3: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2, %o3 = qco.ctrl(%q0) targets(%a = %q1, %b = %q2, %c = %q3) {
+          %i0, %i1, %i2 = qco.ctrl(%a) targets(%d = %b, %e = %c) {
+            qco.yield %e, %d : !qco.qubit, !qco.qubit
+          } : ({!qco.qubit}, {!qco.qubit, !qco.qubit}) -> ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+          qco.yield %i0, %i1, %i2 : !qco.qubit, !qco.qubit, !qco.qubit
+        } : ({!qco.qubit}, {!qco.qubit, !qco.qubit, !qco.qubit}) -> ({!qco.qubit}, {!qco.qubit, !qco.qubit, !qco.qubit})
+        return %o0, %o1, %o2, %o3 : !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 1U, 0U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto control = *function.getBody().getOps<CtrlOp>().begin();
+  EXPECT_EQ(control.getNumControls(), 2U);
+  EXPECT_EQ(control.getNumTargets(), 2U);
+  auto yielded = cast<YieldOp>(control.getBody()->getTerminator());
+  EXPECT_EQ(yielded.getOperand(0), control.getBody()->getArgument(1));
+  EXPECT_EQ(yielded.getOperand(1), control.getBody()->getArgument(0));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       InverseControlMovesInnerYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2 = qco.inv(%a = %q0, %b = %q1, %c = %q2) {
+          %i0, %i1, %i2 = qco.ctrl(%a) targets(%d = %b, %e = %c) {
+            qco.yield %e, %d : !qco.qubit, !qco.qubit
+          } : ({!qco.qubit}, {!qco.qubit, !qco.qubit}) -> ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+          qco.yield %i0, %i1, %i2 : !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 1U, 1U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto control = *function.getBody().getOps<CtrlOp>().begin();
+  EXPECT_TRUE(llvm::hasSingleElement(control.getBody()->getOps<InvOp>()));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       PoweredControlMovesInnerYieldPermutation) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %half = arith.constant 0.5 : f64
+        %o0, %o1, %o2 = qco.pow(%half) (%a = %q0, %b = %q1, %c = %q2) {
+          %i0, %i1, %i2 = qco.ctrl(%a) targets(%d = %b, %e = %c) {
+            qco.yield %e, %d : !qco.qubit, !qco.qubit
+          } : ({!qco.qubit}, {!qco.qubit, !qco.qubit}) -> ({!qco.qubit}, {!qco.qubit, !qco.qubit})
+          qco.yield %i0, %i1, %i2 : !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 1U, 0U, 1U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto control = *function.getBody().getOps<CtrlOp>().begin();
+  EXPECT_TRUE(llvm::hasSingleElement(control.getBody()->getOps<PowOp>()));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       InversePowerPreservesInnerYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit) {
+        %half = arith.constant 0.5 : f64
+        %o0, %o1, %o2 = qco.inv(%a = %q0, %b = %q1, %c = %q2) {
+          %i0, %i1, %i2 = qco.pow(%half) (%d = %a, %e = %b, %f = %c) {
+            qco.yield %e, %f, %d : !qco.qubit, !qco.qubit, !qco.qubit
+          } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+          qco.yield %i0, %i1, %i2 : !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2 : !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 1U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto power = *function.getBody().getOps<PowOp>().begin();
+  const auto exponent = mlir::mqt::valueToDouble(power.getExponent());
+  ASSERT_TRUE(exponent);
+  EXPECT_DOUBLE_EQ(*exponent, -0.5);
+  auto yielded = cast<YieldOp>(power.getBody()->getTerminator());
+  EXPECT_EQ(yielded.getOperand(0), power.getBody()->getArgument(1));
+  EXPECT_EQ(yielded.getOperand(1), power.getBody()->getArgument(2));
+  EXPECT_EQ(yielded.getOperand(2), power.getBody()->getArgument(0));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       InverseDropsUnusedWireAroundYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit, %q3: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2, %o3 = qco.inv(%a = %q0, %b = %q1, %c = %q2, %d = %q3) {
+          qco.yield %b, %c, %a, %d : !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2, %o3 : !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 1U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto modifier = *function.getBody().getOps<InvOp>().begin();
+  EXPECT_EQ(modifier.getNumTargets(), 3U);
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(3), function.getArgument(3));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       PowerDropsUnusedWireAroundYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit, %q3: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit) {
+        %two = arith.constant 2.0 : f64
+        %o0, %o1, %o2, %o3 = qco.pow(%two) (%a = %q0, %b = %q1, %c = %q2, %d = %q3) {
+          qco.yield %b, %c, %a, %d : !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit
+        } : {!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit} -> {!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit}
+        return %o0, %o1, %o2, %o3 : !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 0U, 0U, 1U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto modifier = *function.getBody().getOps<PowOp>().begin();
+  EXPECT_EQ(modifier.getNumTargets(), 3U);
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(3), function.getArgument(3));
+}
+
+TEST_F(QCOModifierYieldCanonicalizationTest,
+       ControlDropsUnusedWireAroundYieldCycle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q0: !qco.qubit, %q1: !qco.qubit, %q2: !qco.qubit, %q3: !qco.qubit, %q4: !qco.qubit) -> (!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit) {
+        %o0, %o1, %o2, %o3, %o4 = qco.ctrl(%q0) targets(%a = %q1, %b = %q2, %c = %q3, %d = %q4) {
+          qco.yield %b, %c, %a, %d : !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit
+        } : ({!qco.qubit}, {!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit}) -> ({!qco.qubit}, {!qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit})
+        return %o0, %o1, %o2, %o3, %o4 : !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit, !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  expectModifiers(*moduleOp, 1U, 0U, 0U);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto control = *function.getBody().getOps<CtrlOp>().begin();
+  EXPECT_EQ(control.getNumTargets(), 3U);
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(4), function.getArgument(4));
+}
+
+} // namespace

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_wire_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_wire_canonicalization.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "ExactUnitaryTest.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
+
+#include <gtest/gtest.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/Passes.h>
+
+#include <cstddef>
+
+using namespace mlir;
+using namespace mlir::qco;
+
+namespace {
+
+class QCOWireCanonicalizationTest : public testing::Test {
+protected:
+  MLIRContext context_;
+
+  void SetUp() override {
+    context_.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+  }
+
+  OwningOpRef<ModuleOp> twoQubitFunction() {
+    return parseSourceString<ModuleOp>(R"mlir(
+      module {
+        func.func @main(%q0: !qco.qubit, %q1: !qco.qubit)
+            -> (!qco.qubit, !qco.qubit) {
+          return %q0, %q1 : !qco.qubit, !qco.qubit
+        }
+      }
+    )mlir",
+                                       &context_);
+  }
+
+  void canonicalize(ModuleOp moduleOp) {
+    ASSERT_TRUE(succeeded(verify(moduleOp)));
+    ASSERT_TRUE(succeeded(verifyLinearity(moduleOp)));
+    PassManager manager(&context_);
+    manager.addPass(createCanonicalizerPass());
+    ASSERT_TRUE(succeeded(manager.run(moduleOp)));
+    ASSERT_TRUE(succeeded(verify(moduleOp)));
+    ASSERT_TRUE(succeeded(verifyLinearity(moduleOp)));
+  }
+
+  template <typename GateOp>
+  void checkMerge(bool reverseTargets, double secondBeta,
+                  size_t expectedGates) {
+    auto original = twoQubitFunction();
+    ASSERT_TRUE(original);
+    auto function = original->lookupSymbol<func::FuncOp>("main");
+    auto returned = cast<func::ReturnOp>(function.getBody().front().back());
+    OpBuilder builder(returned);
+    auto first =
+        GateOp::create(builder, function.getLoc(), function.getArgument(0),
+                       function.getArgument(1), 0.045, 0.456);
+    auto second = GateOp::create(builder, function.getLoc(),
+                                 first.getOutputQubit(reverseTargets ? 1 : 0),
+                                 first.getOutputQubit(reverseTargets ? 0 : 1),
+                                 0.078, secondBeta);
+    returned->setOperands(ValueRange{
+        second.getOutputQubit(reverseTargets ? 1 : 0),
+        second.getOutputQubit(reverseTargets ? 0 : 1),
+    });
+    ASSERT_TRUE(succeeded(verify(*original)));
+    ASSERT_TRUE(succeeded(verifyLinearity(*original)));
+    OwningOpRef<ModuleOp> rewritten(original->clone());
+    ASSERT_NO_FATAL_FAILURE(canonicalize(*rewritten));
+
+    size_t gateCount = 0;
+    rewritten->walk([&](GateOp) { ++gateCount; });
+    EXPECT_EQ(gateCount, expectedGates);
+    ::mqt::test::expectFullUnitaryEqual(*original, *rewritten, 2);
+  }
+};
+
+TEST_F(QCOWireCanonicalizationTest, XXPlusYYMergesOrderedWires) {
+  checkMerge<XXPlusYYOp>(false, 0.456, 1);
+}
+
+TEST_F(QCOWireCanonicalizationTest, XXPlusYYDoesNotMergeReversedWires) {
+  checkMerge<XXPlusYYOp>(true, 0.456, 2);
+}
+
+TEST_F(QCOWireCanonicalizationTest, XXMinusYYMergesReversedWires) {
+  checkMerge<XXMinusYYOp>(true, 0.456, 1);
+}
+
+TEST_F(QCOWireCanonicalizationTest, XXPlusYYDoesNotMergeDifferentAxes) {
+  checkMerge<XXPlusYYOp>(false, 0.789, 2);
+}
+
+TEST_F(QCOWireCanonicalizationTest, XXMinusYYDoesNotMergeDifferentAxes) {
+  checkMerge<XXMinusYYOp>(true, 0.789, 2);
+}
+
+} // namespace


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Preserve operand and yield mappings when simplifying QC and QCO modifiers, and require ordered targets when merging XXPlusYY gates. QCO algebraic rewrites retain modifiers whose bodies yield a wire permutation; direct inlining preserves those mappings.

Allow zero-control inlining, nested-inverse cancellation, and supported modifier rewrites to handle valid multi-operation bodies, eager arithmetic, and unused qubits. Add regressions for wire identity, yield permutations, and linearity.

Extracted from https://github.com/munich-quantum-toolkit/core/pull/2477.

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
