### PR TITLE
✨ Add concatenated magic-state distillation

### DIFF
--- a/.agent/plans/magic-state-distillation.md
+++ b/.agent/plans/magic-state-distillation.md
@@ -61,44 +61,53 @@ stubs, C++ lint, and executable documentation also passed after rebasing onto
 
 - Native benchmark references: 65 tests passed, including invalid options and
   counts, both rejection-bit values, strict JSON, manifests, and case IDs.
-- Native benchmark generation: 34 tests passed. The new tests sample 256 ideal
-  shots, reject all 15 single and 105 double input Z errors, and report a wrong
-  root state for all 35 accepted triple-error patterns. Faults are injected only
-  into leaf preparation in tests. Expected syndromes come independently from
-  XORing the erroneous column labels.
+- Native benchmark generation: 34 tests passed. The tests sample 16 ideal shots,
+  reject all 15 single and 105 double input Z errors, and report a wrong root
+  state for all 35 accepted triple-error patterns. Faults are injected only into
+  leaf preparation in tests. Expected syndromes come independently from XORing
+  the erroneous column labels.
 - Levels 2–4 generate and convert to QCO with the exact qubit counts and compact
   operation growth. Tests check parent indices, leaf-only preparation, and
   accumulated rejection. Simulation of levels 3–4 was not run.
 - DD functionality: all 89 tests passed, including a new parameterized nested
   unitary-call regression covering functionality, statevectors, sampling, and
   global phase.
-- Python: 111 tests passed across `test/python/bench/` and
-  `test/python/qdmi/test_compilation.py`. These include level 2 smoke tests with
-  one shot through direct sampling and both DDSIM formats. The CLI and JSON
-  CTest selection also passed.
+- Python: 108 tests cover `test/python/bench/` and
+  `test/python/qdmi/test_compilation.py`. CI simulates level 1 only, using 16
+  shots per execution path. Higher levels retain inexpensive generation and
+  metadata checks. Level 2 simulation was validated manually and is excluded
+  from CI. The CLI and JSON CTest selection also passed.
 - `uvx nox -s stubs` and changed-file C++ lint passed. Repository lint passed
   with unrelated untracked audit scripts excluded from type checking through a
   temporary configuration; tracked lint settings are unchanged.
 - Generated MLIR references and `uvx nox --non-interactive -s docs` passed,
   including all executable examples and generated local-link checks.
 
-The examples in `docs/benchmarks.md` reproduce the required 15-qubit execution
-through `sample`, then `compile_program` and `submit_program` for both DDSIM
-payload paths. Each uses 256 shots and seed 17 (`custom1=17` for QDMI), waits
-for the job, and asserts the full histogram. Measured wall times below include
-program generation and, for QDMI, compilation and submission. The timing runs
-used the initial implementation based on `383827e64`, before the rebase:
+The examples in `docs/benchmarks.md` reproduce the 15-qubit execution through
+`sample`, then `compile_program` and `submit_program` for both DDSIM payload
+paths. Each uses 16 shots and seed 17 (`custom1=17` for QDMI), waits for the
+job, and asserts `{"00": 16}`. Intermediate measurements control subsequent
+gates, so the simulator executes the circuit once per shot. These examples check
+a deterministic ideal output; they do not need a large statistical sample.
 
-| Path                                 | Counts        | Wall time |
-| ------------------------------------ | ------------- | --------- |
-| Direct DD sampling                   | `{"00": 256}` | 2.649 s   |
-| DDSIM, selected Adaptive QIR bitcode | `{"00": 256}` | 2.806 s   |
-| DDSIM, explicit OpenQASM 3           | `{"00": 256}` | 2.238 s   |
+Shot-count measurements on 2026-09-12 used the same generated level 1 program,
+reused the compiled QDMI payloads, and took the median of three runs per case.
+Every histogram matched its ideal output. Generation took 0.014 s; target
+compilation took 0.070 s for Adaptive QIR and 0.038 s for OpenQASM 3.
 
-These adaptive jobs are validated through counts. They do not expose an
-uncollapsed statevector; see `docs/qdmi/ddsim_device.md`.
+| Path                        | 256 shots | 16 shots |
+| --------------------------- | --------- | -------- |
+| Direct DD sampling          | 4.163 s   | 0.190 s  |
+| DDSIM, Adaptive QIR bitcode | 2.164 s   | 0.181 s  |
+| DDSIM, OpenQASM 3           | 2.335 s   | 0.155 s  |
 
-Level 2 uses 225 qubits. Direct sampling returned `{"00": 256}` in 225.325 s,
-and DDSIM Adaptive QIR returned `{"00": 256}` in 175.874 s, using the same shot
-count and seed. The post-rebase OpenQASM 3 smoke test returned `{"00": 1}`. The
-timings are individual runs on the shared host, not controlled comparisons.
+The QDMI timings include submission and execution but exclude target
+compilation. These are shared-host observations, not performance guarantees.
+Adaptive jobs are validated through counts and do not expose an uncollapsed
+statevector; see `docs/qdmi/ddsim_device.md`.
+
+Manual level 2 validation used 225 qubits and 256 shots per path with seed 17.
+Direct sampling returned `{"00": 256}` in 225.325 s, DDSIM Adaptive QIR returned
+`{"00": 256}` in 175.874 s, and DDSIM OpenQASM 3 returned `{"00": 256}` in
+262.640 s. These individual runs used the implementation based on `383827e64`,
+before the rebase, and are not CI tests.

