### PR TITLE
🐛 Bound canonicalization angle arithmetic

### DIFF
--- a/.agent/plans/canonicalization-safe-arithmetic.md
+++ b/.agent/plans/canonicalization-safe-arithmetic.md
@@ -1,0 +1,43 @@
+# Safe arithmetic in gate canonicalization
+
+Status: complete and validated locally.
+
+## Goal and scope
+
+Keep canonicalization from overflowing finite gate angles or discarding a
+rotation through binary64 rounding. The shared angle helpers in
+`mlir/include/mlir/Dialect/MQT/Utils/Angles.h` and
+`mlir/lib/Dialect/MQT/Utils/Angles.cpp` own the arithmetic bound. QCO gate
+merges and QC/QCO power rewrites use those helpers before changing IR. Fixed
+named gates reduce their exponents by their exact periods before computing
+angles.
+
+This change covers canonicalization and its tests. Matrix evaluation, U-gate
+power synthesis, wire correspondence, and transformation implementations are
+outside its scope.
+
+## Decisions
+
+- Accept constant sums and products only when their absolute rounding error does
+  not exceed `PARAMETER_COMPARISON_TOLERANCE`; retain dynamic arithmetic because
+  its error has no known bound. This restricts rewrites, not valid input angles.
+  Keep the existing global-phase range and principal-branch limits.
+- Use TwoSum for addition and `std::fma` for multiplication error. Check every
+  failure condition before hoisting supporting operations from modifier bodies.
+- Share phase-gate classification across QC and QCO. Validate named phases
+  against sine and cosine to reject inaccurate reduction of large angles.
+- Preserve consumer matrix checks when updating expectations for short dynamic
+  rotation runs. Retain a nontrivial branch-cut negative when squared Pauli
+  gates simplify directly to identity.
+
+## Validation
+
+With LLVM/MLIR 23.1.0, the release build and complete CTest run pass: 3,353
+entries passed and one skipped because the SC device does not support job IDs.
+The focused MQT utility, QC/QCO IR, and decomposition suites also pass. Tests
+retain nested powers with a dynamic inner exponent and keep the exponent
+computation in the outer body.
+
+Full-file C++ lint against the main base `46f98eabe` covers both the wire and
+arithmetic changes and passes. Repository lint and final diff checks pass.
+Hosted CI has not tested this extracted change.

--- a/mlir/include/mlir/Dialect/MQT/Utils/Angles.h
+++ b/mlir/include/mlir/Dialect/MQT/Utils/Angles.h
@@ -14,10 +14,28 @@
 #include <mlir/IR/Value.h>
 #include <mlir/Support/LogicalResult.h>
 
