### PR TITLE
✨ Add Python compiler target helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,14 +43,15 @@ releases may include breaking changes.
   payload-aware control-flow legalization, QDMI device integration, ordered
   operation applicability, directional native synthesis, and target compilation
   through C++, Python, and `mqt-cc` ([#2285], [#2219], [#2162], [#2049],
-  [#1999], [#1993], [#1687]) ([**@MatthiasReumann**], [**@simon1hofmann**],
-  [**@burgholzer**])
+  [#1999], [#1993], [#1687], [#2497]) ([**@MatthiasReumann**],
+  [**@simon1hofmann**], [**@burgholzer**])
 
 #### Import and export
 
 - ✨ Add Qiskit circuit import, target-aware export, and reusable custom Gate
   round trips to the compiler collection ([#2031], [#2133], [#2140], [#2150],
-  [#2175], [#2176], [#2178], [#2342]) ([**@burgholzer**], [**@simon1hofmann**])
+  [#2175], [#2176], [#2178], [#2342], [#2497]) ([**@burgholzer**],
+  [**@simon1hofmann**])
 - ✨ Add conversions between `jeff` and QCO ([#1479], [#1548], [#1565], [#1637],
   [#1676], [#1706], [#1776], [#1836], [#1934], [#2000], [#2018], [#2105],
   [#2339], [#2457]) ([**@denialhaag**], [**@burgholzer**])
@@ -933,6 +934,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2497]: https://github.com/munich-quantum-toolkit/core/pull/2497
 [#2494]: https://github.com/munich-quantum-toolkit/core/pull/2494
 [#2493]: https://github.com/munich-quantum-toolkit/core/pull/2493
 [#2478]: https://github.com/munich-quantum-toolkit/core/pull/2478

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -55,6 +55,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <type_traits>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -164,8 +165,8 @@ entryFunc(const mlir::QCOProgram& program) {
 /// appending any emitted MLIR diagnostics to @p message.
 template <nb::exception_type Exception = nb::exception_type::value_error,
           typename Fn>
-[[nodiscard]] static auto takeFailureOr(mlir::MLIRContext* context,
-                                        const char* message, Fn&& fn) {
+static auto withDiagnostics(mlir::MLIRContext* context, const char* message,
+                            Fn&& fn) {
   std::string diagnostics;
   const mlir::ScopedDiagnosticHandler handler(
       context, [&](mlir::Diagnostic& diag) {
@@ -187,7 +188,9 @@ template <nb::exception_type Exception = nb::exception_type::value_error,
     }
     throw nb::builtin_exception(Exception, full.c_str());
   }
-  return *std::move(result);
+  if constexpr (!std::is_same_v<decltype(result), mlir::LogicalResult>) {
+    return *std::move(result);
+  }
 }
 
 template <class ProgramType>
@@ -348,7 +351,7 @@ template <class Function>
 [[nodiscard]] static dd::MatrixDD
 buildQCOFunctionality(const mlir::QCOProgram& program, dd::Package& ddPackage) {
   auto func = entryFunc(program);
-  return takeFailureOr(
+  return withDiagnostics(
       func.getContext(), "cannot build DD functionality for this QCO program",
       [&] { return mlir::qco::buildFunctionality(func, ddPackage); });
 }
@@ -364,7 +367,7 @@ buildQCOFunctionality(const mlir::QCOProgram& program, dd::Package& ddPackage) {
   }
   auto func = entryFunc(program);
   auto rng = makeRng(seed);
-  return takeFailureOr(
+  return withDiagnostics(
       func.getContext(), "cannot simulate this QCO program",
       [&] { return mlir::qco::simulate(func, initialState, ddPackage, rng); });
 }
@@ -372,8 +375,8 @@ buildQCOFunctionality(const mlir::QCOProgram& program, dd::Package& ddPackage) {
 [[nodiscard]] static std::map<std::string, size_t>
 sampleQCO(const mlir::QCOProgram& program, size_t shots, uint64_t seed) {
   auto func = entryFunc(program);
-  return takeFailureOr(func.getContext(), "cannot sample this QCO program",
-                       [&] { return mlir::qco::sample(func, shots, seed); });
+  return withDiagnostics(func.getContext(), "cannot sample this QCO program",
+                         [&] { return mlir::qco::sample(func, shots, seed); });
 }
 
 [[nodiscard]] static DenseVector toDenseVector(const dd::VectorDD& state) {
@@ -435,7 +438,7 @@ buildDenseFunctionality(const nb::object& program) {
   return withQCOProgram(program, [](const mlir::QCOProgram& qco) {
     dd::Package ddPackage(0);
     auto func = entryFunc(qco);
-    const auto state = takeFailureOr(
+    const auto state = withDiagnostics(
         func.getContext(), "cannot simulate this QCO program",
         [&] { return mlir::qco::simulateStatevector(func, ddPackage); });
     return toDenseVector(state);
@@ -505,21 +508,37 @@ NB_MODULE(MQT_CORE_MODULE_NAME, m) {
       .def_rw("profile", &mlir::PayloadFormat::profile)
       .def_rw("encoding", &mlir::PayloadFormat::encoding);
 
-  nb::class_<mlir::ProgramConstraint>(m, "ProgramConstraint",
-                                      "One payload capability constraint.")
-      .def(nb::init<std::string, uint64_t>(), "constraint_id"_a, "value"_a)
-      .def_rw("constraint_id", &mlir::ProgramConstraint::id)
-      .def_rw("value", &mlir::ProgramConstraint::value);
+  auto programConstraint =
+      nb::class_<mlir::ProgramConstraint>(m, "ProgramConstraint",
+                                          "One payload capability constraint.")
+          .def(nb::init<std::string, uint64_t>(), "constraint_id"_a, "value"_a)
+          .def_rw("constraint_id", &mlir::ProgramConstraint::id)
+          .def_rw("value", &mlir::ProgramConstraint::value);
+  programConstraint.attr("MAX_NESTING_DEPTH") =
+      mlir::ProgramConstraint::MAX_NESTING_DEPTH.str();
+  programConstraint.attr("MAX_ITERATION_COUNT") =
+      mlir::ProgramConstraint::MAX_ITERATION_COUNT.str();
+  programConstraint.attr("MAX_CASE_COUNT") =
+      mlir::ProgramConstraint::MAX_CASE_COUNT.str();
 
-  nb::class_<mlir::ProgramCapability>(m, "ProgramCapability",
-                                      "One payload execution capability.")
-      .def(nb::init<std::string, uint64_t,
-                    std::vector<mlir::ProgramConstraint>>(),
-           "capability_id"_a, "value"_a = 0,
-           "constraints"_a = std::vector<mlir::ProgramConstraint>{})
-      .def_rw("capability_id", &mlir::ProgramCapability::id)
-      .def_rw("value", &mlir::ProgramCapability::value)
-      .def_rw("constraints", &mlir::ProgramCapability::constraints);
+  auto programCapability =
+      nb::class_<mlir::ProgramCapability>(m, "ProgramCapability",
+                                          "One payload execution capability.")
+          .def(nb::init<std::string, uint64_t,
+                        std::vector<mlir::ProgramConstraint>>(),
+               "capability_id"_a, "value"_a = 0,
+               "constraints"_a = std::vector<mlir::ProgramConstraint>{})
+          .def_rw("capability_id", &mlir::ProgramCapability::id)
+          .def_rw("value", &mlir::ProgramCapability::value)
+          .def_rw("constraints", &mlir::ProgramCapability::constraints);
+  programCapability.attr("FORWARD_BRANCHING") =
+      mlir::ProgramCapability::FORWARD_BRANCHING.str();
+  programCapability.attr("COUNTED_ITERATION") =
+      mlir::ProgramCapability::COUNTED_ITERATION.str();
+  programCapability.attr("CONDITIONAL_LOOP") =
+      mlir::ProgramCapability::CONDITIONAL_LOOP.str();
+  programCapability.attr("MULTIWAY_BRANCHING") =
+      mlir::ProgramCapability::MULTIWAY_BRANCHING.str();
 
   nb::class_<mlir::PayloadSpecification>(m, "PayloadSpecification",
                                          "Selected payload execution contract.")
@@ -1091,7 +1110,7 @@ before conversion to QCO.)pb");
           "to_openqasm3",
           [](const mlir::QCProgram& program) {
             requireValid(program);
-            return takeFailureOr<nb::exception_type::runtime_error>(
+            return withDiagnostics<nb::exception_type::runtime_error>(
                 program.module().getContext(),
                 "cannot export QC program to OpenQASM 3",
                 [&]() -> mlir::FailureOr<mlir::OpenQASMProgram> {
@@ -1237,12 +1256,44 @@ operations.)pb");
            "constant-angle phase gates that act on at least min_qubits qubits "
            "(min_qubits must be at least 3; default 3 means wider than "
            "two-qubit).")
-      .def("compile_for_target",
-           &BooleanMemberAdapter<&mlir::QCOProgram::compileForTarget>::call,
-           "target_environment"_a, nb::kw_only(), "enable_timing"_a = false,
-           "enable_statistics"_a = false,
-           "Compile this QCO program for the target in place. Do not rely on "
-           "its contents if compilation fails.")
+      .def(
+          "compile_for_target",
+          [](mlir::QCOProgram& program,
+             const mlir::TargetEnvironment& environment, bool enableTiming,
+             bool enableStatistics) {
+            requireValid(program);
+            withDiagnostics<nb::exception_type::runtime_error>(
+                program.module().getContext(), "Target compilation failed",
+                [&] {
+                  return mlir::success(program.compileForTarget(
+                      environment, enableTiming, enableStatistics));
+                });
+          },
+          "target_environment"_a, nb::kw_only(), "enable_timing"_a = false,
+          "enable_statistics"_a = false,
+          "Compile this QCO program for the target in place. Do not rely on "
+          "its contents if compilation fails. Failures raise RuntimeError "
+          "with the emitted MLIR diagnostics.")
+      .def(
+          "to_qiskit",
+          [](const mlir::QCOProgram& program,
+             const mlir::CompilerTarget* target) {
+            requireValid(program);
+            auto qc = takeResult(program.copy().intoQC());
+            return bindings::qiskit::exportCircuit(qc, target);
+          },
+          nb::kw_only(), "target"_a = nb::none(),
+          nb::sig(
+              "def to_qiskit(self, *, target: CompilerTarget | None = None) "
+              "-> qiskit.circuit.QuantumCircuit"),
+          R"pb(Export a Qiskit circuit without consuming or modifying this program.
+
+Uses the QC exporter on a copy.
+
+Args:
+    target: The optional compiler target used for mapping. When provided, static
+        site IDs map to dense physical-qubit indices in target site order.
+        Dynamic qubits and static IDs absent from the target are rejected.)pb")
       .def(
           "to_qc",
           [](mlir::QCOProgram& value, const bool copy) {

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -154,6 +154,17 @@ assert restored.count_ops() == qiskit_bell.count_ops()
 assert compiled_qiskit.is_valid
 ```
 
+QCO programs also provide {py:meth}`~mqt.core.mlir.QCOProgram.to_qiskit`. It
+converts a copy through QC and leaves the original program unchanged, even if
+export fails. Both exporters accept `target=target` to map static target site
+IDs to dense physical-qubit indices in target site order.
+
+```{code-cell} ipython3
+qco = direct.to_qco(copy=True)
+restored = qco.to_qiskit()
+assert qco.is_valid
+```
+
 This compiler route is the Qiskit circuit interface in MQT Core v4.
 
 See {doc}`qiskit` for supported circuit features and translation limitations.

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -78,6 +78,22 @@ typed `#mqt.payload_spec` attribute.
 
 ### Payload control flow
 
+Use the constants on {py:class}`~mqt.core.mlir.ProgramCapability` and
+{py:class}`~mqt.core.mlir.ProgramConstraint` when declaring supported control
+flow:
+
+```{code-cell} ipython3
+from mqt.core.mlir import ProgramCapability, ProgramConstraint
+
+forward_branching = ProgramCapability(
+    ProgramCapability.FORWARD_BRANCHING,
+    constraints=[ProgramConstraint(ProgramConstraint.MAX_NESTING_DEPTH, 8)],
+)
+```
+
+Add this capability to a payload specification only if the device supports it.
+Custom capability and constraint identifiers remain accepted as strings.
+
 Target compilation requires structured QCO/SCF input. Producers of raw CFG
 branches must normalize them before target compilation; runtime assertions are
 allowed. The pipeline removes unused symbols, propagates constants, unrolls
@@ -198,8 +214,10 @@ unobservable global phase of the entry point.
 Use {py:meth}`~mqt.core.mlir.QCOProgram.compile_for_target` with the target
 environment to apply target compilation to an existing QCO program. Compilation
 runs in place. If a pass fails, the environment and earlier pass changes remain
-on the program. Copy the program before compilation if the caller must preserve
-the input. The pipeline takes one `TargetEnvironment`, replaces any existing
+on the program. In Python, `compile_for_target` raises `RuntimeError` with the
+emitted MLIR diagnostics, including operation and source-location details when
+available. Copy the program before compilation if the caller must preserve the
+input. The pipeline takes one `TargetEnvironment`, replaces any existing
 `mqt.target_env` module attribute, and shares the prepared target with all
 target passes without rebuilding its connectivity tables. The selected
 environment must remain unchanged during pipeline execution. Standalone passes

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -102,6 +102,12 @@ class ProgramConstraint:
     @value.setter
     def value(self, arg: int, /) -> None: ...
 
+    MAX_NESTING_DEPTH: str = "max-control-flow-nesting-depth"
+
+    MAX_ITERATION_COUNT: str = "max-iteration-count"
+
+    MAX_CASE_COUNT: str = "max-case-count"
+
 class ProgramCapability:
     """One payload execution capability."""
 
@@ -118,6 +124,14 @@ class ProgramCapability:
     def constraints(self) -> list[ProgramConstraint]: ...
     @constraints.setter
     def constraints(self, arg: Sequence[ProgramConstraint], /) -> None: ...
+
+    FORWARD_BRANCHING: str = "forward-branching"
+
+    COUNTED_ITERATION: str = "counted-iteration"
+
+    CONDITIONAL_LOOP: str = "conditional-loop"
+
+    MULTIWAY_BRANCHING: str = "multiway-branching"
 
 class PayloadSpecification:
     """Selected payload execution contract."""
@@ -638,7 +652,18 @@ class QCOProgram(Program):
     def compile_for_target(
         self, target_environment: TargetEnvironment, *, enable_timing: bool = False, enable_statistics: bool = False
     ) -> None:
-        """Compile this QCO program for the target in place. Do not rely on its contents if compilation fails."""
+        """Compile this QCO program for the target in place. Do not rely on its contents if compilation fails. Failures raise RuntimeError with the emitted MLIR diagnostics."""
+
+    def to_qiskit(self, *, target: CompilerTarget | None = None) -> qiskit.circuit.QuantumCircuit:
+        """Export a Qiskit circuit without consuming or modifying this program.
+
+        Uses the QC exporter on a copy.
+
+        Args:
+            target: The optional compiler target used for mapping. When provided, static
+                site IDs map to dense physical-qubit indices in target site order.
+                Dynamic qubits and static IDs absent from the target are rejected.
+        """
 
     def to_qc(self, *, copy: bool = False) -> QCProgram:
         """Convert this program to QC.

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -85,7 +85,11 @@ def _test_payload_specification() -> PayloadSpecification:
     """Return one explicit selected payload contract for target tests."""
     return PayloadSpecification(
         PayloadFormat("qir", "2.1.0", "base", PayloadEncoding.BINARY),
-        [ProgramCapability("forward-branching", 0, [ProgramConstraint("max-control-flow-nesting-depth", 8)])],
+        [
+            ProgramCapability(
+                ProgramCapability.FORWARD_BRANCHING, 0, [ProgramConstraint(ProgramConstraint.MAX_NESTING_DEPTH, 8)]
+            )
+        ],
         optional_capabilities_known=True,
     )
 
@@ -527,13 +531,72 @@ def test_target_compilation_exports_canonical_physical_qiskit_circuit() -> None:
     mapped.compile_for_target(_test_target_environment(target))
     assert 0 < mapped.ir.count("qco.static") < target.num_sites
 
-    qc = mapped.to_qc(copy=True)
-    restored = qc.to_qiskit(target=target)
+    source_ir = mapped.ir
+    restored = mapped.to_qiskit(target=target)
 
     assert mapped.is_valid
+    assert mapped.ir == source_ir
+    assert restored == mapped.to_qc(copy=True).to_qiskit(target=target)
     assert restored.num_qubits == 5
     assert [(register.name, len(register)) for register in restored.qregs] == [("q", 5)]
     assert restored.layout is None
+
+
+@requires_qiskit_translation
+def test_qco_qiskit_export_preserves_program() -> None:
+    """Reuse QC export without consuming QCO, including when export fails."""
+    source = QuantumCircuit(2)
+    source.h(0)
+    source.cx(0, 1)
+    program = QCProgram.from_qiskit(source).to_qco()
+    source_ir = program.ir
+
+    assert np.allclose(Operator(program.to_qiskit()).data, Operator(source).data)
+    assert program.ir == source_ir
+
+    target = CompilerTarget(
+        2,
+        connectivity=CompilerTarget.Connectivity.all_to_all(),
+        native_operations=CompilerTarget.NativeOperations.unrestricted(),
+    )
+    with pytest.raises(RuntimeError, match="requires statically mapped qubits"):
+        program.to_qiskit(target=target)
+    assert program.ir == source_ir
+
+    program.to_qc()
+    with pytest.raises(RuntimeError, match="already been consumed"):
+        program.to_qiskit()
+
+
+@pytest.mark.parametrize("capability_id", [None, "forward-branching-typo"])
+def test_target_compilation_preserves_diagnostics(capability_id: str | None) -> None:
+    """Keep native control-flow legality errors in the Python exception."""
+    program = QCProgram.from_qasm_str("""OPENQASM 3.0;
+include "stdgates.inc";
+qubit q;
+bit c;
+h q;
+c = measure q;
+if (c) { x q; }
+""").to_qco()
+    target = CompilerTarget(
+        1,
+        connectivity=CompilerTarget.Connectivity.all_to_all(),
+        native_operations=CompilerTarget.NativeOperations.unrestricted(),
+    )
+    payload = PayloadSpecification(
+        PayloadFormat("openqasm", "3.0"),
+        [ProgramCapability(capability_id)] if capability_id is not None else [],
+    )
+    valid = program.copy()
+    with pytest.raises(RuntimeError, match=r"Target compilation failed.*qco\.if"):
+        program.compile_for_target(TargetEnvironment(target, payload))
+
+    # A copy shares the context, whose diagnostic handler must be restored.
+    valid.compile_for_target(_test_target_environment(target))
+    valid.to_qc()
+    with pytest.raises(RuntimeError, match="already been consumed"):
+        valid.compile_for_target(TargetEnvironment(target, payload))
 
 
 def test_compiler_target_constructors_preserve_python_api() -> None:
@@ -629,8 +692,8 @@ def test_compiler_target_accepts_plain_site_tuples(arity: int | CompilerTarget.O
 def test_payload_specification_preserves_python_api() -> None:
     """Construct and validate one context-free selected payload contract."""
     payload_format = PayloadFormat("qir", "2.1.0", "base", PayloadEncoding.BINARY)
-    constraint = ProgramConstraint("max-control-flow-nesting-depth", 8)
-    capability = ProgramCapability("forward-branching", 0, [constraint])
+    constraint = ProgramConstraint(ProgramConstraint.MAX_NESTING_DEPTH, 8)
+    capability = ProgramCapability(ProgramCapability.FORWARD_BRANCHING, 0, [constraint])
     environment = PayloadSpecification(
         payload_format,
         [capability],
@@ -646,6 +709,11 @@ def test_payload_specification_preserves_python_api() -> None:
     assert environment.capabilities[0].constraints[0].constraint_id == "max-control-flow-nesting-depth"
     assert environment.capabilities[0].constraints[0].value == 8
     assert environment.optional_capabilities_known
+    assert ProgramCapability.COUNTED_ITERATION == "counted-iteration"
+    assert ProgramCapability.CONDITIONAL_LOOP == "conditional-loop"
+    assert ProgramCapability.MULTIWAY_BRANCHING == "multiway-branching"
+    assert ProgramConstraint.MAX_ITERATION_COUNT == "max-iteration-count"
+    assert ProgramConstraint.MAX_CASE_COUNT == "max-case-count"
 
     payload_format.version = "9.9.9"
     exposed_descriptor = environment.format

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -2050,7 +2050,7 @@ def test_classical_switch_compiles_for_selected_payload_capabilities(capability:
     )
     environment = TargetEnvironment(target, payload)
     if capability is None:
-        with pytest.raises(RuntimeError, match="MLIR operation failed"):
+        with pytest.raises(RuntimeError, match=r"failed to legalize operation 'scf\.index_switch'"):
             program.compile_for_target(environment)
     else:
         program.compile_for_target(environment)


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Simplify Python compiler integration for callers such as Benchpress:

- Expose the existing `ProgramCapability` and `ProgramConstraint` identifiers as class constants. Custom identifiers remain accepted.
- Include emitted MLIR diagnostics in `QCOProgram.compile_for_target()` exceptions, retaining the `RuntimeError` exception type.
- Add `QCOProgram.to_qiskit(*, target=None)`. It converts a copy through QC and reuses the existing exporter, including target-aware physical-qubit mapping. The source remains unchanged on success and failure.

Update the Python documentation and generated stubs. No new dependencies.

Validation:

- 450 Python tests pass across `test_mlir.py`, `test_mlir_qiskit_translation.py`, and `test_qco_dd.py`, using the rebuilt bindings and local SC device.
- `uvx nox -s stubs`, `uvx nox -s lint`, and `uvx nox -s cpp-lint` pass. C++ lint checks the complete changed file.

AI assistance: Codex implemented and tested these changes. Human review is still required.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
