### PR TITLE
⚡️ Speed up QIR output preparation

### DIFF
--- a/mlir/include/mqt/Conversion/QCToQIR/QIRCommon/QIRCommon.h
+++ b/mlir/include/mqt/Conversion/QCToQIR/QIRCommon/QIRCommon.h
@@ -20,6 +20,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringMap.h"
 
 #include <cstddef>
@@ -38,7 +39,7 @@ enum class AllocationMode : std::uint8_t {
 /// State object for tracking lowering information during QIR conversion
 struct LoweringState {
   /// Result-array pointers to be deallocated at the end of the program
-  DenseSet<Value> resultArrays;
+  llvm::SmallSetVector<Value, 4> resultArrays;
 
   /// CBit read operations whose register is backed by a result array.
   DenseSet<Operation*> returnedCBitReads;

--- a/mlir/include/mqt/Dialect/QIR/Builder/QIRProgramBuilder.h
+++ b/mlir/include/mqt/Dialect/QIR/Builder/QIRProgramBuilder.h
@@ -18,6 +18,7 @@
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/StringSaver.h"
@@ -1161,16 +1162,16 @@ private:
   Value exitCode;
 
   /// Qubit pointers to be deallocated at the end of the program
-  DenseSet<Value> qubitPtrs;
+  SmallVector<Value> qubitPtrs;
 
   /// Qubit-array pointers to be deallocated at the end of the program
-  DenseSet<Value> qubitArrays;
+  SmallVector<Value> qubitArrays;
 
   /// Result pointers to be deallocated at the end of the program
-  DenseSet<Value> resultPtrs;
+  SmallVector<Value> resultPtrs;
 
   /// Result-array pointers to be deallocated at the end of the program
-  DenseSet<Value> resultArrays;
+  SmallVector<Value> resultArrays;
 
   /// Cache static qubit pointers for reuse
   DenseMap<int64_t, Value> staticQubits;

--- a/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.cpp
@@ -697,21 +697,25 @@ struct QCToQIRAdaptive final : impl::QCToQIRAdaptiveBase<QCToQIRAdaptive> {
 
     builder.setInsertionPoint(state->outputBlock->getTerminator());
 
-    for (auto& [_, result] : state->scalarResults) {
+    if (!state->scalarResults.empty()) {
       auto sig = LLVM::LLVMFunctionType::get(voidType, {ptrType});
       auto dec = getOrCreateFunctionDeclaration(builder, main,
                                                 QIR_RESULT_RELEASE, sig);
-      LLVM::CallOp::create(builder, main->getLoc(), dec, result.pointer);
+      for (auto& [_, result] : state->scalarResults) {
+        LLVM::CallOp::create(builder, main->getLoc(), dec, result.pointer);
+      }
     }
 
-    for (auto array : state->resultArrays) {
+    if (!state->resultArrays.empty()) {
       auto sig = LLVM::LLVMFunctionType::get(voidType,
                                              {builder.getI64Type(), ptrType});
       auto dec = getOrCreateFunctionDeclaration(builder, main,
                                                 QIR_RESULT_ARRAY_RELEASE, sig);
-      auto size = array.getDefiningOp<LLVM::AllocaOp>().getArraySize();
-      LLVM::CallOp::create(builder, main->getLoc(), dec,
-                           ValueRange{size, array});
+      for (auto array : state->resultArrays) {
+        auto size = array.getDefiningOp<LLVM::AllocaOp>().getArraySize();
+        LLVM::CallOp::create(builder, main->getLoc(), dec,
+                             ValueRange{size, array});
+      }
     }
   }
 

--- a/mlir/lib/Conversion/QCToQIR/QIRCommon/QIRCommon.cpp
+++ b/mlir/lib/Conversion/QCToQIR/QIRCommon/QIRCommon.cpp
@@ -46,9 +46,11 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -446,6 +448,70 @@ Value getResultPtr(LoweringState& state, Operation* op,
   return result;
 }
 
+/// Summarize the interference before each store in one block traversal.
+/// Only disjoint constant-index stores to the same register can be crossed.
+static DenseSet<Operation*> findStoreFusionCandidates(Block* block) {
+  DenseSet<Operation*> candidates;
+  DenseMap<Operation*, size_t> measurements;
+  DenseMap<std::pair<Value, int64_t>, size_t> lastStoreAtIndex;
+  Value lastRegister;
+  size_t lastStore = 0;
+  size_t lastOtherRegisterStore = 0;
+  size_t lastBarrier = 0;
+  size_t position = 0;
+  for (auto& operation : *block) {
+    ++position;
+    if (isa<MeasureOp>(operation)) {
+      measurements[&operation] = position;
+    }
+    if (auto store = dyn_cast<cbit::StoreOp>(operation)) {
+      const auto index = getConstantIntValue(store.getIndex());
+      auto conflict = std::max(lastBarrier, lastStore);
+      if (index) {
+        conflict = std::max({
+            lastBarrier,
+            lastRegister == store.getReg() ? lastOtherRegisterStore : lastStore,
+            lastStoreAtIndex.lookup({store.getReg(), *index}),
+        });
+      }
+      auto measure = store.getValue().getDefiningOp<MeasureOp>();
+      if (measure && measurements.lookup(measure.getOperation()) > conflict) {
+        candidates.insert(store.getOperation());
+      }
+      if (index) {
+        if (lastRegister != store.getReg()) {
+          lastOtherRegisterStore = lastStore;
+          lastRegister = store.getReg();
+        }
+        lastStore = position;
+        lastStoreAtIndex[{store.getReg(), *index}] = position;
+      } else {
+        lastBarrier = position;
+      }
+      continue;
+    }
+    /// These unscoped quantum effects cannot access CBit storage.
+    if (isa<qc::AllocOp, qc::DeallocOp, qc::GPhaseOp>(operation)) {
+      continue;
+    }
+    const auto effects = getEffectsRecursively(&operation);
+    if (!effects || !llvm::all_of(*effects, [](const auto& effect) {
+          auto value = effect.getValue();
+          if (!value) {
+            return false;
+          }
+          if (isa<QubitType>(value.getType())) {
+            return true;
+          }
+          auto memref = dyn_cast<MemRefType>(value.getType());
+          return memref && isa<QubitType>(memref.getElementType());
+        })) {
+      lastBarrier = position;
+    }
+  }
+  return candidates;
+}
+
 LogicalResult prepareClassicalResults(Operation* moduleOp,
                                       LoweringState& state) {
   bool hasInvalidMemory = false;
@@ -531,6 +597,7 @@ LogicalResult prepareClassicalResults(Operation* moduleOp,
     }
   }
 
+  DenseMap<Block*, DenseSet<Operation*>> fusionCandidates;
   funcOp.walk([&](cbit::StoreOp storeOp) {
     auto allocOp = storeOp.getReg().getDefiningOp<cbit::AllocOp>();
     if (!allocOp || !state.cregIndices.contains(allocOp.getOperation())) {
@@ -556,33 +623,13 @@ LogicalResult prepareClassicalResults(Operation* moduleOp,
         measureOp->getBlock() == storeOp->getBlock() &&
         (dominance.dominates(storeOp.getIndex(), measureOp) ||
          (indexProducer && indexProducer->hasTrait<OpTrait::ConstantLike>()));
-    for (auto* next = measureOp->getNextNode();
-         canFuse && next != storeOp.getOperation();
-         next = next->getNextNode()) {
-      /// These unscoped quantum effects cannot access CBit storage.
-      if (isa<qc::AllocOp, qc::DeallocOp, qc::GPhaseOp>(next)) {
-        continue;
+    if (canFuse && measureOp->getNextNode() != storeOp.getOperation()) {
+      const auto [candidates, newBlock] =
+          fusionCandidates.try_emplace(storeOp->getBlock());
+      if (newBlock) {
+        candidates->second = findStoreFusionCandidates(storeOp->getBlock());
       }
-      if (auto otherStore = dyn_cast<cbit::StoreOp>(next);
-          otherStore && otherStore.getReg() == storeOp.getReg()) {
-        const auto index = getConstantIntValue(storeOp.getIndex());
-        const auto otherIndex = getConstantIntValue(otherStore.getIndex());
-        if (index && otherIndex && *index != *otherIndex) {
-          continue;
-        }
-      }
-      const auto effects = getEffectsRecursively(next);
-      canFuse = effects && llvm::all_of(*effects, [](const auto& effect) {
-                  auto value = effect.getValue();
-                  if (!value) {
-                    return false;
-                  }
-                  if (isa<QubitType>(value.getType())) {
-                    return true;
-                  }
-                  auto memref = dyn_cast<MemRefType>(value.getType());
-                  return memref && isa<QubitType>(memref.getElementType());
-                });
+      canFuse = candidates->second.contains(storeOp.getOperation());
     }
     if (!canFuse) {
       storeOp.emitError("QIR output cannot fuse this measurement/store pair: "

--- a/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QIR/Builder/QIRProgramBuilder.cpp
@@ -158,7 +158,7 @@ Value QIRProgramBuilder::allocQubit() {
     qubit = staticQubit(static_cast<int64_t>(numQubits));
   }
 
-  qubitPtrs.insert(qubit);
+  qubitPtrs.push_back(qubit);
 
   return qubit;
 }
@@ -227,7 +227,7 @@ Value QIRProgramBuilder::getResult(int64_t index, bool record,
       auto zero = LLVM::ZeroOp::create(*this, ptrType);
       result = LLVM::CallOp::create(*this, declaration, zero.getResult())
                    .getResult();
-      resultPtrs.insert(result);
+      resultPtrs.push_back(result);
     } else {
       result = createPointerFromIndex(*this, getLoc(), index);
     }
@@ -278,7 +278,7 @@ QIRProgramBuilder::allocQubitRegister(const int64_t size) {
     LLVM::CallOp::create(*this, allocFnDecl,
                          ValueRange{intConstant(size), array, zero});
 
-    qubitArrays.insert(array);
+    qubitArrays.push_back(array);
 
     for (int64_t i = 0; i < size; ++i) {
       auto index = intConstant(i);
@@ -330,7 +330,6 @@ QIRProgramBuilder::allocClassicalBitRegister(const int64_t size,
   auto& reg = cregs.try_emplace(label).first->second;
   reg.label = label;
   reg.size = size;
-  reg.results.assign(size, Value{});
   reg.record = record;
 
   // Save current insertion point
@@ -354,10 +353,11 @@ QIRProgramBuilder::allocClassicalBitRegister(const int64_t size,
     LLVM::CallOp::create(*this, fnDec,
                          ValueRange{intConstant(size), array, zero});
 
-    resultArrays.insert(array);
+    resultArrays.push_back(array);
     reg.array = array;
   } else {
-    // Base Profile: Create static result pointers
+    /// Base Profile: Create static result pointers
+    reg.results.assign(size, Value{});
     for (int64_t i = 0; i < size; ++i) {
       // The results are recorded as part of the register
       reg.results[i] = staticResult(static_cast<int64_t>(numResults), false);
@@ -1048,19 +1048,23 @@ OwningOpRef<ModuleOp> QIRProgramBuilder::finalize(Value returnValue) {
   generateOutputRecording();
 
   if (isAdaptive) {
-    for (auto result : resultPtrs) {
+    if (!resultPtrs.empty()) {
       auto sig = LLVM::LLVMFunctionType::get(voidType, {ptrType});
       auto dec = getOrCreateFunctionDeclaration(*this, module,
                                                 QIR_RESULT_RELEASE, sig);
-      LLVM::CallOp::create(*this, dec, result);
+      for (auto result : resultPtrs) {
+        LLVM::CallOp::create(*this, dec, result);
+      }
     }
 
-    for (auto array : resultArrays) {
+    if (!resultArrays.empty()) {
       auto sig = LLVM::LLVMFunctionType::get(voidType, {getI64Type(), ptrType});
       auto dec = getOrCreateFunctionDeclaration(*this, module,
                                                 QIR_RESULT_ARRAY_RELEASE, sig);
-      auto size = array.getDefiningOp<LLVM::AllocaOp>().getArraySize();
-      LLVM::CallOp::create(*this, dec, ValueRange{size, array});
+      for (auto array : resultArrays) {
+        auto size = array.getDefiningOp<LLVM::AllocaOp>().getArraySize();
+        LLVM::CallOp::create(*this, dec, ValueRange{size, array});
+      }
     }
   }
 

--- a/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
+++ b/mlir/lib/Dialect/QIR/Utils/QIRUtils.cpp
@@ -290,24 +290,17 @@ LLVM::LLVMFuncOp getOrCreateFunctionDeclaration(OpBuilder& builder,
   return function;
 }
 
-LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
-                                    const StringRef label,
-                                    const StringRef symbolPrefix) {
-  // Save current insertion point
+static LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
+                                           StringRef label,
+                                           StringRef symbolPrefix,
+                                           SymbolTable& symbols,
+                                           LLVM::LLVMFuncOp main) {
   const OpBuilder::InsertionGuard guard(builder);
+  auto moduleOp = cast<ModuleOp>(symbols.getOp());
 
-  auto moduleOp = dyn_cast<ModuleOp>(op);
-  if (!moduleOp) {
-    moduleOp = op->getParentOfType<ModuleOp>();
-  }
-  if (!moduleOp) {
-    llvm::reportFatalInternalError("Module not found");
-  }
+  auto symbolName = builder.getStringAttr((symbolPrefix + "_" + label).str());
 
-  const auto symbolName =
-      builder.getStringAttr((symbolPrefix + "_" + label).str());
-
-  if (!moduleOp.lookupSymbol<LLVM::GlobalOp>(symbolName)) {
+  if (!symbols.lookup<LLVM::GlobalOp>(symbolName)) {
     const auto llvmArrayType = LLVM::LLVMArrayType::get(
         builder.getIntegerType(8), static_cast<unsigned>(label.size() + 1));
     const auto stringInitializer = builder.getStringAttr(label.str() + '\0');
@@ -320,11 +313,11 @@ LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
         LLVM::Linkage::Internal, symbolName, stringInitializer);
     globalOp->setAttr("addr_space", builder.getI32IntegerAttr(0));
     globalOp->setAttr("dso_local", builder.getUnitAttr());
+    symbolName = symbols.insert(globalOp);
   }
 
   // Create AddressOfOp
   // Shall be added to the first block of the `main` function in the module
-  auto main = getMainFunction(op);
   if (!main) {
     llvm::reportFatalInternalError("Main function not found");
   }
@@ -336,6 +329,20 @@ LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
       symbolName);
 
   return addressOfOp;
+}
+
+LLVM::AddressOfOp createResultLabel(OpBuilder& builder, Operation* op,
+                                    StringRef label, StringRef symbolPrefix) {
+  auto moduleOp = dyn_cast<ModuleOp>(op);
+  if (!moduleOp) {
+    moduleOp = op->getParentOfType<ModuleOp>();
+  }
+  if (!moduleOp) {
+    llvm::reportFatalInternalError("Module not found");
+  }
+  SymbolTable symbols(moduleOp);
+  return createResultLabel(builder, op, label, symbolPrefix, symbols,
+                           getMainFunction(op));
 }
 
 Value createPointerFromIndex(OpBuilder& builder, const Location loc,
@@ -365,6 +372,19 @@ void emitOutputRecording(OpBuilder& builder, Operation* anchor,
   auto resultDec = getOrCreateFunctionDeclaration(builder, anchor,
                                                   QIR_RECORD_OUTPUT, resultSig);
 
+  auto main = getMainFunction(anchor);
+  if (!main) {
+    llvm::reportFatalInternalError("Main function not found");
+  }
+  SymbolTable symbols(main->getParentOfType<ModuleOp>());
+  const auto createLabel = [&](StringRef label) {
+    return createResultLabel(builder, anchor, label, "qir.result_label",
+                             symbols, main)
+        .getResult();
+  };
+
+  LLVM::LLVMFuncOp baseArrayDec;
+  LLVM::LLVMFuncOp adaptiveArrayDec;
   // Classical registers
   for (const auto& reg : classicalRegisters) {
     if (!reg.record) {
@@ -372,30 +392,31 @@ void emitOutputRecording(OpBuilder& builder, Operation* anchor,
     }
 
     auto size = resolveIntVariant(builder, loc, reg.size);
-    auto label = createResultLabel(builder, anchor, reg.label).getResult();
+    auto label = createLabel(reg.label);
 
     // Adaptive Profile: emit `__quantum__rt__result_array_record_output`
     if (reg.array) {
-      auto arraySig =
-          LLVM::LLVMFunctionType::get(voidType, {i64Type, ptrType, ptrType});
-      auto arrayDec = getOrCreateFunctionDeclaration(
-          builder, anchor, QIR_RESULT_ARRAY_RECORD_OUTPUT, arraySig);
-      LLVM::CallOp::create(builder, loc, arrayDec,
+      if (!adaptiveArrayDec) {
+        auto arraySig =
+            LLVM::LLVMFunctionType::get(voidType, {i64Type, ptrType, ptrType});
+        adaptiveArrayDec = getOrCreateFunctionDeclaration(
+            builder, anchor, QIR_RESULT_ARRAY_RECORD_OUTPUT, arraySig);
+      }
+      LLVM::CallOp::create(builder, loc, adaptiveArrayDec,
                            ValueRange{size, reg.array, label});
       continue;
     }
 
     // Base Profile: emit `__quantum__rt__array_record_output` followed by
     // `__quantum__rt__result_record_output` for each bit
-    auto arraySig =
-        LLVM::LLVMFunctionType::get(voidType, {builder.getI64Type(), ptrType});
-    auto arrayDec = getOrCreateFunctionDeclaration(
-        builder, anchor, QIR_ARRAY_RECORD_OUTPUT, arraySig);
-    LLVM::CallOp::create(builder, loc, arrayDec, ValueRange{size, label});
+    if (!baseArrayDec) {
+      auto arraySig = LLVM::LLVMFunctionType::get(voidType, {i64Type, ptrType});
+      baseArrayDec = getOrCreateFunctionDeclaration(
+          builder, anchor, QIR_ARRAY_RECORD_OUTPUT, arraySig);
+    }
+    LLVM::CallOp::create(builder, loc, baseArrayDec, ValueRange{size, label});
     for (auto [index, ptr] : llvm::enumerate(reg.results)) {
-      auto bitLabel = createResultLabel(builder, anchor,
-                                        reg.label + "_" + std::to_string(index))
-                          .getResult();
+      auto bitLabel = createLabel(reg.label + "_" + std::to_string(index));
       LLVM::CallOp::create(builder, loc, resultDec, ValueRange{ptr, bitLabel});
     }
   }
@@ -405,9 +426,7 @@ void emitOutputRecording(OpBuilder& builder, Operation* anchor,
     if (!result.record) {
       continue;
     }
-    auto label = createResultLabel(builder, anchor,
-                                   "__unnamed__" + std::to_string(index))
-                     .getResult();
+    auto label = createLabel("__unnamed__" + std::to_string(index));
     LLVM::CallOp::create(builder, loc, resultDec,
                          ValueRange{result.pointer, label});
   }

--- a/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
+++ b/mlir/unittests/Conversion/QCToQIR/QCToQIRAdaptive/test_qc_to_qir_adaptive.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "mqt/Conversion/QCToQIR/QIRAdaptive/QCToQIRAdaptive.h"
+#include "mqt/Conversion/QCToQIR/QIRCommon/QIRCommon.h"
 #include "mqt/Dialect/CBit/IR/CBitOps.h"
 #include "mqt/Dialect/MQT/IR/MQTDialect.h"
 #include "mqt/Dialect/MQT/Transforms/Passes.h"
@@ -37,6 +38,7 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
@@ -51,6 +53,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <utility>
 
 using namespace mlir;
 
@@ -290,6 +293,110 @@ TEST(QCToQIRAdaptiveNativeTest, FusesStoresAcrossDisjointConstantIndices) {
   ASSERT_TRUE(succeeded(verify(*module)));
   EXPECT_TRUE(succeeded(runQCToQIRAdaptiveConversionSimple(*module)));
   EXPECT_TRUE(succeeded(verify(*module)));
+}
+
+TEST(QCToQIRAdaptiveNativeTest, PreservesClassicalStoreFusionBarriers) {
+  for (const auto& [intervening, accepted] : {
+           std::pair{"", true},
+           {
+               "%extra = qc.alloc : !qc.qubit\n"
+               "qc.dealloc %extra : !qc.qubit\n",
+               true,
+           },
+           {"cbit.store %b, %r[%one] : !cbit.reg<2>\n", true},
+           {"cbit.store %b, %r[%zero] : !cbit.reg<2>\n", false},
+           {"cbit.store %b, %scratch[%one] : !cbit.reg<2>\n", false},
+           {
+               "cbit.store %b, %scratch[%one] : !cbit.reg<2>\n"
+               "cbit.store %b, %r[%one] : !cbit.reg<2>\n",
+               false,
+           },
+           {
+               "cbit.store %b, %r[%one] : !cbit.reg<2>\n"
+               "cbit.store %b, %scratch[%one] : !cbit.reg<2>\n",
+               false,
+           },
+           {"cbit.store %b, %r[%dynamic] : !cbit.reg<2>\n", false},
+           {"scf.if %condition { func.call @observe() : () -> () }\n", false},
+       }) {
+    SCOPED_TRACE(intervening);
+    MLIRContext context;
+    context
+        .loadDialect<qc::QCDialect, cbit::CBitDialect, mlir::mqt::MQTDialect,
+                     arith::ArithDialect, func::FuncDialect, scf::SCFDialect>();
+    auto source = std::string(R"mlir(module {
+      func.func private @observe()
+      func.func private @index() -> index
+      func.func @main() -> !cbit.reg<2> attributes {mqt.entry_point} {
+        %q = qc.alloc : !qc.qubit
+        %r = cbit.alloc(#cbit.init<zero>) : !cbit.reg<2>
+        %scratch = cbit.alloc(#cbit.init<zero>) : !cbit.reg<2>
+        %zero = arith.constant 0 : index
+        %one = arith.constant 1 : index
+        %condition = arith.constant false
+        %dynamic = func.call @index() : () -> index
+        %b = qc.measure %q : !qc.qubit -> i1
+        %a = qc.measure %q : !qc.qubit -> i1
+    )mlir") + intervening +
+                  R"mlir(
+        cbit.store %a, %r[%zero] : !cbit.reg<2>
+        qc.dealloc %q : !qc.qubit
+        return %r : !cbit.reg<2>
+      }
+    })mlir";
+    auto moduleOp = parseSourceString<ModuleOp>(source, &context);
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    std::string before;
+    llvm::raw_string_ostream beforeStream(before);
+    moduleOp->print(beforeStream);
+    bool diagnosed = false;
+    ScopedDiagnosticHandler handler(&context, [&](Diagnostic& diagnostic) {
+      diagnosed |=
+          diagnostic.str().find("cannot fuse this measurement/store pair") !=
+          std::string::npos;
+      return success();
+    });
+    LoweringState state;
+    EXPECT_EQ(succeeded(prepareClassicalResults(*moduleOp, state)), accepted);
+    EXPECT_EQ(diagnosed, !accepted);
+    if (!accepted) {
+      std::string after;
+      llvm::raw_string_ostream afterStream(after);
+      moduleOp->print(afterStream);
+      EXPECT_EQ(after, before);
+    }
+    EXPECT_TRUE(succeeded(verify(*moduleOp)));
+  }
+}
+
+TEST(QCToQIRAdaptiveNativeTest, ReleasesResultArraysInAllocationOrder) {
+  MLIRContext context;
+  context.loadDialect<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
+                      LLVM::LLVMDialect>();
+  qc::QCProgramBuilder builder(&context);
+  builder.initialize();
+  SmallVector<Value> registers;
+  for (size_t i = 0; i < 12; ++i) {
+    registers.push_back(builder.allocClassicalBitRegister(1));
+  }
+  builder.retype(TypeRange(registers));
+  auto moduleOp = builder.finalize(registers);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  ASSERT_TRUE(succeeded(runQCToQIRAdaptiveConversionSimple(*moduleOp)));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  SmallVector<Value> allocated;
+  SmallVector<Value> released;
+  moduleOp->walk([&](LLVM::CallOp call) {
+    if (call.getCallee() == qir::QIR_RESULT_ARRAY_ALLOC) {
+      allocated.push_back(call.getOperand(1));
+    } else if (call.getCallee() == qir::QIR_RESULT_ARRAY_RELEASE) {
+      released.push_back(call.getOperand(1));
+    }
+  });
+  ASSERT_EQ(allocated.size(), 12);
+  EXPECT_EQ(released, allocated);
 }
 
 TEST(QCToQIRAdaptiveNativeTest, DynamicallyAllocatesScalarAndRegisterResults) {

--- a/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
+++ b/mlir/unittests/Dialect/QIR/IR/test_qir_ir.cpp
@@ -39,6 +39,7 @@
 #include "mlir/Target/LLVMIR/Export.h"
 
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Constants.h"
@@ -56,6 +57,7 @@
 #include <ostream>
 #include <string>
 #include <tuple>
+#include <variant>
 
 using namespace mlir;
 using namespace qir;
@@ -189,6 +191,98 @@ TEST_F(QIRTest, AdaptiveBuilderOwnsScalarAndRegisterResults) {
   });
   EXPECT_EQ(scalarReleases, 1);
   EXPECT_EQ(arrayReleases, 1);
+}
+
+TEST_F(QIRTest, AdaptiveBuilderReleasesEachResourceKindInAllocationOrder) {
+  QIRProgramBuilder builder(context.get());
+  builder.initialize();
+  std::array<SmallVector<Value>, 4> allocated;
+  for (int64_t i = 0; i < 12; ++i) {
+    auto qubit = builder.allocQubit();
+    allocated[0].push_back(qubit);
+    auto qubits = builder.allocQubitRegister(1);
+    allocated[1].push_back(qubits.value);
+    auto result = builder.measure(qubit, i, false);
+    allocated[2].push_back(result);
+    auto results = builder.allocClassicalBitRegister(1);
+    allocated[3].push_back(results.array);
+  }
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  std::array<SmallVector<Value>, 4> released;
+  moduleOp->walk([&](LLVM::CallOp call) {
+    if (call.getCallee() == QIR_QUBIT_RELEASE) {
+      released[0].push_back(call.getOperand(0));
+    } else if (call.getCallee() == QIR_QUBIT_ARRAY_RELEASE) {
+      released[1].push_back(call.getOperand(1));
+    } else if (call.getCallee() == QIR_RESULT_RELEASE) {
+      released[2].push_back(call.getOperand(0));
+    } else if (call.getCallee() == QIR_RESULT_ARRAY_RELEASE) {
+      released[3].push_back(call.getOperand(1));
+    }
+  });
+  EXPECT_EQ(released, allocated);
+}
+
+TEST_F(QIRTest, AdaptiveBuilderUsesAnArrayForWideClassicalRegisters) {
+  QIRProgramBuilder builder(context.get());
+  builder.initialize();
+  auto reg = builder.allocClassicalBitRegister(1000000);
+  EXPECT_TRUE(reg.results.empty());
+  EXPECT_TRUE(reg.array);
+  EXPECT_EQ(std::get<int64_t>(reg.size), 1000000);
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(moduleOp);
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+}
+
+TEST_F(QIRTest, OutputRecordingReusesLabelsAcrossBatches) {
+  ClassicalRegister reg;
+  auto moduleOp = QIRProgramBuilder::build(
+      context.get(),
+      [&](QIRProgramBuilder& builder) {
+        reg = builder.allocClassicalBitRegister(2);
+        return builder.intConstant(0);
+      },
+      QIRProgramBuilder::Profile::Base);
+  ASSERT_TRUE(moduleOp);
+  auto main = getMainFunction(*moduleOp);
+  ASSERT_TRUE(main);
+  OpBuilder builder(main.getBody().back().getTerminator());
+  auto existing = createResultLabel(builder, main, "c0_0");
+  const DenseMap<int64_t, StaticResult> staticResults;
+  emitOutputRecording(builder, main, {reg}, staticResults);
+  EXPECT_EQ(existing.getGlobalName(), "qir.result_label_c0_0");
+  SmallVector<StringRef> labels;
+  for (auto global : moduleOp->getOps<LLVM::GlobalOp>()) {
+    labels.push_back(global.getSymName());
+  }
+  llvm::sort(labels);
+  EXPECT_EQ(labels, (SmallVector<StringRef>{"qir.result_label_c0",
+                                            "qir.result_label_c0_0",
+                                            "qir.result_label_c0_1"}));
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
+}
+
+TEST_F(QIRTest, ResultLabelsAvoidExistingFunctionSymbols) {
+  auto moduleOp =
+      QIRProgramBuilder::build(context.get(), [](QIRProgramBuilder& builder) {
+        return builder.intConstant(0);
+      });
+  ASSERT_TRUE(moduleOp);
+  OpBuilder builder(context.get());
+  builder.setInsertionPointToEnd(moduleOp->getBody());
+  auto function = LLVM::LLVMFuncOp::create(
+      builder, moduleOp->getLoc(), "qir.result_label_collision",
+      LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(context.get()), {}));
+  auto address = createResultLabel(builder, *moduleOp, "collision");
+  auto global = moduleOp->lookupSymbol<LLVM::GlobalOp>(address.getGlobalName());
+  ASSERT_TRUE(global);
+  EXPECT_NE(global.getSymName(), function.getSymName());
+  EXPECT_EQ(global.getValueAttr(),
+            builder.getStringAttr(StringRef("collision\0", 10)));
+  EXPECT_TRUE(succeeded(verify(*moduleOp)));
 }
 
 TEST_F(QIRTest, AdaptiveBuilderDoesNotReleaseExplicitStaticResults) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Make QC-to-QIR output deterministic and remove repeated work when compiling wide or delayed measurement output. Related to #2253.

- Emit owned-resource releases in allocation order, using vectors for unique builder allocations and an ordered set where conversion needs membership queries.
- Summarize classical interference once per relevant block while preserving the existing fusion barriers and the adjacent-store fast path.
- Reuse the symbol table, entry function, and output/release declarations during output emission.
- Allocate per-bit result descriptors only for Base; Adaptive keeps its runtime array.

The implementation uses existing LLVM containers and type views. No new dependencies or public API changes.

### Validation

- 640 native tests pass: 137 Base, 161 Adaptive, 130 QIR IR/builder, and 212 compiler tests, with Clang 23.1.1, LLVM/MLIR 23.1.0, ThinLTO, and IPO enabled.
- Full lint and full changed-file C++ lint pass.
- Twelve fresh processes produce identical IR for each of four conversion/builder scenarios. Release multisets and all other output match the baseline.
- A comparison of 240 verified fusion inputs against the original implementation accepts the same 22 and rejects the same 218; all accepted outputs are byte-identical.
- The final paired run at 8,000 bits reduced grouped preparation from 3,285.27 ms to 4.453 ms (fixed range: 4.371–4.490 ms); adjacent preparation measured 2.764 ms before and 3.085 ms after. The Adaptive descriptor stress case retains identical IR while reducing peak process RSS from about 175 MiB to about 24 MiB. These measurements cover generated inputs on a shared DGX Spark; elapsed times and CPU samples are retained locally.

AI assistance: GPT-6 via Codex implemented the changes, applied the complexity review, and ran local validation.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

Documentation, changelog, and migration updates are not needed for these internal changes to unreleased v4 functionality. Hosted CI and human review remain pending.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