+#include <optional>
+
 namespace mlir::mqt {
 
 /// Largest supported magnitude of a global-phase angle in radians.
 inline constexpr double MAX_GLOBAL_PHASE_ANGLE = 1.0e4;
+
+/// Add finite constant angles when the absolute rounding error is no greater
+/// than PARAMETER_COMPARISON_TOLERANCE. Return no value on overflow or excess
+/// error. This bounds a rewrite's arithmetic, not the accepted input angles.
+[[nodiscard]] std::optional<double> addConstantAngles(double lhs, double rhs);
+
+/// Multiply finite constants with the same error bound as addConstantAngles.
+[[nodiscard]] std::optional<double> scaleConstantAngle(double angle,
+                                                       double factor);
+
+/// Named gates represented by a constant P-gate angle.
+enum class PhaseGate { Identity, Z, S, Sdg, T, Tdg };
+
+/// Classify a finite phase angle modulo 2*pi using the parameter tolerance.
+/// Return no value when the angle needs a general P gate.
+[[nodiscard]] std::optional<PhaseGate> classifyPhaseGate(double angle);
 
 /// Normalize an angle to (-pi, pi].
 [[nodiscard]] double normalizeAngle(double theta);

--- a/mlir/include/mlir/Dialect/MQT/Utils/Angles.h
+++ b/mlir/include/mlir/Dialect/MQT/Utils/Angles.h
@@ -22,8 +22,10 @@ namespace mlir::mqt {
 inline constexpr double MAX_GLOBAL_PHASE_ANGLE = 1.0e4;
 
 /// Add finite constant angles when the absolute rounding error is no greater
-/// than PARAMETER_COMPARISON_TOLERANCE. Return no value on overflow or excess
-/// error. This bounds a rewrite's arithmetic, not the accepted input angles.
+/// than PARAMETER_COMPARISON_TOLERANCE.
+///
+/// Return no value on overflow or excess error. This bounds a rewrite's
+/// arithmetic, not the accepted input angles.
 [[nodiscard]] std::optional<double> addConstantAngles(double lhs, double rhs);
 
 /// Multiply finite constants with the same error bound as addConstantAngles.
@@ -34,6 +36,7 @@ inline constexpr double MAX_GLOBAL_PHASE_ANGLE = 1.0e4;
 enum class PhaseGate { Identity, Z, S, Sdg, T, Tdg };
 
 /// Classify a finite phase angle modulo 2*pi using the parameter tolerance.
+///
 /// Return no value when the angle needs a general P gate.
 [[nodiscard]] std::optional<PhaseGate> classifyPhaseGate(double angle);
 

--- a/mlir/include/mlir/Dialect/MQT/Utils/GatePowering.h
+++ b/mlir/include/mlir/Dialect/MQT/Utils/GatePowering.h
@@ -19,8 +19,10 @@
 namespace mlir::mqt {
 
 /// Return the exact exponent period of a supported fixed named gate, or zero
-/// for a gate without such a period. All returned periods are powers of two,
-/// so reducing a finite binary64 exponent does not lose a fractional part.
+/// for a gate without such a period.
+///
+/// All returned periods are powers of two, so reducing a finite binary64
+/// exponent does not lose a fractional part.
 [[nodiscard]] unsigned getFixedGatePowerPeriod(StringRef baseSymbol);
 
 /**

--- a/mlir/include/mlir/Dialect/MQT/Utils/GatePowering.h
+++ b/mlir/include/mlir/Dialect/MQT/Utils/GatePowering.h
@@ -10,10 +10,18 @@
 
 #pragma once
 
+#include <llvm/ADT/StringRef.h>
+#include <mlir/Support/LLVM.h>
+
 #include <cstdint>
 #include <optional>
 
 namespace mlir::mqt {
+
+/// Return the exact exponent period of a supported fixed named gate, or zero
+/// for a gate without such a period. All returned periods are powers of two,
+/// so reducing a finite binary64 exponent does not lose a fractional part.
+[[nodiscard]] unsigned getFixedGatePowerPeriod(StringRef baseSymbol);
 
 /**
  * Maximum exponent considered for safe binary64 U-gate powering.

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "mlir/Dialect/MQT/Utils/Angles.h"
 #include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
 #include "mlir/Dialect/MQT/Utils/Parameters.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
@@ -222,7 +223,8 @@ LogicalResult mergeOneTargetZeroParameter(OpType op,
  * @brief Merge two compatible one-target, one-parameter operations
  *
  * @details
- * The new parameter is computed as the sum of the two original parameters.
+ * Merge constant angles only when their sum satisfies the arithmetic error
+ * bound in @ref mqt::addConstantAngles. Dynamic parameters have no known bound.
  *
  * @tparam OpType The type of the operation to be merged.
  * @param op The operation instance.
@@ -237,14 +239,19 @@ LogicalResult mergeOneTargetOneParameter(OpType op, PatternRewriter& rewriter) {
     return failure();
   }
 
-  // Compute the new parameter where both operands dominate, then move the
-  // merged gate behind it.
-  rewriter.setInsertionPoint(nextOp);
-  auto newParameter = arith::AddFOp::create(
-      rewriter, op.getLoc(), op.getOperand(1), nextOp.getOperand(1));
+  const auto lhs = mqt::valueToDouble(op.getOperand(1));
+  const auto rhs = mqt::valueToDouble(nextOp.getOperand(1));
+  const auto sum =
+      lhs && rhs ? mqt::addConstantAngles(*lhs, *rhs) : std::nullopt;
+  if (!sum) {
+    return failure();
+  }
+
+  rewriter.setInsertionPoint(op);
+  auto newParameter = arith::ConstantOp::create(rewriter, op.getLoc(),
+                                                rewriter.getF64FloatAttr(*sum));
   rewriter.modifyOpInPlace(
       op, [&] { op->setOperand(1, newParameter.getResult()); });
-  rewriter.moveOpBefore(op, nextOp);
 
   // Replace the second operation with the result of the first operation
   rewriter.replaceOp(nextOp, op.getResult());
@@ -279,14 +286,19 @@ static LogicalResult mergeTwoTargetOneParameterImpl(OpType op, OpType nextOp,
 
   auto output0 = op.getOutputQubit(0);
   if (symmetric || output0 == nextOp.getInputQubit(0)) {
-    // Compute the new parameter where both operands dominate, then move the
-    // merged gate behind it.
-    rewriter.setInsertionPoint(nextOp);
-    auto newParameter = arith::AddFOp::create(
-        rewriter, op.getLoc(), op.getOperand(2), nextOp.getOperand(2));
+    const auto lhs = mqt::valueToDouble(op.getOperand(2));
+    const auto rhs = mqt::valueToDouble(nextOp.getOperand(2));
+    const auto sum =
+        lhs && rhs ? mqt::addConstantAngles(*lhs, *rhs) : std::nullopt;
+    if (!sum) {
+      return failure();
+    }
+
+    rewriter.setInsertionPoint(op);
+    auto newParameter = arith::ConstantOp::create(
+        rewriter, op.getLoc(), rewriter.getF64FloatAttr(*sum));
     rewriter.modifyOpInPlace(
         op, [&] { op->setOperand(2, newParameter.getResult()); });
-    rewriter.moveOpBefore(op, nextOp);
     rewriter.replaceOp(nextOp, nextOp.getInputQubits());
     return success();
   }

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -17,7 +17,6 @@
 #include "mlir/Dialect/QCO/Utils/Matrix.h"
 
 #include <llvm/ADT/TypeSwitch.h>
-#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Block.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Support/LLVM.h>
@@ -246,10 +245,8 @@ LogicalResult mergeOneTargetOneParameter(OpType op, PatternRewriter& rewriter) {
   }
 
   rewriter.setInsertionPoint(op);
-  auto newParameter = arith::ConstantOp::create(rewriter, op.getLoc(),
-                                                rewriter.getF64FloatAttr(*sum));
-  rewriter.modifyOpInPlace(
-      op, [&] { op->setOperand(1, newParameter.getResult()); });
+  auto newParameter = mqt::constantFromScalar(rewriter, op.getLoc(), *sum);
+  rewriter.modifyOpInPlace(op, [&] { op->setOperand(1, newParameter); });
 
   // Replace the second operation with the result of the first operation
   rewriter.replaceOp(nextOp, op.getResult());
@@ -293,10 +290,8 @@ static LogicalResult mergeTwoTargetOneParameterImpl(OpType op, OpType nextOp,
     }
 
     rewriter.setInsertionPoint(op);
-    auto newParameter = arith::ConstantOp::create(
-        rewriter, op.getLoc(), rewriter.getF64FloatAttr(*sum));
-    rewriter.modifyOpInPlace(
-        op, [&] { op->setOperand(2, newParameter.getResult()); });
+    auto newParameter = mqt::constantFromScalar(rewriter, op.getLoc(), *sum);
+    rewriter.modifyOpInPlace(op, [&] { op->setOperand(2, newParameter); });
     rewriter.replaceOp(nextOp, nextOp.getInputQubits());
     return success();
   }

--- a/mlir/include/mlir/Dialect/QCO/QCOUtils.h
+++ b/mlir/include/mlir/Dialect/QCO/QCOUtils.h
@@ -219,18 +219,16 @@ LogicalResult mergeOneTargetZeroParameter(OpType op,
   return success();
 }
 
-/**
- * @brief Merge two compatible one-target, one-parameter operations
- *
- * @details
- * Merge constant angles only when their sum satisfies the arithmetic error
- * bound in @ref mqt::addConstantAngles. Dynamic parameters have no known bound.
- *
- * @tparam OpType The type of the operation to be merged.
- * @param op The operation instance.
- * @param rewriter The pattern rewriter.
- * @return LogicalResult Success or failure of the merge.
- */
+/// Merge two compatible one-target, one-parameter operations.
+///
+/// Merge constant angles only when their sum satisfies the arithmetic error
+/// bound in @ref mqt::addConstantAngles. Dynamic parameters have no known
+/// bound.
+///
+/// @tparam OpType The type of the operation to be merged.
+/// @param op The operation instance.
+/// @param rewriter The pattern rewriter.
+/// @return LogicalResult Success or failure of the merge.
 template <typename OpType>
 LogicalResult mergeOneTargetOneParameter(OpType op, PatternRewriter& rewriter) {
   // Check if the successor is the same operation

--- a/mlir/lib/Dialect/MQT/Utils/Angles.cpp
+++ b/mlir/lib/Dialect/MQT/Utils/Angles.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/MQT/Utils/Angles.h"
 
 #include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
+#include "mlir/Dialect/MQT/Utils/Parameters.h"
 
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/Value.h>
@@ -18,8 +19,74 @@
 
 #include <cmath>
 #include <numbers>
+#include <optional>
 
 namespace mlir::mqt {
+
+std::optional<double> addConstantAngles(double lhs, double rhs) {
+  const double sum = lhs + rhs;
+  if (!std::isfinite(lhs) || !std::isfinite(rhs) || !std::isfinite(sum)) {
+    return std::nullopt;
+  }
+  // TwoSum recovers the rounding error even when one operand is much smaller.
+  const double rhsRounded = sum - lhs;
+  const double error = (lhs - (sum - rhsRounded)) + (rhs - rhsRounded);
+  if (!std::isfinite(error) ||
+      std::abs(error) > PARAMETER_COMPARISON_TOLERANCE) {
+    return std::nullopt;
+  }
+  return sum;
+}
+
+std::optional<double> scaleConstantAngle(double angle, double factor) {
+  const double product = angle * factor;
+  if (!std::isfinite(angle) || !std::isfinite(factor) ||
+      !std::isfinite(product) ||
+      std::abs(std::fma(angle, factor, -product)) >
+          PARAMETER_COMPARISON_TOLERANCE) {
+    return std::nullopt;
+  }
+  return product;
+}
+
+std::optional<PhaseGate> classifyPhaseGate(double angle) {
+  if (!std::isfinite(angle)) {
+    return std::nullopt;
+  }
+  const double normalized = normalizeAngle(angle);
+  const double pi = std::numbers::pi;
+  const auto validatedGate = [&](PhaseGate gate, double real,
+                                 double imaginary) -> std::optional<PhaseGate> {
+    // Reduction by binary64 pi can lose phase information for large angles.
+    if (std::abs(std::cos(angle) - real) <= PARAMETER_COMPARISON_TOLERANCE &&
+        std::abs(std::sin(angle) - imaginary) <=
+            PARAMETER_COMPARISON_TOLERANCE) {
+      return gate;
+    }
+    return std::nullopt;
+  };
+  if (std::abs(normalized) < PARAMETER_COMPARISON_TOLERANCE) {
+    return validatedGate(PhaseGate::Identity, 1.0, 0.0);
+  }
+  if (std::abs(std::abs(normalized) - pi) < PARAMETER_COMPARISON_TOLERANCE) {
+    return validatedGate(PhaseGate::Z, -1.0, 0.0);
+  }
+  if (std::abs(normalized - pi / 2.0) < PARAMETER_COMPARISON_TOLERANCE) {
+    return validatedGate(PhaseGate::S, 0.0, 1.0);
+  }
+  if (std::abs(normalized + pi / 2.0) < PARAMETER_COMPARISON_TOLERANCE) {
+    return validatedGate(PhaseGate::Sdg, 0.0, -1.0);
+  }
+  if (std::abs(normalized - pi / 4.0) < PARAMETER_COMPARISON_TOLERANCE) {
+    const double component = std::sqrt(0.5);
+    return validatedGate(PhaseGate::T, component, component);
+  }
+  if (std::abs(normalized + pi / 4.0) < PARAMETER_COMPARISON_TOLERANCE) {
+    const double component = std::sqrt(0.5);
+    return validatedGate(PhaseGate::Tdg, component, -component);
+  }
+  return std::nullopt;
+}
 
 double normalizeAngle(double theta) {
   const double twoPi = 2.0 * std::numbers::pi;

--- a/mlir/lib/Dialect/MQT/Utils/GatePowering.cpp
+++ b/mlir/lib/Dialect/MQT/Utils/GatePowering.cpp
@@ -10,6 +10,8 @@
 
 #include "mlir/Dialect/MQT/Utils/GatePowering.h"
 
+#include <llvm/ADT/StringSwitch.h>
+
 #include <array>
 #include <cmath>
 #include <complex>
@@ -20,6 +22,14 @@
 #include <optional>
 
 namespace mlir::mqt {
+
+unsigned getFixedGatePowerPeriod(StringRef baseSymbol) {
+  return llvm::StringSwitch<unsigned>(baseSymbol)
+      .Cases({"x", "y", "z", "h", "ecr", "rccx", "swap"}, 2)
+      .Cases({"s", "sdg", "sx", "sxdg", "iswap"}, 4)
+      .Cases({"t", "tdg"}, 8)
+      .Default(0);
+}
 
 bool isIntegerExponent(const double value) {
   return value == std::floor(value) && std::isfinite(value);

--- a/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
@@ -222,9 +222,8 @@ struct MoveCtrlOutsidePow final : OpRewritePattern<PowOp> {
   }
 };
 
-/// @brief Fold pow(r) around gates into simpler operations.
+/// Fold pow(r) around gates into simpler operations.
 ///
-/// @details
 /// - Rotation gates: multiply a constant angle by an integer exponent when
 ///   the product meets the constant-angle rounding bound
 /// - Phase/diagonal gates: named gate if angle matches, else `P` gate,
@@ -501,7 +500,7 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
   }
 };
 
-/// @brief Erase power modifiers that do not have any body unitaries.
+/// Erase power modifiers that do not have any body unitaries.
 struct EraseEmptyPow final : OpRewritePattern<PowOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(PowOp op,
@@ -515,7 +514,7 @@ struct EraseEmptyPow final : OpRewritePattern<PowOp> {
   }
 };
 
-/// @brief Drop the qubits that the body does not use.
+/// Drop the qubits that the body does not use.
 struct DropUnusedPowQubits final : OpRewritePattern<PowOp> {
   using OpRewritePattern::OpRewritePattern;
 

--- a/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QC/IR/Modifiers/PowOp.cpp
@@ -21,7 +21,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
-#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <llvm/Support/ErrorHandling.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
@@ -30,7 +30,6 @@
 #include <mlir/Support/LLVM.h>
 #include <mlir/Support/LogicalResult.h>
 
-#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <numbers>
@@ -41,80 +40,34 @@ using namespace mlir;
 using namespace mlir::qc;
 using namespace mlir::mqt;
 
-/**
- * @brief If the computed P-gate angle corresponds to a named gate, emit it
- * directly.
- *
- * @details Uses these equivalences:
- *
- * `Z = P(π)`, `S = P(π/2)`, `Sdg = P(-π/2)`, `T = P(π/4)`, `Tdg = P(-π/4)`
- *
- * Since `P` is diagonal, raising to a power just multiplies the angle:
- *
- * ```
- * Z^r   = P(π)^r    = P(r·π)
- * S^r   = P(π/2)^r  = P(r·π/2)
- * Sdg^r = P(-π/2)^r = P(-r·π/2)
- * T^r   = P(π/4)^r  = P(r·π/4)
- * Tdg^r = P(-π/4)^r = P(-r·π/4)
- * ```
- *
- * The caller computes `angle = r * base_angle` and passes the raw
- * (unnormalized) value here; normalization to (-π, π] is performed internally.
- *
- * Matched angles and their replacements:
- *
- * | Angle          | Replacement |
- * |----------------|-------------|
- * | `angle ≈ 0`    | identity (op replaced with qubit pass-through) |
- * | `angle ≈ +/-π` | `Z`         |
- * | `angle ≈ π/2`  | `S`         |
- * | `angle ≈ -π/2` | `Sdg`       |
- * | `angle ≈ π/4`  | `T`         |
- * | `angle ≈ -π/4` | `Tdg`       |
- *
- * @param angle    Raw phase angle (`r * base_angle`), in radians.
- * @param op       The `PowOp` being rewritten.
- * @param rewriter The pattern rewriter.
- * @return `success()` if replaced, `failure()` if a general `P` gate should be
- * used.
- */
-static LogicalResult tryReplacePOpWithNamedGate(double angle, PowOp op,
-                                                Value target,
-                                                PatternRewriter& rewriter) {
-  const double norm = normalizeAngle(angle);
-  const double pi = std::numbers::pi;
-
-  if (std::abs(norm) < PARAMETER_COMPARISON_TOLERANCE) {
+/// Replace a power of a fixed phase gate with a named gate or a P gate.
+static void replaceWithPhaseGate(double angle, PowOp op, Value target,
+                                 PatternRewriter& rewriter) {
+  const auto phaseGate = classifyPhaseGate(angle);
+  if (!phaseGate) {
+    rewriter.replaceOpWithNewOp<POp>(op, target, angle);
+    return;
+  }
+  switch (*phaseGate) {
+  case PhaseGate::Identity:
     rewriter.eraseOp(op);
-    return success();
-  }
-  if (std::abs(std::abs(norm) - pi) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::Z:
     rewriter.replaceOpWithNewOp<ZOp>(op, target);
-    return success();
-  }
-  if (std::abs(norm - (pi / 2.0)) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::S:
     rewriter.replaceOpWithNewOp<SOp>(op, target);
-    return success();
-  }
-  if (std::abs(norm + (pi / 2.0)) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::Sdg:
     rewriter.replaceOpWithNewOp<SdgOp>(op, target);
-    return success();
-  }
-  if (std::abs(norm - (pi / 4.0)) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::T:
     rewriter.replaceOpWithNewOp<TOp>(op, target);
-    return success();
-  }
-  if (std::abs(norm + (pi / 4.0)) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::Tdg:
     rewriter.replaceOpWithNewOp<TdgOp>(op, target);
-    return success();
+    return;
   }
-  return failure();
-}
-
-/// Materialize exponent * param as arith ops
-static Value scaleByExponent(Value param, PowOp op, PatternRewriter& rewriter) {
-  return arith::MulFOp::create(rewriter, op.getLoc(), op.getExponent(), param);
 }
 
 namespace {
@@ -195,6 +148,15 @@ struct MergeNestedPow final : OpRewritePattern<PowOp> {
     if (!innerPow) {
       return failure();
     }
+    const auto innerExponent = innerPow.getExponentValue();
+    if (!innerExponent) {
+      return failure();
+    }
+    const auto mergedExponent =
+        scaleConstantAngle(*innerExponent, *outerExponent);
+    if (!mergedExponent) {
+      return failure();
+    }
     // The inner pow's operands alias the outer pow's block args, possibly in a
     // different order / subset. Translate them back to the outer pow's operands
     // so the merged pow's footprint matches the inner pow positionally.
@@ -206,9 +168,8 @@ struct MergeNestedPow final : OpRewritePattern<PowOp> {
     // Values are accessible from outside and survive PowOp erasure.
     mqt::hoistSupportingOpsBefore(*op.getBody(), innerPow.getOperation(), op,
                                   rewriter);
-    auto merged = scaleByExponent(innerPow.getExponent(), op, rewriter);
     rewriter.replaceOpWithNewOp<PowOp>(
-        op, merged, qubits, [&](ValueRange powArgs) {
+        op, *mergedExponent, qubits, [&](ValueRange powArgs) {
           // Inner pow body args now match the new pow's args positionally.
           mqt::inlineBodyReturningYields(*innerPow.getBody(), powArgs,
                                          rewriter);
@@ -261,19 +222,17 @@ struct MoveCtrlOutsidePow final : OpRewritePattern<PowOp> {
   }
 };
 
-/**
- * @brief Fold pow(r) around gates into simpler operations.
- *
- * @details
- * - Rotation gates: multiply angle by exponent,
- *   e.g., `pow(r) { rx(θ) } => rx(r*θ)`
- * - Phase/diagonal gates: named gate if angle matches, else `P` gate,
- *   e.g., `pow(r) { s } => s/sdg/t/tdg/z` or `p(r*π/2)`
- * - Hermitian gates (integer exponent): even => erase, odd => gate
- * - Constant U gates (positive integer exponent): synthesize as a U gate and
- *   phase
- * - Identity/barrier: pass through unchanged
- */
+/// @brief Fold pow(r) around gates into simpler operations.
+///
+/// @details
+/// - Rotation gates: multiply a constant angle by an integer exponent when
+///   the product meets the constant-angle rounding bound
+/// - Phase/diagonal gates: named gate if angle matches, else `P` gate,
+///   e.g., `pow(r) { s } => s/sdg/t/tdg/z` or `p(r*π/2)`
+/// - Hermitian gates (integer exponent): even => erase, odd => gate
+/// - Constant U gates (positive integer exponent): synthesize as a U gate and
+///   phase
+/// - Identity/barrier: pass through unchanged
 struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -288,7 +247,11 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     if (!exponent) {
       return failure();
     }
-    const double r = *exponent;
+    double r = *exponent;
+    const auto period = getFixedGatePowerPeriod(inner.getBaseSymbol());
+    if (period != 0U) {
+      r = std::remainder(r, static_cast<double>(period));
+    }
     auto loc = op.getLoc();
 
     std::optional<UPowerParameters> uPower;
@@ -308,10 +271,21 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     // Scaling a gate parameter represents a principal matrix power only for an
     // integral exponent unless the parameter is known to remain within the
     // principal branch. Keep arbitrary parameters inside fractional powers.
+    std::optional<double> scaledParameter;
     if (isa<GPhaseOp, RXOp, RYOp, RZOp, POp, ROp, RXXOp, RYYOp, RZXOp, RZZOp,
-            XXPlusYYOp, XXMinusYYOp>(innerOp) &&
-        !mqt::isIntegerExponent(r)) {
-      return failure();
+            XXPlusYYOp, XXMinusYYOp>(innerOp)) {
+      if (!mqt::isIntegerExponent(r)) {
+        return failure();
+      }
+      const auto parameter = valueToDouble(inner.getParameter(0));
+      if (!parameter) {
+        return failure();
+      }
+      scaledParameter = scaleConstantAngle(*parameter, r);
+      if (!scaledParameter || (isa<GPhaseOp>(innerOp) &&
+                               !isValidGlobalPhaseAngle(*scaledParameter))) {
+        return failure();
+      }
     }
     // HOp, ECROp, RCCXOp, and SWAPOp also only have the simple parity fold for
     // integral exponents.
@@ -330,50 +304,61 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     // Values are accessible from outside and survive PowOp erasure.
     mqt::hoistSupportingOpsBefore(*op.getBody(), innerOp, op, rewriter);
 
+    if (period != 0U) {
+      if (r == 0.0) {
+        rewriter.eraseOp(op);
+        return success();
+      }
+      if (r == 1.0 || (period == 2U && r == -1.0)) {
+        mqt::inlineModifierBody(op, *op.getBody(), op.getQubits(), rewriter);
+        return success();
+      }
+    }
+
+    Value scaledValue;
+    if (scaledParameter) {
+      scaledValue = constantFromScalar(rewriter, loc, *scaledParameter);
+    }
+
     return TypeSwitch<Operation*, LogicalResult>(innerOp)
         // --- Rotation gates: multiply angle by exponent ---
         // pow(r) { gphase(θ) } => gphase(r*θ)
-        .Case([&](GPhaseOp gate) {
-          auto newParam = scaleByExponent(gate.getTheta(), op, rewriter);
-          rewriter.replaceOpWithNewOp<GPhaseOp>(op, newParam);
+        .Case([&](GPhaseOp) {
+          rewriter.replaceOpWithNewOp<GPhaseOp>(op, scaledValue);
           return success();
         })
         // pow(r) { rx/ry/rz/p(θ) } => rx/ry/rz/p(r*θ)
         .Case<RXOp, RYOp, RZOp, POp>([&](auto gate) {
-          auto newParam = scaleByExponent(gate.getTheta(), op, rewriter);
           rewriter.replaceOpWithNewOp<decltype(gate)>(
               op,
               mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
-              newParam);
+              scaledValue);
           return success();
         })
         // pow(r) { rxx/ryy/rzx/rzz(θ) } => rxx/ryy/rzx/rzz(r*θ)
         .Case<RXXOp, RYYOp, RZXOp, RZZOp>([&](auto gate) {
-          auto newParam = scaleByExponent(gate.getTheta(), op, rewriter);
           rewriter.replaceOpWithNewOp<decltype(gate)>(
               op,
               mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
               mqt::getValueFromBlockArgument(gate.getTarget(1), op.getQubits()),
-              newParam);
+              scaledValue);
           return success();
         })
         // pow(r) { r(θ, φ) } => r(r*θ, φ)
         .Case([&](ROp gate) {
-          auto mul = scaleByExponent(gate.getTheta(), op, rewriter);
           rewriter.replaceOpWithNewOp<ROp>(
               op,
               mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
-              mul, gate.getPhi());
+              scaledValue, gate.getPhi());
           return success();
         })
         // pow(r) { xx±yy(θ, β) } => xx±yy(r*θ, β)
         .Case<XXPlusYYOp, XXMinusYYOp>([&](auto gate) {
-          auto mul = scaleByExponent(gate.getTheta(), op, rewriter);
           rewriter.replaceOpWithNewOp<decltype(gate)>(
               op,
               mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
               mqt::getValueFromBlockArgument(gate.getTarget(1), op.getQubits()),
-              mul, gate.getBeta());
+              scaledValue, gate.getBeta());
           return success();
         })
         // pow(n) { u(theta, phi, lambda) } =>
@@ -389,22 +374,16 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
               uPower->theta, uPower->phi, uPower->lambda);
           return success();
         })
-        // --- Pauli gates: decompose to rotation + global phase ---
-        // pow(r) { z } => named gate if angle matches, else p(r*π)
-        .Case([&](ZOp gate) {
-          const double angle = r * std::numbers::pi;
-          if (succeeded(tryReplacePOpWithNamedGate(
-                  angle, op,
-                  mqt::getValueFromBlockArgument(gate.getTarget(0),
-                                                 op.getQubits()),
-                  rewriter))) {
-            return success();
-          }
-          rewriter.replaceOpWithNewOp<POp>(
-              op,
+        // Powers of Z, S, Sdg, T, and Tdg are phase gates.
+        .Case<ZOp, SOp, SdgOp, TOp, TdgOp>([&](auto gate) {
+          const double signedExponent =
+              isa<SdgOp, TdgOp>(gate.getOperation()) ? -r : r;
+          const double angle = signedExponent * (2.0 * std::numbers::pi /
+                                                 static_cast<double>(period));
+          replaceWithPhaseGate(
+              angle, op,
               mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
-              mqt::constantFromScalar(rewriter, op.getLoc(),
-                                      r * std::numbers::pi));
+              rewriter);
           return success();
         })
         // pow(r) { x } => gphase(r*π/2); rx(r*π)
@@ -445,75 +424,6 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
               mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
               mqt::constantFromScalar(rewriter, op.getLoc(),
                                       r * std::numbers::pi));
-          return success();
-        })
-        // --- Phase/diagonal gates: named gate if angle matches, else P gate
-        // --- pow(r) { s } => named gate if angle matches, else p(r*π/2)
-        .Case([&](SOp gate) {
-          const double angle = r * std::numbers::pi / 2.0;
-          if (succeeded(tryReplacePOpWithNamedGate(
-                  angle, op,
-                  mqt::getValueFromBlockArgument(gate.getTarget(0),
-                                                 op.getQubits()),
-                  rewriter))) {
-            return success();
-          }
-          rewriter.replaceOpWithNewOp<POp>(
-              op,
-              mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
-              mqt::constantFromScalar(rewriter, op.getLoc(),
-                                      r * (std::numbers::pi / 2.0)));
-          return success();
-        })
-        // pow(r) { sdg } => named gate if angle matches, else p(-r*π/2)
-        .Case([&](SdgOp gate) {
-          const double angle = r * -std::numbers::pi / 2.0;
-          if (succeeded(tryReplacePOpWithNamedGate(
-                  angle, op,
-                  mqt::getValueFromBlockArgument(gate.getTarget(0),
-                                                 op.getQubits()),
-                  rewriter))) {
-            return success();
-          }
-          rewriter.replaceOpWithNewOp<POp>(
-              op,
-              mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
-              mqt::constantFromScalar(rewriter, op.getLoc(),
-                                      r * (-std::numbers::pi / 2.0)));
-          return success();
-        })
-        // pow(r) { t } => named gate if angle matches, else p(r*π/4)
-        .Case([&](TOp gate) {
-          const double angle = r * std::numbers::pi / 4.0;
-          if (succeeded(tryReplacePOpWithNamedGate(
-                  angle, op,
-                  mqt::getValueFromBlockArgument(gate.getTarget(0),
-                                                 op.getQubits()),
-                  rewriter))) {
-            return success();
-          }
-          rewriter.replaceOpWithNewOp<POp>(
-              op,
-              mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
-              mqt::constantFromScalar(rewriter, op.getLoc(),
-                                      r * (std::numbers::pi / 4.0)));
-          return success();
-        })
-        // pow(r) { tdg } => named gate if angle matches, else p(-r*π/4)
-        .Case([&](TdgOp gate) {
-          const double angle = r * -std::numbers::pi / 4.0;
-          if (succeeded(tryReplacePOpWithNamedGate(
-                  angle, op,
-                  mqt::getValueFromBlockArgument(gate.getTarget(0),
-                                                 op.getQubits()),
-                  rewriter))) {
-            return success();
-          }
-          rewriter.replaceOpWithNewOp<POp>(
-              op,
-              mqt::getValueFromBlockArgument(gate.getTarget(0), op.getQubits()),
-              mqt::constantFromScalar(rewriter, op.getLoc(),
-                                      r * (-std::numbers::pi / 4.0)));
           return success();
         })
         // --- SX/SXdg gates: decompose to rotation + global phase ---
@@ -557,35 +467,6 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
                                       r * (-std::numbers::pi / 2.0)));
           return success();
         })
-        // --- Hermitian gates (integer exponent): even => erase/id, odd => gate
-        // --- pow(n) { h } => id (n even) | h (n odd)
-        .Case([&](HOp) {
-          if (mqt::isEvenExponent(r)) {
-            // pow(even) { h } => identity. Erase it.
-            rewriter.eraseOp(op);
-          } else {
-            // pow(odd) { h } => h. The body gate's operands alias the pow's
-            // block args; inline the body, remapping them to the outer qubit
-            // operands, instead of hoisting the gate out (which would leave it
-            // referencing the erased block args).
-            mqt::inlineModifierBody(op, *op.getBody(), op.getQubits(),
-                                    rewriter);
-          }
-          return success();
-        })
-        // pow(n) { ecr/rccx/swap } => erase (n even) | gate (n odd)
-        .Case<ECROp, RCCXOp, SWAPOp>([&](auto) {
-          if (mqt::isEvenExponent(r)) {
-            // pow(even) { ecr/rccx/swap } => identity. Erase it.
-            rewriter.eraseOp(op);
-          } else {
-            // pow(odd) { ecr/rccx/swap } => gate. Inline the body, remapping
-            // its block args to the outer qubit operands (see HOp case above).
-            mqt::inlineModifierBody(op, *op.getBody(), op.getQubits(),
-                                    rewriter);
-          }
-          return success();
-        })
         // --- iSWAP: decompose to parametric gate ---
         // pow(r) { iswap } => xx_plus_yy(-r*π, 0)
         .Case([&](iSWAPOp gate) {
@@ -614,13 +495,13 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
               }));
           return success();
         })
