### PR TITLE
💥 Align compiler terminology and public names

### DIFF
--- a/.agent/audits/mlir-terminology.md
+++ b/.agent/audits/mlir-terminology.md
@@ -1,0 +1,140 @@
+# Compiler terminology and public naming
+
+Status: complete. Baseline: `a66a9b20698d5a7450541002a8122352d8275957` (upstream
+main).
+
+## Scope and evidence
+
+The audit follows
+[issue #2251](https://github.com/munich-quantum-toolkit/core/issues/2251),
+including its proposed changes and the linked
+[PR #2149 discussion](https://github.com/munich-quantum-toolkit/core/pull/2149#issuecomment-5330271608).
+The naming decisions below were approved for implementation without aliases.
+Terminology follows `docs/glossary.md` and the
+[MLIR glossary](https://mlir.llvm.org/getting_started/Glossary/).
+
+Reviewed the compiler headers and implementations, Python bindings and stub
+patterns, OpenQASM frontend and QC importer/exporter, CLI format dispatch,
+QC/QCO/QTensor operation and builder descriptions, conversion/pass descriptions,
+documentation, and their callers and tests. Existing plan references were
+updated with the renamed symbols.
+
+## Applied findings
+
+1. **OpenQASM import names omitted the language name or implied version 3.**
+   `OpenQASMSemantics.cpp::analyzeVersion` accepts versionless input, 2.0, 3.0,
+   and 3.1. Both `QCProgram` factories and the lower-level importer route
+   through that frontend. Rename the complete import surface and document its
+   actual version contract. Correct the options documentation to identify
+   `gatePolicy`, the field read by the importer.
+2. **The CLI advertised MLIR as a specific output checkpoint.**
+   `parseOutputFormat` mapped both `mlir` and `qc` to `OutputFormat::QC`. Use
+   `qc` exclusively and advertise it as the default. QC, QCO, and the jeff
+   dialect all use MLIR; `--input-format=mlir` and isolated-pipeline MLIR output
+   remain accurate. Filename inference still recognizes `.qasm`.
+3. **Target metadata shadowed MLIR operations.** `CompilerTarget::Operation`
+   describes native support and calibration, while `supports` consumes
+   `mlir::Operation` instances. Rename the capability class consistently in C++,
+   Python, binding patterns, tests, and examples.
+4. **Gate catalog identifiers were named after a transformation.**
+   `GateLowering` was an alias for `qc::StandardGate`, and `lowering` stored
+   that enum. Remove the alias and use the existing type with the field `gate`.
+   Catalog lookup, parameter counts, and gate emission are unchanged.
+5. **jeff conversion and serialization were conflated in Python.**
+   `QCOProgram::intoJeff` runs a dialect conversion; the resulting `JeffProgram`
+   retains an MLIR module. Byte/file methods perform serialization. Align the
+   Python descriptions and guide with the existing C++ ownership contract.
+6. **Operation, pass, target, and ownership descriptions were imprecise.**
+   Describe canonicalization patterns separately from passes, barriers as
+   operations that preserve quantum state, and dialect changes as conversions.
+   Distinguish MQT compiler targets from MLIR conversion targets. Describe QCO
+   and QTensor use constraints as linear semantics/ownership, checked by
+   `qco::verifyLinearity`, rather than implying type checking alone enforces
+   them. Replace the generic Python failure text with `Compiler action failed`
+   and name the QC translation in unsupported-input diagnostics.
+7. **Gate-count summaries did not identify their static scope.**
+   `Programs.cpp::countGatesIf` walks the entry point, skips barrier counts and
+   modifier bodies, and does not follow calls. Every SCF region is visited once.
+   Clarify that scope in all three C++/Python count methods and the guide,
+   consistent with PR #2149. Counting behavior is unchanged.
+
+## Public migration impact
+
+These are unreleased v4 interfaces. Development-branch users must update the
+following names and rebuild C++ consumers; there is no compatibility alias or
+deprecation period. A deprecated forwarding layer was considered and rejected in
+favor of completing the naming changes before v4.
+
+| Previous spelling                                        | Replacement                                                                  |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `QCProgram::fromQASMString` / `fromQASMFile`             | `fromOpenQASMString` / `fromOpenQASMFile`                                    |
+| `QCProgram.from_qasm_str` / `from_qasm_file`             | `from_openqasm_str` / `from_openqasm_file`                                   |
+| `translateQASM3ToQC`                                     | `translateOpenQASMToQC`                                                      |
+| `TranslateQASM3ToQC.h`                                   | `TranslateOpenQASMToQC.h`                                                    |
+| `QASM3ImportOptions`                                     | `OpenQASMImportOptions`                                                      |
+| `mlir::oq3::frontend`                                    | `mlir::openqasm::frontend`                                                   |
+| `CompilerTarget::Operation` / `CompilerTarget.Operation` | `CompilerTarget::OperationCapability` / `CompilerTarget.OperationCapability` |
+| `GateLowering` / `GateCatalogEntry::lowering`            | `qc::StandardGate` / `GateCatalogEntry::gate`                                |
+| `--input-format=qasm`                                    | `--input-format=openqasm`                                                    |
+| `--emit=mlir`                                            | `--emit=qc`                                                                  |
+
+In-tree consumers include compiler pipelines, DDSIM import, target adapters,
+Python bindings, compiler/translation tests, and documentation examples. All are
+updated together. Existing unreleased changelog and upgrade-guide examples use
+the final names; no separate upgrade section is added for unreleased APIs.
+
+GitHub code searches of indexed MQT repositories found no affected downstream
+calls. The QMAP compiler-target consumer found by search uses `from_device_id`,
+which is unchanged. Searches for the old importer in the MQSC organization found
+no matches. These checks do not cover private/unindexed code or nondefault
+branches. Open Core PRs #2260 and #2506 touch compiler inspection or pipeline
+surfaces and may require mechanical conflict resolution after this change.
+
+## Deliberately retained terminology
+
+- OpenQASM 3 export names and QDMI's external `QASM3` format constants identify
+  a versioned output contract and remain unchanged.
+- Python convenience functions use the `OPENQASM` header to recognize source
+  strings. Versionless text uses the explicit `QCProgram` factory; `.qasm` file
+  import also accepts it. Document this boundary without changing source
+  detection or guessing whether a string is a path.
+- `LinearType`/`isLinearType` classify quantum types to which ownership rules
+  apply; they do not claim that MLIR's type system proves linearity.
+- QIR and CBit lowering genuinely move toward a lower-level representation. QC
+  target operands are gate operands, distinct from compiler targets.
+- Static qubit identifiers and dynamic resource allocation retain their
+  established names. The glossary distinguishes them from known quantum states
+  and compile-time allocation sizes.
+- The reported cast phrase about "different value semantics" no longer exists at
+  the baseline. Current cast descriptions specify numeric behavior.
+
+## Validation
+
+- Native Clang 23/LLVM-MLIR 23.1 release build with ThinLTO: passed.
+- `ctest --preset release-clang-ipo`: 3,505 passed, one existing sample-device
+  job-ID query skipped. Includes compiler, OpenQASM, conversion, DDSIM, and CLI
+  coverage. The final target-test formatting correction also passed all 19
+  `CompilerTargetTest` cases.
+- `uvx nox -s tests` with `test_mlir.py`, `test_mlir_integer_interchange.py`,
+  `test_mlir_loops.py`, `test_mlir_qiskit_translation.py`, and `test_qco_dd.py`
+  under `test/python/`: 653 tests passed on each of Python 3.11, 3.12, 3.13, and
+  3.14. The final versionless-input example passed the four focused
+  import-version cases.
+- `uvx nox -s stubs`: passed; regenerated the MLIR stub from the bindings.
+- `uvx nox --non-interactive -s docs`: passed, including executable examples and
+  generated local-link checks.
+- `uvx nox -s lint`: passed.
+- `uvx nox -s cpp-lint -- a66a9b20698d5a7450541002a8122352d8275957`: passed with
+  zero findings across the complete changed C++ files.
+- The final symbol search found old public spellings only in the audit's
+  migration discussion and CLI rejection tests. CLI help advertises `openqasm`
+  input and the default `qc` output checkpoint.
+
+These are local results; hosted CI is separate.
+
+## Complexity review
+
+The Ponytail review found one redundant forwarding helper in the touched gate
+emitter. Removed `emitPrimitive` and called `qc::emitStandardGate` directly at
+all three call sites, saving six lines. No new abstraction or dependency is
+needed. The final pass found no further complexity to remove.

--- a/.agent/audits/openqasm-import-export.md
+++ b/.agent/audits/openqasm-import-export.md
@@ -43,8 +43,8 @@ The parser builds persistent expression IDs directly. Operands, bit references,
 and modifiers have one shared representation. Gate-call arrays remain borrowed
 while parsing and owned in stored syntax. Parsing remains separate from analysis
 so source lifetimes, diagnostics, and reanalysis under different policies
-survive. `GatePolicy` is passed directly to analysis; `QASM3ImportOptions` owns
-a flat policy and emission limit.
+survive. `GatePolicy` is passed directly to analysis; `OpenQASMImportOptions`
+owns a flat policy and emission limit.
 
 For 100,000 distinct declarations, the original syntax-ID change reduced peak
 RSS from about 137,600 KiB to 88,000 KiB. Three-run median parse time fell from

--- a/.agent/plans/1687-int-final-qdmi-bridge.md
+++ b/.agent/plans/1687-int-final-qdmi-bridge.md
@@ -32,9 +32,9 @@ historical merge-heavy implementation.
   augmentation, native-gate menu, and duplicated pipeline are obsolete and must
   not be ported.
 
-- `CompilerTarget::Operation` deliberately models homogeneous target-wide
-  support, while QDMI can report a restricted site list. The adapter must
-  therefore verify that a one-qubit operation covers every site and that a
+- `CompilerTarget::OperationCapability` deliberately models homogeneous
+  target-wide support, while QDMI can report a restricted site list. The adapter
+  must therefore verify that a one-qubit operation covers every site and that a
   two-qubit operation covers every topology edge or all-to-all pair before
   treating it as target-wide. Ordered site tuples then carry calibration
   overrides only.

--- a/.agent/plans/1687-pipe-01-target-pipeline.md
+++ b/.agent/plans/1687-pipe-01-target-pipeline.md
@@ -242,5 +242,5 @@ The sole default-pipeline entry point declares:
         bool enableTiming = false, bool enableStatistics = false);
 
 `MQTCompilerPipeline` owns `TargetCompilation.cpp` and links only the existing
-MLIR compiler target, QCO transform, and support libraries. CoreFoMaC, QDMI,
+MQT compiler target, QCO transform, and support libraries. CoreFoMaC, QDMI,
 CoreIR, and a dynamic provider boundary are not added by this slice.

--- a/.agent/plans/issue-1590-remove-qc-mlir.md
+++ b/.agent/plans/issue-1590-remove-qc-mlir.md
@@ -105,7 +105,7 @@ translator and that the useful MLIR-to-DD integration remains available.
 ## Interfaces
 
 At completion, `QCProgram` retains `fromMLIRString`, `fromMLIRFile`,
-`fromQASMString`, and `fromQASMFile`; it no longer declares
+`fromOpenQASMString`, and `fromOpenQASMFile`; it no longer declares
 `fromQuantumComputation`; it also retains the direct `from_qiskit` and
 `to_qiskit` binding methods. `compile_program` accepts strings, paths, Qiskit
 circuits, `QCProgram`, `QCOProgram`, `JeffProgram`, and `OpenQASMProgram` in

--- a/.agent/plans/mlir-terminology.md
+++ b/.agent/plans/mlir-terminology.md
@@ -1,0 +1,14 @@
+# MLIR terminology and public naming
+
+Status: complete.
+
+Compiler C++, Python, CLI, diagnostics, tests, and documentation use the
+terminology established by issue #2251 and the PR #2149 discussion. The approved
+clean renames apply to unreleased v4 interfaces without deprecated aliases. The
+accepted input subset, program ownership, static gate-count behavior, and
+emitted representations are preserved.
+
+The [audit record](../audits/mlir-terminology.md) contains the baseline, source
+evidence, complete rename table, downstream impact, retained terms, and local
+validation. The Ponytail review removed a redundant gate-emission forwarder; the
+final review found no remaining complexity to cut.

--- a/.agent/plans/openqasm-audit-fixes.md
+++ b/.agent/plans/openqasm-audit-fixes.md
@@ -7,8 +7,8 @@ Status: complete.
 The frontend builds syntax IDs directly, shares leaf types, bounds affine
 analysis per proof, and deduplicates static operands with sets. Typed register
 comparisons use bit vectors. QC emission counts actual inserted operations.
-Analysis accepts `GatePolicy` directly; `QASM3ImportOptions` owns the policy and
-emission limit.
+Analysis accepts `GatePolicy` directly; `OpenQASMImportOptions` owns the policy
+and emission limit.
 
 OpenQASM export preserves ordered results and zero-valued data, rejects repeated
 register outputs, and keeps absent outputs void. It materializes scalar

--- a/.agent/plans/openqasm3-emission.md
+++ b/.agent/plans/openqasm3-emission.md
@@ -156,7 +156,7 @@ limitation does not invalidate the focused results or establish full coverage.
 performs QC/QCO/QIR conversions, and coordinates the default pipeline. The new
 textual artifact and pipeline branch belong there.
 
-`mlir/include/mlir/Dialect/QC/Translation/TranslateQASM3ToQC.h` and
+`mlir/include/mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h` and
 `mlir/lib/Dialect/QC/Translation/` contain the modern OpenQASM frontend and its
 QC emitter. The reverse translator will live beside them under the separate
 public header `TranslateQCToOpenQASM3.h` and will be compiled into
@@ -182,7 +182,7 @@ maps SSA values to deterministic generated OpenQASM variables.
 ## Acceptance
 
 The public translator succeeds for a representative QC module and returns
-strictly parseable OpenQASM 3.1. Passing its text to `translateQASM3ToQC`
+strictly parseable OpenQASM 3.1. Passing its text to `translateOpenQASMToQC`
 produces a verified QC module. Gate tests cover each standard or generated gate
 and modifier nesting; helper definitions are compared against the QC unitary,
 including global phase.

--- a/.agent/plans/oq3-foundation.md
+++ b/.agent/plans/oq3-foundation.md
@@ -29,11 +29,11 @@ The legacy `QuantumComputation` parser was outside this change.
   `TypedProgram`, and diagnostic-bearing parse/analysis results.
   `MLIROpenQASMFrontend` remains independent of QC and MLIR contexts.
 - `mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp` owns private QC
-  construction. `TranslateQASM3ToQC.cpp` is the small public adapter used by
-  `QCProgram::fromQASMString`.
+  construction. `TranslateOpenQASMToQC.cpp` is the small public adapter used by
+  `QCProgram::fromOpenQASMString`.
 - `GateCatalog.h` and `GateCatalog.cpp` share gate identity and lowering recipes
-  between semantic analysis and emission. The `oq3::frontend` namespace names
-  the language frontend, not a retained MLIR dialect.
+  between semantic analysis and emission. The `openqasm::frontend` namespace
+  names the language frontend, not a retained MLIR dialect.
 
 ## Decisions and constraints
 

--- a/.agent/plans/qdmi-adapter-convenience.md
+++ b/.agent/plans/qdmi-adapter-convenience.md
@@ -9,7 +9,7 @@ Later removal of transitional aliases:
 
 MQT Core registers QDMI devices under stable string identifiers, but users still
 need to assemble framework adapters manually. This change makes the stable ID
-the common entry point for Qiskit backends and MLIR compiler targets.
+the common entry point for Qiskit backends and MQT compiler targets.
 
 After the change, a user can call `QDMIBackend.from_device_id`, then construct a
 sampler or estimator from that backend. A user can also call

--- a/.agent/plans/split-compiler-programs.md
+++ b/.agent/plans/split-compiler-programs.md
@@ -116,7 +116,7 @@ into `MQTCompilerPipeline` and attaches `Programs.h` and `TargetCompilation.h`
 to that target.
 
 `src/qdmi/devices/dd/Device.cpp` translates QASM in `parseQASMToQCO` by calling
-`QCProgram::fromQASMString` and then `QCProgram::intoQCO`. The device only
+`QCProgram::fromOpenQASMString` and then `QCProgram::intoQCO`. The device only
 borrows the resulting QCO module for DD sampling or statevector simulation.
 Nevertheless, `src/qdmi/devices/dd/CMakeLists.txt` links `MQTCompilerPipeline`,
 which exposes the device to every higher-level compiler dependency.
@@ -219,7 +219,7 @@ has no comments. No open PR already implements this split.
 
 `MQTCompilerPrograms` must provide the existing symbols used by the DDSIM path:
 
-    mlir::QCProgram::fromQASMString(std::string_view)
+    mlir::QCProgram::fromOpenQASMString(std::string_view)
     mlir::QCProgram::intoQCO() &&
     mlir::Program::module() const
 

--- a/.agent/plans/typed-compilation-target.md
+++ b/.agent/plans/typed-compilation-target.md
@@ -25,8 +25,8 @@ module attachment. Those contracts require separate design work.
 - The final #2218 model treats missing connectivity and operation support as
   target-inference errors and gives operations a fixed or variadic arity.
   Evidence: `CompilerTarget::Connectivity` and `NativeOperations` have no
-  unknown state, and `CompilerTarget::Operation::Arity` distinguishes fixed
-  widths from inclusive variadic minima.
+  unknown state, and `CompilerTarget::OperationCapability::Arity` distinguishes
+  fixed widths from inclusive variadic minima.
 
 ## Decisions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ releases may include breaking changes.
   direct lowering and dense-array helpers for supported compiler inputs
   ([#1915], [#1973], [#2077], [#2078], [#2079], [#2334]) ([**@simon1hofmann**],
   [**@burgholzer**])
-- ✨ Add immutable MLIR compiler targets, selected payload specifications,
+- ✨ Add immutable MQT compiler targets, selected payload specifications,
   payload-aware control-flow legalization, QDMI device integration, ordered
   operation applicability, directional native synthesis, target compilation
   through C++, Python, and `mqt-cc`, and device submission APIs ([#2497],

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,11 +25,11 @@ Use the compiler-backed Python interface in new code:
 ```python
 from mqt.core.mlir import OutputFormat, QCProgram, compile_program
 
-qc_program = QCProgram.from_qasm_file("circuit.qasm")
+qc_program = QCProgram.from_openqasm_file("circuit.qasm")
 qco_program = compile_program(qc_program, output=OutputFormat.QCO_OPTIMIZED)
 ```
 
-Use `QCProgram.from_qasm_str` for source text, `QCProgram.from_qiskit` for a
+Use `QCProgram.from_openqasm_str` for source text, `QCProgram.from_qiskit` for a
 Qiskit `QuantumCircuit`, and `QCProgram.to_qiskit` for conversion back to
 Qiskit. For decision-diagram simulation, pass any compiler input to the
 `sample`, `simulate`, or `build_functionality` function in `mqt.core.mlir`. The

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -77,7 +77,7 @@ template <class T>
 [[nodiscard]] static T takeResult(std::optional<T>&& result) {
   if (!result) {
     throw std::runtime_error(
-        "MLIR operation failed; see diagnostics for details.");
+        "Compiler action failed; see diagnostics for details.");
   }
   return *std::move(result);
 }
@@ -98,7 +98,7 @@ static void constructFromExpected(T& self, llvm::Expected<T>&& result) {
 static void requireSuccess(const bool succeeded) {
   if (!succeeded) {
     throw std::runtime_error(
-        "MLIR operation failed; see diagnostics for details.");
+        "Compiler action failed; see diagnostics for details.");
   }
 }
 
@@ -250,7 +250,7 @@ programFromPath(const std::filesystem::path& path) {
     return takeResult(mlir::QCProgram::fromMLIRFile(path));
   }
   if (extension == ".qasm") {
-    return takeResult(mlir::QCProgram::fromQASMFile(path));
+    return takeResult(mlir::QCProgram::fromOpenQASMFile(path));
   }
   throw std::runtime_error("Input file '" + path.string() +
                            "' has unsupported extension '" + extension + "'.");
@@ -261,7 +261,7 @@ programFromPath(const std::filesystem::path& path) {
 programFromString(const std::string& input) {
   if (isSourceString(input)) {
     if (input.find("OPENQASM") != std::string::npos) {
-      return takeResult(mlir::QCProgram::fromQASMString(input));
+      return takeResult(mlir::QCProgram::fromOpenQASMString(input));
     }
     return takeResult(mlir::QCProgram::fromMLIRString(input));
   }
@@ -681,7 +681,7 @@ NB_MODULE(MQT_CORE_MODULE_NAME, m) {
                    "Whether optional capability metadata is complete.");
 
   auto compilerTarget = nb::class_<mlir::CompilerTarget>(
-      m, "CompilerTarget", R"pb(Immutable MLIR compiler target.
+      m, "CompilerTarget", R"pb(Immutable MQT compiler target.
 
 Every target has either all-to-all or explicitly enumerated connectivity and
 either unrestricted or explicitly enumerated native-operation support.)pb");
@@ -767,38 +767,45 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
   nb::implicitly_convertible<std::vector<mlir::CompilerTarget::SiteId>,
                              mlir::CompilerTarget::SiteTuple>();
 
-  nb::enum_<mlir::CompilerTarget::Operation::Arity::Kind>(
+  nb::enum_<mlir::CompilerTarget::OperationCapability::Arity::Kind>(
       compilerTarget, "OperationArityKind",
       "How an operation capability accepts qubit widths.")
-      .value("FIXED", mlir::CompilerTarget::Operation::Arity::Kind::Fixed)
+      .value("FIXED",
+             mlir::CompilerTarget::OperationCapability::Arity::Kind::Fixed)
       .value("VARIADIC",
-             mlir::CompilerTarget::Operation::Arity::Kind::Variadic);
+             mlir::CompilerTarget::OperationCapability::Arity::Kind::Variadic);
 
-  auto operationArity = nb::class_<mlir::CompilerTarget::Operation::Arity>(
-      compilerTarget, "OperationArity", "Accepted operation qubit widths.");
+  auto operationArity =
+      nb::class_<mlir::CompilerTarget::OperationCapability::Arity>(
+          compilerTarget, "OperationArity", "Accepted operation qubit widths.");
   operationArity
-      .def_static("fixed", &mlir::CompilerTarget::Operation::Arity::fixed,
+      .def_static("fixed",
+                  &mlir::CompilerTarget::OperationCapability::Arity::fixed,
                   "value"_a, "Create an exact operation arity.")
-      .def_static("variadic", &mlir::CompilerTarget::Operation::Arity::variadic,
+      .def_static("variadic",
+                  &mlir::CompilerTarget::OperationCapability::Arity::variadic,
                   "minimum"_a,
                   "Create an operation arity with an inclusive minimum. "
-                  "Operation construction requires a positive minimum.")
-      .def_prop_ro("kind", &mlir::CompilerTarget::Operation::Arity::kind,
+                  "Capability construction requires a positive minimum.")
+      .def_prop_ro("kind",
+                   &mlir::CompilerTarget::OperationCapability::Arity::kind,
                    "The arity kind.")
-      .def_prop_ro("value", &mlir::CompilerTarget::Operation::Arity::value,
+      .def_prop_ro("value",
+                   &mlir::CompilerTarget::OperationCapability::Arity::value,
                    "The exact arity or inclusive variadic minimum.")
-      .def("accepts", &mlir::CompilerTarget::Operation::Arity::accepts,
+      .def("accepts",
+           &mlir::CompilerTarget::OperationCapability::Arity::accepts,
            "width"_a, "Whether this arity accepts a concrete width.");
 
-  auto targetOperation = nb::class_<mlir::CompilerTarget::Operation>(
-      compilerTarget, "Operation",
+  auto targetOperation = nb::class_<mlir::CompilerTarget::OperationCapability>(
+      compilerTarget, "OperationCapability",
       "A target operation capability, calibration, and ordered "
       "applicability.");
   targetOperation
       .def(
           "__init__",
-          [](mlir::CompilerTarget::Operation& self, std::string name,
-             const mlir::CompilerTarget::Operation::Arity arity,
+          [](mlir::CompilerTarget::OperationCapability& self, std::string name,
+             const mlir::CompilerTarget::OperationCapability::Arity arity,
              const size_t numParameters,
              std::optional<std::vector<mlir::CompilerTarget::SiteTuple>>
                  siteTuples,
@@ -806,7 +813,7 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
              const std::optional<double> fidelity) {
             constructFromExpected(
                 self,
-                mlir::CompilerTarget::Operation::create(
+                mlir::CompilerTarget::OperationCapability::create(
                     std::move(name), arity, numParameters,
                     std::move(siteTuples)
                         .value_or(
@@ -817,7 +824,7 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
           "duration"_a = nb::none(), "fidelity"_a = nb::none())
       .def(
           "__init__",
-          [](mlir::CompilerTarget::Operation& self, std::string name,
+          [](mlir::CompilerTarget::OperationCapability& self, std::string name,
              const size_t arity, const size_t numParameters,
              std::optional<std::vector<mlir::CompilerTarget::SiteTuple>>
                  siteTuples,
@@ -825,7 +832,7 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
              const std::optional<double> fidelity) {
             constructFromExpected(
                 self,
-                mlir::CompilerTarget::Operation::create(
+                mlir::CompilerTarget::OperationCapability::create(
                     std::move(name), arity, numParameters,
                     std::move(siteTuples)
                         .value_or(
@@ -836,32 +843,34 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
           "duration"_a = nb::none(), "fidelity"_a = nb::none())
       .def_prop_ro(
           "name",
-          [](const mlir::CompilerTarget::Operation& operation) {
+          [](const mlir::CompilerTarget::OperationCapability& operation) {
             return operation.name().str();
           },
           "The exact reported operation name.")
       .def_prop_ro(
           "canonical_name",
-          [](const mlir::CompilerTarget::Operation& operation) {
+          [](const mlir::CompilerTarget::OperationCapability& operation) {
             return operation.canonicalName().str();
           },
           "The normalized compiler operation name.")
-      .def_prop_ro("arity", &mlir::CompilerTarget::Operation::arity,
+      .def_prop_ro("arity", &mlir::CompilerTarget::OperationCapability::arity,
                    "The accepted operation arity.")
       .def_prop_ro("num_parameters",
-                   &mlir::CompilerTarget::Operation::numParameters,
+                   &mlir::CompilerTarget::OperationCapability::numParameters,
                    "The number of real-valued parameters.")
       .def_prop_ro(
           "site_tuples",
-          [](const mlir::CompilerTarget::Operation& operation) {
+          [](const mlir::CompilerTarget::OperationCapability& operation) {
             return std::vector<mlir::CompilerTarget::SiteTuple>(
                 operation.siteTuples().begin(), operation.siteTuples().end());
           },
           "Supported ordered placements with optional calibration; empty means "
           "general applicability.")
-      .def_prop_ro("duration", &mlir::CompilerTarget::Operation::duration,
+      .def_prop_ro("duration",
+                   &mlir::CompilerTarget::OperationCapability::duration,
                    "The raw default duration, if available.")
-      .def_prop_ro("fidelity", &mlir::CompilerTarget::Operation::fidelity,
+      .def_prop_ro("fidelity",
+                   &mlir::CompilerTarget::OperationCapability::fidelity,
                    "The default fidelity, if available.");
 
   nb::enum_<mlir::CompilerTarget::GateKind>(
@@ -946,7 +955,8 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
       .def(
           "__init__",
           [](mlir::CompilerTarget::NativeOperations& self,
-             const std::vector<mlir::CompilerTarget::Operation>& operations) {
+             const std::vector<mlir::CompilerTarget::OperationCapability>&
+                 operations) {
             new (&self) mlir::CompilerTarget::NativeOperations(
                 mlir::CompilerTarget::NativeOperations::fromOperations(
                     operations));
@@ -960,7 +970,7 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
       .def_prop_ro(
           "operations",
           [](const mlir::CompilerTarget::NativeOperations& value) {
-            return std::vector<mlir::CompilerTarget::Operation>(
+            return std::vector<mlir::CompilerTarget::OperationCapability>(
                 value.operations().begin(), value.operations().end());
           },
           "The explicit operations, if present.");
@@ -1112,7 +1122,7 @@ either unrestricted or explicitly enumerated native-operation support.)pb");
       .def_prop_ro(
           "operations",
           [](const mlir::CompilerTarget& target) {
-            return std::vector<mlir::CompilerTarget::Operation>(
+            return std::vector<mlir::CompilerTarget::OperationCapability>(
                 target.operations().begin(), target.operations().end());
           },
           "Operation capabilities in reported order.")
@@ -1190,13 +1200,17 @@ before conversion to QCO.)pb");
           &OptionalFunctionAdapter<&mlir::QCProgram::fromMLIRFile>::call,
           "path"_a, "Parse QC MLIR from a file.")
       .def_static(
-          "from_qasm_str",
-          &OptionalFunctionAdapter<&mlir::QCProgram::fromQASMString>::call,
-          "source"_a, "Translate an OpenQASM 3 source string to QC MLIR.")
+          "from_openqasm_str",
+          &OptionalFunctionAdapter<&mlir::QCProgram::fromOpenQASMString>::call,
+          "source"_a,
+          "Translate supported OpenQASM to QC MLIR. Accepts versionless input "
+          "and versions 2.0, 3.0, and 3.1.")
       .def_static(
-          "from_qasm_file",
-          &OptionalFunctionAdapter<&mlir::QCProgram::fromQASMFile>::call,
-          "path"_a, "Translate an OpenQASM 3 file to QC MLIR.")
+          "from_openqasm_file",
+          &OptionalFunctionAdapter<&mlir::QCProgram::fromOpenQASMFile>::call,
+          "path"_a,
+          "Translate a supported OpenQASM file to QC MLIR. Accepts versionless "
+          "input and versions 2.0, 3.0, and 3.1.")
       .def_static(
           "from_qiskit",
           [](const nb::object& circuit) {
@@ -1273,9 +1287,9 @@ Set ``copy=True`` to preserve it.)pb")
             requireValid(program);
             return program.numGates();
           },
-          R"pb(Count the gates in the program.
+          R"pb(Return the static gate count of the entry-point IR.
 
-Any operation that implements the ``UnitaryOpInterface`` is counted. Operations
+Any entry-point operation that implements the ``UnitaryOpInterface`` is counted. Operations
 in every structured control-flow region are counted once, regardless of how
 often the region executes. Operations within modifiers are not counted
 recursively, and barriers are skipped.)pb")
@@ -1285,9 +1299,9 @@ recursively, and barriers are skipped.)pb")
             requireValid(program);
             return program.numSingleQubitGates();
           },
-          R"pb(Count the single-qubit gates in the program.
+          R"pb(Return the static single-qubit gate count of the entry-point IR.
 
-Any operation that implements the ``UnitaryOpInterface`` and acts on one qubit
+Any entry-point operation that implements the ``UnitaryOpInterface`` and acts on one qubit
 is counted. Operations in every structured control-flow region are counted
 once, regardless of how often the region executes. Operations within modifiers
 are not counted recursively, and barriers are skipped.)pb")
@@ -1297,9 +1311,9 @@ are not counted recursively, and barriers are skipped.)pb")
             requireValid(program);
             return program.numTwoQubitGates();
           },
-          R"pb(Count the two-qubit gates in the program.
+          R"pb(Return the static two-qubit gate count of the entry-point IR.
 
-Any operation that implements the ``UnitaryOpInterface`` and acts on two qubits
+Any entry-point operation that implements the ``UnitaryOpInterface`` and acts on two qubits
 is counted. Operations in every structured control-flow region are counted
 once, regardless of how often the region executes. Operations within modifiers
 are not counted recursively, and barriers are skipped.)pb");
@@ -1416,12 +1430,13 @@ Set ``copy=True`` to preserve it.)pb")
             return takeResult(std::move(source).intoJeff());
           },
           nb::kw_only(), "copy"_a = false,
-          R"pb(Serialize this program as ``jeff``.
+          R"pb(Convert this program to ``jeff`` MLIR.
 
 Set ``copy=True`` to preserve it.)pb");
 
   auto jeffProgram = nb::class_<mlir::JeffProgram, mlir::Program>(
-      m, "JeffProgram", R"pb(A serialized ``jeff`` compiler program.
+      m, "JeffProgram",
+      R"pb(A serializable compiler program in the ``jeff`` dialect.
 
 ``jeff`` programs can be stored as bytes or files and converted back to QCO for
 further compilation.)pb");
@@ -1459,7 +1474,7 @@ further compilation.)pb");
             return takeResult(std::move(source).intoQCO());
           },
           nb::kw_only(), "copy"_a = false,
-          R"pb(Deserialize this program to QCO.
+          R"pb(Convert this program to QCO.
 
 Set ``copy=True`` to preserve it.)pb");
 
@@ -1607,7 +1622,7 @@ Raises:
                 "qiskit.circuit.QuantumCircuit | QCProgram | QCOProgram | "
                 "JeffProgram | OpenQASMProgram, shots: int = 1024, seed: int = "
                 "0) -> dict[str, int]"),
-        R"pb(Sample a supported input after lowering it directly to QCO.
+        R"pb(Sample a supported input after translating or converting it to QCO.
 
 An existing QCO program is used without copying. See
 {py:meth}`QCOProgram.sample` for the shot, seed, histogram, and error

--- a/bindings/patterns.txt
+++ b/bindings/patterns.txt
@@ -128,7 +128,7 @@ mqt\.core\.mlir\.CompilerTarget\.__init__$:
         duration_unit: CompilerTarget.DurationUnit | None = None,
     ) -> None: ...
 
-mqt\.core\.mlir\.CompilerTarget\.Operation\.__init__$:
+mqt\.core\.mlir\.CompilerTarget\.OperationCapability\.__init__$:
     \from collections.abc import Sequence
     def __init__(
         self,

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -151,8 +151,8 @@ canonicalization
   a particular downstream target.
 
 conversion
-  A change from one legal set of MLIR operations or types to another within the
-  MLIR framework. Conversion can be partial or complete and is governed by a
+  A change between or within MLIR dialects, from one legal set of operations or
+  types to another. Conversion can be partial or complete and is governed by a
   conversion target that states what is legal.
 
 translation
@@ -165,6 +165,13 @@ import
 
 export
   A translation from MQT Core or MLIR into an external representation.
+
+serialization
+  **Preferred term:** serialization. **Accepted aliases:** none. Encoding a
+  program as bytes or writing that encoding to a file. Deserialization reads
+  the encoding back into a program. Converting QCO to the `jeff` MLIR dialect
+  prepares a serializable program; `JeffProgram.to_bytes` and
+  `JeffProgram.write` serialize it.
 
 lowering
   A transformation from a higher-level representation to one closer to the
@@ -179,6 +186,19 @@ compiler target
   An immutable MQT description of the operations, topology, and properties that
   a compiler pipeline may use for one destination. It is a snapshot used for
   compilation, not a live device connection.
+
+operation capability
+  **Preferred term:** operation capability. **Accepted aliases:** none. A
+  compiler target's description of a supported operation, including its name,
+  arity, parameters, placements, and optional calibration data. Represented by
+  `CompilerTarget::OperationCapability` in C++ and
+  `CompilerTarget.OperationCapability` in Python. An MLIR operation is an IR
+  instance, not this capability description.
+
+conversion target
+  **Preferred term:** conversion target. **Accepted aliases:** none. The MLIR
+  legality rules used by a dialect conversion. It is distinct from an MQT
+  compiler target, which describes a compilation destination.
 
 compiled program
   A serialized program with the target and payload specification used to compile
@@ -205,10 +225,20 @@ execution payload
 
 static
   Known while compiling the program. Static does not necessarily mean a C++
-  object with static storage duration.
+  object with static storage duration. In `qc.static` and `qco.static`, it
+  describes a known qubit identifier, not a known quantum state.
 
 dynamic
   Known only while executing the compiled program or interacting with a target.
+  A dynamic quantum allocation acquires resources during execution, even when
+  its size is a compile-time constant.
+
+static gate count
+  **Preferred term:** static gate count. **Accepted aliases:** none. The number
+  of gate operations in the entry-point IR. Each structured control-flow region
+  is counted once, including every branch and loop body. Modifier bodies are
+  not counted recursively, and barriers are excluded. This is not the number
+  of gates executed at runtime or a count expanded through function calls.
 
 QC
   MQT's compatibility-oriented quantum-circuit dialect. QC uses reference
@@ -233,9 +263,13 @@ value semantics
   values. QCO uses this model to make quantum data flow explicit in SSA form.
 
 linear semantics
-  A value-ownership rule under which a quantum value has one live use along a
-  program path. The rule prevents copying unknown quantum state and makes
-  ownership transfers explicit.
+linear ownership
+  **Preferred term:** linear semantics. **Accepted alias:** linear ownership
+  when discussing ownership transfers. Each quantum SSA value in valid QCO IR
+  has exactly one use, including block arguments. Control-flow operations
+  transfer ownership through their operands, region arguments, and results.
+  `qco::verifyLinearity` checks this rule; ordinary MLIR type checking alone
+  does not establish it. Linearity does not imply positional wire correspondence.
 ```
 
 ## Quantum benchmark terms

--- a/docs/mlir/OpenQASM.md
+++ b/docs/mlir/OpenQASM.md
@@ -12,12 +12,12 @@ The frontend parses and validates the source before translating it directly to
 QC. The C++ compiler API accepts strings and files:
 
 ```cpp
-auto fromString = mlir::QCProgram::fromQASMString(source);
-auto fromFile = mlir::QCProgram::fromQASMFile("program.qasm");
+auto fromString = mlir::QCProgram::fromOpenQASMString(source);
+auto fromFile = mlir::QCProgram::fromOpenQASMFile("program.qasm");
 ```
 
-The lower-level `mlir::qc::translateQASM3ToQC` importer accepts
-`QASM3ImportOptions`. Its `frontend` field selects the gate policy, and
+The lower-level `mlir::qc::translateOpenQASMToQC` importer accepts
+`OpenQASMImportOptions`. Its `gatePolicy` field selects the gate policy, and
 `maxOperations` limits the number of inserted QC operations (10,000,000 by
 default). Exceeding the limit emits a diagnostic and returns no program.
 
@@ -26,28 +26,38 @@ Python provides the corresponding constructors:
 ```python
 from mqt.core.mlir import QCProgram
 
-from_string = QCProgram.from_qasm_str(source)
-from_file = QCProgram.from_qasm_file("program.qasm")
-qiskit_circuit = QCProgram.from_qasm_str(source).to_qiskit()
+from_string = QCProgram.from_openqasm_str(source)
+from_file = QCProgram.from_openqasm_file("program.qasm")
+qiskit_circuit = QCProgram.from_openqasm_str(source).to_qiskit()
 ```
 
-`mqt-cc` recognizes `.qasm` files automatically. Use `--input-format=qasm` when
-the filename does not identify the format:
+Python convenience functions such as `compile_program` recognize OpenQASM source
+strings by the `OPENQASM` header. For versionless source, construct a
+`QCProgram` with `from_openqasm_str` first. The explicit constructors and
+`.qasm` file imports accept versionless input directly.
+
+`mqt-cc` recognizes `.qasm` files automatically. Use `--input-format=openqasm`
+when the filename does not identify the format:
 
 ```console
 mqt-cc program.qasm
-mqt-cc --input-format=qasm program.txt
+mqt-cc --input-format=openqasm program.txt
 ```
+
+The default output checkpoint is `--emit=qc`, which emits QC MLIR after the
+default compiler pipeline. Use `--emit=qc-import` to inspect the imported QC
+before cleanup or QCO optimization. MLIR is the representation shared by the QC,
+QCO, and `jeff` dialects, so each output checkpoint names its dialect.
 
 ### Input support
 
 | OpenQASM concept           | Support and restrictions                                                                                                                                                                                                                                                  |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Versions and includes      | Versionless input and versions 3.0 and 3.1 use the maintained OpenQASM profile. `stdgates.inc`, `qelib1.inc`, and nested textual includes are supported.                                                                                                                  |
+| Versions and includes      | Versionless input and versions 2.0, 3.0, and 3.1 are accepted within the supported subset below. `stdgates.inc`, `qelib1.inc`, and nested textual includes are supported.                                                                                                 |
 | Classical types            | `bit`, `bool`, `int`, `uint`, and `float` declarations are supported, including integer widths 1–64. Initialized compile-time `angle[N]` values support widths 1–52. Other sized numeric declarations, general arrays, complex values, and aliases are not yet supported. |
 | Outputs                    | Explicit `output` declarations are preserved in source order. Without any explicit output, global classical variables become outputs.                                                                                                                                     |
 | Gates                      | Language gates, the standard libraries, custom gates, broadcasting, and `inv`, `ctrl`, `negctrl`, and `pow` modifiers are supported. Custom definitions remain private QC functions instead of being expanded at every use. Recursive custom gates are rejected.          |
-| Quantum statements         | Measurement, reset, barrier, logical qubits, and physical qubits are supported. The QC target rejects programs that mix logical allocation with physical qubits.                                                                                                          |
+| Quantum statements         | Measurement, reset, barrier, logical qubits, and physical qubits are supported. The QC translation rejects programs that mix logical allocation with physical qubits.                                                                                                     |
 | Expressions                | Scalar arithmetic, comparisons, Boolean expressions, and the supported math functions are type checked before translation. Initialized bit registers support `~`, `&`, `\|`, `^`, `<<`, `>>`, `popcount`, `rotl`, and `rotr`.                                             |
 | Structured control         | `if`, `switch`, supported range-based `for`, and `while`. `break` exits the innermost enclosing loop; `continue` advances to its next iteration. Both may appear inside conditional and switch bodies.                                                                    |
 | Dynamic indexing           | Classical bit indices can be dynamic and receive runtime bounds checks. A nonconstant qubit index must be a proven affine expression as described below.                                                                                                                  |
@@ -165,7 +175,7 @@ if (mlir::failed(source)) {
 The compiler API returns an owned textual program:
 
 ```cpp
-auto qc = mlir::QCProgram::fromQASMFile("input.qasm");
+auto qc = mlir::QCProgram::fromOpenQASMFile("input.qasm");
 auto direct = qc->toOpenQASM3(); // Export without QCO optimization.
 direct->write("direct.qasm");
 auto reimported = mlir::runDefaultPipeline(
@@ -180,7 +190,7 @@ Python exposes both forms:
 ```python
 from mqt.core.mlir import OutputFormat, QCProgram, compile_program
 
-qc = QCProgram.from_qasm_file("input.qasm")
+qc = QCProgram.from_openqasm_file("input.qasm")
 direct = qc.to_openqasm3()
 print(direct.source)
 direct.write("direct.qasm")

--- a/docs/mlir/index.md
+++ b/docs/mlir/index.md
@@ -17,18 +17,18 @@ We define multiple dialects, each with its dedicated purpose:
   remains meaningful across dialect conversions.
 - The {doc}`QC dialect <QC>` uses reference semantics and is designed as a
   compatibility dialect that simplifies translations from and to existing
-  languages such as Qiskit, OpenQASM, or QIR.
+  representations such as Qiskit circuits, OpenQASM, or QIR.
 - The {doc}`QCO dialect <QCO>` uses value semantics and is mainly designed for
   running optimizations.
 - The {doc}`QTensor dialect <QTensor>` adds support for one-dimensional tensors
-  of qubits with linear typing and is used in the QCO dialect to represent
+  of qubits with linear semantics and is used in the QCO dialect to represent
   collections of qubits such as registers.
 - The {doc}`CBit dialect <CBit>` represents initialized classical-bit registers
   shared by QC and QCO.
 
-These dialects define various canonicalization and transformation passes that
-enable the compilation of quantum programs to native quantum hardware. Passes
-that are not tied to a single dialect are documented on the
+These dialects define various canonicalization patterns and transformation
+passes that enable the compilation of quantum programs to native quantum
+hardware. Passes that are not tied to a single dialect are documented on the
 {doc}`passes <Transforms>` page. For interoperability, we provide
 {doc}`conversions <Conversions>` between dialects.
 

--- a/docs/mlir/python_compiler_collection.md
+++ b/docs/mlir/python_compiler_collection.md
@@ -52,6 +52,11 @@ returns a {py:class}`~mqt.core.mlir.QCProgram`. Its
 representation for inspection and debugging. Programs do not need to be written
 in MLIR to use the compiler.
 
+For versionless OpenQASM text, use
+`compile_program(QCProgram.from_openqasm_str(source))`. Automatic source-string
+detection uses the `OPENQASM` header; see {doc}`OpenQASM` for the import
+contract.
+
 ## Inspect a QC program
 
 Use the inspection methods of a {py:class}`~mqt.core.mlir.QCProgram` to count
@@ -63,9 +68,11 @@ print("Single-qubit gates:", compiled.num_single_qubit_gates())
 print("Two-qubit gates:", compiled.num_two_qubit_gates())
 ```
 
-These counts describe the entry-point IR. A gate in each structured control-flow
-region counts once, regardless of the runtime path or loop iteration count.
-Barriers do not count, and operations inside gate modifiers do not count again.
+These are static gate counts of the entry-point IR. A gate in each structured
+control-flow region counts once, regardless of the runtime path or loop
+iteration count. Barriers do not count, and operations inside gate modifiers do
+not count again. The counts do not expand function calls or estimate the gates
+executed at runtime.
 
 ## Select an output format
 
@@ -78,7 +85,7 @@ Select an output format to stop the pipeline at a particular representation:
 | Inspect QCO after optimization           | `OutputFormat.QCO_OPTIMIZED`                           | `QCOProgram`      |
 | Obtain the optimized circuit             | `OutputFormat.QC` (default)                            | `QCProgram`       |
 | Emit an optimized OpenQASM program       | `OutputFormat.OPENQASM3`                               | `OpenQASMProgram` |
-| Serialize a compiler program             | `OutputFormat.JEFF`                                    | `JeffProgram`     |
+| Convert to the jeff dialect              | `OutputFormat.JEFF`                                    | `JeffProgram`     |
 | Generate QIR                             | `OutputFormat.QIR_BASE` or `OutputFormat.QIR_ADAPTIVE` | `QIRProgram`      |
 
 For example, select optimized QCO to inspect the representation after the
@@ -109,7 +116,7 @@ from tempfile import TemporaryDirectory
 with TemporaryDirectory() as directory:
     path = Path(directory) / "bell.qasm"
     openqasm.write(path)
-    reparsed = QCProgram.from_qasm_file(path)
+    reparsed = QCProgram.from_openqasm_file(path)
 
 assert reparsed.is_valid
 ```
@@ -182,7 +189,7 @@ The following example keeps the imported QC program, applies transformations to
 QCO, and converts the result back to QC:
 
 ```{code-cell} ipython3
-qc = QCProgram.from_qasm_str(bell_qasm)
+qc = QCProgram.from_openqasm_str(bell_qasm)
 qco = qc.to_qco(copy=True)
 qco.cleanup()
 qco.merge_single_qubit_rotation_gates()
@@ -287,8 +294,10 @@ pipeline. It is applied when compilation proceeds beyond the raw
 
 ## Serialize programs and generate QIR
 
-{code}`jeff` is a serializable representation that can be stored and compiled
-again in a later process.
+{py:class}`~mqt.core.mlir.JeffProgram` holds MLIR in the {code}`jeff` dialect.
+Use {py:meth}`~mqt.core.mlir.JeffProgram.to_bytes` or
+{py:meth}`~mqt.core.mlir.JeffProgram.write` to serialize it. The bytes or file
+can be loaded and compiled again in a later process.
 
 Integer expressions support widths through 64 bits. Integer absolute value and
 power require jeff's native widths: 1, 8, 16, 32, or 64. Import preserves
@@ -341,5 +350,5 @@ filenames, including filenames without an extension, retain the bitcode output
 used by earlier versions.
 
 The {doc}`QC <QC>`, {doc}`QCO <QCO>`, and {doc}`QTensor <QTensor>` references
-describe the underlying operations. See {doc}`Conversions` for the lowering
-steps between dialects.
+describe the underlying operations. See {doc}`Conversions` for conversions
+between dialects.

--- a/docs/mlir/qiskit.md
+++ b/docs/mlir/qiskit.md
@@ -50,8 +50,8 @@ unsupported.
 Private gate parameters bind by position and receive generated local names
 during Qiskit export; their original names and grouping are not preserved.
 Public program inputs still require explicit names. OpenQASM custom gates can
-therefore use `QCProgram.from_qasm_str(source).to_qiskit()` directly within the
-supported subset below.
+therefore use `QCProgram.from_openqasm_str(source).to_qiskit()` directly within
+the supported subset below.
 
 Export folds scalar expressions on a copy of the QC program. Constant
 arithmetic, casts, and idempotent expressions can therefore disappear;

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -89,20 +89,20 @@ target = CompilerTarget(
     3,
     connectivity=CompilerTarget.Connectivity([(0, 1), (1, 2)]),
     native_operations=CompilerTarget.NativeOperations([
-        CompilerTarget.Operation(
+        CompilerTarget.OperationCapability(
             "gphase",
             arity=CompilerTarget.OperationArity.fixed(0),
             num_parameters=1,
         ),
-        CompilerTarget.Operation("u", arity=1, num_parameters=3),
-        CompilerTarget.Operation(
+        CompilerTarget.OperationCapability("u", arity=1, num_parameters=3),
+        CompilerTarget.OperationCapability(
             "cx",
             arity=2,
             num_parameters=0,
             site_tuples=[(1, 0), (1, 2)],
         ),
-        CompilerTarget.Operation("measure", arity=1, num_parameters=0),
-        CompilerTarget.Operation("reset", arity=1, num_parameters=0),
+        CompilerTarget.OperationCapability("measure", arity=1, num_parameters=0),
+        CompilerTarget.OperationCapability("reset", arity=1, num_parameters=0),
     ]),
 )
 mapped = compile_program(
@@ -269,7 +269,7 @@ Compile a file and submit it to DDSIM:
 #include "llvm/Support/raw_ostream.h"
 
 auto device = qdmi::Session::openDevice("mqt.ddsim.default");
-auto input = mlir::QCProgram::fromQASMFile("input.qasm");
+auto input = mlir::QCProgram::fromOpenQASMFile("input.qasm");
 if (!input) {
   return 1;
 }

--- a/mlir/include/mqt/Compiler/Programs.h
+++ b/mlir/include/mqt/Compiler/Programs.h
@@ -140,13 +140,17 @@ public:
   [[nodiscard]] static std::optional<QCProgram>
   fromMLIRFile(const std::filesystem::path& path);
 
-  /// Translate OpenQASM 3 source to QC.
+  /// Translate supported OpenQASM source to QC.
+  ///
+  /// Accepts versionless input and versions 2.0, 3.0, and 3.1.
   [[nodiscard]] static std::optional<QCProgram>
-  fromQASMString(std::string_view source);
+  fromOpenQASMString(std::string_view source);
 
-  /// Translate an OpenQASM 3 file to QC.
+  /// Translate a supported OpenQASM file to QC.
+  ///
+  /// Accepts versionless input and versions 2.0, 3.0, and 3.1.
   [[nodiscard]] static std::optional<QCProgram>
-  fromQASMFile(const std::filesystem::path& path);
+  fromOpenQASMFile(const std::filesystem::path& path);
 
   /// Take ownership of an MLIR module that contains a QC program.
   ///
@@ -167,7 +171,7 @@ public:
   /// Normalize scoped global phases in place.
   [[nodiscard]] bool normalizeGlobalPhases();
 
-  /// Translate this program to portable OpenQASM without consuming it.
+  /// Translate this program to portable OpenQASM 3.1 without consuming it.
   [[nodiscard]] std::optional<OpenQASMProgram> toOpenQASM3() const;
 
   /// Consume this program and convert it to QCO.
@@ -176,30 +180,30 @@ public:
   /// Consume this program and lower it to QIR.
   [[nodiscard]] std::optional<QIRProgram> intoQIR(QIRProfile profile) &&;
 
-  /// Count the gates in the program.
+  /// Return the static gate count of the entry-point IR.
   ///
-  /// Any operation that implements the `UnitaryOpInterface` is counted.
-  /// The count includes operations in every structured control-flow region
-  /// once, regardless of how often the region executes. Operations within
-  /// modifiers are not counted recursively, and barriers are skipped.
+  /// Any entry-point operation that implements the `UnitaryOpInterface` is
+  /// counted. The count includes operations in every structured control-flow
+  /// region once, regardless of how often the region executes. Operations
+  /// within modifiers are not counted recursively, and barriers are skipped.
   [[nodiscard]] size_t numGates() const;
 
-  /// Count the single-qubit gates in the program.
+  /// Return the static single-qubit gate count of the entry-point IR.
   ///
-  /// Any operation that implements the `UnitaryOpInterface` and acts on
-  /// one qubit is counted. The count includes operations in every structured
-  /// control-flow region once, regardless of how often the region executes.
-  /// Operations within modifiers are not counted recursively, and barriers are
-  /// skipped.
+  /// Any entry-point operation that implements the `UnitaryOpInterface` and
+  /// acts on one qubit is counted. The count includes operations in every
+  /// structured control-flow region once, regardless of how often the region
+  /// executes. Operations within modifiers are not counted recursively, and
+  /// barriers are skipped.
   [[nodiscard]] size_t numSingleQubitGates() const;
 
-  /// Count the two-qubit gates in the program.
+  /// Return the static two-qubit gate count of the entry-point IR.
   ///
-  /// Any operation that implements the `UnitaryOpInterface` and acts on
-  /// two qubits is counted. The count includes operations in every structured
-  /// control-flow region once, regardless of how often the region executes.
-  /// Operations within modifiers are not counted recursively, and barriers are
-  /// skipped.
+  /// Any entry-point operation that implements the `UnitaryOpInterface` and
+  /// acts on two qubits is counted. The count includes operations in every
+  /// structured control-flow region once, regardless of how often the region
+  /// executes. Operations within modifiers are not counted recursively, and
+  /// barriers are skipped.
   [[nodiscard]] size_t numTwoQubitGates() const;
 };
 
@@ -283,7 +287,7 @@ private:
   [[nodiscard]] bool hasValidLinearity() const;
 };
 
-/// A serializable `jeff` program.
+/// A serializable compiler program in the `jeff` dialect.
 class JeffProgram final : public Program {
 public:
   explicit JeffProgram(Storage storage) : Program(std::move(storage)) {}

--- a/mlir/include/mqt/Compiler/QDMIAdapter.h
+++ b/mlir/include/mqt/Compiler/QDMIAdapter.h
@@ -30,7 +30,7 @@ class Job;
 
 namespace mlir {
 
-/// Snapshot a circuit-model QDMI device as an MLIR compiler target.
+/// Snapshot a circuit-model QDMI device as an MQT compiler target.
 ///
 /// The returned target owns all queried metadata and remains valid
 /// after the originating device and session have been destroyed. Neutral-atom

--- a/mlir/include/mqt/Compiler/Target.h
+++ b/mlir/include/mqt/Compiler/Target.h
@@ -31,7 +31,7 @@ namespace mlir {
 class MLIRContext;
 class Operation;
 
-/// Immutable description of an MLIR compiler target.
+/// Immutable description of an MQT compiler target.
 ///
 /// Hardware sites retain their target-defined nonnegative i64
 /// identifiers. Routing algorithms use dense zero-based vertices in site order.
@@ -159,7 +159,7 @@ public:
   /// with no site tuples are generally applicable. A nonempty list gives all
   /// supported ordered placements. Missing tuple calibration values inherit
   /// the operation defaults.
-  class Operation {
+  class OperationCapability {
   public:
     /// The accepted number of qubits for an operation capability.
     class Arity {
@@ -170,7 +170,7 @@ public:
       [[nodiscard]] static Arity fixed(size_t value) noexcept;
 
       /// Create an operation arity with the given inclusive minimum.
-      /// Operation construction requires a positive minimum.
+      /// Capability construction requires a positive minimum.
       [[nodiscard]] static Arity variadic(size_t minimum) noexcept;
 
       /// Return the arity kind.
@@ -192,14 +192,14 @@ public:
     };
 
     /// Create a validated operation capability.
-    [[nodiscard]] static llvm::Expected<Operation>
+    [[nodiscard]] static llvm::Expected<OperationCapability>
     create(std::string name, size_t arity, size_t numParameters,
            std::vector<SiteTuple> siteTuples = {},
            std::optional<uint64_t> duration = std::nullopt,
            std::optional<double> fidelity = std::nullopt);
 
     /// Create a validated operation capability.
-    [[nodiscard]] static llvm::Expected<Operation>
+    [[nodiscard]] static llvm::Expected<OperationCapability>
     create(std::string name, Arity arity, size_t numParameters,
            std::vector<SiteTuple> siteTuples = {},
            std::optional<uint64_t> duration = std::nullopt,
@@ -227,9 +227,11 @@ public:
     [[nodiscard]] std::optional<double> fidelity() const noexcept;
 
   private:
-    Operation(std::string name, std::string canonicalName, Arity arity,
-              size_t numParameters, std::vector<SiteTuple> siteTuples,
-              std::optional<uint64_t> duration, std::optional<double> fidelity);
+    OperationCapability(std::string name, std::string canonicalName,
+                        Arity arity, size_t numParameters,
+                        std::vector<SiteTuple> siteTuples,
+                        std::optional<uint64_t> duration,
+                        std::optional<double> fidelity);
 
     std::string name_;
     std::string canonicalName_;
@@ -250,21 +252,22 @@ public:
 
     /// Create explicitly enumerated native-operation support.
     [[nodiscard]] static NativeOperations
-    fromOperations(llvm::ArrayRef<Operation> operations);
+    fromOperations(llvm::ArrayRef<OperationCapability> operations);
 
     /// Return the native-operation support kind.
     [[nodiscard]] Kind kind() const noexcept;
 
     /// Return explicitly enumerated operations, if any.
-    [[nodiscard]] llvm::ArrayRef<Operation> operations() const noexcept;
+    [[nodiscard]] llvm::ArrayRef<OperationCapability>
+    operations() const noexcept;
 
   private:
     friend class CompilerTarget;
 
-    NativeOperations(Kind kind, llvm::ArrayRef<Operation> operations);
+    NativeOperations(Kind kind, llvm::ArrayRef<OperationCapability> operations);
 
     Kind kind_;
-    llvm::SmallVector<Operation> operations_;
+    llvm::SmallVector<OperationCapability> operations_;
   };
 
   /// Recognized native gate capability independent of synthesis code.
@@ -385,7 +388,7 @@ public:
   [[nodiscard]] NativeOperations::Kind nativeOperationsKind() const noexcept;
 
   /// Return operation capabilities in reported order.
-  [[nodiscard]] llvm::ArrayRef<Operation> operations() const noexcept;
+  [[nodiscard]] llvm::ArrayRef<OperationCapability> operations() const noexcept;
 
   /// Return whether an operation capability is supported by the target.
   [[nodiscard]] bool

--- a/mlir/include/mqt/Dialect/QC/IR/QCOps.td
+++ b/mlir/include/mqt/Dialect/QC/IR/QCOps.td
@@ -929,9 +929,9 @@ def UnitaryOp : QCOp<"unitary", traits = [UnitaryOpInterface]> {
 }
 
 def BarrierOp : QCOp<"barrier", traits = [UnitaryOpInterface]> {
-  let summary = "Apply a barrier gate to a set of qubits";
+  let summary = "Apply a barrier operation to a set of qubits";
   let description = [{
-        Applies a barrier gate to a set of qubits, modifying them in place.
+        Marks a barrier on the given qubit references without changing their quantum state.
 
         Example:
         ```mlir

--- a/mlir/include/mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h
+++ b/mlir/include/mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h
@@ -28,36 +28,40 @@ class ModuleOp;
 namespace qc {
 
 /// Controls source acceptance and the size of the emitted QC program.
-struct QASM3ImportOptions {
-  oq3::frontend::GatePolicy gatePolicy =
-      oq3::frontend::GatePolicy::MQTCompatibility;
+struct OpenQASMImportOptions {
+  openqasm::frontend::GatePolicy gatePolicy =
+      openqasm::frontend::GatePolicy::MQTCompatibility;
   /// Maximum number of inserted operations, excluding the module itself.
   size_t maxOperations = 10'000'000;
 };
 
-/// Translate an OpenQASM 3 program to a QC program.
+/// Translate supported OpenQASM to QC.
 ///
-/// Frontend and lowering failures are reported through the diagnostic engine of
+/// Accepts versionless input and versions 2.0, 3.0, and 3.1.
+///
+/// Frontend and emission failures are reported through the diagnostic engine of
 /// @p context and result in a null return value.
 ///
 /// @param sourceMgr Source manager containing the OpenQASM program.
 /// @param context MLIRContext to create the module in.
 /// @param options Frontend policy and emission resource limit.
 [[nodiscard]] OwningOpRef<ModuleOp>
-translateQASM3ToQC(llvm::SourceMgr& sourceMgr, MLIRContext* context,
-                   const QASM3ImportOptions& options = {});
+translateOpenQASMToQC(llvm::SourceMgr& sourceMgr, MLIRContext* context,
+                      const OpenQASMImportOptions& options = {});
 
-/// Translate an OpenQASM 3 program to a QC program.
+/// Translate supported OpenQASM to QC.
 ///
-/// Frontend and lowering failures are reported through the diagnostic engine of
+/// Accepts versionless input and versions 2.0, 3.0, and 3.1.
+///
+/// Frontend and emission failures are reported through the diagnostic engine of
 /// @p context and result in a null return value.
 ///
 /// @param source String containing the OpenQASM program.
 /// @param context MLIRContext to create the module in.
 /// @param options Frontend policy and emission resource limit.
 [[nodiscard]] OwningOpRef<ModuleOp>
-translateQASM3ToQC(StringRef source, MLIRContext* context,
-                   const QASM3ImportOptions& options = {});
+translateOpenQASMToQC(StringRef source, MLIRContext* context,
+                      const OpenQASMImportOptions& options = {});
 
 } // namespace qc
 

--- a/mlir/include/mqt/Dialect/QCO/Builder/QCOProgramBuilder.h
+++ b/mlir/include/mqt/Dialect/QCO/Builder/QCOProgramBuilder.h
@@ -44,8 +44,8 @@ namespace qco {
 /// SSA values and produce new output values, following the functional
 /// programming paradigm.
 ///
-/// @par Linear Type Enforcement:
-/// The builder enforces linear type semantics by tracking valid qubit SSA
+/// @par Linear Ownership:
+/// The builder enforces linear semantics by tracking valid qubit SSA
 /// values. Once a qubit is consumed by an operation producing a new version
 /// (e.g., reset, measure), the old SSA value is invalidated. This prevents
 /// use-after-consume errors and mirrors quantum computing's no-cloning theorem.
@@ -1522,7 +1522,7 @@ public:
   //===--------------------------------------------------------------------===//
 
   /// Construct an if operation for qubits or tensors of qubits with
-  /// linear typing
+  /// linear semantics
   ///
   /// Constructs an if operation that takes a bool Value and a range of qubit
   /// and qtensor values that are used in the then/else region of this
@@ -1619,7 +1619,7 @@ public:
               function_ref<Value(Value)> elseBody = nullptr);
 
   /// Construct an index switch operation for qubits or tensors of qubits
-  /// with linear typing.
+  /// with linear semantics.
   ///
   /// Constructs an index switch operation that takes an index Value and a range
   /// of qubit and qtensor values that are used in the case regions of this
@@ -1863,7 +1863,7 @@ private:
   void checkFinalized() const;
 
   //===--------------------------------------------------------------------===//
-  // Linear Type Tracking Helpers
+  /// Linear Ownership Tracking Helpers
   //===--------------------------------------------------------------------===//
 
   /// Validate that a qubit value is valid and unconsumed
@@ -1888,7 +1888,7 @@ private:
     }
   };
 
-  /// Track valid (unconsumed) qubit SSA values for linear type enforcement.
+  /// Track valid (unconsumed) qubit SSA values for linear ownership.
   /// Only values present in this set are valid for use in operations.
   /// When an operation consumes a qubit and produces a new one, the old value
   /// is removed and the new output is added.
@@ -1960,7 +1960,7 @@ private:
     }
   };
 
-  /// Track valid (unconsumed) tensor SSA values for linear type enforcement.
+  /// Track valid (unconsumed) tensor SSA values for linear ownership.
   /// Only values present in this set are valid for use in operations.
   /// When an operation consumes a tensor and produces a new one, the old value
   /// is removed and the new output is added.

--- a/mlir/include/mqt/Dialect/QCO/IR/QCOOps.td
+++ b/mlir/include/mqt/Dialect/QCO/IR/QCOOps.td
@@ -59,7 +59,7 @@ def SinkOp : QCOOp<"sink", [MemoryEffects<[MemFree]>]> {
   let description = [{
         Consumes a qubit SSA value and marks the end of its lifetime.
 
-        This operation is the canonical "sink" for QCO's linear/value semantics:
+        This operation is the canonical "sink" for QCO's linear ownership:
         every qubit value must be consumed exactly once on all paths.
 
         When converting back to QC (reference semantics), sinks corresponding to
@@ -1088,9 +1088,10 @@ def UnitaryOp : QCOOp<"unitary", traits = [UnitaryOpInterface, Pure]> {
 }
 
 def BarrierOp : QCOOp<"barrier", traits = [UnitaryOpInterface, Pure]> {
-  let summary = "Apply a barrier gate to a set of qubits";
+  let summary = "Apply a barrier operation to a set of qubits";
   let description = [{
-        Applies a barrier gate to a set of qubits and returns the transformed qubits.
+        Marks a barrier and transfers ownership of the input qubits to the results
+        without changing their quantum state.
 
         Example:
         ```mlir

--- a/mlir/include/mqt/Dialect/QTensor/IR/QTensorDialect.td
+++ b/mlir/include/mqt/Dialect/QTensor/IR/QTensorDialect.td
@@ -15,12 +15,14 @@ def QTensorDialect : Dialect {
   let name = "qtensor";
 
   let summary = "The QTensor dialect for one-dimensional tensors of qubits "
-                "with linear typing.";
+                "with linear semantics.";
 
   let description = [{
-    The QTensor dialect is an adjusted variant of the standard tensor dialect of MLIR that supports linear typing for one-dimensional tensors of qubits.
-    In order to support linear typing, the extract operations of this dialect are modified so that they also return the updated tensor.
-    In addition, alloc/dealloc operations are added to the dialect to support the bulk allocation and deallocation of qubit tensors with linear types.
+    The QTensor dialect represents one-dimensional tensors of qubits with
+    linear ownership. Each quantum SSA value must have exactly one use.
+    Extraction consumes a tensor and returns both the extracted qubits and
+    the remaining tensor. Allocation and deallocation create and consume
+    whole qubit tensors.
   }];
 
   let dependentDialects = ["::mlir::qco::QCODialect",

--- a/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMLexer.h
+++ b/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMLexer.h
@@ -18,7 +18,7 @@
 #include <cstdint>
 #include <iterator>
 
-namespace mlir::oq3::frontend::detail {
+namespace mlir::openqasm::frontend::detail {
 
 /// The kind of a lexical token.
 enum class TokenKind : uint8_t {
@@ -133,7 +133,7 @@ struct Token {
   bool wideInteger = false; ///< True when an integer literal exceeds `uint64_t`
 };
 
-/// A zero-copy lexer over an OpenQASM 3 source buffer.
+/// A zero-copy lexer over an OpenQASM source buffer.
 ///
 /// The lexer holds pointers into the buffer and produces tokens on demand
 /// without allocating. Token locations are `SMLoc`s into the buffer, so they
@@ -171,4 +171,4 @@ private:
   const char* end;
 };
 
-} // namespace mlir::oq3::frontend::detail
+} // namespace mlir::openqasm::frontend::detail

--- a/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMParser.h
+++ b/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMParser.h
@@ -31,9 +31,9 @@
 #include <optional>
 #include <utility>
 
-namespace mlir::oq3::frontend::detail {
+namespace mlir::openqasm::frontend::detail {
 
-/// A single-pass recursive-descent parser for OpenQASM 3.
+/// A single-pass recursive-descent parser for OpenQASM.
 ///
 /// The parser is target-independent. Its builder materializes a persistent
 /// syntax program and stores expressions directly in its ID arena.
@@ -1538,4 +1538,4 @@ private:
   size_t recursiveExpressionDepth = 0;
 };
 
-} // namespace mlir::oq3::frontend::detail
+} // namespace mlir::openqasm::frontend::detail

--- a/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMSemantics.h
+++ b/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMSemantics.h
@@ -15,7 +15,7 @@
 
 #include "llvm/Support/SourceMgr.h"
 
-namespace mlir::oq3::frontend::detail {
+namespace mlir::openqasm::frontend::detail {
 
 [[nodiscard]] AnalysisResult
 analyzeSyntaxProgram(const SyntaxProgram& syntax,
@@ -24,4 +24,4 @@ analyzeSyntaxProgram(const SyntaxProgram& syntax,
 [[nodiscard]] SourceLocation sourceLocation(const llvm::SourceMgr& sources,
                                             llvm::SMLoc location);
 
-} // namespace mlir::oq3::frontend::detail
+} // namespace mlir::openqasm::frontend::detail

--- a/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMSyntax.h
+++ b/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMSyntax.h
@@ -25,7 +25,7 @@
 #include <variant>
 #include <vector>
 
-namespace mlir::oq3::frontend::detail {
+namespace mlir::openqasm::frontend::detail {
 
 using SyntaxExpressionId = uint32_t;
 
@@ -400,4 +400,4 @@ private:
   bool sawConstruct = false;
 };
 
-} // namespace mlir::oq3::frontend::detail
+} // namespace mlir::openqasm::frontend::detail

--- a/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMUnicode.h
+++ b/mlir/include/mqt/Target/OpenQASM/Detail/OpenQASMUnicode.h
@@ -15,7 +15,7 @@
 #include <cstdint>
 #include <iterator>
 
-namespace mlir::oq3::frontend::detail {
+namespace mlir::openqasm::frontend::detail {
 
 struct UnicodeRange {
   constexpr UnicodeRange(const uint32_t first, const uint32_t last) noexcept
@@ -275,4 +275,4 @@ isOpenQASMIdentifierCodePoint(const uint32_t codePoint) noexcept {
   return false;
 }
 
-} // namespace mlir::oq3::frontend::detail
+} // namespace mlir::openqasm::frontend::detail

--- a/mlir/include/mqt/Target/OpenQASM/Frontend.h
+++ b/mlir/include/mqt/Target/OpenQASM/Frontend.h
@@ -25,7 +25,7 @@ namespace llvm {
 class SourceMgr;
 } // namespace llvm
 
-namespace mlir::oq3::frontend {
+namespace mlir::openqasm::frontend {
 
 /// Builtin floating constants reserved by the source language.
 [[nodiscard]] std::optional<double> getBuiltinConstant(llvm::StringRef name);
@@ -416,4 +416,4 @@ analyzeOpenQASM(llvm::SourceMgr& sourceMgr,
 analyzeOpenQASM(llvm::StringRef source,
                 GatePolicy gatePolicy = GatePolicy::MQTCompatibility);
 
-} // namespace mlir::oq3::frontend
+} // namespace mlir::openqasm::frontend

--- a/mlir/include/mqt/Target/OpenQASM/GateCatalog.h
+++ b/mlir/include/mqt/Target/OpenQASM/GateCatalog.h
@@ -18,7 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace mlir::oq3::frontend {
+namespace mlir::openqasm::frontend {
 
 enum class GateAvailability : uint8_t {
   Language,
@@ -28,22 +28,20 @@ enum class GateAvailability : uint8_t {
   Compatibility,
 };
 
-using GateLowering = qc::StandardGate;
-
 struct GateCatalogEntry {
-  GateCatalogEntry(llvm::StringRef name, GateLowering lowering,
+  GateCatalogEntry(llvm::StringRef name, qc::StandardGate gate,
                    size_t controlCount, GateAvailability availability,
                    bool variadicControls = false, bool inverse = false) noexcept
-      : name(name), lowering(lowering),
-        parameterCount(qc::getStandardGateDescriptor(lowering).parameterCount),
+      : name(name), gate(gate),
+        parameterCount(qc::getStandardGateDescriptor(gate).parameterCount),
         controlCount(controlCount +
-                     qc::getStandardGateDescriptor(lowering).controlCount),
-        targetCount(qc::getStandardGateDescriptor(lowering).targetCount),
+                     qc::getStandardGateDescriptor(gate).controlCount),
+        targetCount(qc::getStandardGateDescriptor(gate).targetCount),
         availability(availability), variadicControls(variadicControls),
         inverse(inverse) {}
 
   llvm::StringRef name;
-  GateLowering lowering;
+  qc::StandardGate gate;
   size_t parameterCount;
   size_t controlCount;
   size_t targetCount;
@@ -58,6 +56,6 @@ struct GateCatalogEntry {
 
 [[nodiscard]] const GateCatalogEntry* lookupGate(llvm::StringRef name);
 
-[[nodiscard]] llvm::StringRef canonicalGateName(GateLowering lowering);
+[[nodiscard]] llvm::StringRef canonicalGateName(qc::StandardGate gate);
 
-} // namespace mlir::oq3::frontend
+} // namespace mlir::openqasm::frontend

--- a/mlir/lib/Compiler/Pipeline.cpp
+++ b/mlir/lib/Compiler/Pipeline.cpp
@@ -443,7 +443,7 @@ runDefaultPipelineImpl(CompilerInput&& program, ProgramFormat output,
       return CompilerProgram(std::move(std::get<QCProgram>(program)));
     }
     if (std::holds_alternative<OpenQASMProgram>(program)) {
-      auto qc = QCProgram::fromQASMString(
+      auto qc = QCProgram::fromOpenQASMString(
           std::get<OpenQASMProgram>(program).source());
       if (qc) {
         return CompilerProgram(std::move(*qc));
@@ -462,7 +462,7 @@ runDefaultPipelineImpl(CompilerInput&& program, ProgramFormat output,
         if constexpr (std::is_same_v<ProgramType, QCOProgram>) {
           return std::forward<T>(value);
         } else if constexpr (std::is_same_v<ProgramType, OpenQASMProgram>) {
-          auto qc = QCProgram::fromQASMString(value.source());
+          auto qc = QCProgram::fromOpenQASMString(value.source());
           if (!qc) {
             return std::nullopt;
           }

--- a/mlir/lib/Compiler/Programs.cpp
+++ b/mlir/lib/Compiler/Programs.cpp
@@ -16,7 +16,7 @@
 #include "mqt/Dialect/QC/IR/QCDialect.h"
 #include "mqt/Dialect/QC/IR/QCInterfaces.h"
 #include "mqt/Dialect/QC/IR/QCOps.h"
-#include "mqt/Dialect/QC/Translation/TranslateQASM3ToQC.h"
+#include "mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h"
 #include "mqt/Dialect/QCO/IR/QCODialect.h"
 #include "mqt/Dialect/QCO/QCOUtils.h"
 #include "mqt/Dialect/QTensor/IR/QTensorDialect.h"
@@ -242,29 +242,28 @@ QCProgram::fromMLIRFile(const std::filesystem::path& path) {
 }
 
 std::optional<QCProgram>
-QCProgram::fromQASMString(const std::string_view source) {
+QCProgram::fromOpenQASMString(const std::string_view source) {
   auto context = createCompilerContext();
-  auto mod = qc::translateQASM3ToQC(source, context.get());
+  auto mod = qc::translateOpenQASMToQC(source, context.get());
   if (!mod) {
     emitError(UnknownLoc::get(context.get()),
-              "failed to translate OpenQASM 3 source to QC");
+              "failed to translate OpenQASM source to QC");
     return std::nullopt;
   }
   return QCProgram({.context = std::move(context), .mod = std::move(mod)});
 }
 
 std::optional<QCProgram>
-QCProgram::fromQASMFile(const std::filesystem::path& path) {
+QCProgram::fromOpenQASMFile(const std::filesystem::path& path) {
   auto context = createCompilerContext();
   llvm::SourceMgr sourceMgr;
   if (failed(openSourceMgr(path, context.get(), sourceMgr))) {
     return std::nullopt;
   }
-  auto mod = qc::translateQASM3ToQC(sourceMgr, context.get());
+  auto mod = qc::translateOpenQASMToQC(sourceMgr, context.get());
   if (!mod) {
     emitError(UnknownLoc::get(context.get()))
-        << "failed to translate OpenQASM 3 file '" << path.string()
-        << "' to QC";
+        << "failed to translate OpenQASM file '" << path.string() << "' to QC";
     return std::nullopt;
   }
   return QCProgram({.context = std::move(context), .mod = std::move(mod)});

--- a/mlir/lib/Compiler/QDMIAdapter.cpp
+++ b/mlir/lib/Compiler/QDMIAdapter.cpp
@@ -91,7 +91,7 @@ requireCircuitDevice(bool condition, llvm::StringRef deviceName,
                      llvm::StringRef detail) {
   return requireAdapterInput(
       condition, llvm::Twine("QDMI device '") + deviceName +
-                     "' cannot be used as an MLIR compiler target: only "
+                     "' cannot be used as an MQT compiler target: only "
                      "circuit-model devices with one qubit per non-zone site "
                      "are supported (" +
                      detail + ")");
@@ -104,7 +104,7 @@ requireRepresentableOperation(bool condition, llvm::StringRef deviceName,
   return requireAdapterInput(
       condition, llvm::Twine("QDMI device '") + deviceName + "' operation '" +
                      operationName +
-                     "' cannot be represented by the MLIR compiler target (" +
+                     "' cannot be represented by the MQT compiler target (" +
                      detail + ")");
 }
 
@@ -344,7 +344,7 @@ snapshotOperations(
       expectedCouplings->insert(canonicalCoupling(first, second));
     }
   }
-  std::vector<CompilerTarget::Operation> targetOperations;
+  std::vector<CompilerTarget::OperationCapability> targetOperations;
   targetOperations.reserve(operations.size());
   for (const auto& operation : operations) {
     if (auto error =
@@ -419,9 +419,9 @@ snapshotOperations(
     }
     const auto targetArity =
         hasArbitraryPositiveControls
-            ? CompilerTarget::Operation::Arity::variadic(*arity)
-            : CompilerTarget::Operation::Arity::fixed(*arity);
-    auto targetOperation = CompilerTarget::Operation::create(
+            ? CompilerTarget::OperationCapability::Arity::variadic(*arity)
+            : CompilerTarget::OperationCapability::Arity::fixed(*arity);
+    auto targetOperation = CompilerTarget::OperationCapability::create(
         std::move(operationName), targetArity, operation.getParametersNum(),
         std::move(siteTuples), includeCalibration ? duration : std::nullopt,
         includeCalibration ? fidelity : std::nullopt);
@@ -490,7 +490,7 @@ snapshotCompilerTarget(const qdmi::Device& device,
   if (auto error = requireAdapterInput(
           couplings || hasHomogeneousAllToAllMetadata || sites.size() == 1,
           llvm::Twine("QDMI device '") + deviceName +
-              "' cannot be used as an MLIR compiler target: connectivity is "
+              "' cannot be used as an MQT compiler target: connectivity is "
               "not reported")) {
     return error;
   }
@@ -574,8 +574,8 @@ static llvm::Error incompatible(const llvm::Twine& detail) {
           "; recompile for this device");
 }
 
-static bool sameOperation(const CompilerTarget::Operation& lhs,
-                          const CompilerTarget::Operation& rhs) {
+static bool sameOperation(const CompilerTarget::OperationCapability& lhs,
+                          const CompilerTarget::OperationCapability& rhs) {
   if (lhs.canonicalName() != rhs.canonicalName() ||
       lhs.arity() != rhs.arity() ||
       lhs.numParameters() != rhs.numParameters() ||

--- a/mlir/lib/Compiler/Target.cpp
+++ b/mlir/lib/Compiler/Target.cpp
@@ -348,44 +348,50 @@ std::optional<double> CompilerTarget::SiteTuple::fidelity() const noexcept {
   return fidelity_;
 }
 
-CompilerTarget::Operation::Arity
-CompilerTarget::Operation::Arity::fixed(size_t value) noexcept {
+CompilerTarget::OperationCapability::Arity
+CompilerTarget::OperationCapability::Arity::fixed(size_t value) noexcept {
   return {Kind::Fixed, value};
 }
 
-CompilerTarget::Operation::Arity
-CompilerTarget::Operation::Arity::variadic(size_t minimum) noexcept {
+CompilerTarget::OperationCapability::Arity
+CompilerTarget::OperationCapability::Arity::variadic(size_t minimum) noexcept {
   return {Kind::Variadic, minimum};
 }
 
-CompilerTarget::Operation::Arity::Kind
-CompilerTarget::Operation::Arity::kind() const noexcept {
+CompilerTarget::OperationCapability::Arity::Kind
+CompilerTarget::OperationCapability::Arity::kind() const noexcept {
   return kind_;
 }
 
-size_t CompilerTarget::Operation::Arity::value() const noexcept {
+size_t CompilerTarget::OperationCapability::Arity::value() const noexcept {
   return value_;
 }
 
-bool CompilerTarget::Operation::Arity::accepts(size_t width) const noexcept {
+bool CompilerTarget::OperationCapability::Arity::accepts(
+    size_t width) const noexcept {
   return kind_ == Kind::Variadic ? width >= value_ : width == value_;
 }
 
-CompilerTarget::Operation::Arity::Arity(Kind kind, size_t value) noexcept
+CompilerTarget::OperationCapability::Arity::Arity(Kind kind,
+                                                  size_t value) noexcept
     : kind_(kind), value_(value) {}
 
-llvm::Expected<CompilerTarget::Operation> CompilerTarget::Operation::create(
-    std::string name, size_t arity, size_t numParameters,
-    std::vector<SiteTuple> siteTuples, std::optional<uint64_t> duration,
-    std::optional<double> fidelity) {
+llvm::Expected<CompilerTarget::OperationCapability>
+CompilerTarget::OperationCapability::create(std::string name, size_t arity,
+                                            size_t numParameters,
+                                            std::vector<SiteTuple> siteTuples,
+                                            std::optional<uint64_t> duration,
+                                            std::optional<double> fidelity) {
   return create(std::move(name), Arity::fixed(arity), numParameters,
                 std::move(siteTuples), duration, fidelity);
 }
 
-llvm::Expected<CompilerTarget::Operation> CompilerTarget::Operation::create(
-    std::string name, Arity arity, size_t numParameters,
-    std::vector<SiteTuple> siteTuples, std::optional<uint64_t> duration,
-    std::optional<double> fidelity) {
+llvm::Expected<CompilerTarget::OperationCapability>
+CompilerTarget::OperationCapability::create(std::string name, Arity arity,
+                                            size_t numParameters,
+                                            std::vector<SiteTuple> siteTuples,
+                                            std::optional<uint64_t> duration,
+                                            std::optional<double> fidelity) {
   auto canonicalName = canonicalOperationName(name);
   if (canonicalName.empty()) {
     return invalidTarget("Compiler target operation name must not be empty");
@@ -420,46 +426,49 @@ llvm::Expected<CompilerTarget::Operation> CompilerTarget::Operation::create(
     }
   }
 
-  return Operation(std::move(name), std::move(canonicalName), arity,
-                   numParameters, std::move(siteTuples), duration, fidelity);
+  return OperationCapability(std::move(name), std::move(canonicalName), arity,
+                             numParameters, std::move(siteTuples), duration,
+                             fidelity);
 }
 
-CompilerTarget::Operation::Operation(std::string name,
-                                     std::string canonicalName, Arity arity,
-                                     size_t numParameters,
-                                     std::vector<SiteTuple> siteTuples,
-                                     std::optional<uint64_t> duration,
-                                     std::optional<double> fidelity)
+CompilerTarget::OperationCapability::OperationCapability(
+    std::string name, std::string canonicalName, Arity arity,
+    size_t numParameters, std::vector<SiteTuple> siteTuples,
+    std::optional<uint64_t> duration, std::optional<double> fidelity)
     : name_(std::move(name)), canonicalName_(std::move(canonicalName)),
       arity_(arity), numParameters_(numParameters),
       siteTuples_(std::move(siteTuples)), duration_(duration),
       fidelity_(fidelity) {}
 
-StringRef CompilerTarget::Operation::name() const noexcept { return name_; }
+StringRef CompilerTarget::OperationCapability::name() const noexcept {
+  return name_;
+}
 
-StringRef CompilerTarget::Operation::canonicalName() const noexcept {
+StringRef CompilerTarget::OperationCapability::canonicalName() const noexcept {
   return canonicalName_;
 }
 
-CompilerTarget::Operation::Arity
-CompilerTarget::Operation::arity() const noexcept {
+CompilerTarget::OperationCapability::Arity
+CompilerTarget::OperationCapability::arity() const noexcept {
   return arity_;
 }
 
-size_t CompilerTarget::Operation::numParameters() const noexcept {
+size_t CompilerTarget::OperationCapability::numParameters() const noexcept {
   return numParameters_;
 }
 
 ArrayRef<CompilerTarget::SiteTuple>
-CompilerTarget::Operation::siteTuples() const noexcept {
+CompilerTarget::OperationCapability::siteTuples() const noexcept {
   return siteTuples_;
 }
 
-std::optional<uint64_t> CompilerTarget::Operation::duration() const noexcept {
+std::optional<uint64_t>
+CompilerTarget::OperationCapability::duration() const noexcept {
   return duration_;
 }
 
-std::optional<double> CompilerTarget::Operation::fidelity() const noexcept {
+std::optional<double>
+CompilerTarget::OperationCapability::fidelity() const noexcept {
   return fidelity_;
 }
 
@@ -470,7 +479,7 @@ CompilerTarget::NativeOperations::unrestricted() {
 
 CompilerTarget::NativeOperations
 CompilerTarget::NativeOperations::fromOperations(
-    ArrayRef<Operation> operations) {
+    ArrayRef<OperationCapability> operations) {
   return {Kind::Explicit, operations};
 }
 
@@ -479,13 +488,13 @@ CompilerTarget::NativeOperations::kind() const noexcept {
   return kind_;
 }
 
-ArrayRef<CompilerTarget::Operation>
+ArrayRef<CompilerTarget::OperationCapability>
 CompilerTarget::NativeOperations::operations() const noexcept {
   return operations_;
 }
 
 CompilerTarget::NativeOperations::NativeOperations(
-    Kind kind, ArrayRef<Operation> operations)
+    Kind kind, ArrayRef<OperationCapability> operations)
     : kind_(kind), operations_(operations) {}
 
 struct CompilerTarget::Storage {
@@ -493,7 +502,7 @@ struct CompilerTarget::Storage {
           Connectivity::Kind targetConnectivityKind,
           SmallVector<Coupling> targetCouplings,
           NativeOperations::Kind targetNativeOperationsKind,
-          SmallVector<Operation> targetOperations,
+          SmallVector<OperationCapability> targetOperations,
           std::optional<DurationUnit> targetDurationUnit);
 
   [[nodiscard]] llvm::Error initialize();
@@ -521,7 +530,7 @@ struct CompilerTarget::Storage {
   mutable std::once_flag distancesOnce;
   size_t maximumDegree = 0;
   NativeOperations::Kind nativeOperationsKind;
-  SmallVector<Operation> operations;
+  SmallVector<OperationCapability> operations;
   llvm::StringMap<SmallVector<size_t, 1>> capabilities;
   /// Keys borrow the immutable site tuples owned by operations.
   std::vector<llvm::DenseSet<ArrayRef<SiteId>>> operationSites;
@@ -534,7 +543,7 @@ CompilerTarget::Storage::Storage(
     Connectivity::Kind targetConnectivityKind,
     SmallVector<Coupling> targetCouplings,
     NativeOperations::Kind targetNativeOperationsKind,
-    SmallVector<Operation> targetOperations,
+    SmallVector<OperationCapability> targetOperations,
     std::optional<DurationUnit> targetDurationUnit)
     : name(std::move(targetName)), durationUnit(std::move(targetDurationUnit)),
       sites(std::move(targetSites)), connectivityKind(targetConnectivityKind),
@@ -622,7 +631,8 @@ llvm::Error CompilerTarget::Storage::initialize() {
     operationSites.resize(operations.size());
     for (const auto [index, operation] : llvm::enumerate(operations)) {
       if (operation.arity().value() > sites.size()) {
-        if (operation.arity().kind() == Operation::Arity::Kind::Variadic) {
+        if (operation.arity().kind() ==
+            OperationCapability::Arity::Kind::Variadic) {
           return invalidTarget("Compiler target operation variadic minimum "
                                "exceeds its site count");
         }
@@ -694,8 +704,8 @@ bool CompilerTarget::Storage::supportsOperation(
   }
   return llvm::any_of(found->second, [&](const auto index) {
     const auto& operation = operations[index];
-    return (!variadicOnly ||
-            operation.arity().kind() == Operation::Arity::Kind::Variadic) &&
+    return (!variadicOnly || operation.arity().kind() ==
+                                 OperationCapability::Arity::Kind::Variadic) &&
            operation.arity().accepts(arity) &&
            (!numParameters || operation.numParameters() == *numParameters) &&
            (!orderedSites || operation.siteTuples().empty() ||
@@ -735,7 +745,8 @@ CompilerTarget::Storage::resolveSynthesisBasis() const {
     return llvm::any_of(found->second, [&](const auto index) {
       const auto& operation = operations[index];
       return (!variadicOnly ||
-              operation.arity().kind() == Operation::Arity::Kind::Variadic) &&
+              operation.arity().kind() ==
+                  OperationCapability::Arity::Kind::Variadic) &&
              operation.arity().accepts(arity) &&
              operation.numParameters() == numParameters &&
              operation.siteTuples().empty();
@@ -927,7 +938,7 @@ CompilerTarget::create(const mqt::CompilationTargetAttr attribute) {
 
   auto nativeOperations = NativeOperations::unrestricted();
   if (attribute.getNativeOperations() == mqt::NativeOperationsKind::Explicit) {
-    std::vector<Operation> operations;
+    std::vector<OperationCapability> operations;
     operations.reserve(attribute.getOperations().size());
     for (const auto operationAttr : attribute.getOperations()) {
       if (operationAttr.getArity().getValue() >
@@ -960,11 +971,11 @@ CompilerTarget::create(const mqt::CompilationTargetAttr attribute) {
       }
       const auto arity =
           operationAttr.getArity().getKind() == mqt::OperationArityKind::Fixed
-              ? Operation::Arity::fixed(
+              ? OperationCapability::Arity::fixed(
                     static_cast<size_t>(operationAttr.getArity().getValue()))
-              : Operation::Arity::variadic(
+              : OperationCapability::Arity::variadic(
                     static_cast<size_t>(operationAttr.getArity().getValue()));
-      auto operation = Operation::create(
+      auto operation = OperationCapability::create(
           operationAttr.getName().getValue().str(), arity,
           static_cast<size_t>(operationAttr.getNumParameters()),
           std::move(siteTuples), operationAttr.getDuration(), fidelity);
@@ -1097,7 +1108,7 @@ CompilerTarget::nativeOperationsKind() const noexcept {
   return storage_->nativeOperationsKind;
 }
 
-ArrayRef<CompilerTarget::Operation>
+ArrayRef<CompilerTarget::OperationCapability>
 CompilerTarget::operations() const noexcept {
   return storage_->operations;
 }
@@ -1254,7 +1265,7 @@ CompilerTarget::materialize(MLIRContext& context) const {
       fidelityAttr = builder.getF64FloatAttr(*fidelity);
     }
     const auto arityKind =
-        operation.arity().kind() == Operation::Arity::Kind::Fixed
+        operation.arity().kind() == OperationCapability::Arity::Kind::Fixed
             ? mqt::OperationArityKind::Fixed
             : mqt::OperationArityKind::Variadic;
     const auto arityAttr = mqt::OperationArityAttr::get(

--- a/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
+++ b/mlir/lib/Conversion/QCToQCO/QCToQCO.cpp
@@ -732,11 +732,11 @@ namespace {
 
 /// Converts func.return and sinks remaining live qubits.
 ///
-/// QC uses reference semantics and does not enforce linear typing for qubits.
-/// After conversion, QCO requires that every qubit SSA value is consumed
-/// exactly once. For allocations (including static qubits), the sink is
-/// `qco.sink`. This pattern inserts `qco.sink` operations for all
-/// still-live qubits tracked in the lowering state right before the return.
+/// QC uses reference semantics and does not enforce linear semantics for
+/// qubits. After conversion, QCO requires that every qubit SSA value is
+/// consumed exactly once. For allocations (including static qubits), the sink
+/// is `qco.sink`. This pattern inserts `qco.sink` operations for all still-live
+/// qubits tracked in the lowering state right before the return.
 struct ConvertFuncReturnOp final : StatefulOpConversionPattern<func::ReturnOp> {
   using StatefulOpConversionPattern::StatefulOpConversionPattern;
 

--- a/mlir/lib/Dialect/QC/Translation/CMakeLists.txt
+++ b/mlir/lib/Dialect/QC/Translation/CMakeLists.txt
@@ -20,7 +20,7 @@ add_mlir_library(
   MLIRQCOpenQASMTranslation
   PARTIAL_SOURCES_INTENDED
   OpenQASMToQCEmitter.cpp
-  TranslateQASM3ToQC.cpp
+  TranslateOpenQASMToQC.cpp
   TranslateQCToOpenQASM3.cpp
   LINK_LIBS
   MLIRAnalysis
@@ -48,5 +48,5 @@ target_sources(
          BASE_DIRS
          ${MQT_MLIR_SOURCE_INCLUDE_DIR}
          FILES
-         ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mqt/Dialect/QC/Translation/TranslateQASM3ToQC.h
+         ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h
          ${MQT_MLIR_SOURCE_INCLUDE_DIR}/mqt/Dialect/QC/Translation/TranslateQCToOpenQASM3.h)

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.cpp
@@ -65,9 +65,8 @@
 namespace mlir::qc::detail {
 namespace {
 
-namespace frontend = oq3::frontend;
-using oq3::frontend::GateCatalogEntry;
-using oq3::frontend::GateLowering;
+namespace frontend = openqasm::frontend;
+using openqasm::frontend::GateCatalogEntry;
 
 class OpenQASMToQCEmitter {
   class EmissionBudget final : public OpBuilder::Listener {
@@ -111,12 +110,12 @@ class OpenQASMToQCEmitter {
       exhausted = true;
       emitError(location)
           << "OpenQASM QC emission error: emitted operation count exceeds the "
-             "safe lowering limit";
+             "safe emission limit";
     }
   };
 
 public:
-  OpenQASMToQCEmitter(const oq3::frontend::TypedProgram& typedProgram,
+  OpenQASMToQCEmitter(const openqasm::frontend::TypedProgram& typedProgram,
                       MLIRContext& mlirContext, size_t operationLimit)
       : program(typedProgram), context(mlirContext),
         emissionBudget(context, operationLimit), builder(&context),
@@ -198,7 +197,7 @@ public:
 
 private:
   // The engine cannot exist without the program and context that outlive it.
-  const oq3::frontend::TypedProgram& program;
+  const openqasm::frontend::TypedProgram& program;
   MLIRContext& context;
   EmissionBudget emissionBudget;
   qc::QCProgramBuilder builder;
@@ -206,10 +205,10 @@ private:
   std::vector<Value> classicalRegisters;
   std::vector<Value> scalarValues;
   llvm::DenseMap<frontend::ScalarId, Value> provenInductionValues;
-  DenseMap<const oq3::frontend::GateDefinition*, bool>
+  DenseMap<const openqasm::frontend::GateDefinition*, bool>
       structuredGateCapabilities;
-  llvm::StringMap<const oq3::frontend::GateDefinition*> customGateIndex;
-  DenseMap<const oq3::frontend::GateDefinition*, func::FuncOp>
+  llvm::StringMap<const openqasm::frontend::GateDefinition*> customGateIndex;
+  DenseMap<const openqasm::frontend::GateDefinition*, func::FuncOp>
       customGateFunctions_;
   bool emissionFailed = false;
   QCProgramBuilder::LoopBuilder* activeLoop = nullptr;
@@ -256,21 +255,21 @@ private:
     return isExactlyRepresentableAsDouble(magnitude);
   }
 
-  [[nodiscard]] const oq3::frontend::GateDefinition*
+  [[nodiscard]] const openqasm::frontend::GateDefinition*
   findCustomGate(const StringRef name) const {
     return customGateIndex.lookup(name);
   }
 
   [[nodiscard]] bool statementsRequireStructuredControlFlow(
-      const ArrayRef<oq3::frontend::StatementId> statements) const {
+      const ArrayRef<openqasm::frontend::StatementId> statements) const {
     return llvm::any_of(statements, [&](const auto id) {
       const auto& data = program.statements.at(id).data;
-      if (std::holds_alternative<oq3::frontend::ForStatement>(data) ||
-          std::holds_alternative<oq3::frontend::WhileStatement>(data)) {
+      if (std::holds_alternative<openqasm::frontend::ForStatement>(data) ||
+          std::holds_alternative<openqasm::frontend::WhileStatement>(data)) {
         return true;
       }
       const auto* application =
-          std::get_if<oq3::frontend::GateApplication>(&data);
+          std::get_if<openqasm::frontend::GateApplication>(&data);
       const auto* callee = application == nullptr
                                ? nullptr
                                : findCustomGate(application->callee);
@@ -279,7 +278,7 @@ private:
   }
 
   [[nodiscard]] bool gateRequiresStructuredControlFlow(
-      const oq3::frontend::GateDefinition& gate) const {
+      const openqasm::frontend::GateDefinition& gate) const {
     return structuredGateCapabilities.lookup(&gate);
   }
 
@@ -356,7 +355,7 @@ private:
                 frontend::QubitReferenceKind::Hardware) {
           emitError(getLocation(condition.location))
               << "OpenQASM QC emission error: mixing physical and declared "
-                 "qubits is not supported by the QC target";
+                 "qubits is not supported by the QC translation";
           return false;
         }
       }
@@ -378,7 +377,7 @@ private:
         if (containsHardwareQubit) {
           emitError(getLocation(statement.location))
               << "OpenQASM QC emission error: mixing physical and declared "
-                 "qubits is not supported by the QC target";
+                 "qubits is not supported by the QC translation";
           return false;
         }
       }
@@ -977,12 +976,6 @@ private:
         resolveQubit(reference, gateQubits, indices.front()));
   }
 
-  static LogicalResult emitPrimitive(OpBuilder& opBuilder, const Location loc,
-                                     const GateLowering lowering,
-                                     ValueRange parameters, ValueRange qubits) {
-    return qc::emitStandardGate(opBuilder, loc, lowering, parameters, qubits);
-  }
-
   static Value
   emitOpenQASM3Phase(OpBuilder& opBuilder, const Location loc,
                      ValueRange uParameters,
@@ -1064,7 +1057,7 @@ private:
     }
 
     const GateCatalogEntry* catalog =
-        oq3::frontend::lookupGate(application.callee);
+        openqasm::frontend::lookupGate(application.callee);
     if (catalog == nullptr || qubits.size() < catalog->targetCount) {
       return failure();
     }
@@ -1076,7 +1069,7 @@ private:
     }
     auto controlValues = qubits.take_front(controls);
     auto targets = qubits.drop_front(controls);
-    if (catalog->lowering == GateLowering::CU) {
+    if (catalog->gate == qc::StandardGate::CU) {
       if (controls != 1 || parameters.size() != 4 || targets.size() != 1) {
         return failure();
       }
@@ -1086,33 +1079,33 @@ private:
       LogicalResult result = success();
       qc::CtrlOp::create(
           opBuilder, loc, controlValues, targets, [&](ValueRange aliases) {
-            result = emitPrimitive(opBuilder, loc, GateLowering::U3,
-                                   parameters.take_front(3), aliases);
+            result = qc::emitStandardGate(opBuilder, loc, qc::StandardGate::U3,
+                                          parameters.take_front(3), aliases);
           });
       return result;
     }
 
     const auto emitCatalogLowering = [&](ValueRange primitiveQubits) {
       const auto emitBody = [&](ValueRange bodyQubits) {
-        if (catalog->lowering == GateLowering::BuiltinU ||
-            catalog->lowering == GateLowering::U2 ||
-            catalog->lowering == GateLowering::U3) {
+        if (catalog->gate == qc::StandardGate::BuiltinU ||
+            catalog->gate == qc::StandardGate::U2 ||
+            catalog->gate == qc::StandardGate::U3) {
           Value phase;
-          if (catalog->lowering == GateLowering::BuiltinU &&
+          if (catalog->gate == qc::StandardGate::BuiltinU &&
               !program.openQASM2) {
             phase = emitOpenQASM3Phase(opBuilder, loc, parameters);
           } else {
             phase = emitOpenQASM2UPhase(opBuilder, loc, parameters);
           }
           qc::GPhaseOp::create(opBuilder, loc, phase);
-          const auto primitive = catalog->lowering == GateLowering::U2
-                                     ? GateLowering::U2
-                                     : GateLowering::U3;
-          return emitPrimitive(opBuilder, loc, primitive, parameters,
-                               bodyQubits);
+          const auto primitive = catalog->gate == qc::StandardGate::U2
+                                     ? qc::StandardGate::U2
+                                     : qc::StandardGate::U3;
+          return qc::emitStandardGate(opBuilder, loc, primitive, parameters,
+                                      bodyQubits);
         }
-        return emitPrimitive(opBuilder, loc, catalog->lowering, parameters,
-                             bodyQubits);
+        return qc::emitStandardGate(opBuilder, loc, catalog->gate, parameters,
+                                    bodyQubits);
       };
       if (!catalog->inverse) {
         return emitBody(primitiveQubits);
@@ -1331,7 +1324,7 @@ private:
       emissionFailed = true;
       emitError(loc) << "OpenQASM QC emission error: gate '"
                      << application.callee
-                     << "' has no lowering to the QC dialect";
+                     << "' cannot be translated to the QC dialect";
     }
   }
 

--- a/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h
+++ b/mlir/lib/Dialect/QC/Translation/OpenQASMToQCEmitter.h
@@ -24,11 +24,11 @@ class Location;
 namespace qc::detail {
 
 [[nodiscard]] Location
-getOpenQASMLocation(const oq3::frontend::SourceLocation& source,
+getOpenQASMLocation(const openqasm::frontend::SourceLocation& source,
                     MLIRContext& context);
 
 [[nodiscard]] OwningOpRef<ModuleOp>
-emitOpenQASMToQC(const oq3::frontend::TypedProgram& program,
+emitOpenQASMToQC(const openqasm::frontend::TypedProgram& program,
                  MLIRContext& context, size_t operationLimit);
 
 } // namespace qc::detail

--- a/mlir/lib/Dialect/QC/Translation/TranslateOpenQASMToQC.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateOpenQASMToQC.cpp
@@ -8,7 +8,7 @@
  * Licensed under the MIT License
  */
 
-#include "mqt/Dialect/QC/Translation/TranslateQASM3ToQC.h"
+#include "mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h"
 
 #include "mqt/Target/OpenQASM/Frontend.h"
 
@@ -27,7 +27,7 @@
 namespace mlir::qc {
 
 static void
-emitDiagnostics(const ArrayRef<oq3::frontend::Diagnostic> diagnostics,
+emitDiagnostics(const ArrayRef<openqasm::frontend::Diagnostic> diagnostics,
                 MLIRContext& context) {
   for (const auto& diagnostic : diagnostics) {
     emitError(detail::getOpenQASMLocation(diagnostic.location, context))
@@ -35,10 +35,11 @@ emitDiagnostics(const ArrayRef<oq3::frontend::Diagnostic> diagnostics,
   }
 }
 
-OwningOpRef<ModuleOp> translateQASM3ToQC(llvm::SourceMgr& sourceMgr,
-                                         MLIRContext* context,
-                                         const QASM3ImportOptions& options) {
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr, options.gatePolicy);
+OwningOpRef<ModuleOp>
+translateOpenQASMToQC(llvm::SourceMgr& sourceMgr, MLIRContext* context,
+                      const OpenQASMImportOptions& options) {
+  auto analyzed =
+      openqasm::frontend::analyzeOpenQASM(sourceMgr, options.gatePolicy);
   if (!analyzed) {
     emitDiagnostics(analyzed.diagnostics, *context);
     return nullptr;
@@ -54,14 +55,14 @@ OwningOpRef<ModuleOp> translateQASM3ToQC(llvm::SourceMgr& sourceMgr,
   return moduleOp;
 }
 
-OwningOpRef<ModuleOp> translateQASM3ToQC(const StringRef source,
-                                         MLIRContext* context,
-                                         const QASM3ImportOptions& options) {
+OwningOpRef<ModuleOp>
+translateOpenQASMToQC(const StringRef source, MLIRContext* context,
+                      const OpenQASMImportOptions& options) {
   llvm::SourceMgr sourceMgr;
   sourceMgr.AddNewSourceBuffer(
       llvm::MemoryBuffer::getMemBuffer(source, "<input>", false),
       llvm::SMLoc());
-  return translateQASM3ToQC(sourceMgr, context, options);
+  return translateOpenQASMToQC(sourceMgr, context, options);
 }
 
 } // namespace mlir::qc

--- a/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
+++ b/mlir/lib/Dialect/QC/Translation/TranslateQCToOpenQASM3.cpp
@@ -100,9 +100,9 @@ struct GateCall {
 } // namespace
 
 [[nodiscard]] static bool isValidOutputName(const StringRef value) {
-  return oq3::frontend::isValidIdentifier(value) &&
+  return openqasm::frontend::isValidIdentifier(value) &&
          !value.starts_with("_mqt_") &&
-         oq3::frontend::lookupGate(value) == nullptr;
+         openqasm::frontend::lookupGate(value) == nullptr;
 }
 
 [[nodiscard]] static std::optional<int64_t> getConstantInteger(Value value) {
@@ -1888,15 +1888,16 @@ private:
       fixedHelpers.insert("_mqt_u");
       return std::string("_mqt_u");
     }
-    const auto* gate = oq3::frontend::lookupGate(symbol);
+    const auto* gate = openqasm::frontend::lookupGate(symbol);
     if (gate == nullptr ||
-        gate->availability == oq3::frontend::GateAvailability::QELib1) {
+        gate->availability == openqasm::frontend::GateAvailability::QELib1) {
       emitError(function.getLoc())
           << "OpenQASM emission error: unsupported quantum gate '" << symbol
           << "'";
       return failure();
     }
-    if (gate->availability == oq3::frontend::GateAvailability::Compatibility) {
+    if (gate->availability ==
+        openqasm::frontend::GateAvailability::Compatibility) {
       fixedHelpers.insert(symbol);
     }
     return symbol.str();

--- a/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
+++ b/mlir/lib/Dialect/QCO/Builder/QCOProgramBuilder.cpp
@@ -366,7 +366,7 @@ void QCOProgramBuilder::storeClassicalBit(
 }
 
 //===----------------------------------------------------------------------===//
-// Linear Type Tracking Helpers
+/// Linear Ownership Tracking Helpers
 //===----------------------------------------------------------------------===//
 
 void QCOProgramBuilder::validateQubitValue(Value qubit) const {

--- a/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/WireIterator.cpp
@@ -78,7 +78,7 @@ void WireIterator::forward() {
   }
 
   // Find the user-operation of the qubit SSA value.
-  assert(qubit_.hasOneUse() && "expected linear typing");
+  assert(qubit_.hasOneUse() && "expected linear semantics");
   op_ = *qubit_.user_begin();
 
   if (isTail(op_)) {

--- a/mlir/lib/Dialect/QTensor/IR/QTensorCanonicalization.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/QTensorCanonicalization.cpp
@@ -64,7 +64,7 @@ analyzeQTensorBranch(Block* block, size_t qTensorArgumentIndex,
   bool reachedInsertPhase = false;
 
   while (true) {
-    assert(currentQTensor.hasOneUse() && "expected linear typing");
+    assert(currentQTensor.hasOneUse() && "expected linear semantics");
     Operation* user = *currentQTensor.getUsers().begin();
     if (user->getBlock() != block) {
       return std::nullopt;

--- a/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
+++ b/mlir/lib/Dialect/QTensor/Utils/TensorIterator.cpp
@@ -47,7 +47,7 @@ whileResultForInit(scf::WhileOp op, OpOperand& init) {
       op.getBeforeBody()->getArgument(init.getOperandNumber()));
   TensorIterator iterator(current);
   while (true) {
-    assert(current.hasOneUse() && "expected linear typing");
+    assert(current.hasOneUse() && "expected linear semantics");
     auto* user = *current.user_begin();
     if (auto condition = dyn_cast<scf::ConditionOp>(user)) {
       const auto result = llvm::find(condition.getArgs(), current);
@@ -99,7 +99,7 @@ void TensorIterator::forward() {
   }
 
   // Find the user-operation of the tensor SSA value.
-  assert(tensor_.hasOneUse() && "expected linear typing");
+  assert(tensor_.hasOneUse() && "expected linear semantics");
   op_ = *tensor_.user_begin();
 
   // The following operations define the end of the tensor's life-chain. A

--- a/mlir/lib/Target/OpenQASM/Frontend.cpp
+++ b/mlir/lib/Target/OpenQASM/Frontend.cpp
@@ -37,7 +37,7 @@
 #include <utility>
 #include <vector>
 
-namespace mlir::oq3::frontend {
+namespace mlir::openqasm::frontend {
 
 std::optional<double> getBuiltinConstant(llvm::StringRef name) {
   if (name == "pi" || name == "π") {
@@ -391,4 +391,4 @@ AnalysisResult analyzeOpenQASM(const llvm::StringRef source,
   return analyzeOpenQASM(*parsed.program, gatePolicy);
 }
 
-} // namespace mlir::oq3::frontend
+} // namespace mlir::openqasm::frontend

--- a/mlir/lib/Target/OpenQASM/GateCatalog.cpp
+++ b/mlir/lib/Target/OpenQASM/GateCatalog.cpp
@@ -16,7 +16,7 @@
 
 #include <array>
 
-namespace mlir::oq3::frontend {
+namespace mlir::openqasm::frontend {
 namespace {
 
 using Availability = GateAvailability;
@@ -24,72 +24,74 @@ constexpr auto STD = Availability::StandardLibrary;
 constexpr auto QE_LIB1 = Availability::QELib1;
 constexpr auto BOTH = Availability::StandardLibraryAndQELib1;
 constexpr auto COMPAT = Availability::Compatibility;
-using Lowering = GateLowering;
 
 const std::array CATALOG{
-    GateCatalogEntry{"gphase", Lowering::GPhase, 0, Availability::Language},
-    GateCatalogEntry{"U", Lowering::BuiltinU, 0, Availability::Language},
-    GateCatalogEntry{"id", Lowering::Id, 0, BOTH},
-    GateCatalogEntry{"x", Lowering::X, 0, BOTH},
-    GateCatalogEntry{"y", Lowering::Y, 0, BOTH},
-    GateCatalogEntry{"z", Lowering::Z, 0, BOTH},
-    GateCatalogEntry{"h", Lowering::H, 0, BOTH},
-    GateCatalogEntry{"s", Lowering::S, 0, BOTH},
-    GateCatalogEntry{"sdg", Lowering::Sdg, 0, BOTH},
-    GateCatalogEntry{"t", Lowering::T, 0, BOTH},
-    GateCatalogEntry{"tdg", Lowering::Tdg, 0, BOTH},
-    GateCatalogEntry{"sx", Lowering::SX, 0, STD},
-    GateCatalogEntry{"p", Lowering::P, 0, STD},
-    GateCatalogEntry{"rx", Lowering::RX, 0, BOTH},
-    GateCatalogEntry{"ry", Lowering::RY, 0, BOTH},
-    GateCatalogEntry{"rz", Lowering::RZ, 0, BOTH},
-    GateCatalogEntry{"r", Lowering::R, 0, COMPAT},
-    GateCatalogEntry{"swap", Lowering::SWAP, 0, STD},
-    GateCatalogEntry{"cx", Lowering::X, 1, BOTH},
-    GateCatalogEntry{"cy", Lowering::Y, 1, BOTH},
-    GateCatalogEntry{"cz", Lowering::Z, 1, BOTH},
-    GateCatalogEntry{"ch", Lowering::H, 1, BOTH},
-    GateCatalogEntry{"cp", Lowering::P, 1, STD},
-    GateCatalogEntry{"crx", Lowering::RX, 1, STD},
-    GateCatalogEntry{"cry", Lowering::RY, 1, STD},
-    GateCatalogEntry{"crz", Lowering::RZ, 1, BOTH},
-    GateCatalogEntry{"ccx", Lowering::X, 2, BOTH},
-    GateCatalogEntry{"cswap", Lowering::SWAP, 1, STD},
-    GateCatalogEntry{"cu", Lowering::CU, 0, STD},
-    GateCatalogEntry{"u1", Lowering::P, 0, BOTH},
-    GateCatalogEntry{"cu1", Lowering::P, 1, QE_LIB1},
-    GateCatalogEntry{"phase", Lowering::P, 0, STD},
-    GateCatalogEntry{"cphase", Lowering::P, 1, STD},
-    GateCatalogEntry{"u2", Lowering::U2, 0, BOTH},
-    GateCatalogEntry{"u3", Lowering::U3, 0, BOTH},
-    GateCatalogEntry{"u", Lowering::U3, 0, COMPAT},
-    GateCatalogEntry{"cu3", Lowering::U3, 1, QE_LIB1},
-    GateCatalogEntry{"CX", Lowering::X, 1, STD},
-    GateCatalogEntry{"cnot", Lowering::X, 1, COMPAT},
-    GateCatalogEntry{"c3x", Lowering::X, 3, COMPAT},
-    GateCatalogEntry{"c4x", Lowering::X, 4, COMPAT},
-    GateCatalogEntry{"csx", Lowering::SX, 1, COMPAT},
-    GateCatalogEntry{"sxdg", Lowering::SXdg, 0, COMPAT},
-    GateCatalogEntry{"c3sqrtx", Lowering::SX, 3, COMPAT},
-    GateCatalogEntry{"prx", Lowering::R, 0, COMPAT},
-    GateCatalogEntry{"cr", Lowering::R, 1, COMPAT},
-    GateCatalogEntry{"fredkin", Lowering::SWAP, 1, COMPAT},
-    GateCatalogEntry{"iswap", Lowering::ISWAP, 0, COMPAT},
-    GateCatalogEntry{"iswapdg", Lowering::ISWAP, 0, COMPAT, false, true},
-    GateCatalogEntry{"dcx", Lowering::DCX, 0, COMPAT},
-    GateCatalogEntry{"ecr", Lowering::ECR, 0, COMPAT},
-    GateCatalogEntry{"rccx", Lowering::RCCX, 0, COMPAT},
-    GateCatalogEntry{"rxx", Lowering::RXX, 0, COMPAT},
-    GateCatalogEntry{"ryy", Lowering::RYY, 0, COMPAT},
-    GateCatalogEntry{"rzx", Lowering::RZX, 0, COMPAT},
-    GateCatalogEntry{"rzz", Lowering::RZZ, 0, COMPAT},
-    GateCatalogEntry{"xx_plus_yy", Lowering::XXPlusYY, 0, COMPAT},
-    GateCatalogEntry{"xx_minus_yy", Lowering::XXMinusYY, 0, COMPAT},
-    GateCatalogEntry{"mcx", Lowering::X, 1, COMPAT, true},
-    GateCatalogEntry{"mcx_gray", Lowering::X, 1, COMPAT, true},
-    GateCatalogEntry{"mcx_vchain", Lowering::X, 1, COMPAT, true},
-    GateCatalogEntry{"mcx_recursive", Lowering::X, 1, COMPAT, true},
-    GateCatalogEntry{"mcphase", Lowering::P, 1, COMPAT, true},
+    GateCatalogEntry{"gphase", qc::StandardGate::GPhase, 0,
+                     Availability::Language},
+    GateCatalogEntry{"U", qc::StandardGate::BuiltinU, 0,
+                     Availability::Language},
+    GateCatalogEntry{"id", qc::StandardGate::Id, 0, BOTH},
+    GateCatalogEntry{"x", qc::StandardGate::X, 0, BOTH},
+    GateCatalogEntry{"y", qc::StandardGate::Y, 0, BOTH},
+    GateCatalogEntry{"z", qc::StandardGate::Z, 0, BOTH},
+    GateCatalogEntry{"h", qc::StandardGate::H, 0, BOTH},
+    GateCatalogEntry{"s", qc::StandardGate::S, 0, BOTH},
+    GateCatalogEntry{"sdg", qc::StandardGate::Sdg, 0, BOTH},
+    GateCatalogEntry{"t", qc::StandardGate::T, 0, BOTH},
+    GateCatalogEntry{"tdg", qc::StandardGate::Tdg, 0, BOTH},
+    GateCatalogEntry{"sx", qc::StandardGate::SX, 0, STD},
+    GateCatalogEntry{"p", qc::StandardGate::P, 0, STD},
+    GateCatalogEntry{"rx", qc::StandardGate::RX, 0, BOTH},
+    GateCatalogEntry{"ry", qc::StandardGate::RY, 0, BOTH},
+    GateCatalogEntry{"rz", qc::StandardGate::RZ, 0, BOTH},
+    GateCatalogEntry{"r", qc::StandardGate::R, 0, COMPAT},
+    GateCatalogEntry{"swap", qc::StandardGate::SWAP, 0, STD},
+    GateCatalogEntry{"cx", qc::StandardGate::X, 1, BOTH},
+    GateCatalogEntry{"cy", qc::StandardGate::Y, 1, BOTH},
+    GateCatalogEntry{"cz", qc::StandardGate::Z, 1, BOTH},
+    GateCatalogEntry{"ch", qc::StandardGate::H, 1, BOTH},
+    GateCatalogEntry{"cp", qc::StandardGate::P, 1, STD},
+    GateCatalogEntry{"crx", qc::StandardGate::RX, 1, STD},
+    GateCatalogEntry{"cry", qc::StandardGate::RY, 1, STD},
+    GateCatalogEntry{"crz", qc::StandardGate::RZ, 1, BOTH},
+    GateCatalogEntry{"ccx", qc::StandardGate::X, 2, BOTH},
+    GateCatalogEntry{"cswap", qc::StandardGate::SWAP, 1, STD},
+    GateCatalogEntry{"cu", qc::StandardGate::CU, 0, STD},
+    GateCatalogEntry{"u1", qc::StandardGate::P, 0, BOTH},
+    GateCatalogEntry{"cu1", qc::StandardGate::P, 1, QE_LIB1},
+    GateCatalogEntry{"phase", qc::StandardGate::P, 0, STD},
+    GateCatalogEntry{"cphase", qc::StandardGate::P, 1, STD},
+    GateCatalogEntry{"u2", qc::StandardGate::U2, 0, BOTH},
+    GateCatalogEntry{"u3", qc::StandardGate::U3, 0, BOTH},
+    GateCatalogEntry{"u", qc::StandardGate::U3, 0, COMPAT},
+    GateCatalogEntry{"cu3", qc::StandardGate::U3, 1, QE_LIB1},
+    GateCatalogEntry{"CX", qc::StandardGate::X, 1, STD},
+    GateCatalogEntry{"cnot", qc::StandardGate::X, 1, COMPAT},
+    GateCatalogEntry{"c3x", qc::StandardGate::X, 3, COMPAT},
+    GateCatalogEntry{"c4x", qc::StandardGate::X, 4, COMPAT},
+    GateCatalogEntry{"csx", qc::StandardGate::SX, 1, COMPAT},
+    GateCatalogEntry{"sxdg", qc::StandardGate::SXdg, 0, COMPAT},
+    GateCatalogEntry{"c3sqrtx", qc::StandardGate::SX, 3, COMPAT},
+    GateCatalogEntry{"prx", qc::StandardGate::R, 0, COMPAT},
+    GateCatalogEntry{"cr", qc::StandardGate::R, 1, COMPAT},
+    GateCatalogEntry{"fredkin", qc::StandardGate::SWAP, 1, COMPAT},
+    GateCatalogEntry{"iswap", qc::StandardGate::ISWAP, 0, COMPAT},
+    GateCatalogEntry{"iswapdg", qc::StandardGate::ISWAP, 0, COMPAT, false,
+                     true},
+    GateCatalogEntry{"dcx", qc::StandardGate::DCX, 0, COMPAT},
+    GateCatalogEntry{"ecr", qc::StandardGate::ECR, 0, COMPAT},
+    GateCatalogEntry{"rccx", qc::StandardGate::RCCX, 0, COMPAT},
+    GateCatalogEntry{"rxx", qc::StandardGate::RXX, 0, COMPAT},
+    GateCatalogEntry{"ryy", qc::StandardGate::RYY, 0, COMPAT},
+    GateCatalogEntry{"rzx", qc::StandardGate::RZX, 0, COMPAT},
+    GateCatalogEntry{"rzz", qc::StandardGate::RZZ, 0, COMPAT},
+    GateCatalogEntry{"xx_plus_yy", qc::StandardGate::XXPlusYY, 0, COMPAT},
+    GateCatalogEntry{"xx_minus_yy", qc::StandardGate::XXMinusYY, 0, COMPAT},
+    GateCatalogEntry{"mcx", qc::StandardGate::X, 1, COMPAT, true},
+    GateCatalogEntry{"mcx_gray", qc::StandardGate::X, 1, COMPAT, true},
+    GateCatalogEntry{"mcx_vchain", qc::StandardGate::X, 1, COMPAT, true},
+    GateCatalogEntry{"mcx_recursive", qc::StandardGate::X, 1, COMPAT, true},
+    GateCatalogEntry{"mcphase", qc::StandardGate::P, 1, COMPAT, true},
 };
 
 } // namespace
@@ -107,10 +109,10 @@ const GateCatalogEntry* lookupGate(const llvm::StringRef name) {
   return INDEX.lookup(name);
 }
 
-llvm::StringRef canonicalGateName(const GateLowering lowering) {
-  return lowering == GateLowering::U3
+llvm::StringRef canonicalGateName(const qc::StandardGate gate) {
+  return gate == qc::StandardGate::U3
              ? "u3"
-             : qc::getStandardGateDescriptor(lowering).operationSymbol;
+             : qc::getStandardGateDescriptor(gate).operationSymbol;
 }
 
-} // namespace mlir::oq3::frontend
+} // namespace mlir::openqasm::frontend

--- a/mlir/lib/Target/OpenQASM/OpenQASMLexer.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMLexer.cpp
@@ -26,7 +26,7 @@
 #include <optional>
 #include <utility>
 
-namespace mlir::oq3::frontend::detail {
+namespace mlir::openqasm::frontend::detail {
 
 [[nodiscard]] static bool canStartIdentifier(char c) {
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
@@ -574,4 +574,4 @@ Token Lexer::next() {
   return single(TokenKind::Error);
 }
 
-} // namespace mlir::oq3::frontend::detail
+} // namespace mlir::openqasm::frontend::detail

--- a/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSemantics.cpp
@@ -53,7 +53,7 @@
 #include <variant>
 #include <vector>
 
-namespace mlir::oq3::frontend::detail {
+namespace mlir::openqasm::frontend::detail {
 
 static SourceLocation sourcePosition(const llvm::SourceMgr& sources,
                                      llvm::SMLoc location);
@@ -4773,7 +4773,7 @@ private:
               .value = static_cast<int64_t>(intrinsicControls),
           }),
       });
-      callee = canonicalGateName(standard->lowering).str();
+      callee = canonicalGateName(standard->gate).str();
       emittedOperandCount = addedControls + activeBaseOperands;
     }
 
@@ -5097,4 +5097,4 @@ AnalysisResult analyzeSyntaxProgram(const SyntaxProgram& syntax,
   return SemanticAnalyzer(syntax, sources, gatePolicy).run();
 }
 
-} // namespace mlir::oq3::frontend::detail
+} // namespace mlir::openqasm::frontend::detail

--- a/mlir/lib/Target/OpenQASM/OpenQASMSyntax.cpp
+++ b/mlir/lib/Target/OpenQASM/OpenQASMSyntax.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-namespace mlir::oq3::frontend::detail {
+namespace mlir::openqasm::frontend::detail {
 
 LogicalResult SyntaxBuilder::error(SMLoc location, const Twine& message) {
   diagnostics.push_back({.location = location, .message = message.str()});
@@ -316,4 +316,4 @@ SyntaxBuilder::switchDefault(SMLoc /*location*/,
   return success();
 }
 
-} // namespace mlir::oq3::frontend::detail
+} // namespace mlir::openqasm::frontend::detail

--- a/mlir/tools/mqt-cc/mqt-cc.cpp
+++ b/mlir/tools/mqt-cc/mqt-cc.cpp
@@ -24,7 +24,7 @@
 #include "mqt/Dialect/MQT/IR/MQTDialect.h"
 #include "mqt/Dialect/MQT/Transforms/Passes.h"
 #include "mqt/Dialect/QC/IR/QCDialect.h"
-#include "mqt/Dialect/QC/Translation/TranslateQASM3ToQC.h"
+#include "mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h"
 #include "mqt/Dialect/QC/Translation/TranslateQCToOpenQASM3.h"
 #include "mqt/Dialect/QCO/IR/QCODialect.h"
 #include "mqt/Dialect/QCO/QCOUtils.h"
@@ -93,7 +93,8 @@ static llvm::cl::opt<std::string>
 
 static llvm::cl::opt<std::string> inputFormat(
     "input-format",
-    llvm::cl::desc("Input format: auto, jeff, mlir, or qasm (default: auto)"),
+    llvm::cl::desc(
+        "Input format: auto, jeff, mlir, or openqasm (default: auto)"),
     llvm::cl::value_desc("format"), llvm::cl::init("auto"));
 
 static llvm::cl::opt<std::string> outputFilename(
@@ -103,12 +104,12 @@ static llvm::cl::opt<std::string> outputFilename(
                    "bitcode)"),
     llvm::cl::value_desc("filename"), llvm::cl::init("-"));
 
-static llvm::cl::opt<std::string> outputFormat(
-    "emit",
-    llvm::cl::desc(
-        "Output format: qc-import, mlir, qco, qco-optimized, qir-base, "
-        "qir-adaptive, openqasm3, or jeff"),
-    llvm::cl::value_desc("format"), llvm::cl::init("mlir"));
+static llvm::cl::opt<std::string>
+    outputFormat("emit",
+                 llvm::cl::desc("Output checkpoint: qc-import, qc (default), "
+                                "qco, qco-optimized, qir-base, "
+                                "qir-adaptive, openqasm3, or jeff"),
+                 llvm::cl::value_desc("format"), llvm::cl::init("qc"));
 
 static llvm::cl::opt<std::string> passPipeline(
     "pass-pipeline",
@@ -145,7 +146,7 @@ static llvm::cl::opt<std::string> qdmiConfig(
     llvm::cl::value_desc("registry.json"), llvm::cl::init(""));
 
 namespace {
-enum class InputFormat : std::uint8_t { MLIR, QASM, Jeff };
+enum class InputFormat : std::uint8_t { MLIR, OpenQASM, Jeff };
 enum class InputDialect : std::uint8_t { QC, QCO };
 enum class OutputFormat : std::uint8_t {
   QCImport,
@@ -170,8 +171,9 @@ parseInputFormat(const StringRef format, const StringRef filename) {
   if (format == "mlir" || (format == "auto" && filename.ends_with(".mlir"))) {
     return InputFormat::MLIR;
   }
-  if (format == "qasm" || (format == "auto" && filename.ends_with(".qasm"))) {
-    return InputFormat::QASM;
+  if (format == "openqasm" ||
+      (format == "auto" && filename.ends_with(".qasm"))) {
+    return InputFormat::OpenQASM;
   }
   if (format == "jeff" || (format == "auto" && filename.ends_with(".jeff"))) {
     return InputFormat::Jeff;
@@ -202,7 +204,7 @@ parseOutputFormat(const StringRef format) {
   if (format == "qc-import") {
     return OutputFormat::QCImport;
   }
-  if (format == "mlir" || format == "qc") {
+  if (format == "qc") {
     return OutputFormat::QC;
   }
   if (format == "qco") {
@@ -269,9 +271,9 @@ static llvm::cl::opt<unsigned> decomposeMultiControlledMinQubits(
 }
 
 /// Load and parse a `.qasm` file
-static OwningOpRef<ModuleOp> loadQASMFile(const StringRef filename,
-                                          MLIRContext* const context,
-                                          llvm::SourceMgr& sourceMgr) {
+static OwningOpRef<ModuleOp> loadOpenQASMFile(const StringRef filename,
+                                              MLIRContext* const context,
+                                              llvm::SourceMgr& sourceMgr) {
   std::string errorMessage;
   auto file = openInputFile(filename, &errorMessage);
   if (!file) {
@@ -281,7 +283,7 @@ static OwningOpRef<ModuleOp> loadQASMFile(const StringRef filename,
   }
 
   sourceMgr.AddNewSourceBuffer(std::move(file), SMLoc());
-  return qc::translateQASM3ToQC(sourceMgr, context);
+  return qc::translateOpenQASMToQC(sourceMgr, context);
 }
 
 /// Load and parse an `.mlir` file
@@ -563,8 +565,8 @@ static int runCompiler(int argc, char** argv) {
       program.dialect = detectInputDialect(*program.mod);
     }
     break;
-  case InputFormat::QASM:
-    program.mod = loadQASMFile(inputFilename, &context, sourceMgr);
+  case InputFormat::OpenQASM:
+    program.mod = loadOpenQASMFile(inputFilename, &context, sourceMgr);
     break;
   case InputFormat::Jeff:
     program = loadJeffFile(inputFilename, &context);

--- a/mlir/unittests/Compiler/mqt-cc/verify_debugging.cmake
+++ b/mlir/unittests/Compiler/mqt-cc/verify_debugging.cmake
@@ -31,6 +31,23 @@ function(reject_compiler expected_diagnostic)
 endfunction()
 
 file(MAKE_DIRECTORY "${OUTPUT_DIR}")
+
+# The default checkpoint is QC, including when the input format is explicit.
+run_compiler(0 "${QASM_INPUT}")
+set(default_output "${output}")
+run_compiler(0 "${QASM_INPUT}" --input-format=openqasm --emit=qc)
+if(NOT output STREQUAL default_output OR NOT output MATCHES "qc.h")
+  message(FATAL_ERROR "Default and explicit QC checkpoints disagree: ${output}")
+endif()
+set(openqasm_text "${OUTPUT_DIR}/program.txt")
+configure_file("${QASM_INPUT}" "${openqasm_text}" COPYONLY)
+run_compiler(0 "${openqasm_text}" --input-format=openqasm --emit=qc)
+if(NOT output STREQUAL default_output)
+  message(FATAL_ERROR "Explicit OpenQASM input changed the program: ${output}")
+endif()
+reject_compiler("Could not determine the input format" "${QASM_INPUT}" --input-format=qasm)
+reject_compiler("Unknown output format" "${QASM_INPUT}" --emit=mlir)
+
 set(reduced "${OUTPUT_DIR}/reduced.mlir")
 file(
   WRITE "${reduced}"

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -229,15 +229,16 @@ protected:
 
 [[nodiscard]] static CompilerTarget
 makeSparseUCZTarget(const bool includeMeasure) {
-  using Operation = CompilerTarget::Operation;
+  using OperationCapability = CompilerTarget::OperationCapability;
   using Site = CompilerTarget::Site;
 
   std::vector operations{
-      llvm::cantFail(Operation::create("u", 1, 3)),
-      llvm::cantFail(Operation::create("cz", 2, 0)),
+      llvm::cantFail(OperationCapability::create("u", 1, 3)),
+      llvm::cantFail(OperationCapability::create("cz", 2, 0)),
   };
   if (includeMeasure) {
-    operations.emplace_back(llvm::cantFail(Operation::create("measure", 1, 0)));
+    operations.emplace_back(
+        llvm::cantFail(OperationCapability::create("measure", 1, 0)));
   }
   std::vector sites{
       llvm::cantFail(Site::create(5)),
@@ -254,14 +255,15 @@ using NameAndCount = std::pair<llvm::StringRef, size_t>;
 
 [[nodiscard]] static CompilerTarget
 makeCZTarget(std::initializer_list<NameAndCount> singleQubitGates) {
-  using Operation = CompilerTarget::Operation;
-  std::vector<Operation> operations;
+  using OperationCapability = CompilerTarget::OperationCapability;
+  std::vector<OperationCapability> operations;
   operations.reserve(singleQubitGates.size() + 1);
   for (const auto& [name, numParameters] : singleQubitGates) {
-    operations.emplace_back(
-        llvm::cantFail(Operation::create(name.str(), 1, numParameters)));
+    operations.emplace_back(llvm::cantFail(
+        OperationCapability::create(name.str(), 1, numParameters)));
   }
-  operations.emplace_back(llvm::cantFail(Operation::create("cz", 2, 0)));
+  operations.emplace_back(
+      llvm::cantFail(OperationCapability::create("cz", 2, 0)));
   return llvm::cantFail(CompilerTarget::create(
       2, CompilerTarget::Connectivity::allToAll(),
       CompilerTarget::NativeOperations::fromOperations(operations)));
@@ -555,8 +557,8 @@ qubit q;
 rz(1.0) q;
 rx(1.0) q;
 )";
-  auto rawInput = QCProgram::fromQASMString(qasm);
-  auto optimizedInput = QCProgram::fromQASMString(qasm);
+  auto rawInput = QCProgram::fromOpenQASMString(qasm);
+  auto optimizedInput = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(rawInput);
   ASSERT_TRUE(optimizedInput);
 
@@ -577,7 +579,7 @@ qubit q;
 x q;
 h q;
 )";
-  auto input = QCProgram::fromQASMString(qasm);
+  auto input = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(input);
   auto result =
       runDefaultPipeline(CompilerInput{std::move(*input)},
@@ -587,8 +589,8 @@ h q;
 }
 
 TEST_F(CompilerPipelineTest, MoveAssignmentKeepsModuleContextAlive) {
-  auto first = QCProgram::fromQASMString("OPENQASM 3.0; qubit q; h q;");
-  auto second = QCProgram::fromQASMString("OPENQASM 3.0; qubit q; x q;");
+  auto first = QCProgram::fromOpenQASMString("OPENQASM 3.0; qubit q; h q;");
+  auto second = QCProgram::fromOpenQASMString("OPENQASM 3.0; qubit q; x q;");
   ASSERT_TRUE(first);
   ASSERT_TRUE(second);
   ASSERT_NE(first->module().getContext(), second->module().getContext());
@@ -617,7 +619,7 @@ qubit q;
 h q;
 )";
 
-  auto qcResult = QCProgram::fromQASMString(qasm);
+  auto qcResult = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(qcResult);
   auto qc = std::move(*qcResult);
   EXPECT_TRUE(qc.isValid());
@@ -645,7 +647,7 @@ h $0;
 x $0;
 )";
 
-  auto qcProgram = QCProgram::fromQASMString(qasm.str());
+  auto qcProgram = QCProgram::fromOpenQASMString(qasm.str());
   ASSERT_TRUE(qcProgram);
 
   size_t qcStaticOps = 0;
@@ -737,7 +739,7 @@ inspectEntry(const llvm::StringRef ir) {
 [[nodiscard]] static testing::AssertionResult throughOptimizedQCO(
     const qasm::OpenQASMProgram& source, std::optional<QCProgram>& restored,
     std::vector<std::string>& resultTypes, bool prepareForQIR = false) {
-  auto qc = QCProgram::fromQASMString(source.source.str());
+  auto qc = QCProgram::fromOpenQASMString(source.source.str());
   if (!qc) {
     return testing::AssertionFailure()
            << source.name.str() << ": OpenQASM to QC";
@@ -772,7 +774,7 @@ inspectEntry(const llvm::StringRef ir) {
 roundTripThroughOptimizedJeff(const qasm::OpenQASMProgram& source,
                               std::optional<QCProgram>& restored,
                               std::vector<std::string>& resultTypes) {
-  auto qc = QCProgram::fromQASMString(source.source.str());
+  auto qc = QCProgram::fromOpenQASMString(source.source.str());
   if (!qc) {
     return testing::AssertionFailure()
            << source.name.str() << ": OpenQASM to QC";
@@ -882,7 +884,7 @@ for int i in [0:2] {
 c = measure q;
 )qasm";
 
-  auto qc = QCProgram::fromQASMString(source.str());
+  auto qc = QCProgram::fromOpenQASMString(source.str());
   ASSERT_TRUE(qc);
   const auto imported = qc->str();
   EXPECT_EQ(imported.find("i128"), std::string::npos);
@@ -929,7 +931,7 @@ ratio = 2.0;
   EXPECT_NE(emitted->source().find("output bit[2] bits;"), std::string::npos);
   EXPECT_NE(emitted->source().find("output float _mqt_out1;"),
             std::string::npos);
-  EXPECT_TRUE(QCProgram::fromQASMString(emitted->source()));
+  EXPECT_TRUE(QCProgram::fromOpenQASMString(emitted->source()));
 }
 
 TEST(OpenQASMCompilerOutputTest, GlobalPhasesTraverseQCQCOJeffAndQIRScopes) {
@@ -952,7 +954,7 @@ if (flag) {
 }
 )qasm";
 
-  auto qc = QCProgram::fromQASMString(source.str());
+  auto qc = QCProgram::fromOpenQASMString(source.str());
   ASSERT_TRUE(qc);
   ASSERT_TRUE(qc->cleanup());
   auto qco = std::move(*qc).intoQCO();
@@ -1006,7 +1008,7 @@ h q;
 result = measure q;
 )qasm";
 
-  auto input = QCProgram::fromQASMString(source.str());
+  auto input = QCProgram::fromOpenQASMString(source.str());
   ASSERT_TRUE(input);
   for (const auto profile : {QIRProfile::Base, QIRProfile::Adaptive}) {
     auto qir = std::move(input->copy()).intoQIR(profile);
@@ -1092,7 +1094,7 @@ TEST_P(OpenQASMCompilerPipelineTest, TraversesTheExplicitStandardPipeline) {
 
 TEST_P(OpenQASMCompilerPipelineTest, TraversesTheDefaultAdaptivePipeline) {
   const auto& source = GetParam();
-  auto input = QCProgram::fromQASMString(source.source.str());
+  auto input = QCProgram::fromOpenQASMString(source.source.str());
   ASSERT_TRUE(input) << source.name.str() << ": OpenQASM to QC";
   const auto inputEntry = inspectEntry(input->str());
   ASSERT_TRUE(inputEntry) << source.name.str() << ": inspect QC entry";
@@ -1127,7 +1129,7 @@ class OpenQASMJeffBoundaryTest
 
 TEST_P(OpenQASMJeffBoundaryTest, FailsAtQCOToJeff) {
   const auto& source = GetParam();
-  auto qc = QCProgram::fromQASMString(source.source.str());
+  auto qc = QCProgram::fromOpenQASMString(source.source.str());
   ASSERT_TRUE(qc) << source.name.str() << ": OpenQASM to QC";
   auto qco = std::move(*qc).intoQCO();
   ASSERT_TRUE(qco) << source.name.str() << ": QC to QCO";
@@ -1195,8 +1197,8 @@ h q;
 
   auto qcFromMLIR = QCProgram::fromMLIRString(mlir);
   auto qcFromMLIRFile = QCProgram::fromMLIRFile(mlirPath);
-  auto qcFromQASM = QCProgram::fromQASMString(qasm);
-  auto qcFromQASMFile = QCProgram::fromQASMFile(qasmPath);
+  auto qcFromQASM = QCProgram::fromOpenQASMString(qasm);
+  auto qcFromQASMFile = QCProgram::fromOpenQASMFile(qasmPath);
 
   ASSERT_TRUE(qcFromMLIR);
   ASSERT_TRUE(qcFromMLIRFile);
@@ -1207,8 +1209,9 @@ h q;
   EXPECT_EQ(qcFromMLIR->str(), qcFromMLIR->copy().str());
   EXPECT_FALSE(QCProgram::fromMLIRString("not valid MLIR"));
   EXPECT_FALSE(QCProgram::fromMLIRFile(temporaryDirectory / "missing.mlir"));
-  EXPECT_FALSE(QCProgram::fromQASMString("not valid OpenQASM"));
-  EXPECT_FALSE(QCProgram::fromQASMFile(temporaryDirectory / "missing.qasm"));
+  EXPECT_FALSE(QCProgram::fromOpenQASMString("not valid OpenQASM"));
+  EXPECT_FALSE(
+      QCProgram::fromOpenQASMFile(temporaryDirectory / "missing.qasm"));
   EXPECT_FALSE(QCOProgram::fromMLIRString("not valid MLIR"));
   EXPECT_FALSE(
       QCOProgram::fromMLIRFile(temporaryDirectory / "missing.qco.mlir"));
@@ -1436,7 +1439,7 @@ h q[0];
 ctrl @ x q[0], q[1];
 bit[2] c = measure q;
 )";
-  auto directQC = QCProgram::fromQASMString(qasm);
+  auto directQC = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(directQC);
   const auto importedIR = directQC->str();
   auto direct = directQC->toOpenQASM3();
@@ -1456,7 +1459,7 @@ bit[2] c = measure q;
   const std::string written((std::istreambuf_iterator<char>(input)),
                             std::istreambuf_iterator<char>());
   EXPECT_EQ(written, direct->source());
-  EXPECT_TRUE(QCProgram::fromQASMFile(path));
+  EXPECT_TRUE(QCProgram::fromOpenQASMFile(path));
 
   auto imported =
       runDefaultPipeline(CompilerInput(*direct), ProgramFormat::QCImport);
@@ -1469,7 +1472,7 @@ bit[2] c = measure q;
   ASSERT_TRUE(compiled);
   EXPECT_TRUE(std::holds_alternative<QIRProgram>(*compiled));
 
-  auto pipelineQC = QCProgram::fromQASMString(qasm);
+  auto pipelineQC = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(pipelineQC);
   auto result = runDefaultPipeline(CompilerInput(std::move(*pipelineQC)),
                                    ProgramFormat::OpenQASM3);
@@ -1477,7 +1480,7 @@ bit[2] c = measure q;
   ASSERT_TRUE(std::holds_alternative<OpenQASMProgram>(*result));
   const auto& optimized = std::get<OpenQASMProgram>(*result);
   EXPECT_TRUE(optimized.source().starts_with("OPENQASM 3.1;\n"));
-  auto reparsed = QCProgram::fromQASMString(optimized.source());
+  auto reparsed = QCProgram::fromOpenQASMString(optimized.source());
   ASSERT_TRUE(reparsed);
   auto adaptiveQIR = std::move(*reparsed).intoQIR(QIRProfile::Adaptive);
   EXPECT_TRUE(adaptiveQIR);
@@ -1512,7 +1515,7 @@ bit[2] c;
 c[0] = measure q[1];
 c[1] = measure q[3];
 )";
-  auto program = QCProgram::fromQASMString(source);
+  auto program = QCProgram::fromOpenQASMString(source);
   ASSERT_TRUE(program);
   auto prepared =
       runDefaultPipeline(CompilerInput(program->copy()), ProgramFormat::QC);
@@ -1525,7 +1528,7 @@ c[1] = measure q[3];
   const auto& exported = std::get<OpenQASMProgram>(*output);
   EXPECT_EQ(exported.source(), reference->source());
   EXPECT_EQ(exported.source().find("gate unused"), std::string::npos);
-  EXPECT_TRUE(QCProgram::fromQASMString(exported.source()));
+  EXPECT_TRUE(QCProgram::fromOpenQASMString(exported.source()));
 }
 
 TEST_F(CompilerPipelineTest, TypedOpenQASMExportReportsUnsupportedQC) {
@@ -1930,7 +1933,7 @@ x q;
   const auto path = std::filesystem::path(testing::TempDir()) /
                     "typed_program_round_trip.jeff";
 
-  auto qc = QCProgram::fromQASMString(qasm);
+  auto qc = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(qc);
   auto qco = std::move(*qc).intoQCO();
   ASSERT_TRUE(qco);
@@ -1973,7 +1976,7 @@ h q;
   const auto qcoPath = std::filesystem::path(testing::TempDir()) /
                        "typed_program_input.qco.mlir";
 
-  auto qc = QCProgram::fromQASMString(qasm);
+  auto qc = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(qc);
   auto qco = std::move(*qc).intoQCO();
   ASSERT_TRUE(qco);
@@ -1992,8 +1995,8 @@ h q;
   EXPECT_FALSE(qcoFromString->runPassPipeline("not-a-pass"));
   EXPECT_FALSE(qcoFromString->str().empty());
 
-  auto baseInput = QCProgram::fromQASMString(qasm);
-  auto adaptiveInput = QCProgram::fromQASMString(qasm);
+  auto baseInput = QCProgram::fromOpenQASMString(qasm);
+  auto adaptiveInput = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(baseInput);
   ASSERT_TRUE(adaptiveInput);
   auto base = std::move(*baseInput).intoQIR(QIRProfile::Base);
@@ -2026,7 +2029,7 @@ h q[0];
 x q[0];
 cx q[0], q[2];
 )";
-  auto qc = QCProgram::fromQASMString(qasm);
+  auto qc = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(qc);
   auto qcoResult = std::move(*qc).intoQCO();
   ASSERT_TRUE(qcoResult);
@@ -2052,7 +2055,7 @@ cx q[0], q[2];
 
 // Test: target compilation decomposes, maps, synthesizes, and verifies.
 TEST_F(CompilerPipelineTest, QCOProgramCompilesForTarget) {
-  auto qc = QCProgram::fromQASMString(qasm::multipleControlledX);
+  auto qc = QCProgram::fromOpenQASMString(qasm::multipleControlledX);
   ASSERT_TRUE(qc);
   auto qco = std::move(*qc).intoQCO();
   ASSERT_TRUE(qco);
@@ -2098,7 +2101,7 @@ TEST_F(CompilerPipelineTest, QCOProgramCompilesForTarget) {
   EXPECT_EQ(numSwaps, 0);
   EXPECT_EQ(numHigherArity, 0);
 
-  auto unsupportedQC = QCProgram::fromQASMString(qasm::multipleControlledX);
+  auto unsupportedQC = QCProgram::fromOpenQASMString(qasm::multipleControlledX);
   ASSERT_TRUE(unsupportedQC);
   auto unsupportedQCO = std::move(*unsupportedQC).intoQCO();
   ASSERT_TRUE(unsupportedQCO);
@@ -2207,7 +2210,7 @@ include "stdgates.inc";
 qubit q;
 for int i in [0:2] { x q; }
 )qasm";
-  auto qc = QCProgram::fromQASMString(source);
+  auto qc = QCProgram::fromOpenQASMString(source);
   ASSERT_TRUE(qc);
   auto input = std::move(*qc).intoQCO();
   ASSERT_TRUE(input);
@@ -2246,7 +2249,7 @@ for int outer in [0:2] {
 }
 )qasm";
 
-  auto qc = QCProgram::fromQASMString(source);
+  auto qc = QCProgram::fromOpenQASMString(source);
   ASSERT_TRUE(qc);
   auto program = std::move(*qc).intoQCO();
   ASSERT_TRUE(program);
@@ -2275,7 +2278,7 @@ rx(a) q;
 bit c;
 c = measure q;
 )qasm";
-  auto qc = QCProgram::fromQASMString(source);
+  auto qc = QCProgram::fromOpenQASMString(source);
   ASSERT_TRUE(qc);
   auto program = std::move(*qc).intoQCO();
   ASSERT_TRUE(program);
@@ -2639,7 +2642,7 @@ switch (selector) {
   default { result = 2; }
 }
 )qasm";
-  auto qc = QCProgram::fromQASMString(source);
+  auto qc = QCProgram::fromOpenQASMString(source);
   ASSERT_TRUE(qc);
   auto input = std::move(*qc).intoQCO();
   ASSERT_TRUE(input);
@@ -3274,7 +3277,7 @@ include "stdgates.inc";
 qubit q;
 x q;
 )";
-  auto qc = QCProgram::fromQASMString(source);
+  auto qc = QCProgram::fromOpenQASMString(source);
   ASSERT_TRUE(qc);
   auto qco = std::move(*qc).intoQCO();
   ASSERT_TRUE(qco);
@@ -3292,11 +3295,12 @@ x q;
 
 TEST_F(CompilerPipelineTest, TargetCompilationFusesOnlyWithUsableNativeBasis) {
   using NativeOperations = CompilerTarget::NativeOperations;
-  using TargetOperation = CompilerTarget::Operation;
-  const auto cx = llvm::cantFail(TargetOperation::create("cx", 2, 0));
-  const auto dcx = llvm::cantFail(TargetOperation::create("dcx", 2, 0));
-  const auto u = llvm::cantFail(TargetOperation::create("u", 1, 3));
-  const auto gphase = llvm::cantFail(TargetOperation::create("gphase", 0, 1));
+  using OperationCapability = CompilerTarget::OperationCapability;
+  const auto cx = llvm::cantFail(OperationCapability::create("cx", 2, 0));
+  const auto dcx = llvm::cantFail(OperationCapability::create("dcx", 2, 0));
+  const auto u = llvm::cantFail(OperationCapability::create("u", 1, 3));
+  const auto gphase =
+      llvm::cantFail(OperationCapability::create("gphase", 0, 1));
   const auto makeTarget = [](NativeOperations operations) {
     return llvm::cantFail(CompilerTarget::create(
         2, CompilerTarget::Connectivity::allToAll(), std::move(operations)));
@@ -3456,10 +3460,10 @@ TEST_F(CompilerPipelineTest,
 
   auto program = QCOProgram::fromMLIRString(source.str());
   ASSERT_TRUE(program);
-  using TargetOperation = CompilerTarget::Operation;
+  using OperationCapability = CompilerTarget::OperationCapability;
   std::vector operations{
-      llvm::cantFail(TargetOperation::create("u", 1, 3)),
-      llvm::cantFail(TargetOperation::create("cz", 2, 0)),
+      llvm::cantFail(OperationCapability::create("u", 1, 3)),
+      llvm::cantFail(OperationCapability::create("cz", 2, 0)),
   };
   auto target = llvm::cantFail(CompilerTarget::create(
       2, CompilerTarget::Connectivity::fromCouplings({{0, 1}}),
@@ -3498,7 +3502,7 @@ ctrl(2) @ p(0.4) q[0], q[1], q[4];
 rccx q[0], q[1], q[2];
 gphase(0.5);
 )qasm";
-  auto qc = QCProgram::fromQASMString(source);
+  auto qc = QCProgram::fromOpenQASMString(source);
   ASSERT_TRUE(qc);
   auto qco = std::move(*qc).intoQCO();
   ASSERT_TRUE(qco);
@@ -3539,16 +3543,16 @@ qubit[2] q;
 cx q[0], q[1];
 cx q[1], q[0];
 )qasm";
-  auto qc = QCProgram::fromQASMString(source.str());
+  auto qc = QCProgram::fromOpenQASMString(source.str());
   ASSERT_TRUE(qc);
   auto qco = std::move(*qc).intoQCO();
   ASSERT_TRUE(qco);
 
-  using TargetOperation = CompilerTarget::Operation;
+  using OperationCapability = CompilerTarget::OperationCapability;
   using SiteId = CompilerTarget::SiteId;
   std::vector operations{
-      llvm::cantFail(TargetOperation::create("u", 1, 3)),
-      llvm::cantFail(TargetOperation::create(
+      llvm::cantFail(OperationCapability::create("u", 1, 3)),
+      llvm::cantFail(OperationCapability::create(
           "cx", 2, 0,
           {llvm::cantFail(CompilerTarget::SiteTuple::create({0, 1}))})),
   };
@@ -3693,13 +3697,14 @@ TEST_F(CompilerPipelineTest, QCOProgramMergesDynamicRunInNativeCtrlBody) {
       return
     }
   })mlir";
-  using Operation = CompilerTarget::Operation;
+  using OperationCapability = CompilerTarget::OperationCapability;
   std::vector operations{
-      llvm::cantFail(Operation::create("x", 1, 0)),
-      llvm::cantFail(Operation::create("sx", 1, 0)),
-      llvm::cantFail(Operation::create("rz", 1, 1)),
-      llvm::cantFail(Operation::create("cz", 2, 0)),
-      llvm::cantFail(Operation::create("u", Operation::Arity::variadic(1), 3)),
+      llvm::cantFail(OperationCapability::create("x", 1, 0)),
+      llvm::cantFail(OperationCapability::create("sx", 1, 0)),
+      llvm::cantFail(OperationCapability::create("rz", 1, 1)),
+      llvm::cantFail(OperationCapability::create("cz", 2, 0)),
+      llvm::cantFail(OperationCapability::create(
+          "u", OperationCapability::Arity::variadic(1), 3)),
   };
   const auto target = llvm::cantFail(CompilerTarget::create(
       2, CompilerTarget::Connectivity::allToAll(),
@@ -3751,13 +3756,13 @@ TEST_F(CompilerPipelineTest,
   moduleOp->print(stream);
   auto program = QCOProgram::fromMLIRString(source);
   ASSERT_TRUE(program);
-  using TargetOperation = CompilerTarget::Operation;
+  using OperationCapability = CompilerTarget::OperationCapability;
   const auto target = llvm::cantFail(CompilerTarget::create(
       2, CompilerTarget::Connectivity::allToAll(),
       CompilerTarget::NativeOperations::fromOperations({
-          llvm::cantFail(TargetOperation::create("u", 1, 3)),
-          llvm::cantFail(TargetOperation::create("gphase", 0, 1)),
-          llvm::cantFail(TargetOperation::create("sqrt_iswap", 2, 0)),
+          llvm::cantFail(OperationCapability::create("u", 1, 3)),
+          llvm::cantFail(OperationCapability::create("gphase", 0, 1)),
+          llvm::cantFail(OperationCapability::create("sqrt_iswap", 2, 0)),
       })));
   ASSERT_TRUE(program->compileForTarget(
       TargetEnvironment(target, makePayloadSpecification())));
@@ -3778,7 +3783,7 @@ h q[0];
 cx q[0], q[1];
 c = measure q;
 )";
-  auto qc = QCProgram::fromQASMString(qasm);
+  auto qc = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(qc);
   auto qco = std::move(*qc).intoQCO();
   ASSERT_TRUE(qco);
@@ -3826,7 +3831,7 @@ h q[1];
       CompilerTarget::create(3, CompilerTarget::Connectivity::allToAll(),
                              CompilerTarget::NativeOperations::unrestricted()));
 
-  auto qc = QCProgram::fromQASMString(source);
+  auto qc = QCProgram::fromOpenQASMString(source);
   ASSERT_TRUE(qc);
   auto program = std::move(*qc).intoQCO();
   ASSERT_TRUE(program);
@@ -3851,7 +3856,7 @@ h q[1];
 
 /// Test: the payload specification selects the targeted output.
 TEST_F(CompilerPipelineTest, DefaultPipelineDerivesTargetOutput) {
-  auto input = QCProgram::fromQASMString(qasm::multipleControlledX);
+  auto input = QCProgram::fromOpenQASMString(qasm::multipleControlledX);
   ASSERT_TRUE(input);
   const auto target = makeSparseUCZTarget(true);
   const TargetEnvironment environment(target, makePayloadSpecification());
@@ -3922,7 +3927,7 @@ qubit q;
 h q;
 )";
   const auto compile = [&qasm](const ProgramFormat output) {
-    auto input = QCProgram::fromQASMString(qasm);
+    auto input = QCProgram::fromOpenQASMString(qasm);
     EXPECT_TRUE(input);
     return runDefaultPipeline(CompilerInput{std::move(*input)}, output);
   };
@@ -3940,7 +3945,7 @@ h q;
   EXPECT_TRUE(std::holds_alternative<QCOProgram>(*optimizedQCOOutput));
   EXPECT_TRUE(std::holds_alternative<JeffProgram>(*jeffOutput));
 
-  auto profiledInput = QCProgram::fromQASMString(qasm);
+  auto profiledInput = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(profiledInput);
   auto profiled = runDefaultPipeline(CompilerInput{std::move(*profiledInput)},
                                      ProgramFormat::QCOOptimized,
@@ -3948,7 +3953,7 @@ h q;
   ASSERT_TRUE(profiled);
   EXPECT_TRUE(std::holds_alternative<QCOProgram>(*profiled));
 
-  auto customPipelineInput = QCProgram::fromQASMString(qasm);
+  auto customPipelineInput = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(customPipelineInput);
   EXPECT_FALSE(runDefaultPipeline(
       CompilerInput{std::move(*customPipelineInput)}, ProgramFormat::QCO,
@@ -3965,14 +3970,14 @@ h q;
   ASSERT_TRUE(std::holds_alternative<QIRProgram>(*adaptive));
   EXPECT_EQ(std::get<QIRProgram>(*adaptive).profile(), QIRProfile::Adaptive);
 
-  auto imported = QCProgram::fromQASMString(qasm);
+  auto imported = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(imported);
   auto importedResult = runDefaultPipeline(CompilerInput{std::move(*imported)},
                                            ProgramFormat::QCImport);
   ASSERT_TRUE(importedResult);
   EXPECT_TRUE(std::holds_alternative<QCProgram>(*importedResult));
 
-  auto qcoInput = QCProgram::fromQASMString(qasm);
+  auto qcoInput = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(qcoInput);
   auto qco = std::move(*qcoInput).intoQCO();
   ASSERT_TRUE(qco);
@@ -3986,7 +3991,7 @@ h q;
   ASSERT_TRUE(fromQCO);
   EXPECT_TRUE(std::holds_alternative<QCProgram>(*fromQCO));
 
-  auto jeffInput = QCProgram::fromQASMString(qasm);
+  auto jeffInput = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(jeffInput);
   auto jeffQCO = std::move(*jeffInput).intoQCO();
   ASSERT_TRUE(jeffQCO);
@@ -4004,7 +4009,7 @@ include "stdgates.inc";
 qubit q;
 h q;
 )";
-  auto input = QCProgram::fromQASMString(source);
+  auto input = QCProgram::fromOpenQASMString(source);
   ASSERT_TRUE(input);
   CompilerInput program{std::move(*input)};
   const auto original = std::get<QCProgram>(program).str();
@@ -4203,7 +4208,7 @@ ctrl @ swap q[0], q[1], q[2];
 inv @ cx q[0], q[1];
 barrier q[0], q[1];
 )";
-  auto qc = QCProgram::fromQASMString(qasm);
+  auto qc = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(qc);
   EXPECT_EQ(qc->numGates(), 6);
   EXPECT_EQ(qc->numSingleQubitGates(), 1);
@@ -4251,7 +4256,7 @@ switch (selector) {
   }
 }
 )";
-  auto qc = QCProgram::fromQASMString(qasm);
+  auto qc = QCProgram::fromOpenQASMString(qasm);
   ASSERT_TRUE(qc);
   EXPECT_EQ(qc->numGates(), 5);
   EXPECT_EQ(qc->numSingleQubitGates(), 2);

--- a/mlir/unittests/Compiler/test_compiler_qdmi_adapter.cpp
+++ b/mlir/unittests/Compiler/test_compiler_qdmi_adapter.cpp
@@ -31,7 +31,7 @@
 
 using mlir::CompilerTarget;
 
-[[nodiscard]] static const CompilerTarget::Operation&
+[[nodiscard]] static const CompilerTarget::OperationCapability&
 findOperation(const CompilerTarget& target, const llvm::StringRef name) {
   const auto* const found =
       llvm::find_if(target.operations(),
@@ -140,7 +140,7 @@ TEST(CompilerQDMIAdapterTest, InfersDDSIMTargetFacts) {
             CompilerTarget::NativeOperations::Kind::Explicit);
   const auto& gphase = findOperation(target, "gphase");
   EXPECT_EQ(gphase.arity().kind(),
-            CompilerTarget::Operation::Arity::Kind::Fixed);
+            CompilerTarget::OperationCapability::Arity::Kind::Fixed);
   EXPECT_EQ(gphase.arity().value(), 0);
   for (const auto [name, minimum] :
        std::initializer_list<std::pair<llvm::StringRef, size_t>>{
@@ -153,7 +153,7 @@ TEST(CompilerQDMIAdapterTest, InfersDDSIMTargetFacts) {
        }) {
     const auto& operation = findOperation(target, name);
     EXPECT_EQ(operation.arity().kind(),
-              CompilerTarget::Operation::Arity::Kind::Variadic)
+              CompilerTarget::OperationCapability::Arity::Kind::Variadic)
         << name.str();
     EXPECT_EQ(operation.arity().value(), minimum) << name.str();
     EXPECT_TRUE(operation.siteTuples().empty()) << name.str();
@@ -366,8 +366,10 @@ TEST(CompilerQDMIAdapterTest,
     }
     const auto tuple = llvm::cantFail(CompilerTarget::SiteTuple::create(
         std::move(operands), calibrated ? 50 : 10, calibrated ? 0.99 : 0.9));
-    const auto operation = llvm::cantFail(CompilerTarget::Operation::create(
-        "cx", 2, 0, {tuple}, calibrated ? 50 : 10, calibrated ? 0.99 : 0.9));
+    const auto operation =
+        llvm::cantFail(CompilerTarget::OperationCapability::create(
+            "cx", 2, 0, {tuple}, calibrated ? 50 : 10,
+            calibrated ? 0.99 : 0.9));
     return llvm::cantFail(CompilerTarget::create(
         calibrated ? "updated device" : "original device", std::move(sites),
         CompilerTarget::Connectivity::allToAll(),
@@ -492,8 +494,9 @@ TEST(CompilerQDMIAdapterTest,
           siteTuples.push_back(llvm::cantFail(
               CompilerTarget::SiteTuple::create(std::move(tuple))));
         }
-        const auto operation = llvm::cantFail(CompilerTarget::Operation::create(
-            "cx", 2, 0, std::move(siteTuples)));
+        const auto operation =
+            llvm::cantFail(CompilerTarget::OperationCapability::create(
+                "cx", 2, 0, std::move(siteTuples)));
         const auto target = llvm::cantFail(CompilerTarget::create(
             {
                 llvm::cantFail(CompilerTarget::Site::create(0)),

--- a/mlir/unittests/Compiler/test_compiler_target.cpp
+++ b/mlir/unittests/Compiler/test_compiler_target.cpp
@@ -66,8 +66,8 @@ using Connectivity = Target::Connectivity;
 using Coupling = Target::Coupling;
 using DurationUnit = Target::DurationUnit;
 using GateKind = Target::GateKind;
-using Operation = Target::Operation;
-using Arity = Operation::Arity;
+using OperationCapability = Target::OperationCapability;
+using Arity = OperationCapability::Arity;
 using NativeOperations = Target::NativeOperations;
 using Site = Target::Site;
 using SiteId = Target::SiteId;
@@ -290,14 +290,14 @@ TEST(CompilerTargetTest, ConstructsDetailedNamedTargetAndSharesStorage) {
   sites.emplace_back(valid(Site::create(2, std::nullopt, 120, std::nullopt)));
   sites.emplace_back(valid(Site::create(11, "right")));
 
-  std::vector<Operation> operations;
+  std::vector<OperationCapability> operations;
   std::vector siteTuples{
       valid(SiteTuple::create({7}, 0, 0.99)),
       valid(SiteTuple::create({2}, 5, 0.98)),
       valid(SiteTuple::create({11})),
   };
-  operations.emplace_back(
-      valid(Operation::create(" PRX ", 1, 2, std::move(siteTuples), 0, 0.97)));
+  operations.emplace_back(valid(OperationCapability::create(
+      " PRX ", 1, 2, std::move(siteTuples), 0, 0.97)));
 
   auto target = valid(
       Target::create("device", std::move(sites),
@@ -403,8 +403,10 @@ TEST(CompilerTargetTest, PreservesFullNonnegativeSiteIdDomain) {
   };
   const auto target = valid(Target::create(
       std::move(sites), Connectivity::fromCouplings({{maxSite, nextSite}}),
-      NativeOperations::fromOperations(
-          {valid(Operation::create("cx", 2, 0, {std::move(siteTuple)}))})));
+      NativeOperations::fromOperations({
+          valid(
+              OperationCapability::create("cx", 2, 0, {std::move(siteTuple)})),
+      })));
 
   EXPECT_EQ(target.siteIds(), (llvm::ArrayRef<SiteId>{maxSite, nextSite}));
   EXPECT_EQ(target.vertexForSite(maxSite), 0);
@@ -480,33 +482,33 @@ TEST(CompilerTargetTest, RejectsInvalidMetadata) {
   expectInvalid(
       SiteTuple::create({0}, std::nullopt, -0.1),
       "Compiler target site-tuple fidelity must be finite and in [0, 1]");
-  expectInvalid(Operation::create("", 1, 0),
+  expectInvalid(OperationCapability::create("", 1, 0),
                 "Compiler target operation name must not be empty");
-  expectInvalid(Operation::create("x", Arity::variadic(0), 0),
+  expectInvalid(OperationCapability::create("x", Arity::variadic(0), 0),
                 "Compiler target operation variadic minimum must be positive");
   expectInvalid(
-      Operation::create(
+      OperationCapability::create(
           "gphase", Arity::fixed(0), 1,
           std::vector{valid(SiteTuple::create(std::vector<SiteId>{}))}),
       "Compiler target zero-arity operation cannot contain site tuples");
   expectInvalid(
-      Operation::create(
+      OperationCapability::create(
           "h", Arity::variadic(1), 0,
           std::vector{valid(SiteTuple::create(std::vector<SiteId>{0}))}),
       "Compiler target variadic operation cannot contain site tuples");
   expectInvalid(
-      Operation::create("x", 1, 0,
-                        std::vector{valid(SiteTuple::create({0, 1}))}),
+      OperationCapability::create(
+          "x", 1, 0, std::vector{valid(SiteTuple::create({0, 1}))}),
       "Compiler target operation site tuple does not match its arity");
-  expectInvalid(Operation::create("x", 1, 0,
-                                  std::vector{
-                                      valid(SiteTuple::create({0})),
-                                      valid(SiteTuple::create({0})),
-                                  }),
+  expectInvalid(OperationCapability::create("x", 1, 0,
+                                            std::vector{
+                                                valid(SiteTuple::create({0})),
+                                                valid(SiteTuple::create({0})),
+                                            }),
                 "Compiler target operation contains a duplicate site tuple");
   expectInvalid(
-      Operation::create("x", 1, 0, {}, std::nullopt,
-                        std::numeric_limits<double>::quiet_NaN()),
+      OperationCapability::create("x", 1, 0, {}, std::nullopt,
+                                  std::numeric_limits<double>::quiet_NaN()),
       "Compiler target operation fidelity must be finite and in [0, 1]");
 
   expectInvalid(Target::create(std::vector<Site>{}, Connectivity::allToAll(),
@@ -526,16 +528,17 @@ TEST(CompilerTargetTest, RejectsInvalidMetadata) {
                     std::vector{valid(Site::create(0, std::nullopt, 1))},
                     Connectivity::allToAll(), NativeOperations::unrestricted()),
                 "Compiler target timing metadata requires a duration unit");
-  expectInvalid(Target::create(1, Connectivity::allToAll(),
-                               NativeOperations::fromOperations({
-                                   valid(Operation::create("x", 1, 0, {}, 1)),
-                               })),
-                "Compiler target timing metadata requires a duration unit");
+  expectInvalid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations({
+                         valid(OperationCapability::create("x", 1, 0, {}, 1)),
+                     })),
+      "Compiler target timing metadata requires a duration unit");
   expectInvalid(
       Target::create(
           1, Connectivity::allToAll(),
           NativeOperations::fromOperations({
-              valid(Operation::create(
+              valid(OperationCapability::create(
                   "x", 1, 0, std::vector{valid(SiteTuple::create({0}, 1))})),
           })),
       "Compiler target timing metadata requires a duration unit");
@@ -552,19 +555,22 @@ TEST(CompilerTargetTest, RejectsInvalidMetadata) {
       Target::create(
           2, Connectivity::allToAll(),
           NativeOperations::fromOperations({
-              valid(Operation::create(
+              valid(OperationCapability::create(
                   "x", 1, 0, std::vector{valid(SiteTuple::create({2}))})),
           })),
       "Compiler target operation site tuple references an unknown site");
-  expectInvalid(Target::create(1, Connectivity::allToAll(),
-                               NativeOperations::fromOperations(
-                                   {valid(Operation::create("cx", 2, 0))})),
-                "Compiler target operation arity exceeds its site count");
   expectInvalid(
-      Target::create(2, Connectivity::allToAll(),
+      Target::create(1, Connectivity::allToAll(),
                      NativeOperations::fromOperations({
-                         valid(Operation::create("h", Arity::variadic(3), 0)),
+                         valid(OperationCapability::create("cx", 2, 0)),
                      })),
+      "Compiler target operation arity exceeds its site count");
+  expectInvalid(
+      Target::create(
+          2, Connectivity::allToAll(),
+          NativeOperations::fromOperations({
+              valid(OperationCapability::create("h", Arity::variadic(3), 0)),
+          })),
       "Compiler target operation variadic minimum exceeds its site count");
 }
 
@@ -573,14 +579,14 @@ TEST(CompilerTargetTest, DistinguishesOperationSupport) {
       2, Connectivity::allToAll(), NativeOperations::unrestricted()));
   const auto closed = valid(Target::create(
       2, Connectivity::allToAll(), NativeOperations::fromOperations({})));
-  const auto variadic = valid(
-      Target::create(4, Connectivity::allToAll(),
-                     NativeOperations::fromOperations({
-                         valid(Operation::create("gphase", Arity::fixed(0), 1)),
-                         valid(Operation::create("h", Arity::variadic(1), 0)),
-                         valid(Operation::create("rxx", Arity::variadic(2), 1)),
-                         valid(Operation::create("I", Arity::fixed(1), 0)),
-                     })));
+  const auto variadic = valid(Target::create(
+      4, Connectivity::allToAll(),
+      NativeOperations::fromOperations({
+          valid(OperationCapability::create("gphase", Arity::fixed(0), 1)),
+          valid(OperationCapability::create("h", Arity::variadic(1), 0)),
+          valid(OperationCapability::create("rxx", Arity::variadic(2), 1)),
+          valid(OperationCapability::create("I", Arity::fixed(1), 0)),
+      })));
 
   EXPECT_EQ(unrestricted.nativeOperationsKind(),
             NativeOperations::Kind::Unrestricted);
@@ -614,14 +620,14 @@ TEST(CompilerTargetTest, DistinguishesOperationSupport) {
 
 TEST(CompilerTargetTest, PreservesCalibrationAndResolvesHomogeneousBasis) {
   const std::vector<Coupling> chain{{0, 1}, {1, 2}};
-  const auto globalU = valid(Operation::create("U3", 1, 3));
-  const auto cz =
-      valid(Operation::create("cz", 2, 0,
-                              std::vector{
-                                  valid(SiteTuple::create({1, 0}, 5, 0.99)),
-                                  valid(SiteTuple::create({1, 2})),
-                              },
-                              7, 0.98));
+  const auto globalU = valid(OperationCapability::create("U3", 1, 3));
+  const auto cz = valid(
+      OperationCapability::create("cz", 2, 0,
+                                  std::vector{
+                                      valid(SiteTuple::create({1, 0}, 5, 0.99)),
+                                      valid(SiteTuple::create({1, 2})),
+                                  },
+                                  7, 0.98));
   const auto target =
       valid(Target::create(3, Connectivity::fromCouplings(chain),
                            NativeOperations::fromOperations({globalU, cz}),
@@ -658,14 +664,15 @@ TEST(CompilerTargetTest, RoundTripsTypedCompilationTargetAttribute) {
       valid(Site::create(11, "right")),
   };
   std::vector operations{
-      valid(Operation::create(" PRX ", 1, 2,
-                              std::vector{
-                                  valid(SiteTuple::create({7}, 0, 0.99)),
-                                  valid(SiteTuple::create({2}, 5, 0.98)),
-                              },
-                              0, 0.97)),
-      valid(Operation::create("gphase", Arity::fixed(0), 1)),
-      valid(Operation::create("h", Arity::variadic(1), 0)),
+      valid(OperationCapability::create(
+          " PRX ", 1, 2,
+          std::vector{
+              valid(SiteTuple::create({7}, 0, 0.99)),
+              valid(SiteTuple::create({2}, 5, 0.98)),
+          },
+          0, 0.97)),
+      valid(OperationCapability::create("gphase", Arity::fixed(0), 1)),
+      valid(OperationCapability::create("h", Arity::variadic(1), 0)),
   };
   const auto target =
       valid(Target::create("device", std::move(sites),
@@ -695,13 +702,13 @@ TEST(CompilerTargetTest, SupportsMaximumSiteIds) {
       valid(Site::create(nextSite)),
       valid(Site::create(maxSite)),
   };
-  const auto x =
-      valid(Operation::create("x", 1, 0,
-                              std::vector{
-                                  valid(SiteTuple::create({nextSite})),
-                                  valid(SiteTuple::create({maxSite})),
-                              }));
-  const auto cx = valid(Operation::create(
+  const auto x = valid(
+      OperationCapability::create("x", 1, 0,
+                                  std::vector{
+                                      valid(SiteTuple::create({nextSite})),
+                                      valid(SiteTuple::create({maxSite})),
+                                  }));
+  const auto cx = valid(OperationCapability::create(
       "cx", 2, 0, std::vector{valid(SiteTuple::create({nextSite, maxSite}))}));
   const auto target =
       valid(Target::create(std::move(sites), Connectivity::allToAll(),
@@ -754,20 +761,20 @@ TEST(CompilerTargetTest, EnforcesExactOrderedOperationApplicability) {
       valid(Site::create(20)),
       valid(Site::create(30)),
   };
-  const auto globalU = valid(Operation::create("u", 1, 3));
-  const auto restrictedX = valid(Operation::create(
+  const auto globalU = valid(OperationCapability::create("u", 1, 3));
+  const auto restrictedX = valid(OperationCapability::create(
       "x", 1, 0, std::vector{valid(SiteTuple::create({10}))}));
   const auto directionalCX =
-      valid(Operation::create("cx", 2, 0,
-                              std::vector{
-                                  valid(SiteTuple::create({10, 20})),
-                                  valid(SiteTuple::create({20, 30})),
-                              }));
-  const auto exactCZ = valid(Operation::create(
+      valid(OperationCapability::create("cx", 2, 0,
+                                        std::vector{
+                                            valid(SiteTuple::create({10, 20})),
+                                            valid(SiteTuple::create({20, 30})),
+                                        }));
+  const auto exactCZ = valid(OperationCapability::create(
       "cz", 2, 0, std::vector{valid(SiteTuple::create({10, 20}))}));
-  const auto threeQubit = valid(
-      Operation::create("device.operation", 3, 0,
-                        std::vector{valid(SiteTuple::create({10, 20, 30}))}));
+  const auto threeQubit = valid(OperationCapability::create(
+      "device.operation", 3, 0,
+      std::vector{valid(SiteTuple::create({10, 20, 30}))}));
   const auto target = valid(Target::create(
       std::move(sites), Connectivity::fromCouplings({{10, 20}, {20, 30}}),
       NativeOperations::fromOperations(
@@ -803,9 +810,9 @@ TEST(CompilerTargetTest, ResolvesSingleQubitBasisWithoutEntangler) {
     const auto target =
         valid(Target::create(numSites, Connectivity::allToAll(),
                              NativeOperations::fromOperations({
-                                 valid(Operation::create("sx", 1, 0)),
-                                 valid(Operation::create("x", 1, 0)),
-                                 valid(Operation::create("rz", 1, 1)),
+                                 valid(OperationCapability::create("sx", 1, 0)),
+                                 valid(OperationCapability::create("x", 1, 0)),
+                                 valid(OperationCapability::create("rz", 1, 1)),
                              })));
 
     ASSERT_TRUE(target.synthesisBasis());
@@ -829,12 +836,12 @@ TEST(CompilerTargetTest, ClassifiesEveryEntangler) {
       Entangler{GateKind::RZX, "rzx", 1},
   };
   const std::vector<Coupling> chain{{0, 1}, {1, 2}};
-  const auto globalU = valid(Operation::create("u", 1, 3));
+  const auto globalU = valid(OperationCapability::create("u", 1, 3));
 
   for (const auto& [gate, name, numParameters] : entanglers) {
     SCOPED_TRACE(name);
     const auto operation =
-        valid(Operation::create(std::string{name}, 2, numParameters));
+        valid(OperationCapability::create(std::string{name}, 2, numParameters));
     const auto target = valid(
         Target::create(3, Connectivity::fromCouplings(chain),
                        NativeOperations::fromOperations({globalU, operation})));
@@ -850,12 +857,12 @@ TEST(CompilerTargetTest, DerivesControlledEntanglersFromVariadicBases) {
       std::pair{std::string_view{"x"}, GateKind::CX},
       std::pair{std::string_view{"z"}, GateKind::CZ},
   };
-  const auto globalU = valid(Operation::create("u", 1, 3));
+  const auto globalU = valid(OperationCapability::create("u", 1, 3));
 
   for (const auto& [base, entangler] : bases) {
     SCOPED_TRACE(base);
-    const auto variadic =
-        valid(Operation::create(std::string{base}, Arity::variadic(1), 0));
+    const auto variadic = valid(
+        OperationCapability::create(std::string{base}, Arity::variadic(1), 0));
     const auto target = valid(
         Target::create(2, Connectivity::allToAll(),
                        NativeOperations::fromOperations({globalU, variadic})));
@@ -871,12 +878,12 @@ TEST(CompilerTargetTest, DerivesControlledEntanglersFromVariadicBases) {
 
 TEST(CompilerTargetTest, ResolvesLargeAllToAllVariadicBasis) {
   constexpr size_t numSites = 65'535;
-  const auto target = valid(
-      Target::create(numSites, Connectivity::allToAll(),
-                     NativeOperations::fromOperations({
-                         valid(Operation::create("u", 1, 3)),
-                         valid(Operation::create("x", Arity::variadic(1), 0)),
-                     })));
+  const auto target = valid(Target::create(
+      numSites, Connectivity::allToAll(),
+      NativeOperations::fromOperations({
+          valid(OperationCapability::create("u", 1, 3)),
+          valid(OperationCapability::create("x", Arity::variadic(1), 0)),
+      })));
 
   ASSERT_TRUE(target.synthesisBasis());
   EXPECT_EQ(target.synthesisBasis()->singleQubit, Target::SingleQubitBasis::U);
@@ -949,12 +956,13 @@ TEST(CompilerTargetTest, SupportsRealQCOOperationsAndStructuralOps) {
   std::vector sites{valid(Site::create(10)), valid(Site::create(20))};
   std::vector directionalTuples{valid(SiteTuple::create({10, 20}))};
   std::vector operations{
-      valid(Operation::create("x", 1, 0)),
-      valid(Operation::create("gphase", 0, 1)),
-      valid(Operation::create("measure", 1, 0)),
-      valid(Operation::create("reset", 1, 0)),
-      valid(Operation::create("cnot", 2, 0, std::move(directionalTuples))),
-      valid(Operation::create("cz", 2, 0)),
+      valid(OperationCapability::create("x", 1, 0)),
+      valid(OperationCapability::create("gphase", 0, 1)),
+      valid(OperationCapability::create("measure", 1, 0)),
+      valid(OperationCapability::create("reset", 1, 0)),
+      valid(OperationCapability::create("cnot", 2, 0,
+                                        std::move(directionalTuples))),
+      valid(OperationCapability::create("cz", 2, 0)),
   };
   const auto target =
       valid(Target::create(std::move(sites), Connectivity::allToAll(),
@@ -1018,19 +1026,19 @@ TEST(CompilerTargetTest, SupportsArbitrarilyControlledBaseOperations) {
   const auto target = valid(Target::create(
       5, Connectivity::allToAll(),
       NativeOperations::fromOperations({
-          valid(Operation::create("h", Arity::variadic(1), 0)),
-          valid(Operation::create("rx", Arity::variadic(1), 1)),
-          valid(Operation::create("rxx", Arity::variadic(2), 1)),
-          valid(Operation::create("rccx", Arity::variadic(3), 0)),
+          valid(OperationCapability::create("h", Arity::variadic(1), 0)),
+          valid(OperationCapability::create("rx", Arity::variadic(1), 1)),
+          valid(OperationCapability::create("rxx", Arity::variadic(2), 1)),
+          valid(OperationCapability::create("rccx", Arity::variadic(3), 0)),
       })));
   for (auto* controlled : supportedControls) {
     EXPECT_TRUE(target.supports(controlled));
   }
 
-  const auto fixedOnly = valid(
-      Target::create(5, Connectivity::allToAll(),
-                     NativeOperations::fromOperations(
-                         {valid(Operation::create("h", Arity::fixed(3), 0))})));
+  const auto fixedOnly = valid(Target::create(
+      5, Connectivity::allToAll(),
+      NativeOperations::fromOperations(
+          {valid(OperationCapability::create("h", Arity::fixed(3), 0))})));
   EXPECT_FALSE(fixedOnly.supports(supportedControls.front()));
 
   auto rejectedModule = mlir::qco::QCOProgramBuilder::build(

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm3_emission.cpp
@@ -15,7 +15,7 @@
 #include "mqt/Dialect/QC/Builder/QCProgramBuilder.h"
 #include "mqt/Dialect/QC/IR/QCDialect.h"
 #include "mqt/Dialect/QC/IR/QCOps.h"
-#include "mqt/Dialect/QC/Translation/TranslateQASM3ToQC.h"
+#include "mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h"
 #include "mqt/Dialect/QC/Translation/TranslateQCToOpenQASM3.h"
 #include "mqt/Dialect/QCO/Utils/DDFunctionality.h"
 #include "mqt/Support/Passes.h"
@@ -88,7 +88,7 @@ bit[2] c = measure q;
 
 TEST(OpenQASM3EmissionTest, EmitsStrictPortableBellProgram) {
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(BELL, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(BELL, &context);
   ASSERT_TRUE(moduleOp);
 
   auto source = qc::translateQCToOpenQASM3(*moduleOp);
@@ -106,9 +106,9 @@ TEST(OpenQASM3EmissionTest, EmitsStrictPortableBellProgram) {
   EXPECT_NE(source->find("include \"stdgates.inc\";"), std::string::npos);
   EXPECT_NE(source->find("ctrl @ x"), std::string::npos);
   EXPECT_NE(source->find("output bit[2] c;"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-      *source, oq3::frontend::GatePolicy::Strict));
-  EXPECT_TRUE(qc::translateQASM3ToQC(*source, &context));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *source, openqasm::frontend::GatePolicy::Strict));
+  EXPECT_TRUE(qc::translateOpenQASMToQC(*source, &context));
 }
 
 TEST(OpenQASM3EmissionTest, RoundTripsSwitchBreakContinueAndFallthrough) {
@@ -144,14 +144,14 @@ if (accumulated == )qasm" +
 result = measure q;
 )qasm";
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(source, &context);
     ASSERT_TRUE(moduleOp);
     ASSERT_TRUE(succeeded(verify(*moduleOp)));
     auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
     ASSERT_TRUE(succeeded(emitted));
-    ASSERT_TRUE(oq3::frontend::analyzeOpenQASM(
-        *emitted, oq3::frontend::GatePolicy::Strict));
-    auto restored = qc::translateQASM3ToQC(*emitted, &context);
+    ASSERT_TRUE(openqasm::frontend::analyzeOpenQASM(
+        *emitted, openqasm::frontend::GatePolicy::Strict));
+    auto restored = qc::translateOpenQASMToQC(*emitted, &context);
     ASSERT_TRUE(restored) << *emitted;
     ASSERT_TRUE(succeeded(verify(*restored)));
     expectOneSample(*moduleOp);
@@ -190,8 +190,8 @@ TEST(OpenQASM3EmissionTest, PreservesMeasurementOrderBeforeDelayedStore) {
   ASSERT_NE(store, std::string::npos) << *emitted;
   EXPECT_LT(measurement, gate);
   EXPECT_LT(gate, store);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -223,7 +223,7 @@ TEST(OpenQASM3EmissionTest, PreservesStaleClassicalSnapshots) {
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
   ASSERT_TRUE(succeeded(emitted));
-  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  auto restored = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(restored) << *emitted;
   expectOneSample(*restored);
 }
@@ -238,7 +238,7 @@ output bit result;
 result = measure q;
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
@@ -248,8 +248,8 @@ result = measure q;
   EXPECT_EQ(emitted->find("mqt.openqasm"), std::string::npos);
   EXPECT_NE(emitted->find("rx(1.5707963267948966)"), std::string::npos)
       << *emitted;
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -271,7 +271,7 @@ unsigned_value = 2;
 real = 3.0;
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   auto function = *moduleOp->getOps<func::FuncOp>().begin();
   ASSERT_EQ(function.getNumResults(), 6U);
@@ -286,7 +286,7 @@ real = 3.0;
   EXPECT_NE(emitted->find("output int _mqt_out"), std::string::npos);
   EXPECT_NE(emitted->find("output float _mqt_out"), std::string::npos);
   EXPECT_EQ(emitted->find("output uint "), std::string::npos);
-  EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+  EXPECT_TRUE(qc::translateOpenQASMToQC(*emitted, &context)) << *emitted;
 }
 
 TEST(OpenQASM3EmissionTest, RenamesOutputsThatCollideWithCompatibilityHelpers) {
@@ -298,7 +298,7 @@ r(0.5, 0.25) q;
 r = measure q;
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
@@ -306,8 +306,8 @@ r = measure q;
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("gate r("), std::string::npos);
   EXPECT_NE(emitted->find("output bit[1] _mqt_out0;"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -328,10 +328,10 @@ TEST(OpenQASM3EmissionTest, RenamesOutputsThatCollideWithStandardGates) {
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("output bit[1] _mqt_out0;"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
-  EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+  EXPECT_TRUE(qc::translateOpenQASMToQC(*emitted, &context)) << *emitted;
 }
 
 TEST(OpenQASM3EmissionTest, EmitsStatementOnlyStructuredControl) {
@@ -360,7 +360,7 @@ switch (selector) {
 }
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(runQCCleanupPipeline(*moduleOp)));
 
@@ -370,8 +370,8 @@ switch (selector) {
   EXPECT_NE(emitted->find("if ("), std::string::npos);
   EXPECT_NE(emitted->find("for int "), std::string::npos);
   EXPECT_NE(emitted->find("while ("), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -385,15 +385,15 @@ while (c == 1) {
 }
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("while ("), std::string::npos) << *emitted;
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -476,8 +476,8 @@ module {
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -513,7 +513,7 @@ module {
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
   ASSERT_TRUE(succeeded(emitted));
-  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  auto restored = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(restored) << *emitted;
   expectOneSample(*restored, "001");
 }
@@ -550,8 +550,8 @@ module {
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -602,7 +602,7 @@ module {
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+  EXPECT_TRUE(qc::translateOpenQASMToQC(*emitted, &context)) << *emitted;
 }
 
 TEST(OpenQASM3EmissionTest, EmitsScalarWidthOneRegisterWrites) {
@@ -625,8 +625,8 @@ module {
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -639,13 +639,13 @@ result = measure q;
 result = rotl(result, 2);
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+  EXPECT_TRUE(qc::translateOpenQASMToQC(*emitted, &context)) << *emitted;
 }
 
 TEST(OpenQASM3EmissionTest, RoundTripsWideBitVectorBuiltins) {
@@ -659,11 +659,11 @@ output uint count;
 count = popcount(c);
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
   ASSERT_TRUE(succeeded(emitted));
-  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  auto restored = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(restored) << *emitted;
   EXPECT_TRUE(succeeded(verify(*restored)));
 }
@@ -711,7 +711,7 @@ TEST(OpenQASM3EmissionTest, EmitsIndexArithmetic) {
   ASSERT_TRUE(moduleOp);
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
   ASSERT_TRUE(succeeded(emitted));
-  EXPECT_TRUE(qc::translateQASM3ToQC(*emitted, &context)) << *emitted;
+  EXPECT_TRUE(qc::translateOpenQASMToQC(*emitted, &context)) << *emitted;
 }
 
 TEST(OpenQASM3EmissionTest, EmitsNativeIndexSwitch) {
@@ -745,8 +745,8 @@ module {
   EXPECT_NE(emitted->find("switch (1)"), std::string::npos);
   EXPECT_NE(emitted->find("case 1 {"), std::string::npos);
   EXPECT_NE(emitted->find("default {"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -798,11 +798,11 @@ TEST(OpenQASM3EmissionTest, EmitsCatalogHelpersUnderTheirNativeNames) {
   }
   EXPECT_NE(emitted->find("gate _mqt_gate"), std::string::npos);
   EXPECT_NE(emitted->find("pow(0.5) @ z"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 
-  auto roundTripped = qc::translateQASM3ToQC(*emitted, &context);
+  auto roundTripped = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(roundTripped);
   for (const auto* const helper : helperNames) {
     bool found = false;
@@ -828,7 +828,7 @@ float theta = 0.25;
 inv @ pair(theta) q;
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
@@ -836,10 +836,10 @@ inv @ pair(theta) q;
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("gate pair(p0) q0"), std::string::npos);
   EXPECT_NE(emitted->find("inv @ pair("), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
-  auto roundTripped = qc::translateQASM3ToQC(*emitted, &context);
+  auto roundTripped = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(roundTripped);
   EXPECT_TRUE(roundTripped->lookupSymbol<func::FuncOp>("pair"));
 }
@@ -880,8 +880,8 @@ TEST(OpenQASM3EmissionTest, OrdersNestedGateFunctionsBeforeTheirCallers) {
   ASSERT_NE(call, std::string::npos) << *emitted;
   EXPECT_LT(inner, outer);
   EXPECT_LT(outer, call);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -897,7 +897,7 @@ qubit q;
 wrapper(0.5) q;
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
@@ -910,10 +910,10 @@ wrapper(0.5) q;
   EXPECT_LT(repeated, wrapper);
   EXPECT_NE(emitted->find("for int ", repeated), std::string::npos);
   EXPECT_NE(emitted->find("while (false)", repeated), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
-  auto roundTripped = qc::translateQASM3ToQC(*emitted, &context);
+  auto roundTripped = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(roundTripped);
   EXPECT_TRUE(roundTripped->lookupSymbol<func::FuncOp>("repeated"));
   EXPECT_TRUE(roundTripped->lookupSymbol<func::FuncOp>("wrapper"));
@@ -951,7 +951,7 @@ TEST(OpenQASM3EmissionTest, PreservesFloatingArithmeticOnGateLoopIndices) {
 
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
   ASSERT_TRUE(succeeded(emitted));
-  auto roundTripped = qc::translateQASM3ToQC(*emitted, &context);
+  auto roundTripped = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(roundTripped) << *emitted;
   ASSERT_TRUE(succeeded(runQCCleanupPipeline(*roundTripped)));
   ASSERT_TRUE(succeeded(verify(*roundTripped)));
@@ -995,7 +995,7 @@ TEST(OpenQASM3EmissionTest, OrdersLongReverseDeclaredGateGraph) {
   auto repeated = qc::translateQCToOpenQASM3(*moduleOp);
   ASSERT_TRUE(succeeded(repeated));
   EXPECT_EQ(*emitted, *repeated);
-  auto roundTripped = qc::translateQASM3ToQC(*emitted, &context);
+  auto roundTripped = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(roundTripped) << *emitted;
   EXPECT_TRUE(succeeded(verify(*roundTripped)));
   EXPECT_EQ(std::distance(roundTripped->getOps<func::FuncOp>().begin(),
@@ -1187,8 +1187,8 @@ module {
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("mod(5.5, 2.0)"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -1308,7 +1308,7 @@ TEST(OpenQASM3EmissionTest, RoundTripsNestedDynamicBoundsAndCarriedScalars) {
 
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find(" << "), std::string::npos) << *emitted;
-  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  auto restored = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(restored) << *emitted;
   ASSERT_TRUE(succeeded(verify(*restored)));
   EXPECT_TRUE(succeeded(qc::translateQCToOpenQASM3(*restored)));
@@ -1373,7 +1373,7 @@ TEST(OpenQASM3EmissionTest, PreservesDynamicRangeBoundaries) {
     auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
     ASSERT_TRUE(succeeded(emitted));
-    auto restored = qc::translateQASM3ToQC(*emitted, &context);
+    auto restored = qc::translateOpenQASMToQC(*emitted, &context);
     ASSERT_TRUE(restored) << *emitted;
     expectOneSample(*restored);
   }
@@ -1414,7 +1414,7 @@ TEST(OpenQASM3EmissionTest, SnapshotsDynamicBoundsBeforeClassicalWrites) {
   ASSERT_TRUE(moduleOp);
   auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
   ASSERT_TRUE(succeeded(emitted));
-  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  auto restored = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(restored) << *emitted;
   expectOneSample(*restored);
 }
@@ -1455,7 +1455,7 @@ TEST(OpenQASM3EmissionTest,
     )qasm";
     SCOPED_TRACE(source);
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(source, &context);
     ASSERT_TRUE(moduleOp);
     ASSERT_TRUE(succeeded(verify(*moduleOp)));
     moduleOp->walk([&](Operation* operation) {
@@ -1469,7 +1469,7 @@ TEST(OpenQASM3EmissionTest,
     auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
 
     ASSERT_TRUE(succeeded(emitted));
-    auto restored = qc::translateQASM3ToQC(*emitted, &context);
+    auto restored = qc::translateOpenQASMToQC(*emitted, &context);
     ASSERT_TRUE(restored) << *emitted;
     EXPECT_TRUE(succeeded(qc::translateQCToOpenQASM3(*restored)));
     expectOneSample(*restored);
@@ -1541,8 +1541,8 @@ TEST(OpenQASM3EmissionTest, ReusesQubitRegisterNames) {
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_NE(emitted->find("qubit[2] named_qubits;"), std::string::npos);
   EXPECT_EQ(emitted->find("qubit[2] not-valid;"), std::string::npos);
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(*emitted,
-                                             oq3::frontend::GatePolicy::Strict))
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+      *emitted, openqasm::frontend::GatePolicy::Strict))
       << *emitted;
 }
 
@@ -1567,7 +1567,7 @@ TEST(OpenQASM3EmissionTest, DefinesECRWithOneEntanglingGate) {
 
 TEST(OpenQASM3EmissionTest, LeavesDestinationEmptyOnFailure) {
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(BELL, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(BELL, &context);
   ASSERT_TRUE(moduleOp);
   auto function = *moduleOp->getOps<func::FuncOp>().begin();
   OpBuilder builder(function.getBody());
@@ -1609,7 +1609,7 @@ TEST(OpenQASM3EmissionTest, MaterializesDeepScalarExpressions) {
   auto emitted = qc::translateQCToOpenQASM3(moduleOp);
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_LT(emitted->size(), 100000);
-  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  auto restored = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(restored) << *emitted;
   PassManager manager(&context);
   manager.addPass(createCanonicalizerPass());
@@ -1646,7 +1646,7 @@ TEST(OpenQASM3EmissionTest, MaterializesSharedScalarExpressions) {
   auto emitted = qc::translateQCToOpenQASM3(moduleOp);
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_LT(emitted->size(), 10000);
-  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  auto restored = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(restored) << *emitted;
   PassManager manager(&context);
   manager.addPass(createCanonicalizerPass());
@@ -2034,7 +2034,7 @@ TEST(OpenQASM3EmissionTest, SupportsScalarRegionResults) {
     ASSERT_TRUE(moduleOp);
     auto source = qc::translateQCToOpenQASM3(*moduleOp);
     ASSERT_TRUE(succeeded(source));
-    EXPECT_TRUE(qc::translateQASM3ToQC(*source, &context));
+    EXPECT_TRUE(qc::translateOpenQASMToQC(*source, &context));
   }
 }
 
@@ -2052,7 +2052,7 @@ while (true) {
 }
 )qasm";
   MLIRContext context;
-  auto imported = qc::translateQASM3ToQC(source, &context);
+  auto imported = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(imported);
   size_t loops = 0;
   size_t conditionals = 0;
@@ -2065,7 +2065,7 @@ while (true) {
   EXPECT_EQ(conditionals, 0);
   auto exported = qc::translateQCToOpenQASM3(*imported);
   ASSERT_TRUE(succeeded(exported));
-  auto roundTrip = qc::translateQASM3ToQC(*exported, &context);
+  auto roundTrip = qc::translateOpenQASMToQC(*exported, &context);
   ASSERT_TRUE(roundTrip);
   loops = 0;
   conditionals = 0;
@@ -2093,7 +2093,7 @@ for int i in [0:5] {
 }
 )qasm";
   MLIRContext context;
-  auto imported = qc::translateQASM3ToQC(source, &context);
+  auto imported = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(imported);
   EXPECT_TRUE(succeeded(verify(*imported)));
 }
@@ -2105,11 +2105,11 @@ TEST(OpenQASM3EmissionTest, PreservesZeroAndMixedOutputResults) {
   };
   for (const auto* source : sources) {
     MLIRContext context;
-    auto original = qc::translateQASM3ToQC(source, &context);
+    auto original = qc::translateOpenQASMToQC(source, &context);
     ASSERT_TRUE(original);
     auto emitted = qc::translateQCToOpenQASM3(*original);
     ASSERT_TRUE(succeeded(emitted));
-    auto restored = qc::translateQASM3ToQC(*emitted, &context);
+    auto restored = qc::translateOpenQASMToQC(*emitted, &context);
     ASSERT_TRUE(restored) << *emitted;
     EXPECT_EQ(original->lookupSymbol<func::FuncOp>("main").getResultTypes(),
               restored->lookupSymbol<func::FuncOp>("main").getResultTypes());
@@ -2146,8 +2146,8 @@ TEST(OpenQASM3EmissionTest, UsesFrontendIdentifierRulesForOutputNames) {
     ASSERT_TRUE(moduleOp);
     auto emitted = qc::translateQCToOpenQASM3(*moduleOp);
     ASSERT_TRUE(succeeded(emitted));
-    EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
-        *emitted, oq3::frontend::GatePolicy::Strict))
+    EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
+        *emitted, openqasm::frontend::GatePolicy::Strict))
         << *emitted;
   }
 }
@@ -2155,12 +2155,12 @@ TEST(OpenQASM3EmissionTest, UsesFrontendIdentifierRulesForOutputNames) {
 TEST(OpenQASM3EmissionTest, DoesNotIntroduceOutputsForUnusedMeasurements) {
   MLIRContext context;
   auto original =
-      qc::translateQASM3ToQC("OPENQASM 3.1; qubit q; measure q;", &context);
+      qc::translateOpenQASMToQC("OPENQASM 3.1; qubit q; measure q;", &context);
   ASSERT_TRUE(original);
   auto emitted = qc::translateQCToOpenQASM3(*original);
   ASSERT_TRUE(succeeded(emitted));
   EXPECT_EQ(emitted->find("\nbit "), std::string::npos);
-  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  auto restored = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(restored);
   EXPECT_TRUE(
       restored->lookupSymbol<func::FuncOp>("main").getResultTypes().empty());
@@ -2173,14 +2173,14 @@ TEST(OpenQASM3EmissionTest,
      RoundTripsFloatingInequalityAndRejectsOrderedNotEqual) {
   MLIRContext context;
   auto original =
-      qc::translateQASM3ToQC("OPENQASM 3.1; qubit q; bit value = measure q; "
-                             "float f = float(bool(value)); "
-                             "output bool b; b = f != 2.0;",
-                             &context);
+      qc::translateOpenQASMToQC("OPENQASM 3.1; qubit q; bit value = measure q; "
+                                "float f = float(bool(value)); "
+                                "output bool b; b = f != 2.0;",
+                                &context);
   ASSERT_TRUE(original);
   auto emitted = qc::translateQCToOpenQASM3(*original);
   ASSERT_TRUE(succeeded(emitted));
-  auto restored = qc::translateQASM3ToQC(*emitted, &context);
+  auto restored = qc::translateOpenQASMToQC(*emitted, &context);
   ASSERT_TRUE(restored);
   size_t comparisons = 0;
   restored->walk([&](arith::CmpFOp comparison) {
@@ -2236,13 +2236,13 @@ TEST(OpenQASM3EmissionTest,
       func::registerInlinerExtension(registry);
       LLVM::registerInlinerInterface(registry);
       MLIRContext context(registry);
-      auto original = qc::translateQASM3ToQC(input, &context);
+      auto original = qc::translateOpenQASMToQC(input, &context);
       ASSERT_TRUE(original);
       auto emitted = qc::translateQCToOpenQASM3(*original);
       ASSERT_TRUE(succeeded(emitted));
-      auto restored = qc::translateQASM3ToQC(
+      auto restored = qc::translateOpenQASMToQC(
           *emitted, &context,
-          {.gatePolicy = oq3::frontend::GatePolicy::Strict});
+          {.gatePolicy = openqasm::frontend::GatePolicy::Strict});
       ASSERT_TRUE(restored);
       dd::Package package(width);
       PassManager manager(&context);

--- a/mlir/unittests/Dialect/QC/Translation/test_openqasm_translation.cpp
+++ b/mlir/unittests/Dialect/QC/Translation/test_openqasm_translation.cpp
@@ -17,7 +17,7 @@
 #include "mqt/Dialect/QC/IR/QCDialect.h"
 #include "mqt/Dialect/QC/IR/QCInterfaces.h"
 #include "mqt/Dialect/QC/IR/QCOps.h"
-#include "mqt/Dialect/QC/Translation/TranslateQASM3ToQC.h"
+#include "mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h"
 #include "mqt/Dialect/QCO/IR/QCODialect.h"
 #include "mqt/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mqt/Support/Passes.h"
@@ -57,29 +57,29 @@
 #include <string>
 #include <utility>
 
-namespace mqt::test::qasm3_translation {
+namespace mqt::test::openqasm_translation {
 using namespace mlir;
 
 namespace {
 
-struct QASM3TranslationTestCase {
+struct OpenQASMTranslationTestCase {
   std::string name;
   std::string source;
   ::mqt::test::NamedMLIRBuilder<qc::QCProgramBuilder> referenceBuilder;
 
   friend std::ostream& operator<<(std::ostream& os,
-                                  const QASM3TranslationTestCase& test);
+                                  const OpenQASMTranslationTestCase& test);
 };
 
 // NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)
 std::ostream& operator<<(std::ostream& os,
-                         const QASM3TranslationTestCase& test) {
-  return os << "QASM3Translation{" << test.name << ", reference="
+                         const OpenQASMTranslationTestCase& test) {
+  return os << "OpenQASMTranslation{" << test.name << ", reference="
             << ::mqt::test::displayName(test.referenceBuilder.name) << "}";
 }
 
-class QASM3TranslationTest
-    : public testing::TestWithParam<QASM3TranslationTestCase> {
+class OpenQASMTranslationTest
+    : public testing::TestWithParam<OpenQASMTranslationTestCase> {
 protected:
   std::unique_ptr<MLIRContext> context;
 
@@ -435,7 +435,7 @@ evaluateOneQubitRegion(Region& region) {
 [[nodiscard]] static Matrix2
 translatedOneQubitUnitary(const llvm::StringRef source) {
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   EXPECT_TRUE(moduleOp);
   if (!moduleOp) {
     return Matrix2::identity();
@@ -449,7 +449,7 @@ translatedOneQubitUnitary(const llvm::StringRef source) {
 [[nodiscard]] static Matrix4
 translatedTwoQubitUnitary(const llvm::StringRef source) {
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   EXPECT_TRUE(moduleOp);
   if (!moduleOp) {
     return Matrix4::identity();
@@ -495,7 +495,7 @@ translatedTwoQubitUnitary(const llvm::StringRef source) {
   return result;
 }
 
-TEST(QASM3TranslationMatrixTest, PreservesOpenQASMGatePhaseConventions) {
+TEST(OpenQASMTranslationMatrixTest, PreservesOpenQASMGatePhaseConventions) {
   constexpr double theta = 0.37;
   constexpr double phi = -0.29;
   constexpr double lambda = 0.83;
@@ -975,13 +975,13 @@ static LogicalResult convertQCToQCO(ModuleOp moduleOp) {
   return manager.run(moduleOp);
 }
 
-TEST_P(QASM3TranslationTest, ProgramEquivalence) {
+TEST_P(OpenQASMTranslationTest, ProgramEquivalence) {
   const auto name = " (" + GetParam().name + ")";
   const auto& source = GetParam().source;
   const auto referenceBuilder = GetParam().referenceBuilder;
   ::mqt::test::DeferredPrinter printer;
 
-  auto translated = qc::translateQASM3ToQC(source, context.get());
+  auto translated = qc::translateOpenQASMToQC(source, context.get());
   ASSERT_TRUE(translated);
   printer.record(translated.get(), "Translated QC IR" + name);
   EXPECT_TRUE(verify(*translated).succeeded());
@@ -1025,14 +1025,14 @@ TEST_P(QASM3TranslationTest, ProgramEquivalence) {
       areModulesEquivalentWithPermutations(translated.get(), reference.get()));
 }
 
-TEST(QASM3TranslationErrors, AcceptsFloatingAndRejectsBooleanPowerExponent) {
+TEST(OpenQASMTranslationErrors, AcceptsFloatingAndRejectsBooleanPowerExponent) {
   DialectRegistry registry;
   registry.insert<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
                   memref::MemRefDialect, scf::SCFDialect>();
   MLIRContext context(registry);
   context.loadAllAvailableDialects();
 
-  auto translated = qc::translateQASM3ToQC(qasm::floatingPowX, &context);
+  auto translated = qc::translateOpenQASMToQC(qasm::floatingPowX, &context);
   ASSERT_TRUE(translated);
   SmallVector<qc::PowOp> powers;
   translated->walk([&](qc::PowOp op) { powers.push_back(op); });
@@ -1040,17 +1040,17 @@ TEST(QASM3TranslationErrors, AcceptsFloatingAndRejectsBooleanPowerExponent) {
   ASSERT_TRUE(powers.front().getExponentValue().has_value());
   EXPECT_DOUBLE_EQ(*powers.front().getExponentValue(), 0.5);
 
-  EXPECT_FALSE(qc::translateQASM3ToQC(qasm::booleanPowX, &context));
+  EXPECT_FALSE(qc::translateOpenQASMToQC(qasm::booleanPowX, &context));
 }
 
-TEST(QASM3TranslationErrors, ChecksPowerExponentPrecisionAndNesting) {
+TEST(OpenQASMTranslationErrors, ChecksPowerExponentPrecisionAndNesting) {
   DialectRegistry registry;
   registry.insert<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
                   memref::MemRefDialect, scf::SCFDialect>();
   MLIRContext context(registry);
   context.loadAllAvailableDialects();
 
-  auto translated = qc::translateQASM3ToQC(qasm::exactLargePowX, &context);
+  auto translated = qc::translateOpenQASMToQC(qasm::exactLargePowX, &context);
   ASSERT_TRUE(translated);
   SmallVector<qc::PowOp> powers;
   translated->walk([&](qc::PowOp op) { powers.push_back(op); });
@@ -1059,9 +1059,9 @@ TEST(QASM3TranslationErrors, ChecksPowerExponentPrecisionAndNesting) {
   ASSERT_TRUE(exponent.has_value());
   EXPECT_DOUBLE_EQ(*exponent, 9007199254740992.0);
 
-  EXPECT_FALSE(qc::translateQASM3ToQC(qasm::inexactLargePowX, &context));
+  EXPECT_FALSE(qc::translateOpenQASMToQC(qasm::inexactLargePowX, &context));
 
-  translated = qc::translateQASM3ToQC(qasm::overflowingNestedPowX, &context);
+  translated = qc::translateOpenQASMToQC(qasm::overflowingNestedPowX, &context);
   ASSERT_TRUE(translated);
   powers.clear();
   translated->walk([&](qc::PowOp op) { powers.push_back(op); });
@@ -1072,13 +1072,13 @@ TEST(QASM3TranslationErrors, ChecksPowerExponentPrecisionAndNesting) {
   }
 }
 
-TEST_F(QASM3TranslationTest, RetainsClassicalRegisterName) {
+TEST_F(OpenQASMTranslationTest, RetainsClassicalRegisterName) {
   constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.0;
 qubit q;
 output bit named_result;
 named_result = measure q;
 )qasm";
-  auto translated = qc::translateQASM3ToQC(source, context.get());
+  auto translated = qc::translateOpenQASMToQC(source, context.get());
   ASSERT_TRUE(translated);
 
   cbit::AllocOp classicalRegister;
@@ -1090,7 +1090,7 @@ named_result = measure q;
   EXPECT_EQ(name.getValue(), "named_result");
 }
 
-TEST_F(QASM3TranslationTest, UsesVersionSpecificBitInitialization) {
+TEST_F(OpenQASMTranslationTest, UsesVersionSpecificBitInitialization) {
   constexpr std::array sources{
       std::pair{R"qasm(OPENQASM 2.0;
 include "qelib1.inc";
@@ -1108,7 +1108,7 @@ c[0] = measure q;
   };
 
   for (const auto& [source, expected] : sources) {
-    auto translated = qc::translateQASM3ToQC(source, context.get());
+    auto translated = qc::translateOpenQASMToQC(source, context.get());
     ASSERT_TRUE(translated);
     SmallVector<cbit::AllocOp> registers;
     bool containsPoison = false;
@@ -1124,11 +1124,11 @@ c[0] = measure q;
   }
 }
 
-TEST_F(QASM3TranslationTest, RetainsQubitRegisterName) {
+TEST_F(OpenQASMTranslationTest, RetainsQubitRegisterName) {
   constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.0;
 qubit[2] named_qubits;
 )qasm";
-  auto translated = qc::translateQASM3ToQC(source, context.get());
+  auto translated = qc::translateOpenQASMToQC(source, context.get());
   ASSERT_TRUE(translated);
 
   memref::AllocOp qubitRegister;
@@ -1144,7 +1144,8 @@ qubit[2] named_qubits;
   EXPECT_EQ(name.getValue(), "named_qubits");
 }
 
-TEST_F(QASM3TranslationTest, DistinguishesScalarAndWidthOneQubitAllocations) {
+TEST_F(OpenQASMTranslationTest,
+       DistinguishesScalarAndWidthOneQubitAllocations) {
   constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.1;
 qubit scalar;
 qubit[1] vector;
@@ -1152,7 +1153,7 @@ output bit[2] result;
 result[0] = measure scalar;
 result[1] = measure vector[0];
 )qasm";
-  auto translated = qc::translateQASM3ToQC(source, context.get());
+  auto translated = qc::translateOpenQASMToQC(source, context.get());
   ASSERT_TRUE(translated);
 
   size_t scalarAllocations = 0;
@@ -1170,7 +1171,7 @@ result[1] = measure vector[0];
   EXPECT_EQ(registerAllocations, 1);
 }
 
-TEST_F(QASM3TranslationTest, JoinsMeasurementsFromBothBranches) {
+TEST_F(OpenQASMTranslationTest, JoinsMeasurementsFromBothBranches) {
   constexpr llvm::StringLiteral source = R"qasm(OPENQASM 3.0;
 qubit[2] q;
 bit condition;
@@ -1185,12 +1186,12 @@ if (measured_on_all_paths) {
   x q[1];
 }
 )qasm";
-  auto translated = qc::translateQASM3ToQC(source, context.get());
+  auto translated = qc::translateOpenQASMToQC(source, context.get());
   ASSERT_TRUE(translated);
   EXPECT_TRUE(succeeded(verify(*translated)));
 }
 
-TEST(QASM3TranslationRegression, ReloadsConditionAfterBranchMeasurement) {
+TEST(OpenQASMTranslationRegression, ReloadsConditionAfterBranchMeasurement) {
   DialectRegistry registry;
   registry.insert<qc::QCDialect, arith::ArithDialect, func::FuncDialect,
                   memref::MemRefDialect, scf::SCFDialect>();
@@ -1208,361 +1209,390 @@ if (c) {
   x q;
 }
 )qasm";
-  auto translated = qc::translateQASM3ToQC(source, &context);
+  auto translated = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(translated);
   EXPECT_TRUE(succeeded(verify(*translated)));
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    QASM3TranslationProgramsTest, QASM3TranslationTest,
+    OpenQASMTranslationProgramsTest, OpenQASMTranslationTest,
     testing::Values(
 
-        QASM3TranslationTestCase{"AllocQubit", qasm::allocQubit,
-                                 MQT_NAMED_BUILDER(qc::allocQubit)},
-        QASM3TranslationTestCase{"AllocQubitRegister", qasm::allocQubitRegister,
-                                 MQT_NAMED_BUILDER(qc::allocQubitRegister)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"AllocQubit", qasm::allocQubit,
+                                    MQT_NAMED_BUILDER(qc::allocQubit)},
+        OpenQASMTranslationTestCase{"AllocQubitRegister",
+                                    qasm::allocQubitRegister,
+                                    MQT_NAMED_BUILDER(qc::allocQubitRegister)},
+        OpenQASMTranslationTestCase{
             "AllocMultipleQubitRegisters", qasm::allocMultipleQubitRegisters,
             MQT_NAMED_BUILDER(allocMultipleQubitRegisters)},
-        QASM3TranslationTestCase{"AllocLargeRegister", qasm::allocLargeRegister,
-                                 MQT_NAMED_BUILDER(qc::allocLargeRegister)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"AllocLargeRegister",
+                                    qasm::allocLargeRegister,
+                                    MQT_NAMED_BUILDER(qc::allocLargeRegister)},
+        OpenQASMTranslationTestCase{
             "SingleMeasurementToSingleBit", qasm::singleMeasurementToSingleBit,
             MQT_NAMED_BUILDER(qc::singleMeasurementToSingleBit)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{
             "RepeatedMeasurementToSameBit", qasm::repeatedMeasurementToSameBit,
             MQT_NAMED_BUILDER(qc::repeatedMeasurementToSameBit)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{
             "RepeatedMeasurementToDifferentBits",
             qasm::repeatedMeasurementToDifferentBits,
             MQT_NAMED_BUILDER(qc::repeatedMeasurementToDifferentBits)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{
             "MultipleClassicalRegistersAndMeasurements",
             qasm::multipleClassicalRegistersAndMeasurements,
             MQT_NAMED_BUILDER(qc::multipleClassicalRegistersAndMeasurements)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{
             "ResetQubitAfterSingleOp", qasm::resetQubitAfterSingleOp,
             MQT_NAMED_BUILDER(qc::resetQubitAfterSingleOp)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{
             "ResetMultipleQubitsAfterSingleOp",
             qasm::resetMultipleQubitsAfterSingleOp,
             MQT_NAMED_BUILDER(qc::resetMultipleQubitsAfterSingleOp)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{
             "RepeatedResetAfterSingleOp", qasm::repeatedResetAfterSingleOp,
             MQT_NAMED_BUILDER(qc::repeatedResetAfterSingleOp)},
-        QASM3TranslationTestCase{"GlobalPhase", qasm::globalPhase,
-                                 MQT_NAMED_BUILDER(qc::globalPhase)},
-        QASM3TranslationTestCase{"InverseGlobalPhase", qasm::inverseGlobalPhase,
-                                 MQT_NAMED_BUILDER(qc::inverseGlobalPhase)},
-        QASM3TranslationTestCase{"Identity", qasm::identity,
-                                 MQT_NAMED_BUILDER(qc::identity)},
-        QASM3TranslationTestCase{"SingleControlledIdentity",
-                                 qasm::singleControlledIdentity,
-                                 MQT_NAMED_BUILDER(qc::twoQubitsOneIdentity)},
-        QASM3TranslationTestCase{"MultipleControlledIdentity",
-                                 qasm::multipleControlledIdentity,
-                                 MQT_NAMED_BUILDER(qc::threeQubitsOneIdentity)},
-        QASM3TranslationTestCase{"X", qasm::x, MQT_NAMED_BUILDER(qc::x)},
-        QASM3TranslationTestCase{"TwoX", qasm::twoX, MQT_NAMED_BUILDER(twoX)},
-        QASM3TranslationTestCase{"SingleControlledX", qasm::singleControlledX,
-                                 MQT_NAMED_BUILDER(qc::singleControlledX)},
-        QASM3TranslationTestCase{"SingleNegControlledX",
-                                 qasm::singleNegControlledX,
-                                 MQT_NAMED_BUILDER(singleNegControlledX)},
-        QASM3TranslationTestCase{"MultipleControlledX",
-                                 qasm::multipleControlledX,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledX)},
-        QASM3TranslationTestCase{"TripleControlledXOpenQASM2",
-                                 qasm::tripleControlledXOpenQASM2,
-                                 MQT_NAMED_BUILDER(tripleControlledX)},
-        QASM3TranslationTestCase{"MixedControlledX", qasm::mixedControlledX,
-                                 MQT_NAMED_BUILDER(mixedControlledX)},
-        QASM3TranslationTestCase{"TwoMixedControlledX",
-                                 qasm::twoMixedControlledX,
-                                 MQT_NAMED_BUILDER(twoMixedControlledX)},
-        QASM3TranslationTestCase{"InverseX", qasm::inverseX,
-                                 MQT_NAMED_BUILDER(qc::inverseX)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"GlobalPhase", qasm::globalPhase,
+                                    MQT_NAMED_BUILDER(qc::globalPhase)},
+        OpenQASMTranslationTestCase{"InverseGlobalPhase",
+                                    qasm::inverseGlobalPhase,
+                                    MQT_NAMED_BUILDER(qc::inverseGlobalPhase)},
+        OpenQASMTranslationTestCase{"Identity", qasm::identity,
+                                    MQT_NAMED_BUILDER(qc::identity)},
+        OpenQASMTranslationTestCase{
+            "SingleControlledIdentity", qasm::singleControlledIdentity,
+            MQT_NAMED_BUILDER(qc::twoQubitsOneIdentity)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledIdentity", qasm::multipleControlledIdentity,
+            MQT_NAMED_BUILDER(qc::threeQubitsOneIdentity)},
+        OpenQASMTranslationTestCase{"X", qasm::x, MQT_NAMED_BUILDER(qc::x)},
+        OpenQASMTranslationTestCase{"TwoX", qasm::twoX,
+                                    MQT_NAMED_BUILDER(twoX)},
+        OpenQASMTranslationTestCase{"SingleControlledX",
+                                    qasm::singleControlledX,
+                                    MQT_NAMED_BUILDER(qc::singleControlledX)},
+        OpenQASMTranslationTestCase{"SingleNegControlledX",
+                                    qasm::singleNegControlledX,
+                                    MQT_NAMED_BUILDER(singleNegControlledX)},
+        OpenQASMTranslationTestCase{"MultipleControlledX",
+                                    qasm::multipleControlledX,
+                                    MQT_NAMED_BUILDER(qc::multipleControlledX)},
+        OpenQASMTranslationTestCase{"TripleControlledXOpenQASM2",
+                                    qasm::tripleControlledXOpenQASM2,
+                                    MQT_NAMED_BUILDER(tripleControlledX)},
+        OpenQASMTranslationTestCase{"MixedControlledX", qasm::mixedControlledX,
+                                    MQT_NAMED_BUILDER(mixedControlledX)},
+        OpenQASMTranslationTestCase{"TwoMixedControlledX",
+                                    qasm::twoMixedControlledX,
+                                    MQT_NAMED_BUILDER(twoMixedControlledX)},
+        OpenQASMTranslationTestCase{"InverseX", qasm::inverseX,
+                                    MQT_NAMED_BUILDER(qc::inverseX)},
+        OpenQASMTranslationTestCase{
             "InverseMultipleControlledX", qasm::inverseMultipleControlledX,
             MQT_NAMED_BUILDER(qc::inverseMultipleControlledX)},
-        QASM3TranslationTestCase{"Y", qasm::y, MQT_NAMED_BUILDER(qc::y)},
-        QASM3TranslationTestCase{"SingleControlledY", qasm::singleControlledY,
-                                 MQT_NAMED_BUILDER(qc::singleControlledY)},
-        QASM3TranslationTestCase{"MultipleControlledY",
-                                 qasm::multipleControlledY,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledY)},
-        QASM3TranslationTestCase{"Z", qasm::z, MQT_NAMED_BUILDER(qc::z)},
-        QASM3TranslationTestCase{"SingleControlledZ", qasm::singleControlledZ,
-                                 MQT_NAMED_BUILDER(qc::singleControlledZ)},
-        QASM3TranslationTestCase{"MultipleControlledZ",
-                                 qasm::multipleControlledZ,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledZ)},
-        QASM3TranslationTestCase{"H", qasm::h, MQT_NAMED_BUILDER(qc::h)},
-        QASM3TranslationTestCase{"SingleControlledH", qasm::singleControlledH,
-                                 MQT_NAMED_BUILDER(qc::singleControlledH)},
-        QASM3TranslationTestCase{"MultipleControlledH",
-                                 qasm::multipleControlledH,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledH)},
-        QASM3TranslationTestCase{"S", qasm::s, MQT_NAMED_BUILDER(qc::s)},
-        QASM3TranslationTestCase{"SingleControlledS", qasm::singleControlledS,
-                                 MQT_NAMED_BUILDER(qc::singleControlledS)},
-        QASM3TranslationTestCase{"MultipleControlledS",
-                                 qasm::multipleControlledS,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledS)},
-        QASM3TranslationTestCase{"Sdg", qasm::sdg, MQT_NAMED_BUILDER(qc::sdg)},
-        QASM3TranslationTestCase{"SingleControlledSdg",
-                                 qasm::singleControlledSdg,
-                                 MQT_NAMED_BUILDER(qc::singleControlledSdg)},
-        QASM3TranslationTestCase{"MultipleControlledSdg",
-                                 qasm::multipleControlledSdg,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledSdg)},
-        QASM3TranslationTestCase{"T", qasm::t_, MQT_NAMED_BUILDER(qc::t_)},
-        QASM3TranslationTestCase{"SingleControlledT", qasm::singleControlledT,
-                                 MQT_NAMED_BUILDER(qc::singleControlledT)},
-        QASM3TranslationTestCase{"MultipleControlledT",
-                                 qasm::multipleControlledT,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledT)},
-        QASM3TranslationTestCase{"Tdg", qasm::tdg, MQT_NAMED_BUILDER(qc::tdg)},
-        QASM3TranslationTestCase{"SingleControlledTdg",
-                                 qasm::singleControlledTdg,
-                                 MQT_NAMED_BUILDER(qc::singleControlledTdg)},
-        QASM3TranslationTestCase{"MultipleControlledTdg",
-                                 qasm::multipleControlledTdg,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledTdg)},
-        QASM3TranslationTestCase{"SX", qasm::sx, MQT_NAMED_BUILDER(qc::sx)},
-        QASM3TranslationTestCase{"SingleControlledSX", qasm::singleControlledSx,
-                                 MQT_NAMED_BUILDER(qc::singleControlledSx)},
-        QASM3TranslationTestCase{"MultipleControlledSX",
-                                 qasm::multipleControlledSx,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledSx)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"Y", qasm::y, MQT_NAMED_BUILDER(qc::y)},
+        OpenQASMTranslationTestCase{"SingleControlledY",
+                                    qasm::singleControlledY,
+                                    MQT_NAMED_BUILDER(qc::singleControlledY)},
+        OpenQASMTranslationTestCase{"MultipleControlledY",
+                                    qasm::multipleControlledY,
+                                    MQT_NAMED_BUILDER(qc::multipleControlledY)},
+        OpenQASMTranslationTestCase{"Z", qasm::z, MQT_NAMED_BUILDER(qc::z)},
+        OpenQASMTranslationTestCase{"SingleControlledZ",
+                                    qasm::singleControlledZ,
+                                    MQT_NAMED_BUILDER(qc::singleControlledZ)},
+        OpenQASMTranslationTestCase{"MultipleControlledZ",
+                                    qasm::multipleControlledZ,
+                                    MQT_NAMED_BUILDER(qc::multipleControlledZ)},
+        OpenQASMTranslationTestCase{"H", qasm::h, MQT_NAMED_BUILDER(qc::h)},
+        OpenQASMTranslationTestCase{"SingleControlledH",
+                                    qasm::singleControlledH,
+                                    MQT_NAMED_BUILDER(qc::singleControlledH)},
+        OpenQASMTranslationTestCase{"MultipleControlledH",
+                                    qasm::multipleControlledH,
+                                    MQT_NAMED_BUILDER(qc::multipleControlledH)},
+        OpenQASMTranslationTestCase{"S", qasm::s, MQT_NAMED_BUILDER(qc::s)},
+        OpenQASMTranslationTestCase{"SingleControlledS",
+                                    qasm::singleControlledS,
+                                    MQT_NAMED_BUILDER(qc::singleControlledS)},
+        OpenQASMTranslationTestCase{"MultipleControlledS",
+                                    qasm::multipleControlledS,
+                                    MQT_NAMED_BUILDER(qc::multipleControlledS)},
+        OpenQASMTranslationTestCase{"Sdg", qasm::sdg,
+                                    MQT_NAMED_BUILDER(qc::sdg)},
+        OpenQASMTranslationTestCase{"SingleControlledSdg",
+                                    qasm::singleControlledSdg,
+                                    MQT_NAMED_BUILDER(qc::singleControlledSdg)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledSdg", qasm::multipleControlledSdg,
+            MQT_NAMED_BUILDER(qc::multipleControlledSdg)},
+        OpenQASMTranslationTestCase{"T", qasm::t_, MQT_NAMED_BUILDER(qc::t_)},
+        OpenQASMTranslationTestCase{"SingleControlledT",
+                                    qasm::singleControlledT,
+                                    MQT_NAMED_BUILDER(qc::singleControlledT)},
+        OpenQASMTranslationTestCase{"MultipleControlledT",
+                                    qasm::multipleControlledT,
+                                    MQT_NAMED_BUILDER(qc::multipleControlledT)},
+        OpenQASMTranslationTestCase{"Tdg", qasm::tdg,
+                                    MQT_NAMED_BUILDER(qc::tdg)},
+        OpenQASMTranslationTestCase{"SingleControlledTdg",
+                                    qasm::singleControlledTdg,
+                                    MQT_NAMED_BUILDER(qc::singleControlledTdg)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledTdg", qasm::multipleControlledTdg,
+            MQT_NAMED_BUILDER(qc::multipleControlledTdg)},
+        OpenQASMTranslationTestCase{"SX", qasm::sx, MQT_NAMED_BUILDER(qc::sx)},
+        OpenQASMTranslationTestCase{"SingleControlledSX",
+                                    qasm::singleControlledSx,
+                                    MQT_NAMED_BUILDER(qc::singleControlledSx)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledSX", qasm::multipleControlledSx,
+            MQT_NAMED_BUILDER(qc::multipleControlledSx)},
+        OpenQASMTranslationTestCase{
             "LegacyTripleControlledSqrtX",
             "OPENQASM 2.0; include \"qelib1.inc\"; qreg q[4]; creg c[4]; "
             "c3sqrtx q[0], q[1], q[2], q[3]; measure q -> c;",
             MQT_NAMED_BUILDER(legacyTripleControlledSx)},
-        QASM3TranslationTestCase{"SXdg", qasm::sxdg,
-                                 MQT_NAMED_BUILDER(qc::sxdg)},
-        QASM3TranslationTestCase{"SingleControlledSXdg",
-                                 qasm::singleControlledSxdg,
-                                 MQT_NAMED_BUILDER(qc::singleControlledSxdg)},
-        QASM3TranslationTestCase{"MultipleControlledSXdg",
-                                 qasm::multipleControlledSxdg,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledSxdg)},
-        QASM3TranslationTestCase{"RX", qasm::rx, MQT_NAMED_BUILDER(qc::rx)},
-        QASM3TranslationTestCase{"SingleControlledRX", qasm::singleControlledRx,
-                                 MQT_NAMED_BUILDER(qc::singleControlledRx)},
-        QASM3TranslationTestCase{"MultipleControlledRX",
-                                 qasm::multipleControlledRx,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledRx)},
-        QASM3TranslationTestCase{"RY", qasm::ry, MQT_NAMED_BUILDER(qc::ry)},
-        QASM3TranslationTestCase{"SingleControlledRY", qasm::singleControlledRy,
-                                 MQT_NAMED_BUILDER(qc::singleControlledRy)},
-        QASM3TranslationTestCase{"MultipleControlledRY",
-                                 qasm::multipleControlledRy,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledRy)},
-        QASM3TranslationTestCase{"RZ", qasm::rz, MQT_NAMED_BUILDER(qc::rz)},
-        QASM3TranslationTestCase{"SingleControlledRZ", qasm::singleControlledRz,
-                                 MQT_NAMED_BUILDER(qc::singleControlledRz)},
-        QASM3TranslationTestCase{"MultipleControlledRZ",
-                                 qasm::multipleControlledRz,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledRz)},
-        QASM3TranslationTestCase{"P", qasm::p, MQT_NAMED_BUILDER(qc::p)},
-        QASM3TranslationTestCase{"SingleControlledP", qasm::singleControlledP,
-                                 MQT_NAMED_BUILDER(qc::singleControlledP)},
-        QASM3TranslationTestCase{"MultipleControlledP",
-                                 qasm::multipleControlledP,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledP)},
-        QASM3TranslationTestCase{"R", qasm::r, MQT_NAMED_BUILDER(qc::r)},
-        QASM3TranslationTestCase{"SingleControlledR", qasm::singleControlledR,
-                                 MQT_NAMED_BUILDER(qc::singleControlledR)},
-        QASM3TranslationTestCase{"MultipleControlledR",
-                                 qasm::multipleControlledR,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledR)},
-        QASM3TranslationTestCase{"U2", qasm::u2, MQT_NAMED_BUILDER(legacyU2)},
-        QASM3TranslationTestCase{"SingleControlledU2", qasm::singleControlledU2,
-                                 MQT_NAMED_BUILDER(legacySingleControlledU2)},
-        QASM3TranslationTestCase{"MultipleControlledU2",
-                                 qasm::multipleControlledU2,
-                                 MQT_NAMED_BUILDER(legacyMultipleControlledU2)},
-        QASM3TranslationTestCase{"U", qasm::u, MQT_NAMED_BUILDER(legacyU)},
-        QASM3TranslationTestCase{"SingleControlledU", qasm::singleControlledU,
-                                 MQT_NAMED_BUILDER(legacySingleControlledU)},
-        QASM3TranslationTestCase{"MultipleControlledU",
-                                 qasm::multipleControlledU,
-                                 MQT_NAMED_BUILDER(legacyMultipleControlledU)},
-        QASM3TranslationTestCase{"SWAP", qasm::swap,
-                                 MQT_NAMED_BUILDER(qc::swap)},
-        QASM3TranslationTestCase{"SingleControlledSWAP",
-                                 qasm::singleControlledSwap,
-                                 MQT_NAMED_BUILDER(qc::singleControlledSwap)},
-        QASM3TranslationTestCase{"MultipleControlledSWAP",
-                                 qasm::multipleControlledSwap,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledSwap)},
-        QASM3TranslationTestCase{"iSWAP", qasm::iswap,
-                                 MQT_NAMED_BUILDER(qc::iswap)},
-        QASM3TranslationTestCase{"SingleControllediSWAP",
-                                 qasm::singleControlledIswap,
-                                 MQT_NAMED_BUILDER(qc::singleControlledIswap)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"SXdg", qasm::sxdg,
+                                    MQT_NAMED_BUILDER(qc::sxdg)},
+        OpenQASMTranslationTestCase{
+            "SingleControlledSXdg", qasm::singleControlledSxdg,
+            MQT_NAMED_BUILDER(qc::singleControlledSxdg)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledSXdg", qasm::multipleControlledSxdg,
+            MQT_NAMED_BUILDER(qc::multipleControlledSxdg)},
+        OpenQASMTranslationTestCase{"RX", qasm::rx, MQT_NAMED_BUILDER(qc::rx)},
+        OpenQASMTranslationTestCase{"SingleControlledRX",
+                                    qasm::singleControlledRx,
+                                    MQT_NAMED_BUILDER(qc::singleControlledRx)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledRX", qasm::multipleControlledRx,
+            MQT_NAMED_BUILDER(qc::multipleControlledRx)},
+        OpenQASMTranslationTestCase{"RY", qasm::ry, MQT_NAMED_BUILDER(qc::ry)},
+        OpenQASMTranslationTestCase{"SingleControlledRY",
+                                    qasm::singleControlledRy,
+                                    MQT_NAMED_BUILDER(qc::singleControlledRy)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledRY", qasm::multipleControlledRy,
+            MQT_NAMED_BUILDER(qc::multipleControlledRy)},
+        OpenQASMTranslationTestCase{"RZ", qasm::rz, MQT_NAMED_BUILDER(qc::rz)},
+        OpenQASMTranslationTestCase{"SingleControlledRZ",
+                                    qasm::singleControlledRz,
+                                    MQT_NAMED_BUILDER(qc::singleControlledRz)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledRZ", qasm::multipleControlledRz,
+            MQT_NAMED_BUILDER(qc::multipleControlledRz)},
+        OpenQASMTranslationTestCase{"P", qasm::p, MQT_NAMED_BUILDER(qc::p)},
+        OpenQASMTranslationTestCase{"SingleControlledP",
+                                    qasm::singleControlledP,
+                                    MQT_NAMED_BUILDER(qc::singleControlledP)},
+        OpenQASMTranslationTestCase{"MultipleControlledP",
+                                    qasm::multipleControlledP,
+                                    MQT_NAMED_BUILDER(qc::multipleControlledP)},
+        OpenQASMTranslationTestCase{"R", qasm::r, MQT_NAMED_BUILDER(qc::r)},
+        OpenQASMTranslationTestCase{"SingleControlledR",
+                                    qasm::singleControlledR,
+                                    MQT_NAMED_BUILDER(qc::singleControlledR)},
+        OpenQASMTranslationTestCase{"MultipleControlledR",
+                                    qasm::multipleControlledR,
+                                    MQT_NAMED_BUILDER(qc::multipleControlledR)},
+        OpenQASMTranslationTestCase{"U2", qasm::u2,
+                                    MQT_NAMED_BUILDER(legacyU2)},
+        OpenQASMTranslationTestCase{
+            "SingleControlledU2", qasm::singleControlledU2,
+            MQT_NAMED_BUILDER(legacySingleControlledU2)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledU2", qasm::multipleControlledU2,
+            MQT_NAMED_BUILDER(legacyMultipleControlledU2)},
+        OpenQASMTranslationTestCase{"U", qasm::u, MQT_NAMED_BUILDER(legacyU)},
+        OpenQASMTranslationTestCase{"SingleControlledU",
+                                    qasm::singleControlledU,
+                                    MQT_NAMED_BUILDER(legacySingleControlledU)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledU", qasm::multipleControlledU,
+            MQT_NAMED_BUILDER(legacyMultipleControlledU)},
+        OpenQASMTranslationTestCase{"SWAP", qasm::swap,
+                                    MQT_NAMED_BUILDER(qc::swap)},
+        OpenQASMTranslationTestCase{
+            "SingleControlledSWAP", qasm::singleControlledSwap,
+            MQT_NAMED_BUILDER(qc::singleControlledSwap)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledSWAP", qasm::multipleControlledSwap,
+            MQT_NAMED_BUILDER(qc::multipleControlledSwap)},
+        OpenQASMTranslationTestCase{"iSWAP", qasm::iswap,
+                                    MQT_NAMED_BUILDER(qc::iswap)},
+        OpenQASMTranslationTestCase{
+            "SingleControllediSWAP", qasm::singleControlledIswap,
+            MQT_NAMED_BUILDER(qc::singleControlledIswap)},
+        OpenQASMTranslationTestCase{
             "MultipleControllediSWAP", qasm::multipleControlledIswap,
             MQT_NAMED_BUILDER(qc::multipleControlledIswap)},
-        QASM3TranslationTestCase{"InverseISWAP", qasm::inverseIswap,
-                                 MQT_NAMED_BUILDER(qc::inverseIswap)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"InverseISWAP", qasm::inverseIswap,
+                                    MQT_NAMED_BUILDER(qc::inverseIswap)},
+        OpenQASMTranslationTestCase{
             "InverseMultiControlledISWAP", qasm::inverseMultipleControlledIswap,
             MQT_NAMED_BUILDER(qc::inverseMultipleControlledIswap)},
-        QASM3TranslationTestCase{"DCX", qasm::dcx, MQT_NAMED_BUILDER(qc::dcx)},
-        QASM3TranslationTestCase{"SingleControlledDCX",
-                                 qasm::singleControlledDcx,
-                                 MQT_NAMED_BUILDER(qc::singleControlledDcx)},
-        QASM3TranslationTestCase{"MultipleControlledDCX",
-                                 qasm::multipleControlledDcx,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledDcx)},
-        QASM3TranslationTestCase{"ECR", qasm::ecr, MQT_NAMED_BUILDER(qc::ecr)},
-        QASM3TranslationTestCase{"SingleControlledECR",
-                                 qasm::singleControlledEcr,
-                                 MQT_NAMED_BUILDER(qc::singleControlledEcr)},
-        QASM3TranslationTestCase{"MultipleControlledECR",
-                                 qasm::multipleControlledEcr,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledEcr)},
-        QASM3TranslationTestCase{"RXX", qasm::rxx, MQT_NAMED_BUILDER(qc::rxx)},
-        QASM3TranslationTestCase{"SingleControlledRXX",
-                                 qasm::singleControlledRxx,
-                                 MQT_NAMED_BUILDER(qc::singleControlledRxx)},
-        QASM3TranslationTestCase{"MultipleControlledRXX",
-                                 qasm::multipleControlledRxx,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledRxx)},
-        QASM3TranslationTestCase{"TripleControlledRXX",
-                                 qasm::tripleControlledRxx,
-                                 MQT_NAMED_BUILDER(qc::tripleControlledRxx)},
-        QASM3TranslationTestCase{"RYY", qasm::ryy, MQT_NAMED_BUILDER(qc::ryy)},
-        QASM3TranslationTestCase{"SingleControlledRYY",
-                                 qasm::singleControlledRyy,
-                                 MQT_NAMED_BUILDER(qc::singleControlledRyy)},
-        QASM3TranslationTestCase{"MultipleControlledRYY",
-                                 qasm::multipleControlledRyy,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledRyy)},
-        QASM3TranslationTestCase{"RZX", qasm::rzx, MQT_NAMED_BUILDER(qc::rzx)},
-        QASM3TranslationTestCase{"SingleControlledRZX",
-                                 qasm::singleControlledRzx,
-                                 MQT_NAMED_BUILDER(qc::singleControlledRzx)},
-        QASM3TranslationTestCase{"MultipleControlledRZX",
-                                 qasm::multipleControlledRzx,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledRzx)},
-        QASM3TranslationTestCase{"RZZ", qasm::rzz, MQT_NAMED_BUILDER(qc::rzz)},
-        QASM3TranslationTestCase{"SingleControlledRZZ",
-                                 qasm::singleControlledRzz,
-                                 MQT_NAMED_BUILDER(qc::singleControlledRzz)},
-        QASM3TranslationTestCase{"MultipleControlledRZZ",
-                                 qasm::multipleControlledRzz,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledRzz)},
-        QASM3TranslationTestCase{"XXPlusYY", qasm::xxPlusYY,
-                                 MQT_NAMED_BUILDER(qc::xxPlusYY)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"DCX", qasm::dcx,
+                                    MQT_NAMED_BUILDER(qc::dcx)},
+        OpenQASMTranslationTestCase{"SingleControlledDCX",
+                                    qasm::singleControlledDcx,
+                                    MQT_NAMED_BUILDER(qc::singleControlledDcx)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledDCX", qasm::multipleControlledDcx,
+            MQT_NAMED_BUILDER(qc::multipleControlledDcx)},
+        OpenQASMTranslationTestCase{"ECR", qasm::ecr,
+                                    MQT_NAMED_BUILDER(qc::ecr)},
+        OpenQASMTranslationTestCase{"SingleControlledECR",
+                                    qasm::singleControlledEcr,
+                                    MQT_NAMED_BUILDER(qc::singleControlledEcr)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledECR", qasm::multipleControlledEcr,
+            MQT_NAMED_BUILDER(qc::multipleControlledEcr)},
+        OpenQASMTranslationTestCase{"RXX", qasm::rxx,
+                                    MQT_NAMED_BUILDER(qc::rxx)},
+        OpenQASMTranslationTestCase{"SingleControlledRXX",
+                                    qasm::singleControlledRxx,
+                                    MQT_NAMED_BUILDER(qc::singleControlledRxx)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledRXX", qasm::multipleControlledRxx,
+            MQT_NAMED_BUILDER(qc::multipleControlledRxx)},
+        OpenQASMTranslationTestCase{"TripleControlledRXX",
+                                    qasm::tripleControlledRxx,
+                                    MQT_NAMED_BUILDER(qc::tripleControlledRxx)},
+        OpenQASMTranslationTestCase{"RYY", qasm::ryy,
+                                    MQT_NAMED_BUILDER(qc::ryy)},
+        OpenQASMTranslationTestCase{"SingleControlledRYY",
+                                    qasm::singleControlledRyy,
+                                    MQT_NAMED_BUILDER(qc::singleControlledRyy)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledRYY", qasm::multipleControlledRyy,
+            MQT_NAMED_BUILDER(qc::multipleControlledRyy)},
+        OpenQASMTranslationTestCase{"RZX", qasm::rzx,
+                                    MQT_NAMED_BUILDER(qc::rzx)},
+        OpenQASMTranslationTestCase{"SingleControlledRZX",
+                                    qasm::singleControlledRzx,
+                                    MQT_NAMED_BUILDER(qc::singleControlledRzx)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledRZX", qasm::multipleControlledRzx,
+            MQT_NAMED_BUILDER(qc::multipleControlledRzx)},
+        OpenQASMTranslationTestCase{"RZZ", qasm::rzz,
+                                    MQT_NAMED_BUILDER(qc::rzz)},
+        OpenQASMTranslationTestCase{"SingleControlledRZZ",
+                                    qasm::singleControlledRzz,
+                                    MQT_NAMED_BUILDER(qc::singleControlledRzz)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledRZZ", qasm::multipleControlledRzz,
+            MQT_NAMED_BUILDER(qc::multipleControlledRzz)},
+        OpenQASMTranslationTestCase{"XXPlusYY", qasm::xxPlusYY,
+                                    MQT_NAMED_BUILDER(qc::xxPlusYY)},
+        OpenQASMTranslationTestCase{
             "SingleControlledXXPlusYY", qasm::singleControlledXxPlusYY,
             MQT_NAMED_BUILDER(qc::singleControlledXxPlusYY)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{
             "MultipleControlledXXPlusYY", qasm::multipleControlledXxPlusYY,
             MQT_NAMED_BUILDER(qc::multipleControlledXxPlusYY)},
-        QASM3TranslationTestCase{"XXMinusYY", qasm::xxMinusYY,
-                                 MQT_NAMED_BUILDER(qc::xxMinusYY)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"XXMinusYY", qasm::xxMinusYY,
+                                    MQT_NAMED_BUILDER(qc::xxMinusYY)},
+        OpenQASMTranslationTestCase{
             "SingleControlledXXMinusYY", qasm::singleControlledXxMinusYY,
             MQT_NAMED_BUILDER(qc::singleControlledXxMinusYY)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{
             "MultipleControlledXXMinusYY", qasm::multipleControlledXxMinusYY,
             MQT_NAMED_BUILDER(qc::multipleControlledXxMinusYY)},
-        QASM3TranslationTestCase{"RCCX", qasm::rccx,
-                                 MQT_NAMED_BUILDER(qc::rccx)},
-        QASM3TranslationTestCase{"SingleControlledRCCX",
-                                 qasm::singleControlledRccx,
-                                 MQT_NAMED_BUILDER(qc::singleControlledRccx)},
-        QASM3TranslationTestCase{"MultipleControlledRCCX",
-                                 qasm::multipleControlledRccx,
-                                 MQT_NAMED_BUILDER(qc::multipleControlledRccx)},
-        QASM3TranslationTestCase{"Barrier", qasm::barrier,
-                                 MQT_NAMED_BUILDER(qc::barrier)},
-        QASM3TranslationTestCase{"PowTwoX", qasm::powTwoX,
-                                 MQT_NAMED_BUILDER(powTwoX)},
-        QASM3TranslationTestCase{"PowZeroX", qasm::powZeroX,
-                                 MQT_NAMED_BUILDER(powZeroX)},
-        QASM3TranslationTestCase{"NegativePowS", qasm::negativePowS,
-                                 MQT_NAMED_BUILDER(negativePowS)},
-        QASM3TranslationTestCase{"ControlledInversePowS",
-                                 qasm::controlledInversePowS,
-                                 MQT_NAMED_BUILDER(controlledInversePowS)},
-        QASM3TranslationTestCase{"NestedPowX", qasm::nestedPowX,
-                                 MQT_NAMED_BUILDER(nestedPowX)},
-        QASM3TranslationTestCase{"CustomPowHS", qasm::customPowHS,
-                                 MQT_NAMED_BUILDER(customPowHS)},
-        QASM3TranslationTestCase{"BroadcastPowX", qasm::broadcastPowX,
-                                 MQT_NAMED_BUILDER(broadcastPowX)},
-        QASM3TranslationTestCase{"BarrierTwoQubits", qasm::barrierTwoQubits,
-                                 MQT_NAMED_BUILDER(qc::barrierTwoQubits)},
-        QASM3TranslationTestCase{"BarrierMultipleQubits",
-                                 qasm::barrierMultipleQubits,
-                                 MQT_NAMED_BUILDER(qc::barrierMultipleQubits)},
-        QASM3TranslationTestCase{"CtrlTwo", qasm::ctrlTwo,
-                                 MQT_NAMED_BUILDER(ctrlTwoCalls)},
-        QASM3TranslationTestCase{"CtrlTwoMixed", qasm::ctrlTwoMixed,
-                                 MQT_NAMED_BUILDER(ctrlTwoMixedCalls)},
-        QASM3TranslationTestCase{"SimpleIf", qasm::simpleIf,
-                                 MQT_NAMED_BUILDER(qc::simpleIf)},
-        QASM3TranslationTestCase{"IfElse", qasm::ifElse,
-                                 MQT_NAMED_BUILDER(qc::ifElse)},
-        QASM3TranslationTestCase{"IfTwoQubits", qasm::ifTwoQubits,
-                                 MQT_NAMED_BUILDER(qc::ifTwoQubits)},
-        QASM3TranslationTestCase{"IfWithMeasurement", qasm::ifWithMeasurement,
-                                 MQT_NAMED_BUILDER(ifWithMeasurement)},
-        QASM3TranslationTestCase{"IfNot", qasm::ifNot,
-                                 MQT_NAMED_BUILDER(ifNot)},
-        QASM3TranslationTestCase{"BroadcastRegisterAndQubit",
-                                 qasm::broadcastRegisterAndQubit,
-                                 MQT_NAMED_BUILDER(broadcastRegisterAndQubit)},
-        QASM3TranslationTestCase{"BroadcastCompoundGate",
-                                 qasm::broadcastCompoundGate,
-                                 MQT_NAMED_BUILDER(broadcastCompoundGate)},
-        QASM3TranslationTestCase{"ExpressionArithmetic",
-                                 qasm::expressionArithmetic,
-                                 MQT_NAMED_BUILDER(expressionArithmetic)},
-        QASM3TranslationTestCase{"ExpressionUnaryMinus",
-                                 qasm::expressionUnaryMinus,
-                                 MQT_NAMED_BUILDER(expressionUnaryMinus)},
-        QASM3TranslationTestCase{"ExpressionBuiltinConstants",
-                                 qasm::expressionBuiltinConstants,
-                                 MQT_NAMED_BUILDER(expressionBuiltinConstants)},
-        QASM3TranslationTestCase{"ExpressionMathFunctions",
-                                 qasm::expressionMathFunctions,
-                                 MQT_NAMED_BUILDER(expressionMathFunctions)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"RCCX", qasm::rccx,
+                                    MQT_NAMED_BUILDER(qc::rccx)},
+        OpenQASMTranslationTestCase{
+            "SingleControlledRCCX", qasm::singleControlledRccx,
+            MQT_NAMED_BUILDER(qc::singleControlledRccx)},
+        OpenQASMTranslationTestCase{
+            "MultipleControlledRCCX", qasm::multipleControlledRccx,
+            MQT_NAMED_BUILDER(qc::multipleControlledRccx)},
+        OpenQASMTranslationTestCase{"Barrier", qasm::barrier,
+                                    MQT_NAMED_BUILDER(qc::barrier)},
+        OpenQASMTranslationTestCase{"PowTwoX", qasm::powTwoX,
+                                    MQT_NAMED_BUILDER(powTwoX)},
+        OpenQASMTranslationTestCase{"PowZeroX", qasm::powZeroX,
+                                    MQT_NAMED_BUILDER(powZeroX)},
+        OpenQASMTranslationTestCase{"NegativePowS", qasm::negativePowS,
+                                    MQT_NAMED_BUILDER(negativePowS)},
+        OpenQASMTranslationTestCase{"ControlledInversePowS",
+                                    qasm::controlledInversePowS,
+                                    MQT_NAMED_BUILDER(controlledInversePowS)},
+        OpenQASMTranslationTestCase{"NestedPowX", qasm::nestedPowX,
+                                    MQT_NAMED_BUILDER(nestedPowX)},
+        OpenQASMTranslationTestCase{"CustomPowHS", qasm::customPowHS,
+                                    MQT_NAMED_BUILDER(customPowHS)},
+        OpenQASMTranslationTestCase{"BroadcastPowX", qasm::broadcastPowX,
+                                    MQT_NAMED_BUILDER(broadcastPowX)},
+        OpenQASMTranslationTestCase{"BarrierTwoQubits", qasm::barrierTwoQubits,
+                                    MQT_NAMED_BUILDER(qc::barrierTwoQubits)},
+        OpenQASMTranslationTestCase{
+            "BarrierMultipleQubits", qasm::barrierMultipleQubits,
+            MQT_NAMED_BUILDER(qc::barrierMultipleQubits)},
+        OpenQASMTranslationTestCase{"CtrlTwo", qasm::ctrlTwo,
+                                    MQT_NAMED_BUILDER(ctrlTwoCalls)},
+        OpenQASMTranslationTestCase{"CtrlTwoMixed", qasm::ctrlTwoMixed,
+                                    MQT_NAMED_BUILDER(ctrlTwoMixedCalls)},
+        OpenQASMTranslationTestCase{"SimpleIf", qasm::simpleIf,
+                                    MQT_NAMED_BUILDER(qc::simpleIf)},
+        OpenQASMTranslationTestCase{"IfElse", qasm::ifElse,
+                                    MQT_NAMED_BUILDER(qc::ifElse)},
+        OpenQASMTranslationTestCase{"IfTwoQubits", qasm::ifTwoQubits,
+                                    MQT_NAMED_BUILDER(qc::ifTwoQubits)},
+        OpenQASMTranslationTestCase{"IfWithMeasurement",
+                                    qasm::ifWithMeasurement,
+                                    MQT_NAMED_BUILDER(ifWithMeasurement)},
+        OpenQASMTranslationTestCase{"IfNot", qasm::ifNot,
+                                    MQT_NAMED_BUILDER(ifNot)},
+        OpenQASMTranslationTestCase{
+            "BroadcastRegisterAndQubit", qasm::broadcastRegisterAndQubit,
+            MQT_NAMED_BUILDER(broadcastRegisterAndQubit)},
+        OpenQASMTranslationTestCase{"BroadcastCompoundGate",
+                                    qasm::broadcastCompoundGate,
+                                    MQT_NAMED_BUILDER(broadcastCompoundGate)},
+        OpenQASMTranslationTestCase{"ExpressionArithmetic",
+                                    qasm::expressionArithmetic,
+                                    MQT_NAMED_BUILDER(expressionArithmetic)},
+        OpenQASMTranslationTestCase{"ExpressionUnaryMinus",
+                                    qasm::expressionUnaryMinus,
+                                    MQT_NAMED_BUILDER(expressionUnaryMinus)},
+        OpenQASMTranslationTestCase{
+            "ExpressionBuiltinConstants", qasm::expressionBuiltinConstants,
+            MQT_NAMED_BUILDER(expressionBuiltinConstants)},
+        OpenQASMTranslationTestCase{"ExpressionMathFunctions",
+                                    qasm::expressionMathFunctions,
+                                    MQT_NAMED_BUILDER(expressionMathFunctions)},
+        OpenQASMTranslationTestCase{
             "ExpressionNestedMathFunctions",
             qasm::expressionNestedMathFunctions,
             MQT_NAMED_BUILDER(expressionNestedMathFunctions)},
-        QASM3TranslationTestCase{"ExpressionConstFloat",
-                                 qasm::expressionConstFloat,
-                                 MQT_NAMED_BUILDER(expressionConstFloat)},
-        QASM3TranslationTestCase{"ExpressionMutableFloat",
-                                 qasm::expressionMutableFloat,
-                                 MQT_NAMED_BUILDER(expressionMutableFloat)},
-        QASM3TranslationTestCase{
+        OpenQASMTranslationTestCase{"ExpressionConstFloat",
+                                    qasm::expressionConstFloat,
+                                    MQT_NAMED_BUILDER(expressionConstFloat)},
+        OpenQASMTranslationTestCase{"ExpressionMutableFloat",
+                                    qasm::expressionMutableFloat,
+                                    MQT_NAMED_BUILDER(expressionMutableFloat)},
+        OpenQASMTranslationTestCase{
             "ExpressionConstIntArithmetic", qasm::expressionConstIntArithmetic,
             MQT_NAMED_BUILDER(expressionConstIntArithmetic)},
-        QASM3TranslationTestCase{"ConditionLiteral", qasm::conditionLiteral,
-                                 MQT_NAMED_BUILDER(conditionLiteral)},
-        QASM3TranslationTestCase{"ConditionMeasurement",
-                                 qasm::conditionMeasurement,
-                                 MQT_NAMED_BUILDER(conditionMeasurement)},
-        QASM3TranslationTestCase{"ConditionAnd", qasm::conditionAnd,
-                                 MQT_NAMED_BUILDER(conditionAnd)},
-        QASM3TranslationTestCase{"ConditionOr", qasm::conditionOr,
-                                 MQT_NAMED_BUILDER(conditionOr)},
-        QASM3TranslationTestCase{"ConditionNotAndOr", qasm::conditionNotAndOr,
-                                 MQT_NAMED_BUILDER(conditionNotAndOr)},
-        QASM3TranslationTestCase{"ConditionBoolVariable",
-                                 qasm::conditionBoolVariable,
-                                 MQT_NAMED_BUILDER(conditionBoolVariable)},
-        QASM3TranslationTestCase{"ConditionIndexedBit",
-                                 qasm::conditionIndexedBit,
-                                 MQT_NAMED_BUILDER(conditionIndexedBit)}));
+        OpenQASMTranslationTestCase{"ConditionLiteral", qasm::conditionLiteral,
+                                    MQT_NAMED_BUILDER(conditionLiteral)},
+        OpenQASMTranslationTestCase{"ConditionMeasurement",
+                                    qasm::conditionMeasurement,
+                                    MQT_NAMED_BUILDER(conditionMeasurement)},
+        OpenQASMTranslationTestCase{"ConditionAnd", qasm::conditionAnd,
+                                    MQT_NAMED_BUILDER(conditionAnd)},
+        OpenQASMTranslationTestCase{"ConditionOr", qasm::conditionOr,
+                                    MQT_NAMED_BUILDER(conditionOr)},
+        OpenQASMTranslationTestCase{"ConditionNotAndOr",
+                                    qasm::conditionNotAndOr,
+                                    MQT_NAMED_BUILDER(conditionNotAndOr)},
+        OpenQASMTranslationTestCase{"ConditionBoolVariable",
+                                    qasm::conditionBoolVariable,
+                                    MQT_NAMED_BUILDER(conditionBoolVariable)},
+        OpenQASMTranslationTestCase{"ConditionIndexedBit",
+                                    qasm::conditionIndexedBit,
+                                    MQT_NAMED_BUILDER(conditionIndexedBit)}));
 
-} // namespace mqt::test::qasm3_translation
+} // namespace mqt::test::openqasm_translation

--- a/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Decomposition/test_multi_controlled_decomposition.cpp
@@ -702,14 +702,14 @@ TEST_F(MultiControlledDecompositionTest, RotationsRespectMinQubits) {
 }
 
 TEST_F(MultiControlledDecompositionTest, PreservesTargetNativeRotations) {
-  using TargetOperation = CompilerTarget::Operation;
+  using OperationCapability = CompilerTarget::OperationCapability;
   const std::vector operations{
-      llvm::cantFail(TargetOperation::create(
-          "rx", TargetOperation::Arity::variadic(4), 1)),
-      llvm::cantFail(TargetOperation::create(
-          "ry", TargetOperation::Arity::variadic(4), 1)),
-      llvm::cantFail(TargetOperation::create(
-          "rz", TargetOperation::Arity::variadic(4), 1)),
+      llvm::cantFail(OperationCapability::create(
+          "rx", OperationCapability::Arity::variadic(4), 1)),
+      llvm::cantFail(OperationCapability::create(
+          "ry", OperationCapability::Arity::variadic(4), 1)),
+      llvm::cantFail(OperationCapability::create(
+          "rz", OperationCapability::Arity::variadic(4), 1)),
   };
   const auto target = llvm::cantFail(CompilerTarget::create(
       4, CompilerTarget::Connectivity::allToAll(),
@@ -906,10 +906,10 @@ TEST_F(MultiControlledDecompositionTest,
       });
   ASSERT_TRUE(moduleOp);
 
-  using Operation = CompilerTarget::Operation;
+  using OperationCapability = CompilerTarget::OperationCapability;
   std::vector operations{
-      llvm::cantFail(
-          Operation::create("rccx", Operation::Arity::variadic(4), 0)),
+      llvm::cantFail(OperationCapability::create(
+          "rccx", OperationCapability::Arity::variadic(4), 0)),
   };
   const auto target = llvm::cantFail(CompilerTarget::create(
       4, CompilerTarget::Connectivity::allToAll(),
@@ -959,10 +959,10 @@ TEST_F(MultiControlledDecompositionTest, PreservesTargetNativeMcy) {
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(moduleOp.get())));
   ASSERT_TRUE(succeeded(verifyLinearity(moduleOp.get())));
-  using TargetOperation = CompilerTarget::Operation;
+  using OperationCapability = CompilerTarget::OperationCapability;
   const std::vector operations{
-      llvm::cantFail(
-          TargetOperation::create("y", TargetOperation::Arity::variadic(4), 0)),
+      llvm::cantFail(OperationCapability::create(
+          "y", OperationCapability::Arity::variadic(4), 0)),
   };
   const auto target = llvm::cantFail(CompilerTarget::create(
       4, CompilerTarget::Connectivity::allToAll(),

--- a/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
@@ -66,7 +66,7 @@ namespace mqt::test::qco {
 using Target = mlir::CompilerTarget;
 using Connectivity = Target::Connectivity;
 using NativeOperations = Target::NativeOperations;
-using Operation = Target::Operation;
+using OperationCapability = Target::OperationCapability;
 using Site = Target::Site;
 using SiteTuple = Target::SiteTuple;
 using mlir::ModuleOp;
@@ -159,9 +159,9 @@ makeUCxTarget(std::optional<std::vector<Site>> sites = std::nullopt) {
     sites = std::vector{valid(Site::create(0)), valid(Site::create(1))};
   }
   std::vector operations{
-      valid(Operation::create("u", 1, 3)),
-      valid(Operation::create("cx", 2, 0)),
-      valid(Operation::create("gphase", 0, 1)),
+      valid(OperationCapability::create("u", 1, 3)),
+      valid(OperationCapability::create("cx", 2, 0)),
+      valid(OperationCapability::create("gphase", 0, 1)),
   };
   return valid(Target::create(std::move(*sites), Connectivity::allToAll(),
                               NativeOperations::fromOperations(operations)));
@@ -170,9 +170,10 @@ makeUCxTarget(std::optional<std::vector<Site>> sites = std::nullopt) {
 [[nodiscard]] static Target
 makeOneWayUCxTarget(Connectivity connectivity = Connectivity::allToAll()) {
   std::vector operations{
-      valid(Operation::create("u", 1, 3)),
-      valid(Operation::create("cx", 2, 0, {valid(SiteTuple::create({1, 0}))})),
-      valid(Operation::create("gphase", 0, 1)),
+      valid(OperationCapability::create("u", 1, 3)),
+      valid(OperationCapability::create("cx", 2, 0,
+                                        {valid(SiteTuple::create({1, 0}))})),
+      valid(OperationCapability::create("gphase", 0, 1)),
   };
   return valid(Target::create(2, std::move(connectivity),
                               NativeOperations::fromOperations(operations)));
@@ -180,7 +181,8 @@ makeOneWayUCxTarget(Connectivity connectivity = Connectivity::allToAll()) {
 
 [[nodiscard]] static Target makeOneWayRxxTarget() {
   std::vector operations{
-      valid(Operation::create("rxx", 2, 1, {valid(SiteTuple::create({1, 0}))})),
+      valid(OperationCapability::create("rxx", 2, 1,
+                                        {valid(SiteTuple::create({1, 0}))})),
   };
   return valid(Target::create(2, Connectivity::allToAll(),
                               NativeOperations::fromOperations(operations)));
@@ -517,13 +519,13 @@ TEST_F(TargetSynthesisTest,
 }
 
 TEST_F(TargetSynthesisTest, SqrtISwapSynthesisIsMinimalAndConforms) {
-  const auto target =
-      valid(Target::create(2, Connectivity::allToAll(),
-                           NativeOperations::fromOperations({
-                               valid(Operation::create("u", 1, 3)),
-                               valid(Operation::create("gphase", 0, 1)),
-                               valid(Operation::create("sqrt_iswap", 2, 0)),
-                           })));
+  const auto target = valid(
+      Target::create(2, Connectivity::allToAll(),
+                     NativeOperations::fromOperations({
+                         valid(OperationCapability::create("u", 1, 3)),
+                         valid(OperationCapability::create("gphase", 0, 1)),
+                         valid(OperationCapability::create("sqrt_iswap", 2, 0)),
+                     })));
   for (int gate = 0; gate < 4; ++gate) {
     const auto circuit = [gate](QCOProgramBuilder& builder) {
       auto q0 = builder.staticQubit(0);
@@ -602,19 +604,20 @@ TEST_F(TargetSynthesisTest,
 
   for (const bool useRxx : {false, true}) {
     SCOPED_TRACE(useRxx ? "R/RXX" : "U/sqrtISWAP");
-    const auto target = valid(Target::create(
-        3, Connectivity::allToAll(),
-        NativeOperations::fromOperations({
-            valid(Operation::create(useRxx ? "r" : "u", 1, useRxx ? 2 : 3)),
-            valid(Operation::create(useRxx ? "rxx" : "sqrt_iswap", 2,
-                                    useRxx ? 1 : 0,
-                                    {
-                                        valid(SiteTuple::create({0, 1})),
-                                        valid(SiteTuple::create({0, 2})),
-                                        valid(SiteTuple::create({1, 2})),
-                                    })),
-            valid(Operation::create("gphase", 0, 1)),
-        })));
+    const auto target = valid(
+        Target::create(3, Connectivity::allToAll(),
+                       NativeOperations::fromOperations({
+                           valid(OperationCapability::create(
+                               useRxx ? "r" : "u", 1, useRxx ? 2 : 3)),
+                           valid(OperationCapability::create(
+                               useRxx ? "rxx" : "sqrt_iswap", 2, useRxx ? 1 : 0,
+                               {
+                                   valid(SiteTuple::create({0, 1})),
+                                   valid(SiteTuple::create({0, 2})),
+                                   valid(SiteTuple::create({1, 2})),
+                               })),
+                           valid(OperationCapability::create("gphase", 0, 1)),
+                       })));
     auto expected = build(circuit);
     auto synthesized = build(circuit);
     ASSERT_TRUE(mlir::succeeded(mlir::verify(*synthesized)));
@@ -666,10 +669,10 @@ TEST_F(TargetSynthesisTest, NativeSynthesisSharesRepeatedParameterConstants) {
 }
 
 TEST_F(TargetSynthesisTest, SqrtISwapCapabilityRequiresFixedParameters) {
-  const auto target = valid(
-      Target::create(2, Connectivity::allToAll(),
-                     NativeOperations::fromOperations(
-                         {valid(Operation::create("sqrt_iswap", 2, 0))})));
+  const auto target = valid(Target::create(
+      2, Connectivity::allToAll(),
+      NativeOperations::fromOperations(
+          {valid(OperationCapability::create("sqrt_iswap", 2, 0))})));
   auto program = build([](QCOProgramBuilder& builder) {
     auto [q0, q1] = builder.xx_plus_yy(.2, 0., builder.staticQubit(0),
                                        builder.staticQubit(1));
@@ -685,8 +688,8 @@ TEST_F(TargetSynthesisTest, SqrtISwapCapabilityHonorsPlacement) {
   const auto target = valid(Target::create(
       2, Connectivity::allToAll(),
       NativeOperations::fromOperations({
-          valid(Operation::create("sqrt_iswap", 2, 0,
-                                  {valid(Target::SiteTuple::create({0, 1}))})),
+          valid(OperationCapability::create(
+              "sqrt_iswap", 2, 0, {valid(Target::SiteTuple::create({0, 1}))})),
       })));
   auto program = build([](QCOProgramBuilder& builder) {
     [[maybe_unused]] auto [q0, q1] =
@@ -705,8 +708,8 @@ TEST_F(TargetSynthesisTest, SqrtISwapReversesPlacementWithoutSynthesisBasis) {
   const auto target = valid(Target::create(
       2, Connectivity::allToAll(),
       NativeOperations::fromOperations({
-          valid(Operation::create("sqrt_iswap", 2, 0,
-                                  {valid(SiteTuple::create({0, 1}))})),
+          valid(OperationCapability::create(
+              "sqrt_iswap", 2, 0, {valid(SiteTuple::create({0, 1}))})),
       })));
   ASSERT_FALSE(target.synthesisBasis());
   const auto circuit = [](QCOProgramBuilder& builder) {
@@ -1105,12 +1108,13 @@ TEST_F(TargetSynthesisTest,
     qubit = builder.h(qubit);
     return builder.intConstant(0);
   });
-  const auto target = valid(Target::create(
-      2, Connectivity::allToAll(),
-      NativeOperations::fromOperations({
-          valid(Operation::create("u", 1, 3, {valid(SiteTuple::create({0}))})),
-          valid(Operation::create("cx", 2, 0)),
-      })));
+  const auto target =
+      valid(Target::create(2, Connectivity::allToAll(),
+                           NativeOperations::fromOperations({
+                               valid(OperationCapability::create(
+                                   "u", 1, 3, {valid(SiteTuple::create({0}))})),
+                               valid(OperationCapability::create("cx", 2, 0)),
+                           })));
 
   const auto diagnostics = expectTargetFailure(
       *module, target, mlir::qco::createTargetNativeSynthesis());
@@ -1126,17 +1130,18 @@ TEST_F(TargetSynthesisTest,
     [[maybe_unused]] const auto [q1, q2] = builder.swap(q1Input, q2Input);
     return builder.intConstant(0);
   });
-  const auto target = valid(Target::create(
-      3, Connectivity::fromCouplings({{0, 1}, {1, 2}}),
-      NativeOperations::fromOperations({
-          valid(Operation::create("u", 1, 3)),
-          valid(Operation::create("cx", 2, 0,
-                                  {
-                                      valid(SiteTuple::create({0, 1})),
-                                      valid(SiteTuple::create({1, 2})),
-                                  })),
-          valid(Operation::create("gphase", 0, 1)),
-      })));
+  const auto target = valid(
+      Target::create(3, Connectivity::fromCouplings({{0, 1}, {1, 2}}),
+                     NativeOperations::fromOperations({
+                         valid(OperationCapability::create("u", 1, 3)),
+                         valid(OperationCapability::create(
+                             "cx", 2, 0,
+                             {
+                                 valid(SiteTuple::create({0, 1})),
+                                 valid(SiteTuple::create({1, 2})),
+                             })),
+                         valid(OperationCapability::create("gphase", 0, 1)),
+                     })));
 
   const auto diagnostics = expectTargetFailure(
       *module, target, mlir::qco::createTargetNativeSynthesis());
@@ -1206,14 +1211,14 @@ TEST_F(TargetSynthesisTest, SingleQubitSynthesisNeedsNoEntangler) {
   };
   auto expected = build(rotation);
   auto synthesized = build(rotation);
-  const auto target =
-      valid(Target::create(1, Connectivity::allToAll(),
-                           NativeOperations::fromOperations({
-                               valid(Operation::create("sx", 1, 0)),
-                               valid(Operation::create("x", 1, 0)),
-                               valid(Operation::create("rz", 1, 1)),
-                               valid(Operation::create("gphase", 0, 1)),
-                           })));
+  const auto target = valid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations({
+                         valid(OperationCapability::create("sx", 1, 0)),
+                         valid(OperationCapability::create("x", 1, 0)),
+                         valid(OperationCapability::create("rz", 1, 1)),
+                         valid(OperationCapability::create("gphase", 0, 1)),
+                     })));
 
   ASSERT_TRUE(mlir::succeeded(mlir::verify(*synthesized)));
   ASSERT_TRUE(mlir::succeeded(runTargetPass(
@@ -1236,9 +1241,10 @@ TEST_F(TargetSynthesisTest, RuntimeSingleQubitSynthesisNeedsNoEntangler) {
   )mlir",
                                                     context.get());
   ASSERT_TRUE(moduleOp);
-  const auto target = valid(Target::create(
-      1, Connectivity::allToAll(),
-      NativeOperations::fromOperations({valid(Operation::create("u", 1, 3))})));
+  const auto target = valid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations(
+                         {valid(OperationCapability::create("u", 1, 3))})));
 
   ASSERT_TRUE(mlir::succeeded(runTargetPass(
       *moduleOp, target, mlir::qco::createTargetNativeSynthesis())));
@@ -1255,9 +1261,10 @@ TEST_F(TargetSynthesisTest, TwoQubitSynthesisRequiresEntangler) {
     [[maybe_unused]] auto [q0, q1] = builder.cx(input0, input1);
     return builder.intConstant(0);
   });
-  const auto target = valid(Target::create(
-      2, Connectivity::allToAll(),
-      NativeOperations::fromOperations({valid(Operation::create("u", 1, 3))})));
+  const auto target = valid(
+      Target::create(2, Connectivity::allToAll(),
+                     NativeOperations::fromOperations(
+                         {valid(OperationCapability::create("u", 1, 3))})));
   attachTestEnvironment(*moduleOp, target);
   ASSERT_TRUE(mlir::succeeded(mlir::verify(*moduleOp)));
   const auto before = printModule(*moduleOp);
@@ -1290,13 +1297,13 @@ TEST(TargetSynthesisPassContract, LoadsMathDialectForRuntimeSynthesis) {
                                                     &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(mlir::succeeded(mlir::verify(*moduleOp)));
-  const auto target =
-      valid(Target::create(2, Connectivity::allToAll(),
-                           NativeOperations::fromOperations({
-                               valid(Operation::create("r", 1, 2)),
-                               valid(Operation::create("cx", 2, 0)),
-                               valid(Operation::create("gphase", 0, 1)),
-                           })));
+  const auto target = valid(
+      Target::create(2, Connectivity::allToAll(),
+                     NativeOperations::fromOperations({
+                         valid(OperationCapability::create("r", 1, 2)),
+                         valid(OperationCapability::create("cx", 2, 0)),
+                         valid(OperationCapability::create("gphase", 0, 1)),
+                     })));
 
   EXPECT_EQ(context.getLoadedDialect<mlir::math::MathDialect>(), nullptr);
   ASSERT_TRUE(mlir::succeeded(runTargetPass(
@@ -1381,10 +1388,10 @@ TEST_F(TargetSynthesisTest, TargetNativeSynthesisPreservesNativeSwap) {
     [[maybe_unused]] auto [q0, q1] = builder.swap(q0Input, q1Input);
     return builder.intConstant(0);
   });
-  const auto swapTarget =
-      valid(Target::create(2, Connectivity::allToAll(),
-                           NativeOperations::fromOperations(
-                               {valid(Operation::create("swap", 2, 0))})));
+  const auto swapTarget = valid(
+      Target::create(2, Connectivity::allToAll(),
+                     NativeOperations::fromOperations(
+                         {valid(OperationCapability::create("swap", 2, 0))})));
   ASSERT_FALSE(swapTarget.synthesisBasis());
   attachTestEnvironment(*module, swapTarget);
   const auto before = printModule(*module);
@@ -1406,12 +1413,12 @@ TEST_F(TargetSynthesisTest, TargetNativeSynthesisPreservesNativeGlobalPhase) {
   };
   auto expected = build(phasedX);
   auto synthesized = build(phasedX);
-  const auto target =
-      valid(Target::create(1, Connectivity::allToAll(),
-                           NativeOperations::fromOperations({
-                               valid(Operation::create("x", 1, 0)),
-                               valid(Operation::create("gphase", 0, 1)),
-                           })));
+  const auto target = valid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations({
+                         valid(OperationCapability::create("x", 1, 0)),
+                         valid(OperationCapability::create("gphase", 0, 1)),
+                     })));
 
   ASSERT_TRUE(mlir::succeeded(runTargetPass(
       *synthesized, target, mlir::qco::createTargetNativeSynthesis())));
@@ -1484,9 +1491,10 @@ TEST_F(TargetSynthesisTest,
   };
   auto expected = build(controlledPhase);
   auto synthesized = build(controlledPhase);
-  const auto target = valid(Target::create(
-      1, Connectivity::allToAll(),
-      NativeOperations::fromOperations({valid(Operation::create("p", 1, 1))})));
+  const auto target = valid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations(
+                         {valid(OperationCapability::create("p", 1, 1))})));
 
   ASSERT_TRUE(mlir::succeeded(runTargetPass(
       *synthesized, target, mlir::qco::createTargetNativeSynthesis())));
@@ -1507,13 +1515,13 @@ TEST_F(TargetSynthesisTest, TargetNativeSynthesisUsesHomogeneousCapability) {
   };
   auto expected = build(swap);
   auto synthesized = build(swap);
-  const auto target =
-      valid(Target::create(2, Connectivity::allToAll(),
-                           NativeOperations::fromOperations({
-                               valid(Operation::create("u", 1, 3)),
-                               valid(Operation::create("cz", 2, 0)),
-                               valid(Operation::create("gphase", 0, 1)),
-                           })));
+  const auto target = valid(
+      Target::create(2, Connectivity::allToAll(),
+                     NativeOperations::fromOperations({
+                         valid(OperationCapability::create("u", 1, 3)),
+                         valid(OperationCapability::create("cz", 2, 0)),
+                         valid(OperationCapability::create("gphase", 0, 1)),
+                     })));
   ASSERT_TRUE(target.synthesisBasis());
   ASSERT_EQ(target.synthesisBasis()->entangler, Target::GateKind::CZ);
 
@@ -1554,10 +1562,10 @@ TEST_F(TargetSynthesisTest, NativePowShellHidesItsImplementationBody) {
                         [&](Value argument) { return builder.h(argument); });
     return builder.intConstant(0);
   });
-  const auto powOnly =
-      valid(Target::create(1, Connectivity::allToAll(),
-                           NativeOperations::fromOperations(
-                               {valid(Operation::create("pow", 1, 1))})));
+  const auto powOnly = valid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations(
+                         {valid(OperationCapability::create("pow", 1, 1))})));
   ASSERT_FALSE(powOnly.synthesisBasis());
   attachTestEnvironment(*module, powOnly);
   const auto before = printModule(*module);
@@ -1604,9 +1612,10 @@ TEST_F(TargetSynthesisTest, RejectsUnsupportedMultiTargetControlShell) {
 }
 
 TEST_F(TargetSynthesisTest, MissingBasisIsDiagnosedOnlyWhenLoweringIsNeeded) {
-  const auto hOnly = valid(Target::create(
-      1, Connectivity::allToAll(),
-      NativeOperations::fromOperations({valid(Operation::create("h", 1, 0))})));
+  const auto hOnly = valid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations(
+                         {valid(OperationCapability::create("h", 1, 0))})));
   ASSERT_FALSE(hOnly.synthesisBasis());
 
   auto supported = build([](QCOProgramBuilder& builder) {
@@ -1653,8 +1662,8 @@ TEST_F(TargetSynthesisTest, SupportedRuntimeParameterizedGateStaysUntouched) {
   const auto target =
       valid(Target::create(2, Connectivity::allToAll(),
                            NativeOperations::fromOperations({
-                               valid(Operation::create("u", 1, 3)),
-                               valid(Operation::create("rxx", 2, 1)),
+                               valid(OperationCapability::create("u", 1, 3)),
+                               valid(OperationCapability::create("rxx", 2, 1)),
                            })));
   attachTestEnvironment(*module, target);
   const auto before = printModule(*module);
@@ -1762,7 +1771,7 @@ TEST_F(TargetSynthesisTest,
       std::vector{valid(Site::create(10)), valid(Site::create(20))},
       Connectivity::allToAll(),
       NativeOperations::fromOperations(
-          {valid(Operation::create("cx", 2, 0))})));
+          {valid(OperationCapability::create("cx", 2, 0))})));
   ASSERT_FALSE(target.synthesisBasis());
 
   auto reversed = build([](QCOProgramBuilder& builder) {
@@ -1790,9 +1799,10 @@ TEST_F(TargetSynthesisTest,
 }
 
 TEST_F(TargetSynthesisTest, ConformanceRejectsDynamicAllocations) {
-  const auto target = valid(Target::create(
-      1, Connectivity::allToAll(),
-      NativeOperations::fromOperations({valid(Operation::create("x", 1, 0))})));
+  const auto target = valid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations(
+                         {valid(OperationCapability::create("x", 1, 0))})));
   const auto expectDynamicAllocationFailure =
       [&](OwningOpRef<ModuleOp> module) {
         const auto diagnostics = expectTargetFailure(
@@ -1826,9 +1836,10 @@ TEST_F(TargetSynthesisTest, ConformanceRejectsQuantumFunctionInputs) {
   )mlir",
                                                   context.get());
   ASSERT_TRUE(module);
-  const auto target = valid(Target::create(
-      1, Connectivity::allToAll(),
-      NativeOperations::fromOperations({valid(Operation::create("x", 1, 0))})));
+  const auto target = valid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations(
+                         {valid(OperationCapability::create("x", 1, 0))})));
 
   const auto diagnostics = expectTargetFailure(
       *module, target, mlir::qco::createVerifyTargetConformance());
@@ -1850,10 +1861,10 @@ TEST_F(TargetSynthesisTest, ConformanceChecksTypeArityAndParameters) {
   };
 
   expectUnsupported(
-      valid(Target::create(std::vector{valid(Site::create(10))},
-                           Connectivity::allToAll(),
-                           NativeOperations::fromOperations(
-                               {valid(Operation::create("x", 1, 0))}))),
+      valid(Target::create(
+          std::vector{valid(Site::create(10))}, Connectivity::allToAll(),
+          NativeOperations::fromOperations(
+              {valid(OperationCapability::create("x", 1, 0))}))),
       build([](QCOProgramBuilder& builder) {
         auto qubit = builder.staticQubit(10);
         qubit = builder.h(qubit);
@@ -1866,7 +1877,7 @@ TEST_F(TargetSynthesisTest, ConformanceChecksTypeArityAndParameters) {
           std::vector{valid(Site::create(10)), valid(Site::create(20))},
           Connectivity::allToAll(),
           NativeOperations::fromOperations(
-              {valid(Operation::create("x", 2, 0))}))),
+              {valid(OperationCapability::create("x", 2, 0))}))),
       build([](QCOProgramBuilder& builder) {
         auto qubit = builder.staticQubit(10);
         qubit = builder.x(qubit);
@@ -1875,10 +1886,10 @@ TEST_F(TargetSynthesisTest, ConformanceChecksTypeArityAndParameters) {
       "'qco.x'", "arity 1 and 0 parameter(s)");
 
   expectUnsupported(
-      valid(Target::create(std::vector{valid(Site::create(10))},
-                           Connectivity::allToAll(),
-                           NativeOperations::fromOperations(
-                               {valid(Operation::create("rz", 1, 0))}))),
+      valid(Target::create(
+          std::vector{valid(Site::create(10))}, Connectivity::allToAll(),
+          NativeOperations::fromOperations(
+              {valid(OperationCapability::create("rz", 1, 0))}))),
       build([](QCOProgramBuilder& builder) {
         auto qubit = builder.staticQubit(10);
         qubit = builder.rz(0.25, qubit);
@@ -1895,9 +1906,10 @@ TEST_F(TargetSynthesisTest, ConformanceChecksNonUnitaryCapabilities) {
     measured = builder.reset(measured);
     return builder.intConstant(0);
   });
-  const auto xOnly = valid(Target::create(
-      1, Connectivity::allToAll(),
-      NativeOperations::fromOperations({valid(Operation::create("x", 1, 0))})));
+  const auto xOnly = valid(
+      Target::create(1, Connectivity::allToAll(),
+                     NativeOperations::fromOperations(
+                         {valid(OperationCapability::create("x", 1, 0))})));
   const auto diagnostics = expectTargetFailure(
       *module, xOnly, mlir::qco::createVerifyTargetConformance());
   EXPECT_NE(diagnostics.find("'qco.measure' with arity 1 and 0 parameter(s)"),

--- a/mlir/unittests/Target/OpenQASM/OpenQASMTestUtils.h
+++ b/mlir/unittests/Target/OpenQASM/OpenQASMTestUtils.h
@@ -13,7 +13,7 @@
 #include "mqt/Dialect/CBit/IR/CBitAttributes.h"
 #include "mqt/Dialect/CBit/IR/CBitDialect.h"
 #include "mqt/Dialect/CBit/IR/CBitOps.h"
-#include "mqt/Dialect/QC/Translation/TranslateQASM3ToQC.h"
+#include "mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h"
 
 #include "gtest/gtest.h"
 
@@ -36,7 +36,7 @@
 #include <cstdint>
 #include <optional>
 
-namespace mlir::oq3::test {
+namespace mlir::openqasm::test {
 
 inline constexpr llvm::StringLiteral BROADCAST_PROGRAM = R"qasm(
 OPENQASM 3.0;
@@ -169,4 +169,4 @@ inline SmallVector<std::optional<Value>> returnedBitValues(ModuleOp moduleOp) {
   return values;
 }
 
-} // namespace mlir::oq3::test
+} // namespace mlir::openqasm::test

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_emitter.cpp
@@ -14,7 +14,7 @@
 #include "mqt/Dialect/MQT/IR/MQTDialect.h"
 #include "mqt/Dialect/QC/IR/QCDialect.h"
 #include "mqt/Dialect/QC/IR/QCOps.h"
-#include "mqt/Dialect/QC/Translation/TranslateQASM3ToQC.h"
+#include "mqt/Dialect/QC/Translation/TranslateOpenQASMToQC.h"
 #include "mqt/Target/OpenQASM/Frontend.h"
 
 #include "OpenQASMTestUtils.h"
@@ -59,7 +59,7 @@
 #include <vector>
 
 using namespace mlir;
-using namespace mlir::oq3::test;
+using namespace mlir::openqasm::test;
 
 namespace {
 
@@ -67,7 +67,7 @@ TEST(OpenQASMTargetTest, ImportsNonNullTerminatedSourceView) {
   std::string storage = "OPENQASM 3.1; qubit q; U(0, 0, 0) q;invalid suffix";
   const auto source = StringRef(storage).take_front(storage.find("invalid"));
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   storage.assign(storage.size(), 'x');
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
@@ -83,7 +83,7 @@ for int i in [0:1] {
 }
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
   size_t localRegisters = 0;
@@ -108,7 +108,7 @@ for int i in [0:0] {
 result = value;
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
   moduleOp->walk([&](Operation* operation) {
@@ -134,7 +134,7 @@ while (again) {
 }
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
   size_t unreachableGates = 0;
@@ -144,7 +144,7 @@ while (again) {
 
 TEST(OpenQASMTargetTest, EmitsVerifiedQCDirectly) {
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(BROADCAST_PROGRAM, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(BROADCAST_PROGRAM, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -155,7 +155,7 @@ TEST(OpenQASMTargetTest, EmitsVerifiedQCDirectly) {
 
 TEST(OpenQASMTargetTest, ProductionTranslationUsesTheStagedPipeline) {
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(BROADCAST_PROGRAM, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(BROADCAST_PROGRAM, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -178,7 +178,7 @@ shifted(0.5) q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -200,7 +200,7 @@ rx(sin(value) + cos(value) + tan(value) + exp(value) + log(value) +
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -224,7 +224,7 @@ rx(arccos(unsigned_value) + arcsin(signed_value) + arctan(float_value)) q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -263,7 +263,7 @@ float float_from_int = source_int;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -316,7 +316,7 @@ bool unsigned_greater_equal = unsigned_left >= unsigned_right;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -402,20 +402,21 @@ rx(ceiling(runtime_value) + floor(runtime_value)) q;
 rounded(0.5) q;
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
-  const auto& constantApplication = std::get<oq3::frontend::GateApplication>(
-      analyzed.program->statements[analyzed.program->body[2]].data);
+  const auto& constantApplication =
+      std::get<openqasm::frontend::GateApplication>(
+          analyzed.program->statements[analyzed.program->body[2]].data);
   const auto& parameter =
       analyzed.program->expressions.at(constantApplication.parameters.front());
-  ASSERT_EQ(parameter.kind, oq3::frontend::ExpressionKind::Cast);
-  EXPECT_EQ(parameter.type, oq3::frontend::ScalarType::Angle);
+  ASSERT_EQ(parameter.kind, openqasm::frontend::ExpressionKind::Cast);
+  EXPECT_EQ(parameter.type, openqasm::frontend::ScalarType::Angle);
   const auto& constant = analyzed.program->expressions.at(parameter.lhs);
-  ASSERT_EQ(constant.kind, oq3::frontend::ExpressionKind::Constant);
+  ASSERT_EQ(constant.kind, openqasm::frontend::ExpressionKind::Constant);
   EXPECT_DOUBLE_EQ(std::get<double>(constant.constant), 0.0);
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -438,7 +439,7 @@ ctrl(2) @ negctrl @ inv @ ctrl @ x q[0], q[1], q[2], q[3], q[4];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
 
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
@@ -468,7 +469,7 @@ qubit[4] q;
 negctrl(3) @ x q[0], q[1], q[2], q[3];
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t controlRegions = 0;
@@ -494,7 +495,7 @@ pow(exponent) @ x q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -537,7 +538,7 @@ pow(exponent) @ x q;
   for (const auto source : sources) {
     SCOPED_TRACE(source.str());
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(source, &context);
     ASSERT_TRUE(moduleOp);
     ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -582,7 +583,7 @@ out = measure q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -636,7 +637,7 @@ TEST(OpenQASMTargetTest, ResolvesManyCustomGateDefinitionsThroughTheIndex) {
   }
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -657,7 +658,7 @@ measure q -> c;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -675,7 +676,7 @@ x $3;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -697,7 +698,7 @@ x q;
 x $0;
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 
   MLIRContext context;
@@ -706,12 +707,12 @@ x $0;
     diagnostic = value.str();
     return success();
   });
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   EXPECT_FALSE(moduleOp);
   EXPECT_NE(diagnostic.find("mixing physical and declared qubits"),
             std::string::npos)
       << diagnostic;
-  EXPECT_NE(diagnostic.find("QC target"), std::string::npos) << diagnostic;
+  EXPECT_NE(diagnostic.find("QC translation"), std::string::npos) << diagnostic;
 }
 
 TEST(OpenQASMTargetTest, AllocatesCBitStorageForAllBitRegisters) {
@@ -728,7 +729,7 @@ result = measure q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -755,25 +756,25 @@ bits[0] = true;
 bits[1] = false;
 float ratio = 2.0;
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(implicitSource);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(implicitSource);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_EQ(analyzed.program->outputs.size(), 3);
   EXPECT_EQ(analyzed.program->outputs[0].kind,
-            oq3::frontend::OutputKind::Scalar);
+            openqasm::frontend::OutputKind::Scalar);
   EXPECT_EQ(analyzed.program->scalars[analyzed.program->outputs[0].symbol].name,
             "count");
   EXPECT_EQ(analyzed.program->outputs[1].kind,
-            oq3::frontend::OutputKind::BitRegister);
+            openqasm::frontend::OutputKind::BitRegister);
   EXPECT_EQ(
       analyzed.program->registers[analyzed.program->outputs[1].symbol].name,
       "bits");
   EXPECT_EQ(analyzed.program->outputs[2].kind,
-            oq3::frontend::OutputKind::Scalar);
+            openqasm::frontend::OutputKind::Scalar);
   EXPECT_EQ(analyzed.program->scalars[analyzed.program->outputs[2].symbol].name,
             "ratio");
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(implicitSource, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(implicitSource, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   func::ReturnOp result;
@@ -793,11 +794,11 @@ int internal = 1;
 output int result;
 result = internal + 1;
 )qasm";
-  auto explicitAnalysis = oq3::frontend::analyzeOpenQASM(explicitSource);
+  auto explicitAnalysis = openqasm::frontend::analyzeOpenQASM(explicitSource);
   ASSERT_TRUE(explicitAnalysis) << explicitAnalysis.diagnostics.front().message;
   ASSERT_EQ(explicitAnalysis.program->outputs.size(), 1);
   EXPECT_EQ(explicitAnalysis.program->outputs.front().kind,
-            oq3::frontend::OutputKind::Scalar);
+            openqasm::frontend::OutputKind::Scalar);
   EXPECT_EQ(explicitAnalysis.program
                 ->scalars[explicitAnalysis.program->outputs.front().symbol]
                 .name,
@@ -816,7 +817,7 @@ cx q[i], aux[j];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t loads = 0;
@@ -844,7 +845,7 @@ TEST(OpenQASMTargetTest, PreservesCompactCustomGateGraph) {
   source += "qubit q;\ng24 q;\n";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
   EXPECT_EQ(std::distance(moduleOp->getOps<func::FuncOp>().begin(),
@@ -870,7 +871,7 @@ main q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   auto gate = moduleOp->lookupSymbol<func::FuncOp>("main");
@@ -894,7 +895,7 @@ TEST(OpenQASMTargetTest, DoesNotMultiplyCustomGatesByRegisterWidth) {
             "expanded q[i], aux[j];\n";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t loads = 0;
@@ -921,7 +922,7 @@ bit result = measure q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t forLoops = 0;
@@ -959,7 +960,7 @@ g q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   qc::RXOp rotation;
@@ -981,12 +982,12 @@ target = source;
 if (target[0] || target[1]) { x q[0]; }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
-  const oq3::frontend::BitVectorAssignmentStatement* assignment = nullptr;
+  const openqasm::frontend::BitVectorAssignmentStatement* assignment = nullptr;
   for (const auto& statement : analyzed.program->statements) {
     if (const auto* current =
-            std::get_if<oq3::frontend::BitVectorAssignmentStatement>(
+            std::get_if<openqasm::frontend::BitVectorAssignmentStatement>(
                 &statement.data)) {
       ASSERT_EQ(assignment, nullptr);
       assignment = current;
@@ -997,12 +998,12 @@ if (target[0] || target[1]) { x q[0]; }
   EXPECT_EQ(analyzed.program->registers[assignment->target].name, "target");
   const auto& value =
       analyzed.program->bitVectorExpressions.at(assignment->value);
-  EXPECT_EQ(value.kind, oq3::frontend::BitVectorExpressionKind::Register);
+  EXPECT_EQ(value.kind, openqasm::frontend::BitVectorExpressionKind::Register);
   EXPECT_EQ(analyzed.program->registers[value.reg].name, "source");
   EXPECT_EQ(value.width, 2);
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   PassManager canonicalizer(&context);
@@ -1033,17 +1034,18 @@ qubit q;
 if (count == 3) { x q; }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_FALSE(analyzed.program->bitVectorExpressions.empty());
   EXPECT_TRUE(
       llvm::any_of(analyzed.program->expressions, [](const auto& expression) {
-        return expression.kind == oq3::frontend::ExpressionKind::PopCount &&
-               expression.type == oq3::frontend::ScalarType::Uint;
+        return expression.kind ==
+                   openqasm::frontend::ExpressionKind::PopCount &&
+               expression.type == openqasm::frontend::ScalarType::Uint;
       }));
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t populationCounts = 0;
@@ -1067,14 +1069,14 @@ result = (~value & 6) | (value ^ 1);
 if ((result >> 1) < (result << 2)) { x q[0]; }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   EXPECT_TRUE(llvm::any_of(analyzed.program->conditions, [](const auto& value) {
-    return value.kind == oq3::frontend::ConditionKind::BitVectorComparison;
+    return value.kind == openqasm::frontend::ConditionKind::BitVectorComparison;
   }));
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 }
@@ -1089,7 +1091,7 @@ result = value << 3;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   bool hasLeftShift = false;
@@ -1110,7 +1112,7 @@ if ((value << (value & 1)) == 0) {}
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   bool hasShift = false;
@@ -1144,7 +1146,7 @@ pow(unsignedExponent) @ x q;
   for (const auto source : sources) {
     SCOPED_TRACE(source.str());
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(source, &context);
     ASSERT_TRUE(moduleOp);
     EXPECT_TRUE(succeeded(verify(*moduleOp)));
   }
@@ -1165,7 +1167,7 @@ rx(count) q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t populationCounts = 0;
@@ -1192,7 +1194,7 @@ uint count = popcount(value);
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -1227,7 +1229,7 @@ if (c == 1) x q[0];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t conditionals = 0;
@@ -1256,7 +1258,7 @@ if (c >= 5) { x q; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -1286,7 +1288,7 @@ if (c == 18446744073709551616) x q[0];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   arith::CmpIOp comparison;
   moduleOp->walk([&](arith::CmpIOp op) { comparison = op; });
@@ -1317,7 +1319,7 @@ if (uint[2](syndrome) < 3) {
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -1356,7 +1358,7 @@ if (-1 <= int[2](syndrome)) { x q[0]; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -1389,7 +1391,7 @@ signed_value = int[3](signed_bits);
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -1415,7 +1417,7 @@ if (c == 0) x q[0];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   PassManager canonicalizer(&context);
@@ -1446,7 +1448,7 @@ if (c == 1) x q[0];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   PassManager canonicalizer(&context);
@@ -1472,7 +1474,7 @@ if (result == 0.0625) { x q; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   bool foundResult = false;
@@ -1491,12 +1493,12 @@ output int result;
 result = pow(base, exponent);
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
-  const oq3::frontend::ScalarAssignmentStatement* assignment = nullptr;
+  const openqasm::frontend::ScalarAssignmentStatement* assignment = nullptr;
   for (const auto& statement : analyzed.program->statements) {
     if (const auto* current =
-            std::get_if<oq3::frontend::ScalarAssignmentStatement>(
+            std::get_if<openqasm::frontend::ScalarAssignmentStatement>(
                 &statement.data);
         current != nullptr &&
         analyzed.program->scalars[current->scalar].name == "result") {
@@ -1506,15 +1508,15 @@ result = pow(base, exponent);
   ASSERT_NE(assignment, nullptr);
   ASSERT_TRUE(assignment->value);
   const auto& power = analyzed.program->expressions[*assignment->value];
-  EXPECT_EQ(power.kind, oq3::frontend::ExpressionKind::Power);
-  EXPECT_EQ(power.type, oq3::frontend::ScalarType::Int);
+  EXPECT_EQ(power.kind, openqasm::frontend::ExpressionKind::Power);
+  EXPECT_EQ(power.type, openqasm::frontend::ScalarType::Int);
   EXPECT_EQ(analyzed.program->expressions[power.lhs].type,
-            oq3::frontend::ScalarType::Int);
+            openqasm::frontend::ScalarType::Int);
   EXPECT_EQ(analyzed.program->expressions[power.rhs].type,
-            oq3::frontend::ScalarType::Uint);
+            openqasm::frontend::ScalarType::Uint);
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t integerPowers = 0;
@@ -1538,7 +1540,7 @@ measured = measure q;
 if (!measured) { h q; }
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t measurements = 0;
@@ -1569,7 +1571,7 @@ TEST(OpenQASMTargetTest, EmitsStructuredDiagnosticsWithIncludeStacks) {
     location = diagnostic.getLocation();
     return success();
   });
-  auto moduleOp = qc::translateQASM3ToQC(sourceMgr, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(sourceMgr, &context);
   EXPECT_FALSE(moduleOp);
   EXPECT_NE(message.find("cannot be represented exactly"), std::string::npos);
   const auto mainCall = dyn_cast<CallSiteLoc>(location);
@@ -1606,7 +1608,7 @@ output bit[3] result;
 result = measure q;
 )qasm";
   MLIRContext indexContext;
-  auto indexed = qc::translateQASM3ToQC(indexSource, &indexContext);
+  auto indexed = qc::translateOpenQASMToQC(indexSource, &indexContext);
   ASSERT_TRUE(indexed);
   EXPECT_TRUE(succeeded(verify(*indexed)));
 
@@ -1618,7 +1620,7 @@ cx q[i], q[i];
 bit[2] result = measure q;
 )qasm";
   MLIRContext aliasContext;
-  auto aliased = qc::translateQASM3ToQC(aliasSource, &aliasContext);
+  auto aliased = qc::translateOpenQASMToQC(aliasSource, &aliasContext);
   EXPECT_FALSE(aliased);
 }
 
@@ -1632,7 +1634,7 @@ x q[i];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t switches = 0;
@@ -1672,7 +1674,7 @@ switch (selector) {
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t switches = 0;
@@ -1711,7 +1713,7 @@ switch (int(choose)) {
 }
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t switches = 0;
@@ -1745,7 +1747,7 @@ while (true) {
 }
 )qasm";
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(source, &context);
     ASSERT_TRUE(moduleOp);
     ASSERT_TRUE(succeeded(verify(*moduleOp)));
     PassManager canonicalizer(&context);
@@ -1772,7 +1774,7 @@ switch (selector) {
 }
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   PassManager canonicalizer(&context);
@@ -1798,7 +1800,7 @@ c = measure q[i];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t switches = 0;
@@ -1824,7 +1826,7 @@ x q[i];
 )qasm";
   MLIRContext widthOneContext;
   auto widthOneModule =
-      qc::translateQASM3ToQC(widthOneSource, &widthOneContext);
+      qc::translateOpenQASMToQC(widthOneSource, &widthOneContext);
   ASSERT_TRUE(widthOneModule);
   size_t widthOneSwitches = 0;
   size_t widthOneLoads = 0;
@@ -1845,7 +1847,7 @@ int j = 1;
 cx left[i], right[j];
 )qasm";
   MLIRContext nestedContext;
-  auto nestedModule = qc::translateQASM3ToQC(nestedSource, &nestedContext);
+  auto nestedModule = qc::translateOpenQASMToQC(nestedSource, &nestedContext);
   ASSERT_TRUE(nestedModule);
   ASSERT_TRUE(succeeded(verify(*nestedModule)));
   size_t switches = 0;
@@ -1875,7 +1877,7 @@ barrier q[i], q[j];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -1909,7 +1911,7 @@ TEST(OpenQASMTargetTest, QuantumEmissionDoesNotScaleWithRegisterWidth) {
     const auto source = "OPENQASM 3.1;\ninclude \"stdgates.inc\";\nqubit[" +
                         std::to_string(width) + "] q;\nint i = 0;\nh q[i];\n";
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(source, &context);
     EXPECT_TRUE(moduleOp);
     if (!moduleOp) {
       return size_t{0};
@@ -1928,7 +1930,7 @@ TEST(OpenQASMTargetTest, LargeStaticBarrierAvoidsAliasChecks) {
   const auto source =
       "OPENQASM 3.1;\nqubit[" + std::to_string(width) + "] q;\nbarrier q;\n";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -1961,7 +1963,7 @@ if (flags[0] && !flags[1]) { x q; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t xGates = 0;
@@ -1977,7 +1979,7 @@ measure q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t measurements = 0;
@@ -1996,7 +1998,7 @@ for uint i in [start:-1:stop] { x q; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   PassManager canonicalizer(&context);
@@ -2022,7 +2024,7 @@ for int i in [-1:stop] { x q; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   PassManager canonicalizer(&context);
@@ -2050,7 +2052,7 @@ conditional(0.0) q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t loops = 0;
@@ -2075,7 +2077,7 @@ inv @ looped(pi / 2) q;
     diagnostic = value.str();
     return success();
   });
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   EXPECT_FALSE(moduleOp);
   EXPECT_NE(diagnostic.find("structured control flow"), std::string::npos);
 }
@@ -2099,7 +2101,7 @@ inv @ wrapper q;
     location = value.getLocation();
     return success();
   });
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   EXPECT_FALSE(moduleOp);
   const auto fileLocation = dyn_cast<FileLineColLoc>(location);
   ASSERT_TRUE(fileLocation);
@@ -2120,7 +2122,7 @@ x q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
   auto looped = moduleOp->lookupSymbol<func::FuncOp>("looped");
@@ -2146,7 +2148,7 @@ x q[i];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   EXPECT_FALSE(moduleOp);
 }
 
@@ -2171,7 +2173,7 @@ if (c[i]) { x q[0]; })qasm",
   for (const auto source : sources) {
     SCOPED_TRACE(source.str());
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(source, &context);
     ASSERT_TRUE(moduleOp);
     EXPECT_TRUE(succeeded(verify(*moduleOp)));
   }
@@ -2185,7 +2187,7 @@ if (c[i]) { x q[0]; })qasm",
   for (const auto source : rejectedQuantumSources) {
     SCOPED_TRACE(source.str());
     MLIRContext context;
-    EXPECT_FALSE(qc::translateQASM3ToQC(source, &context));
+    EXPECT_FALSE(qc::translateOpenQASMToQC(source, &context));
   }
 }
 
@@ -2200,7 +2202,7 @@ while (repeat) { x q[i]; i = 1; repeat = measure q[0]; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   EXPECT_FALSE(moduleOp);
 }
 
@@ -2213,7 +2215,7 @@ for uint i in [0:2] { int x = i + 1; h q[x]; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
 }
@@ -2241,7 +2243,7 @@ for int i in [0:stride:6] { x q[i]; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t forLoops = 0;
@@ -2284,7 +2286,7 @@ if (value + 1 > 0) { x q; })qasm",
   for (const auto source : sources) {
     SCOPED_TRACE(source.str());
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(source, &context);
     ASSERT_TRUE(moduleOp);
     ASSERT_TRUE(succeeded(verify(*moduleOp)));
     moduleOp->walk([&](arith::AddIOp add) {
@@ -2317,7 +2319,7 @@ unsignedValue = unsignedValue ** unsignedOperand;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t powerLoops = 0;
@@ -2338,7 +2340,7 @@ qubit[2] reg;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
 }
@@ -2356,7 +2358,7 @@ for int i in [9223372036854775806:1:9223372036854775807] { x q; })qasm",
   for (const auto source : sources) {
     SCOPED_TRACE(source.str());
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(source, &context);
     ASSERT_TRUE(moduleOp);
     ASSERT_TRUE(succeeded(verify(*moduleOp)));
     size_t forLoops = 0;
@@ -2384,7 +2386,7 @@ for int i in [start:step:stop] { x q; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t whileLoops = 0;
@@ -2409,7 +2411,7 @@ x q[i];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t conditionals = 0;
@@ -2443,7 +2445,7 @@ x q[i];
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
 }
@@ -2461,7 +2463,7 @@ result = measure q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -2518,7 +2520,7 @@ bit result = measure q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -2584,7 +2586,7 @@ result = measure q;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   bool branchStoresBit = false;
@@ -2633,7 +2635,7 @@ if (state[0]) { x q; }
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -2668,7 +2670,7 @@ qubit q;
 for uint i in [maximum:maximum] { if (i == maximum) { x q; } }
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   scf::ForOp loop;
@@ -2702,7 +2704,7 @@ barrier;
 bit[3] result = measure q;
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t barriers = 0;
@@ -2723,7 +2725,7 @@ mcx_vchain q[0], q[1], q[2], q[3], q[4], q[8], q[9];
 mcx_recursive q[0], q[1], q[2], q[3], q[4], q[9];
 )qasm";
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   size_t controls = 0;
@@ -2751,7 +2753,7 @@ bit right = measure target;
 )qasm";
 
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   size_t controls = 0;
   moduleOp->walk([&](qc::CtrlOp) { ++controls; });
@@ -2810,7 +2812,7 @@ TEST(OpenQASMTargetTest, PreservesImportedWhileBehavior) {
   for (const auto& fixture : fixtures) {
     SCOPED_TRACE(fixture.name.str());
     MLIRContext context;
-    auto moduleOp = qc::translateQASM3ToQC(fixture.source, &context);
+    auto moduleOp = qc::translateOpenQASMToQC(fixture.source, &context);
     ASSERT_TRUE(moduleOp);
     ASSERT_TRUE(succeeded(verify(*moduleOp)));
 
@@ -2966,7 +2968,7 @@ TEST(OpenQASMTargetTest, StopsEmissionAtEveryOperationBudgetBoundary) {
         return success();
       });
       auto moduleOp =
-          qc::translateQASM3ToQC(source, &context, {.maxOperations = limit});
+          qc::translateOpenQASMToQC(source, &context, {.maxOperations = limit});
       if (moduleOp) {
         EXPECT_TRUE(succeeded(verify(*moduleOp)));
         EXPECT_EQ(diagnostics, 0);
@@ -2990,7 +2992,7 @@ TEST(OpenQASMTargetTest, DynamicStoresDoNotChargeForEveryRegisterBit) {
     source += "c[i] = false;";
   }
   MLIRContext context;
-  auto moduleOp = qc::translateQASM3ToQC(source, &context);
+  auto moduleOp = qc::translateOpenQASMToQC(source, &context);
   ASSERT_TRUE(moduleOp);
   EXPECT_TRUE(succeeded(verify(*moduleOp)));
   size_t stores = 0;

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_parser.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_parser.cpp
@@ -28,11 +28,11 @@ using namespace mlir;
 namespace {
 
 TEST(OpenQASMFrontendTest, PreservesExactAndOptionalVersionSemantics) {
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM("qubit q; x q;"));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM("OPENQASM 3; qubit q; x q;"));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM("qubit q; x q;"));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM("OPENQASM 3; qubit q; x q;"));
 
   auto unsupported =
-      oq3::frontend::analyzeOpenQASM("OPENQASM 3.10; qubit q; x q;");
+      openqasm::frontend::analyzeOpenQASM("OPENQASM 3.10; qubit q; x q;");
   ASSERT_FALSE(unsupported);
   ASSERT_FALSE(unsupported.diagnostics.empty());
   EXPECT_NE(unsupported.diagnostics.front().message.find("3.10"),
@@ -45,7 +45,7 @@ OPENQASM 3.2;
 qubit q;
 x q;
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("Unsupported OpenQASM"),
@@ -64,11 +64,11 @@ include "stdgates.inc";
 qubit q;
 x q;
 )qasm";
-  const auto strict = oq3::frontend::GatePolicy::Strict;
+  const auto strict = openqasm::frontend::GatePolicy::Strict;
 
-  EXPECT_FALSE(oq3::frontend::analyzeOpenQASM(withoutInclude, strict));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(withInclude, strict));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(withoutInclude));
+  EXPECT_FALSE(openqasm::frontend::analyzeOpenQASM(withoutInclude, strict));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(withInclude, strict));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(withoutInclude));
 }
 
 TEST(OpenQASMFrontendTest, PreservesSourceNamesInSemanticDiagnostics) {
@@ -77,7 +77,7 @@ TEST(OpenQASMFrontendTest, PreservesSourceNamesInSemanticDiagnostics) {
       llvm::MemoryBuffer::getMemBufferCopy(
           "OPENQASM 3.0;\nqubit q;\nunknown q;\n", "fixture.qasm"),
       llvm::SMLoc());
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(sourceMgr);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_EQ(analyzed.diagnostics.front().location.filename, "fixture.qasm");
@@ -90,7 +90,7 @@ TEST(OpenQASMFrontendTest, LocatesVersionAndOutputDiagnosticsPrecisely) {
       llvm::MemoryBuffer::getMemBufferCopy("OPENQASM 3.2;\nqubit q;\n",
                                            "unsupported-version.qasm"),
       llvm::SMLoc());
-  auto version = oq3::frontend::analyzeOpenQASM(versionSources);
+  auto version = openqasm::frontend::analyzeOpenQASM(versionSources);
   ASSERT_FALSE(version);
   ASSERT_FALSE(version.diagnostics.empty());
   EXPECT_EQ(version.diagnostics.front().location.filename,
@@ -103,7 +103,7 @@ TEST(OpenQASMFrontendTest, LocatesVersionAndOutputDiagnosticsPrecisely) {
           "OPENQASM 3.1;\nqubit q;\noutput bit result;\n",
           "incomplete-output.qasm"),
       llvm::SMLoc());
-  auto output = oq3::frontend::analyzeOpenQASM(outputSources);
+  auto output = openqasm::frontend::analyzeOpenQASM(outputSources);
   ASSERT_FALSE(output);
   ASSERT_FALSE(output.diagnostics.empty());
   EXPECT_EQ(output.diagnostics.front().location.filename,
@@ -124,7 +124,7 @@ if (true) {
 value += 5;
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_EQ(analyzed.program->scalars.size(), 2);
 
@@ -132,7 +132,7 @@ value += 5;
   size_t innerAssignments = 0;
   for (const auto& statement : analyzed.program->statements) {
     if (const auto* assignment =
-            std::get_if<oq3::frontend::ScalarAssignmentStatement>(
+            std::get_if<openqasm::frontend::ScalarAssignmentStatement>(
                 &statement.data)) {
       outerAssignments += static_cast<size_t>(assignment->scalar == 0);
       innerAssignments += static_cast<size_t>(assignment->scalar == 1);
@@ -143,7 +143,7 @@ value += 5;
 }
 
 TEST(OpenQASMFrontendTest, OwnsAndAnalyzesProvidedIncludeBuffers) {
-  oq3::frontend::ParseResult parsed;
+  openqasm::frontend::ParseResult parsed;
   {
     llvm::SourceMgr sourceMgr;
     sourceMgr.AddNewSourceBuffer(
@@ -162,11 +162,11 @@ gate custom q { x q; }
 )qasm",
                                              "custom.inc"),
         llvm::SMLoc());
-    parsed = oq3::frontend::parseOpenQASM(sourceMgr);
+    parsed = openqasm::frontend::parseOpenQASM(sourceMgr);
   }
 
   ASSERT_TRUE(parsed) << parsed.diagnostics.front().message;
-  auto analyzed = oq3::frontend::analyzeOpenQASM(*parsed.program);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(*parsed.program);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_EQ(analyzed.program->gates.size(), 1);
   EXPECT_EQ(analyzed.program->gates.front().name, "custom");
@@ -195,7 +195,7 @@ int after = nested;
       llvm::MemoryBuffer::getMemBufferCopy("int nested = 2;\n", "nested.inc"),
       llvm::SMLoc());
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(sourceMgr);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_EQ(analyzed.program->scalars.size(), 4);
   EXPECT_EQ(analyzed.program->scalars[0].name, "outer");
@@ -217,7 +217,7 @@ TEST(OpenQASMFrontendTest, PreservesNestedIncludeStacksInDiagnostics) {
                                    "int value = missing;\n", "nested.inc"),
                                llvm::SMLoc());
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(sourceMgr);
   ASSERT_FALSE(analyzed);
   ASSERT_EQ(analyzed.diagnostics.size(), 1);
   const auto& location = analyzed.diagnostics.front().location;
@@ -247,7 +247,7 @@ TEST(OpenQASMFrontendTest, PreservesDistinctProvenanceForRepeatedIncludes) {
                                    "int duplicate = 1;\n", "shared.inc"),
                                llvm::SMLoc());
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(sourceMgr);
   ASSERT_FALSE(analyzed);
   ASSERT_EQ(analyzed.diagnostics.size(), 1);
   const auto& location = analyzed.diagnostics.front().location;
@@ -275,13 +275,13 @@ TEST(OpenQASMFrontendTest, CachesSearchPathIncludesAndKeepsEveryOccurrence) {
           "main.qasm"),
       llvm::SMLoc());
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(sourceMgr);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   /// One failed direct lookup and one successful search-path lookup.
   EXPECT_EQ(traced->NumOpenFileForReadCalls, 2);
   size_t assignments = 0;
   for (const auto& statement : analyzed.program->statements) {
-    if (std::holds_alternative<oq3::frontend::ScalarAssignmentStatement>(
+    if (std::holds_alternative<openqasm::frontend::ScalarAssignmentStatement>(
             statement.data)) {
       EXPECT_EQ(statement.location.filename, "/includes/body.inc");
       ASSERT_EQ(statement.location.includeStack.size(), 1);
@@ -307,7 +307,7 @@ TEST(OpenQASMFrontendTest, RejectsRecursiveIncludesResolvedThroughSearchPaths) {
           "OPENQASM 3.1; include \"recursive.inc\";", "main.qasm"),
       llvm::SMLoc());
 
-  auto parsed = oq3::frontend::parseOpenQASM(sourceMgr);
+  auto parsed = openqasm::frontend::parseOpenQASM(sourceMgr);
   ASSERT_FALSE(parsed);
   ASSERT_FALSE(parsed.diagnostics.empty());
   EXPECT_NE(parsed.diagnostics.front().message.find("recursive include"),
@@ -333,7 +333,7 @@ TEST(OpenQASMFrontendTest, LimitsIncludeNesting) {
         llvm::SMLoc());
   }
 
-  auto parsed = oq3::frontend::parseOpenQASM(sourceMgr);
+  auto parsed = openqasm::frontend::parseOpenQASM(sourceMgr);
   ASSERT_FALSE(parsed);
   ASSERT_FALSE(parsed.diagnostics.empty());
   EXPECT_NE(parsed.diagnostics.front().message.find("include nesting"),
@@ -366,7 +366,7 @@ TEST(OpenQASMFrontendTest, LimitsTextualIncludeExpansion) {
           llvm::SMLoc());
     }
 
-    auto parsed = oq3::frontend::parseOpenQASM(sourceMgr);
+    auto parsed = openqasm::frontend::parseOpenQASM(sourceMgr);
     ASSERT_FALSE(parsed);
     ASSERT_FALSE(parsed.diagnostics.empty());
     EXPECT_NE(parsed.diagnostics.front().message.find(
@@ -376,17 +376,18 @@ TEST(OpenQASMFrontendTest, LimitsTextualIncludeExpansion) {
 }
 
 TEST(OpenQASMFrontendTest, EnforcesUnicodeIdentifierCategoriesAndUtf8) {
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
       "OPENQASM 3.1; int θ = 1; int Ångström = θ;"));
 
-  auto symbol = oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; int 💥 = 1;");
+  auto symbol =
+      openqasm::frontend::analyzeOpenQASM("OPENQASM 3.1; int 💥 = 1;");
   ASSERT_FALSE(symbol);
   ASSERT_FALSE(symbol.diagnostics.empty());
 
   std::string invalid = "OPENQASM 3.1; int ";
   invalid.push_back(static_cast<char>(0xC3));
   invalid += " = 1;";
-  auto malformed = oq3::frontend::analyzeOpenQASM(invalid);
+  auto malformed = openqasm::frontend::analyzeOpenQASM(invalid);
   ASSERT_FALSE(malformed);
   ASSERT_FALSE(malformed.diagnostics.empty());
 }
@@ -412,7 +413,7 @@ bit result = measure q;
                                    "bool enabled = true;\n", "b/defs.inc"),
                                llvm::SMLoc());
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sourceMgr);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(sourceMgr);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_EQ(analyzed.program->scalars.size(), 2);
   EXPECT_EQ(analyzed.program->scalars[0].name, "counter");
@@ -434,12 +435,13 @@ bit result = measure q;
       llvm::MemoryBuffer::getMemBufferCopy("x q;\n", "operations.inc"),
       llvm::SMLoc());
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sources);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(sources);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   size_t applications = 0;
   for (const auto& statement : analyzed.program->statements) {
     applications += static_cast<size_t>(
-        std::holds_alternative<oq3::frontend::GateApplication>(statement.data));
+        std::holds_alternative<openqasm::frontend::GateApplication>(
+            statement.data));
   }
   EXPECT_EQ(applications, 2);
 }
@@ -456,13 +458,13 @@ TEST(OpenQASMFrontendTest, RejectsRecursiveAndRepeatedStandardIncludes) {
   recursiveSources.AddNewSourceBuffer(
       llvm::MemoryBuffer::getMemBufferCopy("include \"a.inc\";", "b.inc"),
       llvm::SMLoc());
-  auto recursive = oq3::frontend::parseOpenQASM(recursiveSources);
+  auto recursive = openqasm::frontend::parseOpenQASM(recursiveSources);
   ASSERT_FALSE(recursive);
   ASSERT_FALSE(recursive.diagnostics.empty());
   EXPECT_NE(recursive.diagnostics.front().message.find("recursive"),
             std::string::npos);
 
-  auto repeated = oq3::frontend::analyzeOpenQASM(
+  auto repeated = openqasm::frontend::analyzeOpenQASM(
       "OPENQASM 3.1; include \"stdgates.inc\"; include "
       "\"stdgates.inc\";");
   ASSERT_FALSE(repeated);
@@ -472,7 +474,7 @@ TEST(OpenQASMFrontendTest, RejectsRecursiveAndRepeatedStandardIncludes) {
 }
 
 TEST(OpenQASMFrontendTest, RejectsIncludesInsideBlocks) {
-  auto parsed = oq3::frontend::parseOpenQASM(
+  auto parsed = openqasm::frontend::parseOpenQASM(
       "OPENQASM 3.1; if (true) { include \"nested.inc\"; }");
   ASSERT_FALSE(parsed);
   ASSERT_FALSE(parsed.diagnostics.empty());
@@ -481,10 +483,10 @@ TEST(OpenQASMFrontendTest, RejectsIncludesInsideBlocks) {
 }
 
 TEST(OpenQASMFrontendTest, AcceptsBothIncludeStringQuoteStyles) {
-  EXPECT_TRUE(
-      oq3::frontend::parseOpenQASM("OPENQASM 3.1; include \"stdgates.inc\";"));
-  EXPECT_TRUE(
-      oq3::frontend::parseOpenQASM("OPENQASM 3.1; include 'stdgates.inc';"));
+  EXPECT_TRUE(openqasm::frontend::parseOpenQASM(
+      "OPENQASM 3.1; include \"stdgates.inc\";"));
+  EXPECT_TRUE(openqasm::frontend::parseOpenQASM(
+      "OPENQASM 3.1; include 'stdgates.inc';"));
 }
 
 TEST(OpenQASMFrontendTest, RejectsInvalidIncludeStringsAtTheOffendingByte) {
@@ -506,7 +508,7 @@ TEST(OpenQASMFrontendTest, RejectsInvalidIncludeStringsAtTheOffendingByte) {
     sources.AddNewSourceBuffer(llvm::MemoryBuffer::getMemBufferCopy(
                                    include.source, "invalid-include.qasm"),
                                llvm::SMLoc());
-    auto parsed = oq3::frontend::parseOpenQASM(sources);
+    auto parsed = openqasm::frontend::parseOpenQASM(sources);
     ASSERT_FALSE(parsed);
     ASSERT_FALSE(parsed.diagnostics.empty());
     EXPECT_EQ(parsed.diagnostics.front().location.filename,
@@ -529,13 +531,13 @@ first q;
 bit result = measure q;
 )qasm";
 
-  auto misplaced = oq3::frontend::analyzeOpenQASM(misplacedVersion);
+  auto misplaced = openqasm::frontend::analyzeOpenQASM(misplacedVersion);
   ASSERT_FALSE(misplaced);
   ASSERT_FALSE(misplaced.diagnostics.empty());
   EXPECT_NE(misplaced.diagnostics.front().message.find("must be the first"),
             std::string::npos);
 
-  auto recursive = oq3::frontend::analyzeOpenQASM(recursiveGates);
+  auto recursive = openqasm::frontend::analyzeOpenQASM(recursiveGates);
   ASSERT_FALSE(recursive);
   ASSERT_FALSE(recursive.diagnostics.empty());
   EXPECT_NE(recursive.diagnostics.front().message.find("recursive"),
@@ -614,7 +616,7 @@ TEST(OpenQASMFrontendTest, DiagnosesMalformedLexicalAndGrammarFamilies) {
 
   for (const auto& fixture : fixtures) {
     SCOPED_TRACE(fixture.name.str());
-    auto parsed = oq3::frontend::parseOpenQASM(fixture.source);
+    auto parsed = openqasm::frontend::parseOpenQASM(fixture.source);
     ASSERT_FALSE(parsed);
     ASSERT_FALSE(parsed.diagnostics.empty());
     EXPECT_FALSE(parsed.diagnostics.front().message.empty());
@@ -632,7 +634,7 @@ if (uint[2](value) == 3) {}
 if (int[2](value) == -1) {}
 )qasm";
 
-  auto parsed = oq3::frontend::parseOpenQASM(source);
+  auto parsed = openqasm::frontend::parseOpenQASM(source);
   ASSERT_TRUE(parsed) << parsed.diagnostics.front().message;
 }
 
@@ -646,7 +648,7 @@ TEST(OpenQASMFrontendTest, RejectsUnsupportedReservedWordsAsIdentifiers) {
   for (const auto keyword : reservedWords) {
     SCOPED_TRACE(keyword.str());
     const std::string source = "OPENQASM 3.1; int " + keyword.str() + " = 0;";
-    auto parsed = oq3::frontend::parseOpenQASM(source);
+    auto parsed = openqasm::frontend::parseOpenQASM(source);
     ASSERT_FALSE(parsed);
     ASSERT_FALSE(parsed.diagnostics.empty());
     EXPECT_NE(parsed.diagnostics.front().message.find("reserved keyword"),
@@ -664,7 +666,7 @@ TEST(OpenQASMFrontendTest, DiagnosesUnsupportedReservedFeatureSyntax) {
   });
   for (const auto source : sources) {
     SCOPED_TRACE(source.str());
-    auto parsed = oq3::frontend::parseOpenQASM(source);
+    auto parsed = openqasm::frontend::parseOpenQASM(source);
     ASSERT_FALSE(parsed);
     ASSERT_FALSE(parsed.diagnostics.empty());
     EXPECT_NE(parsed.diagnostics.front().message.find("reserved keyword"),
@@ -687,12 +689,12 @@ TEST(OpenQASMFrontendTest, EnforcesNumericSeparatorPlacement) {
     SCOPED_TRACE(literal.str());
     const std::string source =
         "OPENQASM 3.1; float value = " + literal.str() + ";";
-    auto parsed = oq3::frontend::parseOpenQASM(source);
+    auto parsed = openqasm::frontend::parseOpenQASM(source);
     ASSERT_FALSE(parsed);
     ASSERT_FALSE(parsed.diagnostics.empty());
   }
 
-  auto valid = oq3::frontend::parseOpenQASM(
+  auto valid = openqasm::frontend::parseOpenQASM(
       "OPENQASM 3.1; int hex = 0xA_B; float value = 1_2.3_4e+5_6;");
   ASSERT_TRUE(valid) << valid.diagnostics.front().message;
 }
@@ -700,7 +702,7 @@ TEST(OpenQASMFrontendTest, EnforcesNumericSeparatorPlacement) {
 TEST(OpenQASMFrontendTest, AcceptsWideIntegerLiteralsWithDigitSeparators) {
   // DecimalIntegerLiteral allows '_' separators; values beyond uint64_t are
   // still valid tokens (wide integers). Constant evaluation may reject them.
-  auto parsed = oq3::frontend::parseOpenQASM(
+  auto parsed = openqasm::frontend::parseOpenQASM(
       "OPENQASM 3.1; int value = 999_999_999_999_999_999_999;");
   ASSERT_TRUE(parsed) << parsed.diagnostics.front().message;
 }
@@ -711,12 +713,12 @@ TEST(OpenQASMFrontendTest, SourceManagerOverloadsPreserveParseFailures) {
                                  "OPENQASM 3.1; qubit ;", "broken.qasm"),
                              llvm::SMLoc());
 
-  auto parsed = oq3::frontend::parseOpenQASM(sources);
+  auto parsed = openqasm::frontend::parseOpenQASM(sources);
   ASSERT_FALSE(parsed);
   ASSERT_FALSE(parsed.diagnostics.empty());
   EXPECT_EQ(parsed.diagnostics.front().location.filename, "broken.qasm");
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(sources);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(sources);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_EQ(analyzed.diagnostics.front().location.filename, "broken.qasm");
@@ -742,7 +744,7 @@ if (precedence && powered == binary && binary == octal && octal == hexadecimal &
 }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 

--- a/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
+++ b/mlir/unittests/Target/OpenQASM/test_openqasm_semantics.cpp
@@ -32,7 +32,7 @@
 #include <vector>
 
 using namespace mlir;
-using namespace mlir::oq3::test;
+using namespace mlir::openqasm::test;
 
 namespace {
 
@@ -44,20 +44,20 @@ TEST(OpenQASMFrontendTest, ContinuePreservesDefiniteInitialization) {
            "OPENQASM 3.0; bool c = true; int x; while (c) { c "
            "= false; continue; x = 1; } int y = x;",
        }) {
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     EXPECT_FALSE(analyzed);
   }
-  auto analyzed =
-      oq3::frontend::analyzeOpenQASM("OPENQASM 3.0; int x; for int i in [0:1] "
-                                     "{ x = 1; continue; } int y = x;");
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(
+      "OPENQASM 3.0; int x; for int i in [0:1] "
+      "{ x = 1; continue; } int y = x;");
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
 TEST(OpenQASMFrontendTest, SemanticAnalysisIsIndependentOfMLIR) {
-  auto parsed = oq3::frontend::parseOpenQASM(BROADCAST_PROGRAM);
+  auto parsed = openqasm::frontend::parseOpenQASM(BROADCAST_PROGRAM);
   ASSERT_TRUE(parsed) << parsed.diagnostics.front().message;
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(*parsed.program);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(*parsed.program);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_EQ(analyzed.program->registers.size(), 2);
   EXPECT_EQ(analyzed.program->body.size(), 5);
@@ -71,8 +71,8 @@ include "stdgates.inc";
 qubit q;
 x q;
 )qasm";
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(BROADCAST_PROGRAM));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(v31));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(BROADCAST_PROGRAM));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(v31));
 }
 
 TEST(OpenQASMFrontendTest, AcceptsSizedIntegerDeclarations) {
@@ -80,7 +80,7 @@ TEST(OpenQASMFrontendTest, AcceptsSizedIntegerDeclarations) {
 OPENQASM 3.1;
 int[32] counter = 0;
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed);
   EXPECT_EQ(analyzed.program->scalars.front().integerWidth, 32);
 }
@@ -91,7 +91,7 @@ OPENQASM 3.1;
 qubit q;
 mcx q;
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("qubit operands"),
@@ -104,7 +104,7 @@ OPENQASM 3.1;
 qubit q;
 cx q, q;
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("distinct qubits"),
@@ -141,7 +141,7 @@ int stride = 2;
 for int i in [0:stride:6] { x q[i]; }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
@@ -156,7 +156,7 @@ if (choose) { i = i + 1; } else { i = 1; }
 x q[i];
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
@@ -195,7 +195,7 @@ switch (int(choose)) {
 int after_switch = index;
 x q[after_switch];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
@@ -216,7 +216,7 @@ TEST(OpenQASMFrontendTest, DoesNotInheritFactsFromExpiredLocalDeclarations) {
         "OPENQASM 3.1; qubit[2] q; bit choose = measure q[0]; "
         "output int result; result = 0; " +
         body.str();
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
   }
@@ -287,7 +287,7 @@ TEST(OpenQASMFrontendTest, RejectsUnprovedQuantumIndices) {
 
   for (const auto& [source, diagnostic] : rejections) {
     SCOPED_TRACE(source.str());
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find(diagnostic),
@@ -308,7 +308,7 @@ TEST(OpenQASMFrontendTest, BoundsNontrivialAffineDistinctnessProofWork) {
   }
   source += "; }";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("distinct qubits"),
@@ -322,18 +322,18 @@ qubit[2] q;
 qubit[2048] other;
 for int i in [0:0] { pair q[i], q[i + 1], other; }
 )qasm";
-  auto broadcast = oq3::frontend::analyzeOpenQASM(broadcastSource);
+  auto broadcast = openqasm::frontend::analyzeOpenQASM(broadcastSource);
   ASSERT_TRUE(broadcast) << broadcast.diagnostics.front().message;
 }
 
 TEST(OpenQASMFrontendTest, AcceptsWideBarrierWithUnrelatedAffineOperand) {
-  auto analyzed = oq3::frontend::analyzeOpenQASM(
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(
       "OPENQASM 3.1; qubit[64000] q; qubit[2] r; "
       "for int i in [0:1] { barrier q, r[i]; }");
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   for (const auto& statement : analyzed.program->statements) {
-    if (const auto* barrier =
-            std::get_if<oq3::frontend::BarrierStatement>(&statement.data)) {
+    if (const auto* barrier = std::get_if<openqasm::frontend::BarrierStatement>(
+            &statement.data)) {
       ASSERT_EQ(barrier->qubits.size(), 64001);
       EXPECT_NE(barrier->qubits.front().symbol, barrier->qubits.back().symbol);
       EXPECT_TRUE(barrier->qubits.back().provenIndex.has_value());
@@ -353,7 +353,7 @@ TEST(OpenQASMFrontendTest, RejectsDuplicateBarrierQubits) {
 
   for (const auto source : sources) {
     SCOPED_TRACE(source.str());
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find("same qubit"),
@@ -367,10 +367,10 @@ OPENQASM 3.0;
 qubit[2] q;
 cu3(0.1, 0.2, 0.3) q[0], q[1];
 )qasm";
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(source));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(source));
 
-  const auto strict = oq3::frontend::GatePolicy::Strict;
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source, strict);
+  const auto strict = openqasm::frontend::GatePolicy::Strict;
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source, strict);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("No OpenQASM definition"),
@@ -378,9 +378,9 @@ cu3(0.1, 0.2, 0.3) q[0], q[1];
 }
 
 TEST(OpenQASMFrontendTest, PreservesStandardLibraryIdentity) {
-  const auto strict = oq3::frontend::GatePolicy::Strict;
+  const auto strict = openqasm::frontend::GatePolicy::Strict;
 
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(R"qasm(
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[2] q;
@@ -388,47 +388,47 @@ phase(0.5) q[0];
 u1(0.5) q[0];
 CX q[0], q[1];
 )qasm",
-                                             strict));
-  EXPECT_FALSE(oq3::frontend::analyzeOpenQASM(R"qasm(
+                                                  strict));
+  EXPECT_FALSE(openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit q;
 r(0.5, 0.25) q;
 )qasm",
-                                              strict));
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(R"qasm(
+                                                   strict));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 include "qelib1.inc";
 qubit[2] q;
 crz(0.5) q[0], q[1];
 cu1(0.5) q[0], q[1];
 )qasm",
-                                             strict));
-  EXPECT_FALSE(oq3::frontend::analyzeOpenQASM(R"qasm(
+                                                  strict));
+  EXPECT_FALSE(openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit[2] q;
 cu1(0.5) q[0], q[1];
 )qasm",
-                                              strict));
-  EXPECT_FALSE(oq3::frontend::analyzeOpenQASM(R"qasm(
+                                                   strict));
+  EXPECT_FALSE(openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 include "qelib1.inc";
 qubit[2] q;
 swap q[0], q[1];
 )qasm",
-                                              strict));
+                                                   strict));
 }
 
 TEST(OpenQASMFrontendTest, AcceptsHybridOpenQASM2Libraries) {
-  const auto strict = oq3::frontend::GatePolicy::Strict;
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(R"qasm(
+  const auto strict = openqasm::frontend::GatePolicy::Strict;
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 2.0;
 include "stdgates.inc";
 qreg q[1];
 sx q[0];
 )qasm",
-                                             strict));
+                                                  strict));
 }
 
 TEST(OpenQASMFrontendTest, StrictPolicyAllowsUserDefinedGateNames) {
@@ -440,8 +440,8 @@ gate x q {
 qubit q;
 x q;
 )qasm";
-  const auto strict = oq3::frontend::GatePolicy::Strict;
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(source, strict));
+  const auto strict = openqasm::frontend::GatePolicy::Strict;
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(source, strict));
 }
 
 TEST(OpenQASMFrontendTest, RequiresGateDefinitionScopes) {
@@ -449,7 +449,7 @@ TEST(OpenQASMFrontendTest, RequiresGateDefinitionScopes) {
 OPENQASM 3.1;
 gate unbraced q x q;
 )qasm";
-  auto parsed = oq3::frontend::parseOpenQASM(source);
+  auto parsed = openqasm::frontend::parseOpenQASM(source);
   ASSERT_FALSE(parsed);
   ASSERT_FALSE(parsed.diagnostics.empty());
   EXPECT_NE(parsed.diagnostics.front().message.find("expected '{'"),
@@ -466,17 +466,18 @@ gate trailing(theta,) control, target, {
 qubit[2] q;
 trailing(0.5) q[0], q[1];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
 TEST(OpenQASMFrontendTest, CanonicalGateNamesRoundTripThroughTheCatalog) {
-  for (const auto& entry : oq3::frontend::getGateCatalog()) {
-    const auto& descriptor = qc::getStandardGateDescriptor(entry.lowering);
-    const auto canonicalName = oq3::frontend::canonicalGateName(entry.lowering);
-    const auto* canonicalEntry = oq3::frontend::lookupGate(canonicalName);
+  for (const auto& entry : openqasm::frontend::getGateCatalog()) {
+    const auto& descriptor = qc::getStandardGateDescriptor(entry.gate);
+    const auto canonicalName =
+        openqasm::frontend::canonicalGateName(entry.gate);
+    const auto* canonicalEntry = openqasm::frontend::lookupGate(canonicalName);
     ASSERT_NE(canonicalEntry, nullptr) << canonicalName.str();
-    EXPECT_EQ(canonicalEntry->lowering, entry.lowering) << entry.name.str();
+    EXPECT_EQ(canonicalEntry->gate, entry.gate) << entry.name.str();
     EXPECT_EQ(canonicalEntry->parameterCount, descriptor.parameterCount)
         << entry.name.str();
     EXPECT_EQ(canonicalEntry->controlCount, descriptor.controlCount)
@@ -494,7 +495,7 @@ TEST(OpenQASMFrontendTest, RestrictsMathBuiltinsOnGateAngles) {
        }) {
     const auto source = "OPENQASM 3.1; gate invalid(theta) q { rx(" +
                         function.str() + "(theta)) q; }";
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed) << function.str();
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find("angle"),
@@ -504,11 +505,11 @@ TEST(OpenQASMFrontendTest, RestrictsMathBuiltinsOnGateAngles) {
 }
 
 TEST(OpenQASMFrontendTest, AcceptsLogAndRejectsLnBuiltInSpelling) {
-  auto log = oq3::frontend::analyzeOpenQASM(
+  auto log = openqasm::frontend::analyzeOpenQASM(
       "OPENQASM 3.1; const float value = log(2.0);");
   ASSERT_TRUE(log) << log.diagnostics.front().message;
 
-  auto nonstandardLn = oq3::frontend::parseOpenQASM(
+  auto nonstandardLn = openqasm::frontend::parseOpenQASM(
       "OPENQASM 3.1; const float value = ln(2.0);");
   ASSERT_FALSE(nonstandardLn);
   ASSERT_FALSE(nonstandardLn.diagnostics.empty());
@@ -536,7 +537,8 @@ bit[2] c;
 if (c >= 1) { x q; }
 )qasm";
 
-  auto uninitializedOutput = oq3::frontend::analyzeOpenQASM(unmeasuredOutput);
+  auto uninitializedOutput =
+      openqasm::frontend::analyzeOpenQASM(unmeasuredOutput);
   ASSERT_FALSE(uninitializedOutput);
   ASSERT_FALSE(uninitializedOutput.diagnostics.empty());
   EXPECT_NE(uninitializedOutput.diagnostics.front().message.find(
@@ -544,7 +546,7 @@ if (c >= 1) { x q; }
             std::string::npos);
 
   auto uninitializedCondition =
-      oq3::frontend::analyzeOpenQASM(unmeasuredCondition);
+      openqasm::frontend::analyzeOpenQASM(unmeasuredCondition);
   ASSERT_FALSE(uninitializedCondition);
   ASSERT_FALSE(uninitializedCondition.diagnostics.empty());
   EXPECT_NE(uninitializedCondition.diagnostics.front().message.find(
@@ -552,7 +554,7 @@ if (c >= 1) { x q; }
             std::string::npos);
 
   auto uninitializedRegister =
-      oq3::frontend::analyzeOpenQASM(unmeasuredRegisterCondition);
+      openqasm::frontend::analyzeOpenQASM(unmeasuredRegisterCondition);
   ASSERT_FALSE(uninitializedRegister);
   ASSERT_FALSE(uninitializedRegister.diagnostics.empty());
   EXPECT_NE(uninitializedRegister.diagnostics.front().message.find(
@@ -562,7 +564,7 @@ if (c >= 1) { x q; }
 
 TEST(OpenQASMFrontendTest, RejectsUninitializedScalarOutputs) {
   auto analyzed =
-      oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; output int result;");
+      openqasm::frontend::analyzeOpenQASM("OPENQASM 3.1; output int result;");
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("Output scalar 'result'"),
@@ -577,7 +579,7 @@ gate recursive q {
 }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_EQ(analyzed.diagnostics.size(), 1);
   EXPECT_EQ(analyzed.diagnostics.front().message,
@@ -613,7 +615,7 @@ int d = 3;
 mcx q[a], q[b], q[c], q[d];
 )qasm";
 
-  auto zeroControlResult = oq3::frontend::analyzeOpenQASM(zeroControl);
+  auto zeroControlResult = openqasm::frontend::analyzeOpenQASM(zeroControl);
   ASSERT_FALSE(zeroControlResult);
   ASSERT_FALSE(zeroControlResult.diagnostics.empty());
   EXPECT_NE(
@@ -621,7 +623,7 @@ mcx q[a], q[b], q[c], q[d];
       std::string::npos);
 
   auto mismatchedBroadcastResult =
-      oq3::frontend::analyzeOpenQASM(mismatchedBroadcast);
+      openqasm::frontend::analyzeOpenQASM(mismatchedBroadcast);
   ASSERT_FALSE(mismatchedBroadcastResult);
   ASSERT_FALSE(mismatchedBroadcastResult.diagnostics.empty());
   EXPECT_NE(
@@ -629,7 +631,7 @@ mcx q[a], q[b], q[c], q[d];
       std::string::npos);
 
   auto overflowingControlCountResult =
-      oq3::frontend::analyzeOpenQASM(overflowingControlCount);
+      openqasm::frontend::analyzeOpenQASM(overflowingControlCount);
   ASSERT_FALSE(overflowingControlCountResult);
   ASSERT_FALSE(overflowingControlCountResult.diagnostics.empty());
   EXPECT_NE(overflowingControlCountResult.diagnostics.front().message.find(
@@ -637,7 +639,7 @@ mcx q[a], q[b], q[c], q[d];
             std::string::npos);
 
   auto excessiveDispatch =
-      oq3::frontend::analyzeOpenQASM(excessiveDynamicDispatch);
+      openqasm::frontend::analyzeOpenQASM(excessiveDynamicDispatch);
   EXPECT_TRUE(excessiveDispatch);
 }
 
@@ -660,9 +662,9 @@ TEST(OpenQASMFrontendTest, RejectsMutableGlobalCapturesInGateBodies) {
       });
   for (const auto& [name, source] : fixtures) {
     SCOPED_TRACE(name.str());
-    auto parsed = oq3::frontend::parseOpenQASM(source);
+    auto parsed = openqasm::frontend::parseOpenQASM(source);
     ASSERT_TRUE(parsed) << parsed.diagnostics.front().message;
-    auto analyzed = oq3::frontend::analyzeOpenQASM(*parsed.program);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(*parsed.program);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
   }
@@ -676,7 +678,7 @@ bit[1] vector;
 vector[0] = scalar;
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_EQ(analyzed.program->registers.size(), 2);
   EXPECT_EQ(analyzed.program->registers[0].width, 1);
@@ -723,13 +725,13 @@ if (rotr(value, 1)) { x q; }
 )qasm",
   };
   for (const auto source : invalidSources) {
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     EXPECT_FALSE(analyzed) << source.str();
   }
 
-  EXPECT_FALSE(oq3::frontend::parseOpenQASM(
+  EXPECT_FALSE(openqasm::frontend::parseOpenQASM(
       "OPENQASM 3.1; bit[2] value; value = rotl(value);"));
-  EXPECT_FALSE(oq3::frontend::parseOpenQASM(
+  EXPECT_FALSE(openqasm::frontend::parseOpenQASM(
       "OPENQASM 3.1; bit[2] value; uint n = popcount(value, 1);"));
 }
 
@@ -748,7 +750,7 @@ output bit out;
 out = true;
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("uninitialized bit"),
@@ -766,7 +768,7 @@ if (target[popcount(source)]) { x q; }
 output bit out;
 out = true;
 )qasm";
-  auto preserved = oq3::frontend::analyzeOpenQASM(noMutation);
+  auto preserved = openqasm::frontend::analyzeOpenQASM(noMutation);
   EXPECT_FALSE(preserved);
 }
 
@@ -786,7 +788,7 @@ output bit out;
 out = true;
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("uninitialized bit"),
@@ -804,7 +806,7 @@ if (target[uint[2](source)]) { x q; }
 output bit out;
 out = true;
 )qasm";
-  auto preserved = oq3::frontend::analyzeOpenQASM(noMutation);
+  auto preserved = openqasm::frontend::analyzeOpenQASM(noMutation);
   EXPECT_FALSE(preserved);
 }
 
@@ -818,7 +820,7 @@ TEST(OpenQASMFrontendTest, RejectsBoolMeasurementTargetsInAllSourceModes) {
   });
   for (const auto source : sourcePrograms) {
     SCOPED_TRACE(source.str());
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find(
@@ -833,7 +835,7 @@ TEST(OpenQASMFrontendTest, RejectsBoolMeasurementTargetsInAllSourceModes) {
           "measured = measure q;\n",
           "bool-measurement.qasm"),
       llvm::SMLoc());
-  auto located = oq3::frontend::analyzeOpenQASM(sourceManager);
+  auto located = openqasm::frontend::analyzeOpenQASM(sourceManager);
   ASSERT_FALSE(located);
   ASSERT_FALSE(located.diagnostics.empty());
   EXPECT_EQ(located.diagnostics.front().location.filename,
@@ -852,7 +854,7 @@ c[i] = measure q[i];
 i = 1;
 if (c[i]) { x q[i]; }
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("uninitialized bit"),
@@ -864,7 +866,7 @@ TEST(OpenQASMFrontendTest, RejectsAConstantZeroRangeStep) {
 OPENQASM 3.1;
 for int i in [0:0:3] {}
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("must not be zero"),
@@ -872,14 +874,15 @@ for int i in [0:0:3] {}
 }
 
 TEST(OpenQASMFrontendTest, BoundsRegisterStorageBeforeAllocation) {
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; qubit[100000] q;"));
+  EXPECT_TRUE(
+      openqasm::frontend::analyzeOpenQASM("OPENQASM 3.1; qubit[100000] q;"));
 
   for (const auto* const source : {
            "OPENQASM 3.1; qubit[100001] q;",
            "OPENQASM 3.1; qubit[18446744073709551615] q;",
            "OPENQASM 3.1; qubit[60000] q; bit[40001] c;",
        }) {
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed) << source;
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find("limit"),
@@ -895,7 +898,7 @@ TEST(OpenQASMFrontendTest, BoundsExpressionAndBlockDepth) {
     flatExpression += " + 1";
   }
   flatExpression += ';';
-  auto flat = oq3::frontend::analyzeOpenQASM(flatExpression);
+  auto flat = openqasm::frontend::analyzeOpenQASM(flatExpression);
   ASSERT_FALSE(flat);
   ASSERT_FALSE(flat.diagnostics.empty());
   EXPECT_NE(flat.diagnostics.front().message.find("expression depth"),
@@ -906,7 +909,7 @@ TEST(OpenQASMFrontendTest, BoundsExpressionAndBlockDepth) {
   nestedExpression += '1';
   nestedExpression.append(257, ')');
   nestedExpression += ';';
-  auto nested = oq3::frontend::parseOpenQASM(nestedExpression);
+  auto nested = openqasm::frontend::parseOpenQASM(nestedExpression);
   ASSERT_FALSE(nested);
   ASSERT_FALSE(nested.diagnostics.empty());
   EXPECT_NE(nested.diagnostics.front().message.find("expression nesting"),
@@ -918,7 +921,7 @@ TEST(OpenQASMFrontendTest, BoundsExpressionAndBlockDepth) {
   }
   nestedBlocks += "int value = 0;";
   nestedBlocks.append(65, '}');
-  auto blocks = oq3::frontend::parseOpenQASM(nestedBlocks);
+  auto blocks = openqasm::frontend::parseOpenQASM(nestedBlocks);
   ASSERT_FALSE(blocks);
   ASSERT_FALSE(blocks.diagnostics.empty());
   EXPECT_NE(blocks.diagnostics.front().message.find("block depth"),
@@ -931,7 +934,7 @@ TEST(OpenQASMFrontendTest, BoundsModifierDepth) {
     modifiers += "ctrl @ ";
   }
   modifiers += "x q;";
-  auto parsed = oq3::frontend::parseOpenQASM(modifiers);
+  auto parsed = openqasm::frontend::parseOpenQASM(modifiers);
   ASSERT_FALSE(parsed);
   ASSERT_FALSE(parsed.diagnostics.empty());
   EXPECT_NE(parsed.diagnostics.front().message.find("modifier depth"),
@@ -945,7 +948,7 @@ TEST(OpenQASMFrontendTest, RejectsShadowingBuiltInConstants) {
       "OPENQASM 3.1; gate g(euler) q { U(euler, 0, 0) q; }",
   });
   for (const auto source : sources) {
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed) << source.str();
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find("already declared"),
@@ -964,7 +967,7 @@ if (c[i]) { x q[0]; }
 output bit result;
 result = measure q[0];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   EXPECT_NE(analyzed.diagnostics.front().message.find("uninitialized bit"),
             std::string::npos);
@@ -993,12 +996,12 @@ if (c[i]) {}
 output bit result;
 result = measure q;
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
 TEST(OpenQASMFrontendTest, DiagnosesUnselectedKnownBranches) {
-  auto analyzed = oq3::frontend::analyzeOpenQASM(R"qasm(
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 if (true) {
   int valid = 1;
@@ -1015,26 +1018,26 @@ if (true) {
 }
 
 TEST(OpenQASMFrontendTest, ActivatesStandardGatesSequentially) {
-  const auto strict = oq3::frontend::GatePolicy::Strict;
-  auto beforeInclude = oq3::frontend::analyzeOpenQASM(R"qasm(
+  const auto strict = openqasm::frontend::GatePolicy::Strict;
+  auto beforeInclude = openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 qubit q;
 x q;
 include "stdgates.inc";
 )qasm",
-                                                      strict);
+                                                           strict);
   ASSERT_FALSE(beforeInclude);
 
-  auto afterInclude = oq3::frontend::analyzeOpenQASM(R"qasm(
+  auto afterInclude = openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit q;
 x q;
 )qasm",
-                                                     strict);
+                                                          strict);
   ASSERT_TRUE(afterInclude) << afterInclude.diagnostics.front().message;
 
-  auto collision = oq3::frontend::analyzeOpenQASM(R"qasm(
+  auto collision = openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 gate x q { U(0, 0, 0) q; }
 include "stdgates.inc";
@@ -1051,7 +1054,7 @@ OPENQASM 3.1;
 qubit ;
 bit ;
 )qasm";
-  auto parsed = oq3::frontend::parseOpenQASM(source);
+  auto parsed = openqasm::frontend::parseOpenQASM(source);
   ASSERT_FALSE(parsed);
   EXPECT_EQ(parsed.diagnostics.size(), 2);
   EXPECT_EQ(parsed.diagnostics[0].location.line, 3);
@@ -1077,7 +1080,7 @@ const int integer_arithmetic =
     (1 + 2) - (3 * 1) + (8 / 2) + (5 % 2) + pow(2, 3);
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   EXPECT_TRUE(analyzed.program->body.empty());
 }
@@ -1127,7 +1130,7 @@ rx(sin(angle[4](pi / 8.0))) q;
 if (a > b && b < a && a == 7.0 * pi / 8.0) { x q; }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 
   const auto defaultStep = std::ldexp(2.0 * std::numbers::pi, -52);
@@ -1156,26 +1159,27 @@ if (a > b && b < a && a == 7.0 * pi / 8.0) { x q; }
   for (const auto statement : analyzed.program->body) {
     const auto& data = analyzed.program->statements[statement].data;
     if (const auto* application =
-            std::get_if<oq3::frontend::GateApplication>(&data);
+            std::get_if<openqasm::frontend::GateApplication>(&data);
         application != nullptr && application->callee == "rx") {
       ASSERT_LT(parameterIndex, expectedParameters.size());
       const auto& parameter =
           analyzed.program->expressions.at(application->parameters.front());
-      ASSERT_EQ(parameter.type, oq3::frontend::ScalarType::Angle);
-      const auto& value = parameter.kind == oq3::frontend::ExpressionKind::Cast
-                              ? analyzed.program->expressions.at(parameter.lhs)
-                              : parameter;
-      ASSERT_EQ(value.kind, oq3::frontend::ExpressionKind::Constant);
+      ASSERT_EQ(parameter.type, openqasm::frontend::ScalarType::Angle);
+      const auto& value =
+          parameter.kind == openqasm::frontend::ExpressionKind::Cast
+              ? analyzed.program->expressions.at(parameter.lhs)
+              : parameter;
+      ASSERT_EQ(value.kind, openqasm::frontend::ExpressionKind::Constant);
       EXPECT_DOUBLE_EQ(std::get<double>(value.constant),
                        expectedParameters[parameterIndex]);
       ++parameterIndex;
     }
     if (const auto* conditional =
-            std::get_if<oq3::frontend::IfStatement>(&data)) {
+            std::get_if<openqasm::frontend::IfStatement>(&data)) {
       const auto& condition =
           analyzed.program->conditions.at(conditional->condition);
       sawTrueCondition =
-          condition.kind == oq3::frontend::ConditionKind::Literal &&
+          condition.kind == openqasm::frontend::ConditionKind::Literal &&
           condition.literal;
     }
   }
@@ -1206,7 +1210,7 @@ TEST(OpenQASMFrontendTest, RejectsUnsupportedFixedAnglePrograms) {
 
   for (const auto source : sources) {
     SCOPED_TRACE(source.str());
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
   }
@@ -1218,7 +1222,7 @@ OPENQASM 3.1;
 const float circle = pi + tau;
 const float inverse = arccos(0.5) + arcsin(0.5) + arctan(0.5);
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   EXPECT_TRUE(analyzed.program->body.empty());
 }
@@ -1236,7 +1240,7 @@ rx(wrapped_add) q;
 if (mixed_order) { x q; }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 
   bool sawWrappedParameter = false;
@@ -1244,23 +1248,24 @@ if (mixed_order) { x q; }
   for (const auto statement : analyzed.program->body) {
     const auto& data = analyzed.program->statements[statement].data;
     if (const auto* application =
-            std::get_if<oq3::frontend::GateApplication>(&data);
+            std::get_if<openqasm::frontend::GateApplication>(&data);
         application != nullptr && application->callee == "rx") {
       ASSERT_EQ(application->parameters.size(), 1);
       const auto& parameter =
           analyzed.program->expressions[application->parameters.front()];
-      ASSERT_EQ(parameter.kind, oq3::frontend::ExpressionKind::Cast);
-      ASSERT_EQ(parameter.type, oq3::frontend::ScalarType::Angle);
+      ASSERT_EQ(parameter.kind, openqasm::frontend::ExpressionKind::Cast);
+      ASSERT_EQ(parameter.type, openqasm::frontend::ScalarType::Angle);
       const auto& operand = analyzed.program->expressions[parameter.lhs];
-      sawWrappedParameter = operand.type == oq3::frontend::ScalarType::Uint &&
-                            std::get<uint64_t>(operand.constant) == 0;
+      sawWrappedParameter =
+          operand.type == openqasm::frontend::ScalarType::Uint &&
+          std::get<uint64_t>(operand.constant) == 0;
     }
     if (const auto* conditional =
-            std::get_if<oq3::frontend::IfStatement>(&data)) {
+            std::get_if<openqasm::frontend::IfStatement>(&data)) {
       const auto& condition =
           analyzed.program->conditions[conditional->condition];
       sawFalseCondition =
-          condition.kind == oq3::frontend::ConditionKind::Literal &&
+          condition.kind == openqasm::frontend::ConditionKind::Literal &&
           !condition.literal;
     }
   }
@@ -1296,7 +1301,7 @@ if (10.0 > operand) { x q; }
 if (operand >= 9.0) { x q; }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 
   constexpr std::array<uint64_t, 8> expectedParameters{
@@ -1307,26 +1312,26 @@ if (operand >= 9.0) { x q; }
   for (const auto statement : analyzed.program->body) {
     const auto& data = analyzed.program->statements[statement].data;
     if (const auto* application =
-            std::get_if<oq3::frontend::GateApplication>(&data);
+            std::get_if<openqasm::frontend::GateApplication>(&data);
         application != nullptr && application->callee == "rx") {
       ASSERT_LT(parameterIndex, expectedParameters.size());
       ASSERT_EQ(application->parameters.size(), 1);
       const auto& parameter =
           analyzed.program->expressions[application->parameters.front()];
-      ASSERT_EQ(parameter.kind, oq3::frontend::ExpressionKind::Cast);
-      ASSERT_EQ(parameter.type, oq3::frontend::ScalarType::Angle);
+      ASSERT_EQ(parameter.kind, openqasm::frontend::ExpressionKind::Cast);
+      ASSERT_EQ(parameter.type, openqasm::frontend::ScalarType::Angle);
       const auto& operand = analyzed.program->expressions[parameter.lhs];
-      ASSERT_EQ(operand.kind, oq3::frontend::ExpressionKind::Constant);
-      ASSERT_EQ(operand.type, oq3::frontend::ScalarType::Uint);
+      ASSERT_EQ(operand.kind, openqasm::frontend::ExpressionKind::Constant);
+      ASSERT_EQ(operand.type, openqasm::frontend::ScalarType::Uint);
       EXPECT_EQ(std::get<uint64_t>(operand.constant),
                 expectedParameters[parameterIndex]);
       ++parameterIndex;
     }
     if (const auto* conditional =
-            std::get_if<oq3::frontend::IfStatement>(&data)) {
+            std::get_if<openqasm::frontend::IfStatement>(&data)) {
       const auto& condition =
           analyzed.program->conditions[conditional->condition];
-      ASSERT_EQ(condition.kind, oq3::frontend::ConditionKind::Literal);
+      ASSERT_EQ(condition.kind, openqasm::frontend::ConditionKind::Literal);
       trueConditions += static_cast<size_t>(condition.literal);
     }
   }
@@ -1356,7 +1361,7 @@ const float float_value = 4.0;
 const float float_copy = float_value;
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   EXPECT_TRUE(analyzed.program->body.empty());
 }
@@ -1397,14 +1402,14 @@ TEST(OpenQASMFrontendTest, RejectsInvalidConstInitializerPromotions) {
 
   for (const auto& promotion : promotions) {
     SCOPED_TRACE(promotion.source.str());
-    auto analyzed = oq3::frontend::analyzeOpenQASM(promotion.source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(promotion.source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find(promotion.diagnostic),
               std::string::npos);
   }
 
-  auto nonConstant = oq3::frontend::analyzeOpenQASM(
+  auto nonConstant = openqasm::frontend::analyzeOpenQASM(
       "OPENQASM 3.1; int source = 1; const int value = source;");
   ASSERT_FALSE(nonConstant);
   ASSERT_FALSE(nonConstant.diagnostics.empty());
@@ -1429,21 +1434,23 @@ rx(mutable_int + mutable_float) q;
 if (mutable_bool) { x q; }
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_GE(analyzed.program->statements.size(), 5);
 
-  const auto& declaration = std::get<oq3::frontend::ScalarDeclarationStatement>(
-      analyzed.program->statements[0].data);
+  const auto& declaration =
+      std::get<openqasm::frontend::ScalarDeclarationStatement>(
+          analyzed.program->statements[0].data);
   ASSERT_TRUE(declaration.initializer);
   EXPECT_EQ(analyzed.program->expressions[*declaration.initializer].kind,
-            oq3::frontend::ExpressionKind::Cast);
+            openqasm::frontend::ExpressionKind::Cast);
 
-  const auto& assignment = std::get<oq3::frontend::ScalarAssignmentStatement>(
-      analyzed.program->statements[4].data);
+  const auto& assignment =
+      std::get<openqasm::frontend::ScalarAssignmentStatement>(
+          analyzed.program->statements[4].data);
   ASSERT_TRUE(assignment.value);
   EXPECT_EQ(analyzed.program->expressions[*assignment.value].kind,
-            oq3::frontend::ExpressionKind::Cast);
+            openqasm::frontend::ExpressionKind::Cast);
 }
 
 TEST(OpenQASMFrontendTest, RejectsInvalidProgramsAcrossSemanticFamilies) {
@@ -1650,9 +1657,9 @@ TEST(OpenQASMFrontendTest, RejectsInvalidProgramsAcrossSemanticFamilies) {
 
   for (const auto& fixture : fixtures) {
     SCOPED_TRACE(fixture.name.str());
-    auto parsed = oq3::frontend::parseOpenQASM(fixture.source);
+    auto parsed = openqasm::frontend::parseOpenQASM(fixture.source);
     ASSERT_TRUE(parsed) << parsed.diagnostics.front().message;
-    auto analyzed = oq3::frontend::analyzeOpenQASM(*parsed.program);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(*parsed.program);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_FALSE(analyzed.diagnostics.front().message.empty());
@@ -1687,11 +1694,11 @@ output bit[2] result;
 result = measure q;
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   ASSERT_EQ(analyzed.program->outputs.size(), 1);
   EXPECT_EQ(analyzed.program->outputs.front().kind,
-            oq3::frontend::OutputKind::BitRegister);
+            openqasm::frontend::OutputKind::BitRegister);
   EXPECT_EQ(
       analyzed.program->registers[analyzed.program->outputs.front().symbol]
           .name,
@@ -1706,7 +1713,7 @@ TEST(OpenQASMFrontendTest, RejectsSignedMinimumDivisionAndModuloOverflow) {
       "const int value = minimum % -1;",
   });
   for (const auto source : sources) {
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find("overflows"),
@@ -1771,12 +1778,12 @@ output bit[4] result;
 result = measure q;
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
 TEST(OpenQASMFrontendTest, ConstantEvaluationShortCircuitsLogicalOperands) {
-  auto analyzed = oq3::frontend::analyzeOpenQASM(R"qasm(
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(R"qasm(
 OPENQASM 3.1;
 bool andValue = false && (1 / 0 == 0);
 bool orValue = true || (1 / 0 == 0);
@@ -1785,13 +1792,13 @@ bool orValue = true || (1 / 0 == 0);
   ASSERT_EQ(analyzed.program->scalars.size(), 2);
   ASSERT_EQ(analyzed.program->conditions.size(), 2);
   EXPECT_EQ(analyzed.program->conditions[0].kind,
-            oq3::frontend::ConditionKind::Literal);
+            openqasm::frontend::ConditionKind::Literal);
   EXPECT_FALSE(analyzed.program->conditions[0].literal);
   EXPECT_EQ(analyzed.program->conditions[1].kind,
-            oq3::frontend::ConditionKind::Literal);
+            openqasm::frontend::ConditionKind::Literal);
   EXPECT_TRUE(analyzed.program->conditions[1].literal);
 
-  auto invalid = oq3::frontend::analyzeOpenQASM(
+  auto invalid = openqasm::frontend::analyzeOpenQASM(
       "OPENQASM 3.1; const bool value = false && (1 / 0);");
   ASSERT_FALSE(invalid);
   ASSERT_FALSE(invalid.diagnostics.empty());
@@ -1810,7 +1817,7 @@ TEST(OpenQASMFrontendTest, RejectsMeasurementsInGeneralExpressions) {
       "OPENQASM 3.1; qubit q; bit value; value += measure q;",
   });
   for (const auto source : sources) {
-    auto parsed = oq3::frontend::parseOpenQASM(source);
+    auto parsed = openqasm::frontend::parseOpenQASM(source);
     ASSERT_FALSE(parsed) << source.str();
     ASSERT_FALSE(parsed.diagnostics.empty());
   }
@@ -1822,7 +1829,7 @@ TEST(OpenQASMFrontendTest, AcceptsMixedPhysicalAndDeclaredQubits) {
       "OPENQASM 3.1; x $0; qubit q; x q;",
   });
   for (const auto source : sources) {
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     EXPECT_TRUE(analyzed) << source.str();
   }
 }
@@ -1837,7 +1844,7 @@ qreg q[1];
 gate sx a { U(pi/2, -pi/2, pi/2) a; }
 sx q[0];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   EXPECT_TRUE(llvm::none_of(analyzed.program->gates, [](const auto& gate) {
     return gate.name == "sx";
@@ -1851,7 +1858,7 @@ include "stdgates.inc";
 qubit q;
 gate sx a { U(pi/2, -pi/2, pi/2) a; }
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("already declared"),
@@ -1869,13 +1876,13 @@ qubit q;
 r(0.5, 0.25) q;
 )qasm";
 
-  auto compatible = oq3::frontend::analyzeOpenQASM(source);
+  auto compatible = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(compatible) << compatible.diagnostics.front().message;
   EXPECT_TRUE(llvm::none_of(compatible.program->gates,
                             [](const auto& gate) { return gate.name == "r"; }));
 
-  auto strict =
-      oq3::frontend::analyzeOpenQASM(source, oq3::frontend::GatePolicy::Strict);
+  auto strict = openqasm::frontend::analyzeOpenQASM(
+      source, openqasm::frontend::GatePolicy::Strict);
   ASSERT_TRUE(strict) << strict.diagnostics.front().message;
   EXPECT_TRUE(llvm::any_of(strict.program->gates,
                            [](const auto& gate) { return gate.name == "r"; }));
@@ -1891,7 +1898,7 @@ gate r(theta, phi) q0, q1 {}
 )qasm",
   });
   for (const auto source : sources) {
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed) << source.str();
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find(
@@ -1911,7 +1918,7 @@ h q[0];
 measure q[0] -> c[0];
 if(c==1) x q[1];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
@@ -1925,11 +1932,12 @@ creg c[80];
 measure q[0] -> c[0];
 if(c==1180591620717411303433) x q[0];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   EXPECT_TRUE(
       llvm::any_of(analyzed.program->bitVectorExpressions, [](const auto& c) {
-        return c.kind == oq3::frontend::BitVectorExpressionKind::Constant &&
+        return c.kind ==
+                   openqasm::frontend::BitVectorExpressionKind::Constant &&
                c.width == 80 && c.constant[70];
       }));
 }
@@ -1942,17 +1950,17 @@ bit[2] value = measure q;
 if (uint[2](value) < -1) {}
 )qasm";
 
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   const auto comparison =
       llvm::find_if(analyzed.program->conditions, [](const auto& condition) {
-        return condition.kind == oq3::frontend::ConditionKind::Comparison;
+        return condition.kind == openqasm::frontend::ConditionKind::Comparison;
       });
   ASSERT_NE(comparison, analyzed.program->conditions.end());
   EXPECT_EQ(analyzed.program->expressions[comparison->comparisonLhs].type,
-            oq3::frontend::ScalarType::Int);
+            openqasm::frontend::ScalarType::Int);
   EXPECT_EQ(analyzed.program->expressions[comparison->comparisonRhs].type,
-            oq3::frontend::ScalarType::Int);
+            openqasm::frontend::ScalarType::Int);
 }
 
 TEST(OpenQASMFrontendTest, RejectsUnsupportedBitRegisterExpressionOperands) {
@@ -1981,7 +1989,7 @@ TEST(OpenQASMFrontendTest, RejectsUnsupportedBitRegisterExpressionOperands) {
 
   for (const auto& invalid : invalidExpressions) {
     SCOPED_TRACE(invalid.source.str());
-    auto analyzed = oq3::frontend::analyzeOpenQASM(invalid.source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(invalid.source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find(invalid.diagnostic),
@@ -2030,7 +2038,7 @@ TEST(OpenQASMFrontendTest, RejectsInvalidSizedBitRegisterCasts) {
 
   for (const auto& invalid : invalidCasts) {
     SCOPED_TRACE(invalid.source.str());
-    auto analyzed = oq3::frontend::analyzeOpenQASM(invalid.source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(invalid.source);
     ASSERT_FALSE(analyzed);
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find(invalid.diagnostic),
@@ -2050,11 +2058,12 @@ creg c[80];
 measure q[0] -> c[0];
 if(c==1_180_591_620_717_411_303_433) x q[0];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   EXPECT_TRUE(
       llvm::any_of(analyzed.program->bitVectorExpressions, [](const auto& c) {
-        return c.kind == oq3::frontend::BitVectorExpressionKind::Constant &&
+        return c.kind ==
+                   openqasm::frontend::BitVectorExpressionKind::Constant &&
                c.width == 80 && c.constant[70];
       }));
 }
@@ -2069,11 +2078,11 @@ creg c[80];
 measure q[0] -> c[0];
 if(c==123456789012345678901234567890) x q[0];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
-  const oq3::frontend::IfStatement* conditional = nullptr;
+  const openqasm::frontend::IfStatement* conditional = nullptr;
   for (const auto statement : analyzed.program->body) {
-    conditional = std::get_if<oq3::frontend::IfStatement>(
+    conditional = std::get_if<openqasm::frontend::IfStatement>(
         &analyzed.program->statements[statement].data);
     if (conditional != nullptr) {
       break;
@@ -2081,7 +2090,7 @@ if(c==123456789012345678901234567890) x q[0];
   }
   ASSERT_NE(conditional, nullptr);
   const auto& condition = analyzed.program->conditions[conditional->condition];
-  ASSERT_EQ(condition.kind, oq3::frontend::ConditionKind::Literal);
+  ASSERT_EQ(condition.kind, openqasm::frontend::ConditionKind::Literal);
   EXPECT_FALSE(condition.literal);
 }
 
@@ -2095,12 +2104,13 @@ creg c[80];
 measure q[0] -> c[0];
 if(c==1) x q[0];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
   /// Truncating to 64 bits would omit the leading zero bits.
   EXPECT_TRUE(
       llvm::any_of(analyzed.program->bitVectorExpressions, [](const auto& c) {
-        return c.kind == oq3::frontend::BitVectorExpressionKind::Constant &&
+        return c.kind ==
+                   openqasm::frontend::BitVectorExpressionKind::Constant &&
                c.constant.getBitWidth() == 80U && c.constant == 1U;
       }));
 }
@@ -2113,7 +2123,7 @@ qreg q[1];
 creg c[2];
 if(c==-1) x q[0];
 )qasm";
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_FALSE(analyzed);
   ASSERT_FALSE(analyzed.diagnostics.empty());
   EXPECT_NE(analyzed.diagnostics.front().message.find("unsigned integer"),
@@ -2126,7 +2136,7 @@ TEST(OpenQASMFrontendTest, RejectsWideIntegerLiteralInOrdinaryConstants) {
       "OPENQASM 3.1; int value = 999_999_999_999_999_999_999_999_999_999;",
   });
   for (const auto source : sources) {
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed) << source.str();
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find("exceeds 64-bit"),
@@ -2144,7 +2154,7 @@ TEST(OpenQASMFrontendTest,
       "(999999999999999999999999999999 == 0);",
   });
   for (const auto source : sources) {
-    auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+    auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
     ASSERT_FALSE(analyzed) << source.str();
     ASSERT_FALSE(analyzed.diagnostics.empty());
     EXPECT_NE(analyzed.diagnostics.front().message.find("exceeds 64-bit"),
@@ -2158,7 +2168,7 @@ TEST(OpenQASMFrontendTest, BoundsAffineProofWorkAcrossAssignments) {
   for (size_t i = 0; i < 60; ++i) {
     source += "a = a + a;";
   }
-  auto analyzed = oq3::frontend::analyzeOpenQASM(source);
+  auto analyzed = openqasm::frontend::analyzeOpenQASM(source);
   ASSERT_TRUE(analyzed) << analyzed.diagnostics.front().message;
 }
 
@@ -2169,21 +2179,22 @@ TEST(OpenQASMFrontendTest, DeduplicatesLargeStaticControlledGateOperands) {
   for (size_t i = 0; i < width; ++i) {
     source += "q[" + std::to_string(i) + "]" + (i + 1 == width ? ";" : ",");
   }
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(source));
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(source));
   source.replace(source.rfind("q["), std::string::npos, "q[0];");
-  EXPECT_FALSE(oq3::frontend::analyzeOpenQASM(source));
+  EXPECT_FALSE(openqasm::frontend::analyzeOpenQASM(source));
 }
 
 TEST(OpenQASMFrontendTest, AcceptsExactWidthBitStringsAndFloatCasts) {
-  EXPECT_TRUE(oq3::frontend::analyzeOpenQASM(
+  EXPECT_TRUE(openqasm::frontend::analyzeOpenQASM(
       "OPENQASM 3.1; bit[5] b = \"10_001\"; float f = float(int[64](1));"));
+  EXPECT_FALSE(openqasm::frontend::analyzeOpenQASM(
+      "OPENQASM 3.1; bit[4] b = \"10_001\";"));
   EXPECT_FALSE(
-      oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; bit[4] b = \"10_001\";"));
+      openqasm::frontend::analyzeOpenQASM("OPENQASM 3.1; bit[3] b = \"102\";"));
   EXPECT_FALSE(
-      oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; bit[3] b = \"102\";"));
-  EXPECT_FALSE(oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; bit b = \"_\";"));
-  EXPECT_FALSE(
-      oq3::frontend::analyzeOpenQASM("OPENQASM 3.1; float f = float[32](1);"));
+      openqasm::frontend::analyzeOpenQASM("OPENQASM 3.1; bit b = \"_\";"));
+  EXPECT_FALSE(openqasm::frontend::analyzeOpenQASM(
+      "OPENQASM 3.1; float f = float[32](1);"));
 }
 
 } // namespace

--- a/mlir/unittests/programs/qc_programs.h
+++ b/mlir/unittests/programs/qc_programs.h
@@ -193,7 +193,7 @@ Value threeQubitsOneIdentity(QCProgramBuilder& b);
 /// Creates a multi-controlled identity gate with multiple control qubits.
 Value multipleControlledIdentity(QCProgramBuilder& b);
 
-/// Creates an barrier gate on a single qubit in a two-qubit register.
+/// Creates a barrier operation on a single qubit in a two-qubit register.
 Value twoQubitsOneBarrier(QCProgramBuilder& b);
 
 /// Creates a circuit with a nested controlled identity gate.

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -156,7 +156,7 @@ class PayloadSpecification:
         """Whether optional capability metadata is complete."""
 
 class CompilerTarget:
-    """Immutable MLIR compiler target.
+    """Immutable MQT compiler target.
 
     Every target has either all-to-all or explicitly enumerated connectivity and
     either unrestricted or explicitly enumerated native-operation support.
@@ -269,7 +269,7 @@ class CompilerTarget:
 
         @staticmethod
         def variadic(minimum: int) -> CompilerTarget.OperationArity:
-            """Create an operation arity with an inclusive minimum. Operation construction requires a positive minimum."""
+            """Create an operation arity with an inclusive minimum. Capability construction requires a positive minimum."""
 
         @property
         def kind(self) -> CompilerTarget.OperationArityKind:
@@ -282,7 +282,7 @@ class CompilerTarget:
         def accepts(self, width: int) -> bool:
             """Whether this arity accepts a concrete width."""
 
-    class Operation:
+    class OperationCapability:
         """A target operation capability, calibration, and ordered applicability."""
 
         def __init__(
@@ -420,7 +420,7 @@ class CompilerTarget:
     class NativeOperations:
         """Native-operation support."""
 
-        def __init__(self, operations: Sequence[CompilerTarget.Operation]) -> None:
+        def __init__(self, operations: Sequence[CompilerTarget.OperationCapability]) -> None:
             """Create explicit native-operation support."""
 
         @staticmethod
@@ -432,7 +432,7 @@ class CompilerTarget:
             """The native-operation support model."""
 
         @property
-        def operations(self) -> list[CompilerTarget.Operation]:
+        def operations(self) -> list[CompilerTarget.OperationCapability]:
             """The explicit operations, if present."""
 
     @staticmethod
@@ -472,7 +472,7 @@ class CompilerTarget:
         """The target native-operation support model."""
 
     @property
-    def operations(self) -> list[CompilerTarget.Operation]:
+    def operations(self) -> list[CompilerTarget.OperationCapability]:
         """Operation capabilities in reported order."""
 
     @property
@@ -531,12 +531,12 @@ class QCProgram(Program):
         """Parse QC MLIR from a file."""
 
     @staticmethod
-    def from_qasm_str(source: str) -> QCProgram:
-        """Translate an OpenQASM 3 source string to QC MLIR."""
+    def from_openqasm_str(source: str) -> QCProgram:
+        """Translate supported OpenQASM to QC MLIR. Accepts versionless input and versions 2.0, 3.0, and 3.1."""
 
     @staticmethod
-    def from_qasm_file(path: str | os.PathLike) -> QCProgram:
-        """Translate an OpenQASM 3 file to QC MLIR."""
+    def from_openqasm_file(path: str | os.PathLike) -> QCProgram:
+        """Translate a supported OpenQASM file to QC MLIR. Accepts versionless input and versions 2.0, 3.0, and 3.1."""
 
     @staticmethod
     def from_qiskit(circuit: qiskit.circuit.QuantumCircuit) -> QCProgram:
@@ -576,27 +576,27 @@ class QCProgram(Program):
         """
 
     def num_gates(self) -> int:
-        """Count the gates in the program.
+        """Return the static gate count of the entry-point IR.
 
-        Any operation that implements the ``UnitaryOpInterface`` is counted. Operations
+        Any entry-point operation that implements the ``UnitaryOpInterface`` is counted. Operations
         in every structured control-flow region are counted once, regardless of how
         often the region executes. Operations within modifiers are not counted
         recursively, and barriers are skipped.
         """
 
     def num_single_qubit_gates(self) -> int:
-        """Count the single-qubit gates in the program.
+        """Return the static single-qubit gate count of the entry-point IR.
 
-        Any operation that implements the ``UnitaryOpInterface`` and acts on one qubit
+        Any entry-point operation that implements the ``UnitaryOpInterface`` and acts on one qubit
         is counted. Operations in every structured control-flow region are counted
         once, regardless of how often the region executes. Operations within modifiers
         are not counted recursively, and barriers are skipped.
         """
 
     def num_two_qubit_gates(self) -> int:
-        """Count the two-qubit gates in the program.
+        """Return the static two-qubit gate count of the entry-point IR.
 
-        Any operation that implements the ``UnitaryOpInterface`` and acts on two qubits
+        Any entry-point operation that implements the ``UnitaryOpInterface`` and acts on two qubits
         is counted. Operations in every structured control-flow region are counted
         once, regardless of how often the region executes. Operations within modifiers
         are not counted recursively, and barriers are skipped.
@@ -671,7 +671,7 @@ class QCOProgram(Program):
         """
 
     def to_jeff(self, *, copy: bool = False) -> JeffProgram:
-        """Serialize this program as ``jeff``.
+        """Convert this program to ``jeff`` MLIR.
 
         Set ``copy=True`` to preserve it.
         """
@@ -728,7 +728,7 @@ class QCOProgram(Program):
         """
 
 class JeffProgram(Program):
-    """A serialized ``jeff`` compiler program.
+    """A serializable compiler program in the ``jeff`` dialect.
 
     ``jeff`` programs can be stored as bytes or files and converted back to QCO for
     further compilation.
@@ -755,7 +755,7 @@ class JeffProgram(Program):
         """Write this program to a ``jeff`` file."""
 
     def to_qco(self, *, copy: bool = False) -> QCOProgram:
-        """Deserialize this program to QCO.
+        """Convert this program to QCO.
 
         Set ``copy=True`` to preserve it.
         """
@@ -858,7 +858,7 @@ def sample(
     shots: int = 1024,
     seed: int = 0,
 ) -> dict[str, int]:
-    """Sample a supported input after lowering it directly to QCO.
+    """Sample a supported input after translating or converting it to QCO.
 
     An existing QCO program is used without copying. See
     {py:meth}`QCOProgram.sample` for the shot, seed, histogram, and error

--- a/src/qdmi/devices/dd/Device.cpp
+++ b/src/qdmi/devices/dd/Device.cpp
@@ -185,7 +185,7 @@ constexpr std::array SUPPORTED_PROGRAM_FORMATS = {
 
 [[nodiscard]] auto parseQASMToQCO(const std::string_view source)
     -> std::optional<mlir::QCOProgram> {
-  auto qcProgram = mlir::QCProgram::fromQASMString(source);
+  auto qcProgram = mlir::QCProgram::fromOpenQASMString(source);
   if (!qcProgram) {
     return std::nullopt;
   }

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -155,6 +155,19 @@ def test_compile_program_mlir_string_with_leading_whitespace() -> None:
     assert result.ir.startswith("module")
 
 
+@pytest.mark.parametrize("version_header", ["", "OPENQASM 2.0;", "OPENQASM 3.0;", "OPENQASM 3.1;"])
+def test_openqasm_import_versions(version_header: str, tmp_path: Path) -> None:
+    """Both OpenQASM factories accept every supported version."""
+    source = f'{version_header}\ninclude "qelib1.inc"; qreg q[1]; h q[0];'
+    path = tmp_path / "program.qasm"
+    path.write_text(source, encoding="utf-8")
+
+    for program in (QCProgram.from_openqasm_str(source), QCProgram.from_openqasm_file(path)):
+        assert program.is_valid
+        assert program.num_gates() == 1
+        assert compile_program(program, output=OutputFormat.QCO).is_valid
+
+
 def test_compile_program_mlir_file(tmp_path: Path) -> None:
     """Compile a ``.mlir`` file."""
     path = tmp_path / "program.mlir"
@@ -255,7 +268,7 @@ def test_jeff_program_round_trip(tmp_path: Path) -> None:
 
 
 def test_compile_program_jeff_input_runs_from_qco(tmp_path: Path) -> None:
-    """Compile a serialized Jeff program through the QCO pipeline entry point."""
+    """Compile a serialized jeff program through the QCO pipeline entry point."""
     path = tmp_path / "program.jeff"
     compile_program(QASM_STRING, output=OutputFormat.JEFF).write(path)
 
@@ -267,7 +280,7 @@ def test_compile_program_jeff_input_runs_from_qco(tmp_path: Path) -> None:
 
 def test_program_conversions_are_composable() -> None:
     """Compose frontend, cleanup, conversion, and optimization stages."""
-    source = QCProgram.from_qasm_str(QASM_STRING)
+    source = QCProgram.from_openqasm_str(QASM_STRING)
     qco = source.to_qco(copy=True)
     assert source.is_valid
     assert isinstance(qco, QCOProgram)
@@ -282,7 +295,7 @@ def test_program_conversions_are_composable() -> None:
 
 def test_openqasm_program_direct_and_pipeline_output(tmp_path: Path) -> None:
     """Emit OpenQASM directly from QC and through the optimized pipeline."""
-    source = QCProgram.from_qasm_str(QASM_STRING)
+    source = QCProgram.from_openqasm_str(QASM_STRING)
     direct = source.to_openqasm3()
 
     assert isinstance(direct, OpenQASMProgram)
@@ -293,12 +306,12 @@ def test_openqasm_program_direct_and_pipeline_output(tmp_path: Path) -> None:
     path = tmp_path / "program.qasm"
     direct.write(path)
     assert path.read_text(encoding="utf-8") == direct.source
-    _assert_bell_program(QCProgram.from_qasm_file(path), measured=True)
+    _assert_bell_program(QCProgram.from_openqasm_file(path), measured=True)
 
     optimized = compile_program(QASM_STRING, output=OutputFormat.OPENQASM3)
     assert isinstance(optimized, OpenQASMProgram)
     assert "output bit[2] c;" in optimized.source
-    _assert_bell_program(QCProgram.from_qasm_str(optimized.source), measured=True)
+    _assert_bell_program(QCProgram.from_openqasm_str(optimized.source), measured=True)
 
     imported = compile_program(direct, output=OutputFormat.QC_IMPORT)
     assert isinstance(imported, QCProgram)
@@ -334,7 +347,7 @@ def test_openqasm_helper_gate_matrix(gate: Gate) -> None:
     circuit.append(gate, range(gate.num_qubits))
 
     source = QCProgram.from_qiskit(circuit).to_openqasm3().source
-    round_tripped = QCProgram.from_qasm_str(source).to_qiskit()
+    round_tripped = QCProgram.from_openqasm_str(source).to_qiskit()
 
     assert np.allclose(Operator(round_tripped).data, Operator(circuit).data)
 
@@ -362,7 +375,7 @@ def test_qir_program_writes_bitcode(tmp_path: Path) -> None:
 
 def test_compile_program_output_format_convert_to_qir() -> None:
     """Lower a QC program directly to the QIR Adaptive Profile."""
-    result = QCProgram.from_qasm_str(QASM_STRING).to_qir(QIRProfile.ADAPTIVE)
+    result = QCProgram.from_openqasm_str(QASM_STRING).to_qir(QIRProfile.ADAPTIVE)
 
     assert isinstance(result, QIRProgram)
     assert result.profile == QIRProfile.ADAPTIVE
@@ -463,9 +476,9 @@ def test_qco_program_compiles_for_direct_sparse_target() -> None:
         [CompilerTarget.Site(10), CompilerTarget.Site(20)],
         connectivity=CompilerTarget.Connectivity([(10, 20)]),
         native_operations=CompilerTarget.NativeOperations([
-            CompilerTarget.Operation("u", 1, 3),
-            CompilerTarget.Operation("cz", 2, 0),
-            CompilerTarget.Operation("measure", 1, 0),
+            CompilerTarget.OperationCapability("u", 1, 3),
+            CompilerTarget.OperationCapability("cz", 2, 0),
+            CompilerTarget.OperationCapability("measure", 1, 0),
         ]),
     )
     assert target.name == "sparse target"
@@ -495,10 +508,10 @@ def test_target_compiles_single_qubit_gates_without_entangler(num_sites: int) ->
         num_sites,
         connectivity=CompilerTarget.Connectivity.all_to_all(),
         native_operations=CompilerTarget.NativeOperations([
-            CompilerTarget.Operation("sx", 1, 0),
-            CompilerTarget.Operation("x", 1, 0),
-            CompilerTarget.Operation("rz", 1, 1),
-            CompilerTarget.Operation("gphase", 0, 1),
+            CompilerTarget.OperationCapability("sx", 1, 0),
+            CompilerTarget.OperationCapability("x", 1, 0),
+            CompilerTarget.OperationCapability("rz", 1, 1),
+            CompilerTarget.OperationCapability("gphase", 0, 1),
         ]),
     )
     assert target.synthesis_basis is not None
@@ -571,7 +584,7 @@ def test_qco_qiskit_export_preserves_program() -> None:
 @pytest.mark.parametrize("action", ["copy", "cleanup", "compile", "compile_inplace"])
 def test_consumed_program_operations_raise(kind: str, action: str) -> None:
     """Report consumed program use as a Python exception across binding paths."""
-    program: QCProgram | QCOProgram | JeffProgram = QCProgram.from_qasm_str(QASM_STRING)
+    program: QCProgram | QCOProgram | JeffProgram = QCProgram.from_openqasm_str(QASM_STRING)
     if kind != "qc":
         program = program.to_qco()
         if kind == "jeff":
@@ -594,7 +607,7 @@ def test_consumed_program_operations_raise(kind: str, action: str) -> None:
 
 def test_consumed_jeff_write_raises(tmp_path: Path) -> None:
     """Guard const member adapters before entering the native writer."""
-    program = QCProgram.from_qasm_str(QASM_STRING).to_qco().to_jeff()
+    program = QCProgram.from_openqasm_str(QASM_STRING).to_qco().to_jeff()
     program.to_qco()
     with pytest.raises(RuntimeError, match="already been consumed"):
         program.write(tmp_path / "consumed.jeff")
@@ -603,7 +616,7 @@ def test_consumed_jeff_write_raises(tmp_path: Path) -> None:
 @pytest.mark.parametrize("capability_id", [None, "forward-branching-typo"])
 def test_target_compilation_preserves_diagnostics(capability_id: str | None, capfd: pytest.CaptureFixture[str]) -> None:
     """Keep native control-flow legality errors in the Python exception."""
-    program = QCProgram.from_qasm_str("""OPENQASM 3.0;
+    program = QCProgram.from_openqasm_str("""OPENQASM 3.0;
 include "stdgates.inc";
 qubit q;
 bit c;
@@ -643,7 +656,7 @@ def test_compiler_target_constructors_preserve_python_api() -> None:
         CompilerTarget.Site(20, "q1"),
     ]
     site_tuple = CompilerTarget.SiteTuple([10, 20], duration=10, fidelity=0.99)
-    operation = CompilerTarget.Operation(
+    operation = CompilerTarget.OperationCapability(
         "cx",
         2,
         0,
@@ -653,8 +666,8 @@ def test_compiler_target_constructors_preserve_python_api() -> None:
     )
     fixed_zero = CompilerTarget.OperationArity.fixed(0)
     variadic = CompilerTarget.OperationArity.variadic(2)
-    global_phase = CompilerTarget.Operation("gphase", fixed_zero, 1)
-    multi_controlled_x = CompilerTarget.Operation("x", variadic, 0)
+    global_phase = CompilerTarget.OperationCapability("gphase", fixed_zero, 1)
+    multi_controlled_x = CompilerTarget.OperationCapability("x", variadic, 0)
     connectivity = CompilerTarget.Connectivity.all_to_all()
     unrestricted = CompilerTarget.NativeOperations.unrestricted()
 
@@ -687,7 +700,7 @@ def test_compiler_target_constructors_preserve_python_api() -> None:
     assert site_tuple.sites == [10, 20]
     assert len(operation.site_tuples) == 1
     assert operation.site_tuples[0].sites == [10, 20]
-    assert not CompilerTarget.Operation("x", 1, 0).site_tuples
+    assert not CompilerTarget.OperationCapability("x", 1, 0).site_tuples
     assert targets[0].supports_operation("ecr", 2, sites=[0, 1])
     assert not targets[2].supports_operation("ecr", 2, sites=[10, 20])
     assert targets[2].supports_operation("cx", 2, sites=[10, 20])
@@ -709,7 +722,7 @@ def test_compiler_target_constructors_preserve_python_api() -> None:
 @pytest.mark.parametrize("arity", [2, CompilerTarget.OperationArity.fixed(2)])
 def test_compiler_target_accepts_plain_site_tuples(arity: int | CompilerTarget.OperationArity) -> None:
     """Mix plain placements and calibrated tuples without widening support."""
-    operation = CompilerTarget.Operation(
+    operation = CompilerTarget.OperationCapability(
         "cx", arity, 0, site_tuples=[(1, 0), [1, 2], CompilerTarget.SiteTuple([2, 0], fidelity=0.99)]
     )
     target = CompilerTarget(
@@ -722,7 +735,7 @@ def test_compiler_target_accepts_plain_site_tuples(arity: int | CompilerTarget.O
     assert target.supports_operation("cx", 2, sites=[1, 0])
     assert not target.supports_operation("cx", 2, sites=[0, 1])
     with pytest.raises(ValueError, match="site tuple does not match its arity"):
-        CompilerTarget.Operation("cx", arity, 0, site_tuples=[(0,)])
+        CompilerTarget.OperationCapability("cx", arity, 0, site_tuples=[(0,)])
 
 
 def test_payload_specification_preserves_python_api() -> None:
@@ -802,23 +815,23 @@ def test_compiler_target_construction_preserves_validation_errors() -> None:
     with pytest.raises(ValueError, match="duration unit must not be empty"):
         CompilerTarget.DurationUnit("", 1.0)
     with pytest.raises(ValueError, match="zero-arity operation cannot contain site tuples"):
-        CompilerTarget.Operation(
+        CompilerTarget.OperationCapability(
             "gphase",
             CompilerTarget.OperationArity.fixed(0),
             1,
             site_tuples=[CompilerTarget.SiteTuple([])],
         )
     with pytest.raises(ValueError, match="variadic minimum must be positive"):
-        CompilerTarget.Operation("x", CompilerTarget.OperationArity.variadic(0), 0)
+        CompilerTarget.OperationCapability("x", CompilerTarget.OperationArity.variadic(0), 0)
     with pytest.raises(ValueError, match="variadic operation cannot contain site tuples"):
-        CompilerTarget.Operation(
+        CompilerTarget.OperationCapability(
             "x",
             CompilerTarget.OperationArity.variadic(2),
             0,
             site_tuples=[CompilerTarget.SiteTuple([0, 1])],
         )
     with pytest.raises(ValueError, match="site tuple does not match its arity"):
-        CompilerTarget.Operation("cx", 2, 0, site_tuples=[CompilerTarget.SiteTuple([0])])
+        CompilerTarget.OperationCapability("cx", 2, 0, site_tuples=[CompilerTarget.SiteTuple([0])])
 
 
 def test_compiler_target_snapshots_qdmi_device(garnet_target: CompilerTarget) -> None:
@@ -910,7 +923,7 @@ def test_qco_program_runs_textual_pipeline() -> None:
     qco.run_pass_pipeline("mqt-qco-default")
     qco.lift_hadamards()
 
-    with pytest.raises(RuntimeError, match="MLIR operation failed"):
+    with pytest.raises(RuntimeError, match="Compiler action failed"):
         qco.run_pass_pipeline("not-a-pass")
 
 
@@ -1021,7 +1034,7 @@ def test_qco_program_decomposes_multi_controlled(gate: str) -> None:
     assert qco.ir != before
     assert "controls_out:2" not in qco.ir
 
-    with pytest.raises(RuntimeError, match="MLIR operation failed"):
+    with pytest.raises(RuntimeError, match="Compiler action failed"):
         qco.decompose_multi_controlled(min_qubits=2)
 
 
@@ -1033,7 +1046,7 @@ def test_compile_program_fails_for_missing_file() -> None:
 
 def test_qc_program_num_gates() -> None:
     """Expose gate counts to Python."""
-    program = QCProgram.from_qasm_str(QASM_STRING)
+    program = QCProgram.from_openqasm_str(QASM_STRING)
     assert program.num_gates() == 2
     assert program.num_single_qubit_gates() == 1
     assert program.num_two_qubit_gates() == 1
@@ -1078,7 +1091,7 @@ def test_native_compilation_releases_gil(tmp_path: Path, mode: str) -> None:
                 compile_program(program, target=target, program_format=ProgramFormat.QASM3)
             else:
                 # Parsing fails before the compilation release scope can be reached.
-                with pytest.raises(RuntimeError, match="MLIR operation failed"):
+                with pytest.raises(RuntimeError, match="Compiler action failed"):
                     compile_program(path if mode == "path" else invalid_source, output=OutputFormat.QCO)
             if progress.is_set():
                 break

--- a/test/python/test_mlir_integer_interchange.py
+++ b/test/python/test_mlir_integer_interchange.py
@@ -51,7 +51,7 @@ def _observe(program: QCProgram, width: int) -> int:
 
 def _check_paths(program: QCProgram, width: int, expected: int) -> None:
     assert _observe(program, width) == expected
-    restored_qasm = QCProgram.from_qasm_str(program.to_openqasm3().source)
+    restored_qasm = QCProgram.from_openqasm_str(program.to_openqasm3().source)
     assert _observe(restored_qasm, width) == expected
     jeff = program.to_qco(copy=True).to_jeff()
     restored_jeff = JeffProgram.from_bytes(jeff.to_bytes()).to_qco().to_qc()
@@ -146,7 +146,7 @@ def test_source_zero_filling_shifts(width: int, *, runtime: bool, direction: str
     distances = [0, width - 1, width, 256]
     for distance in distances:
         amount = "uint[16](distance)" if runtime else str(distance)
-        program = QCProgram.from_qasm_str(f"""
+        program = QCProgram.from_openqasm_str(f"""
 OPENQASM 3.0;
 include "stdgates.inc";
 qubit q;
@@ -242,7 +242,7 @@ def test_integer_intrinsics(width: int, operation: str) -> None:
 def test_narrow_unsigned_comparison_promotes(*, runtime: bool) -> None:
     """Constant analysis and runtime analysis use the same integer promotion."""
     operand = "uint[3](input_bits)" if runtime else "uint[3](7)"
-    program = QCProgram.from_qasm_str(f"""
+    program = QCProgram.from_openqasm_str(f"""
 OPENQASM 3.0;
 include "stdgates.inc";
 qubit q;
@@ -257,7 +257,7 @@ result = bit[1](uint[1]({operand} > -1));
 @pytest.mark.parametrize("literal", ["255", "-1"])
 def test_constant_integer_casts_truncate(literal: str) -> None:
     """Explicit narrowing also applies before any runtime IR is produced."""
-    program = QCProgram.from_qasm_str(f"""
+    program = QCProgram.from_openqasm_str(f"""
 OPENQASM 3.0;
 include "stdgates.inc";
 qubit q;
@@ -287,5 +287,5 @@ def test_jeff_rejects_wider_general_integer_expressions() -> None:
         65,
         1,
     )
-    with pytest.raises(RuntimeError, match="MLIR operation failed"):
+    with pytest.raises(RuntimeError, match="Compiler action failed"):
         program.to_qco().to_jeff()

--- a/test/python/test_mlir_loops.py
+++ b/test/python/test_mlir_loops.py
@@ -48,7 +48,7 @@ def check_paths(program: QCProgram, expected: int) -> None:
     assert observe(program) == expected
     source = program.to_openqasm3().source
     assert source == program.to_openqasm3().source
-    assert observe(QCProgram.from_qasm_str(source)) == expected
+    assert observe(QCProgram.from_openqasm_str(source)) == expected
     qiskit = program.to_qiskit()
     # Each export owns fresh native variables; their serialized structure is stable.
     assert qasm3.dumps(qiskit) == qasm3.dumps(program.to_qiskit())
@@ -57,7 +57,7 @@ def check_paths(program: QCProgram, expected: int) -> None:
     restored = JeffProgram.from_bytes(jeff.to_bytes()).to_qco().to_qc()
     assert observe(restored) == expected
     assert observe(QCProgram.from_qiskit(restored.to_qiskit())) == expected
-    assert observe(QCProgram.from_qasm_str(restored.to_openqasm3().source)) == expected
+    assert observe(QCProgram.from_openqasm_str(restored.to_openqasm3().source)) == expected
     assert program.ir == original
 
 
@@ -84,7 +84,7 @@ def test_do_while_round_trip(iterations: int) -> None:
     imported = QCProgram.from_qiskit(restored)
     assert imported.ir.count("scf.while") == 1
     assert "scf.if" not in imported.ir
-    qasm = QCProgram.from_qasm_str(program.to_openqasm3().source)
+    qasm = QCProgram.from_openqasm_str(program.to_openqasm3().source)
     assert qasm.ir.count("scf.while") == 1
     assert "scf.if" not in qasm.ir
     check_paths(program, iterations % 2)
@@ -92,7 +92,7 @@ def test_do_while_round_trip(iterations: int) -> None:
 
 def test_general_while_preserves_after_region_global_phase() -> None:
     """A general while loop applies its after-region phase only while continuing."""
-    program = QCProgram.from_qasm_str("""
+    program = QCProgram.from_openqasm_str("""
 OPENQASM 3.1;
 include "stdgates.inc";
 qubit q;
@@ -147,7 +147,7 @@ module {{
     if stale:
         with pytest.raises(RuntimeError, match="stale classical snapshot"):
             program.to_qiskit()
-        assert observe(QCProgram.from_qasm_str(program.to_openqasm3().source)) == 1 << 64
+        assert observe(QCProgram.from_openqasm_str(program.to_openqasm3().source)) == 1 << 64
     else:
         check_paths(program, (1 << 64) | 1)
         assert program.to_qiskit().num_clbits == 65
@@ -203,7 +203,7 @@ module {
 @pytest.mark.parametrize(("condition", "expected"), [("false", 250), ("true", 4)])
 def test_zero_iterations_and_narrow_overflow(condition: str, expected: int) -> None:
     """The initial value survives a zero-trip loop and i8 addition wraps."""
-    program = QCProgram.from_qasm_str(f"""
+    program = QCProgram.from_openqasm_str(f"""
 OPENQASM 3.1;
 output bit[8] result;
 uint[8] value = 250;
@@ -218,7 +218,7 @@ result = bit[8](value);
 
 def test_for_continue_does_not_wrap_induction() -> None:
     """A singleton range stops before its positive step can overflow."""
-    program = QCProgram.from_qasm_str("""
+    program = QCProgram.from_openqasm_str("""
 OPENQASM 3.1;
 output bit[8] result;
 uint[8] iterations = 0;
@@ -233,7 +233,7 @@ result = bit[8](iterations);
 
 def test_nested_breaks_and_switches() -> None:
     """An inner break cannot escape an outer iteration or run its tail."""
-    program = QCProgram.from_qasm_str("""
+    program = QCProgram.from_openqasm_str("""
 OPENQASM 3.1;
 output bit[8] result;
 uint[8] value = 0;
@@ -270,7 +270,7 @@ def test_qiskit_for_jump(indexset: range | list[int], jump: str) -> None:
 @pytest.mark.parametrize("extra_cases", ["", "case -1, 4294967296 { value += 100; break; }"])
 def test_continue_in_nested_loop_and_switch(extra_cases: str) -> None:
     """Continue targets the inner loop and break still skips its remaining iterations."""
-    program = QCProgram.from_qasm_str(
+    program = QCProgram.from_openqasm_str(
         """
 OPENQASM 3.1;
 output bit[8] result;
@@ -311,7 +311,7 @@ def test_qiskit_while_continue() -> None:
 def test_invalid_loop_jump_placement(source: str) -> None:
     """The source diagnostic distinguishes an invalid break from export limits."""
     with pytest.raises((ValueError, RuntimeError)):
-        QCProgram.from_qasm_str("OPENQASM 3.1; " + source)
+        QCProgram.from_openqasm_str("OPENQASM 3.1; " + source)
 
 
 def test_qiskit_uninitialized_local() -> None:
@@ -391,7 +391,7 @@ module {
 
 def test_initialization_on_first_body_and_multiple_exits() -> None:
     """The first body initializes every exit, while unreachable tails do not merge."""
-    program = QCProgram.from_qasm_str("""
+    program = QCProgram.from_openqasm_str("""
 OPENQASM 3.1;
 output bit[8] result;
 uint[8] value;
@@ -416,7 +416,7 @@ result = bit[8](value);
     circuit.measure(0, 0)
     check_paths(QCProgram.from_qiskit(circuit), 1)
     with pytest.raises((ValueError, RuntimeError)):
-        QCProgram.from_qasm_str("""
+        QCProgram.from_openqasm_str("""
 OPENQASM 3.1;
 output bit result;
 bool value;
@@ -490,7 +490,7 @@ module {
 
 def test_loop_resource_allocation_is_rejected_at_import(capfd: pytest.CaptureFixture[str]) -> None:
     """Reject loop-local quantum allocations when constructing the program."""
-    with pytest.raises(RuntimeError, match="MLIR operation failed"):
+    with pytest.raises(RuntimeError, match="Compiler action failed"):
         QCProgram.from_mlir_str("""
 module {
   func.func @main() attributes {mqt.entry_point} {
@@ -514,7 +514,7 @@ module {
 
 def test_first_measurement_initializes_do_while_output() -> None:
     """A measurement in the guaranteed first body defines both its test and output."""
-    program = QCProgram.from_qasm_str("""
+    program = QCProgram.from_openqasm_str("""
 OPENQASM 3.1;
 qubit q;
 output bit result;

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -250,8 +250,8 @@ def test_two_qubit_dense_unitary_compiles_to_target_basis() -> None:
         2,
         connectivity=CompilerTarget.Connectivity.all_to_all(),
         native_operations=CompilerTarget.NativeOperations([
-            CompilerTarget.Operation("u", 1, 3),
-            CompilerTarget.Operation("cx", 2, 0),
+            CompilerTarget.OperationCapability("u", 1, 3),
+            CompilerTarget.OperationCapability("cx", 2, 0),
         ]),
     )
     program = QCProgram.from_qiskit(circuit).to_qco(copy=True)
@@ -517,7 +517,7 @@ def test_flat_circuit_round_trip_preserves_supported_metadata() -> None:
 
 def test_openqasm2_measurements_export_with_zero_initialized_register() -> None:
     """Export an OpenQASM 2 zero-initialized result register."""
-    program = QCProgram.from_qasm_str(
+    program = QCProgram.from_openqasm_str(
         """OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[2];
@@ -577,7 +577,7 @@ def test_target_compiled_openqasm2_measurements_export() -> None:
         connectivity=CompilerTarget.Connectivity.all_to_all(),
         native_operations=CompilerTarget.NativeOperations.unrestricted(),
     )
-    program = QCProgram.from_qasm_str(
+    program = QCProgram.from_openqasm_str(
         """OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[2];
@@ -601,7 +601,7 @@ measure q[0] -> c[1];
 
 def test_cleanup_forwards_measurement_results_to_qiskit_condition() -> None:
     """Export a condition after cleanup forwards its measurement loads."""
-    program = QCProgram.from_qasm_str(
+    program = QCProgram.from_openqasm_str(
         """OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[3];
@@ -625,7 +625,7 @@ if (c == 3) x q[2];
 
 def test_openqasm_register_ordering_exports_to_qiskit_expression() -> None:
     """Export first-class register ordering as a Qiskit Uint expression."""
-    program = QCProgram.from_qasm_str(
+    program = QCProgram.from_openqasm_str(
         """OPENQASM 3.1;
 include "stdgates.inc";
 qubit[3] q;
@@ -832,7 +832,7 @@ def test_wide_signed_cbit_comparison_is_rejected() -> None:
 
 def test_openqasm_signed_register_ordering_exports_to_qiskit_uint_expression() -> None:
     """Encode signed register ordering with Qiskit's unsigned expressions."""
-    program = QCProgram.from_qasm_str(
+    program = QCProgram.from_openqasm_str(
         """OPENQASM 3.1;
 include "stdgates.inc";
 qubit[4] q;
@@ -850,7 +850,7 @@ if (int[3](c) < -1) { x q[3]; }
     assert reimported_program.is_valid
     assert reimported_program.to_qiskit() is not None
 
-    qasm_reimported = QCProgram.from_qasm_str(qiskit.qasm3.dumps(restored))
+    qasm_reimported = QCProgram.from_openqasm_str(qiskit.qasm3.dumps(restored))
     assert qasm_reimported.is_valid
 
 
@@ -1083,7 +1083,7 @@ def test_qiskit_custom_gate_named_store_remains_a_gate() -> None:
 
 def test_openqasm_short_circuit_expression_exports_to_qiskit() -> None:
     """Export nested OpenQASM short-circuit logic through canonical scf.if."""
-    program = QCProgram.from_qasm_str(
+    program = QCProgram.from_openqasm_str(
         """OPENQASM 3.0;
 include "stdgates.inc";
 qubit[3] q;
@@ -1114,7 +1114,7 @@ if (c[0] && (c[1] || !c[0])) x q[2];
 
 def test_openqasm3_measurement_export_uses_undefined_cbit_register() -> None:
     """Represent OpenQASM 3 output initialization without poison values."""
-    program = QCProgram.from_qasm_str(
+    program = QCProgram.from_openqasm_str(
         """OPENQASM 3.0;
 include "stdgates.inc";
 qubit[2] q;
@@ -3386,7 +3386,7 @@ def test_classical_expression_register_captures_round_trip_on_import() -> None:
 
     program = QCProgram.from_qiskit(circuit)
     assert QCProgram.from_mlir_str(program.ir).ir == program.ir
-    assert QCProgram.from_qasm_str(qiskit.qasm3.dumps(circuit)).is_valid
+    assert QCProgram.from_openqasm_str(qiskit.qasm3.dumps(circuit)).is_valid
     ir = program.ir
 
     assert "cbit.read" in ir
@@ -4048,7 +4048,7 @@ def test_bound_parameter_names_are_unique_across_scopes() -> None:
 
 def test_duplicate_named_symbolic_inputs_are_invalid_qc_ir() -> None:
     """Reject duplicate program input names when parsing QC IR."""
-    with pytest.raises(RuntimeError, match="MLIR operation failed"):
+    with pytest.raises(RuntimeError, match="Compiler action failed"):
         QCProgram.from_mlir_str(
             """module {
   func.func @main(
@@ -4079,7 +4079,7 @@ def test_parameter_and_register_names_must_be_unique() -> None:
 
     assert list(circuit.data) == source_data
 
-    with pytest.raises(RuntimeError, match="MLIR operation failed"):
+    with pytest.raises(RuntimeError, match="Compiler action failed"):
         QCProgram.from_mlir_str(
             """module {
   func.func @main(%theta: f64 {mqt.input_name = "theta"}) attributes {mqt.entry_point} {
@@ -4104,7 +4104,7 @@ def test_parameter_names_with_null_characters_fail_closed() -> None:
 
     assert list(circuit.data) == source_data
 
-    with pytest.raises(RuntimeError, match="MLIR operation failed"):
+    with pytest.raises(RuntimeError, match="Compiler action failed"):
         QCProgram.from_mlir_str(
             r"""module {
   func.func @main(%theta: f64 {mqt.input_name = "before\00after"}) attributes {mqt.entry_point} {

--- a/test/python/test_qco_dd.py
+++ b/test/python/test_qco_dd.py
@@ -62,13 +62,13 @@ def _compiler_input(kind: str, tmp_path: Path) -> CompilerInput:
         path.write_text(UNITARY_QASM, encoding="utf-8")
         return path
     if kind == "qc":
-        return QCProgram.from_qasm_str(UNITARY_QASM)
+        return QCProgram.from_openqasm_str(UNITARY_QASM)
     if kind == "qco":
-        return QCProgram.from_qasm_str(UNITARY_QASM).to_qco()
+        return QCProgram.from_openqasm_str(UNITARY_QASM).to_qco()
     if kind == "jeff":
         return compile_program(UNITARY_QASM, output=OutputFormat.JEFF)
     if kind == "openqasm":
-        return QCProgram.from_qasm_str(UNITARY_QASM).to_openqasm3()
+        return QCProgram.from_openqasm_str(UNITARY_QASM).to_openqasm3()
     circuit = QuantumCircuit(1)
     circuit.x(0)
     return circuit


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Align the compiler-facing C++, Python, CLI, diagnostics, and documentation with the glossary and the naming decisions in #2251 and PR #2149. OpenQASM import now uses version-generic names for its supported versionless, 2.0, 3.0, and 3.1 inputs. Target metadata is `CompilerTarget.OperationCapability` / `CompilerTarget::OperationCapability`, and `mqt-cc` advertises and defaults to `--emit=qc`.

These are clean renames of unreleased v4 interfaces: old import spellings and CLI aliases are removed. The [audit and migration table](https://github.com/munich-quantum-toolkit/core/blob/cf6d712df1cbb5af7d7312d241da482baad2eba9/.agent/audits/mlir-terminology.md) records all replacements, downstream checks, and retained terminology. All in-tree callers, binding patterns, generated stubs, tests, and examples are updated.

Correct jeff conversion versus serialization, barrier operations, canonicalization patterns, conversion targets, linear ownership, and static entry-point gate counts. Compilation behavior and the accepted language subset are preserved. The requested Ponytail review removed one forwarding helper and found no remaining complexity to cut. No dependencies are added.

Local validation:

- Native Clang 23/LLVM-MLIR 23.1 release build with ThinLTO; 3,505 native tests passed, one existing sample-device job-ID test skipped.
- 653 Python compiler, Qiskit, and QCO DD tests passed on each of Python 3.11–3.14; the final versionless-input example also passed all four focused version cases.
- Stub generation, executable documentation and generated-link checks, repository lint, and full-file C++ lint passed.
- Hosted CI is separate from these local results.

The existing v4 changelog entry and upgrade-guide examples use the final terminology.

Codex assisted with the audit, implementation, tests, review, and this description. Human review remains required before merge.

Fixes #2251

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
