### PR TITLE
✨ Add basis-only target synthesis

### DIFF
--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -1396,6 +1396,25 @@ operations.)pb");
           "its contents if compilation fails. Failures raise RuntimeError "
           "with the emitted MLIR diagnostics.")
       .def(
+          "synthesize_for_target",
+          [](mlir::QCOProgram& program,
+             const mlir::TargetEnvironment& environment, bool enableTiming,
+             bool enableStatistics) {
+            requireValid(program);
+            withDiagnostics<nb::exception_type::runtime_error>(
+                program.module().getContext(), "Target synthesis failed", [&] {
+                  return mlir::success(program.synthesizeForTarget(
+                      environment, enableTiming, enableStatistics));
+                });
+          },
+          "target_environment"_a, nb::kw_only(), "enable_timing"_a = false,
+          "enable_statistics"_a = false,
+          "Synthesize native operations for an all-to-all target in place. "
+          "Assigns static sites but does not run optimization or routing "
+          "stages. "
+          "Do not rely on the program contents if synthesis fails. Failures "
+          "raise RuntimeError with the emitted MLIR diagnostics.")
+      .def(
           "to_qiskit",
           [](const mlir::QCOProgram& program,
              const mlir::CompilerTarget* target) {

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -175,6 +175,23 @@ registers the required inliner extensions; callers that populate the low-level
 target pipeline directly must register inliner extensions for every callable
 dialect in their context.
 
+### Basis-only synthesis
+
+Use {py:meth}`~mqt.core.mlir.QCOProgram.synthesize_for_target` to translate an
+existing QCO program to an all-to-all target's native gate set without the
+default rotation-merging, two-qubit fusion, or routing stages. This pipeline
+inlines calls, decomposes multi-controlled gates, assigns static sites, performs
+native synthesis, and verifies target conformance. It accepts structured QCO/SCF
+input and uses the same target environment and global-phase policy as target
+compilation. Explicit connectivity is rejected; use `compile_for_target` when
+routing is required.
+
+Synthesis runs in place and raises `RuntimeError` with MLIR diagnostics on
+failure. Earlier pass changes may remain on the program, so copy it first when
+the input must be preserved. The C++ counterpart is
+`QCOProgram::synthesizeForTarget`; low-level clients can populate a pass manager
+with `populateTargetSynthesisPipeline`.
+
 ### Payload control flow
 
 For explicit restrictions, use the constants on

--- a/mlir/include/mqt/Compiler/Programs.h
+++ b/mlir/include/mqt/Compiler/Programs.h
@@ -273,6 +273,14 @@ public:
                                       bool enableTiming = false,
                                       bool enableStatistics = false);
 
+  /// Synthesize native operations for an all-to-all target in place.
+  ///
+  /// Assigns static sites without the default optimization or routing stages.
+  /// Do not rely on the program contents if synthesis fails.
+  [[nodiscard]] bool synthesizeForTarget(const TargetEnvironment& environment,
+                                         bool enableTiming = false,
+                                         bool enableStatistics = false);
+
   /// Consume this program and convert it to QC.
   [[nodiscard]] std::optional<QCProgram> intoQC() &&;
 

--- a/mlir/include/mqt/Compiler/TargetCompilation.h
+++ b/mlir/include/mqt/Compiler/TargetCompilation.h
@@ -30,4 +30,14 @@ class OpPassManager;
 void populateTargetCompilationPipeline(OpPassManager& pm,
                                        const TargetEnvironment& environment);
 
+/// Populate target-native synthesis without the optimization or routing stages.
+///
+/// Requires an all-to-all target. Inlines calls, decomposes supported
+/// multi-controlled gates, assigns static sites, synthesizes native operations,
+/// and verifies target conformance. Input must use structured QCO/SCF control
+/// flow. The supplied environment is authoritative and must remain unchanged
+/// during pipeline execution.
+void populateTargetSynthesisPipeline(OpPassManager& pm,
+                                     const TargetEnvironment& environment);
+
 } // namespace mlir

--- a/mlir/lib/Compiler/Pipeline.cpp
+++ b/mlir/lib/Compiler/Pipeline.cpp
@@ -242,6 +242,17 @@ bool QCOProgram::compileForTarget(const TargetEnvironment& environment,
       enableStatistics));
 }
 