-        .Default([&](auto) { return failure(); });
+        .Default([](auto*) -> LogicalResult {
+          llvm_unreachable("unhandled gate type after pre-check");
+        });
   }
 };
 
-/**
- * @brief Erase power modifiers that do not have any body unitaries.
- */
+/// @brief Erase power modifiers that do not have any body unitaries.
 struct EraseEmptyPow final : OpRewritePattern<PowOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(PowOp op,
@@ -634,9 +515,7 @@ struct EraseEmptyPow final : OpRewritePattern<PowOp> {
   }
 };
 
-/**
- * @brief Drop the qubits that the body does not use.
- */
+/// @brief Drop the qubits that the body does not use.
 struct DropUnusedPowQubits final : OpRewritePattern<PowOp> {
   using OpRewritePattern::OpRewritePattern;
 

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
@@ -25,7 +25,6 @@
 #include <llvm/ADT/SmallVectorExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/ErrorHandling.h>
-#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/IRMapping.h>
@@ -59,81 +58,34 @@ static void replacePowResults(PowOp powOp, UnitaryOpInterface bodyUnitary,
                  [&](Value yielded) { return mapping.lookup(yielded); }));
 }
 
-/**
- * @brief If the computed P-gate angle corresponds to a named gate, emit it
- * directly.
- *
- * @details Uses these equivalences:
- *
- * `Z = P(π)`, `S = P(π/2)`, `Sdg = P(-π/2)`, `T = P(π/4)`, `Tdg = P(-π/4)`
- *
- * Since `P` is diagonal, raising to a power just multiplies the angle:
- *
- * ```
- * Z^r   = P(π)^r    = P(r·π)
- * S^r   = P(π/2)^r  = P(r·π/2)
- * Sdg^r = P(-π/2)^r = P(-r·π/2)
- * T^r   = P(π/4)^r  = P(r·π/4)
- * Tdg^r = P(-π/4)^r = P(-r·π/4)
- * ```
- *
- * The caller computes `angle = r * base_angle` and passes the raw
- * (unnormalized) value here; normalization to (-π, π] is performed internally.
- *
- * Matched angles and their replacements:
- *
- * | Angle          | Replacement |
- * |----------------|-------------|
- * | `angle ≈ 0`    | identity (op replaced with qubit pass-through) |
- * | `angle ≈ +/-π` | `Z`         |
- * | `angle ≈ π/2`  | `S`         |
- * | `angle ≈ -π/2` | `Sdg`       |
- * | `angle ≈ π/4`  | `T`         |
- * | `angle ≈ -π/4` | `Tdg`       |
- *
- * @param angle    Raw phase angle (`r * base_angle`), in radians.
- * @param op       The `PowOp` being rewritten.
- * @param rewriter The pattern rewriter.
- * @return `success()` if replaced, `failure()` if a general `P` gate should be
- * used.
- */
-static LogicalResult tryReplacePOpWithNamedGate(double angle, PowOp op,
-                                                Value target,
-                                                PatternRewriter& rewriter) {
-  const double norm = normalizeAngle(angle);
-  const double pi = std::numbers::pi;
-
-  if (std::abs(norm) < PARAMETER_COMPARISON_TOLERANCE) {
-    // pow(r) folds to the identity: thread the input qubits to the results.
+/// Replace a power of a fixed phase gate with a named gate or a P gate.
+static void replaceWithPhaseGate(double angle, PowOp op, Value target,
+                                 PatternRewriter& rewriter) {
+  const auto phaseGate = classifyPhaseGate(angle);
+  if (!phaseGate) {
+    rewriter.replaceOpWithNewOp<POp>(op, target, angle);
+    return;
+  }
+  switch (*phaseGate) {
+  case PhaseGate::Identity:
     rewriter.replaceOp(op, op.getQubitsIn());
-    return success();
-  }
-  if (std::abs(std::abs(norm) - pi) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::Z:
     rewriter.replaceOpWithNewOp<ZOp>(op, target);
-    return success();
-  }
-  if (std::abs(norm - (pi / 2.0)) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::S:
     rewriter.replaceOpWithNewOp<SOp>(op, target);
-    return success();
-  }
-  if (std::abs(norm + (pi / 2.0)) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::Sdg:
     rewriter.replaceOpWithNewOp<SdgOp>(op, target);
-    return success();
-  }
-  if (std::abs(norm - (pi / 4.0)) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::T:
     rewriter.replaceOpWithNewOp<TOp>(op, target);
-    return success();
-  }
-  if (std::abs(norm + (pi / 4.0)) < PARAMETER_COMPARISON_TOLERANCE) {
+    return;
+  case PhaseGate::Tdg:
     rewriter.replaceOpWithNewOp<TdgOp>(op, target);
-    return success();
+    return;
   }
-  return failure();
-}
-
-/// Materialize exponent * param as arith ops
-static Value scaleByExponent(auto param, PowOp op, PatternRewriter& rewriter) {
-  return arith::MulFOp::create(rewriter, op.getLoc(), op.getExponent(), param);
 }
 
 namespace {
@@ -222,6 +174,15 @@ struct MergeNestedPow final : OpRewritePattern<PowOp> {
     if (!innerPow) {
       return failure();
     }
+    const auto innerExponent = innerPow.getExponentValue();
+    if (!innerExponent) {
+      return failure();
+    }
+    const auto mergedExponent =
+        scaleConstantAngle(*innerExponent, *outerExponent);
+    if (!mergedExponent) {
+      return failure();
+    }
 
     // The rewrite hands the qubits of the modifier to the inner operation, so
     // it must act on all of them.
@@ -245,9 +206,8 @@ struct MergeNestedPow final : OpRewritePattern<PowOp> {
     // Values are accessible from outside and survive PowOp erasure.
     mqt::hoistSupportingOpsBefore(*op.getBody(), innerPow.getOperation(), op,
                                   rewriter);
-    Value merged = scaleByExponent(innerPow.getExponent(), op, rewriter);
     auto newPow =
-        PowOp::create(rewriter, op.getLoc(), qubits, merged,
+        PowOp::create(rewriter, op.getLoc(), qubits, *mergedExponent,
                       [&](ValueRange powArgs) -> llvm::SmallVector<Value> {
                         // Inner pow body args now match the new pow's args
                         // positionally.
@@ -330,19 +290,17 @@ struct MoveCtrlOutsidePow final : OpRewritePattern<PowOp> {
   }
 };
 
-/**
- * @brief Fold pow(r) around gates into simpler operations.
- *
- * @details
- * - Rotation gates: multiply angle by exponent,
- *   e.g., `pow(r) { rx(θ) } => rx(r*θ)`
- * - Phase/diagonal gates: named gate if angle matches, else `P` gate,
- *   e.g., `pow(r) { s } => s/sdg/t/tdg/z` or `p(r*π/2)`
- * - Hermitian gates (integer exponent): even => erase, odd => gate
- * - Constant U gates (positive integer exponent): synthesize as a U gate and
- *   phase
- * - Identity/barrier: pass through unchanged
- */
+/// @brief Fold pow(r) around gates into simpler operations.
+///
+/// @details
+/// - Rotation gates: multiply a constant angle by an integer exponent when
+///   the product meets the constant-angle rounding bound
+/// - Phase/diagonal gates: named gate if angle matches, else `P` gate,
+///   e.g., `pow(r) { s } => s/sdg/t/tdg/z` or `p(r*π/2)`
+/// - Hermitian gates (integer exponent): even => erase, odd => gate
+/// - Constant U gates (positive integer exponent): synthesize as a U gate and
+///   phase
+/// - Identity/barrier: pass through unchanged
 struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -373,7 +331,11 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
       return failure();
     }
 
-    const double r = *exponent;
+    double r = *exponent;
+    const auto period = getFixedGatePowerPeriod(bodyUnitary.getBaseSymbol());
+    if (period != 0U) {
+      r = std::remainder(r, static_cast<double>(period));
+    }
     auto loc = op.getLoc();
 
     std::optional<UPowerParameters> uPower;
@@ -393,10 +355,21 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     // Scaling a gate parameter represents a principal matrix power only for an
     // integral exponent unless the parameter is known to remain within the
     // principal branch. Keep arbitrary parameters inside fractional powers.
+    std::optional<double> scaledParameter;
     if (isa<GPhaseOp, RXOp, RYOp, RZOp, POp, ROp, RXXOp, RYYOp, RZXOp, RZZOp,
-            XXPlusYYOp, XXMinusYYOp>(innerOp) &&
-        !mqt::isIntegerExponent(r)) {
-      return failure();
+            XXPlusYYOp, XXMinusYYOp>(innerOp)) {
+      if (!mqt::isIntegerExponent(r)) {
+        return failure();
+      }
+      const auto parameter = valueToDouble(bodyUnitary.getParameter(0));
+      if (!parameter) {
+        return failure();
+      }
+      scaledParameter = scaleConstantAngle(*parameter, r);
+      if (!scaledParameter || (isa<GPhaseOp>(innerOp) &&
+                               !isValidGlobalPhaseAngle(*scaledParameter))) {
+        return failure();
+      }
     }
     // HOp, ECROp, RCCXOp, and SWAPOp also only have the simple parity fold for
     // integral exponents.
@@ -409,59 +382,74 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
     // Values are accessible from outside and survive PowOp erasure.
     mqt::hoistSupportingOpsBefore(*op.getBody(), innerOp, op, rewriter);
 
+    if (period != 0U) {
+      if (r == 0.0) {
+        const auto identityOutputs =
+            llvm::map_to_vector(bodyUnitary.getInputQubits(), [&](Value input) {
+              return mqt::getValueFromBlockArgument(input, op.getQubitsIn());
+            });
+        replacePowResults(op, bodyUnitary, identityOutputs, rewriter);
+        return success();
+      }
+      if (r == 1.0 || (period == 2U && r == -1.0)) {
+        mqt::inlineModifierBody(op, *op.getBody(), op.getQubitsIn(), rewriter);
+        return success();
+      }
+    }
+
+    Value scaledValue;
+    if (scaledParameter) {
+      scaledValue = constantFromScalar(rewriter, loc, *scaledParameter);
+    }
+
     const LogicalResult result =
         TypeSwitch<Operation*, LogicalResult>(innerOp)
             // --- Rotation gates: multiply angle by exponent ---
             // pow(r) { gphase(θ) } => gphase(r*θ)
-            .Case([&](GPhaseOp gate) {
-              auto newParam = scaleByExponent(gate.getTheta(), op, rewriter);
-              rewriter.replaceOpWithNewOp<GPhaseOp>(op, newParam);
+            .Case([&](GPhaseOp) {
+              rewriter.replaceOpWithNewOp<GPhaseOp>(op, scaledValue);
               return success();
             })
             // pow(r) { rx/ry/rz/p(θ) } => rx/ry/rz/p(r*θ)
             .Case<RXOp, RYOp, RZOp, POp>([&](auto gate) {
-              auto newParam = scaleByExponent(gate.getTheta(), op, rewriter);
               rewriter.replaceOpWithNewOp<decltype(gate)>(
                   op,
                   mqt::getValueFromBlockArgument(gate.getInputTarget(0),
                                                  op.getQubitsIn()),
-                  newParam);
+                  scaledValue);
               return success();
             })
             // pow(r) { rxx/ryy/rzx/rzz(θ) } => rxx/ryy/rzx/rzz(r*θ)
             .Case<RXXOp, RYYOp, RZXOp, RZZOp>([&](auto gate) {
-              auto newParam = scaleByExponent(gate.getTheta(), op, rewriter);
               auto replacement = decltype(gate)::create(
                   rewriter, op.getLoc(),
                   mqt::getValueFromBlockArgument(gate.getInputTarget(0),
                                                  op.getQubitsIn()),
                   mqt::getValueFromBlockArgument(gate.getInputTarget(1),
                                                  op.getQubitsIn()),
-                  newParam);
+                  scaledValue);
               replacePowResults(op, gate, replacement.getOutputQubits(),
                                 rewriter);
               return success();
             })
             // pow(r) { r(θ, φ) } => r(r*θ, φ)
             .Case([&](ROp gate) {
-              auto mul = scaleByExponent(gate.getTheta(), op, rewriter);
               rewriter.replaceOpWithNewOp<ROp>(
                   op,
                   mqt::getValueFromBlockArgument(gate.getInputTarget(0),
                                                  op.getQubitsIn()),
-                  mul, gate.getPhi());
+                  scaledValue, gate.getPhi());
               return success();
             })
             // pow(r) { xx±yy(θ, β) } => xx±yy(r*θ, β)
             .Case<XXPlusYYOp, XXMinusYYOp>([&](auto gate) {
-              auto mul = scaleByExponent(gate.getTheta(), op, rewriter);
               auto replacement = decltype(gate)::create(
                   rewriter, op.getLoc(),
                   mqt::getValueFromBlockArgument(gate.getInputTarget(0),
                                                  op.getQubitsIn()),
                   mqt::getValueFromBlockArgument(gate.getInputTarget(1),
                                                  op.getQubitsIn()),
-                  mul, gate.getBeta());
+                  scaledValue, gate.getBeta());
               replacePowResults(op, gate, replacement.getOutputQubits(),
                                 rewriter);
               return success();
@@ -521,96 +509,18 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
                                           r * std::numbers::pi));
               return success();
             })
-            // pow(r) { z } => named gate if angle matches, else p(r*π)
-            .Case([&](ZOp gate) {
-              const double angle = r * std::numbers::pi;
-              if (succeeded(tryReplacePOpWithNamedGate(
-                      angle, op,
-                      mqt::getValueFromBlockArgument(gate.getInputTarget(0),
-                                                     op.getQubitsIn()),
-                      rewriter))) {
-                return success();
-              }
-              rewriter.replaceOpWithNewOp<POp>(
-                  op,
+            // Powers of Z, S, Sdg, T, and Tdg are phase gates.
+            .Case<ZOp, SOp, SdgOp, TOp, TdgOp>([&](auto gate) {
+              const double signedExponent =
+                  isa<SdgOp, TdgOp>(gate.getOperation()) ? -r : r;
+              const double angle =
+                  signedExponent *
+                  (2.0 * std::numbers::pi / static_cast<double>(period));
+              replaceWithPhaseGate(
+                  angle, op,
                   mqt::getValueFromBlockArgument(gate.getInputTarget(0),
                                                  op.getQubitsIn()),
-                  mqt::constantFromScalar(rewriter, op.getLoc(),
-                                          r * std::numbers::pi));
-              return success();
-            })
-            // --- Phase/diagonal gates: named gate if angle matches, else P
-            // gate
-            // --- pow(r) { s } => named gate if angle matches, else p(r*π/2)
-            .Case([&](SOp gate) {
-              const double angle = r * std::numbers::pi / 2.0;
-              if (succeeded(tryReplacePOpWithNamedGate(
-                      angle, op,
-                      mqt::getValueFromBlockArgument(gate.getInputTarget(0),
-                                                     op.getQubitsIn()),
-                      rewriter))) {
-                return success();
-              }
-              rewriter.replaceOpWithNewOp<POp>(
-                  op,
-                  mqt::getValueFromBlockArgument(gate.getInputTarget(0),
-                                                 op.getQubitsIn()),
-                  mqt::constantFromScalar(rewriter, op.getLoc(),
-                                          r * (std::numbers::pi / 2.0)));
-              return success();
-            })
-            // pow(r) { sdg } => named gate if angle matches, else p(-r*π/2)
-            .Case([&](SdgOp gate) {
-              const double angle = r * -std::numbers::pi / 2.0;
-              if (succeeded(tryReplacePOpWithNamedGate(
-                      angle, op,
-                      mqt::getValueFromBlockArgument(gate.getInputTarget(0),
-                                                     op.getQubitsIn()),
-                      rewriter))) {
-                return success();
-              }
-              rewriter.replaceOpWithNewOp<POp>(
-                  op,
-                  mqt::getValueFromBlockArgument(gate.getInputTarget(0),
-                                                 op.getQubitsIn()),
-                  mqt::constantFromScalar(rewriter, op.getLoc(),
-                                          r * (-std::numbers::pi / 2.0)));
-              return success();
-            })
-            // pow(r) { t } => named gate if angle matches, else p(r*π/4)
-            .Case([&](TOp gate) {
-              const double angle = r * std::numbers::pi / 4.0;
-              if (succeeded(tryReplacePOpWithNamedGate(
-                      angle, op,
-                      mqt::getValueFromBlockArgument(gate.getInputTarget(0),
-                                                     op.getQubitsIn()),
-                      rewriter))) {
-                return success();
-              }
-              rewriter.replaceOpWithNewOp<POp>(
-                  op,
-                  mqt::getValueFromBlockArgument(gate.getInputTarget(0),
-                                                 op.getQubitsIn()),
-                  mqt::constantFromScalar(rewriter, op.getLoc(),
-                                          r * (std::numbers::pi / 4.0)));
-              return success();
-            })
-            // pow(r) { tdg } => named gate if angle matches, else p(-r*π/4)
-            .Case([&](TdgOp gate) {
-              const double angle = r * -std::numbers::pi / 4.0;
-              if (succeeded(tryReplacePOpWithNamedGate(
-                      angle, op,
-                      mqt::getValueFromBlockArgument(gate.getInputTarget(0),
-                                                     op.getQubitsIn()),
-                      rewriter))) {
-                return success();
-              }
-              rewriter.replaceOpWithNewOp<POp>(
-                  op,
-                  mqt::getValueFromBlockArgument(gate.getInputTarget(0),
-                                                 op.getQubitsIn()),
-                  mqt::constantFromScalar(rewriter, op.getLoc(),
-                                          r * (-std::numbers::pi / 4.0)));
+                  rewriter);
               return success();
             })
             // --- SX/SXdg gates: decompose to rotation + global phase ---
@@ -658,22 +568,6 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
                                           r * (-std::numbers::pi / 2.0)));
               return success();
             })
