### PR TITLE
🐛 Fix DD exports, numeric storage, and QCO evaluation

### DIFF
--- a/.agent/plans/dd-classical-evaluation.md
+++ b/.agent/plans/dd-classical-evaluation.md
@@ -1,0 +1,41 @@
+# QCO DD classical evaluation
+
+Status: complete.
+
+The DD interpreter evaluates scalar integer, index, and f64 operations for
+runtime arguments, measurements, and structured control flow. It preserves input
+IR, integer widths, numeric semantics, and existing runtime diagnostics.
+Ordinary values use LLVM APInt/APFloat and standard math functions. MLIR folding
+on a clone retains the behavior of overflow, exact, and non-negative flags,
+floating-point flags, explicit rounding, non-finite inputs, and math domains.
+The shared integer evaluator owns shift-range validation.
+
+`QCOProgram::cleanup()` already runs canonicalization without an iteration
+limit. It remains an optional compiler optimization. MLIR defines
+canonicalization as best effort, not a stable normal form. Dynamic operands
+survive the pass; requiring it would not remove their execution or validation
+code. The low-level APIs accept verified functions and caller-owned argument
+bindings.
+
+The runtime-input tests cover every added operation, all comparison predicates,
+wide integers, signed zero, non-finite values, flags, rounding, and invalid
+shifts and math domains. After rebasing onto the terminology changes in #2519,
+3,513 native tests passed and one existing sample-device job-ID test was
+skipped. Repository lint and full changed-file C++ lint passed. The rebase
+preserves OpenQASM import names and MQT compiler terminology.
+
+A matched Clang 23/LLVM-MLIR 23.1.0 ThinLTO experiment on a DGX Spark used five
+serial runs on CPU 0 per variant. Both variants share the rebased libraries; the
+control retains only the earlier direct-addition optimization. At 9,000
+iterations and 64 dynamic shots, mixed integer evaluation fell from 1,824 ms to
+860 ms and mixed floating-point evaluation from 1,970 ms to 1,411 ms. Observed
+ranges were 1,819–1,836 ms versus 857–919 ms for integers, and 1,927–2,033 ms
+versus 1,378–1,442 ms for floats. Addition and gate-sampling controls stayed
+within the observed spread. All 120 runs preserve ordered outcomes and input IR.
+
+Canonicalization leaves the dynamic loops unchanged. For constant math, it
+reduces the control from 2,825 ms to 1,212 ms; direct evaluation then reduces
+the canonicalized program to 873 ms. Canonicalization costs about 0.5 ms here.
+Unlimited canonicalization reaches the same fixed point on these fixtures. These
+measurements apply to classical interpretation, not general quantum-gate
+simulation. Hosted CI is separate from local validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ releases may include breaking changes.
 - ✨ Add DD construction, simulation, statevector extraction, and sampling for
   QCO programs with structured control and dynamic quantum data, including
   direct lowering and dense-array helpers for supported compiler inputs