--- a/.agent/plans/magic-state-distillation.md
+++ b/.agent/plans/magic-state-distillation.md
@@ -1,0 +1,104 @@
+# Concatenated magic-state distillation benchmark
+
+Status: complete; implementation, required execution paths, tests, generated
+stubs, and executable documentation are validated.
+
+## Outcome and scope
+
+`MagicStateDistillation` and Python `bench.magic_state_distillation` implement
+15-to-1 Reed–Muller distillation of ideal `|T> = T|+>` inputs. The
+`magic-state-distillation` family has definition version 1 and supports
+`levels=1` through `levels=4`, with one level as the default. It allocates
+exactly 15, 225, 3,375, or 50,625 qubits, respectively.
+
+C++, Python, strict JSON, CLI discovery/generation/evaluation, manifests, and
+semantic case IDs use the existing benchmark infrastructure. The two-bit
+`result` has a sticky rejection flag in bit 1 and a root-state check in bit 0;
+ideal big-endian output is `00`. Noise options, physical error correction,
+independent factories, retries, and the separate Shor benchmark are outside this
+change. Ideal inputs check execution, without claiming an improvement in
+noisy-state fidelity.
+
+The implementation lives in `include/mqt-core/bench/MagicStateDistillation.hpp`,
+`src/bench/MagicStateDistillation.cpp`, and
+`mlir/bench/programs/MagicStateDistillation.cpp`. Executable examples are in
+`docs/benchmarks.md`; tests mirror the native, MLIR, and Python entry points.
+
+## Decisions
+
+- Use the direct input-state protocol in
+  [Bravyi–Haah, Appendix A](https://arxiv.org/pdf/1209.2426) and the 15-qubit
+  code of [Bravyi–Kitaev](https://arxiv.org/abs/quant-ph/0403025). Columns are
+  the nonzero four-bit vectors. The logical row is all ones; the four even rows
+  are the coordinate bits.
+- A fixed 52-CNOT decoder exposes ten Z syndromes. Undoing that decoder,
+  applying conditional `SX` corrections and transversal S-dagger, and decoding
+  again leaves four X checks and a retained T state on the first wire. The
+  correction locations and circuit are fixed data; there is no code-synthesis
+  framework. An independent binary-matrix and amplitude calculation checked the
+  output phase for all 1,024 Z-syndrome branches.
+- Allocate qubits in the entry function. A private function borrows 15 scalar
+  qubits and returns a rejection bit. Structured loops feed actual retained
+  child outputs into parent blocks. Cleanup removes the root's single-iteration
+  loop; the other level loops and private block remain in QC/QCO.
+- Keep rejection in a local CBit register. After the root's T-dagger/H check,
+  reset and reuse that measured qubit to return rejection as a measurement. This
+  keeps the exact qubit count and works with QIR's current lack of writes from
+  computed booleans into result slots
+  ([qir-spec #65](https://github.com/qir-alliance/qir-spec/issues/65)).
+- Compiled OpenQASM exposed a DD interpreter gap: parameterized `qco.call`
+  operations reached the constant-matrix fallback. They now reuse the existing
+  `func.call` interpreter, including parameter bindings, return-wire mapping,
+  recursion protection, and the execution budget. Controlled composite modifiers
+  retain their existing constant-matrix requirement.
+
+## Validation
+
+Validated on 2026-09-12 with LLVM/MLIR 23.1.0. Native checks used the configured
+Clang 23 Release build with ThinLTO. The focused native and Python suites,
+stubs, C++ lint, and executable documentation also passed after rebasing onto
+`bb5ec85e5` from current main.
+
+- Native benchmark references: 65 tests passed, including invalid options and
+  counts, both rejection-bit values, strict JSON, manifests, and case IDs.
+- Native benchmark generation: 34 tests passed. The new tests sample 256 ideal
+  shots, reject all 15 single and 105 double input Z errors, and report a wrong
+  root state for all 35 accepted triple-error patterns. Faults are injected only
+  into leaf preparation in tests. Expected syndromes come independently from
+  XORing the erroneous column labels.
+- Levels 2–4 generate and convert to QCO with the exact qubit counts and compact
+  operation growth. Tests check parent indices, leaf-only preparation, and
+  accumulated rejection. Simulation of levels 3–4 was not run.
+- DD functionality: all 89 tests passed, including a new parameterized nested
+  unitary-call regression covering functionality, statevectors, sampling, and
+  global phase.
+- Python: 111 tests passed across `test/python/bench/` and
+  `test/python/qdmi/test_compilation.py`. These include level 2 smoke tests with
+  one shot through direct sampling and both DDSIM formats. The CLI and JSON
+  CTest selection also passed.
+- `uvx nox -s stubs` and changed-file C++ lint passed. Repository lint passed
+  with unrelated untracked audit scripts excluded from type checking through a
+  temporary configuration; tracked lint settings are unchanged.
+- Generated MLIR references and `uvx nox --non-interactive -s docs` passed,
+  including all executable examples and generated local-link checks.
+
+The examples in `docs/benchmarks.md` reproduce the required 15-qubit execution
+through `sample`, then `compile_program` and `submit_program` for both DDSIM
+payload paths. Each uses 256 shots and seed 17 (`custom1=17` for QDMI), waits
+for the job, and asserts the full histogram. Measured wall times below include
+program generation and, for QDMI, compilation and submission. The timing runs
+used the initial implementation based on `383827e64`, before the rebase:
+
+| Path                                 | Counts        | Wall time |
+| ------------------------------------ | ------------- | --------- |
+| Direct DD sampling                   | `{"00": 256}` | 2.649 s   |
+| DDSIM, selected Adaptive QIR bitcode | `{"00": 256}` | 2.806 s   |
+| DDSIM, explicit OpenQASM 3           | `{"00": 256}` | 2.238 s   |
+
+These adaptive jobs are validated through counts. They do not expose an
+uncollapsed statevector; see `docs/qdmi/ddsim_device.md`.
+
+Level 2 uses 225 qubits. Direct sampling returned `{"00": 256}` in 225.325 s,
+and DDSIM Adaptive QIR returned `{"00": 256}` in 175.874 s, using the same shot
+count and seed. The post-rebase OpenQASM 3 smoke test returned `{"00": 1}`. The
+timings are individual runs on the shared host, not controlled comparisons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,20 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- ✨ Add a 15-to-1 magic-state distillation benchmark with one to four
+  concatenated levels, ideal inputs, and C++, Python, and CLI interfaces.
+  ([#2543]) ([**@burgholzer**])
+
+### Changed
+
 - ✨ Optimize constant two-qubit blocks before placement and during native
   synthesis. Remove cancelled interactions before routing and preserve cheaper
   native operations in both target compilation and synthesis. Avoid redundant
   cleanup in both target pipelines. ([#2537]) ([**@burgholzer**])
 
-- ✨ Add a 15-to-1 magic-state distillation benchmark with one to four
-  concatenated levels, ideal inputs, and C++, Python, and CLI interfaces.
-  ([#2543]) ([**@burgholzer**])
+### Fixed
 
 - 🐛 Execute parameterized unitary calls in DD simulation, including gate
   helpers reimported from compiled OpenQASM. ([#2543]) ([**@burgholzer**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ releases may include breaking changes.
   native operations in both target compilation and synthesis. Avoid redundant
   cleanup in both target pipelines. ([#2537]) ([**@burgholzer**])
 
+- ✨ Add a 15-to-1 magic-state distillation benchmark with one to four
+  concatenated levels, ideal inputs, and C++, Python, and CLI interfaces.
+  ([#2543]) ([**@burgholzer**])
+
+- 🐛 Execute parameterized unitary calls in DD simulation, including gate
+  helpers reimported from compiled OpenQASM. ([#2543]) ([**@burgholzer**])
+
 ## [4.0.0] - 2026-09-11
 
 ### MQT Core 4: a compiler foundation built on MLIR and LLVM
@@ -1119,6 +1126,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2543]: https://github.com/munich-quantum-toolkit/core/pull/2543
 [#2538]: https://github.com/munich-quantum-toolkit/core/pull/2538
 [#2537]: https://github.com/munich-quantum-toolkit/core/pull/2537
 [#2535]: https://github.com/munich-quantum-toolkit/core/pull/2535

--- a/bindings/bench/CMakeLists.txt
+++ b/bindings/bench/CMakeLists.txt
@@ -13,6 +13,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-bench-bindings)
       register_modular_multiplier.cpp
       register_ghz.cpp
       register_grover.cpp
+      register_magic_state_distillation.cpp
       register_multiplexer.cpp
       register_qft.cpp
       register_qft_adder.cpp

--- a/bindings/bench/register_bench.cpp
+++ b/bindings/bench/register_bench.cpp
@@ -23,6 +23,7 @@ void registerBV(const nb::module_& m);
 void registerModularMultiplier(const nb::module_& m);
 void registerGHZ(const nb::module_& m);
 void registerGrover(const nb::module_& m);
+void registerMagicStateDistillation(const nb::module_& m);
 void registerMultiplexer(const nb::module_& m);
 void registerQFT(const nb::module_& m);
 void registerQFTAdder(const nb::module_& m);
@@ -68,6 +69,11 @@ NB_MODULE(MQT_CORE_MODULE_NAME, m) {
   const nb::module_ grover =
       m.def_submodule("grover", "Grover benchmark instances and options.");
   registerGrover(grover);
+
+  const nb::module_ magicStateDistillation =
+      m.def_submodule("magic_state_distillation",
+                      "Concatenated 15-to-1 magic-state distillation.");
+  registerMagicStateDistillation(magicStateDistillation);
 
   const nb::module_ multiplexer = m.def_submodule(
       "multiplexer", "Quantum multiplexer benchmark instances and options.");

--- a/bindings/bench/register_magic_state_distillation.cpp
+++ b/bindings/bench/register_magic_state_distillation.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "bench/JSON.hpp"
+#include "bench/MagicStateDistillation.hpp"
+
+#include "nanobind/nanobind.h"
+#include "nanobind/stl/map.h"         /// NOLINT(misc-include-cleaner)
+#include "nanobind/stl/string.h"      /// NOLINT(misc-include-cleaner)
+#include "nanobind/stl/string_view.h" /// NOLINT(misc-include-cleaner)
+
+#include <cstddef>
+
+namespace mqt {
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+/// NOLINTNEXTLINE(misc-use-internal-linkage)
+void registerMagicStateDistillation(const nb::module_& m) {
+  nb::class_<bench::MagicStateDistillationOptions>(
+      m, "Options",
+      "Parameters for concatenated 15-to-1 magic-state distillation.")
+      .def(nb::init<size_t>(), nb::kw_only(), "levels"_a = 1)
+      .def_ro("levels", &bench::MagicStateDistillationOptions::levels,
+              "Concatenated levels in [1, 4], using 15**levels qubits.");
+  auto magicStateDistillation = nb::class_<bench::MagicStateDistillation>(
+      m, "MagicStateDistillation",
+      R"pb(Concatenated 15-to-1 Reed--Muller distillation.
+
+Inputs are ideal :math:`|T\rangle = T|+\rangle` states.
+Bit 1 flags any rejected block; bit 0 checks the retained root state in the T
+basis. Ideal output is ``00``. Each level consumes the preceding level's
+retained quantum outputs, using exactly ``15**levels`` qubits.)pb");
+  magicStateDistillation
+      .def(nb::init<bench::MagicStateDistillationOptions>(),
+           "options"_a = bench::MagicStateDistillationOptions{})
+      .def_prop_ro("options", &bench::MagicStateDistillation::options,
+                   nb::rv_policy::reference_internal,
+                   "The resolved benchmark parameters.")
+      .def_prop_ro("output", &bench::MagicStateDistillation::output,
+                   nb::rv_policy::reference_internal,
+                   "The logical output register.")
+      .def("probability", &bench::MagicStateDistillation::probability,
+           "outcome"_a, "Return the ideal probability of an outcome.")
+      .def("evaluate", &bench::MagicStateDistillation::evaluate, "counts"_a,
+           "Compare sampled counts with the ideal distribution.")
+      .def(
+          "generate",
+          [](const bench::MagicStateDistillation& value) {
+            return nb::module_::import_("mqt.core.mlir")
+                .attr("_generate_benchmark")(
+                    bench::toInstanceSpecificationJSON(value));
+          },
+          nb::sig("def generate(self) -> mqt.core.mlir.QCProgram"),
+          "Generate the benchmark as a QC program.")
+      .def_prop_ro(
+          "instance_specification_json",
+          [](const bench::MagicStateDistillation& value) {
+            return bench::toInstanceSpecificationJSON(value);
+          },
+          "The canonical instance specification JSON.")
+      .def_prop_ro(
+          "manifest_json",
+          [](const bench::MagicStateDistillation& value) {
+            return bench::toManifestJSON(value);
+          },
+          "The canonical manifest JSON.")
+      .def_prop_ro(
+          "case_id",
+          [](const bench::MagicStateDistillation& value) {
+            return bench::caseId(value);
+          },
+          "The stable semantic case ID.")
+      .def_static("from_instance_specification_json",
+                  &bench::magicStateDistillationFromInstanceSpecificationJSON,
+                  "json"_a, nb::kw_only(),
+                  "source"_a = "<instance-specification>",
+                  "Parse a strict benchmark instance specification.")
+      .def_static("from_manifest_json",
+                  &bench::magicStateDistillationFromManifestJSON, "json"_a,
+                  nb::kw_only(), "source"_a = "<manifest>",
+                  "Parse a strict benchmark manifest.");
+}
+
+} /* namespace mqt */

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -431,3 +431,82 @@ The input width limit does not guarantee that a device or compiler supports that
 many qubits. See {doc}`mlir/target_compilation` for device and control-flow
 limits. The benchmark simulates an ideal adaptive circuit; it does not model
 error correction, magic-state distillation, or cultivation.
+
+### Magic-state distillation
+
+The `magic-state-distillation` family implements concatenated 15-to-1
+Reed–Muller distillation of $|T\rangle = T|+\rangle$ states. It follows the
+direct input-state protocol in
+[Bravyi and Haah, Appendix A](https://arxiv.org/pdf/1209.2426), using the
+15-qubit code of [Bravyi and Kitaev](https://arxiv.org/abs/quant-ph/0403025).
+Each block measures Z checks, applies conditional Clifford corrections, measures
+X checks, and decodes one retained state. The fixed code convention labels
+columns by the nonzero four-bit vectors; its four even generator rows are their
+coordinate bits and its odd logical row is all ones.
+
+Set `levels` to 1–4 (default 1). A level consumes the actual retained quantum
+outputs of the preceding level. The circuit allocates exactly
+$15^{\mathrm{levels}}$ qubits: 15, 225, 3,375, or 50,625. A private function
+implements each block, and structured loops traverse the blocks. Syndrome
+measurements use those same qubits, without extra ancillas.
+
+```json
+{"schema_version":1,"benchmark":"magic-state-distillation","parameters":{"levels":1}}
+```
+
+The two-bit `result` combines a sticky rejection flag in bit 1 with a root-state
+check in bit 0. Only the root is measured after T-dagger and H; this checks its
+relative phase as well as its amplitudes. The measured root is then reset and
+reused to return the rejection flag as a measurement. Every block runs once,
+including blocks whose inputs come from a rejected subtree. Ideal input states
+give `00` with probability one. The benchmark does not model input noise,
+physical error correction, or retries, so this example does not measure fidelity
+improvement from noisy inputs.
+
+#### Sample the 15-qubit circuit directly
+
+```{code-cell} ipython3
+from mqt.core.bench import magic_state_distillation
+from mqt.core.mlir import sample
+
+factory = magic_state_distillation.MagicStateDistillation(
+    magic_state_distillation.Options(levels=1)
+)
+direct_counts = sample(factory.generate(), shots=256, seed=17)
+assert direct_counts == {"00": 256}
+print(direct_counts)
+```
+
+#### Run through DDSIM with two program formats
+
+The default DDSIM target selects Adaptive QIR. The second submission selects
+OpenQASM 3 explicitly; both execute the measurement-dependent corrections.
+
+```{code-cell} ipython3
+from mqt.core.mlir import compile_program, submit_program
+from mqt.core.qdmi import ProgramFormat
+from mqt.core.qdmi.driver import open_device
+
+factory_device = open_device("mqt.ddsim.default")
+for requested_format in (None, ProgramFormat.QASM3):
+    compiled_factory = compile_program(
+        factory.generate(), target=factory_device, program_format=requested_format
+    )
+    if requested_format is None:
+        assert compiled_factory.program_format in (
+            ProgramFormat.QIR_ADAPTIVE_MODULE,
+            ProgramFormat.QIR_ADAPTIVE_STRING,
+        )
+    factory_job = submit_program(
+        compiled_factory, target=factory_device, num_shots=256, custom1=17
+    )
+    factory_job.wait()
+    factory_counts = factory_job.get_counts()
+    assert factory_counts == {"00": 256}
+    assert factory.evaluate(factory_counts).success_probability == 1.0
+    print(compiled_factory.program_format.name, factory_counts)
+```
+
+Higher levels provide larger structured programs; support for their generation
+does not guarantee a given device's capacity. These adaptive jobs expose counts,
+without an uncollapsed statevector; see {doc}`qdmi/ddsim_device`.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -465,6 +465,10 @@ improvement from noisy inputs.
 
 #### Sample the 15-qubit circuit directly
 
+These examples use 16 shots to keep execution short. The circuit runs once per
+shot because later gates depend on intermediate measurements. Increase the shot
+count when collecting statistics; the ideal output here is deterministic.
+
 ```{code-cell} ipython3
 from mqt.core.bench import magic_state_distillation
 from mqt.core.mlir import sample
@@ -472,8 +476,8 @@ from mqt.core.mlir import sample
 factory = magic_state_distillation.MagicStateDistillation(
     magic_state_distillation.Options(levels=1)
 )
-direct_counts = sample(factory.generate(), shots=256, seed=17)
-assert direct_counts == {"00": 256}
+direct_counts = sample(factory.generate(), shots=16, seed=17)
+assert direct_counts == {"00": 16}
 print(direct_counts)
 ```
 
@@ -498,11 +502,11 @@ for requested_format in (None, ProgramFormat.QASM3):
             ProgramFormat.QIR_ADAPTIVE_STRING,
         )
     factory_job = submit_program(
-        compiled_factory, target=factory_device, num_shots=256, custom1=17
+        compiled_factory, target=factory_device, num_shots=16, custom1=17
     )
     factory_job.wait()
     factory_counts = factory_job.get_counts()
-    assert factory_counts == {"00": 256}
+    assert factory_counts == {"00": 16}
     assert factory.evaluate(factory_counts).success_probability == 1.0
     print(compiled_factory.program_format.name, factory_counts)
 ```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -307,6 +307,17 @@ manifest
   outputs, reference model, and benchmark-definition version. It accompanies
   the generated program but does not identify its file, format, or bytes.
 
+magic state
+  **Preferred term:** magic state. A non-stabilizer quantum state consumed by
+  protocols that implement non-Clifford operations using Clifford operations
+  and measurements. The distillation benchmark uses $|T\rangle = T|+\rangle$.
+
+magic-state distillation
+  **Preferred term:** magic-state distillation. A protocol that consumes several
+  imperfect magic states and conditionally retains fewer states with smaller
+  errors. Concatenated levels feed retained quantum states into further blocks.
+  The benchmark uses ideal inputs to check the protocol's execution.
+
 iterative quantum phase estimation
 iterative QPE
 iQPE

--- a/include/mqt-core/bench/BenchmarkFamilies.inc
+++ b/include/mqt-core/bench/BenchmarkFamilies.inc
@@ -26,9 +26,10 @@
 MQT_BENCHMARK_FAMILY(BV, bv, "bv", 1)
 MQT_BENCHMARK_FAMILY(GHZ, ghz, "ghz", 1)
 MQT_BENCHMARK_FAMILY(Grover, grover, "grover", 1)
-MQT_BENCHMARK_FAMILY(ModularMultiplier,
-                     modularMultiplier,
-                     "modular-multiplier", 1)
+MQT_BENCHMARK_FAMILY(MagicStateDistillation, magicStateDistillation,
+                     "magic-state-distillation", 1)
+MQT_BENCHMARK_FAMILY(ModularMultiplier, modularMultiplier, "modular-multiplier",
+                     1)
 MQT_BENCHMARK_FAMILY(Multiplexer, multiplexer, "multiplexer", 1)
 MQT_BENCHMARK_FAMILY(QFT, qft, "qft", 1)
 MQT_BENCHMARK_FAMILY(QFTAdder, qftAdder, "qft-adder", 1)

--- a/include/mqt-core/bench/JSON.hpp
+++ b/include/mqt-core/bench/JSON.hpp
@@ -14,6 +14,7 @@
 #include "bench/Evaluation.hpp"
 #include "bench/GHZ.hpp"
 #include "bench/Grover.hpp"
+#include "bench/MagicStateDistillation.hpp"
 #include "bench/ModularMultiplier.hpp"
 #include "bench/Multiplexer.hpp"
 #include "bench/QFT.hpp"

--- a/include/mqt-core/bench/MagicStateDistillation.hpp
+++ b/include/mqt-core/bench/MagicStateDistillation.hpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include "bench/Evaluation.hpp"
+#include "bench/mqt_core_bench_export.h"
+
+#include <cstddef>
+#include <string_view>
+
+namespace mqt::bench {
+
+/// Parameters for concatenated 15-to-1 Reed--Muller distillation.
+struct MagicStateDistillationOptions {
+  /// Concatenated levels in [1, 4], using exactly 15^levels qubits.
+  size_t levels = 1;
+};
+
+/// Distill ideal |T> = T|+> inputs, consuming retained outputs at each level.
+/// Bit 1 flags any rejected block; bit 0 checks the root output in the T basis.
+class MQT_CORE_BENCH_EXPORT MagicStateDistillation final {
+public:
+  explicit MagicStateDistillation(MagicStateDistillationOptions options = {});
+  [[nodiscard]] const MagicStateDistillationOptions& options() const noexcept;
+  [[nodiscard]] const Output& output() const noexcept;
+  /// Return the ideal probability of a big-endian logical outcome.
+  [[nodiscard]] double probability(std::string_view outcome) const;
+  /// Compare sampled logical outcomes with the ideal distribution.
+  [[nodiscard]] Evaluation evaluate(const Counts& counts) const;
+
+private:
+  MagicStateDistillationOptions options_;
+  Output output_;
+};
+
+} /* namespace mqt::bench */

--- a/mlir/bench/programs/CMakeLists.txt
+++ b/mlir/bench/programs/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
   BV.cpp
   GHZ.cpp
   Grover.cpp
+  MagicStateDistillation.cpp
   ModularMultiplier.cpp
   Multiplexer.cpp
   QFT.cpp

--- a/mlir/bench/programs/MagicStateDistillation.cpp
+++ b/mlir/bench/programs/MagicStateDistillation.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "bench/MagicStateDistillation.hpp"
+
+#include "mqt/Dialect/QC/Builder/QCProgramBuilder.h"
+#include "mqt/Dialect/QC/IR/QCDialect.h"
+
+#include "Programs.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace mqt::bench {
+
+using namespace mlir;
+
+namespace {
+
+/// Decoder for columns 1..15, logical row all ones, then the four coordinate
+/// rows. Its inverse maps input bits 0..4 to those five generator rows and
+/// bits 5..14 to the physical unit vectors at CORRECTION_QUBITS.
+/// Fixed Gaussian elimination of that binary encoding matrix gives these CXs.
+constexpr std::array<std::pair<size_t, size_t>, 52> DECODER{
+    {
+        {0, 1},  {0, 2},  {0, 3},  {0, 4},  {0, 5},  {0, 6},  {0, 7}, {0, 8},
+        {0, 9},  {0, 10}, {0, 11}, {0, 12}, {0, 13}, {0, 14}, {1, 0}, {1, 3},
+        {1, 5},  {1, 7},  {1, 9},  {1, 11}, {1, 13}, {2, 0},  {2, 1}, {2, 3},
+        {2, 6},  {2, 7},  {2, 10}, {2, 11}, {2, 14}, {3, 4},  {3, 5}, {3, 6},
+        {3, 11}, {3, 12}, {3, 13}, {3, 14}, {4, 7},  {7, 4},  {4, 7}, {4, 8},
+        {4, 9},  {4, 10}, {4, 11}, {4, 12}, {4, 13}, {4, 14}, {5, 7}, {7, 5},
+        {5, 7},  {6, 7},  {7, 6},  {6, 7},
+    },
+};
+constexpr std::array<size_t, 10> CORRECTION_QUBITS{
+    4, 5, 6, 8, 9, 10, 11, 12, 13, 14,
+};
+
+} /* namespace */
+
+static Value distillMagicStates(qc::QCProgramBuilder& builder,
+                                ValueRange qubits) {
+  assert(qubits.size() == 15);
+  /// Bravyi--Haah, arXiv:1209.2426, Appendix A: project raw magic states
+  /// onto Z checks, correct with A(w), apply U, then postselect X checks.
+  for (const auto& [control, target] : DECODER) {
+    builder.cx(qubits[control], qubits[target]);
+  }
+  SmallVector<Value, 10> syndrome;
+  for (size_t i = 5; i < 15; ++i) {
+    syndrome.push_back(builder.measure(qubits[i]));
+  }
+  for (const auto& [control, target] : llvm::reverse(DECODER)) {
+    builder.cx(qubits[control], qubits[target]);
+  }
+  for (size_t i = 0; i < syndrome.size(); ++i) {
+    builder.scfIf(syndrome[i], [&] {
+      /// A = T X T-dagger equals S X up to global phase and fixes |T>.
+      auto qubit = qubits[CORRECTION_QUBITS[i]];
+      builder.x(qubit);
+      builder.s(qubit);
+    });
+  }
+  /// The even rows have weight eight and the odd row has weight fifteen:
+  /// transversal T-dagger implements logical T, hence U = S-dagger^tensor15.
+  for (auto qubit : qubits) {
+    builder.sdg(qubit);
+  }
+  for (const auto& [control, target] : DECODER) {
+    builder.cx(qubits[control], qubits[target]);
+  }
+  auto rejected = builder.boolConstant(false);
+  for (size_t i = 1; i < 5; ++i) {
+    builder.h(qubits[i]);
+    rejected =
+        arith::OrIOp::create(builder, rejected, builder.measure(qubits[i]));
+  }
+  return rejected;
+}
+
+SmallVector<Value>
+magicStateDistillation(qc::QCProgramBuilder& builder,
+                       const MagicStateDistillation& benchmark) {
+  int64_t size = 1;
+  for (size_t level = 0; level < benchmark.options().levels; ++level) {
+    size *= 15;
+  }
+  auto data = builder.allocQubitRegisterStorage(size, "magic");
+  auto result = builder.allocClassicalBitRegister(2, benchmark.output().name);
+  auto rejection = builder.allocClassicalBitRegister(1);
+  builder.storeClassicalBit(builder.boolConstant(false), rejection, 0);
+  auto block = builder.createFunction(
+      "distill_15_to_1",
+      SmallVector<Type>(15, qc::QubitType::get(builder.getContext())),
+      [&](ValueRange qubits) -> SmallVector<Value> {
+        return {distillMagicStates(builder, qubits)};
+      });
+  builder.scfFor(0, size, 1, [&](Value index) {
+    auto qubit = builder.loadQubit(data, index);
+    builder.h(qubit);
+    builder.t(qubit);
+  });
+  for (int64_t stride = 1; stride < size; stride *= 15) {
+    builder.scfFor(0, size, stride * 15, [&](Value first) {
+      SmallVector<Value, 15> qubits;
+      for (int64_t i = 0; i < 15; ++i) {
+        auto index = arith::AddIOp::create(builder, first,
+                                           builder.indexConstant(i * stride));
+        qubits.push_back(builder.loadQubit(data, index));
+      }
+      auto rejected = builder.call(block, qubits).front();
+      auto sticky = arith::OrIOp::create(
+          builder, builder.loadClassicalBit(rejection, 0), rejected);
+      builder.storeClassicalBit(sticky, rejection, 0);
+    });
+  }
+  auto root = builder.loadQubit(data, builder.indexConstant(0));
+  builder.tdg(root);
+  builder.h(root);
+  builder.measure(root, result, 0);
+  /// QIR lacks writes of computed bits to result slots (qir-spec issue #65).
+  /// Reuse the measured root to expose rejection without another qubit.
+  builder.reset(root);
+  builder.scfIf(builder.loadClassicalBit(rejection, 0),
+                [&] { builder.x(root); });
+  builder.measure(root, result, 1);
+  return {result};
+}
+
+} /* namespace mqt::bench */

--- a/mlir/bench/programs/Programs.h
+++ b/mlir/bench/programs/Programs.h
@@ -22,6 +22,7 @@ class BV;
 class ModularMultiplier;
 class GHZ;
 class Grover;
+class MagicStateDistillation;
 class Multiplexer;
 class QFT;
 class QFTAdder;
@@ -43,6 +44,11 @@ SmallVector<Value> modularMultiplier(qc::QCProgramBuilder& builder,
 
 /// Emit one configured GHZ benchmark.
 SmallVector<Value> ghz(qc::QCProgramBuilder& builder, const GHZ& benchmark);
+
+/// Emit concatenated 15-to-1 magic-state distillation.
+SmallVector<Value>
+magicStateDistillation(qc::QCProgramBuilder& builder,
+                       const MagicStateDistillation& benchmark);
 
 /// Emit one configured Grover benchmark.
 SmallVector<Value> grover(qc::QCProgramBuilder& builder,

--- a/mlir/include/mqt/Dialect/QCO/Utils/DDFunctionality.h
+++ b/mlir/include/mqt/Dialect/QCO/Utils/DDFunctionality.h
@@ -53,9 +53,10 @@ struct DDSamplingState {
 /// wires in instruction order. Measurements, resets, symbolic control, and
 /// other runtime allocation are not supported.
 ///
-/// Runtime-bound parameters are supported for standard gates and for a sole
-/// standard gate inside `qco.ctrl`. Custom matrices and composite modifiers
-/// must have a compile-time-known matrix.
+/// Runtime-bound parameters are supported for standard gates, direct
+/// `qco.call` operations, and a sole standard gate inside `qco.ctrl`.
+/// Custom matrices and composite modifiers must have a compile-time-known
+/// matrix.
 ///
 /// The containing module must pass MLIR verification and
 /// `qco::verifyLinearity`.

--- a/mlir/include/mqt/bench/Generate.h
+++ b/mlir/include/mqt/bench/Generate.h
@@ -21,6 +21,7 @@ class BV;
 class ModularMultiplier;
 class GHZ;
 class Grover;
+class MagicStateDistillation;
 class Multiplexer;
 class QFT;
 class QFTAdder;
@@ -45,6 +46,10 @@ generate(const ModularMultiplier& benchmark);
 
 /// Generate the QC program for a configured GHZ benchmark.
 [[nodiscard]] std::optional<mlir::QCProgram> generate(const GHZ& benchmark);
+
+/// Generate concatenated 15-to-1 magic-state distillation.
+[[nodiscard]] std::optional<mlir::QCProgram>
+generate(const MagicStateDistillation& benchmark);
 
 /// Generate the QC program for a configured Grover benchmark.
 [[nodiscard]] std::optional<mlir::QCProgram> generate(const Grover& benchmark);

--- a/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
+++ b/mlir/lib/Dialect/QCO/Utils/DDFunctionality.cpp
@@ -1693,20 +1693,20 @@ static LogicalResult applyOp(Operation& op, WalkState& walk, StateDD& state) {
                          yield.getOperands().end());
         }
       })
-      .Case([&](func::CallOp call) -> LogicalResult {
+      .template Case<func::CallOp, CallOp>([&](auto call) -> LogicalResult {
         auto callee = walk.symbols.lookupNearestSymbolFrom<func::FuncOp>(
             call, call.getCalleeAttr());
         if (!callee) {
-          return call.emitError() << "func.call callee '" << call.getCallee()
+          return call.emitError() << "call callee '" << call.getCallee()
                                   << "' could not be resolved";
         }
         if (callee.isDeclaration()) {
-          return call.emitError() << "func.call callee must have a body";
+          return call.emitError() << "call callee must have a body";
         }
         Operation* calleeOp = callee.getOperation();
         if (!walk.activeCalls.insert(calleeOp).second) {
           return call.emitError()
-                 << "recursive func.call is not supported for QCO DD "
+                 << "recursive call is not supported for QCO DD "
                     "simulation";
         }
         const auto guard =

--- a/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
+++ b/mlir/unittests/Dialect/QCO/Utils/test_dd_functionality.cpp
@@ -1998,6 +1998,56 @@ TEST_F(QCODDFunctionalityTest, RepeatedCallsRespectNearestSymbolTable) {
   expectEqualToReference(mainFunc(nested), 1, {referenceGate<HOp>({0})});
 }
 
+TEST_F(QCODDFunctionalityTest, ParameterizedUnitaryCallsUseClassicalBindings) {
+  auto mod = parseSourceString<ModuleOp>(R"mlir(
+    module {
+      func.func private @rotate(%theta: f64, %q: !qco.qubit) -> !qco.qubit
+          attributes {mqt.unitary} {
+        qco.gphase(%theta)
+        %out = qco.rx(%theta) %q : !qco.qubit -> !qco.qubit
+        return %out : !qco.qubit
+      }
+      func.func private @twice(%theta: f64, %q: !qco.qubit) -> !qco.qubit
+          attributes {mqt.unitary} {
+        %a = qco.call @rotate(%theta, %q) : (f64, !qco.qubit) -> !qco.qubit
+        %b = qco.call @rotate(%theta, %a) : (f64, !qco.qubit) -> !qco.qubit
+        return %b : !qco.qubit
+      }
+      func.func @main(%theta: f64) {
+        %q = qco.static 0 : !qco.qubit
+        %out = qco.call @twice(%theta, %q) : (f64, !qco.qubit) -> !qco.qubit
+        qco.sink %out : !qco.qubit
+        return
+      }
+    }
+  )mlir",
+                                         context.get());
+  ASSERT_TRUE(mod);
+  ASSERT_TRUE(succeeded(verify(*mod)));
+  auto func = mainFunc(*mod);
+  DDArgumentBindings bindings;
+  bindings[func.getArgument(0)] =
+      FloatAttr::get(Float64Type::get(context.get()), std::numbers::pi / 2.);
+  dd::Package package(1);
+  auto matrix = buildFunctionality(func, package, bindings);
+  ASSERT_TRUE(succeeded(matrix));
+  const auto dense = matrix->getMatrix(1);
+  /// Two rotations and their global phases give iX, checking the phase too.
+  EXPECT_NEAR(std::abs(dense[0][0]), 0., 1e-12);
+  EXPECT_NEAR(std::abs(dense[1][1]), 0., 1e-12);
+  EXPECT_NEAR(std::abs(dense[0][1] - std::complex<double>(0., 1.)), 0., 1e-12);
+  EXPECT_NEAR(std::abs(dense[1][0] - std::complex<double>(0., 1.)), 0., 1e-12);
+  package.decRef(*matrix);
+  auto state = simulateStatevector(func, package, bindings);
+  ASSERT_TRUE(succeeded(state));
+  EXPECT_NEAR(std::abs(state->getVector()[1] - std::complex<double>(0., 1.)),
+              0., 1e-12);
+  package.decRef(*state);
+  auto counts = sample(func, 8, 17, bindings);
+  ASSERT_TRUE(succeeded(counts));
+  EXPECT_EQ(*counts, (std::map<std::string, size_t>{{"1", 8}}));
+}
+
 TEST_F(QCODDFunctionalityTest, RejectsUnsupportedFuncCalls) {
   auto selfRecursive = parseSourceString<ModuleOp>(R"mlir(
     module {

--- a/mlir/unittests/bench/CMakeLists.txt
+++ b/mlir/unittests/bench/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
   test_benchmark_generate_bv.cpp
   test_benchmark_generate_ghz.cpp
   test_benchmark_generate_grover.cpp
+  test_benchmark_generate_magic_state_distillation.cpp
   test_benchmark_generate_modular_multiplier.cpp
   test_benchmark_generate_multiplexer.cpp
   test_benchmark_generate_qft.cpp

--- a/mlir/unittests/bench/test_benchmark_cli.cmake
+++ b/mlir/unittests/bench/test_benchmark_cli.cmake
@@ -45,8 +45,8 @@ endif()
 
 run_success("benchmark listing" list_output "${CLI}" list)
 string(JSON benchmark_count LENGTH "${list_output}" benchmarks)
-if(NOT benchmark_count EQUAL 10)
-  message(FATAL_ERROR "list returned ${benchmark_count} benchmarks instead of 10")
+if(NOT benchmark_count EQUAL 11)
+  message(FATAL_ERROR "list returned ${benchmark_count} benchmarks instead of 11")
 endif()
 
 run_success("multiplexer description" describe_output "${CLI}" describe multiplexer)

--- a/mlir/unittests/bench/test_benchmark_generate_magic_state_distillation.cpp
+++ b/mlir/unittests/bench/test_benchmark_generate_magic_state_distillation.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "bench/Evaluation.hpp"
+#include "bench/MagicStateDistillation.hpp"
+#include "mqt/Compiler/Programs.h"
+#include "mqt/Dialect/CBit/IR/CBitOps.h"
+#include "mqt/Dialect/MQT/IR/MQTDialect.h"
+#include "mqt/Dialect/QC/IR/QCOps.h"
+#include "mqt/Dialect/QCO/Utils/DDFunctionality.h"
+#include "mqt/bench/Generate.h"
+
+#include "TestUtils.h"
+
+#include "gtest/gtest.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace mqt::bench {
+
+using namespace mlir;
+
+TEST(GenerateProgramTest, SamplesMagicStateDistillation) {
+  auto program = test::generateQCO(MagicStateDistillation{});
+  ASSERT_TRUE(program);
+  auto counts =
+      qco::sample(mlir::mqt::getEntryPoint(program->module()), 256, 17);
+  ASSERT_TRUE(succeeded(counts));
+  EXPECT_EQ(*counts, (Counts{{"00", 256}}));
+}
+
+TEST(GenerateProgramTest, ConcatenatesRetainedMagicStatesInCompactLoops) {
+  size_t previousSize = 0;
+  int64_t qubitCount = 1;
+  for (const size_t levels : {1U, 2U, 3U, 4U}) {
+    qubitCount *= 15;
+    auto program = generate(MagicStateDistillation({.levels = levels}));
+    ASSERT_TRUE(program);
+    auto moduleOp = program->module();
+    auto helper = moduleOp.lookupSymbol<func::FuncOp>("distill_15_to_1");
+    ASSERT_TRUE(helper);
+    EXPECT_TRUE(helper.isPrivate());
+    EXPECT_EQ(helper.getNumArguments(), 15U);
+    EXPECT_EQ(test::countOps<qc::AllocOp>(moduleOp), 0U);
+    EXPECT_EQ(test::countOps<memref::AllocOp>(moduleOp), 1U);
+    moduleOp.walk([&](memref::AllocOp op) {
+      EXPECT_EQ(op.getType().getNumElements(), qubitCount);
+    });
+    /// Only the leaf preparation contains T gates; parent inputs stay quantum.
+    EXPECT_EQ(test::countOps<qc::TOp>(moduleOp), 1U);
+    int64_t stride = 1;
+    size_t calls = 0;
+    moduleOp.walk([&](func::CallOp call) {
+      EXPECT_EQ(call.getCallee(), helper.getSymName());
+      auto loop = call->getParentOfType<scf::ForOp>();
+      if (loop) {
+        EXPECT_EQ(loop.getConstantStep(), stride * 15);
+        EXPECT_EQ(getConstantIntValue(loop.getUpperBound()), qubitCount);
+      } else {
+        /// Cleanup removes the root loop because it has only one iteration.
+        EXPECT_EQ(stride * 15, qubitCount);
+      }
+      ASSERT_EQ(call.getNumOperands(), 15U);
+      for (size_t i = 0; i < 15; ++i) {
+        auto load = call.getOperand(i).getDefiningOp<memref::LoadOp>();
+        ASSERT_TRUE(load);
+        auto index = load.getIndices().front();
+        if (!loop) {
+          EXPECT_EQ(getConstantIntValue(index),
+                    static_cast<int64_t>(i) * stride);
+        } else if (i == 0) {
+          EXPECT_EQ(index, loop.getInductionVar());
+        } else {
+          auto add = index.getDefiningOp<arith::AddIOp>();
+          ASSERT_TRUE(add);
+          EXPECT_EQ(add.getLhs(), loop.getInductionVar());
+          EXPECT_EQ(getConstantIntValue(add.getRhs()),
+                    static_cast<int64_t>(i) * stride);
+        }
+      }
+      bool sticky = levels == 1;
+      for (auto* user : call.getResult(0).getUsers()) {
+        auto combine = dyn_cast<arith::OrIOp>(user);
+        if (!combine) {
+          continue;
+        }
+        auto old = combine.getLhs().getDefiningOp<cbit::LoadOp>();
+        ASSERT_TRUE(old);
+        EXPECT_EQ(getConstantIntValue(old.getIndex()), 0);
+        for (auto* consumer : combine.getResult().getUsers()) {
+          if (auto store = dyn_cast<cbit::StoreOp>(consumer)) {
+            EXPECT_EQ(store.getReg(), old.getReg());
+            EXPECT_EQ(getConstantIntValue(store.getIndex()), 0);
+            sticky = true;
+          } else if (auto readout = dyn_cast<scf::IfOp>(consumer)) {
+            EXPECT_FALSE(loop);
+            EXPECT_EQ(readout.getCondition(), combine.getResult());
+            sticky = true;
+          }
+        }
+      }
+      EXPECT_TRUE(sticky);
+      stride *= 15;
+      ++calls;
+    });
+    EXPECT_EQ(calls, levels);
+    auto size = test::countOperations(moduleOp);
+    if (levels > 1) {
+      EXPECT_LT(size - previousSize, 100U);
+    }
+    previousSize = size;
+    auto compiled = runDefaultPipeline(CompilerInput{std::move(*program)},
+                                       ProgramFormat::QCO);
+    ASSERT_TRUE(compiled);
+    auto& qcoProgram = std::get<QCOProgram>(*compiled);
+    EXPECT_LT(test::countOperations(qcoProgram.module()), 2000U);
+  }
+}
+
+TEST(GenerateProgramTest,
+     DistillationRejectsInputErrorsAndDetectsLogicalErrors) {
+  /// Independently, the four X-check syndromes are the XOR of the erroneous
+  /// columns 1..15; the logical Z error is their weight modulo two.
+  for (uint32_t errors = 0; errors < (1U << 15U); ++errors) {
+    const auto weight = std::popcount(errors);
+    if (weight < 1 || weight > 3) {
+      continue;
+    }
+    uint32_t syndrome = 0;
+    for (uint32_t i = 0; i < 15; ++i) {
+      if ((errors & (1U << i)) != 0) {
+        syndrome ^= i + 1;
+      }
+    }
+    if (weight == 3 && syndrome != 0) {
+      continue;
+    }
+    SCOPED_TRACE(errors);
+    auto program = generate(MagicStateDistillation{});
+    ASSERT_TRUE(program);
+    /// Insert faults in the leaf preparation only. The private block and public
+    /// rejection readout remain exactly those emitted for the benchmark.
+    program->module().walk([&](qc::TOp op) {
+      auto qubit = op.getQubit(0);
+      auto index = qubit.getDefiningOp<memref::LoadOp>().getIndices().front();
+      OpBuilder builder(op);
+      builder.setInsertionPointAfter(op);
+      auto loc = op.getLoc();
+      for (uint32_t i = 0; i < 15; ++i) {
+        if ((errors & (1U << i)) == 0) {
+          continue;
+        }
+        auto position = arith::ConstantIndexOp::create(builder, loc, i);
+        auto condition = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::eq, index, position);
+        scf::IfOp::create(builder, loc, condition,
+                          [&](OpBuilder& bodyBuilder, Location bodyLoc) {
+                            qc::ZOp::create(bodyBuilder, bodyLoc, qubit);
+                            scf::YieldOp::create(bodyBuilder, bodyLoc);
+                          });
+      }
+    });
+    auto compiled = runDefaultPipeline(CompilerInput{std::move(*program)},
+                                       ProgramFormat::QCO);
+    ASSERT_TRUE(compiled);
+    auto& qcoProgram = std::get<QCOProgram>(*compiled);
+    auto counts =
+        qco::sample(mlir::mqt::getEntryPoint(qcoProgram.module()), 4, 17);
+    ASSERT_TRUE(succeeded(counts));
+    const std::string expected{
+        syndrome == 0 ? '0' : '1',
+        weight % 2 == 0 ? '0' : '1',
+    };
+    EXPECT_EQ(*counts, (Counts{{expected, 4}}));
+  }
+}
+
+} /* namespace mqt::bench */

--- a/mlir/unittests/bench/test_benchmark_generate_magic_state_distillation.cpp
+++ b/mlir/unittests/bench/test_benchmark_generate_magic_state_distillation.cpp
@@ -45,9 +45,9 @@ TEST(GenerateProgramTest, SamplesMagicStateDistillation) {
   auto program = test::generateQCO(MagicStateDistillation{});
   ASSERT_TRUE(program);
   auto counts =
-      qco::sample(mlir::mqt::getEntryPoint(program->module()), 256, 17);
+      qco::sample(mlir::mqt::getEntryPoint(program->module()), 16, 17);
   ASSERT_TRUE(succeeded(counts));
-  EXPECT_EQ(*counts, (Counts{{"00", 256}}));
+  EXPECT_EQ(*counts, (Counts{{"00", 16}}));
 }
 
 TEST(GenerateProgramTest, ConcatenatesRetainedMagicStatesInCompactLoops) {

--- a/python/mqt/core/bench/__init__.pyi
+++ b/python/mqt/core/bench/__init__.pyi
@@ -11,6 +11,7 @@
 from mqt.core.bench import bv as bv
 from mqt.core.bench import ghz as ghz
 from mqt.core.bench import grover as grover
+from mqt.core.bench import magic_state_distillation as magic_state_distillation
 from mqt.core.bench import modular_multiplier as modular_multiplier
 from mqt.core.bench import multiplexer as multiplexer
 from mqt.core.bench import qft as qft

--- a/python/mqt/core/bench/magic_state_distillation.pyi
+++ b/python/mqt/core/bench/magic_state_distillation.pyi
@@ -1,0 +1,71 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Concatenated 15-to-1 magic-state distillation."""
+
+from collections.abc import Mapping
+
+import mqt.core.bench
+import mqt.core.mlir
+
+class Options:
+    """Parameters for concatenated 15-to-1 magic-state distillation."""
+
+    def __init__(self, *, levels: int = 1) -> None: ...
+    @property
+    def levels(self) -> int:
+        """Concatenated levels in [1, 4], using 15**levels qubits."""
+
+class MagicStateDistillation:
+    """Concatenated 15-to-1 Reed--Muller distillation.
+
+    Inputs are ideal :math:`|T\\rangle = T|+\\rangle` states.
+    Bit 1 flags any rejected block; bit 0 checks the retained root state in the T
+    basis. Ideal output is ``00``. Each level consumes the preceding level's
+    retained quantum outputs, using exactly ``15**levels`` qubits.
+    """
+
+    def __init__(self, options: Options = ...) -> None: ...
+    @property
+    def options(self) -> Options:
+        """The resolved benchmark parameters."""
+
+    @property
+    def output(self) -> mqt.core.bench.Output:
+        """The logical output register."""
+
+    def probability(self, outcome: str) -> float:
+        """Return the ideal probability of an outcome."""
+
+    def evaluate(self, counts: Mapping[str, int]) -> mqt.core.bench.Evaluation:
+        """Compare sampled counts with the ideal distribution."""
+
+    def generate(self) -> mqt.core.mlir.QCProgram:
+        """Generate the benchmark as a QC program."""
+
+    @property
+    def instance_specification_json(self) -> str:
+        """The canonical instance specification JSON."""
+
+    @property
+    def manifest_json(self) -> str:
+        """The canonical manifest JSON."""
+
+    @property
+    def case_id(self) -> str:
+        """The stable semantic case ID."""
+
+    @staticmethod
+    def from_instance_specification_json(
+        json: str, *, source: str = "<instance-specification>"
+    ) -> MagicStateDistillation:
+        """Parse a strict benchmark instance specification."""
+
+    @staticmethod
+    def from_manifest_json(json: str, *, source: str = "<manifest>") -> MagicStateDistillation:
+        """Parse a strict benchmark manifest."""

--- a/src/bench/JSON.cpp
+++ b/src/bench/JSON.cpp
@@ -14,6 +14,7 @@
 #include "bench/Evaluation.hpp"
 #include "bench/GHZ.hpp"
 #include "bench/Grover.hpp"
+#include "bench/MagicStateDistillation.hpp"
 #include "bench/ModularMultiplier.hpp"
 #include "bench/Multiplexer.hpp"
 #include "bench/QFT.hpp"
@@ -513,6 +514,19 @@ parseMultiplexerParameters(const Json& parameters,
   });
 }
 
+[[nodiscard]] MagicStateDistillation
+parseMagicStateDistillationParameters(const Json& parameters,
+                                      const std::string_view source) {
+  rejectUnknownKeys(parameters, {"levels"}, source, "$/parameters");
+  MagicStateDistillationOptions options;
+  if (const auto levels = parameters.find("levels");
+      levels != parameters.end()) {
+    options.levels = sizeValue(*levels, source, "$/parameters/levels");
+  }
+  return constructBenchmark(
+      source, [&options] { return MagicStateDistillation(options); });
+}
+
 [[nodiscard]] RepeatUntilSuccess
 parseRepeatUntilSuccessParameters(const Json& parameters,
                                   const std::string_view source) {
@@ -632,6 +646,10 @@ parseTeleportationParameters(const Json& parameters,
   };
 }
 
+[[nodiscard]] Json parametersJSON(const MagicStateDistillation& benchmark) {
+  return {{"levels", benchmark.options().levels}};
+}
+
 [[nodiscard]] Json parametersJSON(const RepeatUntilSuccess& benchmark) {
   return {{"data_qubits", benchmark.options().dataQubits}};
 }
@@ -690,6 +708,11 @@ parseTeleportationParameters(const Json& parameters,
 
 [[nodiscard]] Json referenceJSON(const QPE& benchmark) {
   return analyticReferenceJSON(benchmark.output(), "qpe_dirichlet");
+}
+
+[[nodiscard]] Json referenceJSON(const MagicStateDistillation& benchmark) {
+  return analyticReferenceJSON(benchmark.output(), "magic_state_distillation",
+                               "00");
 }
 
 [[nodiscard]] Json referenceJSON(const RepeatUntilSuccess& benchmark) {
@@ -1165,6 +1188,27 @@ template <class Benchmark>
           },
       },
       {"required", {"precision", "phase"}},
+      {"type", "object"},
+  });
+}
+
+[[nodiscard]] Json magicStateDistillationInstanceSpecificationSchema() {
+  return baseInstanceSpecificationSchema<MagicStateDistillation>({
+      {"additionalProperties", false},
+      {
+          "properties",
+          {
+              {
+                  "levels",
+                  {
+                      {"default", 1},
+                      {"minimum", 1},
+                      {"maximum", 4},
+                      {"type", "integer"},
+                  },
+              },
+          },
+      },
       {"type", "object"},
   });
 }

--- a/src/bench/MagicStateDistillation.cpp
+++ b/src/bench/MagicStateDistillation.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "bench/MagicStateDistillation.hpp"
+
+#include "bench/Evaluation.hpp"
+
+#include "EvaluationUtils.hpp"
+
+#include <stdexcept>
+#include <string_view>
+
+namespace mqt::bench {
+
+MagicStateDistillation::MagicStateDistillation(
+    MagicStateDistillationOptions options)
+    : options_(options), output_{.name = "result", .width = 2} {
+  if (options_.levels < 1 || options_.levels > 4) {
+    throw std::invalid_argument(
+        "magic-state-distillation levels must be between 1 and 4");
+  }
+}
+
+const MagicStateDistillationOptions&
+MagicStateDistillation::options() const noexcept {
+  return options_;
+}
+
+const Output& MagicStateDistillation::output() const noexcept {
+  return output_;
+}
+
+double
+MagicStateDistillation::probability(const std::string_view outcome) const {
+  detail::validateOutcome(outcome, output_.width);
+  return outcome == "00" ? 1. : 0.;
+}
+
+Evaluation MagicStateDistillation::evaluate(const Counts& counts) const {
+  return detail::evaluate(*this, counts, "00");
+}
+
+} /* namespace mqt::bench */

--- a/test/bench/test_json.cpp
+++ b/test/bench/test_json.cpp
@@ -538,7 +538,7 @@ TEST(BenchmarkJSON, RejectsAlteredOrUnresolvedManifestData) {
 TEST(BenchmarkJSON, ListsBenchmarksAndDescribesStandardSchemas) {
   EXPECT_EQ(
       listBenchmarksJSON(),
-      R"({"benchmarks":[{"definition_version":1,"id":"bv"},{"definition_version":1,"id":"ghz"},{"definition_version":1,"id":"grover"},{"definition_version":1,"id":"modular-multiplier"},{"definition_version":1,"id":"multiplexer"},{"definition_version":1,"id":"qft"},{"definition_version":1,"id":"qft-adder"},{"definition_version":1,"id":"qpe"},{"definition_version":1,"id":"repeat-until-success"},{"definition_version":1,"id":"teleportation"}],"schema_version":1})");
+      R"({"benchmarks":[{"definition_version":1,"id":"bv"},{"definition_version":1,"id":"ghz"},{"definition_version":1,"id":"grover"},{"definition_version":1,"id":"magic-state-distillation"},{"definition_version":1,"id":"modular-multiplier"},{"definition_version":1,"id":"multiplexer"},{"definition_version":1,"id":"qft"},{"definition_version":1,"id":"qft-adder"},{"definition_version":1,"id":"qpe"},{"definition_version":1,"id":"repeat-until-success"},{"definition_version":1,"id":"teleportation"}],"schema_version":1})");
   const auto bv = describeBenchmarkJSON("bv");
   const auto modularMultiplier = describeBenchmarkJSON("modular-multiplier");
   const auto ghz = describeBenchmarkJSON("ghz");

--- a/test/bench/test_magic_state_distillation.cpp
+++ b/test/bench/test_magic_state_distillation.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "bench/Evaluation.hpp"
+#include "bench/JSON.hpp"
+#include "bench/MagicStateDistillation.hpp"
+
+#include "gtest/gtest.h"
+
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace mqt::bench {
+
+TEST(MagicStateDistillation, ValidatesLevelsAndTwoBitReference) {
+  EXPECT_EQ(MagicStateDistillation{}.options().levels, 1U);
+  for (const size_t levels : {1U, 2U, 3U, 4U}) {
+    const MagicStateDistillation benchmark({.levels = levels});
+    EXPECT_EQ(benchmark.output(), (Output{"result", 2}));
+    EXPECT_DOUBLE_EQ(benchmark.probability("00"), 1.);
+    for (const auto* outcome : {"01", "10", "11"}) {
+      EXPECT_DOUBLE_EQ(benchmark.probability(outcome), 0.);
+    }
+  }
+  for (const size_t levels :
+       {size_t{0}, size_t{5}, std::numeric_limits<size_t>::max()}) {
+    EXPECT_THROW(MagicStateDistillation({.levels = levels}),
+                 std::invalid_argument);
+  }
+  const MagicStateDistillation benchmark;
+  for (const auto* outcome : {"", "0", "000", "0x"}) {
+    EXPECT_THROW(static_cast<void>(benchmark.probability(outcome)),
+                 std::invalid_argument);
+    EXPECT_THROW(static_cast<void>(benchmark.evaluate({{outcome, 1}})),
+                 std::invalid_argument);
+  }
+  EXPECT_THROW(static_cast<void>(benchmark.evaluate({})),
+               std::invalid_argument);
+  EXPECT_THROW(static_cast<void>(benchmark.evaluate({{"00", 0}})),
+               std::invalid_argument);
+}
+
+TEST(MagicStateDistillation, EvaluatesAcceptanceAndRootStateTogether) {
+  const MagicStateDistillation benchmark;
+  const auto exact = benchmark.evaluate({{"00", 256}});
+  EXPECT_DOUBLE_EQ(exact.totalVariationDistance, 0.);
+  EXPECT_DOUBLE_EQ(exact.squaredHellingerFidelity, 1.);
+  EXPECT_EQ(exact.successProbability, 1.);
+  const auto mixed =
+      benchmark.evaluate({{"00", 5}, {"01", 1}, {"10", 1}, {"11", 1}});
+  EXPECT_DOUBLE_EQ(mixed.totalVariationDistance, 0.375);
+  EXPECT_DOUBLE_EQ(mixed.squaredHellingerFidelity, 0.625);
+  EXPECT_EQ(mixed.successProbability, 0.625);
+}
+
+TEST(MagicStateDistillation, RoundTripsStrictJSONAndSemanticCaseIds) {
+  const auto defaults = magicStateDistillationFromInstanceSpecificationJSON(
+      R"({"schema_version":1,"benchmark":"magic-state-distillation","parameters":{}})");
+  EXPECT_EQ(caseId(defaults), caseId(MagicStateDistillation({.levels = 1})));
+  EXPECT_EQ(
+      toInstanceSpecificationJSON(defaults),
+      R"({"benchmark":"magic-state-distillation","parameters":{"levels":1},"schema_version":1})");
+  for (const size_t levels : {1U, 2U, 3U, 4U}) {
+    const MagicStateDistillation benchmark({.levels = levels});
+    EXPECT_EQ(caseId(magicStateDistillationFromInstanceSpecificationJSON(
+                  toInstanceSpecificationJSON(benchmark))),
+              caseId(benchmark));
+    EXPECT_EQ(caseId(magicStateDistillationFromManifestJSON(
+                  toManifestJSON(benchmark))),
+              caseId(benchmark));
+    if (levels != 1) {
+      EXPECT_NE(caseId(benchmark), caseId(defaults));
+    }
+  }
+  for (const auto* parameters : {
+           R"({"levels":0})",
+           R"({"levels":5})",
+           R"({"levels":-1})",
+           R"({"levels":1.0})",
+           R"({"levels":true})",
+           R"({"noise":0})",
+       }) {
+    EXPECT_THROW(
+        static_cast<void>(magicStateDistillationFromInstanceSpecificationJSON(
+            std::string(
+                R"({"schema_version":1,"benchmark":"magic-state-distillation","parameters":)") +
+            parameters + "}")),
+        std::invalid_argument);
+  }
+  EXPECT_NE(
+      describeBenchmarkJSON("magic-state-distillation").find(R"("maximum":4)"),
+      std::string::npos);
+  const auto evaluation = evaluateJSON(
+      toManifestJSON(defaults), R"({"schema_version":1,"counts":{"00":256}})");
+  EXPECT_NE(evaluation.find(R"("success_probability":1.0)"), std::string::npos);
+}
+
+} /* namespace mqt::bench */

--- a/test/python/bench/test_magic_state_distillation.py
+++ b/test/python/bench/test_magic_state_distillation.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Public interfaces and execution of concatenated magic-state distillation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mqt.core.bench import magic_state_distillation
+from mqt.core.mlir import compile_program, sample, submit_program
+from mqt.core.qdmi import ProgramFormat
+from mqt.core.qdmi.driver import open_device
+
+from .utils import assert_generates
+
+
+@pytest.mark.parametrize("levels", [1, 2, 3, 4])
+def test_distillation_roundtrip(levels: int) -> None:
+    """Preserve the level count and semantic identity through both JSON forms."""
+    benchmark = magic_state_distillation.MagicStateDistillation(magic_state_distillation.Options(levels=levels))
+    assert benchmark.options.levels == levels
+    assert benchmark.output.name == "result"
+    assert benchmark.output.width == 2
+    assert json.loads(benchmark.instance_specification_json)["parameters"] == {"levels": levels}
+    instance = magic_state_distillation.MagicStateDistillation.from_instance_specification_json(
+        benchmark.instance_specification_json
+    )
+    manifest = magic_state_distillation.MagicStateDistillation.from_manifest_json(benchmark.manifest_json)
+    assert instance.case_id == manifest.case_id == benchmark.case_id
+    if levels != 1:
+        assert benchmark.case_id != magic_state_distillation.MagicStateDistillation().case_id
+    assert_generates(benchmark.generate())
+
+
+@pytest.mark.parametrize("levels", [0, 5])
+def test_distillation_invalid_levels(levels: int) -> None:
+    """Reject unsupported concatenation levels."""
+    with pytest.raises(ValueError, match="levels must be between 1 and 4"):
+        magic_state_distillation.MagicStateDistillation(magic_state_distillation.Options(levels=levels))
+
+
+def test_distillation_reference() -> None:
+    """Success requires both acceptance and the correct root state."""
+    benchmark = magic_state_distillation.MagicStateDistillation()
+    assert benchmark.probability("00") == 1
+    for outcome in ("01", "10", "11"):
+        assert benchmark.probability(outcome) == 0
+    evaluation = benchmark.evaluate({"00": 5, "01": 1, "10": 1, "11": 1})
+    assert evaluation.success_probability == pytest.approx(0.625)
+    assert evaluation.total_variation_distance == pytest.approx(0.375)
+    assert evaluation.squared_hellinger_fidelity == pytest.approx(0.625)
+
+
+@pytest.mark.parametrize(("levels", "shots"), [(1, 256), (2, 1)])
+def test_distillation_direct_sampling(levels: int, shots: int) -> None:
+    """Sample single and concatenated blocks with the public DD interface."""
+    benchmark = magic_state_distillation.MagicStateDistillation(magic_state_distillation.Options(levels=levels))
+    assert sample(benchmark.generate(), shots=shots, seed=17) == {"00": shots}
+
+
+@pytest.mark.parametrize(("levels", "shots"), [(1, 256), (2, 1)])
+@pytest.mark.parametrize("program_format", [None, ProgramFormat.QASM3])
+def test_distillation_ddsim(program_format: ProgramFormat | None, levels: int, shots: int) -> None:
+    """Compile and execute the same circuit through both DDSIM payload paths."""
+    benchmark = magic_state_distillation.MagicStateDistillation(magic_state_distillation.Options(levels=levels))
+    device = open_device("mqt.ddsim.default")
+    compiled = compile_program(benchmark.generate(), target=device, program_format=program_format)
+    if program_format is None:
+        assert compiled.program_format in {ProgramFormat.QIR_ADAPTIVE_MODULE, ProgramFormat.QIR_ADAPTIVE_STRING}
+    job = submit_program(compiled, target=device, num_shots=shots, custom1=17)
+    job.wait()
+    assert job.get_counts() == {"00": shots}

--- a/test/python/bench/test_magic_state_distillation.py
+++ b/test/python/bench/test_magic_state_distillation.py
@@ -59,22 +59,20 @@ def test_distillation_reference() -> None:
     assert evaluation.squared_hellinger_fidelity == pytest.approx(0.625)
 
 
-@pytest.mark.parametrize(("levels", "shots"), [(1, 256), (2, 1)])
-def test_distillation_direct_sampling(levels: int, shots: int) -> None:
-    """Sample single and concatenated blocks with the public DD interface."""
-    benchmark = magic_state_distillation.MagicStateDistillation(magic_state_distillation.Options(levels=levels))
-    assert sample(benchmark.generate(), shots=shots, seed=17) == {"00": shots}
+def test_distillation_direct_sampling() -> None:
+    """Sample the 15-qubit program with the public DD interface."""
+    benchmark = magic_state_distillation.MagicStateDistillation()
+    assert sample(benchmark.generate(), shots=16, seed=17) == {"00": 16}
 
 
-@pytest.mark.parametrize(("levels", "shots"), [(1, 256), (2, 1)])
 @pytest.mark.parametrize("program_format", [None, ProgramFormat.QASM3])
-def test_distillation_ddsim(program_format: ProgramFormat | None, levels: int, shots: int) -> None:
+def test_distillation_ddsim(program_format: ProgramFormat | None) -> None:
     """Compile and execute the same circuit through both DDSIM payload paths."""
-    benchmark = magic_state_distillation.MagicStateDistillation(magic_state_distillation.Options(levels=levels))
+    benchmark = magic_state_distillation.MagicStateDistillation()
     device = open_device("mqt.ddsim.default")
     compiled = compile_program(benchmark.generate(), target=device, program_format=program_format)
     if program_format is None:
         assert compiled.program_format in {ProgramFormat.QIR_ADAPTIVE_MODULE, ProgramFormat.QIR_ADAPTIVE_STRING}
-    job = submit_program(compiled, target=device, num_shots=shots, custom1=17)
+    job = submit_program(compiled, target=device, num_shots=16, custom1=17)
     job.wait()
-    assert job.get_counts() == {"00": shots}
+    assert job.get_counts() == {"00": 16}


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Add the `magic-state-distillation` benchmark for concatenated 15-to-1 Reed–Muller distillation. C++, Python, strict JSON, manifests, and the CLI support levels 1–4, allocating exactly 15, 225, 3,375, or 50,625 qubits. Each level consumes the retained quantum outputs of its children. The two-bit result reports any rejected block and checks the root T state; ideal inputs produce `00`.

The implementation uses a fixed decoder, measurement-dependent Clifford corrections, and structured loops around a reusable block. It models ideal inputs without noise, retries, or physical error correction. Reusing the measured root for the rejection readout preserves the qubit count and permits Adaptive QIR execution through the existing result interface.

Compiled OpenQASM exposed a DD interpreter gap for parameterized `qco.call` gate helpers. Reuse the existing call interpreter with its parameter bindings, wire mapping, and recursion checks. Add a nested-call regression that checks global phase as well as functionality, statevectors, and sampling.

Include executable examples, generated Python stubs, and Unreleased changelog entries. No new dependencies or migrations are needed. Codex assisted with implementation, tests, documentation, and this PR.

### Validation

- CI simulates level 1 only, with 16 shots for direct DD sampling, DDSIM Adaptive QIR, and DDSIM OpenQASM 3. Each returns `{"00": 16}`. Higher levels retain inexpensive generation and metadata checks; level 2 simulation is excluded from CI.
- With 16 shots, median sampling times over three runs were 0.190 s (direct), 0.181 s (Adaptive QIR), and 0.155 s (OpenQASM 3). The corresponding 256-shot medians were 4.163 s, 2.164 s, and 2.335 s. Generation took 0.014 s; target compilation took 0.070 s for Adaptive QIR and 0.038 s for OpenQASM 3. These are shared-host observations. The gain comes from reducing repeated adaptive executions.
- Manual validation: level 1 and level 2 (225 qubits) each returned `{"00": 256}` through all three execution paths with seed 17. The level 2 runs took approximately 225 s (direct), 176 s (Adaptive QIR), and 263 s (OpenQASM 3), including generation and compilation where applicable. Levels 3–4 were validated for generation and QCO conversion only.
- 108 focused Python tests passed in 4.58 s across `test/python/bench/` and `test/python/qdmi/test_compilation.py`. The affected native sampling and generation tests passed in 0.24 s using Clang 23 Release with ThinLTO. The full native benchmark and DD suites passed during feature validation; exhaustive fault coverage still checks all single/double input Z errors and all 35 accepted triple-error patterns.
- Stub generation, whole-changed-file C++ lint, and the complete executable documentation build with local-link validation passed. Repository lint passed with pre-existing untracked audit scripts excluded from type checking through a temporary local configuration; tracked lint settings are unchanged.

Hosted CI is pending. Human review remains required before acceptance or merging.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

