### PR TITLE
🐛 Preserve compiler input parameter identities

### DIFF
--- a/.agent/plans/parameter-input-identities.md
+++ b/.agent/plans/parameter-input-identities.md
@@ -1,6 +1,7 @@
 # Preserve compiler input identities
 
-Status: implementation and semantic validation complete; final lint and review remain.
+Status: implementation and semantic validation complete; final lint and review
+remain.
 
 ## Goal and scope
 
@@ -22,9 +23,14 @@ identities as vector UUIDs, while preserving other valid group identifiers.
 Local helper and loop parameters retain their existing lexical sharing; this
 change preserves externally bindable free inputs.
 
-## Work remaining
+## Validation and limits
 
-- [x] Add the shared metadata contract and verifier tests.
-- [x] Carry parameter IDs through import/export and test original-object binding.
-- [x] Build and regenerate stubs; pass all 385 translation and 33 native metadata tests.
-- [ ] Complete repository and C++ lint, then publish the focused draft PR.
+The built translation suite passes all 385 tests, and all 33 native MQT metadata
+tests pass. Stub generation, repository lint, and changed-file C++ lint pass.
+The regressions cover binding with the original parameter objects after QC/QCO
+conversion, optimization, and serialization, sparse vectors, extreme UUIDs, and
+invalid shared metadata.
+
+Private helper and loop identities are not guaranteed. OpenQASM and QIR do not
+retain compiler input identity metadata. Vector element IDs must have one root
+UUID; inconsistent IDs are rejected at the SDK export boundary.

--- a/.agent/plans/parameter-input-identities.md
+++ b/.agent/plans/parameter-input-identities.md
@@ -1,0 +1,30 @@
+# Preserve compiler input identities
+
+Status: implementation and semantic validation complete; final lint and review remain.
+
+## Goal and scope
+
+Qiskit imports currently retain parameter names and sharing but exports create
+new identities. Preserve original free parameter identities through QC/QCO
+conversion, optimization, and MLIR serialization so callers can bind using the
+original parameters. The MQT dialect owns an optional opaque 128-bit input ID;
+Qiskit UUID conversion stays at the adapter boundary. No Qiskit synthesis or
+transpilation is used.
+
+## Decisions
+
+Attach `mqt.input_id` to named function arguments as an `i128` attribute. Treat
+all bit patterns as IDs, require uniqueness within each function, and carry the
+attribute with its input through transformations. Removing an input removes its
+ID. Frontends that omit it keep the existing fresh-identity export behavior.
+Parameter vectors already retain a group identity: restore UUID-shaped group
+identities as vector UUIDs, while preserving other valid group identifiers.
+Local helper and loop parameters retain their existing lexical sharing; this
+change preserves externally bindable free inputs.
+
+## Work remaining
+
+- [x] Add the shared metadata contract and verifier tests.
+- [x] Carry parameter IDs through import/export and test original-object binding.
+- [x] Build and regenerate stubs; pass all 385 translation and 33 native metadata tests.
+- [ ] Complete repository and C++ lint, then publish the focused draft PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+- 🐛 Preserve free Qiskit parameter UUIDs and parameter-vector identities
+  through QC/QCO conversion and MLIR serialization. Bind exported circuits using
+  the original parameters. Add optional frontend-neutral `mqt.input_id` metadata
+  for named compiler inputs. ([**@simon1hofmann**])
+
 - ⚡ Speed up qubit placement and routing. Skip layout search for flat programs
   whose initial qubit placement already satisfies the target topology. Place
   disjoint interaction paths along connected target sites to avoid needless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ releases may include breaking changes.
 - 🐛 Preserve free Qiskit parameter UUIDs and parameter-vector identities
   through QC/QCO conversion and MLIR serialization. Bind exported circuits using
   the original parameters. Add optional frontend-neutral `mqt.input_id` metadata