-            // --- Hermitian gates (integer exponent): even => id, odd => gate
-            // --- pow(n) { h/ecr/rccx/swap } => id (n even) | gate (n odd)
-            .Case<HOp, ECROp, RCCXOp, SWAPOp>([&](auto gate) {
-              if (mqt::isEvenExponent(r)) {
-                const auto identityOutputs = llvm::map_to_vector(
-                    gate.getInputQubits(), [&](Value input) {
-                      return mqt::getValueFromBlockArgument(input,
-                                                            op.getQubitsIn());
-                    });
-                replacePowResults(op, gate, identityOutputs, rewriter);
-              } else {
-                mqt::inlineModifierBody(op, *op.getBody(), op.getInputQubits(),
-                                        rewriter);
-              }
-              return success();
-            })
             // --- iSWAP: decompose to parametric gate ---
             // pow(r) { iswap } => xx_plus_yy(-r*π, 0)
             // β=0: axis is aligned with XX, matching the iSWAP interaction
@@ -715,7 +609,6 @@ struct FoldPowIntoGate final : OpRewritePattern<PowOp> {
             })
             .Default([](auto*) -> LogicalResult {
               llvm_unreachable("unhandled gate type after pre-check");
-              return failure(); // unreachable — satisfies compiler
             });
     return result;
   }

