### PR TITLE
⚡ Default mapping trials to available CPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,8 @@ releases may include breaking changes.
 - ✨ Add a compiler-target-aware `place-and-route` pass ([#1537], [#1547],
   [#1568], [#1581], [#1583], [#1588], [#1600], [#1664], [#1709], [#1716],
   [#1748], [#1805], [#1870], [#1904], [#1911], [#1951], [#1956], [#1997],
-  [#2016], [#2060], [#2179], [#2184], [#2185], [#2205], [#2240], [#2436])
-  ([**@MatthiasReumann**], [**@burgholzer**], [**@rturrado**],
+  [#2016], [#2060], [#2179], [#2184], [#2185], [#2205], [#2240], [#2436],
+  [#2500]) ([**@MatthiasReumann**], [**@burgholzer**], [**@rturrado**],
   [**@simon1hofmann**])
 - ✨ Add modifier and global-phase normalization passes ([#1986], [#1995],
   [#2015]) ([**@burgholzer**], [**@denialhaag**])
@@ -934,6 +934,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2500]: https://github.com/munich-quantum-toolkit/core/pull/2500
 [#2497]: https://github.com/munich-quantum-toolkit/core/pull/2497
 [#2494]: https://github.com/munich-quantum-toolkit/core/pull/2494
 [#2493]: https://github.com/munich-quantum-toolkit/core/pull/2493

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -207,6 +207,12 @@ one-qubit synthesis does not need one. Two-qubit synthesis requires an entangler
 on every routing edge in at least one direction. A native operation does not
 need a synthesis basis.
 
+Mapping explores one initial-layout trial per available logical CPU by default,
+using LLVM's affinity-aware CPU count with a minimum of one. An explicit
+`ntrials` value overrides this default. Set both `ntrials` and `seed` on the
+`place-and-route` pass for reproducible results across machines. Disabling
+multithreading runs the same trials sequentially.
+
 Target synthesis preserves a native `gphase`. If the target does not support
 `gphase`, target synthesis preserves relative phase effects and removes only the
 unobservable global phase of the entry point.

--- a/mlir/include/mqt/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mqt/Dialect/QCO/Transforms/Passes.h
@@ -14,6 +14,8 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 
+#include "llvm/Support/Threading.h"
+
 #include <cstdint>
 #include <memory>
 

--- a/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
@@ -202,7 +202,13 @@ def MappingPass : Pass<"place-and-route", "mlir::ModuleOp"> {
     made during that traversal. By performing multiple traversals, the pass can iteratively refine the mapping and
     potentially find a more optimal solution. This is behavior is controlled by the `niterations` parameter.
 
-    The pass option `ntrials` determines how many random initial layouts the pass explores. If compiled with multi-threading on, these trials will be executed in parallel.
+    The pass option `ntrials` determines how many random initial layouts the pass explores.
+    It defaults to the number of available logical CPUs reported by LLVM, taking
+    CPU affinity into account, with a minimum of one. Disabling multithreading
+    runs the same trials sequentially; it does not reduce the trial count.
+    If compiled with multi-threading on, these trials will be executed in parallel.
+    Set both `ntrials` and `seed` explicitly for reproducible results across
+    machines with different CPU counts.
   }];
   let options = [Option<"nlookahead", "nlookahead", "std::size_t", "1",
                         "The number of lookahead steps.">,
@@ -213,9 +219,11 @@ def MappingPass : Pass<"place-and-route", "mlir::ModuleOp"> {
                  Option<"niterations", "niterations", "std::size_t", "1",
                         "The number of forwards and backwards traversal to "
                         "improve the initial layout. Must be > 0.">,
-                 Option<"ntrials", "ntrials", "std::size_t", "4",
+                 Option<"ntrials", "ntrials", "std::size_t",
+                        "llvm::hardware_concurrency().compute_thread_count()",
                         "The number of (possibly parallel) random trials of "
-                        "the forwards and backwards mechanism. Must be > 0.">,
+                        "the forwards and backwards mechanism. Defaults to "
+                        "the available logical CPU count. Must be > 0.">,
                  Option<"seed", "seed", "std::size_t", "42",
                         "A seed used for randomization.">];
   let statistics = [Statistic<"numSwaps", "num-inserted-swaps",

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -2674,9 +2674,10 @@ TEST_F(MappingPassFixture, DefaultTrialsMatchAvailableCPUs) {
     OwningOpRef<ModuleOp> automatic = input->clone();
     ASSERT_TRUE(succeeded(runPassPipeline(*automatic, "place-and-route")));
     ASSERT_TRUE(succeeded(verify(*automatic)));
-    for (const auto& options :
-         {MappingPassOptions{},
-          MappingPassOptions{.ntrials = expectedTrials}}) {
+    for (const auto& options : {
+             MappingPassOptions{},
+             MappingPassOptions{.ntrials = expectedTrials},
+         }) {
       OwningOpRef<ModuleOp> explicitOptions = input->clone();
       PassManager pm(context.get());
       pm.addPass(createMappingPass(options));

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -54,6 +54,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
@@ -2643,6 +2644,45 @@ TEST_F(MappingPassFixture, RejectInvalidOptionsBeforeMutation) {
               std::string::npos)
         << diagnostics;
     EXPECT_EQ(printModule(*moduleOp), before);
+  }
+}
+
+TEST_F(MappingPassFixture, DefaultTrialsMatchAvailableCPUs) {
+  const auto expectedTrials =
+      llvm::hardware_concurrency().compute_thread_count();
+  ASSERT_GT(expectedTrials, 0U);
+  EXPECT_EQ(MappingPassOptions{}.ntrials, expectedTrials);
+
+  const auto target = getSquareGridTarget(3);
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  SmallVector<Value> qubits;
+  for (size_t i = 0; i < 5; ++i) {
+    qubits.push_back(builder.allocQubit());
+  }
+  cxcz(builder, qubits);
+  for (Value qubit : qubits) {
+    builder.sink(qubit);
+  }
+  auto input = builder.finalize();
+  attachTestEnvironment(*input, target);
+
+  // The omitted textual option and the C++ default must use the same trials,
+  // even when the context executes them sequentially.
+  for (bool multithreading : {false, true}) {
+    context->enableMultithreading(multithreading);
+    OwningOpRef<ModuleOp> automatic = input->clone();
+    ASSERT_TRUE(succeeded(runPassPipeline(*automatic, "place-and-route")));
+    ASSERT_TRUE(succeeded(verify(*automatic)));
+    for (const auto& options :
+         {MappingPassOptions{},
+          MappingPassOptions{.ntrials = expectedTrials}}) {
+      OwningOpRef<ModuleOp> explicitOptions = input->clone();
+      PassManager pm(context.get());
+      pm.addPass(createMappingPass(options));
+      ASSERT_TRUE(succeeded(pm.run(*explicitOptions)));
+      EXPECT_EQ(printModule(*automatic), printModule(*explicitOptions));
+    }
   }
 }
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Default `place-and-route` to one initial-layout trial per available logical CPU,
instead of a fixed count of four. Reuse LLVM's affinity-aware hardware
concurrency query, which supplies at least one trial.

Explicit positive `ntrials` values still override the default, and zero remains
invalid. The C++ factory, textual pass pipeline, and target-compilation pipeline
share the same default. Disabling context multithreading runs the trials
sequentially without changing their count.

Document that callers should set both `ntrials` and `seed` for reproducible
results across machines with different CPU counts. Add a regression test that
compares omitted and explicit defaults with context multithreading enabled and
disabled.

This change is independent of the identity-layout trial in #2499. It introduces
no new dependency. Codex assisted with the implementation, tests, validation,
and this description.

Validation:

- 106 C++ mapper tests passed in Release mode.
- Generated MLIR documentation built successfully.
- `uvx nox -s lint` passed.
- `uvx nox -s cpp-lint` passed for the complete changed C++ test file.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
