### PR TITLE
⚡ Speed up Qiskit measurement and block export

### DIFF
--- a/bindings/mlir/qiskit/Qiskit2_5.cpp
+++ b/bindings/mlir/qiskit/Qiskit2_5.cpp
@@ -2065,15 +2065,8 @@ public:
         parameters_(std::move(parameters)), gates_(std::move(gates)) {}
 
   [[nodiscard]] std::unique_ptr<CircuitWriter> createBlock() const override {
-    auto block = nb::module_::import_("qiskit.circuit")
-                     .attr("QuantumCircuit")(pythonCircuit_.attr("qubits"),
-                                             pythonCircuit_.attr("clbits"));
-    for (auto reg : nb::iter(pythonCircuit_.attr("qregs"))) {
-      block.attr("add_register")(reg);
-    }
-    for (auto reg : nb::iter(pythonCircuit_.attr("cregs"))) {
-      block.attr("add_register")(reg);
-    }
+    auto block =
+        pythonCircuit_.attr("copy_empty_like")(nb::arg("vars_mode") = "drop");
     return std::make_unique<NativeCircuitWriter>(std::move(block), parameters_,
                                                  gates_, variables_);
   }

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -52,6 +52,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SCCIterator.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSet.h"
@@ -2077,100 +2078,115 @@ static void validateControlFlowDepth(const size_t controlFlowDepth) {
   }
 }
 