--- a/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Modifiers/PowOp.cpp
@@ -290,9 +290,8 @@ struct MoveCtrlOutsidePow final : OpRewritePattern<PowOp> {
   }
 };
 
-/// @brief Fold pow(r) around gates into simpler operations.
+/// Fold pow(r) around gates into simpler operations.
 ///
-/// @details
 /// - Rotation gates: multiply a constant angle by an integer exponent when
 ///   the product meets the constant-angle rounding bound
 /// - Phase/diagonal gates: named gate if angle matches, else `P` gate,

--- a/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ROp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/StandardGates/ROp.cpp
@@ -14,7 +14,6 @@
 #include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QCO/Utils/Matrix.h"
 
-#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/OperationSupport.h>
@@ -86,14 +85,7 @@ struct MergeSubsequentR final : OpRewritePattern<ROp> {
       return failure();
     }
 
-    rewriter.setInsertionPoint(nextOp);
-    auto newParameter = arith::AddFOp::create(rewriter, op.getLoc(),
-                                              op.getTheta(), nextOp.getTheta());
-    rewriter.modifyOpInPlace(
-        op, [&] { op->setOperand(1, newParameter.getResult()); });
-    rewriter.moveOpBefore(op, nextOp);
-    rewriter.replaceOp(nextOp, op.getResult());
-    return success();
+    return mergeOneTargetOneParameter(op, rewriter);
   }
 };
 

--- a/mlir/unittests/Dialect/MQT/Utils/CMakeLists.txt
+++ b/mlir/unittests/Dialect/MQT/Utils/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Licensed under the MIT License
 
 set(mqt_utils_target mqt-core-mlir-unittests-mqt-utils)
-add_executable(${mqt_utils_target} test_constant_folding.cpp test_gate_powering.cpp)
+add_executable(${mqt_utils_target} test_angles.cpp test_constant_folding.cpp test_gate_powering.cpp)
 target_link_libraries(
   ${mqt_utils_target} PRIVATE GTest::gtest_main MLIRArithDialect MLIRFuncDialect MLIRIndexDialect
                               MLIRIR MLIRMQTUtils)

--- a/mlir/unittests/Dialect/MQT/Utils/test_angles.cpp
+++ b/mlir/unittests/Dialect/MQT/Utils/test_angles.cpp
@@ -9,7 +9,7 @@
  */
 
 /// @file
-/// @brief Tests for bounded angle arithmetic and named phase classification.
+/// Tests for bounded angle arithmetic and named phase classification.
 
 #include "mlir/Dialect/MQT/Utils/Angles.h"
 #include "mlir/Dialect/MQT/Utils/Parameters.h"