-  ([#1915], [#1973], [#2077], [#2078], [#2079], [#2334]) ([**@simon1hofmann**],
-  [**@burgholzer**])
+  ([#1915], [#1973], [#2077], [#2078], [#2079], [#2334], [#2518])
+  ([**@simon1hofmann**], [**@burgholzer**])
 - ✨ Add immutable MQT compiler targets, selected payload specifications,
   payload-aware control-flow legalization, QDMI device integration, ordered
   operation applicability, directional native synthesis, target compilation
@@ -118,6 +118,12 @@ releases may include breaking changes.
   default, with one build option for source builds that omit both parts
   ([#1356], [#1549], [#1953], [#2284], [#2298]) ([**@burgholzer**],
   [**@denialhaag**], [**@simon1hofmann**])
+
+### Fixed
+
+- 🐛 Use deterministic, collision-free DOT node IDs, define signed
+  complex-weight hashing, and preserve real-number collection flags during
+  relinking ([#2518]) ([**@burgholzer**])
 
 ### Removed
 
@@ -935,6 +941,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2518]: https://github.com/munich-quantum-toolkit/core/pull/2518
 [#2500]: https://github.com/munich-quantum-toolkit/core/pull/2500
 [#2497]: https://github.com/munich-quantum-toolkit/core/pull/2497
 [#2495]: https://github.com/munich-quantum-toolkit/core/pull/2495

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ releases may include breaking changes.
   ([**@burgholzer**], [**@denialhaag**])
 - ✨ Add DD construction, simulation, statevector extraction, and sampling for
   QCO programs with structured control and dynamic quantum data, including
-  direct lowering and dense-array helpers for supported compiler inputs
-  ([#1915], [#1973], [#2077], [#2078], [#2079], [#2334], [#2518])
-  ([**@simon1hofmann**], [**@burgholzer**])
+  direct lowering, dense-array helpers, and direct scalar arithmetic evaluation
+  for supported compiler inputs ([#1915], [#1973], [#2077], [#2078], [#2079],
+  [#2334], [#2518]) ([**@simon1hofmann**], [**@burgholzer**])
 - ✨ Add immutable MQT compiler targets, selected payload specifications,
   payload-aware control-flow legalization, QDMI device integration, ordered
   operation applicability, directional native synthesis, target compilation

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -46,6 +46,17 @@ stay on that release series. C++ consumers should likewise use a v3 release
 branch or a matching v3 version constraint. MQT Core v3 and v4 cannot provide
 their Python or CMake packages in the same environment.
 
+### DD graph-rendering helpers
+
+`dd::toDot` and `dd::export2Dot` keep their signatures. Their node IDs now
+follow traversal order instead of memory addresses.
+
+Direct users of `modernNode`, `classicNode`, and `memoryNode` must pass a node
+ID between the edge and output stream arguments. Direct users of `bwEdge`,
+`coloredEdge`, and `memoryEdge` must replace the source/destination edge pair
+with the destination edge and explicit source/destination IDs. Use `toDot` to
+assign consistent IDs for a complete graph.
+
 ### Typed benchmark library
 
 MQT Core 4 provides the separate `MQT::CoreBench` library and `mqt-core-bench`

--- a/docs/dd_package.md
+++ b/docs/dd_package.md
@@ -102,7 +102,10 @@ with np.printoptions(precision=3, suppress=True):
 
 If [Graphviz](https://www.graphviz.org/) is installed, use
 {py:meth}`~mqt.core.dd.VectorDD.to_svg` to export a decision diagram as SVG.
-IPython can display the resulting file in a notebook.
+IPython can display the resulting file in a notebook. DOT exports use unique
+node IDs assigned in traversal order, so ordinary exports do not depend on
+memory addresses. The `memory=True` option includes addresses as debugging
+information.
 
 ```{code-cell} ipython3
 ---

--- a/include/mqt-core/dd/ComplexValue.hpp
+++ b/include/mqt-core/dd/ComplexValue.hpp
@@ -144,15 +144,11 @@ std::ostream& operator<<(std::ostream& os, const ComplexValue& c);
 template <> struct std::hash<dd::ComplexValue> {
   /// Compute the hash value for the given complex value.
   ///
-  /// The hash value is computed by scaling the real and imaginary part
-  /// by the tolerance of the complex table, rounding the result to the nearest
-  /// integer and computing the hash value of the resulting pair of integers.
+  /// Scale each component by the table tolerance and round to an integer
+  /// value. Hash the rounded floating-point values without integer conversion.
+  /// Nearby values can lie on opposite sides of a rounding boundary and thus
+  /// have different hashes. Compute-table lookups still compare full keys.
   /// @param c The complex value to compute the hash value for.
   /// @returns The hash value for the given complex value.
-  /// @note It is rather hard to define good hash functions for floating point
-  /// numbers. This hash function is not perfect, but it is fast and should
-  /// provide a good distribution of hash values. Furthermore, two floating
-  /// point numbers that are within the tolerance of the complex table will
-  /// always produce the same hash value.
   std::size_t operator()(dd::ComplexValue const& c) const noexcept;
 };

--- a/include/mqt-core/dd/Export.hpp
+++ b/include/mqt-core/dd/Export.hpp
@@ -19,6 +19,7 @@
 #include "dd/Node.hpp"
 #include "dd/RealNumber.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -49,13 +50,7 @@ static std::ostream& header(const Edge<Node>& e, std::ostream& os,
   os << "t [label=<<font "
         "point-size=\"20\">1</"
         "font>>,shape=box,tooltip=\"1\",width=0.3,height=0.3]\n";
-  auto toplabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U;
-  os << "root->";
-  if (e.isTerminal()) {
-    os << "t";
-  } else {
-    os << toplabel;
-  }
+  os << "root->" << (e.isTerminal() ? "t" : "0");
   os << "[penwidth=\"" << thicknessFromMagnitude(e.w) << "\",tooltip=\""
      << conditionalFormat(e.w, formatAsPolar) << "\"";
   if (!e.w.exactlyOne()) {
@@ -79,15 +74,9 @@ static std::ostream& coloredHeader(const Edge<Node>& e, std::ostream& os,
         "point-size=\"20\">1</"
         "font>>,shape=box,tooltip=\"1\",width=0.3,height=0.3]\n";
 
-  auto toplabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U;
   auto mag = thicknessFromMagnitude(e.w);
   auto color = colorFromPhase(e.w);
-  os << "root->";
-  if (e.isTerminal()) {
-    os << "t";
-  } else {
-    os << toplabel;
-  }
+  os << "root->" << (e.isTerminal() ? "t" : "0");
   os << "[penwidth=\"" << mag << "\",tooltip=\""
      << conditionalFormat(e.w, formatAsPolar) << "\",color=\"" << color << "\"";
   if (edgeLabels) {
@@ -106,15 +95,9 @@ static std::ostream& memoryHeader(const Edge<Node>& e, std::ostream& os,
         "point-size=\"20\">1</"
         "font>>,shape=box,tooltip=\"1\",width=0.3,height=0.3]\n";
 
-  auto toplabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U;
   auto mag = thicknessFromMagnitude(e.w);
   auto color = colorFromPhase(e.w);
-  os << "root->";
-  if (e.isTerminal()) {
-    os << "t";
-  } else {
-    os << toplabel;
-  }
+  os << "root->" << (e.isTerminal() ? "t" : "0");
   os << "[penwidth=\"" << mag << "\",tooltip=\"" << e.w.toString(false, 4)
      << "\" color=\"" << color << "\"";
   if (edgeLabels) {
@@ -150,20 +133,19 @@ static std::ostream& memoryHeader(const Edge<Node>& e, std::ostream& os,
   return os;
 }
 
-std::ostream& modernNode(const mEdge& e, std::ostream& os,
+std::ostream& modernNode(const mEdge& e, size_t nodeId, std::ostream& os,
                          bool formatAsPolar = true);
-std::ostream& modernNode(const vEdge& e, std::ostream& os,
+std::ostream& modernNode(const vEdge& e, size_t nodeId, std::ostream& os,
                          bool formatAsPolar = true);
-std::ostream& classicNode(const mEdge& e, std::ostream& os,
+std::ostream& classicNode(const mEdge& e, size_t nodeId, std::ostream& os,
                           bool formatAsPolar = true);
-std::ostream& classicNode(const vEdge& e, std::ostream& os,
+std::ostream& classicNode(const vEdge& e, size_t nodeId, std::ostream& os,
                           bool formatAsPolar = true);
 template <class Node>
-static std::ostream& memoryNode(const Edge<Node>& e, std::ostream& os) {
+static std::ostream& memoryNode(const Edge<Node>& e, size_t nodeId,
+                                std::ostream& os) {
   constexpr std::size_t n = std::tuple_size_v<decltype(e.p->e)>;
-  auto nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >>
-                   1U; // this allows for 2^20 (roughly 1e6) unique nodes
-  os << nodelabel << "[label=<";
+  os << nodeId << "[label=<";
   os << R"(<font point-size="10"><table border="1" cellspacing="0" cellpadding="2" style="rounded">)";
   os << R"(<tr><td colspan=")" << n << R"(" border="1" sides="B">)" << std::hex
      << reinterpret_cast<std::uintptr_t>(e.p) << std::dec << "</td></tr>";
@@ -186,31 +168,31 @@ static std::ostream& memoryNode(const Edge<Node>& e, std::ostream& os) {
   return os;
 }
 
-std::ostream& bwEdge(const mEdge& from, const mEdge& to, std::uint16_t idx,
-                     std::ostream& os, bool edgeLabels = false,
-                     bool classic = false, bool formatAsPolar = true);
-std::ostream& bwEdge(const vEdge& from, const vEdge& to, std::uint16_t idx,
-                     std::ostream& os, bool edgeLabels = false,
-                     bool classic = false, bool formatAsPolar = true);
-std::ostream& coloredEdge(const mEdge& from, const mEdge& to, std::uint16_t idx,
-                          std::ostream& os, bool edgeLabels = false,
-                          bool classic = false, bool formatAsPolar = true);
-std::ostream& coloredEdge(const vEdge& from, const vEdge& to, std::uint16_t idx,
-                          std::ostream& os, bool edgeLabels = false,
-                          bool classic = false, bool formatAsPolar = true);
+std::ostream& bwEdge(const mEdge& to, size_t fromId, size_t toId,
+                     std::uint16_t idx, std::ostream& os,
+                     bool edgeLabels = false, bool classic = false,
+                     bool formatAsPolar = true);
+std::ostream& bwEdge(const vEdge& to, size_t fromId, size_t toId,
+                     std::uint16_t idx, std::ostream& os,
+                     bool edgeLabels = false, bool classic = false,
+                     bool formatAsPolar = true);
+std::ostream& coloredEdge(const mEdge& to, size_t fromId, size_t toId,
+                          std::uint16_t idx, std::ostream& os,
+                          bool edgeLabels = false, bool classic = false,
+                          bool formatAsPolar = true);
+std::ostream& coloredEdge(const vEdge& to, size_t fromId, size_t toId,
+                          std::uint16_t idx, std::ostream& os,
+                          bool edgeLabels = false, bool classic = false,
+                          bool formatAsPolar = true);
 template <class Node>
-static std::ostream& memoryEdge(const Edge<Node>& from, const Edge<Node>& to,
-                                std::uint16_t idx, std::ostream& os,
-                                bool edgeLabels = false) {
-  auto fromlabel =
-      (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
-  auto tolabel = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
-
-  os << fromlabel << ":" << idx << ":s->";
+static std::ostream& memoryEdge(const Edge<Node>& to, size_t fromId,
+                                size_t toId, std::uint16_t idx,
+                                std::ostream& os, bool edgeLabels = false) {
+  os << fromId << ":" << idx << ":s->";
   if (to.isTerminal()) {
     os << "t";
   } else {
-    os << tolabel;
+    os << toId;
   }
 
   auto mag = thicknessFromMagnitude(to.w);
@@ -264,26 +246,14 @@ static void toDot(const Edge<Node>& e, std::ostream& os, bool colored = true,
     header(e, oss, edgeLabels, formatAsPolar);
   }
 
-  std::unordered_set<decltype(e.p)> nodes{};
-
-  auto priocmp = [](const Edge<Node>* left, const Edge<Node>* right) {
-    if (left->p == nullptr) {
-      return right->p != nullptr;
-    }
-    if (right->p == nullptr) {
-      return false;
-    }
-    return left->p->v < right->p->v;
-  };
-
-  std::priority_queue<const Edge<Node>*, std::vector<const Edge<Node>*>,
-                      decltype(priocmp)>
-      q(priocmp);
+  /// Assign IDs on discovery, independent of allocation addresses.
+  std::unordered_map<const Node*, size_t> nodes{{e.p, 0}};
+  std::queue<const Edge<Node>*> q;
   q.push(&e);
 
   // bfs until finished
   while (!q.empty()) {
-    auto node = q.top();
+    auto node = q.front();
     q.pop();
 
     // base case
@@ -291,20 +261,16 @@ static void toDot(const Edge<Node>& e, std::ostream& os, bool colored = true,
       continue;
     }
 
-    // check if node has already been processed
-    auto ret = nodes.emplace(node->p);
-    if (!ret.second) {
-      continue;
-    }
+    const auto nodeId = nodes.at(node->p);
 
     // node definition as HTML-like label (href="javascript:;" is used as
     // workaround to make tooltips work)
     if (memory) {
-      memoryNode(*node, oss);
+      memoryNode(*node, nodeId, oss);
     } else if (classic) {
-      classicNode(*node, oss, formatAsPolar);
+      classicNode(*node, nodeId, oss, formatAsPolar);
     } else {
-      modernNode(*node, oss, formatAsPolar);
+      modernNode(*node, nodeId, oss, formatAsPolar);
     }
 
     // iterate over edges in reverse to guarantee correct processing order
@@ -316,17 +282,24 @@ static void toDot(const Edge<Node>& e, std::ostream& os, bool colored = true,
         continue;
       }
 
-      // non-zero edge to be included
-      q.push(&edge);
+      size_t childId = 0;
+      if (!edge.isTerminal()) {
+        const auto [it, inserted] = nodes.try_emplace(edge.p, nodes.size());
+        childId = it->second;
+        if (inserted) {
+          q.push(&edge);
+        }
+      }
 
       if (memory) {
-        memoryEdge(*node, edge, static_cast<std::uint16_t>(i), oss, edgeLabels);
+        memoryEdge(edge, nodeId, childId, static_cast<std::uint16_t>(i), oss,
+                   edgeLabels);
       } else if (colored) {
-        coloredEdge(*node, edge, static_cast<std::uint16_t>(i), oss, edgeLabels,
-                    classic, formatAsPolar);
+        coloredEdge(edge, nodeId, childId, static_cast<std::uint16_t>(i), oss,
+                    edgeLabels, classic, formatAsPolar);
       } else {
-        bwEdge(*node, edge, static_cast<std::uint16_t>(i), oss, edgeLabels,
-               classic, formatAsPolar);
+        bwEdge(edge, nodeId, childId, static_cast<std::uint16_t>(i), oss,
+               edgeLabels, classic, formatAsPolar);
       }
     }
   }

--- a/include/mqt-core/dd/RealNumber.hpp
+++ b/include/mqt-core/dd/RealNumber.hpp
@@ -34,6 +34,10 @@ struct RealNumber final : LLBase {
   /// Getter for the next object.
   [[nodiscard]] RealNumber* next() const noexcept;
 
+  /// Relink an entry without discarding its collection flags.
+  /// Use LLBase::setNext to initialize a fresh or reused entry.
+  void setNext(LLBase* next) noexcept;
+
   /// Check whether the number points to the zero number.
   /// @param e The number to check.
   /// @returns Whether the number points to zero.

--- a/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
@@ -60,6 +60,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -784,15 +785,6 @@ static LogicalResult foldClassicalOp(Operation& op, ClassicalEnv& classical) {
       operands.push_back(*attr);
     }
 
-    if (isa<arith::ShLIOp, arith::ShRUIOp, arith::ShRSIOp>(op)) {
-      const auto lhs = cast<IntegerAttr>(operands[0]);
-      const auto rhs = cast<IntegerAttr>(operands[1]);
-      if (rhs.getValue().uge(lhs.getValue().getBitWidth())) {
-        return op.emitError()
-               << "shift amount out of range for QCO DD simulation";
-      }
-    }
-
     SmallVector<OpFoldResult, 1> results;
     if (failed(clone->fold(operands, results))) {
       break;
@@ -817,6 +809,127 @@ static LogicalResult foldClassicalOp(Operation& op, ClassicalEnv& classical) {
   return success();
 }
 
+template <typename OpTy, typename Combine>
+static LogicalResult applyIntegerBinaryOp(OpTy op, ClassicalEnv& classical,
+                                          Combine combine) {
+  auto lhs = lookupInteger(op.getLhs(), classical, op);
+  auto rhs = lookupInteger(op.getRhs(), classical, op);
+  if (failed(lhs) || failed(rhs)) {
+    return failure();
+  }
+  if constexpr (std::is_same_v<OpTy, arith::ShLIOp> ||
+                std::is_same_v<OpTy, arith::ShRUIOp> ||
+                std::is_same_v<OpTy, arith::ShRSIOp>) {
+    if (rhs->uge(lhs->getBitWidth())) {
+      return op.emitError()
+             << "shift amount out of range for QCO DD simulation";
+    }
+  }
+  if constexpr (requires { op.getOverflowFlags(); }) {
+    if (op.getOverflowFlags() != arith::IntegerOverflowFlags::none) {
+      return foldClassicalOp(*op, classical);
+    }
+  }
+  if constexpr (requires { op.getIsExact(); }) {
+    if (op.getIsExact()) {
+      return foldClassicalOp(*op, classical);
+    }
+  }
+  return bindInteger(op.getResult(), combine(*lhs, *rhs), classical);
+}
+
+static LogicalResult applyFloatOp(Operation& op, ClassicalEnv& classical) {
+  /// Keep MLIR's flag-dependent folds and explicit rounding modes.
+  if (auto flagged = dyn_cast<arith::ArithFastMathInterface>(op);
+      (flagged && flagged.getFastMathFlagsAttr().getValue() !=
+                      arith::FastMathFlags::none) ||
+      op.hasAttr("roundingmode")) {
+    return foldClassicalOp(op, classical);
+  }
+  SmallVector<llvm::APFloat, 2> operands;
+  for (Value operand : op.getOperands()) {
+    auto attr = lookupAttribute(operand, classical, &op);
+    if (failed(attr)) {
+      return failure();
+    }
+    auto floating = dyn_cast<FloatAttr>(*attr);
+    if (!floating) {
+      return op.emitError() << "expected an f64 SSA value";
+    }
+    /// Folders can preserve NaN payloads through algebraic identities.
+    if (!floating.getValue().isFinite()) {
+      return foldClassicalOp(op, classical);
+    }
+    operands.push_back(floating.getValue());
+  }
+  auto& lhs = operands.front();
+  if (isa<math::LogOp, math::SqrtOp>(op) && lhs.isNegative()) {
+    return foldClassicalOp(op, classical);
+  }
+  if (auto cmp = dyn_cast<arith::CmpFOp>(op)) {
+    return bindInteger(
+        cmp.getResult(),
+        llvm::APInt(1, static_cast<uint64_t>(arith::applyCmpPredicate(
+                           cmp.getPredicate(), lhs, operands[1]))),
+        classical);
+  }
+  const llvm::APFloat result =
+      TypeSwitch<Operation*, llvm::APFloat>(&op)
+          .Case([&](arith::AddFOp) { return lhs + operands[1]; })
+          .Case([&](arith::SubFOp) { return lhs - operands[1]; })
+          .Case([&](arith::MulFOp) { return lhs * operands[1]; })
+          .Case([&](arith::DivFOp) { return lhs / operands[1]; })
+          .Case([&](arith::RemFOp) {
+            lhs.mod(operands[1]);
+            return lhs;
+          })
+          .Case([&](arith::NegFOp) { return -lhs; })
+          .Case([&](arith::MaximumFOp) {
+            return llvm::maximum(lhs, operands[1]);
+          })
+          .Case([&](arith::MinimumFOp) {
+            return llvm::minimum(lhs, operands[1]);
+          })
+          .Case(
+              [&](arith::MaxNumFOp) { return llvm::maxnum(lhs, operands[1]); })
+          .Case(
+              [&](arith::MinNumFOp) { return llvm::minnum(lhs, operands[1]); })
+          .Case([&](math::AbsFOp) { return llvm::abs(lhs); })
+          .Case([&](math::CeilOp) {
+            lhs.roundToIntegral(llvm::APFloat::rmTowardPositive);
+            return lhs;
+          })
+          .Case([&](math::FloorOp) {
+            lhs.roundToIntegral(llvm::APFloat::rmTowardNegative);
+            return lhs;
+          })
+          .Case([&](math::CosOp) {
+            return llvm::APFloat(std::cos(lhs.convertToDouble()));
+          })
+          .Case([&](math::SinOp) {
+            return llvm::APFloat(std::sin(lhs.convertToDouble()));
+          })
+          .Case([&](math::TanOp) {
+            return llvm::APFloat(std::tan(lhs.convertToDouble()));
+          })
+          .Case([&](math::ExpOp) {
+            return llvm::APFloat(std::exp(lhs.convertToDouble()));
+          })
+          .Case([&](math::LogOp) {
+            return llvm::APFloat(std::log(lhs.convertToDouble()));
+          })
+          .Case([&](math::SqrtOp) {
+            return llvm::APFloat(std::sqrt(lhs.convertToDouble()));
+          })
+          .Case([&](math::PowFOp) {
+            return llvm::APFloat(
+                std::pow(lhs.convertToDouble(), operands[1].convertToDouble()));
+          });
+  classical.values[op.getResult(0)] =
+      FloatAttr::get(op.getResult(0).getType(), result);
+  return success();
+}
+
 static LogicalResult applyClassicalOp(Operation& op, ClassicalEnv& classical) {
   const auto isUnsupportedFloat = [](Type type) {
     return isa<FloatType>(type) && !type.isF64();
@@ -827,29 +940,83 @@ static LogicalResult applyClassicalOp(Operation& op, ClassicalEnv& classical) {
            << "QCO DD simulation only supports f64 classical values";
   }
   return TypeSwitch<Operation*, LogicalResult>(&op)
-      .Case([&](arith::AddIOp add) -> LogicalResult {
-        if (add.getOverflowFlags() != arith::IntegerOverflowFlags::none) {
-          return foldClassicalOp(op, classical);
-        }
-        auto lhs = lookupInteger(add.getLhs(), classical, add);
-        auto rhs = lookupInteger(add.getRhs(), classical, add);
-        if (failed(lhs) || failed(rhs)) {
+      .Case([&](arith::AddIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, std::plus<>{});
+      })
+      .Case([&](arith::SubIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, std::minus<>{});
+      })
+      .Case([&](arith::MulIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, std::multiplies<>{});
+      })
+      .Case([&](arith::AndIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, std::bit_and<>{});
+      })
+      .Case([&](arith::OrIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, std::bit_or<>{});
+      })
+      .Case([&](arith::XOrIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, std::bit_xor<>{});
+      })
+      .Case([&](arith::MaxSIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, llvm::APIntOps::smax);
+      })
+      .Case([&](arith::MinSIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, llvm::APIntOps::smin);
+      })
+      .Case([&](arith::MaxUIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, llvm::APIntOps::umax);
+      })
+      .Case([&](arith::MinUIOp integer) {
+        return applyIntegerBinaryOp(integer, classical, llvm::APIntOps::umin);
+      })
+      .Case([&](arith::ShLIOp shift) {
+        return applyIntegerBinaryOp(
+            shift, classical,
+            [](const llvm::APInt& lhs, const llvm::APInt& rhs) {
+              return lhs.shl(rhs);
+            });
+      })
+      .Case([&](arith::ShRUIOp shift) {
+        return applyIntegerBinaryOp(
+            shift, classical,
+            [](const llvm::APInt& lhs, const llvm::APInt& rhs) {
+              return lhs.lshr(rhs);
+            });
+      })
+      .Case([&](arith::ShRSIOp shift) {
+        return applyIntegerBinaryOp(
+            shift, classical,
+            [](const llvm::APInt& lhs, const llvm::APInt& rhs) {
+              return lhs.ashr(rhs);
+            });
+      })
+      .Case([&](arith::CmpIOp cmp) {
+        return applyIntegerBinaryOp(
+            cmp, classical,
+            [&](const llvm::APInt& lhs, const llvm::APInt& rhs) {
+              return llvm::APInt(1,
+                                 static_cast<uint64_t>(arith::applyCmpPredicate(
+                                     cmp.getPredicate(), lhs, rhs)));
+            });
+      })
+      .Case([&](math::CtPopOp count) -> LogicalResult {
+        auto value = lookupInteger(count.getOperand(), classical, count);
+        if (failed(value)) {
           return failure();
         }
-        return bindInteger(add.getResult(), *lhs + *rhs, classical);
+        return bindInteger(count.getResult(),
+                           llvm::APInt(value->getBitWidth(), value->popcount()),
+                           classical);
       })
-      .Case<arith::AndIOp, arith::OrIOp, arith::XOrIOp, arith::SubIOp,
-            arith::MulIOp, arith::ShLIOp, arith::ShRUIOp, arith::ShRSIOp,
-            arith::CmpIOp, arith::AddFOp, arith::SubFOp, arith::MulFOp,
-            arith::DivFOp, arith::RemFOp, arith::NegFOp, arith::CmpFOp,
-            arith::SIToFPOp, arith::UIToFPOp, arith::MaxSIOp, arith::MinSIOp,
-            arith::MaxUIOp, arith::MinUIOp, arith::MaximumFOp,
+      .Case<arith::AddFOp, arith::SubFOp, arith::MulFOp, arith::DivFOp,
+            arith::RemFOp, arith::NegFOp, arith::CmpFOp, arith::MaximumFOp,
             arith::MinimumFOp, arith::MaxNumFOp, arith::MinNumFOp, math::AbsFOp,
             math::CeilOp, math::CosOp, math::ExpOp, math::FloorOp, math::LogOp,
-            math::SinOp, math::SqrtOp, math::TanOp, math::PowFOp,
-            math::CtPopOp>([&](Operation* foldable) {
-        return foldClassicalOp(*foldable, classical);
-      })
+            math::SinOp, math::SqrtOp, math::TanOp, math::PowFOp>(
+          [&](Operation* floating) {
+            return applyFloatOp(*floating, classical);
+          })
       .Case<LLVM::FshlOp, LLVM::FshrOp>([&](Operation* shift) -> LogicalResult {
         auto lhs = lookupInteger(shift->getOperand(0), classical, shift);
         auto rhs = lookupInteger(shift->getOperand(1), classical, shift);
@@ -912,6 +1079,24 @@ static LogicalResult applyClassicalOp(Operation& op, ClassicalEnv& classical) {
         return applyIntegerCast(cast.getIn(), cast.getOut(), cast, classical,
                                 true);
       })
+      .Case<arith::SIToFPOp, arith::UIToFPOp>(
+          [&](Operation* castOp) -> LogicalResult {
+            if (auto cast = dyn_cast<arith::UIToFPOp>(castOp);
+                cast && cast.getNonNeg()) {
+              return foldClassicalOp(*castOp, classical);
+            }
+            auto value =
+                lookupInteger(castOp->getOperand(0), classical, castOp);
+            if (failed(value)) {
+              return failure();
+            }
+            llvm::APFloat result(0.0);
+            result.convertFromAPInt(*value, isa<arith::SIToFPOp>(castOp),
+                                    llvm::APFloat::rmNearestTiesToEven);
+            classical.values[castOp->getResult(0)] =
+                FloatAttr::get(castOp->getResult(0).getType(), result);
+            return success();
+          })
       .Case<arith::FPToSIOp, arith::FPToUIOp>(
           [&](Operation* castOp) -> LogicalResult {
             auto value = lookupFloat(castOp->getOperand(0), classical, castOp);

--- a/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
@@ -827,12 +827,23 @@ static LogicalResult applyClassicalOp(Operation& op, ClassicalEnv& classical) {
            << "QCO DD simulation only supports f64 classical values";
   }
   return TypeSwitch<Operation*, LogicalResult>(&op)
-      .Case<arith::AndIOp, arith::OrIOp, arith::XOrIOp, arith::AddIOp,
-            arith::SubIOp, arith::MulIOp, arith::ShLIOp, arith::ShRUIOp,
-            arith::ShRSIOp, arith::CmpIOp, arith::AddFOp, arith::SubFOp,
-            arith::MulFOp, arith::DivFOp, arith::RemFOp, arith::NegFOp,
-            arith::CmpFOp, arith::SIToFPOp, arith::UIToFPOp, arith::MaxSIOp,
-            arith::MinSIOp, arith::MaxUIOp, arith::MinUIOp, arith::MaximumFOp,
+      .Case([&](arith::AddIOp add) -> LogicalResult {
+        if (add.getOverflowFlags() != arith::IntegerOverflowFlags::none) {
+          return foldClassicalOp(op, classical);
+        }
+        auto lhs = lookupInteger(add.getLhs(), classical, add);
+        auto rhs = lookupInteger(add.getRhs(), classical, add);
+        if (failed(lhs) || failed(rhs)) {
+          return failure();
+        }
+        return bindInteger(add.getResult(), *lhs + *rhs, classical);
+      })
+      .Case<arith::AndIOp, arith::OrIOp, arith::XOrIOp, arith::SubIOp,
+            arith::MulIOp, arith::ShLIOp, arith::ShRUIOp, arith::ShRSIOp,
+            arith::CmpIOp, arith::AddFOp, arith::SubFOp, arith::MulFOp,
+            arith::DivFOp, arith::RemFOp, arith::NegFOp, arith::CmpFOp,
+            arith::SIToFPOp, arith::UIToFPOp, arith::MaxSIOp, arith::MinSIOp,
+            arith::MaxUIOp, arith::MinUIOp, arith::MaximumFOp,
             arith::MinimumFOp, arith::MaxNumFOp, arith::MinNumFOp, math::AbsFOp,
             math::CeilOp, math::CosOp, math::ExpOp, math::FloorOp, math::LogOp,
             math::SinOp, math::SqrtOp, math::TanOp, math::PowFOp,

--- a/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
@@ -44,6 +44,7 @@
 #include "mlir/Support/LogicalResult.h"
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <array>
@@ -3423,6 +3424,68 @@ TEST_F(QCODDFunctionalityTest, StatevectorSkipsUnreachedAllocations) {
   ASSERT_EQ(vector.size(), 1U);
   EXPECT_NEAR(std::norm(vector[0]), 1.0, 1e-12);
   dd->decRef(*state);
+}
+
+TEST_F(QCODDFunctionalityTest, IntegerAdditionPreservesWidthFlagsAndInputIR) {
+  for (const auto& [type, lhs, rhs, expected, flags] : {
+           std::array{"i8", "127", "1", "-128", ""},
+           std::array{
+               "i64",
+               "9223372036854775807",
+               "1",
+               "-9223372036854775808",
+               "",
+           },
+           std::array{
+               "i129",
+               "170141183460469231731687303715884105728",
+               "170141183460469231731687303715884105728",
+               "340282366920938463463374607431768211456",
+               "",
+           },
+           std::array{"index", "-1", "1", "0", ""},
+           std::array{"i8", "-3", "1", "-2", ""},
+           std::array{"i64", "-3", "1", "-2", "overflow<nsw>"},
+           std::array{"i129", "1", "2", "3", "overflow<nuw, nsw>"},
+       }) {
+    SCOPED_TRACE(::testing::Message()
+                 << type << ": " << lhs << " + " << rhs << " " << flags);
+    auto mod = parseSourceString<ModuleOp>(llvm::formatv(R"mlir(
+      module {{
+        func.func @main() {{
+          %lhs = arith.constant {1} : {0}
+          %rhs = arith.constant {2} : {0}
+          %expected = arith.constant {3} : {0}
+          %sum = arith.addi %lhs, %rhs {4} : {0}
+          %ok = arith.cmpi eq, %sum, %expected : {0}
+          %q = qco.static 0 : !qco.qubit
+          %out = qco.if %ok args(%arg = %q) -> (!qco.qubit) {{
+            %x = qco.x %arg : !qco.qubit -> !qco.qubit
+            qco.yield %x : !qco.qubit
+          } else args(%arg = %q) {{
+            qco.yield %arg : !qco.qubit
+          }
+          qco.sink %out : !qco.qubit
+          return
+        }
+      }
+    )mlir",
+                                                         type, lhs, rhs,
+                                                         expected, flags)
+                                               .str(),
+                                           context.get());
+    ASSERT_TRUE(mod);
+    ASSERT_TRUE(succeeded(verify(*mod)));
+    std::string before;
+    llvm::raw_string_ostream beforeStream(before);
+    mod->print(beforeStream);
+    expectSimulatesFromZero(mainFunc(*mod), true);
+    ASSERT_TRUE(succeeded(verify(*mod)));
+    std::string after;
+    llvm::raw_string_ostream afterStream(after);
+    mod->print(afterStream);
+    EXPECT_EQ(before, after);
+  }
 }
 
 } // namespace

--- a/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
@@ -24,6 +24,7 @@
 
 #include "gtest/gtest.h"
 
+#include "mlir/AsmParser/AsmParser.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -3426,10 +3427,12 @@ TEST_F(QCODDFunctionalityTest, StatevectorSkipsUnreachedAllocations) {
   dd->decRef(*state);
 }
 
-TEST_F(QCODDFunctionalityTest, IntegerAdditionPreservesWidthFlagsAndInputIR) {
-  for (const auto& [type, lhs, rhs, expected, flags] : {
-           std::array{"i8", "127", "1", "-128", ""},
+TEST_F(QCODDFunctionalityTest,
+       IntegerEvaluationPreservesWidthsFlagsAndInputIR) {
+  for (const auto& [opcode, type, lhs, rhs, expected, flags] : {
+           std::array{"arith.addi", "i8", "127", "1", "-128", ""},
            std::array{
+               "arith.addi",
                "i64",
                "9223372036854775807",
                "1",
@@ -3437,27 +3440,73 @@ TEST_F(QCODDFunctionalityTest, IntegerAdditionPreservesWidthFlagsAndInputIR) {
                "",
            },
            std::array{
+               "arith.addi",
                "i129",
                "170141183460469231731687303715884105728",
                "170141183460469231731687303715884105728",
                "340282366920938463463374607431768211456",
                "",
            },
-           std::array{"index", "-1", "1", "0", ""},
-           std::array{"i8", "-3", "1", "-2", ""},
-           std::array{"i64", "-3", "1", "-2", "overflow<nsw>"},
-           std::array{"i129", "1", "2", "3", "overflow<nuw, nsw>"},
+           std::array{"arith.addi", "index", "-1", "1", "0", ""},
+           std::array{"arith.addi", "i8", "-3", "1", "-2", ""},
+           std::array{"arith.addi", "i64", "-3", "1", "-2", "overflow<nsw>"},
+           std::array{
+               "arith.addi",
+               "i129",
+               "1",
+               "2",
+               "3",
+               "overflow<nuw, nsw>",
+           },
+           std::array{"arith.subi", "i8", "-128", "1", "127", ""},
+           std::array{"arith.subi", "i8", "-3", "1", "-4", "overflow<nsw>"},
+           std::array{"arith.muli", "i8", "64", "4", "0", ""},
+           std::array{"arith.muli", "i8", "3", "4", "12", "overflow<nuw, nsw>"},
+           std::array{"arith.andi", "i8", "-86", "15", "10", ""},
+           std::array{"arith.ori", "i8", "-86", "15", "-81", ""},
+           std::array{"arith.xori", "i8", "-86", "15", "-91", ""},
+           std::array{"arith.shli", "i8", "1", "7", "-128", ""},
+           std::array{"arith.shli", "i8", "1", "3", "8", "overflow<nuw, nsw>"},
+           std::array{"arith.shrui", "i8", "-128", "7", "1", ""},
+           std::array{"arith.shrsi", "i8", "-128", "7", "-1", ""},
+           std::array{"arith.shrui", "i8", "-128", "7", "1", "exact"},
+           std::array{"arith.shrsi", "i8", "-128", "7", "-1", "exact"},
+           std::array{
+               "arith.shli",
+               "i129",
+               "1",
+               "128",
+               "340282366920938463463374607431768211456",
+               "",
+           },
+           std::array{"arith.maxsi", "i8", "-1", "1", "1", ""},
+           std::array{"arith.minsi", "i8", "-1", "1", "-1", ""},
+           std::array{"arith.maxui", "i8", "-1", "1", "-1", ""},
+           std::array{"arith.minui", "i8", "-1", "1", "1", ""},
+           std::array{"math.ctpop", "i129", "-1", "0", "129", ""},
+           std::array{"arith.cmpi eq,", "i8", "-1", "1", "0", ""},
+           std::array{"arith.cmpi ne,", "i8", "-1", "1", "1", ""},
+           std::array{"arith.cmpi slt,", "i8", "-1", "1", "1", ""},
+           std::array{"arith.cmpi sle,", "i8", "-1", "1", "1", ""},
+           std::array{"arith.cmpi sgt,", "i8", "-1", "1", "0", ""},
+           std::array{"arith.cmpi sge,", "i8", "-1", "1", "0", ""},
+           std::array{"arith.cmpi ult,", "i8", "-1", "1", "0", ""},
+           std::array{"arith.cmpi ule,", "i8", "-1", "1", "0", ""},
+           std::array{"arith.cmpi ugt,", "i8", "-1", "1", "1", ""},
+           std::array{"arith.cmpi uge,", "i8", "-1", "1", "1", ""},
        }) {
-    SCOPED_TRACE(::testing::Message()
-                 << type << ": " << lhs << " + " << rhs << " " << flags);
-    auto mod = parseSourceString<ModuleOp>(llvm::formatv(R"mlir(
+    SCOPED_TRACE(::testing::Message() << opcode << " " << type << " " << flags);
+    const auto* const resultType =
+        StringRef(opcode).starts_with("arith.cmpi") ? "i1" : type;
+    const auto* const operands =
+        StringRef(opcode) == "math.ctpop" ? "%lhs" : "%lhs, %rhs";
+    auto mod = parseSourceString<ModuleOp>(
+        llvm::formatv(R"mlir(
       module {{
-        func.func @main() {{
-          %lhs = arith.constant {1} : {0}
-          %rhs = arith.constant {2} : {0}
-          %expected = arith.constant {3} : {0}
-          %sum = arith.addi %lhs, %rhs {4} : {0}
-          %ok = arith.cmpi eq, %sum, %expected : {0}
+        func.func @main(%lhs: {0}, %rhs: {0}) {{
+          %expected = arith.constant {1} : {2}
+          %result = {3} {4} {5} : {0}
+          %ok = arith.cmpi eq, %result, %expected : {2}
           %q = qco.static 0 : !qco.qubit
           %out = qco.if %ok args(%arg = %q) -> (!qco.qubit) {{
             %x = qco.x %arg : !qco.qubit -> !qco.qubit
@@ -3470,21 +3519,289 @@ TEST_F(QCODDFunctionalityTest, IntegerAdditionPreservesWidthFlagsAndInputIR) {
         }
       }
     )mlir",
-                                                         type, lhs, rhs,
-                                                         expected, flags)
-                                               .str(),
-                                           context.get());
+                      type, expected, resultType, opcode, operands, flags)
+            .str(),
+        context.get());
     ASSERT_TRUE(mod);
     ASSERT_TRUE(succeeded(verify(*mod)));
+    auto func = mainFunc(*mod);
+    const DDArgumentBindings bindings{
+        {
+            func.getArgument(0),
+            parseAttribute(llvm::formatv("{0} : {1}", lhs, type).str(),
+                           context.get()),
+        },
+        {
+            func.getArgument(1),
+            parseAttribute(llvm::formatv("{0} : {1}", rhs, type).str(),
+                           context.get()),
+        },
+    };
     std::string before;
     llvm::raw_string_ostream beforeStream(before);
     mod->print(beforeStream);
-    expectSimulatesFromZero(mainFunc(*mod), true);
+    for (unsigned repeat = 0; repeat < 2; ++repeat) {
+      const auto counts = sample(func, 2, 1, bindings);
+      ASSERT_TRUE(succeeded(counts));
+      EXPECT_EQ(*counts, (std::map<std::string, size_t>{{"1", 2}}));
+    }
     ASSERT_TRUE(succeeded(verify(*mod)));
     std::string after;
     llvm::raw_string_ostream afterStream(after);
     mod->print(afterStream);
     EXPECT_EQ(before, after);
+  }
+}
+
+TEST_F(QCODDFunctionalityTest,
+       FloatingEvaluationPreservesValuesFlagsAndInputIR) {
+  for (const auto& [opcode, type, lhs, rhs, expected, flags] : {
+           std::array{"arith.addf", "f64", "1.5", "2.5", "4.0", ""},
+           std::array{"arith.subf", "f64", "1.5", "2.5", "-1.0", ""},
+           std::array{"arith.mulf", "f64", "-1.5", "2.0", "-3.0", ""},
+           std::array{"arith.divf", "f64", "-3.0", "2.0", "-1.5", ""},
+           std::array{"arith.remf", "f64", "-5.0", "2.0", "-1.0", ""},
+           std::array{"arith.negf", "f64", "0.0", "0.0", "-0.0", ""},
+           std::array{"arith.addf", "f64", "-0.0", "-0.0", "-0.0", ""},
+           std::array{"arith.subf", "f64", "-0.0", "0.0", "-0.0", ""},
+           std::array{"arith.maximumf", "f64", "-0.0", "0.0", "0.0", ""},
+           std::array{"arith.minimumf", "f64", "0.0", "-0.0", "-0.0", ""},
+           std::array{"arith.maxnumf", "f64", "2.0", "-3.0", "2.0", ""},
+           std::array{"arith.minnumf", "f64", "2.0", "-3.0", "-3.0", ""},
+           std::array{"math.absf", "f64", "-0.0", "0.0", "0.0", ""},
+           std::array{"math.ceil", "f64", "-0.25", "0.0", "-0.0", ""},
+           std::array{"math.floor", "f64", "-0.25", "0.0", "-1.0", ""},
+           std::array{"math.cos", "f64", "0.0", "0.0", "1.0", ""},
+           std::array{"math.sin", "f64", "-0.0", "0.0", "-0.0", ""},
+           std::array{"math.tan", "f64", "-0.0", "0.0", "-0.0", ""},
+           std::array{"math.exp", "f64", "0.0", "0.0", "1.0", ""},
+           std::array{"math.log", "f64", "1.0", "0.0", "0.0", ""},
+           std::array{"math.sqrt", "f64", "4.0", "0.0", "2.0", ""},
+           std::array{"math.powf", "f64", "2.0", "3.0", "8.0", ""},
+           std::array{
+               "arith.addf",
+               "f64",
+               "0x7FF0000000000000",
+               "-0.0",
+               "0x7FF0000000000000",
+               "",
+           },
+           std::array{
+               "arith.maximumf",
+               "f64",
+               "0x7FF8000000000001",
+               "1.0",
+               "0x7FF8000000000001",
+               "",
+           },
+           std::array{
+               "arith.maxnumf",
+               "f64",
+               "0x7FF8000000000001",
+               "1.0",
+               "1.0",
+               "",
+           },
+           std::array{
+               "arith.minimumf",
+               "f64",
+               "1.0",
+               "0x7FF8000000000001",
+               "0x7FF8000000000001",
+               "",
+           },
+           std::array{
+               "arith.minnumf",
+               "f64",
+               "1.0",
+               "0x7FF8000000000001",
+               "1.0",
+               "",
+           },
+           std::array{
+               "math.log",
+               "f64",
+               "0.0",
+               "0.0",
+               "0xFFF0000000000000",
+               "",
+           },
+           std::array{
+               "arith.addf",
+               "f64",
+               "1.0",
+               "1.1102230246251565e-16",
+               "1.0000000000000002",
+               "upward",
+           },
+           std::array{
+               "arith.mulf",
+               "f64",
+               "1.5",
+               "2.0",
+               "3.0",
+               "fastmath<fast>",
+           },
+           std::array{"arith.sitofp", "i8", "-1", "0", "-1.0", ""},
+           std::array{"arith.uitofp", "i8", "-1", "0", "255.0", ""},
+           std::array{"arith.uitofp", "i8", "42", "0", "42.0", "nneg"},
+           std::array{
+               "arith.sitofp",
+               "i64",
+               "9007199254740993",
+               "0",
+               "9007199254740992.0",
+               "",
+           },
+           std::array{
+               "arith.uitofp",
+               "i129",
+               "170141183460469231731687303715884105728",
+               "0",
+               "1.7014118346046923e38",
+               "",
+           },
+           std::array{"arith.cmpf oeq,", "f64", "-1.0", "1.0", "0", ""},
+           std::array{"arith.cmpf ogt,", "f64", "-1.0", "1.0", "0", ""},
+           std::array{"arith.cmpf oge,", "f64", "-1.0", "1.0", "0", ""},
+           std::array{"arith.cmpf olt,", "f64", "-1.0", "1.0", "1", ""},
+           std::array{"arith.cmpf ole,", "f64", "-1.0", "1.0", "1", ""},
+           std::array{"arith.cmpf one,", "f64", "-1.0", "1.0", "1", ""},
+           std::array{"arith.cmpf ord,", "f64", "-1.0", "1.0", "1", ""},
+           std::array{"arith.cmpf ueq,", "f64", "-1.0", "1.0", "0", ""},
+           std::array{"arith.cmpf ugt,", "f64", "-1.0", "1.0", "0", ""},
+           std::array{"arith.cmpf uge,", "f64", "-1.0", "1.0", "0", ""},
+           std::array{"arith.cmpf ult,", "f64", "-1.0", "1.0", "1", ""},
+           std::array{"arith.cmpf ule,", "f64", "-1.0", "1.0", "1", ""},
+           std::array{"arith.cmpf une,", "f64", "-1.0", "1.0", "1", ""},
+           std::array{"arith.cmpf uno,", "f64", "-1.0", "1.0", "0", ""},
+           std::array{"arith.cmpf false,", "f64", "-1.0", "1.0", "0", ""},
+           std::array{"arith.cmpf true,", "f64", "-1.0", "1.0", "1", ""},
+           std::array{
+               "arith.cmpf uno,",
+               "f64",
+               "0x7FF8000000000001",
+               "1.0",
+               "1",
+               "",
+           },
+       }) {
+    SCOPED_TRACE(::testing::Message()
+                 << opcode << " " << lhs << " " << rhs << " " << flags);
+    const StringRef name(opcode);
+    const bool comparison = name.starts_with("arith.cmpf");
+    const bool cast = name == "arith.sitofp" || name == "arith.uitofp";
+    const bool unary = cast || name == "arith.negf" ||
+                       (name.starts_with("math.") && name != "math.powf");
+    const auto* const operands = unary ? "%lhs" : "%lhs, %rhs";
+    const auto signature =
+        cast ? llvm::formatv("{0} to f64", type).str() : std::string(type);
+    const auto* const resultType = comparison ? "i1" : "f64";
+    std::string check = comparison
+                            ? "%ok = arith.cmpi eq, %result, %expected : i1"
+                        : StringRef(expected).starts_with("0x7FF8")
+                            ? "%ok = arith.cmpf uno, %result, %result : f64"
+                            : "%ok = arith.cmpf oeq, %result, %expected : f64";
+    if (StringRef(expected) == "0.0" || StringRef(expected) == "-0.0") {
+      check = R"mlir(
+        %one = arith.constant 1.0 : f64
+        %actual_inverse = arith.divf %one, %result : f64
+        %expected_inverse = arith.divf %one, %expected : f64
+        %ok = arith.cmpf oeq, %actual_inverse, %expected_inverse : f64
+      )mlir";
+    }
+    auto mod = parseSourceString<ModuleOp>(
+        llvm::formatv(R"mlir(
+      module {{
+        func.func @main(%lhs: {0}, %rhs: {0}) {{
+          %expected = arith.constant {1} : {2}
+          %result = {3} {4} {5} : {6}
+          {7}
+          %q = qco.static 0 : !qco.qubit
+          %out = qco.if %ok args(%arg = %q) -> (!qco.qubit) {{
+            %x = qco.x %arg : !qco.qubit -> !qco.qubit
+            qco.yield %x : !qco.qubit
+          } else args(%arg = %q) {{
+            qco.yield %arg : !qco.qubit
+          }
+          qco.sink %out : !qco.qubit
+          return
+        }
+      }
+    )mlir",
+                      type, expected, resultType, opcode, operands, flags,
+                      signature, check)
+            .str(),
+        context.get());
+    ASSERT_TRUE(mod);
+    ASSERT_TRUE(succeeded(verify(*mod)));
+    auto func = mainFunc(*mod);
+    const DDArgumentBindings bindings{
+        {
+            func.getArgument(0),
+            parseAttribute(llvm::formatv("{0} : {1}", lhs, type).str(),
+                           context.get()),
+        },
+        {
+            func.getArgument(1),
+            parseAttribute(llvm::formatv("{0} : {1}", rhs, type).str(),
+                           context.get()),
+        },
+    };
+    std::string before;
+    llvm::raw_string_ostream beforeStream(before);
+    mod->print(beforeStream);
+    for (unsigned repeat = 0; repeat < 2; ++repeat) {
+      const auto counts = sample(func, 2, 1, bindings);
+      ASSERT_TRUE(succeeded(counts));
+      EXPECT_EQ(*counts, (std::map<std::string, size_t>{{"1", 2}}));
+    }
+    ASSERT_TRUE(succeeded(verify(*mod)));
+    std::string after;
+    llvm::raw_string_ostream afterStream(after);
+    mod->print(afterStream);
+    EXPECT_EQ(before, after);
+  }
+}
+
+TEST_F(QCODDFunctionalityTest, RejectsShiftAndMathDomainErrors) {
+  for (const auto* const opcode :
+       {"arith.shli", "arith.shrui", "arith.shrsi"}) {
+    for (const auto* const flags :
+         {"", StringRef(opcode) == "arith.shli" ? "overflow<nsw>" : "exact"}) {
+      for (const auto* const amount : {"-1", "8", "255"}) {
+        SCOPED_TRACE(::testing::Message()
+                     << opcode << " " << amount << " " << flags);
+        expectMlirSimulationFails(0, llvm::formatv(R"mlir(
+        module {{
+          func.func @main() {{
+            %zero = arith.constant 0 : i8
+            %amount = arith.constant {0} : i8
+            %result = {1} %zero, %amount {2} : i8
+            return
+          }
+        }
+      )mlir",
+                                                   amount, opcode, flags)
+                                         .str());
+      }
+    }
+  }
+  for (const auto* const opcode : {"math.log", "math.sqrt"}) {
+    for (const auto* const value : {"-1.0", "-0.0"}) {
+      SCOPED_TRACE(::testing::Message() << opcode << " " << value);
+      expectMlirSimulationFails(0, llvm::formatv(R"mlir(
+        module {{
+          func.func @main() {{
+            %value = arith.constant {0} : f64
+            %result = {1} %value : f64
+            return
+          }
+        }
+      )mlir",
+                                                 value, opcode)
+                                       .str());
+    }
   }
 }
 

--- a/mlir/unittests/Support/CMakeLists.txt
+++ b/mlir/unittests/Support/CMakeLists.txt
@@ -17,4 +17,5 @@ target_link_libraries(
           MLIRLLVMDialect
           MLIRQCOUtils)
 mqt_mlir_configure_unittest_target(mqt-core-mlir-unittests-support)
-gtest_discover_tests(mqt-core-mlir-unittests-support PROPERTIES LABELS mqt-mlir-unittests)
+gtest_discover_tests(mqt-core-mlir-unittests-support PROPERTIES LABELS mqt-mlir-unittests
+                                                                DISCOVERY_TIMEOUT 60)

--- a/src/dd/ComplexValue.cpp
+++ b/src/dd/ComplexValue.cpp
@@ -301,9 +301,7 @@ std::ostream& operator<<(std::ostream& os, const ComplexValue& c) {
 
 std::size_t std::hash<dd::ComplexValue>::operator()(
     const dd::ComplexValue& c) const noexcept {
-  const auto h1 = dd::murmur64(
-      static_cast<std::size_t>(std::round(c.r / dd::RealNumber::eps)));
-  const auto h2 = dd::murmur64(
-      static_cast<std::size_t>(std::round(c.i / dd::RealNumber::eps)));
+  const auto h1 = std::hash<dd::fp>{}(std::round(c.r / dd::RealNumber::eps));
+  const auto h2 = std::hash<dd::fp>{}(std::round(c.i / dd::RealNumber::eps));
   return dd::combineHash(h1, h2);
 }

--- a/src/dd/Export.cpp
+++ b/src/dd/Export.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <iomanip>
@@ -157,12 +158,9 @@ std::string conditionalFormat(const Complex& a, const bool formatAsPolar) {
 
   return ss.str();
 }
-std::ostream& modernNode(const mEdge& e, std::ostream& os,
+std::ostream& modernNode(const mEdge& e, const size_t nodeId, std::ostream& os,
                          const bool formatAsPolar) {
-  const auto nodelabel =
-      (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >>
-      1U; // this allows for 2^20 (roughly 1e6) unique nodes
-  os << nodelabel << "[label=<";
+  os << nodeId << "[label=<";
   os << R"(<font point-size="10"><table border="1" cellspacing="0" cellpadding="2" style="rounded">)";
   os << R"(<tr><td colspan="2" rowspan="2" port="0" href="javascript:;" border="0" tooltip=")"
      << conditionalFormat(e.p->e[0].w, formatAsPolar) << "\">"
@@ -198,12 +196,9 @@ std::ostream& modernNode(const mEdge& e, std::ostream& os,
      << "\"]\n";
   return os;
 }
-std::ostream& modernNode(const vEdge& e, std::ostream& os,
+std::ostream& modernNode(const vEdge& e, const size_t nodeId, std::ostream& os,
                          const bool formatAsPolar) {
-  const auto nodelabel =
-      (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >>
-      1U; // this allows for 2^20 (roughly 1e6) unique nodes
-  os << nodelabel << "[label=<";
+  os << nodeId << "[label=<";
   os << R"(<font point-size="8"><table border="1" cellspacing="0" cellpadding="0" style="rounded">)";
   os << R"(<tr><td colspan="2" border="0" cellpadding="1"><font point-size="20">q<sub><font point-size="12">)"
      << static_cast<std::size_t>(e.p->v)
@@ -226,12 +221,9 @@ std::ostream& modernNode(const vEdge& e, std::ostream& os,
      << "\"]\n";
   return os;
 }
-std::ostream& classicNode(const mEdge& e, std::ostream& os,
+std::ostream& classicNode(const mEdge& e, const size_t nodeId, std::ostream& os,
                           const bool formatAsPolar) {
-  const auto nodelabel =
-      (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >>
-      1U; // this allows for 2^20 (roughly 1e6) unique nodes
-  os << nodelabel << "[shape=circle, width=0.53, fixedsize=true, label=<";
+  os << nodeId << "[shape=circle, width=0.53, fixedsize=true, label=<";
   os << R"(<font point-size="6"><table border="0" cellspacing="0" cellpadding="0">)";
   os << R"(<tr><td colspan="4"><font point-size="18">q<sub><font point-size="10">)"
      << static_cast<std::size_t>(e.p->v)
@@ -278,12 +270,9 @@ std::ostream& classicNode(const mEdge& e, std::ostream& os,
      << static_cast<std::size_t>(e.p->v) << "\"]\n";
   return os;
 }
-std::ostream& classicNode(const vEdge& e, std::ostream& os,
+std::ostream& classicNode(const vEdge& e, const size_t nodeId, std::ostream& os,
                           const bool formatAsPolar) {
-  const auto nodelabel =
-      (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >>
-      1U; // this allows for 2^20 (roughly 1e6) unique nodes
-  os << nodelabel << "[shape=circle, width=0.46, fixedsize=true, label=<";
+  os << nodeId << "[shape=circle, width=0.46, fixedsize=true, label=<";
   os << R"(<font point-size="6"><table border="0" cellspacing="0" cellpadding="0">)";
   os << R"(<tr><td colspan="2"><font point-size="18">q<sub><font point-size="10">)"
      << static_cast<std::size_t>(e.p->v)
@@ -312,16 +301,12 @@ std::ostream& classicNode(const vEdge& e, std::ostream& os,
 }
 namespace {
 template <class Node>
-std::ostream& renderEdge(const Edge<Node>& from, const Edge<Node>& to,
-                         const std::uint16_t idx, std::ostream& os,
-                         const bool colored, const bool edgeLabels,
-                         const bool classic, const bool formatAsPolar) {
-  const auto fromlabel =
-      (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
-  const auto tolabel =
-      (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
-
-  os << fromlabel << ":" << idx << ":";
+std::ostream& renderEdge(const Edge<Node>& to, const size_t fromId,
+                         const size_t toId, const std::uint16_t idx,
+                         std::ostream& os, const bool colored,
+                         const bool edgeLabels, const bool classic,
+                         const bool formatAsPolar) {
+  os << fromId << ":" << idx << ":";
   if constexpr (IsVector<Node>) {
     os << (idx == 0 ? "sw" : "se");
   } else if (classic) {
@@ -345,7 +330,7 @@ std::ostream& renderEdge(const Edge<Node>& from, const Edge<Node>& to,
   if (to.isTerminal()) {
     os << "t";
   } else {
-    os << tolabel;
+    os << toId;
   }
 
   const auto mag = thicknessFromMagnitude(to.w);
@@ -366,32 +351,32 @@ std::ostream& renderEdge(const Edge<Node>& from, const Edge<Node>& to,
 }
 } // namespace
 
-std::ostream& bwEdge(const mEdge& from, const mEdge& to,
+std::ostream& bwEdge(const mEdge& to, const size_t fromId, const size_t toId,
                      const std::uint16_t idx, std::ostream& os,
                      const bool edgeLabels, const bool classic,
                      const bool formatAsPolar) {
-  return renderEdge(from, to, idx, os, false, edgeLabels, classic,
+  return renderEdge(to, fromId, toId, idx, os, false, edgeLabels, classic,
                     formatAsPolar);
 }
-std::ostream& bwEdge(const vEdge& from, const vEdge& to,
+std::ostream& bwEdge(const vEdge& to, const size_t fromId, const size_t toId,
                      const std::uint16_t idx, std::ostream& os,
                      const bool edgeLabels, const bool classic,
                      const bool formatAsPolar) {
-  return renderEdge(from, to, idx, os, false, edgeLabels, classic,
+  return renderEdge(to, fromId, toId, idx, os, false, edgeLabels, classic,
                     formatAsPolar);
 }
-std::ostream& coloredEdge(const mEdge& from, const mEdge& to,
-                          const std::uint16_t idx, std::ostream& os,
-                          const bool edgeLabels, const bool classic,
-                          const bool formatAsPolar) {
-  return renderEdge(from, to, idx, os, true, edgeLabels, classic,
+std::ostream& coloredEdge(const mEdge& to, const size_t fromId,
+                          const size_t toId, const std::uint16_t idx,
+                          std::ostream& os, const bool edgeLabels,
+                          const bool classic, const bool formatAsPolar) {
+  return renderEdge(to, fromId, toId, idx, os, true, edgeLabels, classic,
                     formatAsPolar);
 }
-std::ostream& coloredEdge(const vEdge& from, const vEdge& to,
-                          const std::uint16_t idx, std::ostream& os,
-                          const bool edgeLabels, const bool classic,
-                          const bool formatAsPolar) {
-  return renderEdge(from, to, idx, os, true, edgeLabels, classic,
+std::ostream& coloredEdge(const vEdge& to, const size_t fromId,
+                          const size_t toId, const std::uint16_t idx,
+                          std::ostream& os, const bool edgeLabels,
+                          const bool classic, const bool formatAsPolar) {
+  return renderEdge(to, fromId, toId, idx, os, true, edgeLabels, classic,
                     formatAsPolar);
 }
 void serialize(const vEdge& basic, std::ostream& os, const bool writeBinary) {

--- a/src/dd/RealNumber.cpp
+++ b/src/dd/RealNumber.cpp
@@ -11,6 +11,7 @@
 #include "dd/RealNumber.hpp"
 
 #include "dd/DDDefinitions.hpp"
+#include "dd/LinkedListBase.hpp"
 
 #include <cassert>
 #include <cstdint>
@@ -27,6 +28,12 @@ constexpr std::uintptr_t IMMORTAL_FLAG = std::uintptr_t{1} << 2U;
 
 RealNumber* RealNumber::next() const noexcept {
   return RealNumber::getAlignedPointer(reinterpret_cast<RealNumber*>(next_));
+}
+
+void RealNumber::setNext(LLBase* next) noexcept {
+  const auto flags =
+      reinterpret_cast<uintptr_t>(next_) & (MARK_FLAG | IMMORTAL_FLAG);
+  next_ = reinterpret_cast<LLBase*>(reinterpret_cast<uintptr_t>(next) | flags);
 }
 
 RealNumber* RealNumber::getAlignedPointer(const RealNumber* e) noexcept {
@@ -50,19 +57,19 @@ RealNumber* RealNumber::flipPointerSign(const RealNumber* e) noexcept {
 
 void RealNumber::mark(RealNumber* e) noexcept {
   RealNumber* p = getAlignedPointer(e);
-  p->next_ = reinterpret_cast<RealNumber*>(
+  p->next_ = reinterpret_cast<LLBase*>(
       reinterpret_cast<std::uintptr_t>(p->next_) | MARK_FLAG);
 }
 
 void RealNumber::unmark(RealNumber* e) noexcept {
   RealNumber* p = getAlignedPointer(e);
-  p->next_ = reinterpret_cast<RealNumber*>(
+  p->next_ = reinterpret_cast<LLBase*>(
       reinterpret_cast<std::uintptr_t>(p->next_) & ~MARK_FLAG);
 }
 
 void RealNumber::immortalize(RealNumber* e) noexcept {
   RealNumber* p = +getAlignedPointer(e);
-  p->next_ = reinterpret_cast<RealNumber*>(
+  p->next_ = reinterpret_cast<LLBase*>(
       reinterpret_cast<std::uintptr_t>(p->next_) | IMMORTAL_FLAG);
 }
 

--- a/src/dd/RealNumberUniqueTable.cpp
+++ b/src/dd/RealNumberUniqueTable.cpp
@@ -249,7 +249,7 @@ RealNumber* RealNumberUniqueTable::findOrInsert(const std::int64_t key,
   if (curr == nullptr) {
     auto* entry = memoryManager->get<RealNumber>();
     entry->value = val;
-    entry->setNext(curr);
+    entry->LLBase::setNext(curr);
     table[k] = entry;
     tailTable[k] = entry;
     stats.trackInsert();
@@ -265,7 +265,7 @@ RealNumber* RealNumberUniqueTable::findOrInsert(const std::int64_t key,
     ++stats.collisions;
     auto* entry = memoryManager->get<RealNumber>();
     entry->value = val;
-    entry->setNext(nullptr);
+    entry->LLBase::setNext(nullptr);
     back->setNext(entry);
     tailTable[k] = entry;
     stats.trackInsert();
@@ -308,7 +308,7 @@ RealNumber* RealNumberUniqueTable::findOrInsert(const std::int64_t key,
   } else {
     prev->setNext(entry);
   }
-  entry->setNext(curr);
+  entry->LLBase::setNext(curr);
   if (curr == nullptr) {
     tailTable[k] = entry;
   }
@@ -323,7 +323,7 @@ RealNumber* RealNumberUniqueTable::insertFront(const std::int64_t key,
 
   auto* curr = table[static_cast<std::size_t>(key)];
   table[static_cast<std::size_t>(key)] = entry;
-  entry->setNext(curr);
+  entry->LLBase::setNext(curr);
   if (curr == nullptr) {
     tailTable[static_cast<std::size_t>(key)] = entry;
   }
@@ -335,7 +335,7 @@ RealNumber* RealNumberUniqueTable::insertBack(const std::int64_t key,
                                               const fp val) {
   auto* entry = memoryManager->get<RealNumber>();
   entry->value = val;
-  entry->setNext(nullptr);
+  entry->LLBase::setNext(nullptr);
 
   auto* back = tailTable[static_cast<std::size_t>(key)];
   tailTable[static_cast<std::size_t>(key)] = entry;

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "dd/ComplexNumbers.hpp"
+#include "dd/ComplexValue.hpp"
 #include "dd/DDDefinitions.hpp"
 #include "dd/Export.hpp"
 #include "dd/MemoryManager.hpp"
@@ -20,10 +21,12 @@
 
 #include <array>
 #include <cstddef>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <limits>
 #include <sstream>
+#include <unordered_set>
 #include <vector>
 
 using namespace dd;
@@ -572,4 +575,55 @@ TEST_F(CNTest, ExportConditionalFormat6) {
 
 TEST_F(CNTest, ExportConditionalFormat7) {
   EXPECT_STREQ(conditionalFormat(cn.lookup(-SQRT2_2, 0)).c_str(), "-1/√2");
+}
+
+TEST(DDComplexTest, HashesSignedQuantizedWeights) {
+  const std::hash<ComplexValue> hash;
+  for (const bool imaginary : {false, true}) {
+    std::unordered_set<size_t> hashes;
+    for (const fp value : {-0.125, -0.25, -0.5, -0.75}) {
+      const ComplexValue weight =
+          imaginary ? ComplexValue{0., value} : ComplexValue{value, 0.};
+      hashes.insert(hash(weight));
+      auto nearby = weight;
+      (imaginary ? nearby.i : nearby.r) += RealNumber::eps / 4.;
+      EXPECT_EQ(hash(weight), hash(nearby));
+    }
+    EXPECT_GT(hashes.size(), 1U);
+  }
+  EXPECT_EQ(hash({0., 0.}), hash({-0., -0.}));
+}
+
+TEST_F(CNTest, PreservesFlagsWhenRelinkingNumbers) {
+  auto* half = ut.lookup(0.5);
+  ASSERT_TRUE(RealNumber::isImmortal(half));
+  RealNumber::mark(half);
+  auto* neighbor = ut.lookup(0.500000001);
+  EXPECT_EQ(half->next(), neighbor);
+  EXPECT_TRUE(RealNumber::isImmortal(half));
+  EXPECT_TRUE(RealNumber::isMarked(half));
+  EXPECT_EQ(ut.garbageCollect(true), 1U);
+  EXPECT_EQ(half->next(), nullptr);
+  EXPECT_TRUE(RealNumber::isImmortal(half));
+  EXPECT_TRUE(RealNumber::isMarked(half));
+  RealNumber::unmark(half);
+  EXPECT_FALSE(RealNumber::isMarked(half));
+  EXPECT_TRUE(RealNumber::isImmortal(half));
+}
+
+TEST_F(CNTest, ClearsFlagsWhenReusingNumbers) {
+  auto* entry = mm.get<RealNumber>();
+  RealNumber::mark(entry);
+  RealNumber::immortalize(entry);
+  mm.returnEntry(*entry);
+  auto* reused = ut.lookup(0.123);
+  ASSERT_EQ(reused, entry);
+  EXPECT_FALSE(RealNumber::isMarked(reused));
+  EXPECT_FALSE(RealNumber::isImmortal(reused));
+
+  ut.clear();
+  mm.reset();
+  reused = ut.lookup(0.321);
+  EXPECT_FALSE(RealNumber::isMarked(reused));
+  EXPECT_FALSE(RealNumber::isImmortal(reused));
 }

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "dd/CachedEdge.hpp"
+#include "dd/Complex.hpp"
 #include "dd/ComputeTable.hpp"
 #include "dd/DDDefinitions.hpp"
 #include "dd/Edge.hpp"
@@ -39,6 +40,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <random>
 #include <span>
 #include <sstream>
@@ -76,6 +78,58 @@ void checkDotFile(const Edge<Node>& edge, const std::string& filename) {
   EXPECT_NE(is.peek(), std::ifstream::traits_type::eof());
   is.close();
   std::filesystem::remove(filename);
+}
+
+template <class Node> void checkDotIds() {
+  /// The old address mask aliases nodes a multiple of 2 MiB apart.
+  constexpr size_t distance = std::lcm(size_t{1} << 21U, sizeof(Node));
+  std::vector<Node> spaced((distance / sizeof(Node)) + 1);
+  std::array<Node, 2> adjacent{};
+  const auto makeRoot = [](Node& low, Node& high) {
+    low.v = 0;
+    high.v = 1;
+    low.e.fill(Edge<Node>::zero());
+    high.e.fill(Edge<Node>::zero());
+    low.e[0] = Edge<Node>::one();
+    high.e[0] = {&low, Complex::one()};
+    if constexpr (IsMatrix<Node>) {
+      low.e[3] = Edge<Node>::one();
+      high.e[3] = high.e[0];
+    }
+    return Edge<Node>{&high, Complex::one()};
+  };
+  const auto far = makeRoot(spaced.front(), spaced.back());
+  const auto near = makeRoot(adjacent[0], adjacent[1]);
+  for (const bool colored : {false, true}) {
+    for (const bool classic : {false, true}) {
+      for (const bool memory : {false, true}) {
+        SCOPED_TRACE(::testing::Message() << colored << classic << memory);
+        std::ostringstream first;
+        toDot(far, first, colored, true, classic, memory);
+        const auto dot = first.str();
+        EXPECT_NE(dot.find("root->0["), std::string::npos);
+        EXPECT_NE(dot.find("\n0["), std::string::npos);
+        const auto child = dot.find("\n1[");
+        ASSERT_NE(child, std::string::npos);
+        EXPECT_EQ(dot.find("\n1[", child + 1), std::string::npos);
+        EXPECT_NE(dot.find(memory ? "0:0:s->1[" : "0:0:sw->1["),
+                  std::string::npos);
+        if (!memory) {
+          std::ostringstream second;
+          toDot(near, second, colored, true, classic, memory);
+          EXPECT_EQ(dot, second.str());
+        }
+      }
+    }
+  }
+}
+
+TEST(DDPackageTest, VectorDotIdsAreUniqueAndIndependentOfAddresses) {
+  checkDotIds<vNode>();
+}
+
+TEST(DDPackageTest, MatrixDotIdsAreUniqueAndIndependentOfAddresses) {
+  checkDotIds<mNode>();
 }
 
 enum class Fixture : uint8_t { H, X, Z, S, T, Tdg, SWAP };


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Address the DD/QCO findings from #2253:

- Assign DOT IDs during traversal so addresses separated by a multiple of 2 MiB cannot merge distinct graph nodes. Ordinary exports are deterministic; memory views retain addresses as debug labels.
- Hash quantized complex weights without undefined floating-to-unsigned conversion.
- Preserve real-number mark/immortal bits during relinking, cast tagged links to their stored type, and clear old flags when initializing entries.
- Evaluate scalar integer arithmetic, comparisons, shifts, min/max, population count, floating-point arithmetic, common math, and integer-to-float conversions directly with APInt, APFloat, and standard math functions. Keep MLIR folding for overflow/exact/non-negative flags, floating-point flags, explicit rounding, non-finite values, and math domain errors.

Canonicalization remains optional. `QCOProgram::cleanup()` already runs it without an iteration limit; dynamic operands still require evaluation. [MLIR defines canonicalization as best effort, without a stable normal form](https://mlir.llvm.org/docs/Canonicalization/). Requiring it would not remove the interpreter's runtime operation support or validation. Simulation continues to preserve caller-owned input IR.

Public `toDot`/`export2Dot` signatures are unchanged; the upgrade guide covers direct rendering-helper callers. Rebased onto `fce58f02d` (#2519), preserving the OpenQASM import names and MQT compiler terminology. No new dependencies.

Local validation on the rebased code: full native Clang 23/LLVM-MLIR 23.1 release build with ThinLTO and mold; **3,513 native tests passed**, with one existing sample-device job-ID test skipped; repository lint; and full changed-file C++ lint. The original DD fixes also passed all 191 DD tests with ASan, UBSan, and float-cast-overflow before the terminology rebase. The DOT collision reproducer renders two nodes, and 12 fresh processes produced identical ordinary DOT output.

The Support test target uses the same 60-second discovery limit as the other MLIR targets. Its Windows build exhausted the default five seconds while listing tests. Native configure, build, discovery, all 23 Support tests, and repository lint pass with the corrected limit.

Matched CPU-time medians for 9,000 iterations and 64 dynamic shots, compared with the previous addition-only implementation on the same upstream base:

| Workload | Addition-only | Extended evaluation |
| --- | ---: | ---: |
| Mixed integer operations | 1,824 ms | 860 ms (53% lower) |
| Mixed floating-point operations | 1,970 ms | 1,411 ms (28% lower) |
| Constant math in a loop | 2,825 ms | 1,931 ms (32% lower) |

Five randomized serial repeats on DGX Spark CPU 0, shared host, with no overlapping build or lint. Integer ranges: 1,819–1,836 ms versus 857–919 ms; floating-point ranges: 1,927–2,033 ms versus 1,378–1,442 ms. Parsing is excluded. Addition and gate-sampling controls stay within the observed spread. All 120 runs preserve ordered outcomes and input IR.

Canonicalization leaves the dynamic loops unchanged. For constant math, canonicalization alone reduces the control to 1,212 ms; extended evaluation reduces the canonicalized program to 873 ms. Canonicalization costs about 0.5 ms here. Unlimited canonicalization reaches the same fixed point on all six fixtures. These are classical-interpreter gains, not a general quantum-gate simulation speedup.

Ponytail review consolidated shift-range validation and simplified the DOT root label; no remaining complexity findings. Codex implemented the changes, reviewed the diff, and ran the local checks. Hosted CI is separate; human review remains required.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
