### PR TITLE
⚡ Improve OpenQASM frontend and emission scaling

### DIFF
--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -1606,6 +1606,9 @@ private:
             }
           } else if constexpr (std::is_same_v<T, frontend::ForStatement> ||
                                std::is_same_v<T, frontend::WhileStatement>) {
+            if constexpr (std::is_same_v<T, frontend::ForStatement>) {
+              recordMutation(data.inductionVariable, mutationKeys, mutations);
+            }
             for (const auto nested : data.body) {
               collectMutations(nested, mutationKeys, mutations);
             }
@@ -1631,6 +1634,11 @@ private:
       collectMutations(statement, mutationKeys, mutations);
     }
     llvm::sort(mutations);
+    return mutations;
+  }
+
+  [[nodiscard]] SmallVector<StateSlot>
+  initializedState(ArrayRef<StateSlot> mutations) const {
     SmallVector<StateSlot> slots;
     slots.reserve(mutations.size());
     for (const auto slot : mutations) {
@@ -1893,9 +1901,10 @@ private:
     });
   }
 
-  void emitCFGIf(Value condition, ArrayRef<StateSlot> slots,
+  void emitCFGIf(Value condition, ArrayRef<StateSlot> mutatedSlots,
                  function_ref<void()> thenBody, function_ref<void()> elseBody) {
-    const auto savedScalars = scalarValues;
+    const auto slots = initializedState(mutatedSlots);
+    const auto savedScalars = stateValues(mutatedSlots);
     auto values = stateValues(slots);
     auto* entry = builder.getInsertionBlock();
     auto* region = entry->getParent();
@@ -1907,7 +1916,7 @@ private:
     builder.setInsertionPointToEnd(entry);
     cf::CondBranchOp::create(builder, condition, thenBlock, elseBlock);
     const auto emitBranch = [&](Block* block, function_ref<void()> body) {
-      scalarValues = savedScalars;
+      assignState(mutatedSlots, savedScalars);
       flowReachable = true;
       builder.setInsertionPointToEnd(block);
       body();
@@ -1919,7 +1928,7 @@ private:
     const bool thenReachable = emitBranch(thenBlock, thenBody);
     const bool elseReachable = emitBranch(elseBlock, elseBody);
     flowReachable = thenReachable || elseReachable;
-    scalarValues = savedScalars;
+    assignState(mutatedSlots, savedScalars);
     assignState(slots, join->getArguments());
     builder.setInsertionPointToEnd(join);
     if (!flowReachable) {
@@ -1954,10 +1963,10 @@ private:
         conditional.thenStatements.begin(), conditional.thenStatements.end());
     nestedStatements.append(conditional.elseStatements.begin(),
                             conditional.elseStatements.end());
-    const auto slots = mutatedState(nestedStatements);
+    const auto mutatedSlots = mutatedState(nestedStatements);
     if (activeLoop != nullptr && hasLoopJump(nestedStatements)) {
       emitCFGIf(
-          condition, slots,
+          condition, mutatedSlots,
           [&] {
             for (auto statement : conditional.thenStatements) {
               emitStatement(statement, gateParameters, gateQubits);
@@ -1976,8 +1985,9 @@ private:
           });
       return;
     }
+    const auto slots = initializedState(mutatedSlots);
     const auto initialValues = stateValues(slots);
-    const auto savedScalars = scalarValues;
+    const auto savedScalars = stateValues(mutatedSlots);
     const auto* thenStatements = &conditional.thenStatements;
     const auto* elseStatements = &conditional.elseStatements;
     if (slots.empty() && thenStatements->empty() && !elseStatements->empty()) {
@@ -1991,7 +2001,7 @@ private:
     OpBuilder::InsertionGuard guard(builder);
     const auto emitBranch = [&](Block& block,
                                 ArrayRef<frontend::StatementId> statements) {
-      scalarValues = savedScalars;
+      assignState(mutatedSlots, savedScalars);
       if (!block.empty()) {
         block.back().erase();
       }
@@ -2008,7 +2018,7 @@ private:
     if (withElseRegion) {
       emitBranch(ifOp.getElseRegion().front(), *elseStatements);
     }
-    scalarValues = savedScalars;
+    assignState(mutatedSlots, savedScalars);
     assignState(slots, ifOp.getResults());
   }
 
@@ -2110,9 +2120,11 @@ private:
       emitLoopWithJumps(loop, gateParameters, gateQubits);
       return;
     }
-    const auto slots = mutatedState(loop.body);
+    auto mutatedSlots = mutatedState(loop.body);
+    const auto slots = initializedState(mutatedSlots);
     const auto initialValues = stateValues(slots);
-    const auto savedScalars = scalarValues;
+    mutatedSlots.push_back(loop.inductionVariable);
+    const auto savedScalars = stateValues(mutatedSlots);
 
     if (loop.provenPositiveRange) {
       auto start = emitProvenIndexExpression(builder, loop.start);
@@ -2138,7 +2150,7 @@ private:
           body->back().erase();
         }
         builder.setInsertionPointToEnd(body);
-        scalarValues = savedScalars;
+        assignState(mutatedSlots, savedScalars);
         assignState(slots, forOp.getRegionIterArgs());
         provenInductionValues[loop.inductionVariable] = forOp.getInductionVar();
         scalarValues.at(loop.inductionVariable) = arith::IndexCastOp::create(
@@ -2151,7 +2163,7 @@ private:
         }
         scf::YieldOp::create(builder, stateValues(slots));
       }
-      scalarValues = savedScalars;
+      assignState(mutatedSlots, savedScalars);
       provenInductionValues.erase(loop.inductionVariable);
       assignState(slots, forOp.getResults());
       return;
@@ -2190,7 +2202,7 @@ private:
           body->back().erase();
         }
         builder.setInsertionPointToEnd(body);
-        scalarValues = savedScalars;
+        assignState(mutatedSlots, savedScalars);
         assignState(slots, forOp.getRegionIterArgs());
         auto counter = arith::IndexCastOp::create(builder, builder.getI64Type(),
                                                   forOp.getInductionVar());
@@ -2207,7 +2219,7 @@ private:
         }
         scf::YieldOp::create(builder, stateValues(slots));
       }
-      scalarValues = savedScalars;
+      assignState(mutatedSlots, savedScalars);
       assignState(slots, forOp.getResults());
       return;
     }
@@ -2243,7 +2255,7 @@ private:
           OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPoint(nested.getInsertionBlock(),
                                     nested.getInsertionPoint());
-          scalarValues = savedScalars;
+          assignState(mutatedSlots, savedScalars);
           assignState(slots, arguments.drop_front(stateOffset));
           scalarValues.at(loop.inductionVariable) =
               narrowDynamicRange
@@ -2270,15 +2282,19 @@ private:
           llvm::append_range(yielded, stateValues(slots));
           scf::YieldOp::create(builder, yielded);
         });
-    scalarValues = savedScalars;
+    assignState(mutatedSlots, savedScalars);
     assignState(slots, whileOp.getResults().drop_front(stateOffset));
   }
 
   template <typename Loop>
   void emitLoopWithJumps(const Loop& loop, ValueRange gateParameters,
                          ValueRange gateQubits) {
-    const auto slots = mutatedState(loop.body);
-    const auto savedScalars = scalarValues;
+    auto mutatedSlots = mutatedState(loop.body);
+    const auto slots = initializedState(mutatedSlots);
+    if constexpr (std::is_same_v<Loop, frontend::ForStatement>) {
+      mutatedSlots.push_back(loop.inductionVariable);
+    }
+    const auto savedScalars = stateValues(mutatedSlots);
     SmallVector<Value> initial;
     Value step, stop;
     bool indexRange = false;
@@ -2368,7 +2384,7 @@ private:
     }
     auto results = cfg.finish();
     flowReachable = true;
-    scalarValues = savedScalars;
+    assignState(mutatedSlots, savedScalars);
     if (failed(results)) {
       emissionFailed = true;
       return;
@@ -2387,16 +2403,17 @@ private:
       emitLoopWithJumps(loop, gateParameters, gateQubits);
       return;
     }
-    const auto slots = mutatedState(loop.body);
+    auto mutatedSlots = mutatedState(loop.body);
+    const auto slots = initializedState(mutatedSlots);
     const auto initialValues = stateValues(slots);
-    const auto savedScalars = scalarValues;
+    const auto savedScalars = stateValues(mutatedSlots);
     auto whileOp = scf::WhileOp::create(
         builder, ValueRange(initialValues).getTypes(), initialValues,
         [&](OpBuilder& nested, Location, ValueRange arguments) {
           OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPoint(nested.getInsertionBlock(),
                                     nested.getInsertionPoint());
-          scalarValues = savedScalars;
+          assignState(mutatedSlots, savedScalars);
           assignState(slots, arguments);
           auto condition =
               emitCondition(loop.condition, gateParameters, gateQubits);
@@ -2409,7 +2426,7 @@ private:
           OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPoint(nested.getInsertionBlock(),
                                     nested.getInsertionPoint());
-          scalarValues = savedScalars;
+          assignState(mutatedSlots, savedScalars);
           assignState(slots, arguments);
           for (const auto statement : loop.body) {
             emitStatement(statement, gateParameters, gateQubits);
@@ -2419,7 +2436,7 @@ private:
           }
           scf::YieldOp::create(builder, stateValues(slots));
         });
-    scalarValues = savedScalars;
+    assignState(mutatedSlots, savedScalars);
     assignState(slots, whileOp.getResults());
   }
 
