### PR TITLE
⚡️ Avoid temporary allocations in MLIR synthesis

### DIFF
--- a/mlir/lib/Dialect/MQT/Utils/ConstantFolding.cpp
+++ b/mlir/lib/Dialect/MQT/Utils/ConstantFolding.cpp
@@ -91,6 +91,10 @@ valueToConstantAttr(Value value,
 }
 
 std::optional<Attribute> valueToConstantAttr(Value value) {
+  Attribute literal;
+  if (matchPattern(value, m_Constant(&literal))) {
+    return literal;
+  }
   DenseMap<Value, std::optional<Attribute>> cache;
   return valueToConstantAttr(value, cache);
 }

--- a/mlir/lib/Dialect/QCO/Transforms/Decomposition/Weyl.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Decomposition/Weyl.cpp
@@ -356,8 +356,9 @@ computeOrderedWeylCoordinates(const Matrix4x4& u) {
     cstemp[i] = std::min(tmp, (WEYL_PI / 2.0) - tmp);
   }
   std::array<std::size_t, 3> order{0, 1, 2};
-  std::ranges::stable_sort(
-      order, [&](auto a, auto b) { return cstemp[a] < cstemp[b]; });
+  std::ranges::sort(order, [&](auto a, auto b) {
+    return std::pair{cstemp[a], a} < std::pair{cstemp[b], b};
+  });
   order = {order[1], order[2], order[0]};
   cs = {cs[order[0]], cs[order[1]], cs[order[2]]};
   {

--- a/mlir/unittests/Dialect/MQT/Utils/test_constant_folding.cpp
+++ b/mlir/unittests/Dialect/MQT/Utils/test_constant_folding.cpp
@@ -136,6 +136,16 @@ TEST_F(ConstantFoldingTest, attributeToDoubleUnsignedI128) {
   EXPECT_DOUBLE_EQ(*asDouble, std::ldexp(1.0, 127));
 }
 
+TEST_F(ConstantFoldingTest, valueToConstantAttrPreservesLiteralAttributes) {
+  auto floatAttr = builder->getF64FloatAttr(-0.0);
+  auto floatOp = arith::ConstantOp::create(*builder, floatAttr);
+  EXPECT_EQ(mlir::mqt::valueToConstantAttr(floatOp.getResult()), floatAttr);
+
+  auto indexOp = index::ConstantOp::create(*builder, 42);
+  EXPECT_EQ(mlir::mqt::valueToConstantAttr(indexOp.getResult()),
+            builder->getIndexAttr(42));
+}
+
 TEST_F(ConstantFoldingTest, valueToConstantDoubleNestedFold) {
   auto lhs = arith::ConstantOp::create(*builder, builder->getF64FloatAttr(5.0));
   auto num = arith::ConstantOp::create(*builder, builder->getF64FloatAttr(1.0));


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Literal parameter folding currently creates a temporary cache, and Weyl decomposition uses a heap-backed stable sort for three coordinate indices. Return literal attributes before creating the cache and use `std::ranges::sort` with the original index as a tie-breaker. Recursive folding and stable coordinate ordering are preserved.

Adds one test for exact literal-attribute preservation across arithmetic and index constants, including negative zero. No new dependencies or public API changes. Relates to #2253.

On DGX Spark with Clang 23, ThinLTO and mold, separate allocation-count runs remove all 100,000 allocations from 100,000 literal lookups and all 10,000 allocations from 10,000 Weyl decompositions. The 1,024-pair merge workload drops from 12,375 to 7,252 C++ allocation calls.

Uninstrumented baseline/final runs used three alternating rounds with 18 retained samples per workload. Merge throughput improved about 11% and single-qubit fusion about 4%; full-pipeline and Weyl timings were essentially unchanged. The smaller two-qubit-fusion workload was 1.6% slower. These synthetic constant-angle workloads do not establish a uniform or whole-compiler speedup.

Validation: native release build; 820 tests across MQT utils, decomposition, optimizations, target synthesis and compiler; `uvx nox -s lint`; and `uvx nox -s cpp-lint -- ad74680f1`. All passed. All 60 benchmark output IR files matched the baseline byte-for-byte; phase-sensitive matrix and linearity checks passed. A 512-case finite-key ordering check also passed.

Codex assisted with implementation, validation and this description. The final correctness/performance re-audit and Ponytail complexity review found no additional actionable changes. Documentation and release notes are unchanged because this only optimizes unreleased v4 internals. Hosted CI remains to be verified.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