--- a/mlir/unittests/Dialect/MQT/Utils/test_angles.cpp
+++ b/mlir/unittests/Dialect/MQT/Utils/test_angles.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/// @file
+/// @brief Tests for bounded angle arithmetic and named phase classification.
+
+#include "mlir/Dialect/MQT/Utils/Angles.h"
+#include "mlir/Dialect/MQT/Utils/Parameters.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <numbers>
+#include <utility>
+
+namespace {
+
+using mlir::mqt::addConstantAngles;
+using mlir::mqt::classifyPhaseGate;
+using mlir::mqt::PARAMETER_COMPARISON_TOLERANCE;
+using mlir::mqt::PhaseGate;
+using mlir::mqt::scaleConstantAngle;
+
+TEST(AngleArithmeticTest, AcceptsExactCancellationAndSmallAdditionError) {
+  const auto cancelled = addConstantAngles(1.0e308, -1.0e308);
+  ASSERT_TRUE(cancelled);
+  EXPECT_DOUBLE_EQ(*cancelled, 0.0);
+
+  const auto small = addConstantAngles(0.1, 0.2);
+  ASSERT_TRUE(small);
+  EXPECT_DOUBLE_EQ(*small, 0.3);
+
+  const auto boundary = addConstantAngles(16.0, PARAMETER_COMPARISON_TOLERANCE);
+  ASSERT_TRUE(boundary);
+  EXPECT_DOUBLE_EQ(*boundary, 16.0);
+  EXPECT_FALSE(addConstantAngles(
+      16.0, std::nextafter(PARAMETER_COMPARISON_TOLERANCE,
+                           std::numeric_limits<double>::infinity())));
+}
+
+TEST(AngleArithmeticTest, RejectsAbsorbedRotationAndOverflow) {
+  EXPECT_FALSE(addConstantAngles(1.0e16, 1.0));
+  EXPECT_FALSE(addConstantAngles(1.0, 1.0e16));
+  EXPECT_FALSE(addConstantAngles(1.0e308, 1.0e308));
+  EXPECT_FALSE(addConstantAngles(-1.0e308, -1.0e308));
+}
+
+TEST(AngleArithmeticTest, RejectsOverflowWhileRecoveringAdditionError) {
+  // The sum is finite, but recovering its rounding error overflows.
+  const double negative = -0x1.8p+971;
+  const double maximum = std::numeric_limits<double>::max();
+  ASSERT_TRUE(std::isfinite(negative + maximum));
+  EXPECT_FALSE(addConstantAngles(negative, maximum));
+  EXPECT_FALSE(addConstantAngles(maximum, negative));
+}
+
+TEST(AngleArithmeticTest, AcceptsExactProductsAndSmallProductError) {
+  const auto exact = scaleConstantAngle(0.125, 8.0);
+  ASSERT_TRUE(exact);
+  EXPECT_DOUBLE_EQ(*exact, 1.0);
+
+  const auto zero = scaleConstantAngle(1.0e308, 0.0);
+  ASSERT_TRUE(zero);
+  EXPECT_DOUBLE_EQ(*zero, 0.0);
+
+  const auto small = scaleConstantAngle(0.1, 0.2);
+  ASSERT_TRUE(small);
+  EXPECT_DOUBLE_EQ(*small, 0.02);
+}
+
+TEST(AngleArithmeticTest, RejectsProductOverflowAndExcessRoundingError) {
+  EXPECT_FALSE(scaleConstantAngle(1.0e308, 2.0));
+  EXPECT_FALSE(scaleConstantAngle(-1.0e308, 2.0));
+  EXPECT_FALSE(scaleConstantAngle(1.0e16, 1.1));
+}
+
+TEST(AngleArithmeticTest, RejectsNonfiniteOperands) {
+  for (double value : {
+           std::numeric_limits<double>::infinity(),
+           -std::numeric_limits<double>::infinity(),
+           std::numeric_limits<double>::quiet_NaN(),
+       }) {
+    EXPECT_FALSE(addConstantAngles(value, 0.0));
+    EXPECT_FALSE(addConstantAngles(0.0, value));
+    EXPECT_FALSE(scaleConstantAngle(value, 0.0));
+    EXPECT_FALSE(scaleConstantAngle(0.0, value));
+  }
+}
+
+TEST(PhaseGateClassificationTest, RecognizesNamedPhasesAndTheirInverses) {
+  const double pi = std::numbers::pi;
+  for (auto [angle, expected] : {
+           std::pair{0.0, PhaseGate::Identity},
+           std::pair{pi, PhaseGate::Z},
+           std::pair{-pi, PhaseGate::Z},
+           std::pair{pi / 2.0, PhaseGate::S},
+           std::pair{-pi / 2.0, PhaseGate::Sdg},
+           std::pair{pi / 4.0, PhaseGate::T},
+           std::pair{-pi / 4.0, PhaseGate::Tdg},
+       }) {
+    SCOPED_TRACE(angle);
+    const auto gate = classifyPhaseGate(angle);
+    ASSERT_TRUE(gate);
+    EXPECT_EQ(*gate, expected);
+  }
+}
+
+TEST(PhaseGateClassificationTest, RecognizesEquivalentPhasesModuloTwoPi) {
+  const double pi = std::numbers::pi;
+  for (auto [angle, expected] : {
+           std::pair{2.0 * pi, PhaseGate::Identity},
+           std::pair{-2.0 * pi, PhaseGate::Identity},
+           std::pair{3.0 * pi, PhaseGate::Z},
+           std::pair{5.0 * pi / 2.0, PhaseGate::S},
+           std::pair{-5.0 * pi / 2.0, PhaseGate::Sdg},
+           std::pair{9.0 * pi / 4.0, PhaseGate::T},
+           std::pair{-9.0 * pi / 4.0, PhaseGate::Tdg},
+       }) {
+    SCOPED_TRACE(angle);
+    const auto gate = classifyPhaseGate(angle);
+    ASSERT_TRUE(gate);
+    EXPECT_EQ(*gate, expected);
+  }
+}
+
+TEST(PhaseGateClassificationTest, KeepsGeneralAndNonfiniteAnglesUnclassified) {
+  EXPECT_FALSE(classifyPhaseGate(0.3));
+  EXPECT_FALSE(classifyPhaseGate(-0.3));
+  EXPECT_FALSE(classifyPhaseGate(std::numbers::pi / 8.0));
+  EXPECT_FALSE(classifyPhaseGate(2.0 * PARAMETER_COMPARISON_TOLERANCE));
+  EXPECT_FALSE(classifyPhaseGate(std::numeric_limits<double>::infinity()));
+  EXPECT_FALSE(classifyPhaseGate(std::numeric_limits<double>::quiet_NaN()));
+}
+
+TEST(PhaseGateClassificationTest, PreservesPhaseLostByLargeAngleReduction) {
+  const double angle = std::ldexp(2.0 * std::numbers::pi, 48);
+  ASSERT_GT(std::abs(std::sin(angle)), 0.01);
+  EXPECT_FALSE(classifyPhaseGate(angle));
+  EXPECT_FALSE(classifyPhaseGate(-angle));
+}
+
+} // namespace

--- a/mlir/unittests/Dialect/MQT/Utils/test_gate_powering.cpp
+++ b/mlir/unittests/Dialect/MQT/Utils/test_gate_powering.cpp
@@ -11,8 +11,31 @@
 #include "mlir/Dialect/MQT/Utils/GatePowering.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/StringRef.h>
 
 #include <limits>
+
+TEST(GatePoweringTest, RecognizesFixedGatePowerPeriods) {
+  for (llvm::StringRef gate : {"x", "y", "z", "h", "ecr", "rccx", "swap"}) {
+    SCOPED_TRACE(gate.str());
+    EXPECT_EQ(mlir::mqt::getFixedGatePowerPeriod(gate), 2U);
+  }
+  for (llvm::StringRef gate : {"s", "sdg", "sx", "sxdg", "iswap"}) {
+    SCOPED_TRACE(gate.str());
+    EXPECT_EQ(mlir::mqt::getFixedGatePowerPeriod(gate), 4U);
+  }
+  for (llvm::StringRef gate : {"t", "tdg"}) {
+    SCOPED_TRACE(gate.str());
+    EXPECT_EQ(mlir::mqt::getFixedGatePowerPeriod(gate), 8U);
+  }
+}
+
+TEST(GatePoweringTest, DoesNotAssignFixedPeriodsToOtherGates) {
+  for (llvm::StringRef gate : {"rx", "ry", "rz", "p", "u", "r", "dcx", ""}) {
+    SCOPED_TRACE(gate.str());
+    EXPECT_EQ(mlir::mqt::getFixedGatePowerPeriod(gate), 0U);
+  }
+}
 
 TEST(GatePoweringTest, recognizesIntegerExponents) {
   EXPECT_TRUE(mlir::mqt::isIntegerExponent(-2.0));

--- a/mlir/unittests/Dialect/QC/IR/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QC/IR/CMakeLists.txt
@@ -7,7 +7,8 @@
 # Licensed under the MIT License
 
 set(target_name mqt-core-mlir-unittest-qc-ir)
-add_executable(${target_name} test_qc_ir.cpp test_qc_modifier_canonicalization.cpp)
+add_executable(${target_name} test_qc_ir.cpp test_qc_modifier_canonicalization.cpp
+                              test_qc_numeric_canonicalization.cpp)
 target_link_libraries(
   ${target_name}
   PRIVATE MLIRParser

--- a/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_ir.cpp
@@ -1354,18 +1354,16 @@ TEST_F(QCTest, FractionalPowUDoesNotCanonicalize) {
   EXPECT_EQ(powCount, 1U);
 }
 
-TEST_F(QCTest, NestedPowAcrossBranchCutDoesNotMerge) {
+TEST_F(QCTest, NestedPowerOfSquaredPauliIsIdentity) {
   auto program = ::mqt::test::buildMLIRProgram(
       context.get(), MQT_NAMED_BUILDER(nestedPowBranchCut));
   ASSERT_TRUE(program);
   ASSERT_TRUE(runQCCleanupPipeline(program.get()).succeeded());
+  EXPECT_TRUE(verify(*program).succeeded());
 
-  std::size_t powCount = 0;
-  std::size_t xCount = 0;
-  program->walk([&](PowOp) { ++powCount; });
-  program->walk([&](XOp) { ++xCount; });
-  EXPECT_EQ(powCount, 1);
-  EXPECT_EQ(xCount, 0);
+  size_t unitaryCount = 0;
+  program->walk([&](UnitaryOpInterface) { ++unitaryCount; });
+  EXPECT_EQ(unitaryCount, 0U);
 }
 
 // pow(-0.5) { h } cannot fold a negative fractional exponent

--- a/mlir/unittests/Dialect/QC/IR/test_qc_numeric_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QC/IR/test_qc_numeric_canonicalization.cpp
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
+#include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
+
+#include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/StringRef.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/Passes.h>
+
+using namespace mlir;
+using namespace mlir::qc;
+
+namespace {
+
+class QCNumericCanonicalizationTest : public testing::Test {
+protected:
+  MLIRContext context_;
+
+  void SetUp() override {
+    context_.loadDialect<mlir::mqt::MQTDialect, QCDialect, arith::ArithDialect,
+                         func::FuncDialect>();
+  }
+
+  OwningOpRef<ModuleOp> canonicalize(StringRef source) {
+    auto moduleOp = parseSourceString<ModuleOp>(source, &context_);
+    EXPECT_TRUE(moduleOp);
+    if (!moduleOp) {
+      return {};
+    }
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    PassManager manager(&context_);
+    manager.addPass(createCanonicalizerPass());
+    EXPECT_TRUE(succeeded(manager.run(*moduleOp)));
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    return moduleOp;
+  }
+};
+
+TEST_F(QCNumericCanonicalizationTest, LargeEvenPauliPowerBecomesIdentity) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qc.qubit) {
+        %exponent = arith.constant 10000.0 : f64
+        qc.pow(%exponent) (%a = %q) {
+          qc.x %a : !qc.qubit
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<PowOp>().empty());
+  EXPECT_TRUE(function.getBody().getOps<XOp>().empty());
+  EXPECT_TRUE(function.getBody().getOps<RXOp>().empty());
+  EXPECT_TRUE(function.getBody().getOps<GPhaseOp>().empty());
+}
+
+TEST_F(QCNumericCanonicalizationTest, LargeOddPauliPowerPreservesItsTarget) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qc.qubit) {
+        %exponent = arith.constant 9007199254740991.0 : f64
+        qc.pow(%exponent) (%a = %q) {
+          qc.x %a : !qc.qubit
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<PowOp>().empty());
+  EXPECT_TRUE(function.getBody().getOps<GPhaseOp>().empty());
+  auto gates = function.getBody().getOps<XOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(gates));
+  auto gate = *gates.begin();
+  EXPECT_EQ(gate.getTarget(0), function.getArgument(0));
+}
+
+TEST_F(QCNumericCanonicalizationTest, PowerRetainsDynamicAngle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qc.qubit, %angle: f64) {
+        %exponent = arith.constant 2.0 : f64
+        qc.pow(%exponent) (%a = %q) {
+          qc.rx(%angle) %a : !qc.qubit
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto powers = function.getBody().getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(powers));
+  auto power = *powers.begin();
+  auto rotations = power.getBody()->getOps<RXOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(rotations));
+  auto rotation = *rotations.begin();
+  EXPECT_EQ(rotation.getTheta(), function.getArgument(1));
+}
+
+TEST_F(QCNumericCanonicalizationTest, PowerRetainsUnsafeConstantProducts) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @overflow(%q: !qc.qubit) {
+        %exponent = arith.constant 2.0 : f64
+        %angle = arith.constant 1.0e308 : f64
+        qc.pow(%exponent) (%a = %q) {
+          qc.rx(%angle) %a : !qc.qubit
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+      func.func @rounding(%q: !qc.qubit) {
+        %exponent = arith.constant 3.0 : f64
+        %angle = arith.constant 1.0000000000000002e16 : f64
+        qc.pow(%exponent) (%a = %q) {
+          qc.rx(%angle) %a : !qc.qubit
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  for (auto function : moduleOp->getOps<func::FuncOp>()) {
+    SCOPED_TRACE(function.getSymName().str());
+    EXPECT_TRUE(llvm::hasSingleElement(function.getBody().getOps<PowOp>()));
+    EXPECT_TRUE(function.getBody().getOps<RXOp>().empty());
+  }
+}
+
+TEST_F(QCNumericCanonicalizationTest, PowerRetainsOutOfRangeGlobalPhase) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qc.qubit) {
+        %exponent = arith.constant 2.0 : f64
+        %angle = arith.constant 8000.0 : f64
+        qc.pow(%exponent) (%a = %q) {
+          qc.gphase(%angle)
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto powers = function.getBody().getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(powers));
+  auto power = *powers.begin();
+  EXPECT_TRUE(llvm::hasSingleElement(power.getBody()->getOps<GPhaseOp>()));
+  EXPECT_TRUE(function.getBody().getOps<GPhaseOp>().empty());
+}
+
+TEST_F(QCNumericCanonicalizationTest, NestedPowerOverflowKeepsParameterScope) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qc.qubit, %angle: f64) {
+        %exponent = arith.constant 1.0e308 : f64
+        qc.pow(%exponent) (%a = %q) {
+          %square = arith.mulf %angle, %angle : f64
+          qc.pow(%exponent) (%b = %a) {
+            qc.h %b : !qc.qubit
+            qc.rx(%square) %b : !qc.qubit
+            qc.yield
+          } : !qc.qubit
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto powers = function.getBody().getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(powers));
+  auto outer = *powers.begin();
+  auto innerPowers = outer.getBody()->getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(innerPowers));
+  auto inner = *innerPowers.begin();
+  auto rotations = inner.getBody()->getOps<RXOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(rotations));
+  auto rotation = *rotations.begin();
+  auto square = rotation.getTheta().getDefiningOp<arith::MulFOp>();
+  ASSERT_TRUE(square);
+  EXPECT_EQ(square->getBlock(), outer.getBody());
+  EXPECT_EQ(square.getLhs(), function.getArgument(1));
+  EXPECT_EQ(square.getRhs(), function.getArgument(1));
+}
+
+TEST_F(QCNumericCanonicalizationTest, NestedPowerRetainsDynamicExponentScope) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qc.qubit, %exponent: f64) {
+        %two = arith.constant 2.0 : f64
+        qc.pow(%two) (%a = %q) {
+          %square = arith.mulf %exponent, %exponent : f64
+          qc.pow(%square) (%b = %a) {
+            qc.h %b : !qc.qubit
+            qc.s %b : !qc.qubit
+            qc.yield
+          } : !qc.qubit
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto powers = function.getBody().getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(powers));
+  auto outer = *powers.begin();
+  EXPECT_EQ(outer.getExponentValue(), 2.0);
+  auto innerPowers = outer.getBody()->getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(innerPowers));
+  auto inner = *innerPowers.begin();
+  auto square = inner.getExponent().getDefiningOp<arith::MulFOp>();
+  ASSERT_TRUE(square);
+  EXPECT_EQ(square->getBlock(), outer.getBody());
+  EXPECT_EQ(square.getLhs(), function.getArgument(1));
+  EXPECT_EQ(square.getRhs(), function.getArgument(1));
+}
+
+TEST_F(QCNumericCanonicalizationTest, NestedPowerAcrossBranchCutDoesNotMerge) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qc.qubit) {
+        %half = arith.constant 0.5 : f64
+        %two = arith.constant 2.0 : f64
+        qc.pow(%half) (%a = %q) {
+          qc.pow(%two) (%b = %a) {
+            qc.x %b : !qc.qubit
+            qc.s %b : !qc.qubit
+            qc.yield
+          } : !qc.qubit
+          qc.yield
+        } : !qc.qubit
+        return
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  size_t powerCount = 0;
+  moduleOp->walk([&](PowOp) { ++powerCount; });
+  EXPECT_EQ(powerCount, 2U);
+}
+
+} // namespace