+bool QCOProgram::synthesizeForTarget(const TargetEnvironment& environment,
+                                     bool enableTiming, bool enableStatistics) {
+  return succeeded(runQCOTransformPasses(
+      mod(),
+      [&environment](OpPassManager& pm) {
+        populateTargetSynthesisPipeline(pm, environment);
+      },
+      "failed to synthesize the QCO program for the target", enableTiming,
+      enableStatistics));
+}
+
 std::optional<QCProgram> QCOProgram::intoQC() && {
   if (failed(runQCOTransformPasses(
           mod(), [](OpPassManager& pm) { pm.addPass(createQCOToQC()); },

--- a/mlir/lib/Compiler/TargetCompilation.cpp
+++ b/mlir/lib/Compiler/TargetCompilation.cpp
@@ -34,11 +34,20 @@ class PrepareTargetCompilationPass
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PrepareTargetCompilationPass)
 
-  explicit PrepareTargetCompilationPass(TargetEnvironment environment)
-      : environment_(std::move(environment)) {}
+  explicit PrepareTargetCompilationPass(TargetEnvironment environment,
+                                        bool allToAllOnly = false)
+      : environment_(std::move(environment)), allToAllOnly_(allToAllOnly) {}
 
 protected:
   void runOnOperation() override {
+    if (allToAllOnly_ && environment_.target().connectivityKind() !=
+                             CompilerTarget::Connectivity::Kind::AllToAll) {
+      getOperation().emitError(
+          "target synthesis requires all-to-all connectivity; use target "
+          "compilation for routing");
+      signalPassFailure();
+      return;
+    }
     getAnalysis<TargetEnvironmentAnalysis>().initialize(environment_);
     auto result = getOperation().walk([](Operation* operation) {
       if (operation->getNumSuccessors() == 0) {
@@ -58,6 +67,7 @@ protected:
 
 private:
   TargetEnvironment environment_;
+  bool allToAllOnly_;
 };
 
 } /* namespace */
@@ -94,6 +104,22 @@ void populateTargetCompilationPipeline(OpPassManager& pm,
     pm.addPass(qco::createPlacementPass(target));
     break;
   }
+  populateQCOCleanupPipeline(pm);
+  pm.addPass(qco::createTargetNativeSynthesis());
+  pm.addPass(createCSEPass());
+  pm.addPass(qco::createVerifyTargetConformance());
+}
+
+void populateTargetSynthesisPipeline(OpPassManager& pm,
+                                     const TargetEnvironment& environment) {
+  pm.addPass(std::make_unique<PrepareTargetCompilationPass>(environment, true));
+  const auto& target = environment.target();
+  pm.addPass(createInlinerPass());
+  pm.addPass(createSymbolDCEPass());
+  populateQCOCleanupPipeline(pm);
+  pm.addPass(qco::createLegalizeControlFlow());
+  pm.addPass(qco::createDecomposeMultiControlled(target));
+  pm.addPass(qco::createPlacementPass(target));
   populateQCOCleanupPipeline(pm);
   pm.addPass(qco::createTargetNativeSynthesis());
   pm.addPass(createCSEPass());

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -3474,6 +3474,48 @@ x q;
   EXPECT_NE(qco->str().find("qco.static"), std::string::npos);
 }
 
+TEST_F(CompilerPipelineTest,
+       TargetSynthesisPreservesUnitaryWithoutTwoQubitFusion) {
+  auto ownedContext = createCompilerContext();
+  auto moduleOp = QCOProgramBuilder::build(
+      ownedContext.get(), [](QCOProgramBuilder& builder) {
+        auto [q0, q1] =
+            builder.cx(builder.staticQubit(0), builder.staticQubit(1));
+        q0 = builder.ry(builder.floatConstant(0.3), q0);
+        std::tie(q0, q1) = builder.cx(q0, q1);
+        q1 = builder.rz(builder.floatConstant(0.7), q1);
+        std::tie(q0, q1) = builder.cx(q0, q1);
+        return builder.intConstant(0);
+      });
+  ASSERT_TRUE(verify(*moduleOp).succeeded());
+  auto reference = OwningOpRef<ModuleOp>(moduleOp->clone());
+  auto program = QCOProgram::fromModule(ownedContext, std::move(moduleOp));
+  ASSERT_TRUE(program);
+  using OperationCapability = CompilerTarget::OperationCapability;
+  const auto target = llvm::cantFail(CompilerTarget::create(
+      2, CompilerTarget::Connectivity::allToAll(),
+      CompilerTarget::NativeOperations::fromOperations({
+          llvm::cantFail(OperationCapability::create("u", 1, 3)),
+          llvm::cantFail(OperationCapability::create("cz", 2, 0)),
+          llvm::cantFail(OperationCapability::create("gphase", 0, 1)),
+      })));
+  const TargetEnvironment environment(target, makePayloadSpecification());
+
+  ASSERT_TRUE(program->synthesizeForTarget(environment));
+
+  EXPECT_TRUE(verify(program->module()).succeeded());
+  EXPECT_TRUE(qco::verifyLinearity(program->module()).succeeded());
+  expectFullUnitaryEqual(*reference, program->module(), 2);
+  size_t numTwoQubitGates = 0;
+  program->module().walk([&](qco::UnitaryOpInterface unitary) {
+    numTwoQubitGates += unitary.isTwoQubit();
+  });
+  // Basis translation must not run the full compiler's two-qubit fusion.
+  EXPECT_EQ(numTwoQubitGates, 3);
+  EXPECT_FALSE(program->synthesizeForTarget(TargetEnvironment(
+      makeSparseUCZTarget(true), makePayloadSpecification())));
+}
+
 TEST_F(CompilerPipelineTest, TargetCompilationFusesOnlyWithUsableNativeBasis) {
   using NativeOperations = CompilerTarget::NativeOperations;
   using OperationCapability = CompilerTarget::OperationCapability;

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -655,6 +655,11 @@ class QCOProgram(Program):
     ) -> None:
         """Compile this QCO program for the target in place. Do not rely on its contents if compilation fails. Failures raise RuntimeError with the emitted MLIR diagnostics."""
 
+    def synthesize_for_target(
+        self, target_environment: TargetEnvironment, *, enable_timing: bool = False, enable_statistics: bool = False
+    ) -> None:
+        """Synthesize native operations for an all-to-all target in place. Assigns static sites but does not run optimization or routing stages. Do not rely on the program contents if synthesis fails. Failures raise RuntimeError with the emitted MLIR diagnostics."""
+
     def to_qiskit(self, *, target: CompilerTarget | None = None) -> qiskit.circuit.QuantumCircuit:
         """Export a Qiskit circuit without consuming or modifying this program.
 

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -555,6 +555,40 @@ def test_target_compilation_exports_canonical_physical_qiskit_circuit() -> None:
 
 
 @requires_qiskit_translation
+def test_target_synthesis_decomposes_without_routing() -> None:
+    """Synthesize a controlled rotation through the typed basis-only API."""
+    target = CompilerTarget(
+        3,
+        connectivity=CompilerTarget.Connectivity.all_to_all(),
+        native_operations=CompilerTarget.NativeOperations([
+            CompilerTarget.OperationCapability("sx", 1, 0),
+            CompilerTarget.OperationCapability("x", 1, 0),
+            CompilerTarget.OperationCapability("rz", 1, 1),
+            CompilerTarget.OperationCapability("cz", 2, 0),
+            CompilerTarget.OperationCapability("gphase", 0, 1),
+        ]),
+    )
+    source = QuantumCircuit(3)
+    source.h(0)
+    source.append(library.RYGate(0.7).control(2, annotated=True), [0, 1, 2])
+    program = QCProgram.from_qiskit(source).to_qco()
+
+    program.synthesize_for_target(_test_target_environment(target))
+
+    result = program.to_qiskit(target=target)
+    assert set(result.count_ops()) <= {"sx", "x", "rz", "cz"}
+    assert np.allclose(Operator(result).data, Operator(source).data)
+
+    sparse = CompilerTarget(
+        3,
+        connectivity=CompilerTarget.Connectivity([(0, 1), (1, 2)]),
+        native_operations=CompilerTarget.NativeOperations.unrestricted(),
+    )
+    with pytest.raises(RuntimeError, match="all-to-all connectivity"):
+        program.synthesize_for_target(_test_target_environment(sparse))
+
+
+@requires_qiskit_translation
 def test_qco_qiskit_export_preserves_program() -> None:
     """Reuse QC export without consuming QCO, including when export fails."""
     source = QuantumCircuit(2)


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Add `QCOProgram::synthesizeForTarget`, Python `QCOProgram.synthesize_for_target`, and `populateTargetSynthesisPipeline` for native-basis synthesis without the default rotation-merging, two-qubit fusion, or routing stages.

Benchpress's basis-change workloads need gate translation alone. Using the full target compiler also measures circuit optimization, unlike Qiskit's translation stage. This API lets the adapter measure the intended operation.

The pipeline reuses existing passes to inline calls, decompose multi-controlled gates, assign static sites, synthesize native operations, and verify target conformance. It requires all-to-all connectivity and retains the existing target-environment, global-phase, and in-place failure contracts. Explicit connectivity is rejected with a diagnostic directing callers to target compilation.

Includes API documentation, generated Python stubs, a phase-exact C++ regression that checks the absence of two-qubit fusion, and a Python API test covering controlled-rotation synthesis and connectivity rejection. No new dependencies.

### Validation

- Core Python MLIR tests: **88 passed**.
- Focused C++ target compilation/synthesis tests: **4 passed**.
- Benchpress manipulation workouts using the built extension: **4 passed**.
- Benchpress integration/helper checks using the built extension: **103 passed**.
- `uvx nox -s lint`: **passed**.
- `uvx nox -s cpp-lint`: **passed**, all four changed C++ source files checked with zero findings. The local run supplied explicit macOS SDK paths.
- Python stubs regenerated from the Release extension with nanobind 3.0.1. The standalone `nox -s stubs` build selected an older local MLIR installation, so generation used the verified Release build instead.

Changelog and migration entries are not needed for this additive change to unreleased v4 functionality. CI and human review remain pending.

AI assistance: Codex assisted with implementation, tests, documentation, and this PR description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
