### PR TITLE
🐛 Fix QIR extraction and DDSIM result exports

### DIFF
--- a/.agent/audits/qir-final-performance.md
+++ b/.agent/audits/qir-final-performance.md
@@ -1,0 +1,180 @@
+# Final QIR execution performance and determinism audit
+
+Status: all three findings implemented and re-audited. Date: 2026-09-10.
+Baseline: upstream main `ad74680f1ef380456a1b89a810ef33ee8d218f69`. Scope: QIR
+JIT analysis and execution, the QIR runtime, shared DD calls on its hot path,
+and DDSIM QDMI result serialization. The accompanying Git commit identifies the
+implementation tested against that baseline.
+
+This audit applies the evidence standard in
+[issue #2253](https://github.com/munich-quantum-toolkit/core/issues/2253).
+It covers this subcomponent, not the issue's whole MLIR scope.
+
+## Result
+
+1. **Resolved P1: variable-width histogram buffer sizing.** DDSIM sums each
+   key's actual length. A client buffer of the queried size holds every key and
+   the final terminator; shorter buffers are rejected before any write.
+2. **Resolved P2: quadratic Base extraction boundary search.** Candidate
+   selection and validation each make one pass over the irreversible calls. The
+   existing terminal-region checks and rejection-before-mutation behavior remain
+   intact.
+3. **Resolved P2: unordered sparse serialization.** DDSIM caches sparse entries
+   in a vector sorted once by numerical basis index. All sparse key and value
+   results traverse the same sequence.
+
+The final boundary review also found and fixed an unsupported-width sparse
+export: all four DDSIM sparse-result requests now reject states wider than their
+`size_t` basis-index representation before DD traversal. No further actionable
+issues remain in the reviewed paths and immediate consumers. The histogram
+release blocker is resolved. The performance and scope limits below still apply.
+
+## Histogram contract and verification
+
+Sources: `src/qdmi/devices/dd/Device.cpp`, `submitQIRProgramSampling`,
+`getHistogram`, and `getShots`; `src/qdmi/Client.cpp`, `getSparseResult`.
+
+Adaptive control can record a result a second time only for one measurement
+outcome. The resulting shots and histogram keys need not have equal lengths. The
+old serializer multiplied the first key's length by the number of keys, but then
+wrote every complete key. For keys `0` and `11`, it reported four bytes and
+wrote five: `0,11\0`.
+
+The fixed size calculation follows the adjacent shot serializer's sum of actual
+lengths. The regression checks the exact size, complete output, unchanged
+sentinel, rejection without writes for a short buffer, and agreement between
+histogram values and ordered shots. The C++ client parses variable-length keys
+without imposing a uniform width. Existing empty-output behavior is preserved.
+
+A separate public C API probe now reports and writes five bytes, leaving the
+next sentinel byte unchanged. The experimental artifacts are retained locally.
+
+## Extraction analysis and performance
+
+Source: `mlir/lib/Dialect/QIR/Execution/JIT/IRRewriter.cpp`,
+`prepareForStateExtraction`.
+
+The old search visited irreversible calls in function storage order and compared
+each candidate against the others. A valid terminal chain with blocks stored in
+reverse execution order caused a triangular number of dominance comparisons.
+Repeated terminal measurement of one static qubit is enough to trigger this; it
+does not require a large quantum state.
+
+The first linear pass selects a candidate. A call that dominates every other
+call either replaces the current candidate or is itself dominated by a valid
+candidate. The second pass verifies that the chosen call dominates every other
+irreversible call. Self-comparisons remain excluded. The terminal-region walk,
+helper-call restrictions, IR rewrite, and sampling eligibility are unchanged.
+
+Final seven-trial process CPU medians, pinned to CPU 0:
+
+| Measurement blocks | Baseline reverse layout | Implementation |
+| -----------------: | ----------------------: | -------------: |
+|              1,000 |                7.564 ms |       0.647 ms |
+|              2,000 |               30.665 ms |       1.343 ms |
+|              4,000 |              122.618 ms |       2.661 ms |
+|              8,000 |              495.142 ms |       5.795 ms |
+
+At 8,000 blocks, the ranges were 488.709-521.535 ms and 5.622-6.033 ms. The
+already-favorable forward layout took 5.388 ms baseline and 5.998 ms with the
+implementation. The extra linear pass has a cost on that layout; this is not a
+claim that every input becomes faster. Ordinary compiler output with a flat
+terminal region does not incur the demonstrated quadratic cost.
+
+Measurements include dominance analysis, terminal checking, and rewriting. They
+exclude parsing, verification, JIT compilation, and quantum execution. The table
+uses the final implementation comparison.
+
+The added native regression covers reverse block storage order and multiple
+measurements in one block. Rejected independent regions must remain unchanged.
+The final differential experiment compares complete results and rewritten IR for
+1,024 identical generated control-flow inputs:
+**131 rewritten, 65 unchanged, and 828 rejected**. Both versions match in every
+case; rejected IR remains unchanged and all input/output modules verify. The
+inputs include shuffled blocks, unreachable blocks, branches, cycles, and
+non-terminal quantum work. This bounded check complements the reasoning; it is
+not an equivalence proof for all LLVM IR.
+
+## Sparse ordering and ownership
+
+Sources: `include/mqt-core/dd/DDDefinitions.hpp`, `src/dd/Edge.cpp`, and
+`src/qdmi/devices/dd/Device.cpp`, `getSparseResults`.
+
+The shared `SparseCVec` API returns an unordered map. DDSIM previously
+serialized that map directly. With the same type and ascending insertion of
+indices 0 through 31, the libstdc++ probe begins `31,30,29,12,11,...`, while
+libc++ begins `31,30,29,28,27,...`. The mathematical mapping is the same; this
+demonstrated noncanonical serialization across libraries, not random variation
+between identical runs of one binary. QDMI itself requires paired keys and
+values but does not prescribe ascending order. The project's
+deterministic-output policy and #2253 require avoiding observable unordered
+traversal.
+
+The shared DD map API remains unchanged. DDSIM copies the materialized entries
+into its existing lazy cache and sorts the pairs by their integer keys once.
+Keys, complex amplitudes, and probabilities all use that vector. `call_once`
+publishes the completed sort before any reader proceeds; no reader can observe
+partially sorted entries. The retained DD still owns the source state.
+
+The regression initializes the cache through a probability query, checks exact
+basis order against unequal real and imaginary amplitudes, compares squared
+magnitudes, and repeats both sparse queries. Existing buffer, dense-result,
+job-lifetime, and concurrency tests continue to pass. An additional width
+regression preserves a 64-qubit export on this platform, including its highest
+set bit, and rejects all four sparse result kinds at 65 qubits. This prevents
+out-of-range shifts in DD traversal and bitstring serialization. The guard lives
+at the shared QDMI result boundary; the raw DD sparse-map API is unchanged.
+
+Sorting costs O(k log k) once for k sparse entries and uses a temporary vector
+alongside the materialized map during conversion. The retained vector is
+contiguous and subsequent reads do not sort. No large sparse-export latency or
+peak-memory improvement is claimed. The alternate-library probe isolates the
+container; it is not a complete libc++ build of Core.
+
+## Retained behavior and deferred work
+
+- Static terminal sampling still prepares once. Seeded ordered-shot and SWAP
+  mapping tests pass, including repeated/subset outputs and fallback execution.
+  Different algorithms or software versions need not reproduce the same draws.
+- Runtime maps and the immutable ABI registry are used for lookup, not
+  observable iteration. Metadata and shots retain explicit sequence order. DD
+  root-map traversal marks reachability; it does not define output or arithmetic
+  order. No wholesale container conversion is justified.
+- Warm 100,000-gate probes request 100,000 ordinary C++ allocations for X and
+  200,000 for CX. Shared DD root insertion/erasure and `dd::Controls`
+  construction explain these costs. A shared root-update or control-view change
+  still needs evidence covering multiple roots, garbage collection, and control
+  validation. These deferred observations are not additional unimplemented audit
+  findings.
+- The allocation counter excludes aligned allocation and direct malloc calls.
+  Tiny repeating DD workloads do not establish behavior for large or low-reuse
+  states; X and CX are different workloads, not an A/B comparison.
+- Dynamic allocation and feedback retain per-shot execution. No cross-job JIT
+  cache, general gate cache, or new LLVM optimization pipeline is justified by
+  this evidence. Dense state and probability queries already share a cache.
+- Other local DD audits were checked for overlap and left untouched.
+
+## Validation
+
+Environment: DGX Spark ARM64, Linux 6.17.0-1032-nvidia, Clang 23.1.1, LLVM/MLIR
+23.1.0. Core targets use `release-clang-ipo`, Clang ThinLTO and mold. The
+isolated analysis programs use Clang `-O3` with the installed LLVM libraries.
+
+Publication validation uses upstream base
+`9d6526f4827ed96f7a16880325c61fe725f2f737`. The benchmark table retains its
+original baseline and measurements; rebasing did not change the measured code.
+
+Final local validation:
+
+- **51 QIR JIT/analysis tests, 80 runtime tests, and 75 DDSIM QDMI tests pass.**
+- The isolated implementation passes all **14 IR analysis tests** and the
+  **1,024-case differential check**.
+- The public API histogram probe confirms the exact fixed size and sentinel.
+- C++ lint reports **zero findings** for all changed implementation/test files;
+  the required lint-header target also builds.
+- Full repository lint and strict documentation generation, including local link
+  checking, pass.
+
+No full unrelated CTest sweep or hosted CI validation was performed.
+Experimental harnesses, raw measurements, and logs are retained locally and are
+excluded from the pull request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,9 +97,10 @@ releases may include breaking changes.
 - ✨ Support DDSIM QDMI statevector extraction for Adaptive Profile QIR with
   classical control flow, dynamic allocation, and terminal measurements. Retain
   the uncollapsed state after eligible OpenQASM and QIR sampling for lazy
-  statevector and probability queries ([#2494]) ([**@burgholzer**]).
-- ✨ Expose ordered shots from DDSIM QDMI QIR jobs, with matching histograms
-  ([#2368]) ([**@burgholzer**])
+  statevector and probability queries, with sparse entries in ascending basis
+  order ([#2494]) ([**@burgholzer**]).
+- ✨ Expose ordered shots from DDSIM QDMI QIR jobs, with matching histograms for
+  variable-length recorded outputs ([#2368]) ([**@burgholzer**])
 - 🐳 Add dev container configuration for a consistent local development
   environment ([#1786]) ([**@denialhaag**])
 

--- a/docs/qdmi/ddsim_device.md
+++ b/docs/qdmi/ddsim_device.md
@@ -70,6 +70,13 @@ one prepared DD; other QIR programs run once per shot. See the
 [QIR execution contract](../qir/index.md) for eligibility and resource limits.
 OpenQASM classical registers use reverse declaration order, with each register
 most-significant-bit first. QIR samples follow the program's recorded outputs.
+Adaptive QIR shots can record different numbers of bits; their histogram retains
+these variable-length outcomes.
+
+Sparse statevector and probability results use ascending numerical basis-index
+order. Their keys and values share that order. Sparse exports require at most 64
+qubits on a 64-bit platform; wider states return `QDMI_ERROR_NOTSUPPORTED`
+because their basis indices do not fit the sparse representation.
 
 ## Compile and execute
 

--- a/include/mqt-core/qdmi/devices/dd/Device.hpp
+++ b/include/mqt-core/qdmi/devices/dd/Device.hpp
@@ -19,6 +19,7 @@
 #include "qdmi/common/Common.hpp"
 
 #include <atomic>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -31,6 +32,7 @@
 #include <random>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -200,9 +202,9 @@ private:
   /// measurements are used).
   dd::CVec stateVec_;
 
-  /// The sparse state vector for the job (only available if no mid-circuit
-  /// measurements are used).
-  dd::SparseCVec stateVecSparse_;
+  /// Sparse amplitudes in ascending basis-index order (only available if no
+  /// mid-circuit measurements are used).
+  std::vector<std::pair<size_t, std::complex<dd::fp>>> stateVecSparse_;
 
   /// One-time flags to lazily materialize vectors in a thread-safe way
   std::once_flag stateVecOnce_;

--- a/mlir/lib/Dialect/QIR/Execution/JIT/IRRewriter.cpp
+++ b/mlir/lib/Dialect/QIR/Execution/JIT/IRRewriter.cpp
@@ -187,22 +187,17 @@ bool prepareForStateExtraction(llvm::Function& entryPoint) {
   }
 
   const llvm::DominatorTree dominators(entryPoint);
-  llvm::CallInst* boundary = nullptr;
-  for (auto* candidate : irreversibleCalls) {
-    bool dominatesAll = true;
-    for (auto* call : irreversibleCalls) {
-      if (candidate != call && !dominators.dominates(candidate, call)) {
-        dominatesAll = false;
-        break;
-      }
-    }
-    if (dominatesAll) {
-      boundary = candidate;
-      break;
+  auto* boundary = irreversibleCalls.front();
+  /// An all-dominating call replaces any candidate that cannot dominate it.
+  for (auto* call : irreversibleCalls) {
+    if (boundary != call && !dominators.dominates(boundary, call)) {
+      boundary = call;
     }
   }
-  if (boundary == nullptr) {
-    throw std::invalid_argument(TERMINAL_REGION_ERROR.str());
+  for (auto* call : irreversibleCalls) {
+    if (boundary != call && !dominators.dominates(boundary, call)) {
+      throw std::invalid_argument(TERMINAL_REGION_ERROR.str());
+    }
   }
 
   requireTerminalIrreversibleRegion(*boundary);

--- a/mlir/unittests/Dialect/QIR/Execution/JIT/test_ir_rewriter.cpp
+++ b/mlir/unittests/Dialect/QIR/Execution/JIT/test_ir_rewriter.cpp
@@ -120,6 +120,40 @@ attributes #1 = { "irreversible" }
   EXPECT_EQ(countCallsTo(*module, "must_not_run"), 0U);
 }
 
+TEST(IRRewriter, FindsBoundaryAcrossReverseOrderedBlocks) {
+  constexpr llvm::StringRef ir = R"(
+define i64 @main() #0 {
+entry:
+  call void @prepare()
+  br label %first
+last:
+  call void @measure()
+  ret i64 0
+middle:
+  call void @measure()
+  br label %last
+first:
+  call void @measure()
+  call void @measure()
+  br label %middle
+}
+declare void @prepare()
+declare void @measure() #1
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" }
+attributes #1 = { "irreversible" }
+)";
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic error;
+  auto llvmModule = llvm::parseAssemblyString(ir, error, context);
+  ASSERT_NE(llvmModule, nullptr);
+  ASSERT_FALSE(llvm::verifyModule(*llvmModule));
+
+  EXPECT_TRUE(qir::prepareForStateExtraction(*llvmModule->getFunction("main")));
+  EXPECT_EQ(countCallsTo(*llvmModule, "prepare"), 1U);
+  EXPECT_EQ(countCallsTo(*llvmModule, "measure"), 0U);
+  EXPECT_FALSE(llvm::verifyModule(*llvmModule));
+}
+
 TEST(IRRewriter, RejectsIndependentIrreversibleRegions) {
   constexpr llvm::StringRef ir = R"(
 define i64 @main() #0 {
@@ -141,11 +175,17 @@ attributes #1 = { "irreversible" }
   llvm::SMDiagnostic error;
   auto module = llvm::parseAssemblyString(ir, error, context);
   ASSERT_NE(module, nullptr);
+  ASSERT_FALSE(llvm::verifyModule(*module));
   auto* entryPoint = module->getFunction("main");
   ASSERT_NE(entryPoint, nullptr);
+  std::string before;
+  llvm::raw_string_ostream(before) << *module;
 
   EXPECT_THROW(qir::prepareForStateExtraction(*entryPoint),
                std::invalid_argument);
+  std::string after;
+  llvm::raw_string_ostream(after) << *module;
+  EXPECT_EQ(after, before);
 }
 
 TEST(IRRewriter, RequiresBaseProfile) {

--- a/src/qdmi/devices/dd/Device.cpp
+++ b/src/qdmi/devices/dd/Device.cpp
@@ -727,9 +727,11 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::getHistogram(
     return reportEmptyResult(sizeRet);
   }
   if (result == QDMI_JOB_RESULT_HIST_KEYS) {
-    const size_t bitstringSize =
-        counts_.empty() ? 0 : counts_.begin()->first.length();
-    const size_t reqSize = counts_.size() * (bitstringSize + 1);
+    const size_t reqSize =
+        std::accumulate(counts_.begin(), counts_.end(), size_t{0},
+                        [](const size_t total, const auto& entry) {
+                          return total + entry.first.size() + 1;
+                        });
     if (sizeRet != nullptr) {
       *sizeRet = reqSize;
     }
@@ -801,11 +803,18 @@ auto MQT_DDSIM_QDMI_Device_Job_impl_d::getStateVector(const size_t size,
 auto MQT_DDSIM_QDMI_Device_Job_impl_d::getSparseResults(
     const QDMI_Job_Result result, const size_t size, void* data,
     size_t* sizeRet) -> QDMI_STATUS {
-  std::call_once(stateVecSparseOnce_,
-                 [this] { stateVecSparse_ = stateVecDD_.getSparseVector(); });
   const auto numQubits = stateVecDD_.isTerminal()
                              ? 0U
                              : static_cast<size_t>(stateVecDD_.p->v) + 1U;
+  if (numQubits > std::numeric_limits<size_t>::digits) {
+    return QDMI_ERROR_NOTSUPPORTED;
+  }
+  std::call_once(stateVecSparseOnce_, [this] {
+    const auto sparse = stateVecDD_.getSparseVector();
+    stateVecSparse_.assign(sparse.begin(), sparse.end());
+    std::ranges::sort(stateVecSparse_, {},
+                      &decltype(stateVecSparse_)::value_type::first);
+  });
   switch (result) {
   case QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS:
   case QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS: {

--- a/test/qdmi/devices/dd/results_sampling_test.cpp
+++ b/test/qdmi/devices/dd/results_sampling_test.cpp
@@ -303,6 +303,64 @@ TEST(ResultsSampling, EmptyQASM3YieldsEmptyHistogram) {
   }
 }
 
+TEST(ResultsSampling, AdaptiveHistogramUsesActualKeyLengths) {
+  constexpr std::string_view program = R"(
+define i64 @main() #0 {
+entry:
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__h__body(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  %bit = call i1 @__quantum__rt__read_result(ptr null)
+  br i1 %bit, label %extra, label %done
+extra:
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  br label %done
+done:
+  ret i64 0
+}
+declare void @__quantum__rt__initialize(ptr)
+declare void @__quantum__qis__h__body(ptr)
+declare void @__quantum__qis__mz__body(ptr, ptr) #1
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+declare i1 @__quantum__rt__read_result(ptr)
+attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+attributes #1 = { "irreversible" }
+)";
+  const qdmi_test::SessionGuard session{};
+  const qdmi_test::JobGuard job{session.session};
+  ASSERT_EQ(qdmi_test::setProgram(
+                job.job, QDMI_PROGRAM_FORMAT_QIRADAPTIVESTRING, program),
+            QDMI_SUCCESS);
+  ASSERT_EQ(qdmi_test::setShots(job.job, 64), QDMI_SUCCESS);
+  ASSERT_EQ(qdmi_test::setSeed(job.job, 42), QDMI_SUCCESS);
+  ASSERT_EQ(qdmi_test::submitAndWait(job.job, 0), QDMI_SUCCESS);
+
+  const auto size = qdmi_test::querySize(job.job, QDMI_JOB_RESULT_HIST_KEYS);
+  ASSERT_EQ(size, 5U);
+  std::array<char, 6> buffer{};
+  buffer.fill('?');
+  EXPECT_EQ(
+      MQT_DDSIM_QDMI_device_job_get_results(job.job, QDMI_JOB_RESULT_HIST_KEYS,
+                                            size - 1, buffer.data(), nullptr),
+      QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(std::string_view(buffer.data(), buffer.size()), "??????");
+  ASSERT_EQ(MQT_DDSIM_QDMI_device_job_get_results(job.job,
+                                                  QDMI_JOB_RESULT_HIST_KEYS,
+                                                  size, buffer.data(), nullptr),
+            QDMI_SUCCESS);
+  EXPECT_STREQ(buffer.data(), "0,11");
+  EXPECT_EQ(buffer.back(), '?');
+
+  std::map<std::string, size_t> counts;
+  for (const auto& shot : getShots(job.job)) {
+    ++counts[shot];
+  }
+  const auto [keys, values] = qdmi_test::getHistogram(job.job);
+  EXPECT_EQ(keys, (std::vector<std::string>{"0", "11"}));
+  EXPECT_EQ(values, (std::vector<size_t>{counts["0"], counts["11"]}));
+}
+
 TEST(ResultsSampling, BufferTooSmallErrors) {
   const qdmi_test::SessionGuard s{};
   const qdmi_test::JobGuard j{s.session};

--- a/test/qdmi/devices/dd/results_statevector_test.cpp
+++ b/test/qdmi/devices/dd/results_statevector_test.cpp
@@ -58,6 +58,88 @@ void expectBellState(const QDMI_Program_Format format,
 
 } // namespace
 
+TEST(ResultsStatevector, SparseResultsPreserveBasisOrderAndValuePairing) {
+  constexpr std::string_view program = R"(OPENQASM 3;
+include "stdgates.inc";
+qubit[3] q;
+ry(0.6) q[0];
+x q[1];
+h q[2];
+s q[2];
+)";
+  const qdmi_test::SessionGuard session{};
+  const qdmi_test::JobGuard job{session.session};
+  ASSERT_EQ(qdmi_test::setProgram(job.job, QDMI_PROGRAM_FORMAT_QASM3, program),
+            QDMI_SUCCESS);
+  ASSERT_EQ(qdmi_test::setShots(job.job, 0), QDMI_SUCCESS);
+  ASSERT_EQ(qdmi_test::submitAndWait(job.job, 0), QDMI_SUCCESS);
+
+  const auto probabilities = qdmi_test::getSparseProbabilities(job.job);
+  const auto state = qdmi_test::getSparseState(job.job);
+  const std::vector<std::string> keys{"010", "011", "110", "111"};
+  EXPECT_EQ(state.first, keys);
+  EXPECT_EQ(probabilities.first, keys);
+  ASSERT_EQ(state.second.size(), keys.size());
+  ASSERT_EQ(probabilities.second.size(), keys.size());
+  const auto cosine = std::cos(0.3) / std::numbers::sqrt2;
+  const auto sine = std::sin(0.3) / std::numbers::sqrt2;
+  const std::array<std::complex<double>, 4> expected{
+      std::complex{cosine, 0.},
+      std::complex{sine, 0.},
+      std::complex{0., cosine},
+      std::complex{0., sine},
+  };
+  for (size_t i = 0; i < keys.size(); ++i) {
+    EXPECT_NEAR(std::abs(state.second[i] - expected[i]), 0., 1e-12);
+    EXPECT_NEAR(probabilities.second[i], std::norm(expected[i]), 1e-12);
+  }
+  EXPECT_EQ(qdmi_test::getSparseState(job.job), state);
+  EXPECT_EQ(qdmi_test::getSparseProbabilities(job.job), probabilities);
+}
+
+TEST(ResultsStatevector, SparseResultsRespectBasisIndexWidth) {
+  constexpr size_t maxWidth = std::numeric_limits<size_t>::digits;
+  for (const auto width : {maxWidth, maxWidth + 1}) {
+    SCOPED_TRACE(width);
+    const auto program =
+        "define i64 @main() #0 {\n"
+        "call void @__quantum__qis__x__body(ptr inttoptr (i64 " +
+        std::to_string(width - 1) +
+        " to ptr))\nret i64 0\n}\n"
+        "declare void @__quantum__qis__x__body(ptr)\n"
+        "attributes #0 = { \"entry_point\" \"qir_profiles\"=\"base_profile\" "
+        "\"required_num_qubits\"=\"" +
+        std::to_string(width) + "\" }\n";
+    const qdmi_test::SessionGuard session{};
+    const qdmi_test::JobGuard job{session.session};
+    ASSERT_EQ(qdmi_test::setProgram(job.job, QDMI_PROGRAM_FORMAT_QIRBASESTRING,
+                                    program),
+              QDMI_SUCCESS);
+    ASSERT_EQ(qdmi_test::setShots(job.job, 0), QDMI_SUCCESS);
+    ASSERT_EQ(qdmi_test::submitAndWait(job.job, 0), QDMI_SUCCESS);
+    QDMI_Job_Status status{};
+    ASSERT_EQ(MQT_DDSIM_QDMI_device_job_check(job.job, &status), QDMI_SUCCESS);
+    ASSERT_EQ(status, QDMI_JOB_STATUS_DONE);
+    if (width == maxWidth) {
+      const auto [keys, values] = qdmi_test::getSparseState(job.job);
+      EXPECT_EQ(keys,
+                std::vector<std::string>{"1" + std::string(width - 1, '0')});
+      EXPECT_EQ(values, std::vector<std::complex<double>>{1.});
+    } else {
+      for (const auto result : {
+               QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS,
+               QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES,
+               QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
+               QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES,
+           }) {
+        EXPECT_EQ(MQT_DDSIM_QDMI_device_job_get_results(job.job, result, 0,
+                                                        nullptr, nullptr),
+                  QDMI_ERROR_NOTSUPPORTED);
+      }
+    }
+  }
+}
+
 TEST(ResultsStatevector, SamplingRetainsStateWithoutChangingSamples) {
   const auto base = qdmi_test::getQIRProgram("BellPairStatic.ll");
   auto adaptive = base;


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Fix DDSIM histogram buffer sizing for variable-length Adaptive QIR outputs: keys `0` and `11` require five bytes including the separator and terminator, but the old query reported four. Sparse statevector and probability exports now share ascending basis-index order and reject widths beyond the native index representation before DD traversal.

Replace the quadratic Base QIR extraction-boundary search with two linear passes while preserving terminal-region checks and rejection before mutation. The 8,000-block reverse-layout benchmark improves from 495.1 ms to 5.8 ms; the favorable forward layout changes from 5.39 ms to 6.00 ms. These are seven-trial analysis CPU medians, excluding JIT compilation and quantum execution.

Includes focused regression tests, documentation, and audit findings. Experimental harnesses, raw measurements, and logs are retained locally and excluded from this PR. No new dependencies. Related to #2253; this covers only the QIR execution and DDSIM result paths.

Validation on the rebased implementation:

- 51 QIR JIT/analysis, 80 runtime, and 75 DDSIM QDMI tests pass.
- The local 1,024-case differential experiment matches baseline outcomes and rewritten IR; the public C API probe confirms exact histogram sizing and an untouched sentinel.
- Repository lint, changed-file C++ lint with zero findings, and strict documentation generation with local link validation pass.
- Full unrelated CTest and hosted CI were not run locally. The benchmark measurements remain tied to the recorded audit baseline.

Codex assisted with the audit, implementation, complexity review, validation, and PR preparation. This changes unreleased v4 functionality; the existing feature changelog entries are updated and no migration guide entry is needed.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
