### PR TITLE
⚡ Avoid redundant compiler block-order scans

### DIFF
--- a/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
@@ -69,7 +69,7 @@ namespace {
 
 /// Composed unitary and metadata for a fusable two-qubit run.
 struct FusableTwoQubitRun {
-  SmallVector<Operation*, 8> ops; ///< Members in program order.
+  SmallVector<Operation*, 8> ops; ///< Members in dependency order.
   Matrix4x4 composed = Matrix4x4::identity();
   unsigned numTwoQ = 0; ///< Number of two-qubit members (entanglers consumed).
   Value tailA;          ///< Current output wires of the run's tail.
@@ -220,7 +220,7 @@ static void absorbOneQubitIntoRun(FusableTwoQubitRun& run,
 
 /// Walks forward from `head`, composing the run's matrix and metadata. Absorbs
 /// a following two-qubit gate when it keeps both run wires together, otherwise
-/// the single-qubit gate first in program order; stops at the first boundary
+/// single-qubit gates on either wire; stops at the first boundary
 /// that would split the run's two wires.
 static FusableTwoQubitRun scanFusableTwoQubitRun(UnitaryOpInterface head,
                                                  const Matrix4x4& headMatrix) {
@@ -264,7 +264,9 @@ static FusableTwoQubitRun scanFusableTwoQubitRun(UnitaryOpInterface head,
     if (aSingle && bSingle && nextOnA->getBlock() != nextOnB->getBlock()) {
       break;
     }
-    if (aSingle && (!bSingle || nextOnA->isBeforeInBlock(nextOnB))) {
+    // Gates on distinct wires commute. Comparing their order would rescan the
+    // whole block after each preceding fusion invalidates its order cache.
+    if (aSingle) {
       absorbOneQubitIntoRun(run, nextOnA, *matrixA, /*wireIndex=*/0);
       continue;
     }

--- a/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
+++ b/mlir/lib/Dialect/QTensor/IR/Operations/InsertOp.cpp
@@ -15,6 +15,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LLVM.h"
 
@@ -51,9 +52,12 @@ struct CommuteInsertExtractChains final : OpRewritePattern<InsertOp> {
 
   LogicalResult matchAndRewrite(InsertOp insert,
                                 PatternRewriter& rewriter) const override {
+    // SSA def-use chains already follow block order. Querying that order after
+    // each move would repeatedly rescan the whole block.
+    const bool checkOrder = mayBeGraphRegion(*insert->getParentRegion());
     auto extract = dyn_cast<ExtractOp>(*insert.getResult().getUsers().begin());
     if (!extract || insert->getBlock() != extract->getBlock() ||
-        !insert->isBeforeInBlock(extract)) {
+        (checkOrder && !insert->isBeforeInBlock(extract))) {
       return failure();
     }
 
@@ -70,7 +74,7 @@ struct CommuteInsertExtractChains final : OpRewritePattern<InsertOp> {
     auto tensor = insert.getDest();
     while (auto* definingOp = tensor.getDefiningOp()) {
       if (definingOp->getBlock() != insert->getBlock() ||
-          !definingOp->isBeforeInBlock(firstInsert)) {
+          (checkOrder && !definingOp->isBeforeInBlock(firstInsert))) {
         break;
       }
       if (auto previousExtract = dyn_cast<ExtractOp>(definingOp)) {
@@ -103,7 +107,7 @@ struct CommuteInsertExtractChains final : OpRewritePattern<InsertOp> {
     while (true) {
       auto* user = *tensor.user_begin();
       if (user->getBlock() != insert->getBlock() ||
-          !previous->isBeforeInBlock(user)) {
+          (checkOrder && !previous->isBeforeInBlock(user))) {
         break;
       }
       if (auto nextInsert = dyn_cast<InsertOp>(user)) {

--- a/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -337,12 +338,24 @@ TEST_F(TargetSynthesisTest, TwoQubitGateFusionRequiresStrictImprovement) {
     const auto q0Input = builder.staticQubit(0);
     const auto q1Input = builder.staticQubit(1);
     auto [q0, q1] = builder.cx(q0Input, q1Input);
+    q1 = builder.x(q1);
+    q0 = builder.z(q0);
     std::tie(q1, q0) = builder.cx(q1, q0);
     std::tie(q0, q1) = builder.cx(q0, q1);
     return builder.intConstant(0);
   });
-  ASSERT_TRUE(mlir::succeeded(
-      runPass(*nonImproving, mlir::qco::createFuseTwoQubitGates())));
+  const auto before = printModule(*nonImproving);
+  auto& block = mainFunction(*nonImproving).getBody().front();
+  block.invalidateOpOrder();
+  mlir::PassManager manager(context.get());
+  // Check fusion's order queries separately from the verifier's queries.
+  manager.enableVerifier(false);
+  manager.addPass(mlir::qco::createFuseTwoQubitGates());
+  ASSERT_TRUE(mlir::succeeded(manager.run(*nonImproving)));
+  EXPECT_FALSE(block.isOpOrderValid());
+  EXPECT_EQ(printModule(*nonImproving), before);
+  EXPECT_TRUE(mlir::succeeded(mlir::verify(*nonImproving)));
+  EXPECT_TRUE(mlir::succeeded(mlir::qco::verifyLinearity(*nonImproving)));
   EXPECT_EQ(countOps<CtrlOp>(*nonImproving), 3U);
 }
 

--- a/mlir/unittests/Dialect/QTensor/IR/test_qtensor_pair_canonicalization.cpp
+++ b/mlir/unittests/Dialect/QTensor/IR/test_qtensor_pair_canonicalization.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
@@ -96,13 +97,15 @@ protected:
                                        &context_);
   }
 
-  LogicalResult applyInsertPattern(InsertOp insert) {
+  LogicalResult applyInsertPattern(InsertOp insert,
+                                   RewriterBase::Listener* listener = nullptr) {
     RewritePatternSet patterns(&context_);
     InsertOp::getCanonicalizationPatterns(patterns, &context_);
     FrozenRewritePatternSet frozen(std::move(patterns));
     PatternApplicator applicator(frozen);
     applicator.applyDefaultCostModel();
     PatternRewriter rewriter(&context_);
+    rewriter.setListener(listener);
     rewriter.setInsertionPoint(insert);
     return applicator.matchAndRewrite(insert, rewriter);
   }
@@ -159,8 +162,15 @@ TEST_F(QTensorPairCanonicalizationTest,
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   ASSERT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
 
-  /// One rewrite must normalize the whole chain to avoid quadratic commuting.
-  ASSERT_TRUE(succeeded(applyInsertPattern(inserts[2])));
+  // Each rewrite must traverse only its chain, not recompute whole-block order.
+  struct NoOrderRebuild final : RewriterBase::Listener {
+    void notifyOperationModified(Operation* operation) override {
+      EXPECT_FALSE(operation->getBlock()->isOpOrderValid());
+    }
+  } listener;
+  function.getBody().front().invalidateOpOrder();
+  // One rewrite must normalize the whole chain to avoid quadratic commuting.
+  ASSERT_TRUE(succeeded(applyInsertPattern(inserts[2], &listener)));
   ASSERT_TRUE(succeeded(verify(*moduleOp)));
   ASSERT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
   constexpr std::array<int64_t, 4> indices{3, 0, 2, 1};
@@ -226,6 +236,41 @@ TEST_F(QTensorPairCanonicalizationTest, DoesNotCommuteAcrossADynamicSlot) {
   EXPECT_EQ(extracts[1].getTensor(), inserts[0].getResult());
   EXPECT_EQ(extracts[2].getTensor(), inserts[1].getResult());
   EXPECT_TRUE(extracts[3]->isBeforeInBlock(inserts[2]));
+}
+
+TEST_F(QTensorPairCanonicalizationTest, ChecksOperationOrderInGraphRegions) {
+  for (const bool backwardUse : {false, true}) {
+    SCOPED_TRACE(backwardUse);
+    auto moduleOp = parseSourceString<ModuleOp>(R"mlir(
+      module {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %c2 = arith.constant 2 : index
+        %tensor = qtensor.alloc(%c2) : tensor<2x!qco.qubit>
+        %r0, %q0 = qtensor.extract %tensor[%c0] : tensor<2x!qco.qubit>
+        %h0 = qco.h %q0 : !qco.qubit -> !qco.qubit
+        %t0 = qtensor.insert %h0 into %r0[%c0] : tensor<2x!qco.qubit>
+        %r1, %q1 = qtensor.extract %t0[%c1] : tensor<2x!qco.qubit>
+        %h1 = qco.h %q1 : !qco.qubit -> !qco.qubit
+        %t1 = qtensor.insert %h1 into %r1[%c1] : tensor<2x!qco.qubit>
+        qtensor.dealloc %t1 : tensor<2x!qco.qubit>
+      }
+    )mlir",
+                                                &context_);
+    ASSERT_TRUE(moduleOp);
+    auto insert = *moduleOp->getOps<InsertOp>().begin();
+    auto extract = cast<ExtractOp>(*insert.getResult().user_begin());
+    if (backwardUse) {
+      extract->moveBefore(insert);
+    }
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    ASSERT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+
+    EXPECT_EQ(succeeded(applyInsertPattern(insert)), !backwardUse);
+    ASSERT_TRUE(succeeded(verify(*moduleOp)));
+    ASSERT_TRUE(succeeded(qco::verifyLinearity(*moduleOp)));
+    EXPECT_EQ(extract.getTensor() == insert.getResult(), backwardUse);
+  }
 }
 
 } // namespace


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Avoid repeated whole-block operation-order scans in QTensor canonicalization
and two-qubit fusion. These scans made the eight `bwt_n21` and `factor247_n15`
Benchpress cases exceed a 600-second deadline.

- In SSA regions, follow the existing QTensor def-use chain without querying
  block order. Keep the original order checks for graph and unknown regions.
- In two-qubit fusion, advance independent single-qubit gates without comparing
  their block positions: gates on distinct wires commute. Preserve per-wire
  dependencies and require a strict reduction in two-qubit gate count.
- Extend regression tests to detect order-cache rebuilds without wall-clock
  thresholds, and cover forward and backward uses in graph regions.

The production change is 18 lines across two files. No new dependencies, public
API, pipeline options, or Benchpress adapter changes are required.

### Benchpress results

Baseline: Core `82a8f3a85c3a675dc52caa22a67f1ac49688d2e0`.
Patched source: `b4c96fc` (the exact four-file patch used to build the measured
wheel). All eight baseline cases timed out at **600 seconds**. With this patch,
**all eight pass** under the same deadline.

| Circuit | Topology | Patched whole case (s) | Patched compilation (s) | CZ count |
| --- | --- | ---: | ---: | ---: |
| `bwt_n21` | All-to-all | 57.6 | 29.7 | 169,200 |
| `bwt_n21` | Heavy-hex | 141.5 | 48.7 | 667,218 |
| `bwt_n21` | Linear | 203.6 | 61.8 | 999,522 |
| `bwt_n21` | Square | 103.9 | 41.2 | 492,585 |
| `factor247_n15` | All-to-all | 174.3 | 107.4 | 268,910 |
| `factor247_n15` | Heavy-hex | 205.3 | 109.4 | 521,870 |
| `factor247_n15` | Linear | 210.2 | 111.6 | 528,974 |
| `factor247_n15` | Square | 211.1 | 121.1 | 461,993 |

Release build on macOS arm64, Apple Clang 21, LLVM/MLIR 23.1.0 with assertions
enabled, and Python 3.14.3. Cases run serially, with one timing round and one
iteration each, no calibration or warmup, and unchanged compiler defaults.
The 600-second deadline covers setup, compilation, export, validation, and
teardown; the compilation column is the narrower Benchpress timing boundary.

These are single-run timeout-recovery checks, not an isolated statistical
speed comparison. The first patched BWT case overlapped local lint work.
Timeouts are censored observations, not measured baseline completion times.
The other 252 small/medium cases and other tools were not rerun for this patch.

All outputs passed basis and connectivity validation. For the six cases also
completed by the QTensor-only intermediate patch, CZ counts and two-qubit
depths are identical. Native single-qubit counts can differ because commuting
independent matrix factors changes floating-point evaluation order. The native
regressions check phase-sensitive full-unitary equivalence; the large benchmark
runs do not establish full-unitary equivalence.

### Validation

- QTensor IR, transforms/utilities, and QC/QCO conversions: **212 passed**.
- Target synthesis: **58 passed**, including phase-sensitive equivalence tests.
- Benchpress adapter: **94 passed**.
- Both new order-cache regression checks fail against their original production
  code and pass with this patch.
- Compiler suite: **217 passed, 1 failed**. The unrelated
  `CompilerQDMIAdapterTest.ConvertsUnknownDeviceFailureToError` diagnostic check
  also fails with pristine-main runtime libraries; its cause remains unresolved.
- `nox -s lint`: passed. `nox -s cpp-lint -- 82a8f3a` checks all four committed
  C++ files and reports four
  `readability-redundant-parentheses` warnings on unchanged `(*sites)[i]`
  expressions in `TargetSynthesis.cpp`; no finding in the changed logic or tests.
- Native test discovery in the local wheel-build layout could not resolve its
  DD runtime library. Direct test runs with the runtime library path set produced
  the results above. No build-policy workaround is included.

No changelog or migration entry is added for this internal fix to unreleased
v4 functionality. The benchmark harness, raw results, wheel provenance, and
comparison plot are retained locally, outside the four-file PR diff.

AI assistance: Codex assisted with diagnosis, implementation, regression tests,
benchmark validation, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