@@ -2432,9 +2449,10 @@ private:
       llvm::append_range(labels, switchCase.labels);
     }
     llvm::append_range(nestedStatements, switchStatement.defaultStatements);
-    const auto slots = mutatedState(nestedStatements);
+    const auto mutatedSlots = mutatedState(nestedStatements);
+    const auto slots = initializedState(mutatedSlots);
     const auto initialValues = stateValues(slots);
-    const auto savedScalars = scalarValues;
+    const auto savedScalars = stateValues(mutatedSlots);
 
     auto control = emitExpression(builder, switchStatement.control, {});
     if (!control) {
@@ -2466,7 +2484,7 @@ private:
           match = arith::OrIOp::create(builder, match, equal);
         }
         emitCFGIf(
-            match, slots,
+            match, mutatedSlots,
             [&] {
               for (auto statement : branch.body) {
                 emitStatement(statement, gateParameters, gateQubits);
@@ -2492,7 +2510,7 @@ private:
         [&](Region& region, const ArrayRef<frontend::StatementId> statements) {
           auto& block = region.emplaceBlock();
           builder.setInsertionPointToEnd(&block);
-          scalarValues = savedScalars;
+          assignState(mutatedSlots, savedScalars);
           for (const auto statement : statements) {
             emitStatement(statement, gateParameters, gateQubits);
             if (emissionFailed || emissionBudget.isExhausted()) {
@@ -2511,7 +2529,7 @@ private:
       }
     }
     emitBranch(switchOp.getDefaultRegion(), switchStatement.defaultStatements);
-    scalarValues = savedScalars;
+    assignState(mutatedSlots, savedScalars);
     assignState(slots, switchOp.getResults());
   }
 };

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -150,12 +150,14 @@ public:
     }
     for (const auto& gate : program.gates) {
       emitGateDefinition(gate);
+      scalarUpdates_.clear();
       if (emissionFailed || emissionBudget.isExhausted()) {
         return nullptr;
       }
     }
     for (const auto statement : program.body) {
       emitStatement(statement, {}, {});
+      scalarUpdates_.clear();
       if (emissionFailed || emissionBudget.isExhausted()) {
         return nullptr;
       }
@@ -216,6 +218,8 @@ private:
   bool flowReachable = true;
 
   using StateSlot = frontend::ScalarId;
+  /// Undo only writes since a branch/loop checkpoint, including new locals.
+  SmallVector<std::pair<StateSlot, Value>> scalarUpdates_;
 
   [[nodiscard]] Location
   getLocation(const frontend::SourceLocation& source) const {
@@ -1606,9 +1610,6 @@ private:
             }
           } else if constexpr (std::is_same_v<T, frontend::ForStatement> ||
                                std::is_same_v<T, frontend::WhileStatement>) {
-            if constexpr (std::is_same_v<T, frontend::ForStatement>) {
-              recordMutation(data.inductionVariable, mutationKeys, mutations);
-            }
             for (const auto nested : data.body) {
               collectMutations(nested, mutationKeys, mutations);
             }
@@ -1634,11 +1635,6 @@ private:
       collectMutations(statement, mutationKeys, mutations);
     }
     llvm::sort(mutations);
-    return mutations;
-  }
-
-  [[nodiscard]] SmallVector<StateSlot>
-  initializedState(ArrayRef<StateSlot> mutations) const {
     SmallVector<StateSlot> slots;
     slots.reserve(mutations.size());
     for (const auto slot : mutations) {
@@ -1660,9 +1656,21 @@ private:
     return values;
   }
 
+  void setScalarValue(StateSlot slot, Value value) {
+    scalarUpdates_.emplace_back(slot, scalarValues.at(slot));
+    scalarValues.at(slot) = value;
+  }
+
+  void restoreScalars(size_t checkpoint) {
+    while (scalarUpdates_.size() > checkpoint) {
+      auto [slot, value] = scalarUpdates_.pop_back_val();
+      scalarValues.at(slot) = value;
+    }
+  }
+
   void assignState(ArrayRef<StateSlot> slots, ValueRange values) {
     for (auto [slot, value] : llvm::zip_equal(slots, values)) {
-      scalarValues.at(slot) = value;
+      setScalarValue(slot, value);
     }
   }
 
@@ -1767,7 +1775,7 @@ private:
           arith::ConstantOp::create(builder, type, builder.getZeroAttr(type));
     }
     if (value) {
-      scalarValues.at(statement.scalar) = value;
+      setScalarValue(statement.scalar, value);
     }
   }
 
@@ -1778,7 +1786,7 @@ private:
                      ? emitExpression(builder, *statement.value, {})
                      : emitCondition(*statement.condition, {}, gateQubits);
     if (value) {
-      scalarValues.at(statement.scalar) = value;
+      setScalarValue(statement.scalar, value);
     }
   }
 
@@ -1901,10 +1909,9 @@ private:
     });
   }
 
