### PR TITLE
📝 Refresh README and documentation entry points

### DIFF
--- a/.agent/audits/readme-rtd-next-release.md
+++ b/.agent/audits/readme-rtd-next-release.md
@@ -1,0 +1,70 @@
+# README and next-release documentation audit
+
+Status: findings applied and locally validated. Current baseline: main
+`fce58f02d`, with compiler prerequisite `1f7defd48` (PR #2506).
+
+## Result
+
+1. Replace the outdated feature list and buried example with six concrete
+   capability groups and an executable compile-and-submit workflow.
+2. Route readers from the documentation landing page to examples, guides, and
+   APIs. Put MQSC before CDA/TUM and preserve the funding attribution.
+3. Distinguish executable DDSIM devices from compilation-only SC models.
+4. Correct the installed C++ reference scope and the OpenQASM exporter's
+   classical-index support.
+
+The PR #2519 rebase retains its API names and corrected compiler terminology.
+The RUS demonstration is integrated into `benchmarks.md`, with MyST `math`
+directives for displayed equations. README and documentation prose link to MQSC
+by its short name; full legal names remain only in copyright notices. The
+compiler guide is now `mlir/mqt_compiler_collection.md` and introduces the
+Python, C++, and `mqt-cc` interfaces. All navigation uses the new page, and RUS
+links target its benchmark section. The landing-page device note and the README
+Shor implementation aside are removed.
+
+## Contracts and evidence
+
+- `bindings/mlir/register_mlir.cpp`, `mlir/lib/Compiler/Pipeline.cpp`, and
+  `docs/mlir/target_compilation.md` define device-directed compilation and
+  submission. The README uses those public APIs. The docs session extracts its
+  sole Python block; MyST loads and executes that exact source.
+- `mlir/bench/programs/QPE.cpp` and `src/bench/QPE.cpp` define the generated
+  phase-gate benchmark and analytic distribution. Eight-bit standard and
+  iterative programs use nine and two qubits before target optimization. QIR
+  runtime outputs follow recording order; DDSIM normalizes them before returning
+  QDMI shots and counts. Examples pass counts directly to evaluation.
+  Exact-phase and sampled non-exact-phase checks exercise both the compiler and
+  the result contract.
+- `mlir/bench/programs/RepeatUntilSuccess.cpp`,
+  `src/bench/RepeatUntilSuccess.cpp`, and the existing `docs/benchmarks.md`
+  define the retry circuit and phase-sensitive parity reference. The tutorial
+  checks its sampled distribution. It does not infer retry counts from parity or
+  claim error correction.
+- `src/qdmi/devices/sc/Device.cpp` rejects job creation and execution with
+  `QDMI_ERROR_NOTSUPPORTED`. Its calibration and topology describe compiler
+  targets. The README, QDMI index, and SC guide describe this scope.
+- `docs/Doxyfile` generates the installed `include/mqt-core` reference.
+  `mlir/include/mqt/Dialect/QIR` belongs to the source-tree interface.
+  `docs/cpp_api.md` separates these scopes and compiles its displayed DD/CMake
+  example against the installed wheel, then checks the four amplitudes.
+- `docs/mlir/OpenQASM.md` and the frontend/export implementation permit runtime
+  classical-bit indices while requiring statically resolved exported qubit
+  indices. The compiler overview now matches that distinction and retains the
+  runtime-assertion limitation.
+
+## Retained scope and limits
+
+Reassessed the entry points and current compiler, benchmark, QDMI, QIR, and
+build recipes alongside the earlier `documentation.md` audit. Existing DD
+algebra checks, SDK examples, strict notebook execution, and generated HTML
+navigation checks remain in place. Historical changelogs and generated API
+descriptions were not individually re-audited. Template-owned installation and
+contribution pages remain template-owned; installation already documents LLVM
+23.1 setup. No new documentation framework or dependency is needed.
+
+The adaptive examples depend on
+[PR #2506](https://github.com/munich-quantum-toolkit/core/pull/2506).
+This work targets the next release; new stable-page links become available with
+that publication. No remote device, live calibration, Slurm cluster, or
+non-Linux platform was exercised. Validation results are in the companion
+execution plan.

--- a/.agent/audits/readme-rtd-next-release.md
+++ b/.agent/audits/readme-rtd-next-release.md
@@ -17,6 +17,7 @@ The PR #2519 rebase retains its API names and corrected compiler terminology.
 The RUS demonstration is integrated into `benchmarks.md`, with MyST `math`
 directives for displayed equations. README and documentation prose link to MQSC
 by its short name; full legal names remain only in copyright notices. The
+glossary expands MQSC and CDA and identifies both as developers of MQT Core. The
 compiler guide is now `mlir/mqt_compiler_collection.md` and introduces the
 Python, C++, and `mqt-cc` interfaces. All navigation uses the new page, and RUS
 links target its benchmark section. The landing-page device note and the README
@@ -46,7 +47,9 @@ Shor implementation aside are removed.
 - `docs/Doxyfile` generates the installed `include/mqt-core` reference.
   `mlir/include/mqt/Dialect/QIR` belongs to the source-tree interface.
   `docs/cpp_api.md` separates these scopes and compiles its displayed DD/CMake
-  example against the installed wheel, then checks the four amplitudes.
+  example against the installed wheel, then checks the four amplitudes. Its
+  Ninja generator requires Ninja in the docs environment. Configure and build
+  diagnostics are retained in notebook output so hosted failures are visible.
 - `docs/mlir/OpenQASM.md` and the frontend/export implementation permit runtime
   classical-bit indices while requiring statically resolved exported qubit
   indices. The compiler overview now matches that distinction and retains the
@@ -60,7 +63,8 @@ algebra checks, SDK examples, strict notebook execution, and generated HTML
 navigation checks remain in place. Historical changelogs and generated API
 descriptions were not individually re-audited. Template-owned installation and
 contribution pages remain template-owned; installation already documents LLVM
-23.1 setup. No new documentation framework or dependency is needed.
+23.1 setup. The docs dependency group supplies Ninja for the C++ example; no new
+documentation framework is needed.
 
 The adaptive examples depend on
 [PR #2506](https://github.com/munich-quantum-toolkit/core/pull/2506).

--- a/.agent/plans/readme-rtd-next-release.md
+++ b/.agent/plans/readme-rtd-next-release.md
@@ -1,0 +1,71 @@
+# README and documentation for the next release
+
+Status: implementation and local validation complete. Compiler PR #2506 is at
+`1f7defd48` on main `fce58f02d` after PR #2519.
+
+## Goal and decisions
+
+Refresh the README and documentation entry points for the next release and
+resolve #2419. Describe six capability groups, put a runnable iterative-QPE
+example near the beginning, and list MQSC before CDA/TUM without changing
+funding attribution. Preserve Sphinx, MyST notebooks, and generated-link checks.
+
+The README owns the first example. The getting-started notebook must execute
+that exact source rather than maintaining a second copy. It compares standard
+and iterative QPE and evaluates a non-exact phase. The benchmark catalog
+includes an executed repeat-until-success demonstration and its phase-sensitive
+readout. Both examples run locally on DDSIM and consume QDMI counts directly.
+
+The landing page routes application users, DD users, device integrators,
+benchmark users, and C++/compiler developers to examples, guides, and APIs.
+Audit current authored docs against declarations, implementation, and execution;
+keep historical changelogs and generated API prose outside individual review.
+
+## Result
+
+The README now describes six capability groups and leads with iterative QPE. The
+landing page supplies five routes to examples, guides, and APIs. The QPE and RUS
+examples execute locally; the C++ page builds its displayed example against the
+installed library. Corrected claims and scope limits are recorded in
+`../audits/readme-rtd-next-release.md`.
+
+Preserve PR #2519's OpenQASM import and operation-capability names, static
+gate-count scope, and jeff conversion/serialization distinction. Displayed RUS
+equations use MyST `math` directives within the benchmark catalog. README and
+documentation prose use `[MQSC](https://mq.sc)`; copyright notices retain the
+full legal name. The renamed `mlir/mqt_compiler_collection.md` guide introduces
+Python, C++, and `mqt-cc`. Navigation and incoming links use the new path.
+Remove the redundant RUS README link, the device note below the landing-page
+grid, and the Shor implementation aside.
+
+The adaptive examples required a separate compiler fix, published as PR #2506.
+The documentation PR is stacked on that branch and closes #2419 after merge to
+main. No new dependencies or documentation framework were introduced.
+
+## Validation
+
+- A fresh wheel installed in an isolated CPython 3.14.7 environment executes the
+  exact README source with no stderr: `{'01100000': 1024}`, phase `3/8`.
+- A clean strict HTML build with Doxygen 1.9.8 passes, including generated file
+  and fragment checks. All 11 authored notebooks execute without error or stderr
+  records. Standard and iterative QPE return the same counts; the RUS parity
+  distribution has total variation distance 0.005 from its reference.
+- The renamed compiler page and benchmark RUS anchor resolve. Old page paths are
+  absent. The three moved RUS equations retain their MyST math directives and
+  contents. MQSC links and the compiler page's three interface routes are
+  present; rendered landing and compiler pages were inspected.
+- The generated QPE notebook contains the exact README source. The isolated
+  wheel smoke test uses the same source.
+- External linkcheck, the two generated-link regression tests, general lint, and
+  `git diff --check` pass. The final ponytail review found no further
+  unnecessary code or dependencies in the documentation changes.
+
+Compiler validation is recorded in its separate plan and audit: 922 native
+tests, 315 Python tests, full-file C++ lint, general lint, and generated MLIR
+docs pass.
+
+## Publication
+
+PR #2509 is stacked on PR #2506. Both use signed, verified commits, the
+repository template and AI disclosure, the required assignee, and appropriate
+labels. Hosted CI is not monitored as part of this task.

--- a/.agent/plans/readme-rtd-next-release.md
+++ b/.agent/plans/readme-rtd-next-release.md
@@ -33,14 +33,16 @@ Preserve PR #2519's OpenQASM import and operation-capability names, static
 gate-count scope, and jeff conversion/serialization distinction. Displayed RUS
 equations use MyST `math` directives within the benchmark catalog. README and
 documentation prose use `[MQSC](https://mq.sc)`; copyright notices retain the
-full legal name. The renamed `mlir/mqt_compiler_collection.md` guide introduces
-Python, C++, and `mqt-cc`. Navigation and incoming links use the new path.
-Remove the redundant RUS README link, the device note below the landing-page
-grid, and the Shor implementation aside.
+full legal name. The glossary expands MQSC and CDA and records their joint
+development of MQT Core. The renamed `mlir/mqt_compiler_collection.md` guide
+introduces Python, C++, and `mqt-cc`. Navigation and incoming links use the new
+path. Remove the redundant RUS README link, the device note below the
+landing-page grid, and the Shor implementation aside.
 
 The adaptive examples required a separate compiler fix, published as PR #2506.
 The documentation PR is stacked on that branch and closes #2419 after merge to
-main. No new dependencies or documentation framework were introduced.
+main. The docs dependency group installs Ninja for the C++ example. The existing
+documentation framework remains in use.
 
 ## Validation
 
@@ -56,6 +58,9 @@ main. No new dependencies or documentation framework were introduced.
   present; rendered landing and compiler pages were inspected.
 - The generated QPE notebook contains the exact README source. The isolated
   wheel smoke test uses the same source.
+- The exact C++ notebook cell passes with only the docs environment and system
+  executables on `PATH`. Without Ninja, configuration fails as in RtD build
+  `34501147`; the notebook now includes CMake diagnostics in its output.
 - External linkcheck, the two generated-link regression tests, general lint, and
   `git diff --check` pass. The final ponytail review found no further
   unnecessary code or dependencies in the documentation changes.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 
 # MQT Core - The Backbone of the Munich Quantum Toolkit (MQT)
 
-MQT Core is an open-source C++20 and Python library for quantum computing that
-forms the backbone of the quantum software tools developed as part of the
+MQT Core is a collection of open-source C++20 and Python libraries for quantum
+computing. Generate programs, compile them for a device, execute them, and
+analyze the results. Its libraries form the backbone of the
 [_Munich Quantum Toolkit (MQT)_](https://mqt.readthedocs.io).
 
 <p align="center">
@@ -30,20 +31,104 @@ forms the backbone of the quantum software tools developed as part of the
 
 ## Key Features
 
-- An MLIR-based compiler collection for quantum programs.
-- A state-of-the-art decision diagram (DD) package for quantum computing.
-- A QIR runtime based on the decision diagram package.
+- **[MQT Compiler Collection](https://mqt.readthedocs.io/projects/core/en/stable/mlir/mqt_compiler_collection.html):**
+  Generate and optimize structured quantum/classical programs, map them to
+  devices, synthesize native gates, and exchange programs through OpenQASM,
+  Qiskit, QIR, and jeff.
+- **[Decision diagrams](https://mqt.readthedocs.io/projects/core/en/stable/dd_package.html):**
+  Represent quantum states and operations, simulate programs, and analyze their
+  behavior through C++ and Python.
+- **[QIR execution](https://mqt.readthedocs.io/projects/core/en/stable/qir/index.html):**
+  Execute supported QIR Base and Adaptive Profile programs with the DD runtime.
+- **[QDMI](https://mqt.readthedocs.io/projects/core/en/stable/qdmi/index.html):**
+  Discover devices, query capabilities, compile programs, and submit jobs. Use
+  bundled DDSIM for execution and superconducting hardware models for
+  compilation.
+- **SDK and HPC integration:** connect devices through
+  [Qiskit](https://mqt.readthedocs.io/projects/core/en/stable/qdmi/qdmi_backend.html),
+  [PennyLane](https://mqt.readthedocs.io/projects/core/en/stable/qdmi/pennylane_device.html),
+  and
+  [Slurm](https://mqt.readthedocs.io/projects/core/en/stable/qdmi/slurm.html).
+- **[Structured benchmarks](https://mqt.readthedocs.io/projects/core/en/stable/benchmarks.html):**
+  Generate configurable quantum programs, query analytic references, and
+  evaluate sampled results.
 
-If you have any questions, feel free to create a
+## Getting Started
+
+Install [mqt.core](https://pypi.org/project/mqt.core/) in a Python 3.11 or newer
+virtual environment:
+
+```console
+uv pip install mqt.core
+```
+
+Estimate the phase `3/8` with eight bits of precision using
+**iterative quantum phase estimation (QPE)**. This uses two qubits and
+measurement feedback. Compile for the bundled DDSIM device, then submit the
+compiled program:
+
+```python
+from fractions import Fraction
+
+from mqt.core.bench import qpe
+from mqt.core.mlir import compile_program, submit_program
+from mqt.core.qdmi.driver import open_device
+
+benchmark = qpe.QPE(qpe.Options(precision=8, phase=Fraction(3, 8), method=qpe.Method.ITERATIVE))
+program = benchmark.generate()
+device = open_device("mqt.ddsim.default")
+compiled = compile_program(program, target=device)
+job = submit_program(compiled, target=device, num_shots=1024)
+job.wait()
+
+counts = job.get_counts()
+outcome = max(counts, key=lambda bits: counts[bits])
+phase = Fraction(int(outcome, 2), 2**benchmark.output.width)
+assert phase == benchmark.options.phase
+assert benchmark.evaluate(counts).total_variation_distance < 1e-12
+print(f"Counts: {counts}")
+print(f"Estimated phase: {phase}")
+```
+
+```text
+Counts: {'01100000': 1024}
+Estimated phase: 3/8
+```
+
+The
+[QPE walkthrough](https://mqt.readthedocs.io/projects/core/en/stable/getting_started.html)
+compares standard and iterative QPE and evaluates a phase that cannot be
+represented exactly with eight bits. This phase-gate benchmark illustrates the
+phase-estimation step used in algorithms such as Shor's.
+
+## Further Documentation
+
+- [Install and build MQT Core](https://mqt.readthedocs.io/projects/core/en/stable/installation.html).
+- [Compile and execute programs](https://mqt.readthedocs.io/projects/core/en/stable/getting_started.html).
+- Browse the
+  [Python API](https://mqt.readthedocs.io/projects/core/en/stable/api/mqt/core/index.html)
+  and
+  [C++ entry point](https://mqt.readthedocs.io/projects/core/en/stable/cpp_api.html).
+
+## Development
+
+Source builds require a C++20 compiler and CMake 3.28 or newer. Building the
+compiler collection also requires
+[LLVM/MLIR 23.1 or newer](https://mqt.readthedocs.io/projects/core/en/stable/installation.html#setting-up-mlir).
+Prebuilt Python wheels include the compiler and simulator. Graphviz is optional
+for exporting DD visualizations.
+
+See the
+[contribution guide](https://mqt.readthedocs.io/projects/core/en/stable/contributing.html)
+for development setup and checks. For questions and suggestions, open a
 [discussion](https://github.com/munich-quantum-toolkit/core/discussions) or an
-[issue](https://github.com/munich-quantum-toolkit/core/issues) on
-[GitHub](https://github.com/munich-quantum-toolkit/core).
+[issue](https://github.com/munich-quantum-toolkit/core/issues).
 
 ## Contributors and Supporters
 
-MQT Core is developed by the
+MQT Core is developed by [MQSC](https://mq.sc) and the
 [Chair for Design Automation](https://www.cda.cit.tum.de/) at the
-[Technical University of Munich](https://www.tum.de/) and [MQSC](https://mq.sc).
+[Technical University of Munich](https://www.tum.de/).
 Among others, it is part of the
 [Munich Quantum Software Stack (MQSS)](https://www.munich-quantum-valley.de/research/research-areas/mqss)
 ecosystem, which is being developed as part of the
@@ -85,75 +170,6 @@ To support this endeavor, please consider:
   <img width=20% src="https://img.shields.io/badge/Sponsor-white?style=for-the-badge&logo=githubsponsors&labelColor=black&color=blue" alt="Sponsor the MQT" />
   </a>
 </p>
-
-## Getting Started
-
-`mqt.core` is available via [PyPI](https://pypi.org/project/mqt.core/).
-
-```console
-uv pip install mqt.core
-```
-
-The following example compiles an OpenQASM program to QIR and executes it on the
-QDMI DDSIM device:
-
-```python3
-from mqt.core.mlir import CompilerTarget, OutputFormat, compile_program
-from mqt.core.qdmi import ProgramFormat
-from mqt.core.qdmi.driver import open_device
-
-source = """OPENQASM 3.0;
-include "stdgates.inc";
-qubit[2] q;
-bit[2] result;
-h q[0];
-cx q[0], q[1];
-result = measure q;
-"""
-
-device = open_device("mqt.ddsim.default")
-program = compile_program(
-    source,
-    target=CompilerTarget.from_device(device),
-    output=OutputFormat.QIR_BASE,
-)
-job = device.submit_job(
-    program.to_bitcode(),
-    ProgramFormat.QIR_BASE_MODULE,
-    num_shots=1024,
-)
-job.wait()
-print(job.get_counts())
-```
-
-**Detailed documentation and examples are available at
-[ReadTheDocs](https://mqt.readthedocs.io/projects/core).**
-
-## System Requirements
-
-Building the project requires a C++ compiler with support for C++20 and CMake
-3.28 or newer. For details on how to build the project, please refer to the
-[documentation](https://mqt.readthedocs.io/projects/core). Building (and
-running) is continuously tested under Linux, macOS, and Windows using the
-[latest available system versions for GitHub Actions](https://github.com/actions/runner-images).
-MQT Core is compatible with all
-[officially supported Python versions](https://devguide.python.org/versions/).
-
-The project relies on some external dependencies:
-
-- [nlohmann/json](https://github.com/nlohmann/json):
-  A JSON library for modern C++.
-- [google/googletest](https://github.com/google/googletest):
-  A testing framework for C++ (only used in tests).
-
-CMake will automatically look for installed versions of these libraries. If it
-does not find them, they will be fetched automatically at configure time via the
-[FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html)
-module (check out the documentation for more information on how to customize
-this behavior).
-
-It is recommended (although not required) to have
-[GraphViz](https://www.graphviz.org) installed for visualization purposes.
 
 ## Cite This
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -14,6 +14,11 @@ structured QC program, a resolved manifest, and a stable case ID. The generated
 program returns one classical register named `result`. Outcome strings are
 big-endian: the highest-index result bit is the leftmost character.
 
+For an end-to-end device example, start with {doc}`getting_started`. It compares
+standard and iterative QPE and evaluates exact and non-exact phases. The
+[repeat-until-success example](#repeat-until-success) below demonstrates an
+adaptive retry loop and a phase-sensitive readout.
+
 ## Discover the catalog
 
 The command-line registry is the current list of available families. Each family
@@ -120,8 +125,8 @@ for a distinguished success outcome.
 ## Generate structured IR
 
 Generation returns a {py:class}`~mqt.core.mlir.QCProgram`, the program type used
-by the [MQT Core MLIR compiler collection](mlir/python_compiler_collection.md).
-The program can enter the normal compiler pipeline.
+by the [MQT Compiler Collection](mlir/mqt_compiler_collection.md). The program
+can enter the normal compiler pipeline.
 
 ```{code-cell} ipython3
 program = benchmark.generate()
@@ -340,32 +345,89 @@ every input.
 
 ### Repeat until success
 
-The `repeat-until-success` family generalizes the two-$T$-gate circuit from
-Figure 8 of Paetznick and Svore's
-[repeat-until-success decomposition](https://arxiv.org/abs/1311.1074v2) to
-$P=X^{\otimes n}$. Set `data_qubits` to $n$ (default 1, range 1–1,000,000); the
-circuit uses one additional ancilla. Both registers start in zero.
+A repeat-until-success (RUS) circuit measures an ancilla to decide whether an
+operation succeeded. On failure, it restores the ancilla and retries. RUS
+decompositions can reduce the expected number of costly non-Clifford gates in
+fault-tolerant quantum computing.
 
-Each attempt applies $(I + i\sqrt{2}P)/\sqrt{3}$ with probability $3/4$. Failure
-leaves the data unchanged up to global phase. The circuit restores the ancilla
-to zero and retries through an unbounded `scf.while`. Two controlled Pauli
-strings require $2n$ CNOT gates per attempt. Structured loops keep the generated
-QC program compact; execution still takes linear work per attempt.
+The `repeat-until-success` family generalizes the two-$T$-gate circuit in Figure
+8 of [Paetznick and Svore](https://arxiv.org/abs/1311.1074v2). It applies
 
-After success, the data state is $(|0^n\rangle+i\sqrt{2}|1^n\rangle)/\sqrt{3}$.
-The benchmark measures $Y\otimes X^{\otimes(n-1)}$ by changing basis and
-accumulating parity on the first data qubit. The one-bit `result` has
-probabilities $P(0)=1/2+\sqrt{2}/3$ and $P(1)=1/2-\sqrt{2}/3$ at every width.
-This readout checks the relative phase without an exponentially large output
-distribution.
+```{math}
+U = \frac{I+i\sqrt{2}X^{\otimes n}}{\sqrt{3}}
+```
+
+to $n$ data qubits initially in $|0^n\rangle$. Each attempt succeeds with
+probability $3/4$; failure leaves the data unchanged up to global phase. The
+expected number of attempts is $4/3$, giving $8/3$ $T$ gates on average before
+target synthesis. Two controlled Pauli strings use $2n$ CNOT gates per attempt.
+
+Set `data_qubits` to $n$ (default 1, range 1–1,000,000). The circuit uses one
+additional ancilla, initially zero, and retries through a `while` loop with no
+fixed attempt limit. Canonical instance specifications include `data_qubits`,
+and case IDs distinguish widths:
 
 ```json
 {"schema_version":1,"benchmark":"repeat-until-success","parameters":{"data_qubits":32}}
 ```
 
-The empty parameter object still selects one data qubit. Canonical JSON includes
-`data_qubits`, and semantic case IDs distinguish widths. The width limit bounds
-input size; it does not guarantee that a compiler or execution backend supports
-that many qubits. This family scales width and adaptive execution, while its
-state remains simple for decision diagrams and its expected $T$ count stays
-$8/3$. It does not model magic-state distillation or cultivation.
+#### Compile and execute the retry loop
+
+Four data qubits and one ancilla give five qubits in this example. DDSIM
+executes the generated program through Adaptive QIR. See {doc}`getting_started`
+for the basic compile-and-submit workflow and {doc}`installation` for setup.
+
+```{code-cell} ipython3
+from mqt.core.bench import repeat_until_success
+from mqt.core.mlir import compile_program, submit_program
+from mqt.core.qdmi.driver import open_device
+
+rus = repeat_until_success.RepeatUntilSuccess(
+    repeat_until_success.Options(data_qubits=4)
+)
+device = open_device("mqt.ddsim.default")
+compiled = compile_program(rus.generate(), target=device)
+job = submit_program(compiled, target=device, num_shots=4096, custom1=17)
+job.wait()
+counts = job.get_counts()
+print(f"Counts: {counts}")
+```
+
+#### Check the relative phase
+
+Successful execution prepares
+
+```{math}
+|\psi\rangle = \frac{|0^n\rangle+i\sqrt{2}|1^n\rangle}{\sqrt{3}}.
+```
+
+Measuring only in the computational basis would miss the relative phase. The
+benchmark instead measures $Y\otimes X^{\otimes(n-1)}$ by changing basis and
+accumulating parity on the first data qubit. The one-bit `result` has ideal
+probabilities
+
+```{math}
+P(0)=\frac12+\frac{\sqrt2}{3}, \qquad
+P(1)=\frac12-\frac{\sqrt2}{3}.
+```
+
+The result is a final parity measurement, not the ancilla's success flag or the
+number of retry attempts.
+
+```{code-cell} ipython3
+evaluation = rus.evaluate(counts)
+assert sum(counts.values()) == 4096
+assert evaluation.total_variation_distance < 0.02
+for bit in ("0", "1"):
+    observed = counts.get(bit, 0) / sum(counts.values())
+    print(f"P({bit}): observed {observed:.3f}, ideal {rus.probability(bit):.3f}")
+print(f"Total variation distance: {evaluation.total_variation_distance:.3f}")
+```
+
+The analytic probabilities are independent of width. This readout checks the
+relative phase without an exponentially large output distribution. Structured
+loops keep the program compact; execution still takes linear work per attempt.
+The input width limit does not guarantee that a device or compiler supports that
+many qubits. See {doc}`mlir/target_compilation` for device and control-flow
+limits. The benchmark simulates an ideal adaptive circuit; it does not model
+error correction, magic-state distillation, or cultivation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ except ModuleNotFoundError:
 release = version.split("+")[0]
 
 project = "MQT Core"
-author = "Chair for Design Automation, TUM & Munich Quantum Software Company GmbH"
+author = "MQSC & Chair for Design Automation, TUM"
 language = "en"
 project_copyright = "2023 - 2026 Chair for Design Automation, TUM & 2025 - 2026 Munich Quantum Software Company GmbH"
 

--- a/docs/cpp_api.md
+++ b/docs/cpp_api.md
@@ -1,8 +1,103 @@
-# C++ API reference
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+---
+
+# C++ libraries and API reference
 
 The <a href="cpp/index.html">native C++ API reference</a> documents the
-installed public headers, including decision diagrams, benchmarks, QDMI, and the
-QIR runtime. It is generated from the same source revision as this guide.
+installed public headers, including decision diagrams, benchmarks, and QDMI. It
+is generated from the same source revision as this guide.
 
-For the source-tree compiler interface, see {doc}`mlir/target_compilation` and
-the {doc}`MLIR dialect and pass references <mlir/index>`.
+## Use the DD library
+
+Create a two-qubit GHZ state, which is a Bell state, and print its amplitudes.
+Save this as `main.cpp`:
+
+```cpp
+#include "dd/Package.hpp"
+#include "dd/StateGeneration.hpp"
+
+#include <iostream>
+
+int main() {
+  dd::Package package(2);
+  const auto state = dd::makeGHZState(2, package);
+  for (const auto amplitude : state.getVector()) {
+    std::cout << amplitude << '\n';
+  }
+  package.decRef(state);
+}
+```
+
+The DD package owns its nodes. The state returned by `makeGHZState` holds a
+reference until `decRef` releases it. Keep the package alive while using the
+state. Converting a DD to a dense vector takes space exponential in the number
+of qubits; this example has only four amplitudes.
+
+Save the following as `CMakeLists.txt`:
+
+```cmake
+cmake_minimum_required(VERSION 3.28)
+project(dd-example LANGUAGES CXX)
+find_package(mqt-core CONFIG REQUIRED)
+add_executable(dd-example main.cpp)
+target_link_libraries(dd-example PRIVATE MQT::CoreDD)
+```
+
+With the Python wheel installed in the active environment, CMake and Ninja
+available, run:
+
+```console
+cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH="$(mqt-core-cli --cmake_dir)"
+cmake --build build
+./build/dd-example
+```
+
+The last command is for a Unix shell; on Windows, run `build\dd-example.exe`.
+The output has amplitude $1/\sqrt{2}$ at `00` and `11`, and zero at `01` and
+`10`. For a separate C++ installation, point `CMAKE_PREFIX_PATH` at its install
+prefix instead. See {doc}`installation` for source builds and other CMake
+integration options.
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import math
+import os
+import subprocess
+
+source = Path("cpp_api.md").read_text(encoding="utf-8")
+cpp = source.split("```cpp\n")[1].split("\n```", 1)[0]
+cmake = source.split("```cmake\n")[1].split("\n```", 1)[0]
+prefix = subprocess.run(
+    ["mqt-core-cli", "--cmake_dir"], check=True, capture_output=True, text=True
+).stdout.strip()
+with TemporaryDirectory() as directory:
+    root = Path(directory)
+    (root / "main.cpp").write_text(cpp, encoding="utf-8")
+    (root / "CMakeLists.txt").write_text(cmake, encoding="utf-8")
+    subprocess.run(
+        ["cmake", "-S", directory, "-B", str(root / "build"), "-G", "Ninja",
+         f"-DCMAKE_PREFIX_PATH={prefix}"], check=True, capture_output=True, text=True
+    )
+    subprocess.run(
+        ["cmake", "--build", str(root / "build")], check=True, capture_output=True, text=True
+    )
+    executable = root / "build" / ("dd-example.exe" if os.name == "nt" else "dd-example")
+    result = subprocess.run([str(executable)], check=True, capture_output=True, text=True)
+    amplitudes = [complex(*map(float, line.strip("()").split(","))) for line in result.stdout.splitlines()]
+    expected = [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)]
+    assert len(amplitudes) == len(expected)
+    assert all(abs(actual - ideal) < 1e-6 for actual, ideal in zip(amplitudes, expected))
+```
+
+## Extend the compiler or QIR runtime
+
+The MLIR compiler and QIR runtime use source-tree C++ interfaces. They are not
+part of the installed public-header reference above. See
+[device compilation from C++](mlir/target_compilation.md#c-source-tree-api), the
+{doc}`QIR runtime guide <qir/index>`, and the
+{doc}`MLIR dialect and pass references <mlir/index>`.

--- a/docs/cpp_api.md
+++ b/docs/cpp_api.md
@@ -81,10 +81,10 @@ with TemporaryDirectory() as directory:
     (root / "CMakeLists.txt").write_text(cmake, encoding="utf-8")
     subprocess.run(
         ["cmake", "-S", directory, "-B", str(root / "build"), "-G", "Ninja",
-         f"-DCMAKE_PREFIX_PATH={prefix}"], check=True, capture_output=True, text=True
+         f"-DCMAKE_PREFIX_PATH={prefix}"], check=True, stderr=subprocess.STDOUT
     )
     subprocess.run(
-        ["cmake", "--build", str(root / "build")], check=True, capture_output=True, text=True
+        ["cmake", "--build", str(root / "build")], check=True, stderr=subprocess.STDOUT
     )
     executable = root / "build" / ("dd-example.exe" if os.name == "nt" else "dd-example")
     result = subprocess.run([str(executable)], check=True, capture_output=True, text=True)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,118 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+mystnb:
+  number_source_lines: true
+---
+
+# Compile and execute a quantum program
+
+This walkthrough uses quantum phase estimation (QPE) to show the path from a
+structured program to a device result. Install MQT Core in a Python 3.11 or
+newer environment as described in {doc}`installation`. The Python wheel includes
+the compiler and the DDSIM simulator used here.
+
+## Estimate a known phase
+
+QPE estimates a phase $\phi$ from an eigenvalue $e^{2\pi i\phi}$ of a unitary
+operation. The benchmark supplies a phase gate and its known eigenstate, so we
+can compare execution against an analytic reference.
+
+The following example is the same source as the README. It estimates $3/8$ with
+eight bits of precision. Compilation and submission are separate operations:
+{py:func}`~mqt.core.mlir.compile_program` produces a reusable
+{py:class}`~mqt.core.mlir.CompiledProgram`, and
+{py:func}`~mqt.core.mlir.submit_program` creates a device job.
+
+```{code-cell} ipython3
+:load: _build/readme_example.py
+```
+
+Eight result bits encode an integer $k$ and the estimate $k/2^8$. Here,
+`01100000` is 96, so the estimate is $96/256=3/8$.
+
+DDSIM selects Adaptive QIR for this program. Its QDMI shots and counts place the
+highest-index output bit on the left, so the benchmark evaluates
+`job.get_counts()` directly. Equivalent OpenQASM and QIR payloads use the same
+bitstring order.
+
+`job.wait()` waits for completion and reports execution failure. The counts
+contain the final phase register; measurements used internally for feedback are
+not separate benchmark outputs.
+
+## Standard versus iterative QPE
+
+Both methods estimate the same phase. Standard QPE uses a register of phase
+qubits and an inverse quantum Fourier transform. Iterative QPE reuses one phase
+qubit, measures and resets it after each step, and uses earlier measurements to
+choose later corrections.
+
+| Method    |                      Qubits at eight-bit precision | Execution requirement                        |
+| --------- | -------------------------------------------------: | -------------------------------------------- |
+| Standard  |     9: eight phase qubits and one eigenstate qubit | Coherent phase register and terminal readout |
+| Iterative | 2: one reused phase qubit and one eigenstate qubit | Mid-circuit measurement, reset, and feedback |
+
+These counts describe this phase-gate benchmark before target optimization. They
+do not include the larger registers required by other controlled unitaries.
+
+```{code-cell} ipython3
+standard = qpe.QPE(
+    qpe.Options(precision=8, phase=Fraction(3, 8), method=qpe.Method.STANDARD)
+)
+standard_program = compile_program(standard.generate(), target=device)
+standard_job = submit_program(standard_program, target=device, num_shots=1024)
+standard_job.wait()
+standard_counts = standard_job.get_counts()
+assert standard_counts == counts
+assert standard.evaluate(standard_counts).total_variation_distance < 1e-12
+print(f"Standard QPE: {standard_counts}")
+print(f"Iterative QPE: {counts}")
+```
+
+QPE also appears in Shor's order-finding procedure, where the controlled unitary
+performs modular multiplication. This example uses a phase gate with a supplied
+eigenstate. It demonstrates phase estimation and feedback, not modular
+arithmetic, order finding, or factoring.
+
+## A phase between representable values
+
+The phase $1/3$ is not an integer multiple of $1/256$. QPE therefore produces a
+distribution over nearby estimates. More shots characterize that distribution;
+increasing the number of phase bits makes the estimation grid finer.
+
+```{code-cell} ipython3
+approximate = qpe.QPE(
+    qpe.Options(precision=8, phase=Fraction(1, 3), method=qpe.Method.ITERATIVE)
+)
+approximate_program = compile_program(approximate.generate(), target=device)
+approximate_job = submit_program(
+    approximate_program, target=device, num_shots=4096, custom1=17
+)
+approximate_job.wait()
+approximate_counts = approximate_job.get_counts()
+evaluation = approximate.evaluate(approximate_counts)
+assert evaluation.total_variation_distance < 0.08
+
+total = sum(approximate_counts.values())
+print("Estimate   Observed   Ideal")
+for bits in sorted(approximate_counts, key=lambda bits: approximate_counts[bits], reverse=True)[:4]:
+    estimate = Fraction(int(bits, 2), 2**approximate.output.width)
+    print(f"{str(estimate):9}  {approximate_counts[bits] / total:.3f}      {approximate.probability(bits):.3f}")
+print(f"Total variation distance: {evaluation.total_variation_distance:.3f}")
+```
+
+The total variation distance compares the complete sampled distribution with the
+analytic reference. Zero means agreement; finite-shot samples generally have a
+nonzero distance. `custom1=17` selects DDSIM's random seed for this example;
+custom job properties are device-specific.
+
+## Continue
+
+- Try the [repeat-until-success benchmark](benchmarks.md#repeat-until-success)
+  for a measurement-controlled retry loop.
+- Read {doc}`mlir/mqt_compiler_collection` for input formats, program objects,
+  transformations, and export.
+- Use {doc}`mlir/target_compilation` and {doc}`qdmi/driver` to compile for other
+  devices and inspect their capabilities.
+- Explore {doc}`benchmarks` for other program families and reference metrics.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -22,7 +22,7 @@ Chair for Design Automation
   **Preferred term:** Chair for Design Automation. **Accepted abbreviation:**
   CDA. A
   [research chair at the Technical University of Munich](https://www.cda.cit.tum.de/)
-  that develops design methods for fields including quantum computing.
+  that develops MQT Core together with [MQSC](https://mq.sc).
 
 DD
 DDs
@@ -64,8 +64,10 @@ modular multiplier
   arithmetic circuit that computes a product reduced modulo a specified integer.
 
 MQSC
-  **Preferred term:** [MQSC](https://mq.sc). **Accepted aliases:** none. The
-  company that develops and supports parts of MQT Core. Use the linked short
+Munich Quantum Software Company
+  **Preferred term:** [MQSC](https://mq.sc). **Accepted expansion:** Munich
+  Quantum Software Company. The company develops MQT Core together with the
+  {term}`Chair for Design Automation <CDA>` at {term}`TUM`. Use the linked short
   name in prose; reserve the full legal name for copyright notices.
 
 MQSS

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -64,9 +64,9 @@ modular multiplier
   arithmetic circuit that computes a product reduced modulo a specified integer.
 
 MQSC
-Munich Quantum Software Company
-  **Preferred term:** Munich Quantum Software Company. **Accepted abbreviation:**
-  MQSC. The company that develops and supports parts of MQT Core.
+  **Preferred term:** [MQSC](https://mq.sc). **Accepted aliases:** none. The
+  company that develops and supports parts of MQT Core. Use the linked short
+  name in prose; reserve the full legal name for copyright notices.
 
 MQSS
 Munich Quantum Software Stack
@@ -80,6 +80,11 @@ Munich Quantum Toolkit
   **Preferred term:** Munich Quantum Toolkit. **Accepted abbreviation:** MQT.
   The [open-source software toolkit](https://mqt.readthedocs.io/) of which MQT
   Core is the shared foundation.
+
+MQT Compiler Collection
+  **Preferred term:** MQT Compiler Collection. **Accepted aliases:** none.
+  MQT Core's framework for compiling, optimizing, and exchanging quantum
+  programs through Python, C++, and the `mqt-cc` command-line driver.
 
 MQV
 Munich Quantum Valley

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,66 @@
-# MQT Core - The Backbone of the Munich Quantum Toolkit (MQT)
+# MQT Core
 
-MQT Core is an open-source C++20 and Python library for quantum computing that
-forms the backbone of the quantum software tools developed as part of the
-_{doc}`Munich Quantum Toolkit (MQT) <mqt:index>`_. To this end, MQT Core
-consists of multiple components that are used throughout the MQT, including a
-compiler collection built on MLIR, a state-of-the-art decision diagram (DD)
-package for quantum computing, and a QIR runtime based on the decision diagram
-package.
+MQT Core provides reusable C++20 and Python libraries for quantum computing:
+compilers, decision diagrams, QIR execution, QDMI device access, SDK and HPC
+integrations, and structured benchmarks. It forms the backbone of the
+{doc}`Munich Quantum Toolkit (MQT) <mqt:index>`.
 
-This documentation provides a comprehensive guide to the MQT Core library,
-including {doc}`installation instructions <installation>`, a
-{doc}`guide to the MQT Compiler Collection <mlir/python_compiler_collection>`,
-its {doc}`decision diagram (DD) package <dd_package>`, as well as detailed
-{doc}`API documentation <api/mqt/core/index>` and the
-<a href="cpp/index.html">C++ API reference</a>. The source code of MQT Core is
-publicly available on GitHub at
-[munich-quantum-toolkit/core](https://github.com/munich-quantum-toolkit/core),
-while pre-built binaries are available via
-[PyPI](https://pypi.org/project/mqt.core/) for all major operating systems and
-all supported Python versions. See the
-{doc}`Qiskit compatibility guide <mlir/qiskit>` for the supported backend and
-compiler interfaces.
+## Start with your task
+
+Install the [Python package](https://pypi.org/project/mqt.core/) or follow the
+{doc}`source-build instructions <installation>`. Then choose a starting point:
+
+::::{grid} 1 1 2 2
+:gutter: 3
+
+:::{grid-item-card} Compile and execute a program
+Estimate a phase with two qubits and measurement feedback.
+
+- **First example:** {doc}`QPE walkthrough <getting_started>`
+- **Guide:** {doc}`MQT Compiler Collection <mlir/mqt_compiler_collection>`
+- **API:** {py:mod}`mqt.core.mlir`
+:::
+
+:::{grid-item-card} Use decision diagrams
+Represent and manipulate quantum states and operations in C++ or Python.
+
+- **First example:** [DD quickstart](dd_package.md#quickstart)
+- **Guide:** {doc}`Decision diagrams <dd_package>`
+- **API:** {py:mod}`mqt.core.dd` and {doc}`C++ <cpp_api>`
+:::
+
+:::{grid-item-card} Connect or implement a device
+Discover QDMI devices, integrate SDKs, and implement device interfaces.
+
+- **First example:** [Discover and use a device](qdmi/driver.md#python-bindings)
+- **Guide:** {doc}`QDMI devices and integrations <qdmi/index>`
+- **API:** {py:mod}`mqt.core.qdmi` and {doc}`C++ <cpp_api>`
+:::
+
+:::{grid-item-card} Generate and evaluate benchmarks
+Configure structured programs and compare results with analytic references.
+
+- **First example:**
+  [Configure a benchmark](benchmarks.md#configure-a-typed-instance)
+- **Guide:** {doc}`Structured benchmarks <benchmarks>`
+- **API:** {py:mod}`mqt.core.bench`
+:::
+
+:::{grid-item-card} Embed or extend MQT Core
+Use the C++ libraries or work on the MLIR compiler infrastructure.
+
+- **First example:** [C++ library quickstart](cpp_api.md#use-the-dd-library)
+- **Guide:** [C++ compilation](mlir/target_compilation.md#c-source-tree-api) and
+  {doc}`compiler development <mlir/development>`
+- **API:** {doc}`C++ reference <cpp_api>` and
+  {doc}`MLIR dialects and passes <mlir/index>`
+:::
+
+::::
+
+Source code is available on
+[GitHub](https://github.com/munich-quantum-toolkit/core). For installation
+options, platform requirements, and development setup, see {doc}`installation`.
 
 ```{toctree}
 :hidden:
@@ -34,6 +74,7 @@ self
 :hidden:
 
 installation
+getting_started
 benchmarks
 dd_package
 mlir/index
@@ -60,7 +101,7 @@ support
 ```
 
 ```{toctree}
-:caption: Python API Reference
+:caption: API Reference
 :maxdepth: 1
 :hidden:
 
@@ -70,9 +111,9 @@ cpp_api
 
 ## Contributors and Supporters
 
-MQT Core is developed by the
+MQT Core is developed by [MQSC](https://mq.sc) and the
 [Chair for Design Automation](https://www.cda.cit.tum.de/) at the
-[Technical University of Munich](https://www.tum.de/) and [MQSC](https://mq.sc).
+[Technical University of Munich](https://www.tum.de/).
 Among others, it is part of the
 [Munich Quantum Software Stack (MQSS)](https://www.munich-quantum-valley.de/research/research-areas/mqss)
 ecosystem, which is being developed as part of the
@@ -91,7 +132,7 @@ Thank you to all the contributors who have helped make MQT Core a reality!
 
 <p align="center">
 <a href="https://github.com/munich-quantum-toolkit/core/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=munich-quantum-toolkit/core" />
+  <img src="https://contrib.rocks/image?repo=munich-quantum-toolkit/core" alt="MQT Core contributors" />
 </a>
 </p>
 

--- a/docs/mlir/index.md
+++ b/docs/mlir/index.md
@@ -4,10 +4,10 @@ The MQT Compiler Collection (`mqt-cc`) is a blueprint for a future-proof
 quantum-classical compilation framework built on the Multi-Level Intermediate
 Representation (MLIR). For an overview, see {cite:p}`MQTCompilerCollection2026`.
 
-The {doc}`Python compiler guide <python_compiler_collection>` describes how to
-compile and inspect quantum programs from Python. The
-{doc}`target-compilation guide <target_compilation>` shows how to compile for
-QDMI devices from Python, C++, and `mqt-cc`. The interface guides describe
+The {doc}`compiler guide <mqt_compiler_collection>` introduces the Python,
+command-line, and C++ interfaces for compiling and inspecting quantum programs.
+The {doc}`target-compilation guide <target_compilation>` shows how to compile
+for QDMI devices from Python, C++, and `mqt-cc`. The interface guides describe
 OpenQASM and Qiskit interoperability, followed by the MLIR technical reference
 and compiler development guidance.
 
@@ -38,7 +38,7 @@ directly to QC and emits structured OpenQASM from QC.
 ```{toctree}
 :maxdepth: 2
 
-python_compiler_collection
+mqt_compiler_collection
 target_compilation
 OpenQASM
 qiskit

--- a/docs/mlir/mqt_compiler_collection.md
+++ b/docs/mlir/mqt_compiler_collection.md
@@ -6,15 +6,22 @@ mystnb:
   number_source_lines: true
 ---
 
-# Using the MQT Compiler Collection from Python
+# MQT Compiler Collection
 
-The {py:mod}`mqt.core.mlir` module provides Python access to the MQT Compiler
-Collection. It accepts source strings, {code}`.qasm`, {code}`.mlir`, and
-{code}`.jeff` files, Qiskit {py:class}`~qiskit.circuit.QuantumCircuit` objects,
-and typed compiler programs. The requested output format determines where
-compilation stops and which program type is returned.
+The MQT Compiler Collection compiles, optimizes, and exchanges structured
+quantum programs. It provides the circuit and program interface in MQT Core v4
+through three interfaces that share the same MLIR representations and passes:
 
-The compiler collection is the circuit and program interface in MQT Core v4.
+| Interface    | Entry point                                                         |
+| ------------ | ------------------------------------------------------------------- |
+| Command line | `mqt-cc`, with examples below                                       |
+| Python       | {py:mod}`mqt.core.mlir`                                             |
+| C++          | [Source-tree compiler API](target_compilation.md#c-source-tree-api) |
+
+The Python examples below accept source strings, {code}`.qasm`, {code}`.mlir`,
+and {code}`.jeff` files, Qiskit {py:class}`~qiskit.circuit.QuantumCircuit`
+objects, and typed compiler programs. The requested output format determines
+where compilation stops and which program type is returned.
 
 Install {doc}`MQT Core <../installation>` and import the compiler interface:
 
@@ -131,10 +138,10 @@ recompiled = compile_program(openqasm, output=OutputFormat.QC_IMPORT)
 assert isinstance(recompiled, QCProgram)
 ```
 
-The exporter targets practical structured programs with static qubit and bit
-indices. Dynamic indexing, dynamic ranges, surviving runtime assertions,
-checked-index machinery, and live poison values fail with an MLIR diagnostic.
-See {doc}`OpenQASM` for the complete support table.
+The exporter supports structured control flow and runtime classical-bit indices.
+Quantum register indices and ranges must be static. Surviving runtime
+assertions, checked-index machinery, and live poison values fail with an MLIR
+diagnostic. See {doc}`OpenQASM` for the complete support table.
 
 ## Use Qiskit circuits directly
 

--- a/docs/mlir/qiskit.md
+++ b/docs/mlir/qiskit.md
@@ -2,10 +2,10 @@
 
 MQT Core exposes two distinct Qiskit interfaces:
 
-| Interface                                               | Supported Qiskit versions | Purpose                                                          |
-| ------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------- |
-| {doc}`QDMI backend <../qdmi/qdmi_backend>`              | 2.1 and newer             | Execute circuits through device-specific serializers.            |
-| {doc}`Compiler collection <python_compiler_collection>` | `>=2.5.0,<2.6.0`          | Import and export circuits through the versioned native adapter. |
+| Interface                                                | Supported Qiskit versions | Purpose                                                          |
+| -------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------- |
+| {doc}`QDMI backend <../qdmi/qdmi_backend>`               | 2.1 and newer             | Execute circuits through device-specific serializers.            |
+| {doc}`MQT Compiler Collection <mqt_compiler_collection>` | `>=2.5.0,<2.6.0`          | Import and export circuits through the versioned native adapter. |
 
 Install `mqt-core[qiskit]`. Direct compiler translation requires a version in
 the narrower range above; the adapter checks it before inspecting a circuit.

--- a/docs/qdmi/index.md
+++ b/docs/qdmi/index.md
@@ -3,19 +3,29 @@
 The
 [Quantum Device Management Interface (QDMI)](https://munich-quantum-software-stack.github.io/QDMI/)
 provides a standardized interface for describing and interacting with quantum
-devices. This part of MQT Core contains the implementation of QDMI's different
-components, such as a [QDMI driver](driver.md), a
-[QDMI device for Superconducting Systems](sc_device.md), and a
-[QDMI device for a Classical Quantum Circuit Simulator](ddsim_device).
+devices. MQT Core supplies a driver, C++ and Python client interfaces, device
+implementations, and SDK and HPC integrations.
+
+- **Run a program:** start with {doc}`../getting_started` and the
+  {doc}`DDSIM device <ddsim_device>`, which executes supported OpenQASM and QIR.
+- **Discover or configure devices:** use the {doc}`driver` and
+  {doc}`configuration` guides.
+- **Compile for hardware:** the {doc}`superconducting models <sc_device>` supply
+  topology, native operations, and calibration. They do not execute programs.
+- **Use another interface:** connect through {doc}`Qiskit <qdmi_backend>`,
+  {doc}`PennyLane <pennylane_device>`, or {doc}`Slurm <slurm>`.
+- **Implement a device:** follow the
+  [QDMI device interface](https://munich-quantum-software-stack.github.io/QDMI/)
+  and use MQT Core's bundled devices as implementation examples.
 
 ```{toctree}
 :maxdepth: 1
 :caption: Table of Contents
 
-SC QDMI Device <sc_device>
-DDSIM QDMI Device <ddsim_device>
 QDMI Driver <driver>
 QDMI device configuration <configuration>
+DDSIM QDMI Device <ddsim_device>
+SC QDMI Device <sc_device>
 Slurm integration <slurm>
 QDMI-Qiskit Backend <qdmi_backend>
 PennyLane interface for QDMI devices <pennylane_device>

--- a/docs/qdmi/sc_device.md
+++ b/docs/qdmi/sc_device.md
@@ -1,5 +1,9 @@
 # Superconducting QDMI device
 
+This provider supplies **compilation-only hardware models**. Use their topology,
+native operations, and calibration for target compilation; they do not execute
+submitted quantum programs. Use {doc}`ddsim_device` for local execution.
+
 The MQT Core superconducting (SC) provider builds a session-owned runtime model
 from strict JSON. Separate sessions using the same provider library and prefix
 can expose different names, capacities, topology, operations, and calibration.

--- a/noxfile.py
+++ b/noxfile.py
@@ -289,6 +289,12 @@ def docs(session: nox.Session) -> None:
     parser.add_argument("-b", dest="builder", default="html", help="Build target (default: html)")
     args, posargs = parser.parse_known_args(session.posargs)
 
+    # MyST loads this generated file so the README owns the executable example.
+    _, example = Path("README.md").read_text(encoding="utf-8").split("```python\n")
+    example_file = Path("docs/_build/readme_example.py")
+    example_file.parent.mkdir(parents=True, exist_ok=True)
+    example_file.write_text(example.split("\n```", maxsplit=1)[0] + "\n", encoding="utf-8")
+
     # Retain packaged devices while excluding host file and inline configuration.
     registry = Path(session.create_tmp()) / "qdmi.json"
     registry.write_text('{"schema-version": 1, "qdmi": {"devices": []}}', encoding="utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ docs = [
   "furo>=2025.12.19",
   "mlir-pygments>=1",
   "myst-nb>=1.4",
+  "ninja>=1.13",
   "openqasm-pygments>=0.2",
   "pennylane>=0.45.1,<0.46",
   "qirrunner~=0.9.6",

--- a/uv.lock
+++ b/uv.lock
@@ -1562,6 +1562,7 @@ docs = [
     { name = "furo" },
     { name = "mlir-pygments" },
     { name = "myst-nb" },
+    { name = "ninja" },
     { name = "openqasm-pygments" },
     { name = "pennylane" },
     { name = "qirrunner" },
@@ -1637,6 +1638,7 @@ docs = [
     { name = "furo", specifier = ">=2025.12.19" },
     { name = "mlir-pygments", specifier = ">=1" },
     { name = "myst-nb", specifier = ">=1.4" },
+    { name = "ninja", specifier = ">=1.13" },
     { name = "openqasm-pygments", specifier = ">=0.2" },
     { name = "pennylane", specifier = ">=0.45.1,<0.46" },
     { name = "qirrunner", specifier = "~=0.9.6" },
@@ -1817,6 +1819,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "ninja"
+version = "1.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/92/410b7917d16ab54c04b05cc32b9284803671d91cf79d33be6009c28d4ea8/ninja-1.13.2.tar.gz", hash = "sha256:525bfa3fc88aa30a4467df270fd5be6f9fcae8061d54d4df74ea1dc5abd5a975", size = 243739, upload-time = "2026-08-30T15:49:51.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/b8/90a9518f2264637084d6199bc20c2f3fb97fefc4c474d277720150c3bd6d/ninja-1.13.2-py3-none-macosx_10_9_universal2.whl", hash = "sha256:fd82e26c0706ad4ab88e5fdd26f3fab0a987a90f810160f6c322e752c6af298b", size = 306611, upload-time = "2026-08-30T15:49:28.267Z" },
+    { url = "https://files.pythonhosted.org/packages/35/54/7368ce188625e39acc03ee362bb86cc9bfa6ad15e25c50889ae36e2889b3/ninja-1.13.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d775a5e43e9088f507a6250d57fcf5678eb31268c545feb5064ffeee33735622", size = 177180, upload-time = "2026-08-30T15:49:29.59Z" },
+    { url = "https://files.pythonhosted.org/packages/80/1a/0b5601ece2a5de97253e7c7c442b70315333955593c2b55616fd17f1706f/ninja-1.13.2-py3-none-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:81d95081c0ad7c95f67bf682220361ed2a32659d7861b4766b03433c58f22516", size = 199485, upload-time = "2026-08-30T15:49:30.72Z" },
+    { url = "https://files.pythonhosted.org/packages/48/23/fcbe234a66966e35928c47b86336f92a7612db4781665f4e5f5fddef9630/ninja-1.13.2-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:227cbc3ae3e5e429692388103cae8c09451df086cd2d342dae0795af0d162547", size = 197676, upload-time = "2026-08-30T15:49:32.026Z" },
+    { url = "https://files.pythonhosted.org/packages/24/eb/a6ca97ef0ff7bb8bdcb395ec65a716e65d7c1f40896c3afe0090bb3e1535/ninja-1.13.2-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:1684c60d031c54c1d049541b64243c0c567dca5463dbd77682a8901780af293d", size = 187980, upload-time = "2026-08-30T15:49:33.372Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/53/ebfed7b689c338dd8ebeec9c0730c8d56821292f14e2536e5f3ef1a05744/ninja-1.13.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65a24341b5ac09fcadcc37082660be40a94174e51a937fabf6e2cae26225fa2c", size = 183365, upload-time = "2026-08-30T15:49:34.53Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d6/dcf06d7ab44ade992ae5aa1228feff317684b463a1bd47e8642b30ac922e/ninja-1.13.2-py3-none-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:aa3d2ae5706a2c4d1e93edc951d1c6cbb45107413c404f8fde1741239efbc9a0", size = 155089, upload-time = "2026-08-30T15:49:35.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6b/6513c09c33382b17c05b4349b8e81437b18680d0d7ec6fb8f7edc29adda1/ninja-1.13.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:919572cbc3f233261ecd41fe1f3efc9d44aa02464a4588867e06a8b4f6f416ea", size = 152149, upload-time = "2026-08-30T15:49:36.971Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/70/d59fa4261f5ce586f43d8716de1da33d813afc116f0bf9173bf4cdbfdb2a/ninja-1.13.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e083700470c02ca154a855ae6d692d03564f5064cae52e113896f9ccc078418", size = 525392, upload-time = "2026-08-30T15:49:38.136Z" },
+    { url = "https://files.pythonhosted.org/packages/37/04/c8c2dc5b2f5fee79a1691d490256b178b7e1af97d56769117422ae8a23cc/ninja-1.13.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:59d71c3e15b6b6f3d903eb0c27285544e0747ca59925ada7037bb1af781ad4b3", size = 466268, upload-time = "2026-08-30T15:49:39.479Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6d/fce288647e53e96e0f0929a3c5b23986aae1b7101ea8889a3090237c5d13/ninja-1.13.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f90f84affc441e219f15fe52532806c1c9dbd22fb66c3addddce88a3deaabab7", size = 605088, upload-time = "2026-08-30T15:49:40.826Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a2/d8eedd25d0ae80b9e874aea362013e67416877c8f732eb4d5e7c971fdb9c/ninja-1.13.2-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:b2f687437fac460b27b7eadc99039b1163016fb4ba7276e2782a192d9f24ee0e", size = 610806, upload-time = "2026-08-30T15:49:42.168Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0f/696d96821fad1b5767fd311c1569dde8881a57412369bfe7b11bcbfde036/ninja-1.13.2-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:09de9ab04f7352f51570c73fd4913acb1e6c24be0a72cd8b80243d4d3ed04925", size = 533978, upload-time = "2026-08-30T15:49:43.451Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/69/28844ca579156776a202217a7cd66f60d06a0710a935e879bb89ce396ecc/ninja-1.13.2-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:6a87bf42b123abe2f37737300185f0a303a891899da85d73a3613ee80547e578", size = 653822, upload-time = "2026-08-30T15:49:44.724Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/c511f2952f94ab2966d60edd9c34e744ea32f2724b1184b62270bde55b3a/ninja-1.13.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:915bd482c4be41c75120fd67a22e0bb3f0fbb3bbc5f95b89787deadd59e27ef2", size = 544460, upload-time = "2026-08-30T15:49:46.29Z" },
+    { url = "https://files.pythonhosted.org/packages/79/e7/fb0e828e89ac77ef77183a0834f17c4108e66088732fed86a3cc3c776a7a/ninja-1.13.2-py3-none-win32.whl", hash = "sha256:792cadbb9decfd1f776d4d0a6930feb46d08302eb57c176bcf26b09de5748e9f", size = 270319, upload-time = "2026-08-30T15:49:47.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/dd/3766b5f4d32e8a9b97d195496b0b01fbbe2e1a41669dab0cd6492a6ce199/ninja-1.13.2-py3-none-win_amd64.whl", hash = "sha256:1293f4078278b70d0ee4b6cc8f3a9e030656c9b2f59909970343c4fe76070118", size = 311798, upload-time = "2026-08-30T15:49:49.351Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8d/59a31fa508070d042571d9d226b541a21000756817313f397da22287ad34/ninja-1.13.2-py3-none-win_arm64.whl", hash = "sha256:1db9852e528efa7702f5123969f86678663e46d57ff28ab13f5fd84d64a85fb1", size = 290620, upload-time = "2026-08-30T15:49:50.639Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Refresh the README for the next release with six capability groups and an iterative-QPE example that compiles for DDSIM, submits a job, and checks the phase. The documentation executes the exact README source, compares standard and iterative QPE, and evaluates a non-exact phase. Examples consume QDMI counts directly using the result-ordering fix in #2506.

Integrate the executed repeat-until-success demonstration into the benchmark catalog, retaining its three MyST math equations and analytic parity check. Rename the compiler guide to `mlir/mqt_compiler_collection.md` and introduce the MQT Compiler Collection through Python, C++, and `mqt-cc`. Update navigation and incoming links. Use `[MQSC](https://mq.sc)` in README and documentation prose; retain the full legal name only in copyright notices. Expand MQSC and CDA in the glossary and identify both as developers of MQT Core. Remove the redundant RUS README link, the device note below the landing-page grid, and the Shor implementation aside.

The landing page routes readers to examples, guides, and APIs. A C++ example builds against the installed library. The docs dependency group supplies its Ninja build tool, and notebook output retains CMake diagnostics on failure. The guides describe the installed C++ reference scope, compilation-only SC models, and runtime classical indices in OpenQASM exports. MQSC appears before CDA/TUM; funding attribution is preserved.

Depends on #2506 and remains stacked on its branch. Preserves #2519's OpenQASM import and operation-capability names, static gate-count scope, and distinction between jeff conversion and serialization. No changelog or migration entries are needed for this refresh of unreleased functionality.

Closes #2419.

Validation: clean strict HTML build with Doxygen 1.9.8; generated file and fragment checks; external linkcheck; two link-checker regression tests; general lint; and the exact README example executed from a fresh wheel in an isolated CPython 3.14.7 environment. All 11 authored notebooks execute without error or stderr records. The wheel example returns `01100000` for all 1,024 shots and phase `3/8`. Renamed paths, MQSC links, the moved equations, rendered entry points, and notebook source were checked. The C++ notebook also passes with only the docs environment and system executables on `PATH`, reproducing the missing-Ninja configuration failure when Ninja is absent. The final ponytail review found no further unnecessary code. The RtD failure on the previous revision was investigated; validation of the new hosted build is pending. New stable-page links become available with the next release.

AI assistance: GPT-6 via Codex implemented, reviewed, and validated these changes under explicit user authorization. The audit and execution plan record scope and validation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
