### PR TITLE
⚡ Improve initial layout with greedy candidates

### DIFF
--- a/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
@@ -200,15 +200,24 @@ def MappingPass : Pass<"place-and-route", "mlir::ModuleOp"> {
     To iteratively refine the mapping, the pass performs multiple forward and backward traversals of the circuit. In
     each traversal, the pass routes the circuit and updates the dynamic-to-static mapping based on the routing decisions
     made during that traversal. By performing multiple traversals, the pass can iteratively refine the mapping and
-    potentially find a more optimal solution. This is behavior is controlled by the `niterations` parameter.
+    potentially find a more optimal solution. This behavior is controlled by the `niterations` parameter.
 
-    The pass option `ntrials` determines how many random initial layouts the pass explores.
+    The pass option `ntrials` determines the number of initial refinement trials:
+    one identity layout and the remaining layouts chosen randomly.
     It defaults to the number of available logical CPUs reported by LLVM, taking
     CPU affinity into account, with a minimum of one. Disabling multithreading
     runs the same trials sequentially; it does not reduce the trial count.
     If compiled with multi-threading on, these trials will be executed in parallel.
     Set both `ntrials` and `seed` explicitly for reproducible results across
     machines with different CPU counts.
+
+    For programs with two-qubit interactions and no nested control flow on their
+    wires, the pass also constructs an interaction-weighted greedy layout.
+    It places frequently interacting qubits nearby, starting at a central
+    target site. Both the raw and refined greedy layouts are additional
+    candidates, independent of `ntrials`. A final forward routing traversal
+    scores each candidate. The pass selects the initial layout with the fewest
+    SWAPs in that traversal, retaining the earlier candidate on a tie.
   }];
   let options = [Option<"nlookahead", "nlookahead", "std::size_t", "1",
                         "The number of lookahead steps.">,
@@ -221,7 +230,7 @@ def MappingPass : Pass<"place-and-route", "mlir::ModuleOp"> {
                         "improve the initial layout. Must be > 0.">,
                  Option<"ntrials", "ntrials", "std::size_t",
                         "llvm::hardware_concurrency().compute_thread_count()",
-                        "The number of (possibly parallel) random trials of "
+                        "The number of identity/random trials of "
                         "the forwards and backwards mechanism. Defaults to "
                         "the available logical CPU count. Must be > 0.">,
                  Option<"seed", "seed", "std::size_t", "42",

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -795,8 +795,8 @@ private:
   ///
   /// Nested control flow has no single interaction frequency, so leave those
   /// programs to the identity and random starts.
-  std::optional<Layout> generateGreedyLayout(Wires wires,
-                                             const WireInfos& infos) const {
+  [[nodiscard]] std::optional<Layout>
+  generateGreedyLayout(Wires wires, const WireInfos& infos) const {
     DenseMap<IndexPairType, size_t> weights;
     bool supported = true;
     walkProgramGraph<WireDirection::Forward>(

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -791,37 +791,145 @@ private:
     return iterator.qubit();
   }
 
-  /// Execute `ntrials` many (parallel) initial layout refinement trials and
-  /// return the heuristically best one.
+  /// Place frequently interacting program qubits near each other.
   ///
-  /// The function uses the SABRE Approach to improve the initial layout:
-  /// Traverse the layers of the program from left-to-right-to-left and
-  /// cold-route along the way. Repeat this procedure "niterations" times and
-  /// finally find the trial with the fewest SWAPs on the final backwards pass
-  /// and return the respective layout.
+  /// Nested control flow has no single interaction frequency, so leave those
+  /// programs to the identity and random starts.
+  std::optional<Layout> generateGreedyLayout(Wires wires,
+                                             const WireInfos& infos) const {
+    DenseMap<IndexPairType, size_t> weights;
+    bool supported = true;
+    walkProgramGraph<WireDirection::Forward>(
+        MutableArrayRef(wires.data(), wires.size()),
+        [&](const Frontier& frontier, ReleasedOps& released) {
+          for (const auto& [op, indices] : frontier) {
+            if (op->getNumRegions() != 0 && !isa<UnitaryOpInterface>(op)) {
+              supported = false;
+              return WalkResult::interrupt();
+            }
+            if (indices.size() == 2 && !isa<BarrierOp>(op) &&
+                isa<UnitaryOpInterface>(op)) {
+              ++weights[std::minmax(infos.lookupProgram(indices[0]),
+                                    infos.lookupProgram(indices[1]))];
+            }
+            released.emplace_back(op);
+          }
+          return WalkResult::advance();
+        });
+    if (!supported || weights.empty()) {
+      return std::nullopt;
+    }
+
+    const size_t nprogram = infos.size();
+    const size_t nhardware = target->numSites();
+    SmallVector<SmallVector<IndexPairType>> neighbours(nprogram);
+    SmallVector<size_t> degree(nprogram, 0);
+    SmallVector<size_t> attached(nprogram, 0);
+    for (const auto& [pair, weight] : weights) {
+      const auto [a, b] = pair;
+      neighbours[a].emplace_back(b, weight);
+      neighbours[b].emplace_back(a, weight);
+      degree[a] += weight;
+      degree[b] += weight;
+    }
+
+    SmallVector<size_t> centrality(nhardware, 0);
+    SmallVector<size_t> hardwareDegree(nhardware, 0);
+    for (size_t hw = 0; hw < nhardware; ++hw) {
+      for (size_t other = 0; other < nhardware; ++other) {
+        centrality[hw] += target->distanceBetween(hw, other);
+      }
+      target->forEachNeighbour(hw, [&](size_t) { ++hardwareDegree[hw]; });
+    }
+
+    // The out-of-range hardware index marks an unplaced program qubit.
+    SmallVector<size_t> mapping(nhardware, nhardware);
+    SmallVector<bool> used(nhardware, false);
+    for (size_t placed = 0; placed < nprogram; ++placed) {
+      size_t prog = nprogram;
+      for (size_t candidate = 0; candidate < nprogram; ++candidate) {
+        if (mapping[candidate] == nhardware &&
+            (prog == nprogram ||
+             std::tie(attached[candidate], degree[candidate]) >
+                 std::tie(attached[prog], degree[prog]))) {
+          prog = candidate;
+        }
+      }
+
+      size_t best = nhardware;
+      size_t bestCost = 0;
+      for (size_t hw = 0; hw < nhardware; ++hw) {
+        if (used[hw]) {
+          continue;
+        }
+        size_t cost = 0;
+        for (const auto& [partner, weight] : neighbours[prog]) {
+          if (mapping[partner] != nhardware) {
+            cost += weight * target->distanceBetween(hw, mapping[partner]);
+          }
+        }
+        if (best == nhardware ||
+            std::tuple(cost, centrality[hw], nhardware - hardwareDegree[hw]) <
+                std::tuple(bestCost, centrality[best],
+                           nhardware - hardwareDegree[best])) {
+          best = hw;
+          bestCost = cost;
+        }
+      }
+      mapping[prog] = best;
+      used[best] = true;
+      for (const auto& [partner, weight] : neighbours[prog]) {
+        attached[partner] += weight;
+      }
+    }
+
+    // Complete the permutation with unused sites for routing workspace.
+    size_t prog = nprogram;
+    for (size_t hw = 0; hw < nhardware; ++hw) {
+      if (!used[hw]) {
+        mapping[prog++] = hw;
+      }
+    }
+    return Layout::fromMapping(mapping);
+  }
+
+  /// Refine identity, random, and greedy starts with forward/backward routing.
+  /// Keep the raw greedy start too: refinement can worsen forward routing.
+  /// Score each candidate with a forward traversal, preserving its start
+  /// layout.
   FailureOr<Layout> generateLayout(const Wires& wires, const WireInfos& infos) {
     std::mt19937_64 rng{seed};
 
     struct Trial {
       RoutingBundle bundle;
+      size_t iterations;
       Statistics stats{};
       bool success{false};
     };
 
     SmallVector<Trial, 0> trials;
-    trials.reserve(ntrials);
+    trials.reserve(ntrials + 2);
     for (size_t i = 0; i < ntrials; ++i) {
-      trials.emplace_back(RoutingBundle{
-          .wires = wires,
-          .infos = infos,
-          .layout = i == 0 ? Layout::identity(target->numSites())
-                           : Layout::random(target->numSites(),
-                                            target->numSites(), rng()),
-      });
+      trials.emplace_back(
+          RoutingBundle{
+              .wires = wires,
+              .infos = infos,
+              .layout = i == 0 ? Layout::identity(target->numSites())
+                               : Layout::random(target->numSites(),
+                                                target->numSites(), rng()),
+          },
+          niterations);
+    }
+    if (const auto greedy = generateGreedyLayout(wires, infos)) {
+      trials.emplace_back(
+          RoutingBundle{.wires = wires, .infos = infos, .layout = *greedy},
+          niterations);
+      trials.emplace_back(
+          RoutingBundle{.wires = wires, .infos = infos, .layout = *greedy}, 0);
     }
 
     parallelForEach(&getContext(), trials, [&, this](Trial& t) {
-      for (size_t i = 0; i < niterations; ++i) {
+      for (size_t i = 0; i < t.iterations; ++i) {
         const auto fwRouteRes = route<WireDirection::Forward>(t.bundle);
         if (failed(fwRouteRes)) {
           return;
@@ -831,10 +939,13 @@ private:
         if (failed(bwRouteRes)) {
           return;
         }
-
-        t.stats = *bwRouteRes;
       }
-
+      auto scoringBundle = t.bundle;
+      const auto score = route<WireDirection::Forward>(scoringBundle);
+      if (failed(score)) {
+        return;
+      }
+      t.stats = *score;
       t.success = true;
     });
 

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -2438,16 +2438,11 @@ TEST_F(MappingPassFixture, RetainRawGreedyLayoutWhenRefinementWorsensIt) {
   for (size_t i = 0; i < 4; ++i) {
     qubits.push_back(builder.h(builder.allocQubit()));
   }
-  for (const auto& [a, b] : SmallVector<std::pair<size_t, size_t>>{{3, 0},
-                                                                   {0, 3},
-                                                                   {1, 3},
-                                                                   {3, 2},
-                                                                   {0, 3},
-                                                                   {1, 2},
-                                                                   {3, 1},
-                                                                   {2, 1},
-                                                                   {3, 0},
-                                                                   {3, 2}}) {
+  const SmallVector<std::pair<size_t, size_t>> interactions{
+      {3, 0}, {0, 3}, {1, 3}, {3, 2}, {0, 3},
+      {1, 2}, {3, 1}, {2, 1}, {3, 0}, {3, 2},
+  };
+  for (const auto& [a, b] : interactions) {
     std::tie(qubits[a], qubits[b]) = builder.cx(qubits[a], qubits[b]);
   }
   for (Value qubit : qubits) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -2401,6 +2401,81 @@ TEST_P(MappingPassTest, MapPaddedCXCZGrid) {
   EXPECT_TRUE(isExecutable(getEntryPoint(m.get()), target));
 }
 
+TEST_F(MappingPassFixture, EmbedInteractionHubWithIdleQubitAndSpareSite) {
+  const auto target = llvm::cantFail(CompilerTarget::create(
+      6, Connectivity::fromCouplings({{2, 0}, {2, 1}, {2, 3}, {2, 4}, {2, 5}}),
+      NativeOperations::unrestricted()));
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  SmallVector<Value> qubits;
+  for (size_t i = 0; i < 5; ++i) {
+    qubits.push_back(builder.h(builder.allocQubit()));
+  }
+  for (size_t partner = 1; partner < 4; ++partner) {
+    std::tie(qubits[0], qubits[partner]) =
+        builder.cx(qubits[0], qubits[partner]);
+  }
+  for (Value qubit : qubits) {
+    builder.sink(qubit);
+  }
+  auto moduleOp = builder.finalize();
+  ASSERT_TRUE(
+      succeeded(runPass(*moduleOp, target, MappingPassOptions{.ntrials = 1})));
+  ASSERT_TRUE(succeeded(verify(*moduleOp)));
+  EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+  EXPECT_TRUE(isExecutable(getEntryPoint(*moduleOp), target));
+  size_t swaps = 0;
+  moduleOp->walk([&](SWAPOp) { ++swaps; });
+  // This interaction star embeds in the target without routing overhead.
+  EXPECT_EQ(swaps, 0);
+}
+
+TEST_F(MappingPassFixture, RetainRawGreedyLayoutWhenRefinementWorsensIt) {
+  const auto target = getSquareGridTarget(2);
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  SmallVector<Value> qubits;
+  for (size_t i = 0; i < 4; ++i) {
+    qubits.push_back(builder.h(builder.allocQubit()));
+  }
+  for (const auto& [a, b] : SmallVector<std::pair<size_t, size_t>>{{3, 0},
+                                                                   {0, 3},
+                                                                   {1, 3},
+                                                                   {3, 2},
+                                                                   {0, 3},
+                                                                   {1, 2},
+                                                                   {3, 1},
+                                                                   {2, 1},
+                                                                   {3, 0},
+                                                                   {3, 2}}) {
+    std::tie(qubits[a], qubits[b]) = builder.cx(qubits[a], qubits[b]);
+  }
+  for (Value qubit : qubits) {
+    builder.sink(qubit);
+  }
+  auto input = builder.finalize();
+  std::string expected;
+  for (bool multithreading : {false, true}) {
+    context->enableMultithreading(multithreading);
+    OwningOpRef<ModuleOp> moduleOp = input->clone();
+    ASSERT_TRUE(succeeded(runPass(
+        *moduleOp, target, MappingPassOptions{.ntrials = 1, .seed = 42})));
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+    EXPECT_TRUE(isExecutable(getEntryPoint(*moduleOp), target));
+    size_t swaps = 0;
+    moduleOp->walk([&](SWAPOp) { ++swaps; });
+    // Identity and refined greedy starts need four SWAPs; raw greedy needs
+    // three. Preserve this routing-quality bound across future heuristics.
+    EXPECT_LE(swaps, 3);
+    if (!multithreading) {
+      expected = printModule(*moduleOp);
+    } else {
+      EXPECT_EQ(printModule(*moduleOp), expected);
+    }
+  }
+}
+
 TEST_F(MappingPassFixture, ProduceStableOutputForFixedSeed) {
   constexpr size_t repetitions = 4;
   const auto target = getSquareGridTarget(10);


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Initial-layout refinement currently ranks trials by the last backward traversal, which can mispredict forward routing cost. Refinement can also make a useful starting layout worse.

Add an interaction-weighted greedy layout to the native QCO mapper. Retain both its raw and refined forms alongside the existing identity/random trials, then select the candidate requiring the fewest SWAPs in a forward routing traversal. Scoring preserves the candidate's initial layout.

The implementation reuses the program graph walker, cached target distances, and routing machinery. It adds no dependency or public option. Identity/random trial counts and seeds stay unchanged. Programs with nested control flow on their wires retain the existing starts and use forward scoring.

## Benchmark results

Matched native release builds: baseline `4faf68e3ae5b31bc5dbbd434e5e3ce5795096088` versus `3fd8f66d1` (later commits only adjust test formatting and add `[[nodiscard]]`; runtime behavior is unchanged). Both use AppleClang 21, LLVM/MLIR 23.1, and the same dependency sources.

Benchpress QASMBench small: **42 circuits × 4 topologies = 168 cases**. Topologies are all-to-all, square, heavy-hex, and linear. Mapping uses 10 identity/random trials, seed 42, and one refinement iteration. Aggregate quality covers the **152 static cases**; the 16 control-flow cases are validated and timed but excluded from these totals because top-level counts do not represent their executed cost.

| Metric, summed over static cases | Baseline | This change | Improvement |
| --- | ---: | ---: | ---: |
| CZ gates | 31,283 | 30,950 | **1.06% fewer** |
| Routing SWAPs | 1,497 | 1,386 | **7.41% fewer** |
| Two-qubit depth | 29,422 | 29,128 | **1.00% lower** |
| Single-qubit gates | 216,705 | 214,818 | **0.87% fewer** |

**16 cases improve in CZ/SWAP count; none regress in those counts.** Selected results:

| Case | CZ gates | Routing SWAPs |
| --- | ---: | ---: |
| VQE 8, square | 6,400 → 6,199 | 531 → 464 |
| QAOA 6, heavy-hex | 87 → 69 | 17 → 11 |
| DNN 8, linear | 148 → 127 | 28 → 21 |
| QEC 5, square | 13 → 10 | 1 → 0 |

Depth improves in 10 cases and worsens in five: SAT square 90 → 95, SAT heavy-hex 95 → 103, HHL square 129 → 133, and Simon square/heavy-hex 22 → 23 and 25 → 26. Candidate selection minimizes SWAP count, not depth.

Complete compilation time increases **0.8% geometrically** and **1.60% by summed per-case medians** (6.661 s → 6.767 s). Each case has one warm-up and six timed compilations per build, with balanced execution order. Timing includes copying, lowering, native interaction-graph construction, layout selection, and the complete target pipeline. It excludes parsing, immutable target setup, export, validation, and statistics collection.

Within-case timing spread is 10.3% for baseline and 11.7% for this change, so the sub-percent estimate is imprecise. At the measured defaults, eligible mappings use 34 cold routing traversals instead of 20. Results apply to the pinned revisions on one machine; large interaction graphs remain unmeasured.

## Validation

- **108 native mapper tests pass**, including two new regressions: a hub with an idle qubit and spare hardware site, and a four-qubit circuit where raw greedy needs three SWAPs while identity/refined greedy need four. The latter also checks deterministic threaded/sequential output.
- **336 compiled benchmark outputs pass target validation.**
- **56 complete state comparisons pass**, with maximum deviation from unit fidelity below `2.6e-13`. Logical output order is recovered from terminal measurements, including checks that unused physical sites remain in zero.
- Repository lint and full-file C++ lint pass with zero findings.
- Ponytail complexity review found no unnecessary abstraction or dependency.

## Checklist

- [x] Commits are focused on the mapper, pass documentation, and regression tests.
- [x] Tests cover the changed behavior.
- [x] Pass documentation describes the candidates, defaults, and control-flow boundary.
- [x] Changelog and migration entries are not required for this unreleased v4 functionality.
- [x] Local tests and style checks pass.
- [x] Agent code review is complete.
- [x] Hosted CI checks pass.

**AI assistance:** GPT-6 via Codex implemented, reviewed, and validated this change and prepared this description.

- [x] The user explicitly authorized creating the PR and its description.
- [x] This public text starts with the required AI disclosure.
- [x] AI assistance is disclosed above and in commit trailers.
- [x] A human has personally reviewed and understood the AI-assisted changes and accepted responsibility for them.