-  void emitCFGIf(Value condition, ArrayRef<StateSlot> mutatedSlots,
+  void emitCFGIf(Value condition, ArrayRef<StateSlot> slots,
                  function_ref<void()> thenBody, function_ref<void()> elseBody) {
-    const auto slots = initializedState(mutatedSlots);
-    const auto savedScalars = stateValues(mutatedSlots);
+    const auto scalarCheckpoint = scalarUpdates_.size();
     auto values = stateValues(slots);
     auto* entry = builder.getInsertionBlock();
     auto* region = entry->getParent();
@@ -1916,7 +1923,7 @@ private:
     builder.setInsertionPointToEnd(entry);
     cf::CondBranchOp::create(builder, condition, thenBlock, elseBlock);
     const auto emitBranch = [&](Block* block, function_ref<void()> body) {
-      assignState(mutatedSlots, savedScalars);
+      restoreScalars(scalarCheckpoint);
       flowReachable = true;
       builder.setInsertionPointToEnd(block);
       body();
@@ -1928,7 +1935,7 @@ private:
     const bool thenReachable = emitBranch(thenBlock, thenBody);
     const bool elseReachable = emitBranch(elseBlock, elseBody);
     flowReachable = thenReachable || elseReachable;
-    assignState(mutatedSlots, savedScalars);
+    restoreScalars(scalarCheckpoint);
     assignState(slots, join->getArguments());
     builder.setInsertionPointToEnd(join);
     if (!flowReachable) {
@@ -1963,10 +1970,10 @@ private:
         conditional.thenStatements.begin(), conditional.thenStatements.end());
     nestedStatements.append(conditional.elseStatements.begin(),
                             conditional.elseStatements.end());
-    const auto mutatedSlots = mutatedState(nestedStatements);
+    const auto slots = mutatedState(nestedStatements);
     if (activeLoop != nullptr && hasLoopJump(nestedStatements)) {
       emitCFGIf(
-          condition, mutatedSlots,
+          condition, slots,
           [&] {
             for (auto statement : conditional.thenStatements) {
               emitStatement(statement, gateParameters, gateQubits);
@@ -1985,9 +1992,8 @@ private:
           });
       return;
     }
-    const auto slots = initializedState(mutatedSlots);
     const auto initialValues = stateValues(slots);
-    const auto savedScalars = stateValues(mutatedSlots);
+    const auto scalarCheckpoint = scalarUpdates_.size();
     const auto* thenStatements = &conditional.thenStatements;
     const auto* elseStatements = &conditional.elseStatements;
     if (slots.empty() && thenStatements->empty() && !elseStatements->empty()) {
@@ -2001,7 +2007,7 @@ private:
     OpBuilder::InsertionGuard guard(builder);
     const auto emitBranch = [&](Block& block,
                                 ArrayRef<frontend::StatementId> statements) {
-      assignState(mutatedSlots, savedScalars);
+      restoreScalars(scalarCheckpoint);
       if (!block.empty()) {
         block.back().erase();
       }
@@ -2018,7 +2024,7 @@ private:
     if (withElseRegion) {
       emitBranch(ifOp.getElseRegion().front(), *elseStatements);
     }
-    assignState(mutatedSlots, savedScalars);
+    restoreScalars(scalarCheckpoint);
     assignState(slots, ifOp.getResults());
   }
 
@@ -2120,11 +2126,9 @@ private:
       emitLoopWithJumps(loop, gateParameters, gateQubits);
       return;
     }
-    auto mutatedSlots = mutatedState(loop.body);
-    const auto slots = initializedState(mutatedSlots);
+    const auto slots = mutatedState(loop.body);
     const auto initialValues = stateValues(slots);
-    mutatedSlots.push_back(loop.inductionVariable);
-    const auto savedScalars = stateValues(mutatedSlots);
+    const auto scalarCheckpoint = scalarUpdates_.size();
 
     if (loop.provenPositiveRange) {
       auto start = emitProvenIndexExpression(builder, loop.start);
@@ -2150,11 +2154,12 @@ private:
           body->back().erase();
         }
         builder.setInsertionPointToEnd(body);
-        assignState(mutatedSlots, savedScalars);
+        restoreScalars(scalarCheckpoint);
         assignState(slots, forOp.getRegionIterArgs());
         provenInductionValues[loop.inductionVariable] = forOp.getInductionVar();
-        scalarValues.at(loop.inductionVariable) = arith::IndexCastOp::create(
-            builder, builder.getI64Type(), forOp.getInductionVar());
+        setScalarValue(loop.inductionVariable,
+                       arith::IndexCastOp::create(builder, builder.getI64Type(),
+                                                  forOp.getInductionVar()));
         for (const auto statement : loop.body) {
           emitStatement(statement, gateParameters, gateQubits);
           if (emissionFailed || emissionBudget.isExhausted()) {
@@ -2163,7 +2168,7 @@ private:
         }
         scf::YieldOp::create(builder, stateValues(slots));
       }
-      assignState(mutatedSlots, savedScalars);
+      restoreScalars(scalarCheckpoint);
       provenInductionValues.erase(loop.inductionVariable);
       assignState(slots, forOp.getResults());
       return;
@@ -2202,15 +2207,16 @@ private:
           body->back().erase();
         }
         builder.setInsertionPointToEnd(body);
-        assignState(mutatedSlots, savedScalars);
+        restoreScalars(scalarCheckpoint);
         assignState(slots, forOp.getRegionIterArgs());
         auto counter = arith::IndexCastOp::create(builder, builder.getI64Type(),
                                                   forOp.getInductionVar());
         auto counterWide = arith::ExtUIOp::create(builder, i128, counter);
         auto offset = arith::MulIOp::create(builder, counterWide, stepValue);
         auto inductionWide = arith::AddIOp::create(builder, startValue, offset);
-        scalarValues.at(loop.inductionVariable) = arith::TruncIOp::create(
-            builder, builder.getI64Type(), inductionWide);
+        setScalarValue(loop.inductionVariable,
+                       arith::TruncIOp::create(builder, builder.getI64Type(),
+                                               inductionWide));
         for (const auto statement : loop.body) {
           emitStatement(statement, gateParameters, gateQubits);
           if (emissionFailed || emissionBudget.isExhausted()) {
@@ -2219,7 +2225,7 @@ private:
         }
         scf::YieldOp::create(builder, stateValues(slots));
       }
-      assignState(mutatedSlots, savedScalars);
+      restoreScalars(scalarCheckpoint);
       assignState(slots, forOp.getResults());
       return;
     }
@@ -2255,13 +2261,13 @@ private:
           OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPoint(nested.getInsertionBlock(),
                                     nested.getInsertionPoint());
-          assignState(mutatedSlots, savedScalars);
+          restoreScalars(scalarCheckpoint);
           assignState(slots, arguments.drop_front(stateOffset));
-          scalarValues.at(loop.inductionVariable) =
-              narrowDynamicRange
-                  ? arguments.front()
-                  : arith::TruncIOp::create(builder, builder.getI64Type(),
-                                            arguments.front());
+          setScalarValue(loop.inductionVariable,
+                         narrowDynamicRange ? arguments.front()
+                                            : arith::TruncIOp::create(
+                                                  builder, builder.getI64Type(),
+                                                  arguments.front()));
           for (const auto statement : loop.body) {
             emitStatement(statement, gateParameters, gateQubits);
             if (emissionFailed || emissionBudget.isExhausted()) {
@@ -2282,19 +2288,15 @@ private:
           llvm::append_range(yielded, stateValues(slots));
           scf::YieldOp::create(builder, yielded);
         });
-    assignState(mutatedSlots, savedScalars);
+    restoreScalars(scalarCheckpoint);
     assignState(slots, whileOp.getResults().drop_front(stateOffset));
   }
 
   template <typename Loop>
   void emitLoopWithJumps(const Loop& loop, ValueRange gateParameters,
                          ValueRange gateQubits) {
-    auto mutatedSlots = mutatedState(loop.body);
-    const auto slots = initializedState(mutatedSlots);
-    if constexpr (std::is_same_v<Loop, frontend::ForStatement>) {
-      mutatedSlots.push_back(loop.inductionVariable);
-    }
-    const auto savedScalars = stateValues(mutatedSlots);
+    const auto slots = mutatedState(loop.body);
+    const auto scalarCheckpoint = scalarUpdates_.size();
     SmallVector<Value> initial;
     Value step, stop;
     bool indexRange = false;
@@ -2341,12 +2343,13 @@ private:
         provenInductionValues[loop.inductionVariable] =
             arith::IndexCastOp::create(builder, builder.getIndexType(),
                                        induction);
-        scalarValues.at(loop.inductionVariable) = induction;
+        setScalarValue(loop.inductionVariable, induction);
         condition = arith::CmpIOp::create(builder, arith::CmpIPredicate::slt,
                                           induction, stop);
       } else {
-        scalarValues.at(loop.inductionVariable) =
-            arith::TruncIOp::create(builder, builder.getI64Type(), induction);
+        setScalarValue(
+            loop.inductionVariable,
+            arith::TruncIOp::create(builder, builder.getI64Type(), induction));
         auto positive = arith::CmpIOp::create(
             builder, arith::CmpIPredicate::sgt, step,
             arith::ConstantIntOp::create(builder, 0, 128));
@@ -2384,7 +2387,7 @@ private:
     }
     auto results = cfg.finish();
     flowReachable = true;
-    assignState(mutatedSlots, savedScalars);
+    restoreScalars(scalarCheckpoint);
     if (failed(results)) {
       emissionFailed = true;
       return;
@@ -2403,17 +2406,16 @@ private:
       emitLoopWithJumps(loop, gateParameters, gateQubits);
       return;
     }
-    auto mutatedSlots = mutatedState(loop.body);
-    const auto slots = initializedState(mutatedSlots);
+    const auto slots = mutatedState(loop.body);
     const auto initialValues = stateValues(slots);
-    const auto savedScalars = stateValues(mutatedSlots);
+    const auto scalarCheckpoint = scalarUpdates_.size();
     auto whileOp = scf::WhileOp::create(
         builder, ValueRange(initialValues).getTypes(), initialValues,
         [&](OpBuilder& nested, Location, ValueRange arguments) {
           OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPoint(nested.getInsertionBlock(),
                                     nested.getInsertionPoint());
-          assignState(mutatedSlots, savedScalars);
+          restoreScalars(scalarCheckpoint);
           assignState(slots, arguments);
           auto condition =
               emitCondition(loop.condition, gateParameters, gateQubits);
@@ -2426,7 +2428,7 @@ private:
           OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPoint(nested.getInsertionBlock(),
                                     nested.getInsertionPoint());
-          assignState(mutatedSlots, savedScalars);
+          restoreScalars(scalarCheckpoint);
           assignState(slots, arguments);
           for (const auto statement : loop.body) {
             emitStatement(statement, gateParameters, gateQubits);
@@ -2436,7 +2438,7 @@ private:
           }
           scf::YieldOp::create(builder, stateValues(slots));
         });
-    assignState(mutatedSlots, savedScalars);
+    restoreScalars(scalarCheckpoint);
     assignState(slots, whileOp.getResults());
   }
 
@@ -2449,57 +2451,75 @@ private:
       llvm::append_range(labels, switchCase.labels);
     }
     llvm::append_range(nestedStatements, switchStatement.defaultStatements);
-    const auto mutatedSlots = mutatedState(nestedStatements);
-    const auto slots = initializedState(mutatedSlots);
+    const auto slots = mutatedState(nestedStatements);
     const auto initialValues = stateValues(slots);
-    const auto savedScalars = stateValues(mutatedSlots);
+    const auto scalarCheckpoint = scalarUpdates_.size();
 
     auto control = emitExpression(builder, switchStatement.control, {});
     if (!control) {
       return;
     }
-    if (activeLoop != nullptr && hasLoopJump(nestedStatements)) {
-      const auto emitCases = [&](auto&& self, size_t index) -> void {
-        if (emissionFailed || emissionBudget.isExhausted()) {
-          return;
-        }
-        if (index == switchStatement.cases.size()) {
-          for (auto statement : switchStatement.defaultStatements) {
-            emitStatement(statement, gateParameters, gateQubits);
-            if (emissionFailed || emissionBudget.isExhausted()) {
-              return;
-            }
-          }
-          return;
-        }
-        const auto& branch = switchStatement.cases[index];
-        Value match = builder.boolConstant(false);
-        for (const auto label : branch.labels) {
-          if (emissionBudget.isExhausted()) {
-            return;
-          }
-          auto equal = arith::CmpIOp::create(
-              builder, arith::CmpIPredicate::eq, control,
-              arith::ConstantIntOp::create(builder, control.getType(), label));
-          match = arith::OrIOp::create(builder, match, equal);
-        }
-        emitCFGIf(
-            match, mutatedSlots,
-            [&] {
-              for (auto statement : branch.body) {
-                emitStatement(statement, gateParameters, gateQubits);
-                if (emissionFailed || emissionBudget.isExhausted()) {
-                  return;
-                }
-              }
-            },
-            [&] { self(self, index + 1); });
-      };
-      emitCases(emitCases, 0);
-      return;
-    }
     const auto type = program.expressions.at(switchStatement.control).type;
     control = emitScalarCast(builder, builder.getLoc(), control, type, type);
