### PR TITLE
✨ Synthesize two-qubit blocks in the native basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+- ✨ Optimize constant two-qubit blocks before placement and during native
+  synthesis. Remove cancelled interactions before routing and preserve cheaper
+  native operations in both target compilation and synthesis. ([#2537])
+  ([**@burgholzer**])
+
 ## [4.0.0] - 2026-09-11
 
 ### MQT Core 4: a compiler foundation built on MLIR and LLVM
@@ -126,13 +131,11 @@ relative to v3.10.0. The entries below retain the contributing PRs and authors.
   [**@MatthiasReumann**], [**@simon1hofmann**], [**@taminob**])
 
 - ✨ Decompose multi-controlled X, Z, phase, Pauli rotations, and SWAP
-  operations. Resynthesize two-qubit blocks in the native basis for target
-  compilation and synthesis, preserving cheaper native gates. Simplify
-  interactions before placement when their two-qubit count also shrinks. Support
-  RXX, RYY, RZX, RZZ, iSWAP, ECR, and optimal square-root iSWAP circuits.
-  ([#1774], [#1802], [#1803], [#1809], [#1810], [#1814], [#1832], [#1850],
-  [#1865], [#1961], [#1996], [#1998], [#2001], [#2444], [#2467], [#2468],
-  [#2478], [#2507], [#2531], [#2537]) ([**@burgholzer**], [**@denialhaag**],
+  operations. Fuse two-qubit unitaries and synthesize target-native entanglers,
+  including RXX, RYY, RZX, RZZ, iSWAP, ECR, and optimal square-root iSWAP
+  circuits. ([#1774], [#1802], [#1803], [#1809], [#1810], [#1814], [#1832],
+  [#1850], [#1865], [#1961], [#1996], [#1998], [#2001], [#2444], [#2467],
+  [#2468], [#2478], [#2507], [#2531]) ([**@burgholzer**], [**@denialhaag**],
   [**@simon1hofmann**])
 
 - ✨ Normalize global phases and expand multi-operation quantum modifiers while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,11 +126,12 @@ relative to v3.10.0. The entries below retain the contributing PRs and authors.
   [**@MatthiasReumann**], [**@simon1hofmann**], [**@taminob**])
 
 - ✨ Decompose multi-controlled X, Z, phase, Pauli rotations, and SWAP
-  operations. Fuse two-qubit unitaries and synthesize target-native entanglers,
-  including RXX, RYY, RZX, RZZ, iSWAP, ECR, and optimal square-root iSWAP
-  circuits. ([#1774], [#1802], [#1803], [#1809], [#1810], [#1814], [#1832],
-  [#1850], [#1865], [#1961], [#1996], [#1998], [#2001], [#2444], [#2467],
-  [#2468], [#2478], [#2507], [#2531]) ([**@burgholzer**], [**@denialhaag**],
+  operations. Resynthesize two-qubit blocks in the native basis for target
+  compilation and synthesis, preserving cheaper native gates. Support RXX, RYY,
+  RZX, RZZ, iSWAP, ECR, and optimal square-root iSWAP circuits. ([#1774],
+  [#1802], [#1803], [#1809], [#1810], [#1814], [#1832], [#1850], [#1865],
+  [#1961], [#1996], [#1998], [#2001], [#2444], [#2467], [#2468], [#2478],
+  [#2507], [#2531], [#2537]) ([**@burgholzer**], [**@denialhaag**],
   [**@simon1hofmann**])
 
 - ✨ Normalize global phases and expand multi-operation quantum modifiers while
@@ -1115,6 +1116,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#2538]: https://github.com/munich-quantum-toolkit/core/pull/2538
+[#2537]: https://github.com/munich-quantum-toolkit/core/pull/2537
 [#2535]: https://github.com/munich-quantum-toolkit/core/pull/2535
 [#2531]: https://github.com/munich-quantum-toolkit/core/pull/2531
 [#2526]: https://github.com/munich-quantum-toolkit/core/pull/2526

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,11 +127,12 @@ relative to v3.10.0. The entries below retain the contributing PRs and authors.
 
 - ✨ Decompose multi-controlled X, Z, phase, Pauli rotations, and SWAP
   operations. Resynthesize two-qubit blocks in the native basis for target
-  compilation and synthesis, preserving cheaper native gates. Support RXX, RYY,
-  RZX, RZZ, iSWAP, ECR, and optimal square-root iSWAP circuits. ([#1774],
-  [#1802], [#1803], [#1809], [#1810], [#1814], [#1832], [#1850], [#1865],
-  [#1961], [#1996], [#1998], [#2001], [#2444], [#2467], [#2468], [#2478],
-  [#2507], [#2531], [#2537]) ([**@burgholzer**], [**@denialhaag**],
+  compilation and synthesis, preserving cheaper native gates. Simplify
+  interactions before placement when their two-qubit count also shrinks. Support
+  RXX, RYY, RZX, RZZ, iSWAP, ECR, and optimal square-root iSWAP circuits.
+  ([#1774], [#1802], [#1803], [#1809], [#1810], [#1814], [#1832], [#1850],
+  [#1865], [#1961], [#1996], [#1998], [#2001], [#2444], [#2467], [#2468],
+  [#2478], [#2507], [#2531], [#2537]) ([**@burgholzer**], [**@denialhaag**],
   [**@simon1hofmann**])
 
 - ✨ Normalize global phases and expand multi-operation quantum modifiers while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ releases may include breaking changes.
 
 - ✨ Optimize constant two-qubit blocks before placement and during native
   synthesis. Remove cancelled interactions before routing and preserve cheaper
-  native operations in both target compilation and synthesis. ([#2537])
-  ([**@burgholzer**])
+  native operations in both target compilation and synthesis. Avoid redundant
+  cleanup in both target pipelines. ([#2537]) ([**@burgholzer**])
 
 ## [4.0.0] - 2026-09-11
 

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -1410,8 +1410,8 @@ operations.)pb");
           "target_environment"_a, nb::kw_only(), "enable_timing"_a = false,
           "enable_statistics"_a = false,
           "Synthesize native operations for an all-to-all target in place. "
-          "Assigns static sites but does not run optimization or routing "
-          "stages. "
+          "Assigns static sites and resynthesizes constant two-qubit runs in "
+          "the native basis, without default rotation merging or routing. "
           "Do not rely on the program contents if synthesis fails. Failures "
           "raise RuntimeError with the emitted MLIR diagnostics.")
       .def(

--- a/bindings/mlir/register_mlir.cpp
+++ b/bindings/mlir/register_mlir.cpp
@@ -1411,7 +1411,7 @@ operations.)pb");
           "enable_statistics"_a = false,
           "Synthesize native operations for an all-to-all target in place. "
           "Assigns static sites and resynthesizes constant two-qubit runs in "
-          "the native basis, without default rotation merging or routing. "
+          "the native basis, without routing. "
           "Do not rely on the program contents if synthesis fails. Failures "
           "raise RuntimeError with the emitted MLIR diagnostics.")
       .def(

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -198,12 +198,12 @@ dialect in their context.
 
 Use {py:meth}`~mqt.core.mlir.QCOProgram.synthesize_for_target` to translate an
 existing QCO program to an all-to-all target's native gate set. It uses the same
-native block synthesis as target compilation, without default rotation merging
-or routing. This pipeline inlines calls, decomposes multi-controlled gates,
-assigns static sites, performs native synthesis, and verifies target
-conformance. It accepts structured QCO/SCF input and uses the same target
-environment and global-phase policy as target compilation. Explicit connectivity
-is rejected; use `compile_for_target` when routing is required.
+native block synthesis as target compilation, without routing. This pipeline
+inlines calls, decomposes multi-controlled gates, assigns static sites, performs
+native synthesis, and verifies target conformance. It accepts structured QCO/SCF
+input and uses the same target environment and global-phase policy as target
+compilation. Explicit connectivity is rejected; use `compile_for_target` when
+routing is required.
 
 Synthesis runs in place and raises `RuntimeError` with MLIR diagnostics on
 failure. Earlier pass changes may remain on the program, so copy it first when

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -153,6 +153,20 @@ using LLVM's affinity-aware CPU count with a minimum of one. An explicit
 `place-and-route` pass for reproducible results across machines. Disabling
 multithreading runs the same trials sequentially.
 
+Native synthesis collects constant runs on the same two qubits, including
+interleaved single-qubit gates, and resynthesizes them in the target's selected
+basis. It replaces a run only when the result uses fewer native two-qubit gates
+than preserving supported operations and lowering the others individually. For
+example, a non-native RZZ followed by RXX can require two CZ gates together,
+compared with four when lowered separately. Already-native operations are
+preserved unless block synthesis reduces their native gate count.
+
+Native support includes physical sites and operand direction. Barriers,
+non-unitary operations, and unavailable matrices stop a run. If block
+decomposition fails numerically, synthesis falls back to individual lowering.
+The selected basis uses one entangler family; it does not optimize arbitrary
+mixtures of all target operations or use calibration costs.
+
 Target synthesis preserves a native `gphase`. If the target does not support
 `gphase`, target synthesis preserves relative phase effects and removes only the
 unobservable global phase of the entry point.
@@ -175,16 +189,16 @@ registers the required inliner extensions; callers that populate the low-level
 target pipeline directly must register inliner extensions for every callable
 dialect in their context.
 
-### Basis-only synthesis
+### Synthesis without routing
 
 Use {py:meth}`~mqt.core.mlir.QCOProgram.synthesize_for_target` to translate an
-existing QCO program to an all-to-all target's native gate set without the
-default rotation-merging, two-qubit fusion, or routing stages. This pipeline
-inlines calls, decomposes multi-controlled gates, assigns static sites, performs
-native synthesis, and verifies target conformance. It accepts structured QCO/SCF
-input and uses the same target environment and global-phase policy as target
-compilation. Explicit connectivity is rejected; use `compile_for_target` when
-routing is required.
+existing QCO program to an all-to-all target's native gate set. It uses the same
+native block synthesis as target compilation, without default rotation merging
+or routing. This pipeline inlines calls, decomposes multi-controlled gates,
+assigns static sites, performs native synthesis, and verifies target
+conformance. It accepts structured QCO/SCF input and uses the same target
+environment and global-phase policy as target compilation. Explicit connectivity
+is rejected; use `compile_for_target` when routing is required.
 
 Synthesis runs in place and raises `RuntimeError` with MLIR diagnostics on
 failure. Earlier pass changes may remain on the program, so copy it first when

--- a/docs/mlir/target_compilation.md
+++ b/docs/mlir/target_compilation.md
@@ -161,6 +161,11 @@ example, a non-native RZZ followed by RXX can require two CZ gates together,
 compared with four when lowered separately. Already-native operations are
 preserved unless block synthesis reduces their native gate count.
 
+Before placement, both target pipelines also fuse runs when this reduces the
+number of two-qubit operations in the IR and their native gate count. This
+removes cancelled interactions before routing. Native support at this stage is
+checked without physical sites; the later synthesis pass checks assigned sites.
+
 Native support includes physical sites and operand direction. Barriers,
 non-unitary operations, and unavailable matrices stop a run. If block
 decomposition fails numerically, synthesis falls back to individual lowering.

--- a/mlir/include/mqt/Compiler/Programs.h
+++ b/mlir/include/mqt/Compiler/Programs.h
@@ -275,7 +275,8 @@ public:
 
   /// Synthesize native operations for an all-to-all target in place.
   ///
-  /// Assigns static sites without the default optimization or routing stages.
+  /// Assigns static sites and resynthesizes constant two-qubit runs in the
+  /// native basis, without default rotation merging or routing.
   /// Do not rely on the program contents if synthesis fails.
   [[nodiscard]] bool synthesizeForTarget(const TargetEnvironment& environment,
                                          bool enableTiming = false,

--- a/mlir/include/mqt/Compiler/Programs.h
+++ b/mlir/include/mqt/Compiler/Programs.h
@@ -276,7 +276,7 @@ public:
   /// Synthesize native operations for an all-to-all target in place.
   ///
   /// Assigns static sites and resynthesizes constant two-qubit runs in the
-  /// native basis, without default rotation merging or routing.
+  /// native basis, without routing.
   /// Do not rely on the program contents if synthesis fails.
   [[nodiscard]] bool synthesizeForTarget(const TargetEnvironment& environment,
                                          bool enableTiming = false,

--- a/mlir/include/mqt/Compiler/TargetCompilation.h
+++ b/mlir/include/mqt/Compiler/TargetCompilation.h
@@ -30,13 +30,13 @@ class OpPassManager;
 void populateTargetCompilationPipeline(OpPassManager& pm,
                                        const TargetEnvironment& environment);
 
-/// Populate target-native synthesis without the optimization or routing stages.
+/// Populate target-native block synthesis without rotation merging or routing.
 ///
 /// Requires an all-to-all target. Inlines calls, decomposes supported
-/// multi-controlled gates, assigns static sites, synthesizes native operations,
-/// and verifies target conformance. Input must use structured QCO/SCF control
-/// flow. The supplied environment is authoritative and must remain unchanged
-/// during pipeline execution.
+/// multi-controlled gates, assigns static sites, resynthesizes constant
+/// two-qubit runs in the native basis, and verifies target conformance. Input
+/// must use structured QCO/SCF control flow. The supplied environment is
+/// authoritative and must remain unchanged during pipeline execution.
 void populateTargetSynthesisPipeline(OpPassManager& pm,
                                      const TargetEnvironment& environment);
 

--- a/mlir/include/mqt/Compiler/TargetCompilation.h
+++ b/mlir/include/mqt/Compiler/TargetCompilation.h
@@ -30,7 +30,7 @@ class OpPassManager;
 void populateTargetCompilationPipeline(OpPassManager& pm,
                                        const TargetEnvironment& environment);
 
-/// Populate target-native block synthesis without rotation merging or routing.
+/// Populate target-native block synthesis without routing.
 ///
 /// Requires an all-to-all target. Inlines calls, decomposes supported
 /// multi-controlled gates, assigns static sites, resynthesizes constant

--- a/mlir/include/mqt/Dialect/QCO/Transforms/Passes.h
+++ b/mlir/include/mqt/Dialect/QCO/Transforms/Passes.h
@@ -41,6 +41,11 @@ namespace mlir::qco {
 /// Runs remain unchanged when numerical decomposition fails.
 [[nodiscard]] std::unique_ptr<Pass> createFuseTwoQubitGates();
 
+/// Fuse before placement only when both IR and native two-qubit counts shrink.
+/// Native support is checked without assigning physical sites.
+[[nodiscard]] std::unique_ptr<Pass>
+createFuseTwoQubitGates(const CompilerTarget& target);
+
 /// Create multi-controlled decomposition for one compiler target.
 ///
 /// Supported operations remain native on all-to-all targets. Targets with

--- a/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
@@ -256,7 +256,15 @@ def TargetNativeSynthesis : Pass<"target-native-synthesis", "mlir::ModuleOp"> {
   let description = [{
     Reads the typed `mqt.target_env` module attribute and lowers non-native
     unitary operations to one complete synthesis basis supported throughout the
-    compiler target. Unknown native-operation metadata is valid when no
+    compiler target. Constant two-qubit runs, including interleaved single-qubit
+    gates, are resynthesized together when this strictly reduces the number of
+    native two-qubit gates compared with preserving supported operations and
+    lowering the others individually. Native support includes ordered site
+    placements. Equal-cost runs and runs whose numerical decomposition fails
+    are left for individual lowering. Barriers, non-unitary operations, and
+    unavailable matrices stop a run.
+
+    Unknown native-operation metadata is valid when no
     surviving unitary operation needs it. Otherwise, the pass fails when the
     metadata is unknown, no complete basis exists, or an operation has no
     compile-time unitary matrix and cannot be synthesized as a parameterized

--- a/mlir/lib/Compiler/TargetCompilation.cpp
+++ b/mlir/lib/Compiler/TargetCompilation.cpp
@@ -86,16 +86,6 @@ void populateTargetCompilationPipeline(OpPassManager& pm,
   pm.addPass(qco::createLegalizeControlFlow());
   pm.addPass(qco::createDecomposeMultiControlled(target));
   populateDefaultQCOOptimizationPipeline(pm);
-  // Generic fusion must not introduce gates that the target cannot synthesize.
-  // ponytail: its CX/CZ cost model can increase square-root iSWAP counts;
-  // enable that basis when fusion uses the target entangler's cost.
-  if (const auto basis = target.synthesisBasis();
-      target.nativeOperationsKind() ==
-          CompilerTarget::NativeOperations::Kind::Unrestricted ||
-      (basis && basis->entangler &&
-       basis->entangler != CompilerTarget::GateKind::SQRTISWAP)) {
-    pm.addPass(qco::createFuseTwoQubitGates());
-  }
   switch (target.connectivityKind()) {
   case CompilerTarget::Connectivity::Kind::Explicit:
     pm.addPass(qco::createMappingPass(qco::MappingPassOptions{}));

--- a/mlir/lib/Compiler/TargetCompilation.cpp
+++ b/mlir/lib/Compiler/TargetCompilation.cpp
@@ -85,6 +85,7 @@ void populateTargetCompilationPipeline(OpPassManager& pm,
   populateQCOCleanupPipeline(pm);
   pm.addPass(qco::createLegalizeControlFlow());
   pm.addPass(qco::createDecomposeMultiControlled(target));
+  pm.addPass(qco::createFuseTwoQubitGates(target));
   populateDefaultQCOOptimizationPipeline(pm);
   switch (target.connectivityKind()) {
   case CompilerTarget::Connectivity::Kind::Explicit:
@@ -109,6 +110,7 @@ void populateTargetSynthesisPipeline(OpPassManager& pm,
   populateQCOCleanupPipeline(pm);
   pm.addPass(qco::createLegalizeControlFlow());
   pm.addPass(qco::createDecomposeMultiControlled(target));
+  pm.addPass(qco::createFuseTwoQubitGates(target));
   pm.addPass(qco::createPlacementPass(target));
   populateQCOCleanupPipeline(pm);
   pm.addPass(qco::createTargetNativeSynthesis());

--- a/mlir/lib/Compiler/TargetCompilation.cpp
+++ b/mlir/lib/Compiler/TargetCompilation.cpp
@@ -14,12 +14,14 @@
 #include "mqt/Compiler/TargetEnvironment.h"
 #include "mqt/Dialect/QCO/Transforms/Mapping/Mapping.h"
 #include "mqt/Dialect/QCO/Transforms/Passes.h"
+#include "mqt/Dialect/QTensor/Transforms/Passes.h"
 #include "mqt/Support/Passes.h"
 
 #include "mlir/IR/Visitors.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/WalkResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
 #include <memory>
@@ -72,6 +74,18 @@ private:
 
 } /* namespace */
 
+static void populatePostPlacementPipeline(OpPassManager& pm) {
+  /// Placement consumes allocations; native synthesis normalizes phases.
+  pm.addPass(createCanonicalizerPass(
+      GreedyRewriteConfig{}.setMaxIterations(GreedyRewriteConfig::kNoLimit)));
+  /// Reuse unchanged classical reads before native synthesis splits their uses.
+  pm.addPass(createCSEPass());
+  pm.addPass(createRemoveDeadValuesPass());
+  pm.addPass(qco::createTargetNativeSynthesis());
+  pm.addPass(createCSEPass());
+  pm.addPass(qco::createVerifyTargetConformance());
+}
+
 void populateTargetCompilationPipeline(OpPassManager& pm,
                                        const TargetEnvironment& environment) {
   pm.addPass(std::make_unique<PrepareTargetCompilationPass>(environment));
@@ -82,7 +96,12 @@ void populateTargetCompilationPipeline(OpPassManager& pm,
   populateQCOCleanupPipeline(pm);
   pm.addPass(qco::createUnrollLoopsForPayload());
   pm.addPass(createSCCPPass());
-  populateQCOCleanupPipeline(pm);
+  /// Unrolling exposes static tensor slots and unreachable callees.
+  pm.addPass(createCanonicalizerPass(
+      GreedyRewriteConfig{}.setMaxIterations(GreedyRewriteConfig::kNoLimit)));
+  pm.addPass(createCSEPass());
+  pm.addPass(qtensor::createShrinkQTensorToFitPass());
+  pm.addPass(createSymbolDCEPass());
   pm.addPass(qco::createLegalizeControlFlow());
   pm.addPass(qco::createDecomposeMultiControlled(target));
   pm.addPass(qco::createFuseTwoQubitGates(target));
@@ -95,10 +114,7 @@ void populateTargetCompilationPipeline(OpPassManager& pm,
     pm.addPass(qco::createPlacementPass(target));
     break;
   }
-  populateQCOCleanupPipeline(pm);
-  pm.addPass(qco::createTargetNativeSynthesis());
-  pm.addPass(createCSEPass());
-  pm.addPass(qco::createVerifyTargetConformance());
+  populatePostPlacementPipeline(pm);
 }
 
 void populateTargetSynthesisPipeline(OpPassManager& pm,
@@ -112,10 +128,7 @@ void populateTargetSynthesisPipeline(OpPassManager& pm,
   pm.addPass(qco::createDecomposeMultiControlled(target));
   pm.addPass(qco::createFuseTwoQubitGates(target));
   pm.addPass(qco::createPlacementPass(target));
-  populateQCOCleanupPipeline(pm);
-  pm.addPass(qco::createTargetNativeSynthesis());
-  pm.addPass(createCSEPass());
-  pm.addPass(qco::createVerifyTargetConformance());
+  populatePostPlacementPipeline(pm);
 }
 
 } // namespace mlir

--- a/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
@@ -71,8 +71,8 @@ namespace {
 struct FusableTwoQubitRun {
   SmallVector<Operation*, 8> ops; ///< Members in dependency order.
   Matrix4x4 composed = Matrix4x4::identity();
-  unsigned numTwoQ = 0; ///< Number of two-qubit members (entanglers consumed).
-  Value tailA;          ///< Current output wires of the run's tail.
+  size_t numTwoQ = 0; ///< Number of two-qubit members.
+  Value tailA;        ///< Current output wires of the run's tail.
   Value tailB;
 };
 
@@ -82,6 +82,15 @@ struct FusableTwoQubitRun {
 struct LastTwoQubitDecomposition {
   Matrix4x4 matrix;
   std::optional<decomposition::TwoQubitNativeDecomposition> native;
+
+  const std::optional<decomposition::TwoQubitNativeDecomposition>&
+  get(const Matrix4x4& nextMatrix, CompilerTarget::GateKind entangler) {
+    if (!native || matrix.data != nextMatrix.data) {
+      matrix = nextMatrix;
+      native = decomposeUnitary2QWeyl(matrix, entangler);
+    }
+    return native;
+  }
 };
 
 } // namespace
@@ -287,34 +296,6 @@ static void eraseFusableRun(RewriterBase& rewriter,
   }
 }
 
-/// Fuses a maximal constant run only when generic resynthesis strictly reduces
-/// its two-qubit operation count.
-static bool fuseTwoQubitGateRun(IRRewriter& rewriter, UnitaryOpInterface head,
-                                const Matrix4x4& headMatrix,
-                                CompilerTarget::SynthesisBasis basis) {
-  FusableTwoQubitRun run = scanFusableTwoQubitRun(head, headMatrix);
-  if (run.ops.size() < 2) {
-    return false;
-  }
-
-  const auto native = decomposeUnitary2QWeyl(run.composed, *basis.entangler);
-  if (!native || native->numBasisUses >= run.numTwoQ) {
-    return false;
-  }
-
-  auto firstOp = cast<UnitaryOpInterface>(run.ops.front());
-  rewriter.setInsertionPoint(firstOp);
-  const auto synthesized =
-      emitUnitary2QWeyl(rewriter, firstOp.getLoc(), firstOp.getInputQubit(0),
-                        firstOp.getInputQubit(1), *native, basis);
-  decomposition::emitGPhaseIfNeeded(rewriter, firstOp.getLoc(),
-                                    synthesized.globalPhase);
-  rewriter.replaceAllUsesWith(run.tailA, synthesized.qubit0);
-  rewriter.replaceAllUsesWith(run.tailB, synthesized.qubit1);
-  eraseFusableRun(rewriter, run);
-  return true;
-}
-
 namespace {
 
 using SiteId = CompilerTarget::SiteId;
@@ -508,6 +489,14 @@ static void reorderTwoQubitOperation(IRRewriter& rewriter,
       ValueRange{reordered.getOutputQubit(1), reordered.getOutputQubit(0)});
 }
 
+static bool canReverseNativeOperation(UnitaryOpInterface op,
+                                      const CompilerTarget& target,
+                                      std::optional<ArrayRef<SiteId>> sites) {
+  return sites && op.isTwoQubit() && isOperandSwapInvariant(op) &&
+         target.supports(op.getOperation(),
+                         std::array{(*sites)[1], (*sites)[0]});
+}
+
 static LogicalResult synthesizeTargetOperation(
     IRRewriter& rewriter, UnitaryOpInterface op, const CompilerTarget& target,
     const std::optional<CompilerTarget::SynthesisBasis>& basis,
@@ -517,8 +506,7 @@ static LogicalResult synthesizeTargetOperation(
   if (sites ? target.supports(operation, *sites) : target.supports(operation)) {
     return success();
   }
-  if (sites && op.isTwoQubit() && isOperandSwapInvariant(op) &&
-      target.supports(operation, std::array{(*sites)[1], (*sites)[0]})) {
+  if (canReverseNativeOperation(op, target, sites)) {
     reorderTwoQubitOperation(rewriter, op);
     return success();
   }
@@ -578,14 +566,7 @@ static LogicalResult synthesizeTargetOperation(
     matrix = matrix.reorderForQubits(1, 0);
     std::swap(input0, input1);
   }
-  // Compare the full, direction-adjusted matrix exactly, including its phase.
-  if (!lastDecomposition.native ||
-      lastDecomposition.matrix.data != matrix.data) {
-    lastDecomposition.matrix = matrix;
-    lastDecomposition.native =
-        decomposeUnitary2QWeyl(matrix, *basis->entangler);
-  }
-  const auto& native = lastDecomposition.native;
+  const auto& native = lastDecomposition.get(matrix, *basis->entangler);
   if (!native) {
     return unsupported(
         "its unitary matrix could not be numerically decomposed");
@@ -604,27 +585,116 @@ static LogicalResult synthesizeTargetOperation(
   return success();
 }
 
-static LogicalResult fuseTwoQubitGates(ModuleOp moduleOp) {
-  constexpr CompilerTarget::SynthesisBasis basis{
-      .singleQubit = CompilerTarget::SingleQubitBasis::U,
-      .entangler = CompilerTarget::GateKind::CZ,
-  };
+/// Compare with individual native lowering, stopping once fusion wins.
+static bool reducesNativeCost(const FusableTwoQubitRun& run, size_t fusedCost,
+                              const CompilerTarget& target,
+                              CompilerTarget::GateKind entangler,
+                              const SiteMap* sites,
+                              LastTwoQubitDecomposition& lastDecomposition) {
+  size_t cost = 0;
+  for (Operation* operation : run.ops) {
+    auto unitary = cast<UnitaryOpInterface>(operation);
+    if (!unitary.isTwoQubit()) {
+      continue;
+    }
+    auto siteValues = sites != nullptr ? getOperationSites(operation, *sites)
+                                       : SmallVector<SiteId, 2>{};
+    const auto operationSites =
+        sites != nullptr ? std::optional<ArrayRef<SiteId>>(siteValues)
+                         : std::nullopt;
+    if ((sites != nullptr ? target.supports(operation, siteValues)
+                          : target.supports(operation)) ||
+        canReverseNativeOperation(unitary, target, operationSites)) {
+      ++cost;
+    } else {
+      Matrix4x4 matrix;
+      if (!assignTwoQubitOpMatrix(unitary, matrix)) {
+        return false;
+      }
+      if (sites != nullptr && !target.supports(entangler, siteValues)) {
+        matrix = matrix.reorderForQubits(1, 0);
+      }
+      const auto& native = lastDecomposition.get(matrix, entangler);
+      if (!native) {
+        return false;
+      }
+      cost += native->numBasisUses;
+    }
+    if (cost > fusedCost) {
+      return true;
+    }
+  }
+  return false;
+}
 
+/// Fuses a constant run only when resynthesis reduces its two-qubit cost.
+/// Without a target, the original operation count is a conservative bound.
+static bool fuseTwoQubitGateRun(IRRewriter& rewriter, UnitaryOpInterface head,
+                                const Matrix4x4& headMatrix,
+                                CompilerTarget::SynthesisBasis basis,
+                                const CompilerTarget* target,
+                                const SiteMap* sites,
+                                LastTwoQubitDecomposition& lastDecomposition) {
+  auto run = scanFusableTwoQubitRun(head, headMatrix);
+  if (run.ops.size() < 2) {
+    return false;
+  }
+  bool reverseEntangler = false;
+  if (sites != nullptr) {
+    const auto headSites = getOperationSites(head, *sites);
+    reverseEntangler = !target->supports(*basis.entangler, headSites);
+    if (reverseEntangler &&
+        !target->supports(*basis.entangler,
+                          std::array{headSites[1], headSites[0]})) {
+      return false;
+    }
+  }
+  const auto native = decomposeUnitary2QWeyl(
+      reverseEntangler ? run.composed.reorderForQubits(1, 0) : run.composed,
+      *basis.entangler);
+  if (!native ||
+      (target != nullptr
+           ? !reducesNativeCost(run, native->numBasisUses, *target,
+                                *basis.entangler, sites, lastDecomposition)
+           : native->numBasisUses >= run.numTwoQ)) {
+    return false;
+  }
+
+  Value input0 = head.getInputQubit(0);
+  Value input1 = head.getInputQubit(1);
+  if (reverseEntangler) {
+    std::swap(input0, input1);
+  }
+  rewriter.setInsertionPoint(head);
+  const auto synthesized = emitUnitary2QWeyl(rewriter, head.getLoc(), input0,
+                                             input1, *native, basis);
+  decomposition::emitGPhaseIfNeeded(rewriter, head.getLoc(),
+                                    synthesized.globalPhase);
+  rewriter.replaceAllUsesWith(run.tailA, reverseEntangler ? synthesized.qubit1
+                                                          : synthesized.qubit0);
+  rewriter.replaceAllUsesWith(run.tailB, reverseEntangler ? synthesized.qubit0
+                                                          : synthesized.qubit1);
+  eraseFusableRun(rewriter, run);
+  return true;
+}
+
+static bool fuseTwoQubitGates(IRRewriter& rewriter, ModuleOp moduleOp,
+                              CompilerTarget::SynthesisBasis basis,
+                              const CompilerTarget* target = nullptr,
+                              const SiteMap* sites = nullptr) {
   bool changed = false;
-  IRRewriter rewriter(moduleOp.getContext());
+  LastTwoQubitDecomposition lastDecomposition;
   /// A run's successors have already been visited when its head erases them.
   moduleOp->walk<WalkOrder::PostOrder, ReverseIterator>(
       [&](Operation* operation) {
         auto unitary = dyn_cast<UnitaryOpInterface>(operation);
         const auto matrix = twoQubitRunMemberMatrix(unitary);
         if (matrix && !feedsFromSameTwoQubitRun(unitary)) {
-          changed |= fuseTwoQubitGateRun(rewriter, unitary, *matrix, basis);
+          changed |= fuseTwoQubitGateRun(rewriter, unitary, *matrix, basis,
+                                         target, sites, lastDecomposition);
         }
       });
-  if (!changed) {
-    return success();
-  }
-  return mlir::mqt::normalizeGlobalPhases(moduleOp);
+  return changed;
 }
 
 namespace {
@@ -640,20 +710,38 @@ struct FuseTwoQubitGatesPass final
 protected:
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
-    if (failed(fuseTwoQubitGates(moduleOp))) {
+    constexpr CompilerTarget::SynthesisBasis basis{
+        .singleQubit = CompilerTarget::SingleQubitBasis::U,
+        .entangler = CompilerTarget::GateKind::CZ,
+    };
+    IRRewriter rewriter(&getContext());
+    if (fuseTwoQubitGates(rewriter, moduleOp, basis) &&
+        failed(mlir::mqt::normalizeGlobalPhases(moduleOp))) {
       signalPassFailure();
     }
   }
 };
 
-/// Defer constant folding until gate builders have consumed their new values.
-class SynthesisConstantFolder final : public OpBuilder::Listener {
+/// Track generated wire sites and defer folding until builders finish.
+class SynthesisListener final : public OpBuilder::Listener {
 public:
-  explicit SynthesisConstantFolder(MLIRContext* context) : folder_(context) {}
+  SynthesisListener(MLIRContext* context, SiteMap& sites)
+      : folder_(context), sites_(sites) {}
 
   void notifyOperationInserted(Operation* operation,
                                OpBuilder::InsertPoint previous) override {
     if (!previous.isSet()) {
+      if (isa<UnitaryOpInterface>(operation)) {
+        for (auto [input, output] :
+             llvm::zip_equal(getQubitValues(operation->getOperands()),
+                             getQubitValues(operation->getResults()))) {
+          /// Modifier builders also insert detached bodies with unplaced args.
+          if (auto found = sites_.find(input); found != sites_.end()) {
+            const auto site = found->second;
+            sites_.insert_or_assign(output, site);
+          }
+        }
+      }
       if (auto constant = dyn_cast<arith::ConstantOp>(operation)) {
         pending_.push_back(constant);
       }
@@ -669,6 +757,7 @@ public:
 
 private:
   OperationFolder folder_;
+  SiteMap& sites_;
   SmallVector<arith::ConstantOp> pending_;
 };
 
@@ -687,10 +776,6 @@ protected:
       return;
     }
     const CompilerTarget& target = environment.environment().target();
-    if (target.nativeOperationsKind() ==
-        CompilerTarget::NativeOperations::Kind::Unrestricted) {
-      return;
-    }
     const auto targetBasis = target.synthesisBasis();
     if (failed(prepareGlobalPhases(moduleOp, target))) {
       signalPassFailure();
@@ -703,8 +788,13 @@ protected:
       return;
     }
 
-    SynthesisConstantFolder constants(&getContext());
-    IRRewriter rewriter(&getContext(), &constants);
+    SynthesisListener listener(&getContext(), *sites);
+    IRRewriter rewriter(&getContext(), &listener);
+    if (targetBasis && targetBasis->entangler) {
+      fuseTwoQubitGates(rewriter, moduleOp, *targetBasis, &target,
+                        indexed ? nullptr : &*sites);
+    }
+    listener.foldPending();
     LastTwoQubitDecomposition lastDecomposition;
     /// Rewrite users before producers so each unvisited operation retains its
     /// original operands and their collected sites.
@@ -722,7 +812,7 @@ protected:
               indexed ? std::nullopt
                       : std::optional<ArrayRef<SiteId>>(operationSites),
               lastDecomposition);
-          constants.foldPending();
+          listener.foldPending();
           return failed(synthesized) ? WalkResult::interrupt()
                                      : WalkResult::advance();
         });

--- a/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/NativeSynthesis/TargetSynthesis.cpp
@@ -634,7 +634,8 @@ static bool fuseTwoQubitGateRun(IRRewriter& rewriter, UnitaryOpInterface head,
                                 CompilerTarget::SynthesisBasis basis,
                                 const CompilerTarget* target,
                                 const SiteMap* sites,
-                                LastTwoQubitDecomposition& lastDecomposition) {
+                                LastTwoQubitDecomposition& lastDecomposition,
+                                bool shrinkOnly) {
   auto run = scanFusableTwoQubitRun(head, headMatrix);
   if (run.ops.size() < 2) {
     return false;
@@ -652,7 +653,7 @@ static bool fuseTwoQubitGateRun(IRRewriter& rewriter, UnitaryOpInterface head,
   const auto native = decomposeUnitary2QWeyl(
       reverseEntangler ? run.composed.reorderForQubits(1, 0) : run.composed,
       *basis.entangler);
-  if (!native ||
+  if (!native || (shrinkOnly && native->numBasisUses >= run.numTwoQ) ||
       (target != nullptr
            ? !reducesNativeCost(run, native->numBasisUses, *target,
                                 *basis.entangler, sites, lastDecomposition)
@@ -681,7 +682,8 @@ static bool fuseTwoQubitGateRun(IRRewriter& rewriter, UnitaryOpInterface head,
 static bool fuseTwoQubitGates(IRRewriter& rewriter, ModuleOp moduleOp,
                               CompilerTarget::SynthesisBasis basis,
                               const CompilerTarget* target = nullptr,
-                              const SiteMap* sites = nullptr) {
+                              const SiteMap* sites = nullptr,
+                              bool shrinkOnly = false) {
   bool changed = false;
   LastTwoQubitDecomposition lastDecomposition;
   /// A run's successors have already been visited when its head erases them.
@@ -690,8 +692,9 @@ static bool fuseTwoQubitGates(IRRewriter& rewriter, ModuleOp moduleOp,
         auto unitary = dyn_cast<UnitaryOpInterface>(operation);
         const auto matrix = twoQubitRunMemberMatrix(unitary);
         if (matrix && !feedsFromSameTwoQubitRun(unitary)) {
-          changed |= fuseTwoQubitGateRun(rewriter, unitary, *matrix, basis,
-                                         target, sites, lastDecomposition);
+          changed |=
+              fuseTwoQubitGateRun(rewriter, unitary, *matrix, basis, target,
+                                  sites, lastDecomposition, shrinkOnly);
         }
       });
   return changed;
@@ -703,6 +706,10 @@ struct FuseTwoQubitGatesPass final
     : PassWrapper<FuseTwoQubitGatesPass, OperationPass<ModuleOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FuseTwoQubitGatesPass)
 
+  FuseTwoQubitGatesPass() = default;
+  explicit FuseTwoQubitGatesPass(const CompilerTarget& target)
+      : target_(target) {}
+
   void getDependentDialects(DialectRegistry& registry) const override {
     registry.insert<QCODialect, arith::ArithDialect>();
   }
@@ -710,16 +717,25 @@ struct FuseTwoQubitGatesPass final
 protected:
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
-    constexpr CompilerTarget::SynthesisBasis basis{
-        .singleQubit = CompilerTarget::SingleQubitBasis::U,
-        .entangler = CompilerTarget::GateKind::CZ,
-    };
+    const auto basis =
+        target_ ? target_->synthesisBasis()
+                : std::optional{CompilerTarget::SynthesisBasis{
+                      .singleQubit = CompilerTarget::SingleQubitBasis::U,
+                      .entangler = CompilerTarget::GateKind::CZ,
+                  }};
+    if (!basis || !basis->entangler) {
+      return;
+    }
     IRRewriter rewriter(&getContext());
-    if (fuseTwoQubitGates(rewriter, moduleOp, basis) &&
+    if (fuseTwoQubitGates(rewriter, moduleOp, *basis,
+                          target_ ? &*target_ : nullptr, nullptr, true) &&
         failed(mlir::mqt::normalizeGlobalPhases(moduleOp))) {
       signalPassFailure();
     }
   }
+
+private:
+  std::optional<CompilerTarget> target_;
 };
 
 /// Track generated wire sites and defer folding until builders finish.
@@ -893,6 +909,10 @@ protected:
 
 std::unique_ptr<Pass> createFuseTwoQubitGates() {
   return std::make_unique<FuseTwoQubitGatesPass>();
+}
+
+std::unique_ptr<Pass> createFuseTwoQubitGates(const CompilerTarget& target) {
+  return std::make_unique<FuseTwoQubitGatesPass>(target);
 }
 
 } // namespace mlir::qco

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -23,6 +23,7 @@
 #include "mqt/Dialect/QCO/IR/QCOOps.h"
 #include "mqt/Dialect/QCO/QCOUtils.h"
 #include "mqt/Dialect/QCO/Transforms/Passes.h"
+#include "mqt/Dialect/QCO/Utils/DDFunctionality.h"
 #include "mqt/Dialect/QIR/Builder/QIRProgramBuilder.h"
 #include "mqt/Dialect/QIR/Utils/QIRUtils.h"
 #include "mqt/Dialect/QTensor/IR/QTensorDialect.h"
@@ -3474,17 +3475,13 @@ x q;
   EXPECT_NE(qco->str().find("qco.static"), std::string::npos);
 }
 
-TEST_F(CompilerPipelineTest,
-       TargetSynthesisPreservesUnitaryWithoutTwoQubitFusion) {
+TEST_F(CompilerPipelineTest, TargetSynthesisResynthesizesTwoQubitBlocks) {
   auto ownedContext = createCompilerContext();
   auto moduleOp = QCOProgramBuilder::build(
       ownedContext.get(), [](QCOProgramBuilder& builder) {
         auto [q0, q1] =
-            builder.cx(builder.staticQubit(0), builder.staticQubit(1));
-        q0 = builder.ry(builder.floatConstant(0.3), q0);
-        std::tie(q0, q1) = builder.cx(q0, q1);
-        q1 = builder.rz(builder.floatConstant(0.7), q1);
-        std::tie(q0, q1) = builder.cx(q0, q1);
+            builder.rzz(0.3, builder.staticQubit(0), builder.staticQubit(1));
+        std::tie(q0, q1) = builder.rxx(0.4, q0, q1);
         return builder.intConstant(0);
       });
   ASSERT_TRUE(verify(*moduleOp).succeeded());
@@ -3510,8 +3507,8 @@ TEST_F(CompilerPipelineTest,
   program->module().walk([&](qco::UnitaryOpInterface unitary) {
     numTwoQubitGates += unitary.isTwoQubit();
   });
-  // Basis translation must not run the full compiler's two-qubit fusion.
-  EXPECT_EQ(numTwoQubitGates, 3);
+  /// Individual lowering needs four CZ gates; the whole block needs two.
+  EXPECT_EQ(numTwoQubitGates, 2);
   EXPECT_FALSE(program->synthesizeForTarget(TargetEnvironment(
       makeSparseUCZTarget(true), makePayloadSpecification())));
 }
@@ -3608,6 +3605,60 @@ TEST_F(CompilerPipelineTest, TargetCompilationFusesOnlyWithUsableNativeBasis) {
       });
       EXPECT_LT(numTwoQubitGates, inputGateCount);
     }
+  }
+}
+
+TEST_F(CompilerPipelineTest, TargetCompilationFusesRoutingSwaps) {
+  using Capability = CompilerTarget::OperationCapability;
+  const auto target = llvm::cantFail(CompilerTarget::create(
+      3, CompilerTarget::Connectivity::fromCouplings({{0, 1}, {1, 2}}),
+      CompilerTarget::NativeOperations::fromOperations({
+          llvm::cantFail(Capability::create("u", 1, 3)),
+          llvm::cantFail(Capability::create("cz", 2, 0)),
+          llvm::cantFail(Capability::create("measure", 1, 0)),
+          llvm::cantFail(Capability::create("gphase", 0, 1)),
+      })));
+  for (size_t basis = 0; basis < 8; ++basis) {
+    SCOPED_TRACE(basis);
+    auto ownedContext = createCompilerContext();
+    auto moduleOp = QCOProgramBuilder::build(
+        ownedContext.get(), [&](QCOProgramBuilder& builder) {
+          auto bits = builder.allocClassicalBitRegister(3);
+          SmallVector<Value> qubits;
+          for (size_t i = 0; i < 3; ++i) {
+            Value qubit = builder.allocQubit();
+            qubits.push_back((basis & (size_t{1} << i)) != 0 ? builder.x(qubit)
+                                                             : qubit);
+          }
+          std::tie(qubits[2], qubits[0]) = builder.cx(qubits[2], qubits[0]);
+          std::tie(qubits[0], qubits[1]) = builder.cx(qubits[0], qubits[1]);
+          std::tie(qubits[2], qubits[1]) = builder.cx(qubits[2], qubits[1]);
+          for (size_t i = 0; i < 3; ++i) {
+            std::tie(qubits[i], std::ignore) =
+                builder.measure(qubits[i], bits, static_cast<int64_t>(i));
+            builder.sink(qubits[i]);
+          }
+          return bits;
+        });
+    const auto expected =
+        qco::sample(mlir::mqt::getEntryPoint(*moduleOp), 1, 42);
+    ASSERT_TRUE(succeeded(expected));
+    auto program = QCOProgram::fromModule(ownedContext, std::move(moduleOp));
+    ASSERT_TRUE(program);
+    ASSERT_TRUE(program->compileForTarget(
+        TargetEnvironment(target, makePayloadSpecification())));
+    ASSERT_TRUE(succeeded(verify(program->module())));
+    ASSERT_TRUE(succeeded(qco::verifyLinearity(program->module())));
+    size_t entanglers = 0;
+    program->module().walk([&](qco::UnitaryOpInterface unitary) {
+      entanglers += unitary.isTwoQubit();
+    });
+    /// Routing a triangle on a line needs a SWAP; fusion saves two CZ gates.
+    EXPECT_LE(entanglers, 4);
+    const auto actual =
+        qco::sample(mlir::mqt::getEntryPoint(program->module()), 1, 42);
+    ASSERT_TRUE(succeeded(actual));
+    EXPECT_EQ(*actual, *expected);
   }
 }
 

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -2453,6 +2453,42 @@ TEST_F(CompilerPipelineTest,
   EXPECT_EQ(loops, 1);
 }
 
+TEST_F(CompilerPipelineTest, TargetCompilationShrinksTensorAfterUnrolling) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[8] q;
+bit[2] c;
+for int i in [2:3] { x q[i]; }
+c[0] = measure q[2];
+c[1] = measure q[3];
+)qasm";
+  for (const bool routing : {false, true}) {
+    SCOPED_TRACE(routing);
+    auto qc = QCProgram::fromOpenQASMString(source);
+    ASSERT_TRUE(qc);
+    auto program = std::move(*qc).intoQCO();
+    ASSERT_TRUE(program);
+    const auto target = llvm::cantFail(CompilerTarget::create(
+        2,
+        routing ? CompilerTarget::Connectivity::fromCouplings({{0, 1}})
+                : CompilerTarget::Connectivity::allToAll(),
+        CompilerTarget::NativeOperations::unrestricted()));
+    ASSERT_TRUE(program->compileForTarget(
+        TargetEnvironment(target, makeControlPayloadSpecification({}))));
+    EXPECT_TRUE(succeeded(verify(program->module())));
+    EXPECT_TRUE(succeeded(qco::verifyLinearity(program->module())));
+    size_t qubits = 0;
+    program->module().walk([&](qco::StaticOp) { ++qubits; });
+    EXPECT_EQ(qubits, 2);
+    const auto outcomes =
+        qco::sample(mlir::mqt::getEntryPoint(program->module()), 1, 42);
+    ASSERT_TRUE(succeeded(outcomes));
+    ASSERT_EQ(outcomes->size(), 1);
+    EXPECT_EQ(outcomes->begin()->first, "11");
+  }
+}
+
 TEST_F(CompilerPipelineTest, IndexedPlacementPreservesSparseSitesAndLoopBody) {
   auto program = QCOProgram::fromMLIRString(R"mlir(module {
     func.func @main() -> i1 attributes {mqt.entry_point} {
@@ -3802,6 +3838,44 @@ TEST_F(CompilerPipelineTest,
   pm.addPass(createRemoveDeadValuesPass());
   ASSERT_TRUE(pm.run(program->module()).succeeded());
   EXPECT_EQ(program->str(), before);
+}
+
+TEST_F(CompilerPipelineTest, TargetCompilationReusesUnchangedMeasurementRead) {
+  constexpr llvm::StringLiteral source = R"qasm(
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[3];
+creg c0[1];
+creg c1[1];
+h q[0];
+measure q[0] -> c0[0];
+if(c0==1) u1(pi/2) q[1];
+h q[1];
+measure q[1] -> c1[0];
+if(c0==1) u1(pi/4) q[2];
+)qasm";
+  auto qc = QCProgram::fromOpenQASMString(source);
+  ASSERT_TRUE(qc);
+  auto program = std::move(*qc).intoQCO();
+  ASSERT_TRUE(program);
+  using Capability = CompilerTarget::OperationCapability;
+  const auto target = llvm::cantFail(CompilerTarget::create(
+      3, CompilerTarget::Connectivity::fromCouplings({{0, 1}, {1, 2}}),
+      CompilerTarget::NativeOperations::fromOperations({
+          llvm::cantFail(Capability::create("sx", 1, 0)),
+          llvm::cantFail(Capability::create("x", 1, 0)),
+          llvm::cantFail(Capability::create("rz", 1, 1)),
+          llvm::cantFail(Capability::create("cz", 2, 0)),
+          llvm::cantFail(Capability::create("measure", 1, 0)),
+          llvm::cantFail(Capability::create("gphase", 0, 1)),
+      })));
+  ASSERT_TRUE(program->compileForTarget(
+      TargetEnvironment(target, makePayloadSpecification())));
+  auto entry = mlir::mqt::getEntryPoint(program->module());
+  auto branches = llvm::to_vector(entry.getOps<qco::IfOp>());
+  ASSERT_EQ(branches.size(), 2);
+  /// Measuring c1 does not change c0, so both branches can share its read.
+  EXPECT_EQ(branches[0].getCondition(), branches[1].getCondition());
 }
 
 TEST_F(CompilerPipelineTest, QCOProgramPreservesDDSIMControlledOperations) {

--- a/mlir/unittests/Compiler/test_compiler_pipeline.cpp
+++ b/mlir/unittests/Compiler/test_compiler_pipeline.cpp
@@ -3608,6 +3608,50 @@ TEST_F(CompilerPipelineTest, TargetCompilationFusesOnlyWithUsableNativeBasis) {
   }
 }
 
+TEST_F(CompilerPipelineTest,
+       TargetCompilationCancelsInteractionsBeforeRouting) {
+  using Capability = CompilerTarget::OperationCapability;
+  const auto target = llvm::cantFail(CompilerTarget::create(
+      5,
+      CompilerTarget::Connectivity::fromCouplings(
+          {{0, 1}, {1, 2}, {2, 3}, {3, 4}}),
+      CompilerTarget::NativeOperations::fromOperations({
+          llvm::cantFail(Capability::create("u", 1, 3)),
+          llvm::cantFail(Capability::create("cz", 2, 0)),
+          llvm::cantFail(Capability::create("gphase", 0, 1)),
+      })));
+  auto ownedContext = createCompilerContext();
+  auto moduleOp = QCOProgramBuilder::build(
+      ownedContext.get(), [](QCOProgramBuilder& builder) {
+        SmallVector<Value> qubits;
+        for (size_t i = 0; i < 5; ++i) {
+          qubits.push_back(builder.staticQubit(i));
+        }
+        for (size_t round = 0; round < 4; ++round) {
+          for (size_t i = 1; i < 5; ++i) {
+            std::tie(qubits[0], qubits[i]) = builder.cx(qubits[0], qubits[i]);
+            qubits[0] = builder.rz(0.13, qubits[0]);
+            std::tie(qubits[0], qubits[i]) = builder.cx(qubits[0], qubits[i]);
+          }
+        }
+        return builder.intConstant(0);
+      });
+  auto reference = OwningOpRef<ModuleOp>(moduleOp->clone());
+  auto program = QCOProgram::fromModule(ownedContext, std::move(moduleOp));
+  ASSERT_TRUE(program);
+  ASSERT_TRUE(program->compileForTarget(
+      TargetEnvironment(target, makePayloadSpecification())));
+  ASSERT_TRUE(succeeded(verify(program->module())));
+  ASSERT_TRUE(succeeded(qco::verifyLinearity(program->module())));
+  expectFullUnitaryEqual(*reference, program->module(), 5);
+  size_t entanglers = 0;
+  program->module().walk([&](qco::UnitaryOpInterface unitary) {
+    entanglers += unitary.isTwoQubit();
+  });
+  /// Each pair of CX gates cancels; routing must see no interactions.
+  EXPECT_EQ(entanglers, 0U);
+}
+
 TEST_F(CompilerPipelineTest, TargetCompilationFusesRoutingSwaps) {
   using Capability = CompilerTarget::OperationCapability;
   const auto target = llvm::cantFail(CompilerTarget::create(

--- a/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
@@ -456,6 +456,33 @@ TEST_F(TargetSynthesisTest, NativeSynthesisUsesBlockCostInTargetBasis) {
   }
 }
 
+TEST_F(TargetSynthesisTest, PrePlacementFusionRequiresSmallerNativeCircuit) {
+  for (const bool nativeSwap : {false, true}) {
+    const auto target = valid(
+        Target::create(2, Connectivity::allToAll(),
+                       NativeOperations::fromOperations({
+                           valid(OperationCapability::create("u", 1, 3)),
+                           valid(OperationCapability::create("cz", 2, 0)),
+                           valid(OperationCapability::create("gphase", 0, 1)),
+                           valid(OperationCapability::create(
+                               nativeSwap ? "swap" : "cx", 2, 0)),
+                           valid(OperationCapability::create("rzz", 2, 1)),
+                       })));
+    auto moduleOp = build([&](QCOProgramBuilder& builder) {
+      auto [a, b] =
+          builder.swap(builder.staticQubit(0), builder.staticQubit(1));
+      std::tie(a, b) = nativeSwap ? builder.rzz(0.3, a, b) : builder.cx(a, b);
+      return builder.intConstant(0);
+    });
+    const auto before = printModule(*moduleOp);
+    ASSERT_TRUE(mlir::succeeded(
+        runPass(*moduleOp, mlir::qco::createFuseTwoQubitGates(target))));
+    /// Two native gates stay native; a SWAP plus CX also stays compact until
+    /// placement, even though their individual native lowering costs more.
+    EXPECT_EQ(printModule(*moduleOp), before);
+  }
+}
+
 TEST_F(TargetSynthesisTest, TwoQubitGateFusionPreservesUnevenWireRuns) {
   const auto uneven = [](QCOProgramBuilder& builder) {
     auto q0Input = builder.staticQubit(0);

--- a/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/NativeSynthesis/test_target_synthesis.cpp
@@ -46,6 +46,7 @@
 #include "mlir/Support/LogicalResult.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -379,6 +380,82 @@ TEST_F(TargetSynthesisTest,
   expectEquivalent(expected, optimized);
 }
 
+TEST_F(TargetSynthesisTest, NativeSynthesisFusesSwapWithCx) {
+  for (const bool reverse : {false, true}) {
+    const auto target = reverse ? makeOneWayUCxTarget() : makeUCxTarget();
+    for (const bool swapFirst : {false, true}) {
+      const auto circuit = [&](QCOProgramBuilder& builder) {
+        auto q0 = builder.staticQubit(0);
+        auto q1 = builder.staticQubit(1);
+        if (swapFirst) {
+          std::tie(q0, q1) = builder.swap(q0, q1);
+        }
+        std::tie(q0, q1) = builder.cx(q0, q1);
+        if (!swapFirst) {
+          std::tie(q0, q1) = builder.swap(q0, q1);
+        }
+        return builder.intConstant(0);
+      };
+      auto expected = build(circuit);
+      auto optimized = build(circuit);
+      ASSERT_TRUE(mlir::succeeded(runTargetPass(
+          *optimized, target, mlir::qco::createTargetNativeSynthesis())));
+      ASSERT_TRUE(mlir::succeeded(runTargetPass(
+          *optimized, target, mlir::qco::createVerifyTargetConformance())));
+      EXPECT_EQ(countOps<SWAPOp>(*optimized), 0U);
+      /// A CX and a SWAP need two CX gates after cancellation, rather than
+      /// four.
+      EXPECT_EQ(countOps<CtrlOp>(*optimized), 2U);
+      expectEquivalent(expected, optimized);
+    }
+  }
+}
+
+TEST_F(TargetSynthesisTest, NativeSynthesisUsesBlockCostInTargetBasis) {
+  for (const auto* basis : {"cz", "sqrt_iswap", "rzz"}) {
+    const bool nativeSwap = llvm::StringRef(basis) == "rzz";
+    std::vector operations{
+        valid(OperationCapability::create("u", 1, 3)),
+        valid(OperationCapability::create("gphase", 0, 1)),
+        valid(OperationCapability::create(basis, 2, nativeSwap ? 1 : 0)),
+    };
+    if (nativeSwap) {
+      operations.push_back(valid(OperationCapability::create("swap", 2, 0)));
+    }
+    const auto target =
+        valid(Target::create(2, Connectivity::allToAll(),
+                             NativeOperations::fromOperations(operations)));
+    for (const bool swap : {false, true}) {
+      SCOPED_TRACE(testing::Message() << basis << ", swap=" << swap);
+      const auto circuit = [&](QCOProgramBuilder& builder) {
+        auto a = builder.staticQubit(0);
+        auto b = builder.staticQubit(1);
+        if (swap) {
+          std::tie(a, b) = builder.swap(a, b);
+          std::tie(a, b) = builder.rzz(0.3, a, b);
+        } else {
+          std::tie(a, b) = builder.rzz(0.3, a, b);
+          std::tie(a, b) = builder.rxx(0.4, a, b);
+        }
+        return builder.intConstant(0);
+      };
+      auto expected = build(circuit);
+      auto synthesized = build(circuit);
+      ASSERT_TRUE(mlir::succeeded(runTargetPass(
+          *synthesized, target, mlir::qco::createTargetNativeSynthesis())));
+      ASSERT_TRUE(mlir::succeeded(runTargetPass(
+          *synthesized, target, mlir::qco::createVerifyTargetConformance())));
+      size_t entanglers = 0;
+      synthesized->walk([&](mlir::qco::UnitaryOpInterface op) {
+        entanglers += op.isTwoQubit();
+      });
+      EXPECT_EQ(entanglers, swap && !nativeSwap ? 3U : 2U);
+      EXPECT_EQ(countOps<SWAPOp>(*synthesized), swap && nativeSwap ? 1U : 0U);
+      expectEquivalent(expected, synthesized);
+    }
+  }
+}
+
 TEST_F(TargetSynthesisTest, TwoQubitGateFusionPreservesUnevenWireRuns) {
   const auto uneven = [](QCOProgramBuilder& builder) {
     auto q0Input = builder.staticQubit(0);
@@ -428,6 +505,9 @@ TEST_F(TargetSynthesisTest,
       if (!required) {
         // Optional fusion needs at least two operations in the run.
         static_cast<void>(builder.h(outputs[0]));
+      } else {
+        /// Failed block synthesis must fall back to the individual diagnostic.
+        static_cast<void>(builder.cx(outputs[0], outputs[1]));
       }
       return builder.intConstant(0);
     });
@@ -455,23 +535,46 @@ TEST_F(TargetSynthesisTest,
 }
 
 TEST_F(TargetSynthesisTest, TwoQubitGateFusionExposesEarlierRunContinuations) {
-  const auto adjacentRuns = [](QCOProgramBuilder& builder) {
-    auto q0 = builder.staticQubit(0);
-    auto q1 = builder.staticQubit(1);
-    auto q2 = builder.staticQubit(2);
-    std::tie(q0, q1) = builder.cx(q0, q1);
-    std::tie(q0, q2) = builder.cx(q0, q2);
-    std::tie(q0, q2) = builder.cx(q0, q2);
-    std::tie(q0, q1) = builder.cx(q0, q1);
-    return builder.intConstant(0);
-  };
-  auto expected = build(adjacentRuns);
-  auto optimized = build(adjacentRuns);
+  const auto target = valid(
+      Target::create(3, Connectivity::allToAll(),
+                     NativeOperations::fromOperations({
+                         valid(OperationCapability::create("u", 1, 3)),
+                         valid(OperationCapability::create("cz", 2, 0)),
+                         valid(OperationCapability::create("gphase", 0, 1)),
+                     })));
+  for (const bool native : {false, true}) {
+    for (const bool localGate : {false, true}) {
+      SCOPED_TRACE(native);
+      SCOPED_TRACE(localGate);
+      const auto adjacentRuns = [&](QCOProgramBuilder& builder) {
+        auto q0 = builder.staticQubit(0);
+        auto q1 = builder.staticQubit(1);
+        auto q2 = builder.staticQubit(2);
+        std::tie(q0, q1) = builder.cx(q0, q1);
+        std::tie(q0, q2) = builder.cx(q0, q2);
+        if (localGate) {
+          q0 = builder.x(q0);
+        }
+        std::tie(q0, q2) = builder.cx(q0, q2);
+        std::tie(q0, q1) = builder.cx(q0, q1);
+        return builder.intConstant(0);
+      };
+      auto expected = build(adjacentRuns);
+      auto optimized = build(adjacentRuns);
 
-  ASSERT_TRUE(mlir::succeeded(
-      runPass(*optimized, mlir::qco::createFuseTwoQubitGates())));
-  EXPECT_EQ(countOps<CtrlOp>(*optimized), 0U);
-  expectEquivalent(expected, optimized);
+      if (native) {
+        ASSERT_TRUE(mlir::succeeded(runTargetPass(
+            *optimized, target, mlir::qco::createTargetNativeSynthesis())));
+        ASSERT_TRUE(mlir::succeeded(runTargetPass(
+            *optimized, target, mlir::qco::createVerifyTargetConformance())));
+      } else {
+        ASSERT_TRUE(mlir::succeeded(
+            runPass(*optimized, mlir::qco::createFuseTwoQubitGates())));
+      }
+      EXPECT_EQ(countOps<CtrlOp>(*optimized), 0U);
+      expectEquivalent(expected, optimized);
+    }
+  }
 }
 
 TEST_F(TargetSynthesisTest, TwoQubitGateFusionEmitsSymmetricEntangler) {
@@ -1548,24 +1651,31 @@ TEST_F(TargetSynthesisTest, TargetNativeSynthesisUsesHomogeneousCapability) {
   expectEquivalent(expected, synthesized);
 }
 
-TEST_F(TargetSynthesisTest,
-       UnrestrictedOperationSetTreatsEveryOperationAsNative) {
-  auto module = build([](QCOProgramBuilder& builder) {
-    auto qubit = builder.staticQubit(0);
-    qubit = builder.h(qubit);
+TEST_F(TargetSynthesisTest, UnrestrictedTargetOptimizesNativeBlocks) {
+  const auto circuit = [](QCOProgramBuilder& builder) {
+    auto q0Input = builder.staticQubit(0);
+    auto q1Input = builder.staticQubit(1);
+    auto [q0, q1] = builder.cx(q0Input, q1Input);
+    std::tie(q0, q1) = builder.cx(q0, q1);
+    std::tie(q0, q1) = builder.cx(q0, q1);
+    q0 = builder.h(q0);
     builder.gphase(0.25);
     return builder.intConstant(0);
-  });
+  };
+  auto expected = build(circuit);
+  auto synthesized = build(circuit);
   const auto permissive = valid(Target::create(
-      1, Connectivity::allToAll(), NativeOperations::unrestricted()));
-  attachTestEnvironment(*module, permissive);
-  const auto before = printModule(*module);
+      2, Connectivity::allToAll(), NativeOperations::unrestricted()));
 
   ASSERT_TRUE(mlir::succeeded(runTargetPass(
-      *module, permissive, mlir::qco::createTargetNativeSynthesis())));
+      *synthesized, permissive, mlir::qco::createTargetNativeSynthesis())));
   ASSERT_TRUE(mlir::succeeded(runTargetPass(
-      *module, permissive, mlir::qco::createVerifyTargetConformance())));
-  EXPECT_EQ(printModule(*module), before);
+      *synthesized, permissive, mlir::qco::createVerifyTargetConformance())));
+  size_t entanglers = 0;
+  synthesized->walk(
+      [&](mlir::qco::UnitaryOpInterface op) { entanglers += op.isTwoQubit(); });
+  EXPECT_EQ(entanglers, 1U);
+  expectEquivalent(expected, synthesized);
 }
 
 TEST_F(TargetSynthesisTest, NativePowShellHidesItsImplementationBody) {

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -658,7 +658,7 @@ class QCOProgram(Program):
     def synthesize_for_target(
         self, target_environment: TargetEnvironment, *, enable_timing: bool = False, enable_statistics: bool = False
     ) -> None:
-        """Synthesize native operations for an all-to-all target in place. Assigns static sites and resynthesizes constant two-qubit runs in the native basis, without default rotation merging or routing. Do not rely on the program contents if synthesis fails. Failures raise RuntimeError with the emitted MLIR diagnostics."""
+        """Synthesize native operations for an all-to-all target in place. Assigns static sites and resynthesizes constant two-qubit runs in the native basis, without routing. Do not rely on the program contents if synthesis fails. Failures raise RuntimeError with the emitted MLIR diagnostics."""
 
     def to_qiskit(self, *, target: CompilerTarget | None = None) -> qiskit.circuit.QuantumCircuit:
         """Export a Qiskit circuit without consuming or modifying this program.

--- a/python/mqt/core/mlir.pyi
+++ b/python/mqt/core/mlir.pyi
@@ -658,7 +658,7 @@ class QCOProgram(Program):
     def synthesize_for_target(
         self, target_environment: TargetEnvironment, *, enable_timing: bool = False, enable_statistics: bool = False
     ) -> None:
-        """Synthesize native operations for an all-to-all target in place. Assigns static sites but does not run optimization or routing stages. Do not rely on the program contents if synthesis fails. Failures raise RuntimeError with the emitted MLIR diagnostics."""
+        """Synthesize native operations for an all-to-all target in place. Assigns static sites and resynthesizes constant two-qubit runs in the native basis, without default rotation merging or routing. Do not rely on the program contents if synthesis fails. Failures raise RuntimeError with the emitted MLIR diagnostics."""
 
     def to_qiskit(self, *, target: CompilerTarget | None = None) -> qiskit.circuit.QuantumCircuit:
         """Export a Qiskit circuit without consuming or modifying this program.

--- a/test/python/test_mlir.py
+++ b/test/python/test_mlir.py
@@ -570,7 +570,7 @@ def test_target_compilation_exports_canonical_physical_qiskit_circuit() -> None:
 
 @requires_qiskit_translation
 def test_target_synthesis_decomposes_without_routing() -> None:
-    """Synthesize a controlled rotation through the typed basis-only API."""
+    """Synthesize a controlled rotation through the typed target API."""
     target = CompilerTarget(
         3,
         connectivity=CompilerTarget.Connectivity.all_to_all(),
@@ -600,6 +600,29 @@ def test_target_synthesis_decomposes_without_routing() -> None:
     )
     with pytest.raises(RuntimeError, match="all-to-all connectivity"):
         program.synthesize_for_target(_test_target_environment(sparse))
+
+
+@requires_qiskit_translation
+def test_target_synthesis_resynthesizes_two_qubit_blocks() -> None:
+    """Both target APIs resynthesize an RZZ/RXX block directly into CZ gates."""
+    target = CompilerTarget(
+        2,
+        connectivity=CompilerTarget.Connectivity.all_to_all(),
+        native_operations=CompilerTarget.NativeOperations([
+            CompilerTarget.OperationCapability("u", 1, 3),
+            CompilerTarget.OperationCapability("cz", 2, 0),
+            CompilerTarget.OperationCapability("gphase", 0, 1),
+        ]),
+    )
+    source = QuantumCircuit(2)
+    source.rzz(0.3, 0, 1)
+    source.rxx(0.4, 0, 1)
+    for method in ("synthesize_for_target", "compile_for_target"):
+        program = QCProgram.from_qiskit(source).to_qco()
+        getattr(program, method)(_test_target_environment(target))
+        result = program.to_qiskit(target=target)
+        assert result.count_ops().get("cz", 0) == 2
+        assert np.allclose(Operator(result).data, Operator(source).data)
 
 
 @requires_qiskit_translation


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Target compilation and synthesis without routing now resynthesize constant two-qubit blocks in the selected native basis while preserving cheaper native operations. For example, non-native `RZZ(0.3); RXX(0.4)` needs two CZ gates together instead of four individually; a native SWAP/RZZ pair stays at two gates when block synthesis would need three. Unrestricted targets also optimize their blocks.

Both pipelines reuse the existing fusion implementation at two stages:

- Before placement, replace a block only when both its two-qubit IR operation count and native cost decrease. This removes cancelled interactions before routing and keeps compact gate pairs intact. Native support is checked without assigning physical sites.
- After placement/routing, resynthesize only when native two-qubit cost decreases, using the assigned sites and operand direction. Individual lowering preserves supported native gates and supplies the comparison cost.

Run scanning, Weyl decomposition, phase handling, and emission remain shared. Numerical block failures fall back to individual lowering; the standalone target-independent fusion factory remains available. The selected synthesis basis uses one entangler family and does not search arbitrary native mixtures or calibration costs. No new dependencies or block IR are added.

Cleanup runs at the boundaries that require it, removing five redundant passes from target compilation and three from synthesis without routing. Full cleanup remains before unrolling because dead work affects its resource budget. Tensor shrinking remains after unrolling, and CSE remains before native synthesis to reuse unchanged measurement reads. Both pipelines share the post-placement tail; the generic cleanup pipeline remains available to its other callers.

### Validation

At `1565801f9`, the release build and 3,539 CTest cases passed, with one existing QDMI skip. All 90 Python MLIR tests, whole-file C++ lint, repository lint, and complete executable documentation/internal link checks passed. The native-synthesis suite contains 61 passing tests. Coverage includes full-unitary and phase preservation, pre-routing cancellation, native preservation, reversed connectivity, unrestricted optimization, numerical fallback, and routed measurement results. The two cleanup regressions cover tensor shrinking after unrolling on two-site targets and reuse of unchanged classical reads across an intervening measurement.

### Measurements

Both Benchpress Small studies use 42 circuits across four abstract topologies, five alternating samples per version and case, and 1,680 successful samples per study. The environment is ARM64, GCC 13.3, LLVM/MLIR 23.1.0, the release preset with LTO disabled, CPU 0 affinity, default mapping options, and seed 42. Targets use `id/sx/x/rz/cz` with measurement, reset, and global phase. Timing includes QC/QCO conversion, the target pipeline, cleanup, and OpenQASM export; file import, target construction, and output writes are excluded.

The block-fusion study compared `07374719b` with MQT Core 4.0.0 (`8d9bcfb03`). Native two-qubit counts improved in 41 of 168 cases and never regressed. Depth improved in 38 of 152 comparable cases and never regressed. Geometric mean count/depth reductions were 2.0%/2.2% on square, 5.4%/5.9% on heavy-hex, and 4.8%/5.1% on linear targets; all-to-all quality was unchanged. Runtime was broadly unchanged before the cleanup refinement.

The cleanup study compares `1565801f9` against `a904d3308`, isolating the scheduling change with shared dependency libraries and identical compiler options. Baseline source copies compile as separate translation units; the candidate uses the normal project libraries and unity-build configuration.

| Topology | Compilation time change from cleanup |
| --- | ---: |
| All-to-all | -6.58% |
| Square | -6.48% |
| Heavy-hex | -6.10% |
| Linear | -6.42% |
| All cases | **-6.40%** |

These are geometric means of paired ratios using five-sample medians. Every case median improved, from 1.74% to 11.18%; median within-case sample ranges were about 3.2% for both variants. All 168 outputs were byte-identical across variants and deterministic across repeats. Native counts were unchanged in all 168 cases; depth was unchanged in all 152 cases where the straight-line metric applies. The 16 structured-control-flow cases have no depth metric. The two studies use different baselines; their timing results are not a single measured speedup against 4.0.0.

Separate probes preserve full matrices, including phase, and show 1,024-gate RZZ/RXX synthesis falling from 2,048 native entanglers to two in the release-baseline comparison. The final cleanup probes have maximum matrix error `3.59906e-12`, unchanged from their baseline. These results cover the stated workloads and settings, not a general speedup or global synthesis optimum. Benchmark drivers, exact build metadata, raw measurements, and PNG/PDF plots remain in the local experiment archive.

Codex assisted with implementation, review, validation, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
