### PR TITLE
🐛 Simplify canonicalization and restore QCO tests

### DIFF
--- a/mlir/lib/Dialect/MQT/Utils/GatePowering.cpp
+++ b/mlir/lib/Dialect/MQT/Utils/GatePowering.cpp
@@ -110,12 +110,9 @@ powerUParameters(double theta, double phi, double lambda, double exponent) {
   const auto phase = std::polar(1.0, resultPhase);
   for (size_t i = 0; i < reconstructed.size(); ++i) {
     reconstructed[i] *= phase;
-    if (!std::isfinite(sourcePower[i].real()) ||
-        !std::isfinite(sourcePower[i].imag()) ||
-        !std::isfinite(reconstructed[i].real()) ||
-        !std::isfinite(reconstructed[i].imag()) ||
-        std::abs(sourcePower[i] - reconstructed[i]) >
-            U_POWER_EQUIVALENCE_TOLERANCE) {
+    // The negated comparison also rejects NaN.
+    if (!(std::abs(sourcePower[i] - reconstructed[i]) <=
+          U_POWER_EQUIVALENCE_TOLERANCE)) {
       return std::nullopt;
     }
   }

--- a/mlir/lib/Dialect/QCO/IR/Operations/UnitaryOp.cpp
+++ b/mlir/lib/Dialect/QCO/IR/Operations/UnitaryOp.cpp
@@ -83,8 +83,6 @@ LogicalResult UnitaryOp::fold(FoldAdaptor /*adaptor*/,
   if (!mqt::isExactIdentityMatrix(getMatrix())) {
     return failure();
   }
-  for (auto qubit : getQubitsIn()) {
-    results.emplace_back(qubit);
-  }
+  llvm::append_range(results, getQubitsIn());
   return success();
 }

--- a/mlir/unittests/Dialect/QCO/IR/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/IR/CMakeLists.txt
@@ -9,9 +9,14 @@
 set(qco_ir_target mqt-core-mlir-unittest-qco-ir)
 add_executable(
   ${qco_ir_target}
-  test_qco_canonicalization.cpp test_qco_control_flow_canonicalization.cpp test_qco_ir.cpp
-  test_qco_ir_matrix.cpp test_qco_modifier_canonicalization.cpp
-  test_qco_numeric_canonicalization.cpp)
+  test_qco_canonicalization.cpp
+  test_qco_control_flow_canonicalization.cpp
+  test_qco_ir.cpp
+  test_qco_ir_matrix.cpp
+  test_qco_modifier_canonicalization.cpp
+  test_qco_modifier_yield_canonicalization.cpp
+  test_qco_numeric_canonicalization.cpp
+  test_qco_wire_canonicalization.cpp)
 target_link_libraries(
   ${qco_ir_target}
   PRIVATE MLIRParser

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_canonicalization.cpp
@@ -16,7 +16,6 @@
 #include <gtest/gtest.h>
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
-#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/Builders.h>
@@ -53,7 +52,7 @@ protected:
   MLIRContext context_;
 
   void SetUp() override {
-    context_.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
+    context_.loadDialect<QCODialect, func::FuncDialect>();
   }
 
   OwningOpRef<ModuleOp> singleQubitFunction() {
@@ -140,8 +139,6 @@ TEST_F(QCOCanonicalizationTest, PairCancellationPreservesDifferentGates) {
   auto first = HOp::create(builder, function.getLoc(), function.getArgument(0));
   auto second = XOp::create(builder, function.getLoc(), first.getResult());
   returned->setOperand(0, second.getResult());
-  ASSERT_TRUE(succeeded(verify(*moduleOp)));
-  ASSERT_TRUE(succeeded(verifyLinearity(*moduleOp)));
 
   ASSERT_NO_FATAL_FAILURE(canonicalize(*moduleOp));
   EXPECT_EQ(returned.getOperand(0), second.getResult());

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_modifier_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_modifier_canonicalization.cpp
@@ -9,7 +9,6 @@
  */
 
 #include "ExactUnitaryTest.h"
-#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
@@ -42,8 +41,7 @@ protected:
   MLIRContext context_;
 
   void SetUp() override {
-    context_.loadDialect<mlir::mqt::MQTDialect, QCODialect, arith::ArithDialect,
-                         func::FuncDialect>();
+    context_.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
   }
 
   OwningOpRef<ModuleOp> canonicalize(StringRef source) {

--- a/mlir/unittests/Dialect/QCO/IR/test_qco_numeric_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QCO/IR/test_qco_numeric_canonicalization.cpp
@@ -9,7 +9,6 @@
  */
 
 #include "ExactUnitaryTest.h"
-#include "mlir/Dialect/MQT/IR/MQTDialect.h"
 #include "mlir/Dialect/MQT/Utils/ConstantFolding.h"
 #include "mlir/Dialect/QCO/IR/QCODialect.h"
 #include "mlir/Dialect/QCO/IR/QCOOps.h"
@@ -46,8 +45,7 @@ protected:
   MLIRContext context_;
 
   void SetUp() override {
-    context_.loadDialect<mlir::mqt::MQTDialect, QCODialect, arith::ArithDialect,
-                         func::FuncDialect>();
+    context_.loadDialect<QCODialect, arith::ArithDialect, func::FuncDialect>();
   }
 
   OwningOpRef<ModuleOp> canonicalize(StringRef source) {


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Follow-up to https://github.com/munich-quantum-toolkit/core/pull/2477. Restore the QCO wire-mapping and modifier-yield test sources to the IR test target so their 30 existing cases run again.

Simplify the U-power reconstruction guard while retaining non-finite error rejection, and use `llvm::append_range` for identity folding. Remove unused dialect setup and duplicate input verification from tests.

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