-  for named compiler inputs. ([**@simon1hofmann**])
+  for named compiler inputs. ([#2552]) ([**@simon1hofmann**])
 
 - ⚡ Speed up qubit placement and routing. Skip layout search for flat programs
   whose initial qubit placement already satisfies the target topology. Place
@@ -1770,3 +1770,5 @@ for previous changelogs._
 [munich-quantum-toolkit/workflows]: https://github.com/munich-quantum-toolkit/workflows
 [MQT QMAP]: https://github.com/munich-quantum-toolkit/qmap
 [MQT QCEC]: https://github.com/munich-quantum-toolkit/qcec
+
+[#2552]: https://github.com/munich-quantum-toolkit/core/pull/2552

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,12 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+Qiskit exports now preserve imported free parameter identities, so callers can
+bind with their original `Parameter` or `ParameterVector` objects. Remove
+name-based rebinding workarounds when requiring a Core version with this fix.
+Newly imported MLIR can contain `mqt.input_id` attributes; older Core versions
+cannot read that new metadata. Existing IR without IDs remains supported.
+
 ## [4.0.0]
 
 ### Migrating from MQT Core 3 to 4

--- a/bindings/mlir/qiskit/Qiskit2_5.cpp
+++ b/bindings/mlir/qiskit/Qiskit2_5.cpp
@@ -156,6 +156,11 @@ pythonUnsignedValue(const nb::handle object, const uint32_t width,
   }
 }
 
+[[nodiscard]] static nb::object pythonUuid(const llvm::APInt& identity) {
+  return nb::module_::import_("uuid").attr("UUID")(
+      nb::arg("int") = pythonInteger(identity, "invalid parameter identity"));
+}
+
 [[noreturn]] static void throwPythonError(const std::string_view message) {
   const nb::python_error error;
   throw std::runtime_error(std::string(message) + ": " + error.what());
@@ -236,10 +241,16 @@ normalizePythonParameterLeaf(const nb::handle parameter) {
     throw std::runtime_error(
         "Qiskit parameter names cannot contain null characters");
   }
+  const auto uuid =
+      pythonAttribute(parameter, "uuid", "Qiskit parameter has no identity");
+  auto identity = pythonUnsignedValue(
+      pythonAttribute(uuid, "int", "Qiskit parameter identity is not a UUID"),
+      128U, "Qiskit parameter identity does not fit in 128 bits");
   const auto vectorElement =
       nb::module_::import_("qiskit.circuit").attr("ParameterVectorElement");
   if (!nb::isinstance(parameter, vectorElement)) {
-    return Parameter::symbol(std::move(name));
+    return Parameter::symbol(std::move(name), std::nullopt,
+                             llvm::toString(identity, 16, false));
   }
 
   const auto vector = pythonAttribute(
@@ -271,7 +282,8 @@ normalizePythonParameterLeaf(const nb::handle parameter) {
                                .name = std::move(groupName),
                                .index = groupIndex,
                                .size = groupSize,
-                           });
+                           },
+                           llvm::toString(identity, 16, false));
 }
 
 namespace {
@@ -2358,21 +2370,46 @@ private:
       auto pythonSymbol = symbols.find(symbol->name);
       if (pythonSymbol == symbols.end()) {
         nb::object value;
+        nb::object uuid = nb::none();
+        if (symbol->identity) {
+          uuid = pythonUuid(llvm::APInt(128, *symbol->identity, 16));
+        }
         if (symbol->group) {
           const auto& metadata = *symbol->group;
           const auto [group, inserted] =
               parameters_->groups.try_emplace(metadata.identity);
           if (inserted) {
+            nb::object groupUuid = nb::none();
+            if (symbol->identity) {
+              auto root = llvm::APInt(128, *symbol->identity, 16);
+              root -= metadata.index;
+              groupUuid = pythonUuid(root);
+            } else {
+              try {
+                groupUuid = nb::module_::import_("uuid").attr("UUID")(
+                    metadata.identity);
+              } catch (const nb::python_error& error) {
+                // Other frontends can use non-UUID group identities.
+                if (!error.matches(nb::handle(PyExc_ValueError))) {
+                  throw;
+                }
+              }
+            }
             group->second =
                 nb::module_::import_("qiskit.circuit")
-                    .attr("ParameterVector")(metadata.name, metadata.size);
+                    .attr("ParameterVector")(metadata.name, metadata.size,
+                                             nb::arg("uuid") = groupUuid);
           }
           value = nb::module_::import_("qiskit.circuit")
                       .attr("ParameterVectorElement")(group->second,
                                                       metadata.index);
+          if (!uuid.is_none() && !value.attr("uuid").equal(uuid)) {
+            throw std::runtime_error(
+                "inconsistent parameter-vector input identities");
+          }
         } else {
           value = nb::module_::import_("qiskit.circuit")
-                      .attr("Parameter")(symbol->name);
+                      .attr("Parameter")(symbol->name, nb::arg("uuid") = uuid);
         }
         pythonSymbol =
             symbols.try_emplace(symbol->name, std::move(value)).first;

--- a/bindings/mlir/qiskit/QiskitExport.cpp
+++ b/bindings/mlir/qiskit/QiskitExport.cpp
@@ -54,6 +54,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Casting.h"
 
@@ -509,7 +510,13 @@ static void collectParameters(mlir::func::FuncOp function, ExportState& state,
       }
       state.parameterGroups.add(*group);
     }
-    auto parameter = Parameter::symbol(name.str(), std::move(group));
+    std::optional<std::string> identity;
+    if (const auto id = function.getArgAttrOfType<mlir::IntegerAttr>(
+            index, mlir::mqt::MQTDialect::InputIdAttrHelper::getNameStr())) {
+      identity = llvm::toString(id.getValue(), 16, false);
+    }
+    auto parameter =
+        Parameter::symbol(name.str(), std::move(group), std::move(identity));
     state.parameters[argument] = parameter;
     state.inputParameters.push_back(std::move(parameter));
   }