--- a/mlir/unittests/Dialect/QCO/IR/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/IR/CMakeLists.txt
@@ -8,8 +8,10 @@
 
 set(qco_ir_target mqt-core-mlir-unittest-qco-ir)
 add_executable(
-  ${qco_ir_target} test_qco_ir.cpp test_qco_ir_matrix.cpp test_qco_modifier_canonicalization.cpp
-                   test_qco_modifier_yield_canonicalization.cpp test_qco_wire_canonicalization.cpp)
+  ${qco_ir_target}
+  test_qco_ir.cpp test_qco_ir_matrix.cpp test_qco_modifier_canonicalization.cpp
+  test_qco_modifier_yield_canonicalization.cpp test_qco_numeric_canonicalization.cpp
+  test_qco_wire_canonicalization.cpp)
 target_link_libraries(
   ${qco_ir_target}
   PRIVATE MLIRParser

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_ir.cpp
@@ -2171,7 +2171,7 @@ TEST_F(QCOTest, PowExponentIsUnitaryParameter) {
   EXPECT_EQ(unitary.getParameters().front(), powOp.getExponent());
 }
 
-TEST_F(QCOTest, GateMergesPreserveParameterDominance) {
+TEST_F(QCOTest, UnboundedGateParametersRetainDominance) {
   auto program = parseSourceString<ModuleOp>(R"mlir(
     module {
       func.func @rx(%a: f64, %b: f64) {
@@ -2222,32 +2222,22 @@ TEST_F(QCOTest, GateMergesPreserveParameterDominance) {
   program->walk([&](ROp) { ++rCount; });
   program->walk([&](RXXOp) { ++rxxCount; });
   program->walk([&](arith::AddFOp) { ++addCount; });
-  EXPECT_EQ(rxCount, 1U);
-  EXPECT_EQ(rCount, 1U);
-  EXPECT_EQ(rxxCount, 1U);
-  EXPECT_EQ(addCount, 3U);
+  EXPECT_EQ(rxCount, 2U);
+  EXPECT_EQ(rCount, 2U);
+  EXPECT_EQ(rxxCount, 2U);
+  EXPECT_EQ(addCount, 0U);
 }
 
-TEST_F(QCOTest, NestedPowAcrossBranchCutDoesNotMerge) {
+TEST_F(QCOTest, NestedPowerOfSquaredPauliIsIdentity) {
   auto program = ::mqt::test::buildMLIRProgram(
       context.get(), MQT_NAMED_BUILDER(nestedPowBranchCut));
   ASSERT_TRUE(program);
   ASSERT_TRUE(runQCOCleanupPipeline(program.get()).succeeded());
+  EXPECT_TRUE(verify(*program).succeeded());
 
-  std::size_t powCount = 0;
-  std::size_t xCount = 0;
-  PowOp remainingPow;
-  program->walk([&](PowOp op) {
-    ++powCount;
-    remainingPow = op;
-  });
-  program->walk([&](XOp) { ++xCount; });
-  EXPECT_EQ(powCount, 1);
-  EXPECT_EQ(xCount, 0);
-  ASSERT_TRUE(remainingPow);
-  const auto matrix = remainingPow.getUnitaryMatrix();
-  ASSERT_TRUE(matrix);
-  EXPECT_TRUE(matrix->isApprox(DynamicMatrix::identity(2), 1e-10));
+  size_t unitaryCount = 0;
+  program->walk([&](UnitaryOpInterface) { ++unitaryCount; });
+  EXPECT_EQ(unitaryCount, 0U);
 }
 
 // pow(rxx) folds the exponent into the rotation angle: pow(2){rxx(θ)} =>

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_numeric_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_numeric_canonicalization.cpp
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "ExactUnitaryTest.h"
+#include "mlir/Dialect/MQT/IR/MQTDialect.h"
+#include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
+#include "mlir/Dialect/QCO/IR/QCODialect.h"
+#include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
+
+#include <gtest/gtest.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/StringRef.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/OwningOpRef.h>
+#include <mlir/IR/Verifier.h>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Support/LogicalResult.h>
+#include <mlir/Transforms/Passes.h>
+
+using namespace mlir;
+using namespace mlir::qco;
+
+namespace {
+
+class QCONumericCanonicalizationTest : public testing::Test {
+protected:
+  MLIRContext context_;
+
+  void SetUp() override {
+    context_.loadDialect<mlir::mqt::MQTDialect, QCODialect, arith::ArithDialect,
+                         func::FuncDialect>();
+  }
+
+  OwningOpRef<ModuleOp> canonicalize(StringRef source) {
+    auto moduleOp = parseSourceString<ModuleOp>(source, &context_);
+    EXPECT_TRUE(moduleOp);
+    if (!moduleOp) {
+      return {};
+    }
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+    PassManager manager(&context_);
+    manager.addPass(createCanonicalizerPass());
+    EXPECT_TRUE(succeeded(manager.run(*moduleOp)));
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+    EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+    return moduleOp;
+  }
+};
+
+TEST_F(QCONumericCanonicalizationTest, LargeEvenPauliPowerBecomesIdentity) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit) -> !qco.qubit {
+        %exponent = arith.constant 10000.0 : f64
+        %o = qco.pow(%exponent) (%a = %q) {
+          %x = qco.x %a : !qco.qubit -> !qco.qubit
+          qco.yield %x : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<PowOp>().empty());
+  EXPECT_TRUE(function.getBody().getOps<GPhaseOp>().empty());
+  auto returned =
+      cast<func::ReturnOp>(function.getBody().front().getTerminator());
+  EXPECT_EQ(returned.getOperand(0), function.getArgument(0));
+}
+
+TEST_F(QCONumericCanonicalizationTest, LargeOddPauliPowerPreservesUnitary) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit) -> !qco.qubit {
+        %exponent = arith.constant 9007199254740991.0 : f64
+        %o = qco.pow(%exponent) (%a = %q) {
+          %x = qco.x %a : !qco.qubit -> !qco.qubit
+          qco.yield %x : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+    }
+  )mlir");
+  auto reference = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit) -> !qco.qubit {
+        %x = qco.x %q : !qco.qubit -> !qco.qubit
+        return %x : !qco.qubit
+      }
+    }
+  )mlir",
+                                               &context_);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(reference);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_TRUE(function.getBody().getOps<PowOp>().empty());
+  EXPECT_TRUE(llvm::hasSingleElement(function.getBody().getOps<XOp>()));
+  ::mqt::test::expectFullUnitaryEqual(*reference, *moduleOp, 1);
+}
+
+TEST_F(QCONumericCanonicalizationTest, PowerRetainsDynamicAngle) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit, %angle: f64) -> !qco.qubit {
+        %exponent = arith.constant 2.0 : f64
+        %o = qco.pow(%exponent) (%a = %q) {
+          %r = qco.rx(%angle) %a : !qco.qubit -> !qco.qubit
+          qco.yield %r : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto powers = function.getBody().getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(powers));
+  auto power = *powers.begin();
+  auto rotations = power.getBody()->getOps<RXOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(rotations));
+  auto rotation = *rotations.begin();
+  EXPECT_EQ(rotation.getTheta(), function.getArgument(1));
+}
+
+TEST_F(QCONumericCanonicalizationTest, PowerRetainsUnsafeConstantProducts) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @overflow(%q: !qco.qubit) -> !qco.qubit {
+        %exponent = arith.constant 2.0 : f64
+        %angle = arith.constant 1.0e308 : f64
+        %o = qco.pow(%exponent) (%a = %q) {
+          %r = qco.rx(%angle) %a : !qco.qubit -> !qco.qubit
+          qco.yield %r : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+      func.func @rounding(%q: !qco.qubit) -> !qco.qubit {
+        %exponent = arith.constant 3.0 : f64
+        %angle = arith.constant 1.0000000000000002e16 : f64
+        %o = qco.pow(%exponent) (%a = %q) {
+          %r = qco.rx(%angle) %a : !qco.qubit -> !qco.qubit
+          qco.yield %r : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  for (auto function : moduleOp->getOps<func::FuncOp>()) {
+    SCOPED_TRACE(function.getSymName().str());
+    EXPECT_TRUE(llvm::hasSingleElement(function.getBody().getOps<PowOp>()));
+    EXPECT_TRUE(function.getBody().getOps<RXOp>().empty());
+  }
+}
+
+TEST_F(QCONumericCanonicalizationTest, PowerRetainsOutOfRangeGlobalPhase) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit) -> !qco.qubit {
+        %exponent = arith.constant 2.0 : f64
+        %angle = arith.constant 8000.0 : f64
+        %o = qco.pow(%exponent) (%a = %q) {
+          qco.gphase(%angle)
+          qco.yield %a : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto powers = function.getBody().getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(powers));
+  auto power = *powers.begin();
+  EXPECT_TRUE(llvm::hasSingleElement(power.getBody()->getOps<GPhaseOp>()));
+  EXPECT_TRUE(function.getBody().getOps<GPhaseOp>().empty());
+}
+
+TEST_F(QCONumericCanonicalizationTest, NestedPowerOverflowKeepsParameterScope) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit, %angle: f64) -> !qco.qubit {
+        %exponent = arith.constant 1.0e308 : f64
+        %o = qco.pow(%exponent) (%a = %q) {
+          %square = arith.mulf %angle, %angle : f64
+          %i = qco.pow(%exponent) (%b = %a) {
+            %h = qco.h %b : !qco.qubit -> !qco.qubit
+            %r = qco.rx(%square) %h : !qco.qubit -> !qco.qubit
+            qco.yield %r : !qco.qubit
+          } : {!qco.qubit} -> {!qco.qubit}
+          qco.yield %i : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto powers = function.getBody().getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(powers));
+  auto outer = *powers.begin();
+  auto innerPowers = outer.getBody()->getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(innerPowers));
+  auto inner = *innerPowers.begin();
+  auto rotations = inner.getBody()->getOps<RXOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(rotations));
+  auto rotation = *rotations.begin();
+  auto square = rotation.getTheta().getDefiningOp<arith::MulFOp>();
+  ASSERT_TRUE(square);
+  EXPECT_EQ(square->getBlock(), outer.getBody());
+  EXPECT_EQ(square.getLhs(), function.getArgument(1));
+  EXPECT_EQ(square.getRhs(), function.getArgument(1));
+}
+
+TEST_F(QCONumericCanonicalizationTest, NestedPowerRetainsDynamicExponentScope) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit, %exponent: f64) -> !qco.qubit {
+        %two = arith.constant 2.0 : f64
+        %o = qco.pow(%two) (%a = %q) {
+          %square = arith.mulf %exponent, %exponent : f64
+          %i = qco.pow(%square) (%b = %a) {
+            %h = qco.h %b : !qco.qubit -> !qco.qubit
+            %s = qco.s %h : !qco.qubit -> !qco.qubit
+            qco.yield %s : !qco.qubit
+          } : {!qco.qubit} -> {!qco.qubit}
+          qco.yield %i : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto powers = function.getBody().getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(powers));
+  auto outer = *powers.begin();
+  EXPECT_EQ(outer.getExponentValue(), 2.0);
+  auto innerPowers = outer.getBody()->getOps<PowOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(innerPowers));
+  auto inner = *innerPowers.begin();
+  auto square = inner.getExponent().getDefiningOp<arith::MulFOp>();
+  ASSERT_TRUE(square);
+  EXPECT_EQ(square->getBlock(), outer.getBody());
+  EXPECT_EQ(square.getLhs(), function.getArgument(1));
+  EXPECT_EQ(square.getRhs(), function.getArgument(1));
+}
+
+TEST_F(QCONumericCanonicalizationTest, RotationMergeRetainsOverflowingAngles) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit) -> !qco.qubit {
+        %angle = arith.constant 1.0e308 : f64
+        %a = qco.rx(%angle) %q : !qco.qubit -> !qco.qubit
+        %b = qco.rx(%angle) %a : !qco.qubit -> !qco.qubit
+        return %b : !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_EQ(llvm::range_size(function.getBody().getOps<RXOp>()), 2U);
+}
+
+TEST_F(QCONumericCanonicalizationTest, RotationMergeRetainsLargeRoundingError) {
+  constexpr StringLiteral source = R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit) -> !qco.qubit {
+        %large = arith.constant 1.0e16 : f64
+        %small = arith.constant 1.0 : f64
+        %a = qco.rx(%large) %q : !qco.qubit -> !qco.qubit
+        %b = qco.rx(%small) %a : !qco.qubit -> !qco.qubit
+        return %b : !qco.qubit
+      }
+    }
+  )mlir";
+  auto original = parseSourceString<ModuleOp>(source, &context_);
+  auto moduleOp = canonicalize(source);
+  ASSERT_TRUE(original);
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_EQ(llvm::range_size(function.getBody().getOps<RXOp>()), 2U);
+  ::mqt::test::expectFullUnitaryEqual(*original, *moduleOp, 1);
+}
+
+TEST_F(QCONumericCanonicalizationTest, RotationMergeRetainsDynamicAngles) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit, %theta: f64, %phi: f64) -> !qco.qubit {
+        %a = qco.rx(%theta) %q : !qco.qubit -> !qco.qubit
+        %b = qco.rx(%phi) %a : !qco.qubit -> !qco.qubit
+        return %b : !qco.qubit
+      }
+    }
+  )mlir");
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  EXPECT_EQ(llvm::range_size(function.getBody().getOps<RXOp>()), 2U);
+  EXPECT_TRUE(function.getBody().getOps<arith::AddFOp>().empty());
+}
+
+TEST_F(QCONumericCanonicalizationTest,
+       RotationMergeCombinesSafeConstantAngles) {
+  constexpr StringLiteral source = R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit) -> !qco.qubit {
+        %theta = arith.constant 0.1 : f64
+        %phi = arith.constant 0.2 : f64
+        %a = qco.rx(%theta) %q : !qco.qubit -> !qco.qubit
+        %b = qco.rx(%phi) %a : !qco.qubit -> !qco.qubit
+        return %b : !qco.qubit
+      }
+    }
+  )mlir";
+  auto original = parseSourceString<ModuleOp>(source, &context_);
+  auto moduleOp = canonicalize(source);
+  ASSERT_TRUE(original);
+  ASSERT_TRUE(moduleOp);
+  auto function = moduleOp->lookupSymbol<func::FuncOp>("test");
+  auto rotations = function.getBody().getOps<RXOp>();
+  ASSERT_TRUE(llvm::hasSingleElement(rotations));
+  auto rotation = *rotations.begin();
+  auto angle = mlir::mqt::valueToDouble(rotation.getTheta());
+  ASSERT_TRUE(angle);
+  EXPECT_NEAR(*angle, 0.3, 1e-15);
+  ::mqt::test::expectFullUnitaryEqual(*original, *moduleOp, 1);
+}
+
+TEST_F(QCONumericCanonicalizationTest, NestedPowerAcrossBranchCutDoesNotMerge) {
+  auto moduleOp = canonicalize(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit) -> !qco.qubit {
+        %half = arith.constant 0.5 : f64
+        %two = arith.constant 2.0 : f64
+        %o = qco.pow(%half) (%a = %q) {
+          %i = qco.pow(%two) (%b = %a) {
+            %x = qco.x %b : !qco.qubit -> !qco.qubit
+            %s = qco.s %x : !qco.qubit -> !qco.qubit
+            qco.yield %s : !qco.qubit
+          } : {!qco.qubit} -> {!qco.qubit}
+          qco.yield %i : !qco.qubit
+        } : {!qco.qubit} -> {!qco.qubit}
+        return %o : !qco.qubit
+      }
+    }
+  )mlir");
+  auto reference = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func @test(%q: !qco.qubit) -> !qco.qubit {
+        %angle = arith.constant 0.7853981633974483 : f64
+        qco.gphase(%angle)
+        return %q : !qco.qubit
+      }
+    }
+  )mlir",
+                                               &context_);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(reference);
+  size_t powerCount = 0;
+  moduleOp->walk([&](PowOp) { ++powerCount; });
+  EXPECT_EQ(powerCount, 2U);
+  // (S X)^2 = i I, whose principal square root is exp(i pi/4) I.
+  ::mqt::test::expectFullUnitaryEqual(*reference, *moduleOp, 1);
+}
+
+} // namespace

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_euler_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_euler_decomposition.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOInterfaces.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
+#include "mlir/Dialect/QCO/QCOUtils.h"
 #include "mlir/Dialect/QCO/Transforms/Decomposition/Euler.h"
 #include "mlir/Dialect/QCO/Transforms/Passes.h"
 #include "mlir/Dialect/QCO/Utils/Matrix.h"