+    if (activeLoop != nullptr && hasLoopJump(nestedStatements)) {
+      /// A flat switch avoids nested joins during CFG-to-SCF conversion.
+      auto* entry = builder.getInsertionBlock();
+      auto* region = entry->getParent();
+      auto* join = builder.createBlock(
+          region, {}, ValueRange(initialValues).getTypes(),
+          SmallVector<Location>(initialValues.size(), builder.getLoc()));
+      auto* defaultBlock = builder.createBlock(region);
+      SmallVector<Block*> destinations;
+      /// Shared case destinations introduce poison-filled dispatch results
+      /// during CFG-to-SCF conversion. Keep one block per label.
+      for ([[maybe_unused]] const auto label : labels) {
+        destinations.push_back(builder.createBlock(region));
+      }
+      builder.setInsertionPointToEnd(entry);
+      cf::SwitchOp::create(builder, control, defaultBlock, ValueRange{},
+                           builder.getI64TensorAttr(labels), destinations,
+                           SmallVector<ValueRange>(labels.size()));
+      bool anyReachable = false;
+      const auto emitBranch = [&](Block* block,
+                                  ArrayRef<frontend::StatementId> statements) {
+        restoreScalars(scalarCheckpoint);
+        flowReachable = true;
+        builder.setInsertionPointToEnd(block);
+        for (auto statement : statements) {
+          emitStatement(statement, gateParameters, gateQubits);
+          if (emissionFailed || emissionBudget.isExhausted()) {
+            return;
+          }
+        }
+        if (flowReachable) {
+          cf::BranchOp::create(builder, join, stateValues(slots));
+          anyReachable = true;
+        }
+      };
+      size_t index = 0;
+      for (const auto& branch : switchStatement.cases) {
+        for ([[maybe_unused]] const auto label : branch.labels) {
+          emitBranch(destinations[index++], branch.body);
+          if (emissionFailed || emissionBudget.isExhausted()) {
+            return;
+          }
+        }
+      }
+      emitBranch(defaultBlock, switchStatement.defaultStatements);
+      if (emissionFailed || emissionBudget.isExhausted()) {
+        return;
+      }
+      restoreScalars(scalarCheckpoint);
+      flowReachable = anyReachable;
+      assignState(slots, join->getArguments());
+      builder.setInsertionPointToEnd(join);
+      if (!flowReachable) {
+        auto state = breakPrefix;
+        llvm::append_range(state, stateValues(breakSlots));
+        activeLoop->branch(false, state);
+      }
+      return;
+    }
     auto selector =
         arith::IndexCastOp::create(builder, builder.getIndexType(), control);
     auto switchOp = scf::IndexSwitchOp::create(
@@ -2510,7 +2530,7 @@ private:
         [&](Region& region, const ArrayRef<frontend::StatementId> statements) {
           auto& block = region.emplaceBlock();
           builder.setInsertionPointToEnd(&block);
-          assignState(mutatedSlots, savedScalars);
+          restoreScalars(scalarCheckpoint);
           for (const auto statement : statements) {
             emitStatement(statement, gateParameters, gateQubits);
             if (emissionFailed || emissionBudget.isExhausted()) {
@@ -2529,7 +2549,7 @@ private:
       }
     }
     emitBranch(switchOp.getDefaultRegion(), switchStatement.defaultStatements);
-    assignState(mutatedSlots, savedScalars);
+    restoreScalars(scalarCheckpoint);
     assignState(slots, switchOp.getResults());
   }
 };

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -1657,8 +1657,8 @@ private:
   }
 
   void setScalarValue(StateSlot slot, Value value) {
-    scalarUpdates_.emplace_back(slot, scalarValues.at(slot));
-    scalarValues.at(slot) = value;
+    scalarUpdates_.emplace_back(slot,
+                                std::exchange(scalarValues.at(slot), value));
   }
 
   void restoreScalars(size_t checkpoint) {
@@ -2479,7 +2479,6 @@ private:
       cf::SwitchOp::create(builder, control, defaultBlock, ValueRange{},
                            builder.getI64TensorAttr(labels), destinations,
                            SmallVector<ValueRange>(labels.size()));
-      bool anyReachable = false;
       const auto emitBranch = [&](Block* block,
                                   ArrayRef<frontend::StatementId> statements) {
         restoreScalars(scalarCheckpoint);
@@ -2493,7 +2492,6 @@ private:
         }
         if (flowReachable) {
           cf::BranchOp::create(builder, join, stateValues(slots));
-          anyReachable = true;
         }
       };
       size_t index = 0;
@@ -2510,7 +2508,7 @@ private:
         return;
       }
       restoreScalars(scalarCheckpoint);
