### PR TITLE
⚡ Skip placement search for executable identity layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+- ⚡ Speed up qubit placement and routing. Skip layout search for flat programs
+  whose initial qubit placement already satisfies the target topology. ([#2544])
+  ([**@burgholzer**])
+
 - ✨ Optimize constant two-qubit blocks before placement and during native
   synthesis. Remove cancelled interactions before routing and preserve cheaper
   native operations in both target compilation and synthesis. Avoid redundant
@@ -1119,6 +1123,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2544]: https://github.com/munich-quantum-toolkit/core/pull/2544
 [#2538]: https://github.com/munich-quantum-toolkit/core/pull/2538
 [#2537]: https://github.com/munich-quantum-toolkit/core/pull/2537
 [#2535]: https://github.com/munich-quantum-toolkit/core/pull/2535

--- a/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
@@ -211,7 +211,11 @@ def MappingPass : Pass<"place-and-route", "mlir::ModuleOp"> {
     made during that traversal. By performing multiple traversals, the pass can iteratively refine the mapping and
     potentially find a more optimal solution. This behavior is controlled by the `niterations` parameter.
 
-    The pass option `ntrials` determines the number of initial refinement trials:
+    Programs without nested control flow keep the identity layout immediately
+    when all two-qubit interactions are already adjacent on the target.
+    This avoids constructing and refining alternative layouts.
+
+    Otherwise, the pass option `ntrials` determines the number of initial refinement trials:
     one identity layout and the remaining layouts chosen randomly.
     It defaults to the number of available logical CPUs reported by LLVM, taking
     CPU affinity into account, with a minimum of one. Disabling multithreading

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -879,11 +879,12 @@ private:
     return iterator.qubit();
   }
 
-  /// Place frequently interacting program qubits near each other.
+  /// Return an initial layout and whether identity needs no routing.
   ///
-  /// Nested control flow has no single interaction frequency, so leave those
-  /// programs to the identity and random starts.
-  [[nodiscard]] std::optional<Layout>
+  /// Otherwise, place frequently interacting qubits near each other. Nested
+  /// control flow has no single interaction frequency, so leave those programs
+  /// to the identity and random starts.
+  [[nodiscard]] std::optional<std::pair<Layout, bool>>
   generateGreedyLayout(Wires wires, const WireInfos& infos) const {
     DenseMap<IndexPairType, size_t> weights;
     bool supported = true;
@@ -904,8 +905,14 @@ private:
           }
           return WalkResult::advance();
         });
-    if (!supported || weights.empty()) {
+    if (!supported) {
       return std::nullopt;
+    }
+    if (llvm::all_of(weights, [&](const auto& interaction) {
+          const auto [a, b] = interaction.first;
+          return target->areAdjacent(a, b);
+        })) {
+      return std::pair{Layout::identity(target->numSites()), true};
     }
 
     const size_t nprogram = infos.size();
@@ -978,7 +985,7 @@ private:
         mapping[prog++] = hw;
       }
     }
-    return Layout::fromMapping(mapping);
+    return std::pair{Layout::fromMapping(mapping), false};
   }
 
   /// Refine identity, random, and greedy starts with forward/backward routing.
@@ -986,6 +993,10 @@ private:
   /// Score each candidate with a forward traversal, preserving its start
   /// layout.
   FailureOr<Layout> generateLayout(const Wires& wires, const WireInfos& infos) {
+    const auto greedy = generateGreedyLayout(wires, infos);
+    if (greedy && greedy->second) {
+      return greedy->first;
+    }
     std::mt19937_64 rng{seed};
 
     struct Trial {
@@ -1008,12 +1019,21 @@ private:
           },
           niterations);
     }