-[[nodiscard]] static bool
-disjointClassicalBit(mlir::Value reg, mlir::Value index,
-                     mlir::cbit::StoreOp destination) {
-  if (reg != destination.getReg()) {
-    return true;
-  }
-  const auto bit = mlir::getConstantIntValue(index);
-  const auto destinationBit = mlir::getConstantIntValue(destination.getIndex());
-  return bit && destinationBit && *bit != *destinationBit;
-}
-
-[[nodiscard]] static bool
-canFuseMeasurementAcross(mlir::Operation& operation,
-                         mlir::cbit::StoreOp destination) {
-  const auto result = operation.walk<mlir::WalkOrder::PreOrder>(
-      [&](mlir::Operation* candidate) {
+/// Put each supported measurement store at its emitted position before
+/// snapshot analysis. Quantum operations keep their order.
+static void prepareMeasurementStores(mlir::func::FuncOp function) {
+  function.walk([&](mlir::Block* block) {
+    auto measurements = block->getOps<mlir::qc::MeasureOp>();
+    if (llvm::all_of(measurements, [](mlir::qc::MeasureOp measure) {
+          auto destination = measurementDestination(measure);
+          return destination == measure->getNextNode() &&
+                 mlir::getConstantIntValue(destination.getIndex()).has_value();
+        })) {
+      return;
+    }
+    struct Accesses {
+      llvm::SmallVector<size_t> positions;
+      size_t next = 0U;
+    };
+    Accesses unknownAccesses;
+    llvm::DenseMap<mlir::Value, Accesses> registerAccesses;
+    llvm::DenseMap<std::pair<mlir::Value, int64_t>, Accesses> bitAccesses;
+    llvm::DenseMap<mlir::Operation*, size_t> positions;
+    for (auto [position, operation] : llvm::enumerate(*block)) {
+      positions[&operation] = position;
+      operation.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation*
+                                                        candidate) {
         return llvm::TypeSwitch<mlir::Operation*, mlir::WalkResult>(candidate)
             .Case([](mlir::qc::UnitaryOpInterface) {
-              // Verified unitary regions cannot access classical
-              // memory. Their global phase and call effects are
-              // deliberately broad.
+              /// Verified unitary regions cannot access classical memory.
               return mlir::WalkResult::skip();
             })
             .Case([&](mlir::MemoryEffectOpInterface mem) {
               llvm::SmallVector<mlir::MemoryEffects::EffectInstance> effects;
               mem.getEffects(effects);
-              // CBit registers do not alias. Same-register bit accesses
-              // still need static-index disambiguation.
-              const bool conflicts =
-                  llvm::any_of(effects, [&](const auto& effect) {
-                    if (!effect.getValue()) {
-                      return true;
-                    }
-                    if (effect.getValue() != destination.getReg()) {
-                      return false;
-                    }
-                    return llvm::TypeSwitch<mlir::Operation*, bool>(candidate)
-                        .Case<mlir::cbit::LoadOp, mlir::cbit::StoreOp>(
-                            [&](auto access) {
-                              return !disjointClassicalBit(access.getReg(),
-                                                           access.getIndex(),
-                                                           destination);
-                            })
-                        .Default(true);
-                  });
-              return conflicts ? mlir::WalkResult::interrupt()
-                               : mlir::WalkResult::advance();
+              const auto bit =
+                  llvm::TypeSwitch<mlir::Operation*, std::optional<int64_t>>(
+                      candidate)
+                      .Case<mlir::cbit::LoadOp, mlir::cbit::StoreOp>(
+                          [](auto access) {
+                            return mlir::getConstantIntValue(access.getIndex());
+                          })
+                      .Default(std::nullopt);
+              for (const auto& effect : effects) {
+                auto value = effect.getValue();
+                if (!value) {
+                  unknownAccesses.positions.push_back(position);
+                } else if (bit) {
+                  bitAccesses[{value, *bit}].positions.push_back(position);
+                } else {
+                  registerAccesses[value].positions.push_back(position);
+                }
+              }
+              return mlir::WalkResult::advance();
             })
-            .Default([](mlir::Operation* op) {
-              return op->hasTrait<mlir::OpTrait::HasRecursiveMemoryEffects>()
-                         ? mlir::WalkResult::advance()
-                         : mlir::WalkResult::interrupt();
+            .Default([&](mlir::Operation* op) {
+              if (!op->hasTrait<mlir::OpTrait::HasRecursiveMemoryEffects>()) {
+                unknownAccesses.positions.push_back(position);
+              }
+              return mlir::WalkResult::advance();
             });
       });
-  return !result.wasInterrupted();
-}
-
-[[nodiscard]] static bool isFusableMeasurementStore(mlir::qc::MeasureOp measure,
-                                                    mlir::cbit::StoreOp store) {
-  if (store.getValue() != measure.getResult() ||
-      measure->getBlock() != store->getBlock()) {
-    return false;
-  }
-  for (auto* operation = measure->getNextNode(); operation != store;
-       operation = operation->getNextNode()) {
-    if (operation == nullptr || !canFuseMeasurementAcross(*operation, store)) {
-      return false;
     }
-  }
-  return true;
-}
-
-/// Put each supported measurement store at its emitted position before
-/// snapshot analysis. Quantum operations keep their order.
-static void prepareMeasurementStores(mlir::func::FuncOp function) {
-  function.walk([&](mlir::qc::MeasureOp measure) {
-    auto destination = measurementDestination(measure);
-    const auto index = mlir::getConstantIntValue(destination.getIndex());
-    if (!index) {
-      throw std::runtime_error(
-          "QC measurement uses a dynamic classical destination");
+    llvm::SmallBitVector moved(positions.size());
+    const auto conflicts = [&](Accesses& accesses, size_t measurement,
+                               size_t destination) {
+      /// Queries follow block order. Relocated stores precede every later
+      /// query.
+      while (accesses.next < accesses.positions.size() &&
+             (accesses.positions[accesses.next] <= measurement ||
+              moved[accesses.positions[accesses.next]])) {
+        ++accesses.next;
+      }
+      return accesses.next < accesses.positions.size() &&
+             accesses.positions[accesses.next] < destination;
+    };
+    for (auto measure : measurements) {
+      auto destination = measurementDestination(measure);
+      const auto index = mlir::getConstantIntValue(destination.getIndex());
+      if (!index) {
+        throw std::runtime_error(
+            "QC measurement uses a dynamic classical destination");
+      }
+      if (destination->getBlock() != block ||
+          positions.at(destination) <= positions.at(measure)) {
+        throw std::runtime_error("QC measurement destination must follow the "
+                                 "measurement in the same block");
+      }
+      const auto measurementPosition = positions.at(measure);
+      const auto destinationPosition = positions.at(destination);
+      const auto reg = registerAccesses.find(destination.getReg());
+      const auto bit = bitAccesses.find({destination.getReg(), *index});
+      if (conflicts(unknownAccesses, measurementPosition,
+                    destinationPosition) ||
+          (reg != registerAccesses.end() &&
+           conflicts(reg->second, measurementPosition, destinationPosition)) ||
+          (bit != bitAccesses.end() &&
+           conflicts(bit->second, measurementPosition, destinationPosition))) {
+        throw std::runtime_error("QC measurement destination must follow the "
+                                 "measurement in the same block");
+      }
+      if (auto* definition = destination.getIndex().getDefiningOp();
+          definition && definition->getBlock() == block &&
+          positions.at(definition) > measurementPosition) {
+        mlir::OpBuilder builder(measure);
+        destination.getIndexMutable().assign(
+            mlir::arith::ConstantIndexOp::create(builder, measure.getLoc(),
+                                                 *index));
+      }
+      destination->moveAfter(measure);
+      moved.set(destinationPosition);
     }
-    if (!isFusableMeasurementStore(measure, destination)) {
-      throw std::runtime_error("QC measurement destination must follow the "
-                               "measurement in the same block");
-    }
-    if (auto* definition = destination.getIndex().getDefiningOp();
-        definition && definition->getBlock() == measure->getBlock() &&
-        measure->isBeforeInBlock(definition)) {
-      mlir::OpBuilder builder(measure);
-      destination.getIndexMutable().assign(mlir::arith::ConstantIndexOp::create(
-          builder, measure.getLoc(), *index));
-    }
-    destination->moveAfter(measure);
   });
 }
 

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from itertools import permutations
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -2098,6 +2099,31 @@ def test_root_register_expression_and_nested_condition_preserve_captures(num_clb
     assert {variable.var for variable in expr.iter_vars(inner.condition)} == {body.cregs[0]}
 
 
+def test_control_flow_blocks_keep_registers_and_own_global_phase() -> None:
+    """Keep exact parent resources without copying parent instructions or phase."""
+    registers = [ClassicalRegister(1, f"c{index}") for index in range(8)]
+    circuit = QuantumCircuit(QuantumRegister(1, "q"), *registers, global_phase=0.25)
+    circuit.h(0)
+    body = circuit.copy_empty_like()
+    body.global_phase = 0.5
+    body.x(0)
+    circuit.if_test((registers[-1], 0), body, circuit.qubits, circuit.clbits)
+
+    program = QCProgram.from_qiskit(circuit)
+    original_ir = program.ir
+    restored = program.to_qiskit()
+    restored_body = restored.data[-1].operation.blocks[0]
+
+    assert program.ir == original_ir
+    assert restored.global_phase == pytest.approx(0.25)
+    assert restored_body.global_phase == pytest.approx(0.5)
+    assert [item.operation.name for item in restored_body.data] == ["x"]
+    assert restored_body.qubits == restored.qubits
+    assert restored_body.clbits == restored.clbits
+    assert restored_body.qregs == restored.qregs
+    assert restored_body.cregs == restored.cregs
+
+
 def test_repeated_cbit_uint_expression_falls_back_to_expression_tree() -> None:
     """Do not misidentify repeated source bits as a packed classical register."""
     program = _single_qubit_program(
@@ -2900,6 +2926,46 @@ def test_grouped_measurements_preserve_shared_destination_order(*, via_qco: bool
         assert restored.num_clbits == 1
         assert sample(program, shots=1, seed=1) == {"0": 1}
         assert sample(QCProgram.from_qiskit(restored), shots=1, seed=1) == {"0": 1}
+
+
+@pytest.mark.parametrize("store_order", list(permutations(range(3))))
+def test_grouped_measurements_keep_order_for_each_destination(store_order: tuple[int, ...]) -> None:
+    """Reorder disjoint destinations while preserving repeated-bit writes."""
+    destinations = [0, 1, 0]
+    stores = [f"cbit.store %m{index}, %c[%i{destinations[index]}] : !cbit.reg<2>" for index in store_order]
+    program = QCProgram.from_mlir_str(
+        """module {
+  func.func @main() -> !cbit.reg<2> attributes {mqt.entry_point} {
+    %q = qc.alloc : !qc.qubit
+    %c = cbit.alloc(#cbit.init<zero>) : !cbit.reg<2>
+    qc.x %q : !qc.qubit
+    %m0 = qc.measure %q : !qc.qubit -> i1
+    qc.x %q : !qc.qubit
+    %m1 = qc.measure %q : !qc.qubit -> i1
+    %m2 = qc.measure %q : !qc.qubit -> i1
+    %i0 = arith.constant 0 : index
+    %i1 = arith.constant 1 : index
+    """
+        + "\n    ".join(stores)
+        + """
+    qc.dealloc %q : !qc.qubit
+    return %c : !cbit.reg<2>
+  }
+}
+"""
+    )
+    original_ir = program.ir
+    if store_order.index(2) < store_order.index(0):
+        with pytest.raises(RuntimeError, match="destination must follow the measurement"):
+            program.to_qiskit()
+    else:
+        restored = program.to_qiskit()
+        assert [
+            restored.find_bit(item.clbits[0]).index for item in restored.data if item.operation.name == "measure"
+        ] == destinations
+        assert sample(program, shots=1, seed=1) == {"00": 1}
+        assert sample(QCProgram.from_qiskit(restored), shots=1, seed=1) == {"00": 1}
+    assert program.ir == original_ir
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Qiskit export rescanned overlapping measurement/store intervals and rebuilt every register for each control-flow block. Index classical accesses once per block and use `copy_empty_like(vars_mode="drop")` for block construction. Already adjacent stores avoid the access index.

Preserve quantum order, repeated-bit write order, scalar snapshots, captures, exact register membership, and independent block phase. Seven new regression cases cover store permutations and block ownership. The complexity review also replaced the copied measurement list with MLIR's native operation range.

Contributes to #2253; the broader MLIR audit remains open. Scalar consumer summaries and custom Gate identity optimization remain deferred.

### Local measurements

| Workload | Before | After |
| --- | ---: | ---: |
| 8,000 grouped measurements | 4.82 s | 26.1 ms |
| 100 one-gate branches, 1,000 registers | 9.16 s | 119 ms |

ARM64, Qiskit 2.5.2, release build; medians of three calls after warmup, excluding circuit construction. These are workload-specific export timings. The host was shared; no remote-hardware speedup is claimed.

### Validation

Local checks and final timings apply to signed commit `02298aaba7397f42610654fa8799d5cb84aecafc`.

- 747 translation, loop, integer-interchange, adoption, and Qiskit SDK tests passed. One adoption fixture was deselected because it creates an unsigned Git commit.
- `uvx nox -s lint`, `uvx nox -s cpp-lint -- ad74680f1ef380456a1b89a810ef33ee8d218f69`, and `uvx nox -s stubs` passed. C++ lint checks all lines of both changed files; generated stubs are unchanged.
- Eight fresh-process determinism checks matched before and after the exporter changes.

No public API changed. Documentation, changelog, and migration updates are not applicable to these internal changes to unreleased v4 functionality. Hosted CI remains a separate gate.

Codex implemented the changes, applied the complexity review, and ran local validation. Human review and acceptance remain required.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
