### PR TITLE
⚡ Place interaction paths before routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ releases may include breaking changes.
 ## [Unreleased]
 
 - ⚡ Speed up qubit placement and routing. Skip layout search for flat programs
-  whose initial qubit placement already satisfies the target topology. ([#2544])
-  ([**@burgholzer**])
+  whose initial qubit placement already satisfies the target topology. Place
+  disjoint interaction paths along connected target sites to avoid needless
+  routing SWAPs. ([#2544], [#2547]) ([**@burgholzer**])
 
 - ✨ Optimize constant two-qubit blocks before placement and during native
   synthesis. Remove cancelled interactions before routing and preserve cheaper
@@ -1123,6 +1124,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#2547]: https://github.com/munich-quantum-toolkit/core/pull/2547
 [#2544]: https://github.com/munich-quantum-toolkit/core/pull/2544
 [#2538]: https://github.com/munich-quantum-toolkit/core/pull/2538
 [#2537]: https://github.com/munich-quantum-toolkit/core/pull/2537

--- a/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
+++ b/mlir/include/mqt/Dialect/QCO/Transforms/Passes.td
@@ -226,8 +226,12 @@ def MappingPass : Pass<"place-and-route", "mlir::ModuleOp"> {
 
     For programs with two-qubit interactions and no nested control flow on their
     wires, the pass also constructs an interaction-weighted greedy layout.
-    It places frequently interacting qubits nearby, starting at a central
-    target site. Both the raw and refined greedy layouts are additional
+    For disjoint interaction paths and isolated qubits, it first tries to place
+    them along one path through the target sites. The walk prefers neighbors
+    with fewer unused edges and accepts only a complete placement; it does not
+    backtrack. Other interaction graphs and failed walks use the weighted
+    greedy layout, which places frequently interacting qubits nearby, starting
+    at a central target site. Both the raw and refined layouts are additional
     candidates, independent of `ntrials`. A final forward routing traversal
     scores each candidate. The pass selects the initial layout with the fewest
     SWAPs in that traversal, retaining the earlier candidate on a tie.

--- a/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
+++ b/mlir/lib/Dialect/QCO/Transforms/Mapping/Mapping.cpp
@@ -928,6 +928,69 @@ private:
       degree[b] += weight;
     }
 
+    /// Embed disjoint logical paths along one path through the target sites.
+    /// ponytail: One hardware walk; add bounded backtracking only for measured
+    /// missed embeddings.
+    if (llvm::all_of(neighbours, [](const auto& adjacent) {
+          return adjacent.size() <= 2;
+        })) {
+      SmallVector<size_t> order;
+      SmallVector<bool> visited(nprogram, false);
+      for (size_t start = 0; start < nprogram; ++start) {
+        if (neighbours[start].size() > 1 || visited[start]) {
+          continue;
+        }
+        size_t current = start;
+        while (current != nprogram) {
+          order.push_back(current);
+          visited[current] = true;
+          size_t next = nprogram;
+          for (const auto& [partner, weight] : neighbours[current]) {
+            if (!visited[partner]) {
+              next = partner;
+            }
+          }
+          current = next;
+        }
+      }
+      if (order.size() == nprogram) {
+        SmallVector<size_t> remaining(nhardware, 0);
+        SmallVector<bool> usedHardware(nhardware, false);
+        for (size_t hw = 0; hw < nhardware; ++hw) {
+          target->forEachNeighbour(hw, [&](size_t) { ++remaining[hw]; });
+        }
+        auto current = static_cast<size_t>(
+            std::distance(remaining.begin(), llvm::min_element(remaining)));
+        SmallVector<size_t> mapping(nhardware, nhardware);
+        size_t placed = 0;
+        while (current != nhardware && placed < nprogram) {
+          mapping[order[placed++]] = current;
+          usedHardware[current] = true;
+          target->forEachNeighbour(
+              current, [&](size_t neighbour) { --remaining[neighbour]; });
+          size_t next = nhardware;
+          target->forEachNeighbour(current, [&](size_t neighbour) {
+            if (!usedHardware[neighbour] &&
+                (remaining[neighbour] != 0 || placed + 1 == nprogram) &&
+                (next == nhardware ||
+                 std::tie(remaining[neighbour], neighbour) <
+                     std::tie(remaining[next], next))) {
+              next = neighbour;
+            }
+          });
+          current = next;
+        }
+        if (placed == nprogram) {
+          for (size_t hw = 0; hw < nhardware; ++hw) {
+            if (!usedHardware[hw]) {
+              mapping[placed++] = hw;
+            }
+          }
+          return std::pair{Layout::fromMapping(mapping), false};
+        }
+      }
+    }
+
     SmallVector<size_t> centrality(nhardware, 0);
     SmallVector<size_t> hardwareDegree(nhardware, 0);
     for (size_t hw = 0; hw < nhardware; ++hw) {

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/CMakeLists.txt
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(
           MLIRParser
           MLIRMQTDialect
           MQTCompilerTarget
+          MLIRQCODDFunctionality
           MLIRQCOProgramBuilder
           MLIRQTensorUtils
           MLIRQCOTransforms

--- a/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
+++ b/mlir/unittests/Dialect/QCO/Transforms/Mapping/test_mapping.cpp
@@ -20,6 +20,7 @@
 #include "mqt/Dialect/QCO/QCOUtils.h"
 #include "mqt/Dialect/QCO/Transforms/Mapping/Mapping.h"
 #include "mqt/Dialect/QCO/Transforms/Passes.h"
+#include "mqt/Dialect/QCO/Utils/DDFunctionality.h"
 #include "mqt/Dialect/QCO/Utils/Sorting.h"
 #include "mqt/Dialect/QTensor/IR/QTensorDialect.h"
 #include "mqt/Dialect/QTensor/IR/QTensorOps.h"
@@ -58,6 +59,7 @@
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -2487,6 +2489,134 @@ TEST_F(MappingPassFixture, KeepExecutableIdentityAcrossTrialOptions) {
           expected = output;
         } else {
           EXPECT_EQ(output, expected);
+        }
+      }
+    }
+  }
+}
+
+TEST_F(MappingPassFixture, EmbedShuffledInteractionPathWithoutSwaps) {
+  constexpr size_t numQubits = 64;
+  std::vector<CompilerTarget::Coupling> line;
+  for (size_t i = 1; i < numQubits; ++i) {
+    line.emplace_back(i - 1, i);
+  }
+  const auto lineTarget = llvm::cantFail(
+      CompilerTarget::create(numQubits, Connectivity::fromCouplings(line),
+                             NativeOperations::unrestricted()));
+  auto order = llvm::to_vector(llvm::seq<size_t>(0, numQubits));
+  std::mt19937_64 rng(42);
+  std::shuffle(order.begin(), order.end(), rng);
+  QCOProgramBuilder builder(context.get());
+  builder.initialize();
+  SmallVector<Value> qubits;
+  for (size_t i = 0; i < numQubits; ++i) {
+    qubits.push_back(builder.h(builder.allocQubit()));
+  }
+  for (size_t i = 1; i < numQubits; ++i) {
+    const auto a = order[i - 1];
+    const auto b = order[i];
+    std::tie(qubits[a], qubits[b]) = builder.cx(qubits[a], qubits[b]);
+  }
+  for (Value qubit : qubits) {
+    builder.sink(qubit);
+  }
+  auto input = builder.finalize();
+  for (const auto& target : {lineTarget, getSquareGridTarget(8)}) {
+    std::string expected;
+    for (bool multithreading : {false, true}) {
+      context->enableMultithreading(multithreading);
+      OwningOpRef<ModuleOp> moduleOp = input->clone();
+      ASSERT_TRUE(succeeded(runPass(
+          *moduleOp, target, MappingPassOptions{.ntrials = 1, .seed = 42})));
+      ASSERT_TRUE(succeeded(verify(*moduleOp)));
+      EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+      EXPECT_TRUE(isExecutable(getEntryPoint(*moduleOp), target));
+      size_t swaps = 0;
+      moduleOp->walk([&](SWAPOp) { ++swaps; });
+      /// The interaction path fits both targets without routing overhead.
+      EXPECT_EQ(swaps, 0);
+      const auto output = printModule(*moduleOp);
+      if (!multithreading) {
+        expected = output;
+      } else {
+        EXPECT_EQ(output, expected);
+      }
+    }
+  }
+}
+
+TEST_F(MappingPassFixture, PreserveInteractionPathBasisStates) {
+  const auto lineTarget = llvm::cantFail(CompilerTarget::create(
+      6, Connectivity::fromCouplings({{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}}),
+      NativeOperations::unrestricted()));
+  const auto cycleTarget = llvm::cantFail(CompilerTarget::create(
+      8,
+      Connectivity::fromCouplings(
+          {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}, {6, 7}, {7, 0}}),
+      NativeOperations::unrestricted()));
+  const auto starTarget = llvm::cantFail(CompilerTarget::create(
+      6, Connectivity::fromCouplings({{0, 1}, {0, 2}, {0, 3}, {0, 4}, {0, 5}}),
+      NativeOperations::unrestricted()));
+  const SmallVector<size_t> order{5, 0, 3, 1, 4, 2};
+  for (bool disjoint : {false, true}) {
+    SCOPED_TRACE(disjoint);
+    for (bool xBasis : {false, true}) {
+      SCOPED_TRACE(xBasis);
+      for (size_t basis = 0; basis < 64; ++basis) {
+        SCOPED_TRACE(basis);
+        auto input = QCOProgramBuilder::build(
+            context.get(), [&](QCOProgramBuilder& builder) {
+              auto bits = builder.allocClassicalBitRegister(6);
+              SmallVector<Value> qubits;
+              for (size_t i = 0; i < 6; ++i) {
+                Value qubit = builder.allocQubit();
+                if ((basis & (size_t{1} << i)) != 0) {
+                  qubit = builder.x(qubit);
+                }
+                qubits.push_back(xBasis ? builder.h(qubit) : qubit);
+              }
+              for (size_t i = 1; i < order.size(); ++i) {
+                /// Split into three-qubit and two-qubit paths and an idle
+                /// qubit.
+                if (disjoint && (i == 3 || i == 5)) {
+                  continue;
+                }
+                const auto a = order[i - 1];
+                const auto b = order[i];
+                std::tie(qubits[a], qubits[b]) =
+                    builder.cx(qubits[a], qubits[b]);
+              }
+              for (size_t i = 0; i < qubits.size(); ++i) {
+                if (xBasis) {
+                  qubits[i] = builder.h(qubits[i]);
+                }
+                std::tie(qubits[i], std::ignore) =
+                    builder.measure(qubits[i], bits, static_cast<int64_t>(i));
+                builder.sink(qubits[i]);
+              }
+              return bits;
+            });
+        const auto expected = qco::sample(getEntryPoint(*input), 1, 42);
+        ASSERT_TRUE(succeeded(expected));
+        for (const auto& target :
+             {lineTarget, getSquareGridTarget(3), cycleTarget, starTarget}) {
+          SCOPED_TRACE(target.numSites());
+          OwningOpRef<ModuleOp> moduleOp = input->clone();
+          ASSERT_TRUE(
+              succeeded(runPass(*moduleOp, target,
+                                MappingPassOptions{.ntrials = 1, .seed = 42})));
+          ASSERT_TRUE(succeeded(verify(*moduleOp)));
+          EXPECT_TRUE(succeeded(verifyLinearity(*moduleOp)));
+          EXPECT_TRUE(isExecutable(getEntryPoint(*moduleOp), target));
+          const auto actual = qco::sample(getEntryPoint(*moduleOp), 1, 42);
+          ASSERT_TRUE(succeeded(actual));
+          EXPECT_EQ(*actual, *expected);
+          if (target.maxDegree() != 5) {
+            size_t swaps = 0;
+            moduleOp->walk([&](SWAPOp) { ++swaps; });
+            EXPECT_EQ(swaps, 0);
+          }
         }
       }
     }


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Place disjoint logical interaction paths along adjacent target sites before routing. Aggregate weighted placement can add SWAPs even when those paths fit the target directly. The new placement orders components from their leaves, tries one deterministic hardware walk that favors neighbors with fewer unused edges, and accepts only a complete placement. Other graphs and failed walks use the existing weighted greedy placement. Raw and refined candidates retain the existing trial selection.

Stack: `main` → #2544 → #2547. This second PR is based on #2544. It extends the same new Unreleased changelog entry. No new options or dependencies.

Matched measurements compare this commit against its parent, #2544 (`f904379fb4c866b4768e5bed8313b8821bcd22bc`), using the same release build on an ARM64 DGX Spark, pinned to one CPU with one refinement trial. Across all 168 Benchpress Small cases, native gate count and depth are unchanged. Across 84 Medium cases (21 circuits on four topologies, excluding the long BWT/factoring cases), eight improve native count and none worsen count or depth. Five repeated samples of the affected circuits preserve deterministic output hashes:

| Circuit / target | Native CZ before → after | Two-qubit depth before → after |
| --- | --- | --- |
| GHZ-23 / heavy-hex | 30 → 22 | 30 → 22 |
| Ising-26 / square | 56 → 50 | 11 → 4 |
| Ising-26 / heavy-hex | 63 → 50 | 11 → 4 |
| W-state-27 / heavy-hex | 64 → 52 | 32 → 28 |

A 54-case synthetic chain/ring screen at 32, 64, and 128 qubits, three numbering seeds, and line/grid/heavy-hex targets passes three samples per variant. Every chain on a line or grid needs zero SWAPs; no case worsens native count or depth. For the 64-qubit line chain (four rounds, seed 42), SWAPs drop 613 → 0, direct native CX count 2,091 → 252, and median mapping time 61.2 → 36.1 ms (ranges 61.0–61.3 and 36.0–36.1 ms).

Benchpress measures the complete target pipeline, including post-routing fusion. Synthetic timings isolate mapping and check direct U/CX lowering. These are fixed-workload measurements on a shared host; they do not establish a general speedup or guarantees for arbitrary target graphs. The single hardware walk can miss valid embeddings.

Validation: release build and CTest (3,543 tests, one existing QDMI skip), all 113 mapping tests, whole-file C++ lint, repository lint, and MLIR reference generation pass. New regressions cover a shuffled 64-qubit path on line/grid targets, deterministic output with multithreading enabled or disabled, and 1,024 DD comparisons over every six-qubit Z- and X-basis input. The semantic cases cover chains, disjoint paths with an idle qubit, spare physical sites, and a star target that requires fallback placement. Hosted CI is pending. Codex prepared the code, tests, measurements, and this description.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