-    if (const auto greedy = generateGreedyLayout(wires, infos)) {
+    if (greedy) {
       trials.emplace_back(
-          RoutingBundle{.wires = wires, .infos = infos, .layout = *greedy},
+          RoutingBundle{
+              .wires = wires,
+              .infos = infos,
+              .layout = greedy->first,
+          },
           niterations);
       trials.emplace_back(
-          RoutingBundle{.wires = wires, .infos = infos, .layout = *greedy}, 0);
+          RoutingBundle{
+              .wires = wires,
+              .infos = infos,
+              .layout = greedy->first,
+          },
+          0);
     }
 
     parallelForEach(&getContext(), trials, [&, this](Trial& t) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -47,6 +47,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
@@ -2428,6 +2429,68 @@ TEST_F(MappingPassFixture, EmbedInteractionHubWithIdleQubitAndSpareSite) {
   moduleOp->walk([&](SWAPOp) { ++swaps; });
   // This interaction star embeds in the target without routing overhead.
   EXPECT_EQ(swaps, 0);
+}
+
+TEST_F(MappingPassFixture, KeepExecutableIdentityAcrossTrialOptions) {
+  std::vector sites{
+      llvm::cantFail(CompilerTarget::Site::create(7)),
+      llvm::cantFail(CompilerTarget::Site::create(19)),
+      llvm::cantFail(CompilerTarget::Site::create(42)),
+      llvm::cantFail(CompilerTarget::Site::create(81)),
+  };
+  const auto target = llvm::cantFail(CompilerTarget::create(
+      std::move(sites),
+      Connectivity::fromCouplings({{7, 19}, {19, 42}, {42, 81}}),
+      NativeOperations::unrestricted()));
+  for (const size_t numQubits : {size_t{0}, size_t{1}, size_t{3}}) {
+    SCOPED_TRACE(numQubits);
+    QCOProgramBuilder builder(context.get());
+    builder.initialize(SmallVector<Type>(numQubits, builder.getI1Type()));
+    SmallVector<Value> qubits;
+    SmallVector<Value> bits(numQubits);
+    for (size_t i = 0; i < numQubits; ++i) {
+      qubits.push_back(builder.h(builder.allocQubit()));
+    }
+    if (numQubits == 3) {
+      std::tie(qubits[0], qubits[1]) = builder.cx(qubits[0], qubits[1]);
+      std::tie(qubits[1], qubits[2]) = builder.cz(qubits[1], qubits[2]);
+      qubits = builder.barrier(qubits);
+    }
+    for (size_t i = 0; i < numQubits; ++i) {
+      std::tie(qubits[i], bits[i]) = builder.measure(qubits[i]);
+      builder.sink(qubits[i]);
+    }
+    auto input = builder.finalize(bits);
+    std::string expected;
+    for (bool multithreading : {false, true}) {
+      context->enableMultithreading(multithreading);
+      for (const size_t trials : {size_t{1}, size_t{4}}) {
+        OwningOpRef<ModuleOp> moduleOp = input->clone();
+        ASSERT_TRUE(succeeded(runPass(*moduleOp, target,
+                                      MappingPassOptions{.niterations = 2,
+                                                         .ntrials = trials,
+                                                         .seed = 7})));
+        ASSERT_TRUE(succeeded(verify(*moduleOp)));
+        EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+        EXPECT_TRUE(isExecutable(getEntryPoint(*moduleOp), target));
+        size_t swaps = 0;
+        SmallVector<uint64_t> staticSites;
+        moduleOp->walk([&](SWAPOp) { ++swaps; });
+        moduleOp->walk(
+            [&](StaticOp op) { staticSites.push_back(op.getIndex()); });
+        EXPECT_EQ(swaps, 0);
+        const SmallVector<uint64_t> identitySites{7, 19, 42};
+        EXPECT_EQ(ArrayRef(staticSites),
+                  ArrayRef(identitySites).take_front(numQubits));
+        const auto output = printModule(*moduleOp);
+        if (expected.empty()) {
+          expected = output;
+        } else {
+          EXPECT_EQ(output, expected);
+        }
+      }
+    }
+  }
 }
 
 TEST_F(MappingPassFixture, RetainRawGreedyLayoutWhenRefinementWorsensIt) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Skip placement search when a flat program's identity layout already makes every two-qubit interaction executable. This avoids constructing greedy centralities and routing alternative candidates that cannot beat the first zero-SWAP layout. Programs with no two-qubit interactions are included; structured programs keep their existing candidate search.

Stack: `main` → #2544 → #2547. This first PR introduces one Unreleased routing-speedup changelog entry; #2547 extends it with path placement. No new dependencies or option changes.

Matched release-build measurements against `bb5ec85e5fc6606e634841549bac01ab5a3d9e23` on an ARM64 DGX Spark, pinned to one CPU with one refinement trial, preserve all 168 Benchpress Small output hashes. A synthetic 1,000-qubit grid circuit whose interactions already match the hardware maps in a median 76.1 ms over five runs (range 76.0–77.8 ms); all five baseline runs fail allocation under an 8 GiB address-space limit. These are mapping-only timings on a shared host, not a general compilation-speedup claim.

Validation: release build and CTest (3,541 tests, one existing QDMI skip), 111 mapping tests including identity/empty-program and trial-option coverage, whole-file C++ lint, repository lint, and MLIR reference generation pass. Hosted CI is pending. Codex prepared the code, tests, measurements, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