-      flowReachable = anyReachable;
+      flowReachable = !join->hasNoPredecessors();
       assignState(slots, join->getArguments());
       builder.setInsertionPointToEnd(join);
       if (!flowReachable) {

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -2462,60 +2462,43 @@ private:
     const auto type = program.expressions.at(switchStatement.control).type;
     control = emitScalarCast(builder, builder.getLoc(), control, type, type);
     if (activeLoop != nullptr && hasLoopJump(nestedStatements)) {
-      /// A flat switch avoids nested joins during CFG-to-SCF conversion.
-      auto* entry = builder.getInsertionBlock();
-      auto* region = entry->getParent();
-      auto* join = builder.createBlock(
-          region, {}, ValueRange(initialValues).getTypes(),
-          SmallVector<Location>(initialValues.size(), builder.getLoc()));
-      auto* defaultBlock = builder.createBlock(region);
-      SmallVector<Block*> destinations;
-      /// Shared case destinations introduce poison-filled dispatch results
-      /// during CFG-to-SCF conversion. Keep one block per label.
-      for ([[maybe_unused]] const auto label : labels) {
-        destinations.push_back(builder.createBlock(region));
-      }
-      builder.setInsertionPointToEnd(entry);
-      cf::SwitchOp::create(builder, control, defaultBlock, ValueRange{},
-                           builder.getI64TensorAttr(labels), destinations,
-                           SmallVector<ValueRange>(labels.size()));
-      const auto emitBranch = [&](Block* block,
-                                  ArrayRef<frontend::StatementId> statements) {
-        restoreScalars(scalarCheckpoint);
-        flowReachable = true;
-        builder.setInsertionPointToEnd(block);
-        for (auto statement : statements) {
-          emitStatement(statement, gateParameters, gateQubits);
-          if (emissionFailed || emissionBudget.isExhausted()) {
+      const auto emitCases = [&](auto&& self, size_t index) -> void {
+        if (emissionFailed || emissionBudget.isExhausted()) {
+          return;
+        }
+        if (index == switchStatement.cases.size()) {
+          for (auto statement : switchStatement.defaultStatements) {
+            emitStatement(statement, gateParameters, gateQubits);
+            if (emissionFailed || emissionBudget.isExhausted()) {
+              return;
+            }
+          }
+          return;
+        }
+        const auto& branch = switchStatement.cases[index];
+        Value match = builder.boolConstant(false);
+        for (const auto label : branch.labels) {
+          if (emissionBudget.isExhausted()) {
             return;
           }
+          auto equal = arith::CmpIOp::create(
+              builder, arith::CmpIPredicate::eq, control,
+              arith::ConstantIntOp::create(builder, control.getType(), label));
+          match = arith::OrIOp::create(builder, match, equal);
         }
-        if (flowReachable) {
-          cf::BranchOp::create(builder, join, stateValues(slots));
-        }
+        emitCFGIf(
+            match, slots,
+            [&] {
+              for (auto statement : branch.body) {
+                emitStatement(statement, gateParameters, gateQubits);
+                if (emissionFailed || emissionBudget.isExhausted()) {
+                  return;
+                }
+              }
+            },
+            [&] { self(self, index + 1); });
       };
-      size_t index = 0;
-      for (const auto& branch : switchStatement.cases) {
-        for ([[maybe_unused]] const auto label : branch.labels) {
-          emitBranch(destinations[index++], branch.body);
-          if (emissionFailed || emissionBudget.isExhausted()) {
-            return;
-          }
-        }
-      }
-      emitBranch(defaultBlock, switchStatement.defaultStatements);
-      if (emissionFailed || emissionBudget.isExhausted()) {
-        return;
-      }
-      restoreScalars(scalarCheckpoint);
-      flowReachable = !join->hasNoPredecessors();
-      assignState(slots, join->getArguments());
-      builder.setInsertionPointToEnd(join);
-      if (!flowReachable) {
-        auto state = breakPrefix;
-        llvm::append_range(state, stateValues(breakSlots));
-        activeLoop->branch(false, state);
-      }
+      emitCases(emitCases, 0);
       return;
     }
     auto selector =

--- a/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
@@ -1032,15 +1032,11 @@ private:
         }
         return (Twine("(1.0 * ") + *operand + ")").str();
       }
-      if (isa<arith::IndexCastOp, arith::IndexCastUIOp>(operation) &&
+      if (name == "arith.index_cast" &&
           (operation->getOperand(0).getType().isInteger(64) ||
            operation->getOperand(0).getType().isIndex()) &&
           (value.getType().isInteger(64) || value.getType().isIndex())) {
         return operand;
-      }
-      if (isa<arith::IndexCastUIOp>(operation)) {
-        return failExpression(value,
-                              "unsigned index casts require a 64-bit integer");
       }
       auto type = castTarget(name, value.getType());
       if (type.empty()) {
@@ -1184,7 +1180,7 @@ private:
 
   [[nodiscard]] static bool isScalarCast(const StringRef name) {
     return llvm::StringSwitch<bool>(name)
-        .Cases({"arith.index_cast", "arith.index_castui"}, true)
+        .Case("arith.index_cast", true)
         .Cases({"arith.sitofp", "arith.uitofp"}, true)
         .Cases({"arith.fptosi", "arith.fptoui"}, true)
         .Default(false);

--- a/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
@@ -1032,11 +1032,15 @@ private:
         }
         return (Twine("(1.0 * ") + *operand + ")").str();
       }
-      if (name == "arith.index_cast" &&
+      if (isa<arith::IndexCastOp, arith::IndexCastUIOp>(operation) &&
           (operation->getOperand(0).getType().isInteger(64) ||
            operation->getOperand(0).getType().isIndex()) &&
           (value.getType().isInteger(64) || value.getType().isIndex())) {
         return operand;
+      }
+      if (isa<arith::IndexCastUIOp>(operation)) {
+        return failExpression(value,
+                              "unsigned index casts require a 64-bit integer");
       }
       auto type = castTarget(name, value.getType());
       if (type.empty()) {
@@ -1180,7 +1184,7 @@ private:
 
   [[nodiscard]] static bool isScalarCast(const StringRef name) {
     return llvm::StringSwitch<bool>(name)
-        .Case("arith.index_cast", true)
+        .Cases({"arith.index_cast", "arith.index_castui"}, true)
         .Cases({"arith.sitofp", "arith.uitofp"}, true)
         .Cases({"arith.fptosi", "arith.fptoui"}, true)
         .Default(false);

--- a/mlir/lib/Target/OpenQASM/Frontend.cpp
+++ b/mlir/lib/Target/OpenQASM/Frontend.cpp
@@ -207,6 +207,7 @@ parseBuffer(std::unique_ptr<llvm::MemoryBuffer> buffer,
       failedParsing = true;
       continue;
     }
+    includeBuffers.try_emplace(include.filename, bufferId);
     if (parsedBuffers.insert(bufferId).second) {
       parseSource(bufferId);
       includeDepths.resize(builder.getIncludes().size(),

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -496,7 +496,11 @@ private:
   mutable std::optional<Diagnostic> failureDiagnostic;
 
   void enterScope() {
-    scopes.push_back({{}, initializedBits.size(), initializedScalars.size()});
+    scopes.push_back({
+        .symbols = {},
+        .registers = initializedBits.size(),
+        .scalars = initializedScalars.size(),
+    });
   }
 
   void leaveScope() {

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -22,6 +22,7 @@
 
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/DynamicAPInt.h"
@@ -401,7 +402,7 @@ public:
         constantExpressionStatus(syntax.expressions.size(), 0),
         constantValues(syntax.expressions.size()),
         constantTypes(syntax.expressions.size()) {
-    scopes.emplace_back();
+    enterScope();
   }
 
   [[nodiscard]] AnalysisResult run() {
@@ -425,7 +426,7 @@ private:
     llvm::DynamicAPInt constant{0};
   };
 
-  using BitInitialization = std::vector<bool>;
+  using BitInitialization = llvm::BitVector;
   struct InitializationState {
     std::vector<std::shared_ptr<BitInitialization>> bits;
     std::vector<bool> scalars;
@@ -449,9 +450,8 @@ private:
   void intersectInitialization(const InitializationState& state,
                                size_t registers, size_t scalars) {
     for (size_t reg = 0; reg < registers; ++reg) {
-      auto& bits = mutableBitInitialization(static_cast<RegisterId>(reg));
-      for (size_t bit = 0; bit < bits.size(); ++bit) {
-        bits[bit] = bits[bit] && (*state.bits[reg])[bit];
+      if (initializedBits[reg] != state.bits[reg]) {
+        mutableBitInitialization(reg) &= *state.bits[reg];
       }
     }
     for (size_t scalar = 0; scalar < scalars; ++scalar) {
@@ -465,12 +465,21 @@ private:
   const llvm::SourceMgr& sources;
   GatePolicy gatePolicy;
   TypedProgram program;
-  SmallVector<llvm::StringMap<Symbol>> scopes;
+  struct Scope {
+    llvm::StringMap<Symbol> symbols;
+    size_t registers;
+    size_t scalars;
+  };
+  SmallVector<Scope> scopes;
   llvm::StringMap<GateSignature> customGates;
   std::vector<std::shared_ptr<BitInitialization>> initializedBits;
   std::vector<bool> initializedScalars;
   std::vector<uint64_t> scalarGenerations;
   std::vector<std::optional<ExpressionId>> affineScalarValues;
+  /// Typed IDs remain stable; analysis slots are reused after lexical scope
+  /// exit.
+  std::vector<size_t> registerStateSlots_;
+  std::vector<size_t> scalarStateSlots_;
   llvm::DenseMap<ScalarId, unsigned> activeInductions;
   llvm::DenseSet<ScalarId> loopVariantScalars;
   presburger::IntegerPolyhedron affineDomain{
@@ -485,6 +494,39 @@ private:
   uint64_t totalRegisterElements = 0;
   std::optional<SyntaxIncludeContextId> currentIncludeContext;
   mutable std::optional<Diagnostic> failureDiagnostic;
+
+  void enterScope() {
+    scopes.push_back({{}, initializedBits.size(), initializedScalars.size()});
+  }
+
+  void leaveScope() {
+    const auto& scope = scopes.back();
+    for (const auto& entry : scope.symbols) {
+      const auto& symbol = entry.getValue();
+      if (symbol.kind == SymbolKind::Register) {
+        registerStateSlots_[symbol.id] = std::numeric_limits<size_t>::max();
+      } else if (symbol.kind == SymbolKind::Scalar ||
+                 symbol.kind == SymbolKind::GateLocalScalar) {
+        scalarStateSlots_[symbol.id] = std::numeric_limits<size_t>::max();
+      }
+    }
+    initializedBits.resize(scope.registers);
+    initializedScalars.resize(scope.scalars);
+    scalarGenerations.resize(scope.scalars);
+    affineScalarValues.resize(scope.scalars);
+    scopes.pop_back();
+  }
+
+  [[nodiscard]] std::optional<ExpressionId>
+  affineScalarValue(ScalarId scalar) const {
+    if (scalar < scalarStateSlots_.size()) {
+      const auto slot = scalarStateSlots_[scalar];
+      if (slot < affineScalarValues.size()) {
+        return affineScalarValues[slot];
+      }
+    }
+    return std::nullopt;
+  }
 
   [[nodiscard]] SourceLocation getSourceLocation(const SMLoc location) const {
     if (!currentIncludeContext) {
@@ -664,10 +706,8 @@ private:
         result->coefficients[induction->second] = llvm::DynamicAPInt(1);
         break;
       }
-      if (value.variable < affineScalarValues.size() &&
-          affineScalarValues[value.variable]) {
-        result = buildAffineForm(*affineScalarValues[value.variable], cache,
-                                 depth + 1);
+      if (const auto known = affineScalarValue(value.variable)) {
+        result = buildAffineForm(*known, cache, depth + 1);
       }
       break;
     }
@@ -726,10 +766,7 @@ private:
       if (activeInductions.contains(value.variable)) {
         return expression;
       }
-      if (value.variable < affineScalarValues.size()) {
-        return affineScalarValues[value.variable];
-      }
-      return std::nullopt;
+      return affineScalarValue(value.variable);
     case ExpressionKind::Cast:
     case ExpressionKind::Negate: {
       auto operand = expandAffineScalarValues(value.lhs);
@@ -904,8 +941,7 @@ private:
     affineScalarValues.resize(size);
   }
 
-  [[nodiscard]] BitInitialization&
-  mutableBitInitialization(const RegisterId reg) {
+  [[nodiscard]] BitInitialization& mutableBitInitialization(size_t reg) {
     if (initializedBits[reg].use_count() != 1) {
       initializedBits[reg] =
           std::make_shared<BitInitialization>(*initializedBits[reg]);
@@ -927,7 +963,8 @@ private:
 
   [[nodiscard]] const Symbol* lookup(StringRef name) const {
     for (const auto& scope : llvm::reverse(scopes)) {
-      if (const auto found = scope.find(name); found != scope.end()) {
+      if (const auto found = scope.symbols.find(name);
+          found != scope.symbols.end()) {
         return &found->second;
       }
     }
@@ -949,7 +986,7 @@ private:
          (customGates.contains(name) || catalogNameReserved))) {
       return fail(location, "identifier '" + name + "' is already declared");
     }
-    if (!scopes.back().insert({name, symbol}).second) {
+    if (!scopes.back().symbols.insert({name, symbol}).second) {
       return fail(location, "identifier '" + name + "' is already declared");
     }
     return success();
@@ -2641,7 +2678,7 @@ private:
                                              expression.identifier +
                                              "' is not a scalar value");
       }
-      if (!initializedScalars.at(symbol->id)) {
+      if (!initializedScalars.at(scalarStateSlots_[symbol->id])) {
         return fail(expression.location,
                     "scalar '" + expression.identifier + "' is uninitialized");
       }
@@ -3270,6 +3307,7 @@ private:
         .name = declaration.identifier.str(),
         .location = getSourceLocation(location),
     });
+    scalarStateSlots_.push_back(initializedScalars.size());
     initializedScalars.push_back(false);
     scalarGenerations.push_back(0);
     affineScalarValues.emplace_back();
@@ -3311,11 +3349,11 @@ private:
                 integerWidth));
         typed.initializer = convertedInitializer;
         if (buildAffineForm(convertedInitializer)) {
-          affineScalarValues[id] =
+          affineScalarValues[scalarStateSlots_[id]] =
               expandAffineScalarValues(convertedInitializer);
         }
       }
-      initializedScalars[id] = true;
+      initializedScalars[scalarStateSlots_[id]] = true;
     }
     MQT_OQ3_TRY_ASSIGN(statement, addStatement(location, typed));
     destination.push_back(statement);
@@ -3324,7 +3362,8 @@ private:
 
   void markBitInitialized(const frontend::BitReference& target) {
     if (!target.dynamicIndex) {
-      mutableBitInitialization(target.reg)[target.index] = true;
+      mutableBitInitialization(registerStateSlots_[target.reg])[target.index] =
+          true;
       return;
     }
   }
@@ -3345,7 +3384,7 @@ private:
       if (symbol->type == ScalarType::Bool) {
         MQT_OQ3_TRY_ASSIGN(condition, analyzeBoolValue(assignment.value));
         typed.condition = condition;
-        affineScalarValues[symbol->id].reset();
+        affineScalarValues[scalarStateSlots_[symbol->id]].reset();
       } else {
         MQT_OQ3_TRY_ASSIGN(value, analyzeExpression(assignment.value));
         MQT_OQ3_TRY_ASSIGN(
@@ -3354,13 +3393,13 @@ private:
                            syntax.expressions[assignment.value].location,
                            symbol->integerWidth));
         typed.value = convertedValue;
-        affineScalarValues[symbol->id] =
+        affineScalarValues[scalarStateSlots_[symbol->id]] =
             buildAffineForm(convertedValue)
                 ? expandAffineScalarValues(convertedValue)
                 : std::nullopt;
       }
-      initializedScalars[symbol->id] = true;
-      ++scalarGenerations[symbol->id];
+      initializedScalars[scalarStateSlots_[symbol->id]] = true;
+      ++scalarGenerations[scalarStateSlots_[symbol->id]];
       MQT_OQ3_TRY_ASSIGN(statement, addStatement(location, typed));
       destination.push_back(statement);
       return success();
@@ -3434,8 +3473,9 @@ private:
     });
     // OpenQASM 2 classical bits are zero-initialized; OpenQASM 3 bits are not.
     const bool initiallyInitialized = !isQubit && program.openQASM2;
-    initializedBits.push_back(
-        std::make_shared<BitInitialization>(width, initiallyInitialized));
+    registerStateSlots_.push_back(initializedBits.size());
+    initializedBits.push_back(std::make_shared<BitInitialization>(
+        isQubit ? 0 : width, initiallyInitialized));
     if (failed(declare(location, identifier,
                        {
                            .kind = SymbolKind::Register,
@@ -3535,7 +3575,7 @@ private:
         .body = {},
         .location = getSourceLocation(location),
     };
-    scopes.emplace_back();
+    enterScope();
     for (const auto [index, parameter] :
          llvm::enumerate(declaration.parameters)) {
       if (failed(declare(location, parameter,
@@ -3545,7 +3585,7 @@ private:
                              .id = static_cast<uint32_t>(index),
                              .constant = std::nullopt,
                          }))) {
-        scopes.pop_back();
+        leaveScope();
         return failure();
       }
     }
@@ -3556,7 +3596,7 @@ private:
                              .id = static_cast<uint32_t>(index),
                              .constant = std::nullopt,
                          }))) {
-        scopes.pop_back();
+        leaveScope();
         return failure();
       }
     }
@@ -3564,7 +3604,7 @@ private:
     const auto bodyResult =
         analyzeBody(declaration.body, definition.body, /*global=*/false);
     activeGate_ = {};
-    scopes.pop_back();
+    leaveScope();
     if (failed(bodyResult)) {
       return failure();
     }
@@ -3741,44 +3781,44 @@ private:
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
     const auto beforeAffineScalarValues = affineScalarValues;
-    scopes.emplace_back();
+    enterScope();
     const auto thenResult =
         analyzeBody(conditional.thenStatements, result.thenStatements,
                     /*global=*/false);
     if (failed(thenResult)) {
-      scopes.pop_back();
+      leaveScope();
       return failure();
     }
     const bool thenReachable =
         reachable && (!knownCondition || *knownCondition);
+    leaveScope();
     const auto afterThenBitsInitialized = initializedBits;
     const auto afterThenInitialized = initializedScalars;
     const auto afterThenGenerations = scalarGenerations;
     const auto afterThenAffineScalarValues = affineScalarValues;
-    scopes.pop_back();
 
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                        beforeGenerations);
     restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
     activePath = entryActive && (!knownCondition || !*knownCondition);
     reachable = entryReachable;
-    scopes.emplace_back();
+    enterScope();
     const auto elseResult =
         analyzeBody(conditional.elseStatements, result.elseStatements,
                     /*global=*/false);
     if (failed(elseResult)) {
-      scopes.pop_back();
+      leaveScope();
       return failure();
     }
     const bool elseReachable =
         reachable && (!knownCondition || !*knownCondition);
     activePath = entryActive;
     reachable = thenReachable || elseReachable;
+    leaveScope();
     const auto afterElseBitsInitialized = initializedBits;
     const auto afterElseInitialized = initializedScalars;
     const auto afterElseGenerations = scalarGenerations;
     const auto afterElseAffineScalarValues = affineScalarValues;
-    scopes.pop_back();
 
     if (!thenReachable && elseReachable) {
       return addStatement(location, std::move(result));
@@ -3809,10 +3849,9 @@ private:
                        beforeGenerations);
     restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
     for (size_t reg = 0; reg < beforeBitsInitialized.size(); ++reg) {
-      auto& merged = mutableBitInitialization(static_cast<RegisterId>(reg));
-      for (size_t bit = 0; bit < beforeBitsInitialized[reg]->size(); ++bit) {
-        merged[bit] = (*afterThenBitsInitialized[reg])[bit] &&
-                      (*afterElseBitsInitialized[reg])[bit];
+      initializedBits[reg] = afterThenBitsInitialized[reg];
+      if (initializedBits[reg] != afterElseBitsInitialized[reg]) {
+        mutableBitInitialization(reg) &= *afterElseBitsInitialized[reg];
       }
     }
     for (size_t scalar = 0; scalar < beforeInitialized.size(); ++scalar) {
@@ -3885,7 +3924,7 @@ private:
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
     const auto beforeAffineScalarValues = affineScalarValues;
-    scopes.emplace_back();
+    enterScope();
     const auto scalar = static_cast<ScalarId>(program.scalars.size());
     const auto type = loop.isUnsigned ? ScalarType::Uint : ScalarType::Int;
     program.scalars.push_back({
@@ -3893,6 +3932,7 @@ private:
         .name = loop.inductionVariable.str(),
         .location = {},
     });
+    scalarStateSlots_.push_back(initializedScalars.size());
     initializedScalars.push_back(true);
     scalarGenerations.push_back(0);
     affineScalarValues.emplace_back();
@@ -3905,7 +3945,7 @@ private:
                            .id = scalar,
                            .constant = std::nullopt,
                        }))) {
-      scopes.pop_back();
+      leaveScope();
       return failure();
     }
     result.inductionVariable = scalar;
@@ -3938,7 +3978,7 @@ private:
       activeInductions.erase(scalar);
       affineDomain = outerDomain;
       loopVariantScalars = outerLoopVariantScalars;
-      scopes.pop_back();
+      leaveScope();
       return failure();
     }
     const auto afterBodyBitsInitialized = initializedBits;
@@ -3948,7 +3988,7 @@ private:
     activeInductions.erase(scalar);
     affineDomain = outerDomain;
     loopVariantScalars = outerLoopVariantScalars;
-    scopes.pop_back();
+    leaveScope();
     restoreStatePrefix(beforeBitsInitialized, beforeInitialized,
                        beforeGenerations);
     restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
@@ -4027,7 +4067,7 @@ private:
     const auto beforeInitialized = initializedScalars;
     const auto beforeGenerations = scalarGenerations;
     const auto beforeAffineScalarValues = affineScalarValues;
-    scopes.emplace_back();
+    enterScope();
     const auto outerLoopVariantScalars = loopVariantScalars;
     llvm::DenseSet<StringRef> blockLocalScalars;
     collectLoopMutations(loop.body, loopVariantScalars, blockLocalScalars);
@@ -4039,7 +4079,7 @@ private:
     loopExits.pop_back();
     reachable = entryReachable;
     loopVariantScalars = outerLoopVariantScalars;
-    scopes.pop_back();
+    leaveScope();
     if (failed(bodyResult)) {
       return failure();
     }
@@ -4104,10 +4144,10 @@ private:
                          beforeGenerations);
       restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
       reachable = entryReachable;
-      scopes.emplace_back();
+      enterScope();
       const auto branchResult =
           analyzeBody(syntaxStatements, statements, /*global=*/false);
-      scopes.pop_back();
+      leaveScope();
       if (failed(branchResult)) {
         return failure();
       }
@@ -4168,13 +4208,15 @@ private:
                        mergedScalarGenerations);
     restoreAffineScalarValuesPrefix(beforeAffineScalarValues);
     for (size_t reg = 0; reg < beforeBitsInitialized.size(); ++reg) {
-      auto& initialized =
-          mutableBitInitialization(static_cast<RegisterId>(reg));
-      for (size_t bit = 0; bit < initialized.size(); ++bit) {
-        initialized[bit] =
-            llvm::all_of(branchBitsInitialized, [&](const auto& branch) {
-              return (*branch[reg])[bit];
-            });
+      if (branchBitsInitialized.empty()) {
+        mutableBitInitialization(reg).set();
+        continue;
+      }
+      initializedBits[reg] = branchBitsInitialized.front()[reg];
+      for (const auto& branch : ArrayRef(branchBitsInitialized).drop_front()) {
+        if (initializedBits[reg] != branch[reg]) {
+          mutableBitInitialization(reg) &= *branch[reg];
+        }
       }
     }
     for (size_t scalar = 0; scalar < beforeInitialized.size(); ++scalar) {
@@ -4266,7 +4308,7 @@ private:
       }
       if (symbol->kind == SymbolKind::Scalar &&
           symbol->type == ScalarType::Bool) {
-        if (!initializedScalars.at(symbol->id)) {
+        if (!initializedScalars.at(scalarStateSlots_[symbol->id])) {
           return fail(condition.location,
                       "scalar '" + condition.identifier + "' is uninitialized");
         }
@@ -4957,14 +4999,13 @@ private:
   ensureBitInitialized(const frontend::BitReference& bit,
                        SMLoc location) const {
     if (bit.dynamicIndex) {
-      if (llvm::all_of(*initializedBits[bit.reg],
-                       [](const bool initialized) { return initialized; })) {
+      if (initializedBits[registerStateSlots_[bit.reg]]->all()) {
         return success();
       }
       return fail(location,
                   "dynamic classical index may read an uninitialized bit");
     }
-    if (!(*initializedBits[bit.reg])[bit.index]) {
+    if (!(*initializedBits[registerStateSlots_[bit.reg]])[bit.index]) {
       return fail(location, "classical condition bit has not been initialized");
     }
     return success();
@@ -4975,7 +5016,7 @@ private:
         explicitOutputs.empty() ? implicitOutputs : explicitOutputs;
     for (const auto output : program.outputs) {
       if (output.kind == OutputKind::Scalar) {
-        if (!initializedScalars[output.symbol]) {
+        if (!initializedScalars[scalarStateSlots_[output.symbol]]) {
           return fail(program.scalars[output.symbol].location,
                       "Output scalar '" + program.scalars[output.symbol].name +
                           "' is not initialized.");
@@ -4983,8 +5024,7 @@ private:
         continue;
       }
       const auto reg = static_cast<RegisterId>(output.symbol);
-      if (llvm::any_of(*initializedBits[reg],
-                       [](const bool initialized) { return !initialized; })) {
+      if (!initializedBits[registerStateSlots_[reg]]->all()) {
         return fail(program.registers[reg].location,
                     "Output register '" + program.registers[reg].name +
                         "' is not fully initialized.");

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -111,6 +111,54 @@ TEST(OpenQASM3EmissionTest, EmitsStrictPortableBellProgram) {
   EXPECT_TRUE(qc::translateQASM3ToQC(*source, &context));
 }
 
+TEST(OpenQASM3EmissionTest, RoundTripsSwitchBreakContinueAndFallthrough) {
+  constexpr auto fixtures =
+      std::to_array<std::tuple<const char*, const char*, const char*>>({
+          {"", "0", "6"},
+          {"x seed[0];", "0", "7"},
+          {"x seed[1];", "0", "309"},
+          {"", "4294967296", "11"},
+          {"", "-1", "11"},
+      });
+  for (auto [prepare, offset, expected] : fixtures) {
+    SCOPED_TRACE(expected);
+    const auto source = std::string("OPENQASM 3.1; qubit[2] seed; ") + prepare +
+                        " bit[2] code = measure seed; "
+                        "int selector = int(uint[2](code)) + " +
+                        offset +
+                        R"qasm(;
+qubit q;
+output bit result;
+int accumulated = 0;
+for int i in [0:2] {
+  switch (selector) {
+    case 0 { int local = 2; accumulated += local; continue; }
+    case 1 { accumulated += 7; break; }
+    case -1, 4294967296 { accumulated += 11; break; }
+    default { accumulated += 3; }
+  }
+  accumulated += 100;
+}
+if (accumulated == )qasm" +
+                        expected + R"qasm() { x q; }
+result = measure q;
+)qasm";
+    MLIRContext context;
+    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
+    ASSERT_TRUE(succeeded(emitted));
+    ASSERT_TRUE(oq3::frontend::analyzeOpenQASM(
+        *emitted, oq3::frontend::GatePolicy::Strict));
+    auto restored = qc::translateQASM3ToQC(*emitted, &context);
+    ASSERT_TRUE(restored) << *emitted;
+    ASSERT_TRUE(succeeded(verify(*restored)));
+    expectOneSample(*moduleOp);
+    expectOneSample(*restored);
+  }
+}
+
 TEST(OpenQASM3EmissionTest, PreservesMeasurementOrderBeforeDelayedStore) {
   constexpr llvm::StringLiteral source = R"mlir(module {
     func.func @main() -> !cbit.reg<1>
@@ -1825,6 +1873,16 @@ TEST(OpenQASM3EmissionTest, RejectsUnsupportedSubsetConcerns) {
         func.func @main() -> f32 {
           %value = arith.constant 1.0 : f32
           return %value : f32
+        }
+      })mlir",
+      },
+      Fixture{
+          .name = "narrow-unsigned-index-cast",
+          .source = R"mlir(module {
+        func.func @main() -> index {
+          %input = arith.constant 1 : i8
+          %value = arith.index_castui %input : i8 to index
+          return %value : index
         }
       })mlir",
       },

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -1877,17 +1877,6 @@ TEST(OpenQASM3EmissionTest, RejectsUnsupportedSubsetConcerns) {
       })mlir",
       },
       Fixture{
-          .name = "narrow-unsigned-index-cast",
-          .source = R"mlir(module {
-        func.func @main() -> index {
-          %input = arith.constant 1 : i8
-          %value = arith.index_castui %input : i8 to index
-          return %value : index
-        }
-      })mlir",
-      },
-
-      Fixture{
           .name = "dynamic-index",
           .source = R"mlir(module {
         func.func @main() -> i1 {

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -1684,6 +1684,44 @@ switch (selector) {
   EXPECT_EQ(switches, 1);
 }
 
+TEST(OpenQASMTargetTest, RestoresLocalScalarsWhenEmittingRepeatedSwitchBodies) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+qubit q;
+bit choose = measure q;
+output int result;
+result = 0;
+switch (int(choose)) {
+  case 0, 1 {
+    if (choose) { int local = 1; result = local; }
+    else { int local = 2; result = local; }
+    for int i in [0:1] {
+      int local = i;
+      if (choose) { result = local; continue; }
+      result += local;
+    }
+    while (choose) {
+      int local = 3;
+      if (choose) { result = local; break; }
+      choose = false;
+    }
+  }
+  default { result = 4; }
+}
+)qasm";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  size_t switches = 0;
+  moduleOp->walk([&](scf::IndexSwitchOp switchOp) {
+    ++switches;
+    /// Only the enclosing result is carried; branch locals must not escape.
+    EXPECT_EQ(switchOp.getNumResults(), 1);
+  });
+  EXPECT_EQ(switches, 1);
+}
+
 TEST(OpenQASMTargetTest, PreservesNarrowUnsignedSwitchValues) {
   constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
 uint[3] selector = 7;

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -1723,31 +1723,6 @@ switch (int(choose)) {
   EXPECT_EQ(switches, 1);
 }
 
-TEST(OpenQASMTargetTest, KeepsLoopExitSwitchDispatchFlat) {
-  constexpr size_t caseCount = 64;
-  std::string source = "OPENQASM 3.1; qubit q; bit choose = measure q; "
-                       "output int result; result = int(choose); "
-                       "for int repeat in [0:0] { switch (result) {";
-  for (size_t label = 0; label < caseCount; ++label) {
-    source += "case " + std::to_string(label) +
-              " { int local = " + std::to_string(label) +
-              "; result = local; break; }";
-  }
-  source += "default { break; } } }";
-  MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
-  ASSERT_TRUE(moduleOp);
-  ASSERT_TRUE(succeeded(verify(*moduleOp)));
-  size_t switches = 0;
-  moduleOp->walk([&](scf::IndexSwitchOp switchOp) {
-    ++switches;
-    EXPECT_EQ(switchOp.getCases().size(), caseCount);
-  });
-  /// One dispatch avoids the CFG structuring cost of a nested conditional
-  /// chain.
-  EXPECT_EQ(switches, 1);
-}
-
 TEST(OpenQASMTargetTest, PreservesLoopExitSwitchLabelsAndDefault) {
   constexpr auto selectors =
       std::to_array<std::pair<llvm::StringLiteral, int64_t>>({

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -54,6 +54,7 @@
 #include <limits>
 #include <numbers>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -1720,6 +1721,69 @@ switch (int(choose)) {
     EXPECT_EQ(switchOp.getNumResults(), 1);
   });
   EXPECT_EQ(switches, 1);
+}
+
+TEST(OpenQASMTargetTest, KeepsLoopExitSwitchDispatchFlat) {
+  constexpr size_t caseCount = 64;
+  std::string source = "OPENQASM 3.1; qubit q; bit choose = measure q; "
+                       "output int result; result = int(choose); "
+                       "for int repeat in [0:0] { switch (result) {";
+  for (size_t label = 0; label < caseCount; ++label) {
+    source += "case " + std::to_string(label) +
+              " { int local = " + std::to_string(label) +
+              "; result = local; break; }";
+  }
+  source += "default { break; } } }";
+  MLIRContext context;
+  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  ASSERT_TRUE(moduleOp);
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  size_t switches = 0;
+  moduleOp->walk([&](scf::IndexSwitchOp switchOp) {
+    ++switches;
+    EXPECT_EQ(switchOp.getCases().size(), caseCount);
+  });
+  /// One dispatch avoids the CFG structuring cost of a nested conditional
+  /// chain.
+  EXPECT_EQ(switches, 1);
+}
+
+TEST(OpenQASMTargetTest, PreservesLoopExitSwitchLabelsAndDefault) {
+  constexpr auto selectors =
+      std::to_array<std::pair<llvm::StringLiteral, int64_t>>({
+          {"int selector = -1;", 7},
+          {"int selector = 4294967296;", 7},
+          {"uint[3] selector = 7;", 13},
+          {"int selector = 3;", 9},
+      });
+  for (auto [declaration, expected] : selectors) {
+    SCOPED_TRACE(declaration.str());
+    const auto source = "OPENQASM 3.1; " + declaration.str() + R"qasm(
+output int result;
+result = 0;
+while (true) {
+  switch (selector) {
+    case -1, 4294967296 { int local = 7; result = local; break; }
+    case 7 { result = 13; break; }
+    default { result = 9; break; }
+  }
+}
+)qasm";
+    MLIRContext context;
+    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    ASSERT_TRUE(moduleOp);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    PassManager canonicalizer(&context);
+    canonicalizer.addPass(createCanonicalizerPass());
+    ASSERT_TRUE(succeeded(canonicalizer.run(*moduleOp)));
+    auto function = *moduleOp->getOps<func::FuncOp>().begin();
+    auto returned =
+        cast<func::ReturnOp>(function.getBody().front().getTerminator());
+    ASSERT_EQ(returned.getNumOperands(), 1);
+    APInt value;
+    ASSERT_TRUE(matchPattern(returned.getOperand(0), m_ConstantInt(&value)));
+    EXPECT_EQ(value.getSExtValue(), expected);
+  }
 }
 
 TEST(OpenQASMTargetTest, PreservesNarrowUnsignedSwitchValues) {

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_parser.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_parser.cpp
@@ -259,6 +259,40 @@ TEST(OpenQASMFrontendTest, PreservesDistinctProvenanceForRepeatedIncludes) {
   EXPECT_EQ(location.includeStack[1].line, 3);
 }
 
+TEST(OpenQASMFrontendTest, CachesSearchPathIncludesAndKeepsEveryOccurrence) {
+  auto files = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  ASSERT_TRUE(files->addFile(
+      "/includes/body.inc", 0,
+      llvm::MemoryBuffer::getMemBuffer("result += 1;", "/includes/body.inc")));
+  auto traced = llvm::makeIntrusiveRefCnt<llvm::vfs::TracingFileSystem>(files);
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.setVirtualFileSystem(traced);
+  sourceMgr.setIncludeDirs({"/includes"});
+  sourceMgr.AddNewSourceBuffer(
+      llvm::MemoryBuffer::getMemBufferCopy(
+          "OPENQASM 3.1;\nint result = 0;\ninclude \"body.inc\";\n"
+          "include \"body.inc\";\ninclude \"body.inc\";\n",
+          "main.qasm"),
+      llvm::SMLoc());
+
+  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr);
+  ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+  /// One failed direct lookup and one successful search-path lookup.
+  EXPECT_EQ(traced->NumOpenFileForReadCalls, 2);
+  size_t assignments = 0;
+  for (const auto& statement : analyzed.program->statements) {
+    if (std::holds_alternative<oq3::frontend::ScalarAssignmentStatement>(
+            statement.data)) {
+      EXPECT_EQ(statement.location.filename, "/includes/body.inc");
+      ASSERT_EQ(statement.location.includeStack.size(), 1);
+      EXPECT_EQ(statement.location.includeStack.front().filename, "main.qasm");
+      EXPECT_EQ(statement.location.includeStack.front().line, assignments + 3);
+      ++assignments;
+    }
+  }
+  EXPECT_EQ(assignments, 3);
+}
+
 TEST(OpenQASMFrontendTest, RejectsRecursiveIncludesResolvedThroughSearchPaths) {
   auto fileSystem = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   ASSERT_TRUE(fileSystem->addFile(

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -160,6 +160,68 @@ x q[i];
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
+TEST(OpenQASMFrontendTest, PreservesStateAcrossSuccessiveLocalScopes) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.1;
+qubit[4] q;
+bit choose = measure q[0];
+output bit result;
+int index = 0;
+if (choose) {
+  int local = 1; bit scratch = true;
+  index = local; result = scratch;
+} else {
+  int local = 1; bit scratch = false;
+  index = local; result = scratch;
+}
+int after_if = index;
+x q[after_if];
+for int i in [0:1] {
+  int local = i; bit scratch = true;
+  x q[local]; result = scratch;
+}
+bit after_for = result;
+while (true) {
+  int local = 3; bit scratch = true;
+  x q[local]; result = scratch; break;
+}
+bit after_while = result;
+switch (int(choose)) {
+  case 0 { int local = 2; bit scratch = true;
+           index = local; result = scratch; }
+  default { int local = 2; bit scratch = false;
+            index = local; result = scratch; }
+}
+int after_switch = index;
+x q[after_switch];
+)qasm";
+  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
+}
+
+TEST(OpenQASMFrontendTest, DoesNotInheritFactsFromExpiredLocalDeclarations) {
+  constexpr auto bodies = std::to_array<llvm::StringLiteral>({
+      "if (choose) { int old = 1; } int value; result = value;",
+      "if (choose) { bit old = true; } bit value; if (value) { result = 1; }",
+      "int value; if (choose) { int value = 1; } else { int value = 2; } "
+      "result = value;",
+      "int index; if (choose) { int local = 0; index = local; } "
+      "else { int local = 1; index = local; } x q[index];",
+      "for int i in [0:1] { int value = i; } "
+      "int value = int(choose); x q[value];",
+  });
+  for (auto body : bodies) {
+    SCOPED_TRACE(body.str());
+    const std::string source =
+        "OPENQASM 3.1; qubit[2] q; bit choose = measure q[0]; "
+        "output int result; result = 0; " +
+        body.str();
+    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    ASSERT_FALSE(analyzed);
+    ASSERT_FALSE(analyzed.diagnostics.empty());
+  }
+}
+
 TEST(OpenQASMFrontendTest, RejectsUnprovedQuantumIndices) {
   constexpr auto rejections =
       std::to_array<std::pair<llvm::StringRef, llvm::StringRef>>({

--- a/test/python/test_mlir_loops.py
+++ b/test/python/test_mlir_loops.py
@@ -267,9 +267,11 @@ def test_qiskit_for_jump(indexset: range | list[int], jump: str) -> None:
     check_paths(QCProgram.from_qiskit(circuit), 1 if jump == "break" else len(indexset) % 2)
 
 
-def test_continue_in_nested_loop_and_switch() -> None:
+@pytest.mark.parametrize("extra_cases", ["", "case -1, 4294967296 { value += 100; break; }"])
+def test_continue_in_nested_loop_and_switch(extra_cases: str) -> None:
     """Continue targets the inner loop and break still skips its remaining iterations."""
-    program = QCProgram.from_qasm_str("""
+    program = QCProgram.from_qasm_str(
+        """
 OPENQASM 3.1;
 output bit[8] result;
 uint[8] value = 0;
@@ -280,13 +282,15 @@ while (iteration < 4) {
   for int inner in [0:2] {
     switch (inner) {
       case 0 { continue; }
+      EXTRA_CASES
       default { value += 1; }
     }
     if (inner == 1) { break; }
   }
 }
 result = bit[8](value);
-""")
+""".replace("EXTRA_CASES", extra_cases)
+    )
     check_paths(program, 3)
 
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Programs with many disjoint local scopes repeatedly copy and merge expired
state. Keep semantic snapshots proportional to live lexical state and restore
emitted scalar writes through an undo log. Reuse unchanged initialization
bitmaps, omit unused qubit bitmaps, and cache successful include lookup names.

Stable typed IDs, definite initialization, affine facts, textual include
expansion, and occurrence-specific provenance are preserved. Loop-exit switches
retain conditional dispatch and promote selectors to 64 bits before comparing
labels. Large loop-exit switch structuring remains a known performance limit.
Related to #2253. No new dependencies.

Local validation of the submitted source:

- All 1,328 Python tests passed on Python 3.14, including nested-loop execution
  and round trips through OpenQASM, Qiskit, and jeff. The existing loop test now
  includes negative and above-32-bit case labels.
- All 199 OpenQASM frontend/emitter tests and 210 QC translation tests passed.
- `uvx nox -s lint` passed.
- `uvx nox -s cpp-lint -- 06a1a4a3f0d18f349bc6c6c07d0b597bbf8e48ed` passed for
  all seven changed C++ files.
- Five representative stress inputs retain identical verified QC to `5aac48f1`;
  six general export probes remain byte-identical across three allocation-noise
  settings and pass strict reparsing.

Earlier matched component measurements used three fresh processes pinned to CPU
19 on a shared DGX Spark, GCC 13.3, LLVM/MLIR 23.1, release mode, and IPO
disabled. Times are medians:

| Input and phase                                      |       Before |     After |
| ---------------------------------------------------- | -----------: | --------: |
| 16,384 integer scopes, analysis                      | 1,056.980 ms | 51.269 ms |
| Same input, QC emission                              |   130.786 ms | 19.782 ms |
| 8,192 measured local bits used in branches, analysis | 4,403.490 ms | 40.170 ms |
| 1,000 search-path includes, parsing                  |    25.806 ms |  0.230 ms |

These historical measurements compare baseline `ad74680f` with implementation
`5109eb9a`; they were not rerun after the final review, rebase, or CI fix. Full
raw data, ranges, plots, and scripts remain local in
`.agent/benchmarks/openqasm-release/final/` and its parent directory. Some phase
wall medians increased despite lower whole-process CPU; two narrow inputs had
CPU increases below 0.1 ms. These are component measurements, not a universal
speedup claim.

The additional flat-switch optimization was withdrawn after Python CI exposed
unsupported unsigned index casts in OpenQASM export and structured switches in
jeff conversion. The corresponding exporter workaround and flat-shape test were
removed. The three original performance fixes remain. The earlier flat-switch
benchmark results do not describe this PR's final behavior. Hosted CI for this
update is not yet verified.

Codex assisted with implementation, review, and validation. Documentation and
migration changes are not required for this internal change; repository policy
defers standalone changelog entries for unreleased v4 functionality.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to
      this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions,
      changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new
      warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly
      authorized for that scope, as required by our
      [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the
      visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated
      content, and accept full responsibility for it.