--- a/bindings/mlir/qiskit/QiskitImport.cpp
+++ b/bindings/mlir/qiskit/QiskitImport.cpp
@@ -2881,6 +2881,12 @@ mlir::QCProgram importCircuit(const nb::handle circuit) {
             mlir::mqt::MQTDialect::InputNameAttrHelper::getNameStr(),
             builder.getStringAttr(symbol->name)),
     };
+    if (symbol->identity) {
+      argumentAttributes.push_back(builder.getNamedAttr(
+          mlir::mqt::MQTDialect::InputIdAttrHelper::getNameStr(),
+          builder.getIntegerAttr(builder.getIntegerType(128),
+                                 llvm::APInt(128, *symbol->identity, 16))));
+    }
     if (symbol->group) {
       argumentAttributes.push_back(builder.getNamedAttr(
           mlir::mqt::MQTDialect::ParameterGroupAttrHelper::getNameStr(),

--- a/bindings/mlir/qiskit/QiskitTranslation.h
+++ b/bindings/mlir/qiskit/QiskitTranslation.h
@@ -133,9 +133,11 @@ public:
   [[nodiscard]] static Parameter
   symbol(std::string name, std::optional<ParameterGroup> group = std::nullopt,
          std::optional<std::string> identity = std::nullopt) {
-    return Parameter(Symbol{.name = std::move(name),
-                            .group = std::move(group),
-                            .identity = std::move(identity)});
+    return Parameter(Symbol{
+        .name = std::move(name),
+        .group = std::move(group),
+        .identity = std::move(identity),
+    });
   }
 
   [[nodiscard]] static Parameter unary(const UnaryParameterKind operation,

--- a/bindings/mlir/qiskit/QiskitTranslation.h
+++ b/bindings/mlir/qiskit/QiskitTranslation.h
@@ -109,6 +109,8 @@ public:
   struct Symbol {
     std::string name;
     std::optional<ParameterGroup> group;
+    /// Hexadecimal input ID. String storage keeps expression moves noexcept.
+    std::optional<std::string> identity;
   };
 
   struct Unary {
@@ -129,9 +131,11 @@ public:
   }
 
   [[nodiscard]] static Parameter
-  symbol(std::string name, std::optional<ParameterGroup> group = std::nullopt) {
-    return Parameter(
-        Symbol{.name = std::move(name), .group = std::move(group)});
+  symbol(std::string name, std::optional<ParameterGroup> group = std::nullopt,
+         std::optional<std::string> identity = std::nullopt) {
+    return Parameter(Symbol{.name = std::move(name),
+                            .group = std::move(group),
+                            .identity = std::move(identity)});
   }
 
   [[nodiscard]] static Parameter unary(const UnaryParameterKind operation,

--- a/docs/mlir/qiskit.md
+++ b/docs/mlir/qiskit.md
@@ -59,7 +59,16 @@ expression-tree shape is not preserved. Quantum-resource and classical-snapshot
 canonicalization patterns are not applied, because they can change circuit width
 or introduce scratch bits. Call `cleanup()` explicitly when those broader
 transformations are wanted. Live free parameters retain their identities; unused
-named program inputs remain unsupported.
+named program inputs remain unsupported. Imported free parameter UUIDs survive
+QC/QCO conversion, optimization, and MLIR serialization, so the original
+`Parameter` objects can be used with `assign_parameters` on the exported
+circuit. Core stores an optional opaque 128-bit `mqt.input_id` on each named
+input; programs without this metadata receive fresh scalar parameter identities.
+Parameter-vector group UUIDs also survive, including those of unused elements.
+The exporter rejects vector element IDs that do not share one root UUID.
+Lexically bound loop and private helper parameters retain lexical sharing but do
+not guarantee preservation of their original external UUIDs. Input identities
+are compiler metadata; OpenQASM and QIR serialization do not retain them.
 
 Free symbols become named {code}`f64` program inputs. Parameter-vector elements
 retain their grouping and index, preserving vector order and positional binding

--- a/mlir/include/mqt/Dialect/MQT/IR/MQTDialect.td
+++ b/mlir/include/mqt/Dialect/MQT/IR/MQTDialect.td
@@ -24,6 +24,11 @@ def MQTDialect : Dialect {
     across quantum dialect conversions. It defines no operations or types.
 
     `mqt.input_name` records the source-level name of a function input.
+    `mqt.input_id` optionally records an opaque 128-bit source identity on a
+    named function input. It is an `i128` attribute, unique within the function;
+    every bit pattern is valid. Transformations carry it with the input and
+    remove it when removing the input. It does not identify an SSA value or
+    change execution semantics.
     `mqt.source_name` records a source-level function name when the IR symbol
     must be uniquified.
     `mqt.parameter_group` optionally preserves the source-level vector
@@ -55,7 +60,7 @@ def MQTDialect : Dialect {
   }];
 
   let discardableAttrs = (ins "::mlir::StringAttr":$input_name,
-      "::mlir::StringAttr":$source_name,
+      "::mlir::IntegerAttr":$input_id, "::mlir::StringAttr":$source_name,
       "::mlir::DictionaryAttr":$parameter_group,
       "::mlir::StringAttr":$register_name, "::mlir::UnitAttr":$entry_point,
       "::mlir::UnitAttr":$unitary);

--- a/mlir/lib/Dialect/MQT/IR/MQTDialect.cpp
+++ b/mlir/lib/Dialect/MQT/IR/MQTDialect.cpp
@@ -789,7 +789,8 @@ MQTDialect::verifyOperationAttribute(Operation* operation,
     }
     return verifyParameterGroup(operation, attribute.getValue());
   }
-  if (attribute.getName() == InputNameAttrHelper::getNameStr()) {
+  if (attribute.getName() == InputNameAttrHelper::getNameStr() ||
+      attribute.getName() == InputIdAttrHelper::getNameStr()) {
     return operation->emitError()
            << "attribute '" << attribute.getName().getValue()
            << "' is only valid on a function argument";
@@ -803,6 +804,7 @@ LogicalResult MQTDialect::verifyRegionArgAttribute(
     const NamedAttribute attribute) {
   const auto attributeName = attribute.getName();
   if (attributeName != InputNameAttrHelper::getNameStr() &&
+      attributeName != InputIdAttrHelper::getNameStr() &&
       attributeName != ParameterGroupAttrHelper::getNameStr()) {
     return operation->emitError()
            << "attribute '" << attribute.getName().getValue()
@@ -816,6 +818,23 @@ LogicalResult MQTDialect::verifyRegionArgAttribute(
            << "' requires a function entry-block argument";
   }
 
+  if (attributeName == InputIdAttrHelper::getNameStr()) {
+    const auto id = dyn_cast<IntegerAttr>(attribute.getValue());
+    if (!id || !id.getType().isSignlessInteger(128)) {
+      return operation->emitError("input identity must be an i128 attribute");
+    }
+    if (!function.getArgAttrOfType<StringAttr>(
+            argIndex, InputNameAttrHelper::getNameStr())) {
+      return operation->emitError("input identity requires an input name");
+    }
+    for (unsigned index = 0; index < function.getNumArguments(); ++index) {
+      if (index != argIndex &&
+          function.getArgAttr(index, attributeName) == id) {
+        return operation->emitError("duplicate input identity");
+      }
+    }
+    return success();
+  }
   if (attributeName == ParameterGroupAttrHelper::getNameStr()) {
     return verifyInputGroup(function, operation, argIndex,
                             attribute.getValue());

--- a/mlir/unittests/Dialect/MQT/IR/test_mqt_ir.cpp
+++ b/mlir/unittests/Dialect/MQT/IR/test_mqt_ir.cpp
@@ -720,7 +720,7 @@ TEST_F(MQTIRTest, AcceptsOpaqueInputIdentities) {
 }
 
 TEST_F(MQTIRTest, RejectsInvalidInputIdentities) {
-  for (const auto source : {
+  for (const auto* source : {
            R"mlir(module {
          func.func @main(%arg: f64 {mqt.input_id = 1 : i128}) { return }
        })mlir",

--- a/mlir/unittests/Dialect/MQT/IR/test_mqt_ir.cpp
+++ b/mlir/unittests/Dialect/MQT/IR/test_mqt_ir.cpp
@@ -708,6 +708,44 @@ TEST_F(MQTIRTest, RejectsDuplicateInputNames) {
   )mlir"));
 }
 
+TEST_F(MQTIRTest, AcceptsOpaqueInputIdentities) {
+  EXPECT_TRUE(parse(R"mlir(
+    module {
+      func.func @main(%first: f64 {mqt.input_name = "a", mqt.input_id = 0 : i128},
+                      %second: f64 {mqt.input_name = "b", mqt.input_id = -1 : i128}) {
+        return
+      }
+    }
+  )mlir"));
+}
+
+TEST_F(MQTIRTest, RejectsInvalidInputIdentities) {
+  for (const auto source : {
+           R"mlir(module {
+         func.func @main(%arg: f64 {mqt.input_id = 1 : i128}) { return }
+       })mlir",
+           R"mlir(module {
+         func.func @main(%arg: f64 {mqt.input_name = "a", mqt.input_id = 1 : i64}) { return }
+       })mlir",
+           R"mlir(module {
+         func.func @main(%arg: f64 {mqt.input_name = "a", mqt.input_id = 1 : ui128}) { return }
+       })mlir",
+           R"mlir(module {
+         func.func @main(%arg: f64 {mqt.input_name = "a", mqt.input_id = "id"}) { return }
+       })mlir",
+           R"mlir(module {
+         func.func @main(%a: f64 {mqt.input_name = "a", mqt.input_id = 1 : i128},
+                         %b: f64 {mqt.input_name = "b", mqt.input_id = 1 : i128}) { return }
+       })mlir",
+           R"mlir(module {
+         func.func @main() attributes {mqt.input_id = 1 : i128} { return }
+       })mlir",
+       }) {
+    SCOPED_TRACE(source);
+    EXPECT_FALSE(parse(source));
+  }
+}
+
 TEST_F(MQTIRTest, RejectsInvalidInputGroups) {
   EXPECT_FALSE(parse(R"mlir(
     module {

--- a/test/python/test_mlir_qiskit_translation.py
+++ b/test/python/test_mlir_qiskit_translation.py
@@ -16,6 +16,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from itertools import permutations
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import numpy as np
 import pytest
@@ -3595,6 +3596,92 @@ def test_direct_symbolic_parameters_round_trip_with_shared_identity() -> None:
         Operator(restored.assign_parameters({restored_theta: value})).data,
         Operator(circuit.assign_parameters({theta: value})).data,
     )
+
+
+@pytest.mark.parametrize("identity", [0, (1 << 128) - 1])
+@pytest.mark.parametrize("pipeline", ["qc", "qco", "optimized"])
+def test_original_parameter_binds_after_compiler_round_trip(identity: int, pipeline: str) -> None:
+    """Keep the original externally bindable identity through native IR."""
+    theta = Parameter("theta", uuid=UUID(int=identity))
+    circuit = QuantumCircuit(1, global_phase=theta / 4)
+    circuit.ry(2 * theta, 0)
+    qc = QCProgram.from_qiskit(circuit)
+    program = QCProgram.from_mlir_str(qc.ir)
+    if pipeline != "qc":
+        qco = program.to_qco()
+        if pipeline == "optimized":
+            qco.run_pass_pipeline("mqt-qco-default")
+        program = qco.to_qc()
+    restored = program.to_qiskit()
+
+    assert restored.parameters == {theta}
+    assert np.allclose(
+        Operator(restored.assign_parameters({theta: 0.3})).data,
+        Operator(circuit.assign_parameters({theta: 0.3})).data,
+    )
+    assert program.copy().to_qiskit().parameters == {theta}
+
+
+def test_original_parameter_identity_is_shared_in_control_flow() -> None:
+    """Preserve free parameter identity in sibling conditional blocks."""
+    theta = Parameter("theta")
+    circuit = QuantumCircuit(1, 1, global_phase=theta)
+    with circuit.if_test((circuit.clbits[0], True)) as else_:
+        circuit.rx(theta, 0)
+    with else_:
+        circuit.ry(theta / 2, 0)
+    restored = QCProgram.from_qiskit(circuit).to_qco().to_qiskit()
+
+    assert restored.parameters == {theta}
+    for block in restored.data[0].operation.blocks:
+        assert block.parameters == {theta}
+    assert not restored.assign_parameters({theta: 0.2}).parameters
+
+
+def test_original_parameter_vector_binds_after_mlir_round_trip() -> None:
+    """Preserve vector element and root UUIDs, including unused elements."""
+    vector = ParameterVector("theta", 12)
+    circuit = QuantumCircuit(1, global_phase=vector[0])
+    circuit.rx(vector[10] + vector[2], 0)
+    program = QCProgram.from_qiskit(circuit).to_qco()
+    restored = QCProgram.from_mlir_str(program.to_qc().ir).to_qiskit()
+
+    assert restored.parameters == {vector[0], vector[2], vector[10]}
+    restored_vector = next(iter(restored.parameters)).vector
+    assert restored_vector.uuid == vector.uuid
+    assert list(restored_vector) == list(vector)
+    values = [0.01 * index for index in range(12)]
+    assert np.allclose(
+        Operator(restored.assign_parameters({vector: values}, strict=False)).data,
+        Operator(circuit.assign_parameters({vector: values}, strict=False)).data,
+    )
+
+
+@pytest.mark.parametrize("second_identity", [1, 2])
+def test_vector_input_id_consistency(second_identity: int) -> None:
+    """Support opaque group names but require one root UUID per vector."""
+    program = QCProgram.from_mlir_str(
+        """module {
+  func.func @main(
+      %a: f64 {mqt.input_name = "v[0]", mqt.input_id = 0 : i128,
+               mqt.parameter_group = {identity = "opaque", name = "v", index = 0 : i64, size = 2 : i64}},
+      %b: f64 {mqt.input_name = "v[1]", mqt.input_id = SECOND : i128,
+               mqt.parameter_group = {identity = "opaque", name = "v", index = 1 : i64, size = 2 : i64}})
+      attributes {mqt.entry_point} {
+    %q = qc.alloc : !qc.qubit
+    qc.rx(%a) %q : !qc.qubit
+    qc.rz(%b) %q : !qc.qubit
+    qc.dealloc %q : !qc.qubit
+    return
+  }
+}""".replace("SECOND", str(second_identity))
+    )
+    if second_identity == 1:
+        restored = program.to_qiskit()
+        assert [parameter.uuid.int for parameter in restored.parameters] == [0, 1]
+    else:
+        with pytest.raises(RuntimeError, match="inconsistent parameter-vector input identities"):
+            program.to_qiskit()
 
 
 def test_sparse_parameter_vector_round_trip_preserves_order_and_binding() -> None:


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Free parameters imported from Qiskit currently export with new UUIDs, so binding an exported circuit with the original `Parameter` object fails. Preserve those identities through QC/QCO conversion, optimization, and MLIR serialization using an optional, frontend-neutral `mqt.input_id` attribute on named function inputs.

The MQT dialect owns the opaque 128-bit identity and verifies its type, placement, and uniqueness. The existing SDK adapter converts UUIDs at the import/export boundary. No Qiskit synthesis or transpilation is used. Keep the compatibility guide focused on the binding guarantee and add development and agent guidance for concise documentation.

Changelog and upgrade-guide entries are deferred to release preparation under the policy proposed in #2556 and munich-quantum-toolkit/templates#449. Required migrations are described below.

### Usage

```python
from qiskit import QuantumCircuit
from qiskit.circuit import Parameter
from mqt.core import mlir

angle = Parameter("angle")
circuit = QuantumCircuit(1)
circuit.rx(angle, 0)
program = mlir.from_qiskit(circuit).to_qco()
restored = mlir.QCOProgram.from_mlir_str(str(program)).to_qiskit()
bound = restored.assign_parameters({angle: 0.5})
```

Parameter vectors retain their root UUID, including identities of unused vector elements. Original vectors can be used for binding after export. When requiring a Core version with this fix, remove name-based rebinding workarounds. Older IR without input IDs keeps fresh scalar identity behavior; UUID-shaped vector group identities can still be restored.

### Limitations

- This preserves externally bindable free input identities. Private helper and lexically bound loop parameter UUIDs are not guaranteed.
- OpenQASM and QIR do not retain this compiler metadata. Older Core versions cannot read the new dialect attribute.
- Unused named program inputs remain unsupported by the existing exporter.
- Vector element identities must share one root UUID; inconsistent metadata raises an export error.
- The existing Qiskit 2.5 adapter version constraints still apply.

### Validation

The documentation and guidance update passes repository lint. Existing implementation validation remains unchanged:

- Built Python translation suite: **385 passed**.
- Native MQT IR metadata tests: **33 passed**.
- Native build, generated stubs, repository lint, and changed-file C++ lint: passed.
- Regressions cover original-object binding, serialization, optimized QCO, copies, sibling control flow, sparse vectors, UUID zero and maximum, and malformed metadata.

Codex assisted with the code, tests, documentation, and description. CI for the latest push is pending.

## Checklist

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/core/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