@@ -1117,7 +1118,7 @@ TEST(FuseSingleQubitUnitaryRunsTest, IgnoresDynamicPowerExponent) {
   EXPECT_EQ(countOps<PowOp>(funcOp), 1U);
 }
 
-TEST(FuseSingleQubitUnitaryRunsTest, MergesShortDynamicSameAxisRun) {
+TEST(FuseSingleQubitUnitaryRunsTest, PreservesUnboundedShortSameAxisRun) {
   TestFixture fx;
   fx.setUp();
   auto owned = QCOProgramBuilder::build(fx.ctx(), [](QCOProgramBuilder& b) {
@@ -1137,21 +1138,40 @@ TEST(FuseSingleQubitUnitaryRunsTest, MergesShortDynamicSameAxisRun) {
   ASSERT_EQ(rotations.size(), 2U);
   rotations[0].getThetaMutable().assign(funcOp.getArgument(0));
   rotations[1].getThetaMutable().assign(funcOp.getArgument(1));
+  ASSERT_TRUE(succeeded(verify(*owned)));
+  ASSERT_TRUE(succeeded(verifyLinearity(*owned)));
 
   ASSERT_TRUE(succeeded(runFuse(*owned, "zyz")));
+  ASSERT_TRUE(succeeded(verify(*owned)));
+  ASSERT_TRUE(succeeded(verifyLinearity(*owned)));
   rotations.clear();
   funcOp.walk([&](RZOp op) { rotations.push_back(op); });
-  ASSERT_EQ(rotations.size(), 1U);
-  EXPECT_TRUE(
-      valueDependsOn(rotations.front().getTheta(), funcOp.getArgument(0)));
-  EXPECT_TRUE(
-      valueDependsOn(rotations.front().getTheta(), funcOp.getArgument(1)));
+  // A short run already in the basis needs no resynthesis. Canonicalization
+  // cannot safely add its unbounded dynamic angles.
+  ASSERT_EQ(rotations.size(), 2U);
+  EXPECT_EQ(rotations[0].getTheta(), funcOp.getArgument(0));
+  EXPECT_EQ(rotations[1].getTheta(), funcOp.getArgument(1));
+  EXPECT_EQ(rotations[1].getInputTarget(0), rotations[0].getOutputTarget(0));
 
-  bindLeadingArguments(funcOp, {0.3, 0.4});
-  ASSERT_TRUE(succeeded(canonicalizeBoundValues(*owned)));
-  ASSERT_TRUE(succeeded(verify(*owned)));
-  expectMatrixPreserved(
-      funcOp, RZOp::unitaryMatrix(0.4) * RZOp::unitaryMatrix(0.3), "zyz");
+  for (auto [firstAngle, secondAngle, expectedRotations] : std::array{
+           std::tuple{0.3, 0.4, 1U},
+           std::tuple{1e16, 1.0, 2U},
+           std::tuple{1e308, 1e308, 2U},
+       }) {
+    SCOPED_TRACE(testing::Message()
+                 << "angles=" << firstAngle << ", " << secondAngle);
+    OwningOpRef<ModuleOp> bound(cast<ModuleOp>((*owned)->clone()));
+    auto boundFunc = bound->lookupSymbol<func::FuncOp>("main");
+    bindLeadingArguments(boundFunc, {firstAngle, secondAngle});
+    ASSERT_TRUE(succeeded(canonicalizeBoundValues(*bound)));
+    ASSERT_TRUE(succeeded(verify(*bound)));
+    ASSERT_TRUE(succeeded(verifyLinearity(*bound)));
+    EXPECT_EQ(countOps<RZOp>(boundFunc), expectedRotations);
+    expectMatrixPreserved(boundFunc,
+                          RZOp::unitaryMatrix(secondAngle) *
+                              RZOp::unitaryMatrix(firstAngle),
+                          "zyz");
+  }
 }
 
 TEST(FuseSingleQubitUnitaryRunsTest, FusesNamedDynamicGatesInAllBases) {


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Merge and scale constant angles only when the result is finite, stays within the destination parameter domain, and has an absolute arithmetic error of at most `1e-15`. Leave unbounded dynamic sums and products unchanged. Reduce fixed-gate exponents by their exact periods before computing angles, and share phase classification that checks the original angle.

Add regressions for overflow, absorbed angles, branch cuts, and retained dynamic parameters. This PR is stacked on `codex/canonicalization-wire-mapping`, whose yield guards also protect the new fixed-power shortcuts.

Extracted from https://github.com/munich-quantum-toolkit/core/pull/2477.

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
